### PR TITLE
fix(coverage): honest-downgrade 248 cells citing the dead Java pattern-extractor layer

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -132,28 +132,28 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/13 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 2/16 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/13 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 4/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/18 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 2/16 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 6/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 6/15 | |
 | [kotlin](../by-language/kotlin.md) | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🔴 0/16 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 3/15 | |
 | [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
@@ -179,8 +179,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🔴 0/3 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🔴 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 21/21 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 17/17 | |
@@ -192,7 +192,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🟢 2/2 | 🔴 0/1 | 🟡 19/21 | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 11/11 | |
@@ -209,8 +209,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 4/4 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 8/8 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 8/8 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🔴 0/1 | 🟢 18/18 | 🔴 0/8 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🔴 0/1 | 🟢 18/18 | 🔴 0/8 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 13/13 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
@@ -250,7 +250,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | 🟢 4/4 | |
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | 🟢 4/4 | |
 | [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | 🟢 4/4 | |
 

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -62,16 +62,16 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟢 3/3 | |
 | [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟢 7/7 | |
 | [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟢 7/7 | |
-| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 5/7 | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 5/7 | |
 | [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟢 7/7 | |
 | [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟢 5/5 | |
 | [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟢 3/3 | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟢 3/3 | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟢 3/3 | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟡 2/3 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟡 2/3 | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/7 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 2/3 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟡 2/3 | |
 | [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |
@@ -92,12 +92,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ✅ 1/1 | |
 | [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟢 7/7 | |
-| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟢 8/8 | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/8 | |
 | [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ✅ 2/2 | |
 | [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟢 7/7 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟢 8/8 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/8 | |
 | [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟢 1/1 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟢 8/8 | |
 | [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ✅ 8/8 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -26,49 +26,49 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/13 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 2/16 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/13 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 2/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 3/16 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 4/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/18 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 2/16 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 1/7 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🔴 0/3 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🔴 0/3 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🟢 2/2 | 🔴 0/1 | 🟡 19/21 | 🟡 1/4 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 8/8 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 8/8 | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🔴 0/1 | 🟢 18/18 | 🔴 0/8 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🔴 0/1 | 🟢 18/18 | 🔴 0/8 | |
 
 
 ### AI Integration
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | 🟢 4/4 | |
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | 🟡 1/4 | |
 
 
 ## Tools
@@ -96,16 +96,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟢 3/3 | |
 | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟢 7/7 | |
 | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟢 7/7 | |
-| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟢 7/7 | |
-| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟢 7/7 | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 5/7 | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 5/7 | |
 | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟢 7/7 | |
 | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟢 5/5 | |
 | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟢 7/7 | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟢 3/3 | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟢 3/3 | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟢 7/7 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟢 3/3 | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟢 3/3 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟡 2/3 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟡 2/3 | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/7 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 2/3 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟡 2/3 | |
 | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟢 6/6 | |
 
 
@@ -120,4 +120,4 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
-| [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | 🟢 1/1 | 🟢 4/4 | |
+| [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | 🔴 0/1 | 🟡 1/4 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -28,13 +28,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 6/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 6/15 | |
 | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🔴 0/16 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟡 3/15 | |
 | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
@@ -65,9 +65,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟢 7/7 | |
-| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟢 8/8 | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/8 | |
 | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟢 7/7 | |
 | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ✅ 2/2 | |
 | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟢 7/7 | |
 | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟢 7/7 | |
-| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟢 8/8 | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/8 | |

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
-| Handler attribution | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
-| Route extraction | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Endpoint synthesis | 🟢 `partial` | — | 3092 | `internal/engine/http_endpoint_synthesis.go` | — |
+| Handler attribution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Route extraction | 🟢 `partial` | — | 3092 | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
-| Request validation | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| DTO extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Request validation | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Middleware coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Type System
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🟢 `partial` | — | 3256 | `internal/custom/java/android.go` | extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256) |
+| Context extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256) |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Deep link extraction | 🟢 `partial` | — | 3256 | `internal/custom/java/android.go` | extractAndroidDeepLinks() detects <intent-filter> blocks in AndroidManifest.xml with <data android:scheme> as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256) |
-| Navigation extraction | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
-| Screen detection | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
+| Deep link extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | extractAndroidDeepLinks() detects <intent-filter> blocks in AndroidManifest.xml with <data android:scheme> as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256) |
+| Navigation extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
+| Screen detection | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
 
 ### Platform
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
+| Platform branching | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
+| Native module imports | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
 
 ### Data Flow
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🟢 `partial` | `2026-05-30` | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
-| State management | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
+| Branch conditions | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
+| State management | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
 
 ### Type System
 
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/custom/java/junit5.go` | android_jetpack added to junit5Frameworks map (#3177) |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | android_jetpack added to junit5Frameworks map (#3177) |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🟢 `partial` | — | 3256 | `internal/custom/java/android.go` | extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256) |
+| Context extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256) |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Deep link extraction | 🟢 `partial` | — | 3256 | `internal/custom/java/android.go` | extractAndroidDeepLinks() detects <intent-filter> blocks in AndroidManifest.xml with <data android:scheme> as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256) |
-| Navigation extraction | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
-| Screen detection | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
+| Deep link extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | extractAndroidDeepLinks() detects <intent-filter> blocks in AndroidManifest.xml with <data android:scheme> as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256) |
+| Navigation extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
+| Screen detection | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
 
 ### Platform
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
+| Platform branching | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
+| Native module imports | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
 
 ### Data Flow
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🟢 `partial` | `2026-05-30` | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
-| State management | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
+| Branch conditions | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
+| State management | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
 
 ### Type System
 
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/custom/java/junit5.go` | android_sdk added to junit5Frameworks map (#3177) |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | android_sdk added to junit5Frameworks map (#3177) |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -23,26 +23,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
+| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
-| Request validation | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| DTO extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| Request validation | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
+| Middleware coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,17 +57,17 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
-| DI injection point | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
-| DI scope resolution | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
+| DI binding extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
+| DI injection point | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
+| DI scope resolution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
-| Transaction propagation | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
-| Transaction rollback rules | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3087) | `internal/custom/java/dropwizard.go` | — |
+| Transaction boundary extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
+| Transaction propagation | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
+| Transaction rollback rules | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
 
 ### AOP
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Component extraction | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
+| Component extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vaadin_gwt.go` | — |
 | Context extraction | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; context_extraction is a React/JSX-paradigm capability that does not apply |
 
 ### Data Flow
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | — `not_applicable` | — | — | — | GWT compiles Java to client-side JS but uses Java idioms with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for GWT |
-| Data fetching | 🟢 `partial` | `2026-05-30` | 3190 | `internal/custom/java/gwt_rpc.go` | GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback<T> completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial. |
+| Data fetching | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/gwt_rpc.go` | GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback<T> completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial. |
 | Prop extraction | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; prop_extraction is a React/JSX-paradigm capability that does not apply |
 | State management | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; state_management is a React/JSX-paradigm capability that does not apply |
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Router pattern | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
+| Router pattern | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vaadin_gwt.go` | — |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/custom/java/junit5.go` | gwt, vaadin, android_sdk, android_jetpack added to junit5Frameworks map (#3177) |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | gwt, vaadin, android_sdk, android_jetpack added to junit5Frameworks map (#3177) |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -23,26 +23,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go`<br>`internal/engine/java_auth_policy.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/engine/java_auth_policy.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| Request validation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_jaxrs_dto.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/helidon_filters.go` | — |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/helidon_filters.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,17 +57,17 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/jakarta_ee_advanced.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
-| Transaction propagation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3088) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
+| Transaction propagation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | — |
 
 ### AOP
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_jaxrs_dto.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | — |
 
 ### Middleware
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
-| Transaction propagation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
-| Aspect extraction | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
-| Pointcut resolution | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Advice attribution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
+| Aspect extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
+| Pointcut resolution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
-| Handler attribution | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
-| Route extraction | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/javalin/App.java` | — |
+| Endpoint synthesis | 🟢 `partial` | — | 3085 | `internal/engine/http_endpoint_synthesis.go` | — |
+| Handler attribution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
+| Route extraction | 🟢 `partial` | — | 3085 | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
+| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
-| Request validation | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
+| DTO extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
+| Request validation | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
+| Middleware coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -36,13 +36,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3083) | `internal/custom/java/jaxrs_filters.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java` | — |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jaxrs_filters.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | JUnit 5 tests in JAX-RS projects; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestJakartaEE_TestsLinkage_Issue2996 value-asserting (same JUnit 5 extractor gates on jaxrs) |
+| Tests linkage | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | JUnit 5 tests in JAX-RS projects; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestJakartaEE_TestsLinkage_Issue2996 value-asserting (same JUnit 5 extractor gates on jaxrs) |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3083) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3083) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3083) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; jaxrs in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies jaxrs |
-| Transaction propagation | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation/TxType; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
-| Transaction rollback rules | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; jaxrs in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies jaxrs |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation/TxType; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | CDI @Interceptor + @AroundInvoke/@AroundConstruct methods extracted as SCOPE.Pattern(subtype=advice) with advice_type (around_invoke/around_construct) + aspect + framework properties; OWNS edge; value-asserting TestCDI_JAXRS_InterceptorClass_Issue3082 |
-| Aspect extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | @Interceptor-annotated classes detected as SCOPE.Pattern(subtype=aspect, kind=cdi_interceptor) with framework=jaxrs; TestCDI_JAXRS_InterceptorClass_Issue3082 value-asserting |
-| Pointcut resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | @InterceptorBinding annotation type declarations extracted as SCOPE.Pattern(subtype=pointcut, kind=interceptor_binding); REFERENCES edge from advice to binding; value-asserting TestCDI_JAXRS_InterceptorBinding_Issue3082 |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | CDI @Interceptor + @AroundInvoke/@AroundConstruct methods extracted as SCOPE.Pattern(subtype=advice) with advice_type (around_invoke/around_construct) + aspect + framework properties; OWNS edge; value-asserting TestCDI_JAXRS_InterceptorClass_Issue3082 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | @Interceptor-annotated classes detected as SCOPE.Pattern(subtype=aspect, kind=cdi_interceptor) with framework=jaxrs; TestCDI_JAXRS_InterceptorClass_Issue3082 value-asserting |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/cdi_interceptors_test.go` | @InterceptorBinding annotation type declarations extracted as SCOPE.Pattern(subtype=pointcut, kind=interceptor_binding); REFERENCES edge from advice to binding; value-asserting TestCDI_JAXRS_InterceptorBinding_Issue3082 |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; jaxrs in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies jaxrs |
-| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer + @Timed + @Counted/@Metered/@Gauge; jaxrs in obsFrameworks |
-| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); jaxrs in obsFrameworks |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; jaxrs in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies jaxrs |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer + @Timed + @Counted/@Metered/@Gauge; jaxrs in obsFrameworks |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); jaxrs in obsFrameworks |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.langchain4j.md
+++ b/docs/coverage/detail/lang.java.framework.langchain4j.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Prompt template extraction | 🟢 `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @SystemMessage/@UserMessage annotation extraction: lc4jSystemMessageRE and lc4jUserMessageRE capture annotation-level prompt template strings. Runtime template variable resolution not captured. |
+| Prompt template extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/langchain4j.go` | @SystemMessage/@UserMessage annotation extraction: lc4jSystemMessageRE and lc4jUserMessageRE capture annotation-level prompt template strings. Runtime template variable resolution not captured. |
 
 ### Composition
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Chain composition | 🟢 `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @AiService interface extraction plus RAG/ChatMemory component detection: structural composition captured (AiService, EmbeddingStoreContentRetriever, EmbeddingStoreIngestor, ChatMemory fields). Runtime chain wiring not traced. |
-| Tool use detection | 🟢 `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @Tool annotation extraction: lc4jToolMethodRE extracts @Tool-annotated methods, emitting SCOPE.Operation entities with tool_method property. Dynamic tool registration not captured. |
+| Chain composition | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/langchain4j.go` | @AiService interface extraction plus RAG/ChatMemory component detection: structural composition captured (AiService, EmbeddingStoreContentRetriever, EmbeddingStoreIngestor, ChatMemory fields). Runtime chain wiring not traced. |
+| Tool use detection | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/langchain4j.go` | @Tool annotation extraction: lc4jToolMethodRE extracts @Tool-annotated methods, emitting SCOPE.Operation entities with tool_method property. Dynamic tool registration not captured. |
 
 ### Tracking
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/micronaut.go`<br>`internal/engine/java_annotation_routes.go` | — |
+| Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
 
 ### Auth
 
@@ -29,20 +29,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/micronaut.go`<br>`internal/engine/java_annotation_routes.go` | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3084) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/AuthFilter.java` | — |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/AuthFilter.java` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @MicronautTest + JUnit 5; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestMicronaut_TestsLinkage_Issue2995 value-asserting |
+| Tests linkage | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @MicronautTest + JUnit 5; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestMicronaut_TestsLinkage_Issue2995 value-asserting |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/micronaut.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/micronaut.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/micronaut.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; micronaut in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies micronaut activation |
-| Transaction propagation | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation/TxType captured; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
-| Transaction rollback rules | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; micronaut in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies micronaut activation |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation/TxType captured; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | Micronaut AOP: @InterceptorBean binding + intercept() method extracted as SCOPE.Pattern(subtype=advice) with advice_type=around + binding property; OWNS edge from interceptor class; REFERENCES edge to pointcut; value-asserting tests TestMicronautAOP_AdviceAttribution_Issue3084 |
-| Aspect extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | @Around @interface + MethodInterceptor-implementing classes detected as SCOPE.Pattern(subtype=aspect); TestMicronautAOP_AspectExtraction_Issue3084 proves binding annotation + interceptor class both emitted |
-| Pointcut resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | @Around-annotated binding annotation type emitted as SCOPE.Pattern(subtype=pointcut); REFERENCES edge from advice to pointcut; TestMicronautAOP_PointcutResolution_Issue3084 value-asserting |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | Micronaut AOP: @InterceptorBean binding + intercept() method extracted as SCOPE.Pattern(subtype=advice) with advice_type=around + binding property; OWNS edge from interceptor class; REFERENCES edge to pointcut; value-asserting tests TestMicronautAOP_AdviceAttribution_Issue3084 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | @Around @interface + MethodInterceptor-implementing classes detected as SCOPE.Pattern(subtype=aspect); TestMicronautAOP_AspectExtraction_Issue3084 proves binding annotation + interceptor class both emitted |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go` | @Around-annotated binding annotation type emitted as SCOPE.Pattern(subtype=pointcut); REFERENCES edge from advice to pointcut; TestMicronautAOP_PointcutResolution_Issue3084 value-asserting |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; micronaut in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies micronaut |
-| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer + @Timed + @Counted/@Metered/@Gauge; micronaut in obsFrameworks |
-| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); micronaut in obsFrameworks |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; micronaut in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies micronaut |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer + @Timed + @Counted/@Metered/@Gauge; micronaut in obsFrameworks |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); micronaut in obsFrameworks |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -29,20 +29,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_jaxrs_dto.go` | — |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_jaxrs_dto.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3083) | `internal/custom/java/jaxrs_filters.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/microprofile/MicroProfileFiltersFixture.java` | — |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jaxrs_filters.go`<br>`internal/custom/java/jaxrs_filters_test.go`<br>`testdata/fixtures/sources/java/microprofile/MicroProfileFiltersFixture.java` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/jakarta_ee_advanced.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3079) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
-| Transaction propagation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3079) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3079) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
+| Transaction propagation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go`<br>`testdata/fixtures/sources/java/microprofile/OrderService.java` | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
-| Aspect extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
-| Pointcut resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
+| Advice attribution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
+| Aspect extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
+| Pointcut resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -35,8 +35,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Route extraction | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
-| Router pattern | 🟢 `partial` | `2026-05-29` | — | `internal/custom/java/play_routes.go` | playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178). |
+| Route extraction | 🟢 `partial` | — | 3090 | `internal/engine/http_endpoint_synthesis.go` | — |
+| Router pattern | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178). |
 
 ### Build
 
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | — |
 
 ### Substrate
 
@@ -81,8 +81,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Pure function tagging | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Reachability analysis | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Request shape extraction | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
-| Response shape extraction | 🟢 `partial` | — | 3256 | `internal/custom/java/play_routes.go` | extractPlayResponseShapes() detects Play Result factory call sites (ok/created/badRequest/notFound/redirect/status/etc.) as SCOPE.Reference response_shape entities with result_factory and controller_class properties (#3256) |
+| Request shape extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | — |
+| Response shape extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | extractPlayResponseShapes() detects Play Result factory call sites (ok/created/badRequest/notFound/redirect/status/etc.) as SCOPE.Reference response_shape entities with result_factory and controller_class properties (#3256) |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Schema drift detection | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | Framework-blind payload shapes sniffer fires for all Java sources; no Play-specific gate required (#3178). |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
@@ -94,10 +94,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
+| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | — |
 | Endpoint synthesis | 🟢 `partial` | — | 3090 | `internal/engine/http_endpoint_synthesis.go` | — |
-| Handler attribution | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
-| Middleware coverage | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
+| Handler attribution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | — |
+| Middleware coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/play_routes.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go`<br>`internal/engine/java_annotation_routes.go` | — |
+| Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
 
 ### Auth
 
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go`<br>`internal/engine/java_annotation_routes.go` | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | — |
 
 ### Middleware
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | — |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/quarkus.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/quarkus.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/quarkus.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
-| Transaction propagation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
-| Aspect extraction | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
-| Pointcut resolution | 🟢 `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Advice attribution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
+| Aspect extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
+| Pointcut resolution | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go` | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody parameter types and ResponseEntity<T>/Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody parameter types and ResponseEntity<T>/Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | Bean Validation annotations (@NotNull, @NotBlank, @NotEmpty, @Valid, @Min, @Max, @Size, @Pattern, @Email) captured per handler parameter; required flag set; no field-level constraint recursion |
 
 ### Middleware
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @Test/@ParameterizedTest/@RepeatedTest methods extracted; @BeforeEach/@AfterEach lifecycle methods captured; @Nested classes emitted; @ExtendWith extensions; OWNS edge from class to test method; @SpringBootTest/@WebMvcTest class-level annotations recognised; value-asserting test TestSpringBoot_TestsLinkage_Issue2991 |
+| Tests linkage | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @Test/@ParameterizedTest/@RepeatedTest methods extracted; @BeforeEach/@AfterEach lifecycle methods captured; @Nested classes emitted; @ExtendWith extensions; OWNS edge from class to test method; @SpringBootTest/@WebMvcTest class-level annotations recognised; value-asserting test TestSpringBoot_TestsLinkage_Issue2991 |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
-| DI injection point | 🟢 `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | 3081 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_boot.go` | — |
+| DI binding extraction | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_boot.go` | — |
+| DI injection point | 🔴 `missing` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_boot.go` | — |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_boot.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; class-level boundary + method-level SCOPE.Pattern(subtype=transaction_boundary) with declaring_class, framework; OWNS edges from class to method boundaries; Jakarta/JTA TxType positional form handled; value-asserting fixture TestTransactional_Boundary_Propagation_Rollback_Issue3003 |
-| Transaction propagation | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) extracted into propagation property; isolation + readOnly also captured; all Spring propagation modes + JTA TxType modes covered; value-asserting test TestTransactional_Boundary_Propagation_Rollback_Issue3003 |
-| Transaction rollback rules | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor X.class single + {A.class,B.class} list captured as rollback_for/no_rollback_for properties; value-asserting test covers single + multi-class rollback + noRollbackFor |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; class-level boundary + method-level SCOPE.Pattern(subtype=transaction_boundary) with declaring_class, framework; OWNS edges from class to method boundaries; Jakarta/JTA TxType positional form handled; value-asserting fixture TestTransactional_Boundary_Propagation_Rollback_Issue3003 |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) extracted into propagation property; isolation + readOnly also captured; all Spring propagation modes + JTA TxType modes covered; value-asserting test TestTransactional_Boundary_Propagation_Rollback_Issue3003 |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor X.class single + {A.class,B.class} list captured as rollback_for/no_rollback_for properties; value-asserting test covers single + multi-class rollback + noRollbackFor |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | Spring AOP: @Aspect classes, @Before/@After/@Around/@AfterReturning/@AfterThrowing advice methods extracted as SCOPE.Pattern(subtype=advice) with advice_type+pointcut_expression+aspect properties; OWNS edge from aspect; REFERENCES edge for named pointcuts; all 5 advice types covered; value-asserting tests in TestSpringAOP_AdviceAttribution_Issue3004 |
-| Aspect extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect) with kind=aspect + framework properties; Spring Boot + Spring WebFlux gated; value-asserting tests in TestSpringAOP_Fixture_Issue3004 |
-| Pointcut resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut declarations detected as SCOPE.Pattern(subtype=pointcut) with pointcut_expression; named pointcut references resolved via REFERENCES edges from advice; inline AspectJ execution() excluded from named-reference resolution; value-asserting tests |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | Spring AOP: @Aspect classes, @Before/@After/@Around/@AfterReturning/@AfterThrowing advice methods extracted as SCOPE.Pattern(subtype=advice) with advice_type+pointcut_expression+aspect properties; OWNS edge from aspect; REFERENCES edge for named pointcuts; all 5 advice types covered; value-asserting tests in TestSpringAOP_AdviceAttribution_Issue3004 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect) with kind=aspect + framework properties; Spring Boot + Spring WebFlux gated; value-asserting tests in TestSpringAOP_Fixture_Issue3004 |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut declarations detected as SCOPE.Pattern(subtype=pointcut) with pointcut_expression; named pointcut references resolved via REFERENCES edges from advice; inline AspectJ execution() excluded from named-reference resolution; value-asserting tests |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | SLF4J @Slf4j logger + LoggerFactory.getLogger, Log4j LogManager.getLogger, JUL Logger.getLogger; log statement calls (log.info/debug/warn/error/trace) per call site; library + framework + log_level properties; value-asserting tests TestObservability_Slf4jLogging_Issue3006 + TestObservability_LoggerFactoryVariants_Issue3006 |
-| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer Counter/Timer/Gauge/DistributionSummary.builder(), MeterRegistry usage, @Timed annotation; MicroProfile @Counted/@Metered/@Gauge; metric_type + metric_name + library + framework properties; value-asserting tests TestObservability_MicrometerMetrics_Issue3006 + TestObservability_MicroProfileMetrics_Issue3006 |
-| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + tracer.spanBuilder(); Micrometer Tracing @Observed + tracer.nextSpan(); span_kind (annotation/programmatic) + span_name + library + framework; value-asserting tests TestObservability_OtelTracing_Issue3006 + TestObservability_MicrometerTracing_Issue3006 |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | SLF4J @Slf4j logger + LoggerFactory.getLogger, Log4j LogManager.getLogger, JUL Logger.getLogger; log statement calls (log.info/debug/warn/error/trace) per call site; library + framework + log_level properties; value-asserting tests TestObservability_Slf4jLogging_Issue3006 + TestObservability_LoggerFactoryVariants_Issue3006 |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer Counter/Timer/Gauge/DistributionSummary.builder(), MeterRegistry usage, @Timed annotation; MicroProfile @Counted/@Metered/@Gauge; metric_type + metric_name + library + framework properties; value-asserting tests TestObservability_MicrometerMetrics_Issue3006 + TestObservability_MicroProfileMetrics_Issue3006 |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + tracer.spanBuilder(); Micrometer Tracing @Observed + tracer.nextSpan(); span_kind (annotation/programmatic) + span_name + library + framework; value-asserting tests TestObservability_OtelTracing_Issue3006 + TestObservability_MicrometerTracing_Issue3006 |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes.go` | — |
-| Route extraction | 🟢 `partial` | `2026-05-29` | 3080 | `internal/custom/java/spring_webflux_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/spring_webflux/RouterConfig.java` | — |
+| Route extraction | 🟢 `partial` | `2026-05-29` | 3080 | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
@@ -29,20 +29,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody types and Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody types and Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
 | Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | Bean Validation annotations (@Valid, @NotNull, @NotBlank, @NotEmpty) captured per handler parameter; required flag set; same extractor as spring-boot; no field-level recursion |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | 3080 | `internal/custom/java/spring_webflux_routes.go`<br>`testdata/fixtures/sources/java/spring_webflux/RouterConfig.java` | WebFilter implementations detected via 'implements WebFilter' class declaration; Middleware entities emitted with middleware_type=web_filter and filter_class. Multiple WebFilter classes in one file each produce a distinct entity. |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_webflux_routes.go`<br>`testdata/fixtures/sources/java/spring_webflux/RouterConfig.java` | WebFilter implementations detected via 'implements WebFilter' class declaration; Middleware entities emitted with middleware_type=web_filter and filter_class. Multiple WebFilter classes in one file each produce a distinct entity. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @Test/@WebFluxTest; @Test/@ParameterizedTest/@RepeatedTest methods extracted; OWNS edge class->method; TestSpringWebFlux_TestsLinkage_Issue2991 value-asserting |
+| Tests linkage | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/junit5.go` | @Test/@WebFluxTest; @Test/@ParameterizedTest/@RepeatedTest methods extracted; OWNS edge class->method; TestSpringWebFlux_TestsLinkage_Issue2991 value-asserting |
 
 ### Type System
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🟢 `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution. |
-| DI injection point | 🟢 `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution. |
-| DI scope resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | spring_boot.go gate includes spring-webflux (line 13); emits spring_scope property (line 427) for @Scope/@RequestScope/@SessionScope/@ApplicationScope annotations. Registry cite was missing (#3176). |
+| DI binding extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_boot.go` | spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution. |
+| DI injection point | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_boot.go` | spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution. |
+| DI scope resolution | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/spring_boot.go` | spring_boot.go gate includes spring-webflux (line 13); emits spring_scope property (line 427) for @Scope/@RequestScope/@SessionScope/@ApplicationScope annotations. Registry cite was missing (#3176). |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; spring-webflux in txFrameworks; OWNS edge; same extractor as spring-boot; TestTransactional_FrameworkGating_Issue3003 verifies spring_webflux activation |
-| Transaction propagation | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> and TxType.<MODE>; isolation + readOnly; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
-| Transaction rollback rules | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor single + list; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional class/method boundaries; spring-webflux in txFrameworks; OWNS edge; same extractor as spring-boot; TestTransactional_FrameworkGating_Issue3003 verifies spring_webflux activation |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> and TxType.<MODE>; isolation + readOnly; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor/noRollbackFor single + list; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003 |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | Spring AOP shares same extractor as spring-boot; all 5 advice types (@Before/@After/@Around/@AfterReturning/@AfterThrowing) with advice_type+pointcut_expression+aspect; OWNS+REFERENCES edges; spring-webflux in aopFrameworks gate; value-asserting tests TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
-| Aspect extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect); spring-webflux is explicitly gated in aopFrameworks; same extraction as spring-boot; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
-| Pointcut resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut declarations extracted; named reference resolution via REFERENCES; spring-webflux in aopFrameworks; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | Spring AOP shares same extractor as spring-boot; all 5 advice types (@Before/@After/@Around/@AfterReturning/@AfterThrowing) with advice_type+pointcut_expression+aspect; OWNS+REFERENCES edges; spring-webflux in aopFrameworks gate; value-asserting tests TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect); spring-webflux is explicitly gated in aopFrameworks; same extraction as spring-boot; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut declarations extracted; named reference resolution via REFERENCES; spring-webflux in aopFrameworks; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; spring-webflux in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies spring-webflux |
-| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer builders + MeterRegistry + @Timed; MicroProfile @Counted/@Metered/@Gauge; spring-webflux in obsFrameworks |
-| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer Tracing @Observed + nextSpan(); spring-webflux in obsFrameworks |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Same extractor as spring-boot; spring-webflux in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies spring-webflux |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | Micrometer builders + MeterRegistry + @Timed; MicroProfile @Counted/@Metered/@Gauge; spring-webflux in obsFrameworks |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | OTel @WithSpan + spanBuilder(); Micrometer Tracing @Observed + nextSpan(); spring-webflux in obsFrameworks |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -17,32 +17,32 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
-| Route extraction | 🟢 `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Extracts @Action(value=...) annotations and struts.xml <action> elements; @Namespace prefix composition; HANDLED_BY relationships to action classes |
+| Route extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Extracts @Action(value=...) annotations and struts.xml <action> elements; @Namespace prefix composition; HANDLED_BY relationships to action classes |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns |
+| Auth coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | 3191 | `internal/custom/java/struts_dto_test.go`<br>`internal/custom/java/struts_routes.go`<br>`testdata/fixtures/sources/java/struts/StrutsDtoFixture.java` | Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven<T>. Heuristic regex over setters / extends-clauses, hence partial |
-| Request validation | 🟢 `partial` | — | 3256 | `internal/custom/java/struts_routes.go` | extractStrutsRequestValidation() detects Struts 2 validate() overrides, @Validations/@Validation annotations, field-validator annotations (@RequiredStringValidator etc.), Struts 1 ActionForm.validate() overrides, and validation.xml field/validator elements (#3256) |
+| DTO extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_dto_test.go`<br>`internal/custom/java/struts_routes.go`<br>`testdata/fixtures/sources/java/struts/StrutsDtoFixture.java` | Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven<T>. Heuristic regex over setters / extends-clauses, hence partial |
+| Request validation | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_routes.go` | extractStrutsRequestValidation() detects Struts 2 validate() overrides, @Validations/@Validation annotations, field-validator annotations (@RequiredStringValidator etc.), Struts 1 ActionForm.validate() overrides, and validation.xml field/validator elements (#3256) |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects Interceptor/AbstractInterceptor implementors and intercept(ActionInvocation) overrides; the Struts interceptor stack is the primary middleware mechanism |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects Interceptor/AbstractInterceptor implementors and intercept(ActionInvocation) overrides; the Struts interceptor stack is the primary middleware mechanism |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | struts, struts2, apache-struts keys included in junit5Frameworks map in junit5.go; test-class detection fires for JUnit 5 @Test methods and Struts Test Plugin patterns |
+| Tests linkage | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | struts, struts2, apache-struts keys included in junit5Frameworks map in junit5.go; test-class detection fires for JUnit 5 @Test methods and Struts Test Plugin patterns |
 
 ### Type System
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Component extraction | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
+| Component extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vaadin_gwt.go` | — |
 | Context extraction | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; context_extraction is a React/JSX-paradigm capability that does not apply |
 
 ### Data Flow
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | — `not_applicable` | — | — | — | Vaadin is a server-side Java UI framework with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for Vaadin |
-| Data fetching | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
+| Data fetching | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vaadin_gwt.go` | — |
 | Prop extraction | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; prop_extraction is a React/JSX-paradigm capability that does not apply |
 | State management | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; state_management is a React/JSX-paradigm capability that does not apply |
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Router pattern | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
+| Router pattern | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vaadin_gwt.go` | — |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/custom/java/junit5.go` | vaadin added to junit5Frameworks map (#3177) |
+| Tests linkage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | vaadin added to junit5Frameworks map (#3177) |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -17,32 +17,32 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
-| Route extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
+| Route extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
+| Auth coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
+| DTO extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vertx_routes.go` | — |
+| Request validation | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
+| Middleware coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/junit5.go`<br>`internal/custom/java/vertx_routes.go` | — |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go`<br>`internal/custom/java/vertx_routes.go` | — |
 
 ### Type System
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Log extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` | — |
-| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | @Table table_name + @Column(name/nullable/length) attribute depth parsed; full DDL index/sequence introspection not parsed. |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @Table table_name + @Column(name/nullable/length) attribute depth parsed; full DDL index/sequence introspection not parsed. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
-| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed; emits SCOPE.Component/foreign_key entities with column_name and constraint_name properties |
-| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities with fetch_type property |
-| Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Association extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed; emits SCOPE.Component/foreign_key entities with column_name and constraint_name properties |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities with fetch_type property |
+| Relationship extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` | — |
-| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | @Table table_name + @Column(name/nullable/length) attribute depth parsed via hibernate.go shared helper; full DDL introspection not parsed. |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @Table table_name + @Column(name/nullable/length) attribute depth parsed via hibernate.go shared helper; full DDL introspection not parsed. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
-| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed via hibernate.go shared helper; emits SCOPE.Component/foreign_key entities |
-| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go` | FetchType.LAZY and FetchType.EAGER parsed; emits SCOPE.Component/fetch_config entities |
-| Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Association extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed via hibernate.go shared helper; emits SCOPE.Component/foreign_key entities |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | FetchType.LAZY and FetchType.EAGER parsed; emits SCOPE.Component/fetch_config entities |
+| Relationship extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.panache.md
+++ b/docs/coverage/detail/lang.java.orm.panache.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entity records synthesized from PanacheEntity/PanacheEntityBase subclasses; field schema parsed via Hibernate extractor (hibernate.go) for JPA annotations; panache.go does not independently extract column-level schema |
-| Schema extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/java/panache.go` | Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations |
+| Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/java/panache.go` | Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations |
 | Foreign key extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180). |
 | Lazy loading recognition | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180). |
-| Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution |
+| Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/java/panache.go` | Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| Schema extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| Schema extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` | — |
-| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go`<br>`internal/custom/java/spring_ecosystem.go` | @Column(name/nullable/length) depth parsed via spring_ecosystem.go FK helper; table_name and entity extraction remain via hibernate.go. Full DDL not parsed. |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @Column(name/nullable/length) depth parsed via spring_ecosystem.go FK helper; table_name and entity extraction remain via hibernate.go. Full DDL not parsed. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
-| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go`<br>`internal/custom/java/spring_ecosystem.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed via ExtractJPAFKAndLazy from spring_ecosystem.go; emits SCOPE.Component/foreign_key entities |
-| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/jpa_fk_lazy_test.go`<br>`internal/custom/java/spring_ecosystem.go` | FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities |
-| Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Association extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | @JoinColumn(name=) and @ForeignKey(name=) parsed via ExtractJPAFKAndLazy from spring_ecosystem.go; emits SCOPE.Component/foreign_key entities |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3097) | `internal/custom/java/jpa_fk_lazy.go` | FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities |
+| Relationship extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| Schema extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| Schema extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3095 | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.validation.bean-validation.md
+++ b/docs/coverage/detail/lang.java.validation.bean-validation.md
@@ -15,15 +15,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Nested model extraction | ✅ `full` | `2026-05-29` | 3100 | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go` | @Valid (cascade/nested validation marker) is recognized and lifts the annotated parameter to required; no recursion into the nested type's own fields. |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3100 | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go`<br>`testdata/fixtures/sources/java/bean_validation/ValidatedDtoFixture.java` | Parameter-level Bean Validation constraints (@NotNull, @NotBlank, @Size, @Min, @Max, @Email, @Pattern) are captured in the Annotations slice on each handler parameter and drive the Required flag. Field-level recursion into nested DTO classes is not implemented (partial scope). Proven by TestBeanValidation_SchemaExtraction_Issue3002 and TestBeanValidation_MultipleConstraints_Issue3002. |
+| Nested model extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go` | @Valid (cascade/nested validation marker) is recognized and lifts the annotated parameter to required; no recursion into the nested type's own fields. |
+| Schema extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go`<br>`testdata/fixtures/sources/java/bean_validation/ValidatedDtoFixture.java` | Parameter-level Bean Validation constraints (@NotNull, @NotBlank, @Size, @Min, @Max, @Email, @Pattern) are captured in the Annotations slice on each handler parameter and drive the Required flag. Field-level recursion into nested DTO classes is not implemented (partial scope). Proven by TestBeanValidation_SchemaExtraction_Issue3002 and TestBeanValidation_MultipleConstraints_Issue3002. |
 
 ### Constraints
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Constraint extraction | ✅ `full` | `2026-05-29` | 3100 | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go`<br>`internal/engine/java_annotation_params.go` | Bean-Validation annotations (@NotNull/@NotBlank/@NotEmpty/@Size/@Min/@Max/@Pattern/@Email) are collected on each handler parameter and drive the Required flag; captured as annotation strings, not structured constraint records (no value bounds parsed). |
-| Custom validator extraction | 🟢 `partial` | `2026-05-29` | 3100 | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go` | Extracting classes that implement ConstraintValidator<A,T> requires scanning for the interface-implementation pattern. No current extractor does this. Leave red — out of scope for #3002. |
+| Constraint extraction | ✅ `full` | `2026-05-29` | 3100 | `internal/engine/java_annotation_params.go` | Bean-Validation annotations (@NotNull/@NotBlank/@NotEmpty/@Size/@Min/@Max/@Pattern/@Email) are collected on each handler parameter and drive the Required flag; captured as annotation strings, not structured constraint records (no value bounds parsed). |
+| Custom validator extraction | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/bean_validation.go`<br>`internal/custom/java/bean_validation_test.go` | Extracting classes that implement ConstraintValidator<A,T> requires scanning for the interface-implementation pattern. No current extractor does this. Leave red — out of scope for #3002. |
 
 ### Coercion
 
@@ -35,7 +35,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | Bean Validation integration tests use JUnit 5 with jakarta.validation.Validator. The junit5 extractor (internal/custom/java/junit5.go) captures @Test methods for the junit5 framework tag. Tests for bean-validation handlers are linked via the same JUnit 5 test-method extraction path used by other Java frameworks (e.g. Jakarta EE, Spring Boot — see #2996, #2991). |
+| Tests linkage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/junit5.go` | Bean Validation integration tests use JUnit 5 with jakarta.validation.Validator. The junit5 extractor (internal/custom/java/junit5.go) captures @Test methods for the junit5 framework tag. Tests for bean-validation handlers are linked via the same JUnit 5 test-method extraction path used by other Java frameworks (e.g. Jakarta EE, Spring Boot — see #2996, #2991). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -15,15 +15,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; Kotlin trailing-lambda route DSL proven by TestKotlinJavalin_Routes_Issue3274 |
-| Handler attribution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; handler attribution proven by TestKotlinJavalin_Routes_Issue3274 |
-| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274 |
+| Endpoint synthesis | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; Kotlin trailing-lambda route DSL proven by TestKotlinJavalin_Routes_Issue3274 |
+| Handler attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; handler attribution proven by TestKotlinJavalin_Routes_Issue3274 |
+| Route extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274 |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | — | `internal/custom/java/javalin_routes.go` | JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies |
+| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/java/javalin_routes.go` | app.before() and app.after() global/path-scoped middleware — Kotlin Javalin trailing lambda matches same regex |
+| Middleware coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | app.before() and app.after() global/path-scoped middleware — Kotlin Javalin trailing lambda matches same regex |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -65,25 +65,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; @Transactional (JTA/Spring) on Kotlin proven by TestKotlinTransactional_Quarkus_Issue3274 (JTA path covers micronaut too) |
-| Transaction propagation | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; propagation capture via transactional.go txFrameworks["micronaut"] |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; rollbackFor rules parsed by transactional.go txFrameworks["micronaut"] |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; @Transactional (JTA/Spring) on Kotlin proven by TestKotlinTransactional_Quarkus_Issue3274 (JTA path covers micronaut too) |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; propagation capture via transactional.go txFrameworks["micronaut"] |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; rollbackFor rules parsed by transactional.go txFrameworks["micronaut"] |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; Micronaut @Around/@InterceptorBean on Kotlin proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
-| Aspect extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; Micronaut interceptor/aspect extraction proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
-| Pointcut resolution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; Micronaut @Around/@InterceptorBean on Kotlin proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; Micronaut interceptor/aspect extraction proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/micronaut_aop.go` | java extractor language-gated to kotlin; proven by TestKotlinMicronautAOP_Interceptor_Issue3274 |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; SLF4J/@Slf4j on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 (obsFrameworks["micronaut"]=true) |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; Micrometer @Timed on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 (obsFrameworks["micronaut"]=true) |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274 |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; SLF4J/@Slf4j on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 (obsFrameworks["micronaut"]=true) |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; Micrometer @Timed on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 (obsFrameworks["micronaut"]=true) |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274 |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -65,25 +65,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; Jakarta @Transactional on Kotlin quarkus class proven by TestKotlinTransactional_Quarkus_Issue3274 |
-| Transaction propagation | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; txFrameworks["quarkus"]=true in transactional.go |
-| Transaction rollback rules | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; txFrameworks["quarkus"]=true in transactional.go |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; Jakarta @Transactional on Kotlin quarkus class proven by TestKotlinTransactional_Quarkus_Issue3274 |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; txFrameworks["quarkus"]=true in transactional.go |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | java extractor language-gated to kotlin; txFrameworks["quarkus"]=true in transactional.go |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin (cdiFrameworks["quarkus"]=true); @Interceptor/@AroundInvoke on Kotlin proven by TestKotlinCDIInterceptors_Issue3274 |
-| Aspect extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; CDI interceptor aspect extraction proven by TestKotlinCDIInterceptors_Issue3274 |
-| Pointcut resolution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; proven by TestKotlinCDIInterceptors_Issue3274 |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin (cdiFrameworks["quarkus"]=true); @Interceptor/@AroundInvoke on Kotlin proven by TestKotlinCDIInterceptors_Issue3274 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; CDI interceptor aspect extraction proven by TestKotlinCDIInterceptors_Issue3274 |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/cdi_interceptors.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; proven by TestKotlinCDIInterceptors_Issue3274 |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; obsFrameworks["quarkus"]=true; SLF4J/@Slf4j proven by TestKotlinObservability_Slf4j_Issue3274 |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Timed Micrometer proven by TestKotlinObservability_Micrometer_Issue3274 |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel proven by TestKotlinObservability_OTel_Issue3274 |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; obsFrameworks["quarkus"]=true; SLF4J/@Slf4j proven by TestKotlinObservability_Slf4j_Issue3274 |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Timed Micrometer proven by TestKotlinObservability_Micrometer_Issue3274 |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel proven by TestKotlinObservability_OTel_Issue3274 |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | Kotlin Spring Boot @Service/@Repository/@Component stereotypes + @Bean methods; value-asserted by TestKotlinSpringBoot_DI_BindingNames_3435 (stereotype=service/repository, bean_method=passwordEncoder/config_class=AppConfig) |
-| DI injection point | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | Kotlin primary-constructor injection (class Foo @Autowired constructor(private val x: Bar)) + @Autowired lateinit var props now captured (new Kotlin-gated regexes in spring_boot.go); injected_type+injection_kind asserted by TestKotlinSpringBoot_DI_ConstructorInjection_3435 and _PrimaryCtorNoAnnotation_3435 |
-| DI scope resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | @RequestScope/@Scope("prototype") on Kotlin classes; spring_scope value asserted by TestKotlinSpringBoot_DI_ScopeValues_3435 (request, prototype) |
+| DI binding extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | Kotlin Spring Boot @Service/@Repository/@Component stereotypes + @Bean methods; value-asserted by TestKotlinSpringBoot_DI_BindingNames_3435 (stereotype=service/repository, bean_method=passwordEncoder/config_class=AppConfig) |
+| DI injection point | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | Kotlin primary-constructor injection (class Foo @Autowired constructor(private val x: Bar)) + @Autowired lateinit var props now captured (new Kotlin-gated regexes in spring_boot.go); injected_type+injection_kind asserted by TestKotlinSpringBoot_DI_ConstructorInjection_3435 and _PrimaryCtorNoAnnotation_3435 |
+| DI scope resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_boot.go` | @RequestScope/@Scope("prototype") on Kotlin classes; spring_scope value asserted by TestKotlinSpringBoot_DI_ScopeValues_3435 (request, prototype) |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on Kotlin fun/class; method/class boundary names asserted by TestKotlinTransactional_Attributes_3435 (getOrders, processPayment, reconcile) |
-| Transaction propagation | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.REQUIRES_NEW captured + asserted by TestKotlinTransactional_Attributes_3435; readOnly=true also asserted |
-| Transaction rollback rules | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | Kotlin rollbackFor=[X::class]/noRollbackFor + isolation captured (txClassRefRE now accepts ::class); rollback_for=PaymentException, no_rollback_for=WarnException, isolation=SERIALIZABLE asserted by TestKotlinTransactional_Attributes_3435 |
+| Transaction boundary extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on Kotlin fun/class; method/class boundary names asserted by TestKotlinTransactional_Attributes_3435 (getOrders, processPayment, reconcile) |
+| Transaction propagation | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.REQUIRES_NEW captured + asserted by TestKotlinTransactional_Attributes_3435; readOnly=true also asserted |
+| Transaction rollback rules | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/transactional.go` | Kotlin rollbackFor=[X::class]/noRollbackFor + isolation captured (txClassRefRE now accepts ::class); rollback_for=PaymentException, no_rollback_for=WarnException, isolation=SERIALIZABLE asserted by TestKotlinTransactional_Attributes_3435 |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Before/@Around advice on Kotlin fun; advice_type (before/around) + method names asserted by TestKotlinSpringAOP_Attributes_3435 |
-| Aspect extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect on Kotlin class; aspect name=LoggingAspect asserted by TestKotlinSpringAOP_Attributes_3435 |
-| Pointcut resolution | ✅ `full` | `2026-05-30` | — | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut expression + advice->named-pointcut REFERENCES edge asserted by TestKotlinSpringAOP_Attributes_3435 (execution(* com.example.service.*.*(..))) |
+| Advice attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Before/@Around advice on Kotlin fun; advice_type (before/around) + method names asserted by TestKotlinSpringAOP_Attributes_3435 |
+| Aspect extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Aspect on Kotlin class; aspect name=LoggingAspect asserted by TestKotlinSpringAOP_Attributes_3435 |
+| Pointcut resolution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/spring_aop.go` | @Pointcut expression + advice->named-pointcut REFERENCES edge asserted by TestKotlinSpringAOP_Attributes_3435 (execution(* com.example.service.*.*(..))) |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Slf4j and SLF4J logger on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Timed Micrometer on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274 |
+| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Slf4j and SLF4J logger on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 |
+| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Timed Micrometer on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 |
+| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274 |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
-| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/hibernate.go` | Recording win: hibernate.go ExtractHibernate() accepts ctx.Language=="kotlin" — @Entity/@Table on Kotlin data classes matched identically to Java. Partial because Kotlin-specific JPA idioms (constructor-param columns, data class shorthand) may not all be captured. |
+| Schema extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/hibernate.go` | Recording win: hibernate.go ExtractHibernate() accepts ctx.Language=="kotlin" — @Entity/@Table on Kotlin data classes matched identically to Java. Partial because Kotlin-specific JPA idioms (constructor-param columns, data class shorthand) may not all be captured. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go` | Recording win: hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne/@OneToOne/@ManyToMany before Kotlin 'var/val' properties. jpa_fk_lazy.go ExtractJPAFKAndLazy also runs on Kotlin (language gate: java or kotlin). Partial because collection types differ from Java generics. |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Recording win: hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne/@OneToOne/@ManyToMany before Kotlin 'var/val' properties. jpa_fk_lazy.go ExtractJPAFKAndLazy also runs on Kotlin (language gate: java or kotlin). Partial because collection types differ from Java generics. |
 | Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; @JoinColumn/@ForeignKey on Kotlin entities proven by TestKotlinHibernate_Issue3274 |
 | Lazy loading recognition | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; FetchType.LAZY/EAGER on Kotlin val/var properties proven by TestKotlinHibernate_Issue3274 |
-| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; @OneToMany/@ManyToOne/@ManyToMany on Kotlin proved by TestKotlinHibernate_Issue3274 |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go` | java extractor language-gated to kotlin; @OneToMany/@ManyToOne/@ManyToMany on Kotlin proved by TestKotlinHibernate_Issue3274 |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
-| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/hibernate.go` | Recording win: hibernate.go accepts kotlin language with spring_data_jpa framework. Spring Data JPA entities use the same @Entity/@Table annotations as Hibernate — regex patterns match Kotlin data class declarations. spring_ecosystem.go is Java-only but the JPA schema layer is shared. |
+| Schema extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/hibernate.go` | Recording win: hibernate.go accepts kotlin language with spring_data_jpa framework. Spring Data JPA entities use the same @Entity/@Table annotations as Hibernate — regex patterns match Kotlin data class declarations. spring_ecosystem.go is Java-only but the JPA schema layer is shared. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go` | Recording win: same as orm.hibernate — hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne on Kotlin Spring Data JPA entities. @JoinColumn / @ForeignKey handled by jpa_fk_lazy.go ExtractJPAFKAndLazy. |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Recording win: same as orm.hibernate — hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne on Kotlin Spring Data JPA entities. @JoinColumn / @ForeignKey handled by jpa_fk_lazy.go ExtractJPAFKAndLazy. |
 | Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; same jpa_fk_lazy.go covers Spring Data JPA entities with @JoinColumn/@ForeignKey |
 | Lazy loading recognition | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; FetchType.LAZY/EAGER on Kotlin Spring Data JPA entities |
-| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/hibernate.go`<br>`internal/custom/java/jpa_fk_lazy.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; @OneToMany/@ManyToOne on Kotlin Spring Data entities covered by hibernate.go hibAssociationRE |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/jpa_fk_lazy.go` | java extractor language-gated to kotlin; @OneToMany/@ManyToOne on Kotlin Spring Data entities covered by hibernate.go hibAssociationRE |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17168,51 +17168,51 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/custom/java/akka_http_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3092"
           },
           "handler_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/akka_http_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3092"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "3092"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Type System": {
@@ -17289,21 +17289,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -17429,54 +17429,60 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256)"
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractAndroidDeepLinks() detects \u003cintent-filter\u003e blocks in AndroidManifest.xml with \u003cdata android:scheme\u003e as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256)"
           },
           "navigation_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179)"
           },
           "screen_detection": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179)"
           }
         },
         "Platform": {
           "platform_branching": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188)"
           }
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188)"
           }
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android",
             "verified_at": "2026-05-30"
           },
           "state_management": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179)"
           }
         },
@@ -17506,8 +17512,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "android_jetpack added to junit5Frameworks map (#3177)"
           }
         },
@@ -17628,54 +17635,60 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractAndroidContexts() detects getContext()/requireContext()/getApplicationContext()/getBaseContext()/requireActivity() call sites and Context parameter names as SCOPE.Reference context_site entities (#3256)"
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractAndroidDeepLinks() detects \u003cintent-filter\u003e blocks in AndroidManifest.xml with \u003cdata android:scheme\u003e as SCOPE.Reference deep_link entities with scheme/host/path URI templates (#3256)"
           },
           "navigation_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179)"
           },
           "screen_detection": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179)"
           }
         },
         "Platform": {
           "platform_branching": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188)"
           }
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188)"
           }
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android",
             "verified_at": "2026-05-30"
           },
           "state_management": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/android.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179)"
           }
         },
@@ -17705,8 +17718,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "android_sdk added to junit5Frameworks map (#3177)"
           }
         },
@@ -17846,35 +17860,35 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go","internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go","internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go","internal/custom/java/junit5.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Type System": {
@@ -17900,36 +17914,36 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3087"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "AOP": {
@@ -17951,21 +17965,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18105,9 +18119,9 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vaadin_gwt.go"],
-            "issue": "3091"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "context_extraction": {
             "status": "not_applicable",
@@ -18121,9 +18135,9 @@
             "notes": "GWT compiles Java to client-side JS but uses Java idioms with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for GWT"
           },
           "data_fetching": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/gwt_rpc.go"],
-            "issue": "3190",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback\u003cT\u003e completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial.",
             "verified_at": "2026-05-30"
           },
@@ -18140,9 +18154,9 @@
         },
         "Navigation": {
           "router_pattern": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vaadin_gwt.go"],
-            "issue": "3091"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Type System": {
@@ -18173,8 +18187,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "gwt, vaadin, android_sdk, android_jetpack added to junit5Frameworks map (#3177)"
           }
         },
@@ -18320,38 +18335,38 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_ee_advanced.go","internal/engine/java_auth_policy.go"],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3088",
             "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/helidon_filters.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/junit5.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18378,41 +18393,41 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3088",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18435,21 +18450,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18614,9 +18629,9 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "request_validation": {
@@ -18635,9 +18650,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18664,81 +18679,81 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
             "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
             "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
             "verified_at": "2026-05-29"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "aspect_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "pointcut_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -18879,51 +18894,51 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/custom/java/javalin_routes.go","internal/engine/http_endpoint_synthesis.go"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3085"
           },
           "handler_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/javalin_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/javalin/App.java"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3085"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/junit5.go"],
-            "issue": "3085"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Type System": {
@@ -19000,21 +19015,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -19193,16 +19208,17 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jaxrs_filters.go","internal/custom/java/jaxrs_filters_test.go","testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3083",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "JUnit 5 tests in JAX-RS projects; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestJakartaEE_TestsLinkage_Issue2996 value-asserting (same JUnit 5 extractor gates on jaxrs)",
             "verified_at": "2026-05-30"
           }
@@ -19230,80 +19246,89 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go","internal/custom/java/jaxrs_filters_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3083",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go","internal/custom/java/jaxrs_filters_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3083",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go","internal/custom/java/jaxrs_filters_test.go","testdata/fixtures/sources/java/jaxrs/JaxrsFiltersFixture.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3083",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional class/method boundaries; jaxrs in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies jaxrs",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation/TxType; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor/noRollbackFor; jaxrs in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/cdi_interceptors_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "CDI @Interceptor + @AroundInvoke/@AroundConstruct methods extracted as SCOPE.Pattern(subtype=advice) with advice_type (around_invoke/around_construct) + aspect + framework properties; OWNS edge; value-asserting TestCDI_JAXRS_InterceptorClass_Issue3082",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/cdi_interceptors_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Interceptor-annotated classes detected as SCOPE.Pattern(subtype=aspect, kind=cdi_interceptor) with framework=jaxrs; TestCDI_JAXRS_InterceptorClass_Issue3082 value-asserting",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/cdi_interceptors_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@InterceptorBinding annotation type declarations extracted as SCOPE.Pattern(subtype=pointcut, kind=interceptor_binding); REFERENCES edge from advice to binding; value-asserting TestCDI_JAXRS_InterceptorBinding_Issue3082",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Same extractor as spring-boot; jaxrs in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies jaxrs",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Micrometer + @Timed + @Counted/@Metered/@Gauge; jaxrs in obsFrameworks",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); jaxrs in obsFrameworks",
             "verified_at": "2026-05-30"
           }
@@ -19444,22 +19469,25 @@
       "capabilities": {
         "Prompts": {
           "prompt_template_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/langchain4j.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@SystemMessage/@UserMessage annotation extraction: lc4jSystemMessageRE and lc4jUserMessageRE capture annotation-level prompt template strings. Runtime template variable resolution not captured.",
             "verified_at": "2026-05-29"
           }
         },
         "Composition": {
           "chain_composition": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/langchain4j.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@AiService interface extraction plus RAG/ChatMemory component detection: structural composition captured (AiService, EmbeddingStoreContentRetriever, EmbeddingStoreIngestor, ChatMemory fields). Runtime chain wiring not traced.",
             "verified_at": "2026-05-29"
           },
           "tool_use_detection": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/langchain4j.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Tool annotation extraction: lc4jToolMethodRE extracts @Tool-annotated methods, emitting SCOPE.Operation entities with tool_method property. Dynamic tool registration not captured.",
             "verified_at": "2026-05-29"
           }
@@ -19495,7 +19523,7 @@
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/micronaut.go","internal/engine/java_annotation_routes.go"],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
           }
@@ -19510,7 +19538,7 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/micronaut.go","internal/engine/java_annotation_routes.go"],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
           },
@@ -19523,16 +19551,17 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go","testdata/fixtures/sources/java/micronaut/AuthFilter.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3084",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@MicronautTest + JUnit 5; @Test/@ParameterizedTest/@RepeatedTest extracted; OWNS edge; TestMicronaut_TestsLinkage_Issue2995 value-asserting",
             "verified_at": "2026-05-30"
           }
@@ -19560,80 +19589,89 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/micronaut.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/micronaut.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/micronaut.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional class/method boundaries; micronaut in txFrameworks; OWNS edge; TestTransactional_FrameworkGating_Issue3003 verifies micronaut activation",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation/TxType captured; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor/noRollbackFor; micronaut in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Micronaut AOP: @InterceptorBean binding + intercept() method extracted as SCOPE.Pattern(subtype=advice) with advice_type=around + binding property; OWNS edge from interceptor class; REFERENCES edge to pointcut; value-asserting tests TestMicronautAOP_AdviceAttribution_Issue3084",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Around @interface + MethodInterceptor-implementing classes detected as SCOPE.Pattern(subtype=aspect); TestMicronautAOP_AspectExtraction_Issue3084 proves binding annotation + interceptor class both emitted",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Around-annotated binding annotation type emitted as SCOPE.Pattern(subtype=pointcut); REFERENCES edge from advice to pointcut; TestMicronautAOP_PointcutResolution_Issue3084 value-asserting",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Same extractor as spring-boot; micronaut in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies micronaut",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Micrometer + @Timed + @Counted/@Metered/@Gauge; micronaut in obsFrameworks",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "OTel @WithSpan + spanBuilder(); Micrometer @Observed + nextSpan(); micronaut in obsFrameworks",
             "verified_at": "2026-05-30"
           }
@@ -19799,9 +19837,9 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_jaxrs_dto.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "request_validation": {
@@ -19813,17 +19851,17 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jaxrs_filters.go","internal/custom/java/jaxrs_filters_test.go","testdata/fixtures/sources/java/microprofile/MicroProfileFiltersFixture.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3083",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -19850,84 +19888,84 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go","testdata/fixtures/sources/java/microprofile/OrderService.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3079",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go","testdata/fixtures/sources/java/microprofile/OrderService.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3079",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go","testdata/fixtures/sources/java/microprofile/OrderService.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3079",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
             "verified_at": "2026-05-29"
           },
           "aspect_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
             "verified_at": "2026-05-29"
           },
           "pointcut_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
             "verified_at": "2026-05-29"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -20099,12 +20137,13 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/play_routes.go","internal/engine/http_endpoint_synthesis.go"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3090"
           },
           "router_pattern": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178).",
             "verified_at": "2026-05-29"
           }
@@ -20143,9 +20182,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3090"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Substrate": {
@@ -20223,14 +20262,14 @@
             "issue": "3154"
           },
           "request_shape_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3090"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "response_shape_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractPlayResponseShapes() detects Play Result factory call sites (ok/created/badRequest/notFound/redirect/status/etc.) as SCOPE.Reference response_shape entities with result_factory and controller_class properties (#3256)"
           },
           "sanitizer_recognition": {
@@ -20268,9 +20307,9 @@
         },
         "Uncategorized": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3090"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "endpoint_synthesis": {
             "status": "partial",
@@ -20278,14 +20317,14 @@
             "issue": "3090"
           },
           "handler_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3090"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/play_routes.go"],
-            "issue": "3090"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         }
       }
@@ -20310,7 +20349,7 @@
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/quarkus.go","internal/engine/java_annotation_routes.go"],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
           }
@@ -20325,7 +20364,7 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/quarkus.go","internal/engine/java_annotation_routes.go"],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
           },
@@ -20345,9 +20384,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -20374,81 +20413,81 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/quarkus.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/quarkus.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/quarkus.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
             "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
             "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
             "verified_at": "2026-05-29"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "aspect_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "pointcut_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go"],
-            "issue": "3082"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -20614,9 +20653,9 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_request_response.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "SCOPE.Schema(kind=dto) entities emitted for @RequestBody parameter types and ResponseEntity\u003cT\u003e/Mono\u003cT\u003e/Flux\u003cT\u003e return types; generic collections (List/Map/Set) skipped via srrSkipTypes",
             "verified_at": "2026-05-29"
           },
@@ -20637,8 +20676,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Test/@ParameterizedTest/@RepeatedTest methods extracted; @BeforeEach/@AfterEach lifecycle methods captured; @Nested classes emitted; @ExtendWith extensions; OWNS edge from class to test method; @SpringBootTest/@WebMvcTest class-level annotations recognised; value-asserting test TestSpringBoot_TestsLinkage_Issue2991",
             "verified_at": "2026-05-30"
           }
@@ -20666,80 +20706,89 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_boot.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_boot.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-28"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_boot.go"],
-            "issue": "3081",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional on class/method detected; class-level boundary + method-level SCOPE.Pattern(subtype=transaction_boundary) with declaring_class, framework; OWNS edges from class to method boundaries; Jakarta/JTA TxType positional form handled; value-asserting fixture TestTransactional_Boundary_Propagation_Rollback_Issue3003",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) extracted into propagation property; isolation + readOnly also captured; all Spring propagation modes + JTA TxType modes covered; value-asserting test TestTransactional_Boundary_Propagation_Rollback_Issue3003",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor/noRollbackFor X.class single + {A.class,B.class} list captured as rollback_for/no_rollback_for properties; value-asserting test covers single + multi-class rollback + noRollbackFor",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Spring AOP: @Aspect classes, @Before/@After/@Around/@AfterReturning/@AfterThrowing advice methods extracted as SCOPE.Pattern(subtype=advice) with advice_type+pointcut_expression+aspect properties; OWNS edge from aspect; REFERENCES edge for named pointcuts; all 5 advice types covered; value-asserting tests in TestSpringAOP_AdviceAttribution_Issue3004",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect) with kind=aspect + framework properties; Spring Boot + Spring WebFlux gated; value-asserting tests in TestSpringAOP_Fixture_Issue3004",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Pointcut declarations detected as SCOPE.Pattern(subtype=pointcut) with pointcut_expression; named pointcut references resolved via REFERENCES edges from advice; inline AspectJ execution() excluded from named-reference resolution; value-asserting tests",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "SLF4J @Slf4j logger + LoggerFactory.getLogger, Log4j LogManager.getLogger, JUL Logger.getLogger; log statement calls (log.info/debug/warn/error/trace) per call site; library + framework + log_level properties; value-asserting tests TestObservability_Slf4jLogging_Issue3006 + TestObservability_LoggerFactoryVariants_Issue3006",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Micrometer Counter/Timer/Gauge/DistributionSummary.builder(), MeterRegistry usage, @Timed annotation; MicroProfile @Counted/@Metered/@Gauge; metric_type + metric_name + library + framework properties; value-asserting tests TestObservability_MicrometerMetrics_Issue3006 + TestObservability_MicroProfileMetrics_Issue3006",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "OTel @WithSpan + tracer.spanBuilder(); Micrometer Tracing @Observed + tracer.nextSpan(); span_kind (annotation/programmatic) + span_name + library + framework; value-asserting tests TestObservability_OtelTracing_Issue3006 + TestObservability_MicrometerTracing_Issue3006",
             "verified_at": "2026-05-30"
           }
@@ -20898,7 +20947,7 @@
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_webflux_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/spring_webflux/RouterConfig.java"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3080",
             "verified_at": "2026-05-29"
           }
@@ -20912,9 +20961,9 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_request_response.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "SCOPE.Schema(kind=dto) entities emitted for @RequestBody types and Mono\u003cT\u003e/Flux\u003cT\u003e return types; generic collections (List/Map/Set) skipped via srrSkipTypes",
             "verified_at": "2026-05-29"
           },
@@ -20928,17 +20977,18 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_webflux_routes.go","testdata/fixtures/sources/java/spring_webflux/RouterConfig.java"],
-            "issue": "3080",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "WebFilter implementations detected via 'implements WebFilter' class declaration; Middleware entities emitted with middleware_type=web_filter and filter_class. Multiple WebFilter classes in one file each produce a distinct entity.",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Test/@WebFluxTest; @Test/@ParameterizedTest/@RepeatedTest methods extracted; OWNS edge class-\u003emethod; TestSpringWebFlux_TestsLinkage_Issue2991 value-asserting",
             "verified_at": "2026-05-30"
           }
@@ -20966,83 +21016,92 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_boot.go"],
-            "issue": "#2991",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution.",
             "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_boot.go"],
-            "issue": "#2991",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution.",
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/spring_boot.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "spring_boot.go gate includes spring-webflux (line 13); emits spring_scope property (line 427) for @Scope/@RequestScope/@SessionScope/@ApplicationScope annotations. Registry cite was missing (#3176).",
             "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional class/method boundaries; spring-webflux in txFrameworks; OWNS edge; same extractor as spring-boot; TestTransactional_FrameworkGating_Issue3003 verifies spring_webflux activation",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation=Propagation.\u003cMODE\u003e and TxType.\u003cMODE\u003e; isolation + readOnly; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "rollbackFor/noRollbackFor single + list; spring-webflux in txFrameworks; TestTransactional_FrameworkGating_Issue3003",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Spring AOP shares same extractor as spring-boot; all 5 advice types (@Before/@After/@Around/@AfterReturning/@AfterThrowing) with advice_type+pointcut_expression+aspect; OWNS+REFERENCES edges; spring-webflux in aopFrameworks gate; value-asserting tests TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Aspect-annotated classes detected as SCOPE.Pattern(subtype=aspect); spring-webflux is explicitly gated in aopFrameworks; same extraction as spring-boot; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Pointcut declarations extracted; named reference resolution via REFERENCES; spring-webflux in aopFrameworks; TestSpringAOP_AllAdviceTypes_Issue3004 uses spring-webflux framework",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Same extractor as spring-boot; spring-webflux in obsFrameworks gate; SLF4J/@Slf4j, Log4j, JUL + log statement call surface; TestObservability_FrameworkGating_Issue3006 verifies spring-webflux",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Micrometer builders + MeterRegistry + @Timed; MicroProfile @Counted/@Metered/@Gauge; spring-webflux in obsFrameworks",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "OTel @WithSpan + spanBuilder(); Micrometer Tracing @Observed + nextSpan(); spring-webflux in obsFrameworks",
             "verified_at": "2026-05-30"
           }
@@ -21193,51 +21252,51 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
-            "issue": "3089",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Extracts @Action(value=...) annotations and struts.xml \u003caction\u003e elements; @Namespace prefix composition; HANDLED_BY relationships to action classes",
             "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
-            "issue": "3089",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns",
             "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/struts_dto_test.go","internal/custom/java/struts_routes.go","testdata/fixtures/sources/java/struts/StrutsDtoFixture.java"],
-            "issue": "3191",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven\u003cT\u003e. Heuristic regex over setters / extends-clauses, hence partial",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/struts_routes.go"],
-            "issue": "3256",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "extractStrutsRequestValidation() detects Struts 2 validate() overrides, @Validations/@Validation annotations, field-validator annotations (@RequiredStringValidator etc.), Struts 1 ActionForm.validate() overrides, and validation.xml field/validator elements (#3256)"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
-            "issue": "3089",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Detects Interceptor/AbstractInterceptor implementors and intercept(ActionInvocation) overrides; the Struts interceptor stack is the primary middleware mechanism",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "struts, struts2, apache-struts keys included in junit5Frameworks map in junit5.go; test-class detection fires for JUnit 5 @Test methods and Struts Test Plugin patterns",
             "verified_at": "2026-05-30"
           }
@@ -21325,21 +21384,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -21465,9 +21524,9 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vaadin_gwt.go"],
-            "issue": "3091"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "context_extraction": {
             "status": "not_applicable",
@@ -21481,9 +21540,9 @@
             "notes": "Vaadin is a server-side Java UI framework with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for Vaadin"
           },
           "data_fetching": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vaadin_gwt.go"],
-            "issue": "3091"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           },
           "prop_extraction": {
             "status": "not_applicable",
@@ -21498,9 +21557,9 @@
         },
         "Navigation": {
           "router_pattern": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vaadin_gwt.go"],
-            "issue": "3091"
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
           }
         },
         "Type System": {
@@ -21531,8 +21590,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "vaadin added to junit5Frameworks map (#3177)"
           }
         },
@@ -21667,46 +21727,46 @@
           },
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/vertx_routes.go","internal/engine/http_endpoint_synthesis.go"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3086",
             "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go","internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -21784,21 +21844,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22136,7 +22196,7 @@
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@Table table_name + @Column(name/nullable/length) attribute depth parsed; full DDL index/sequence introspection not parsed.",
             "verified_at": "2026-05-29"
@@ -22144,29 +22204,29 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@JoinColumn(name=) and @ForeignKey(name=) parsed; emits SCOPE.Component/foreign_key entities with column_name and constraint_name properties",
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities with fetch_type property",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22264,7 +22324,7 @@
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@Table table_name + @Column(name/nullable/length) attribute depth parsed via hibernate.go shared helper; full DDL introspection not parsed.",
             "verified_at": "2026-05-29"
@@ -22272,29 +22332,29 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@JoinColumn(name=) and @ForeignKey(name=) parsed via hibernate.go shared helper; emits SCOPE.Component/foreign_key entities",
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "FetchType.LAZY and FetchType.EAGER parsed; emits SCOPE.Component/fetch_config entities",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22464,7 +22524,7 @@
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "cites": ["internal/extractors/java/panache.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas",
             "verified_at": "2026-05-29"
@@ -22473,7 +22533,7 @@
         "Relationships": {
           "association_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "cites": ["internal/extractors/java/panache.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations",
             "verified_at": "2026-05-29"
@@ -22494,7 +22554,7 @@
           },
           "relationship_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "cites": ["internal/extractors/java/panache.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution",
             "verified_at": "2026-05-29"
@@ -22528,14 +22588,14 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
-            "issue": "3095",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22564,7 +22624,7 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           }
@@ -22588,14 +22648,14 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
-            "issue": "3095",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22624,7 +22684,7 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           }
@@ -22653,7 +22713,7 @@
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go","internal/custom/java/spring_ecosystem.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@Column(name/nullable/length) depth parsed via spring_ecosystem.go FK helper; table_name and entity extraction remain via hibernate.go. Full DDL not parsed.",
             "verified_at": "2026-05-29"
@@ -22661,29 +22721,29 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go","internal/custom/java/spring_ecosystem.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "@JoinColumn(name=) and @ForeignKey(name=) parsed via ExtractJPAFKAndLazy from spring_ecosystem.go; emits SCOPE.Component/foreign_key entities",
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
             "status": "partial",
-            "cites": ["internal/custom/java/jpa_fk_lazy.go","internal/custom/java/jpa_fk_lazy_test.go","internal/custom/java/spring_ecosystem.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3097",
             "notes": "FetchType.LAZY and FetchType.EAGER parsed from association annotations; emits SCOPE.Component/fetch_config entities",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22713,14 +22773,14 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
-            "issue": "3095",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22749,7 +22809,7 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           }
@@ -22773,14 +22833,14 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
-            "issue": "3095",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "verified_at": "2026-05-29"
           }
         },
@@ -22809,7 +22869,7 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
             "issue": "3095",
             "verified_at": "2026-05-29"
           }
@@ -22832,16 +22892,16 @@
       "capabilities": {
         "Schema": {
           "nested_model_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/bean_validation.go","internal/custom/java/bean_validation_test.go"],
-            "issue": "3100",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Valid (cascade/nested validation marker) is recognized and lifts the annotated parameter to required; no recursion into the nested type's own fields.",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/bean_validation.go","internal/custom/java/bean_validation_test.go","testdata/fixtures/sources/java/bean_validation/ValidatedDtoFixture.java"],
-            "issue": "3100",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Parameter-level Bean Validation constraints (@NotNull, @NotBlank, @Size, @Min, @Max, @Email, @Pattern) are captured in the Annotations slice on each handler parameter and drive the Required flag. Field-level recursion into nested DTO classes is not implemented (partial scope). Proven by TestBeanValidation_SchemaExtraction_Issue3002 and TestBeanValidation_MultipleConstraints_Issue3002.",
             "verified_at": "2026-05-29"
           }
@@ -22849,15 +22909,15 @@
         "Constraints": {
           "constraint_extraction": {
             "status": "full",
-            "cites": ["internal/custom/java/bean_validation.go","internal/custom/java/bean_validation_test.go","internal/engine/java_annotation_params.go"],
+            "cites": ["internal/engine/java_annotation_params.go"],
             "issue": "3100",
             "notes": "Bean-Validation annotations (@NotNull/@NotBlank/@NotEmpty/@Size/@Min/@Max/@Pattern/@Email) are collected on each handler parameter and drive the Required flag; captured as annotation strings, not structured constraint records (no value bounds parsed).",
             "verified_at": "2026-05-29"
           },
           "custom_validator_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/bean_validation.go","internal/custom/java/bean_validation_test.go"],
-            "issue": "3100",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Extracting classes that implement ConstraintValidator\u003cA,T\u003e requires scanning for the interface-implementation pattern. No current extractor does this. Leave red — out of scope for #3002.",
             "verified_at": "2026-05-29"
           }
@@ -22873,9 +22933,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/junit5.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Bean Validation integration tests use JUnit 5 with jakarta.validation.Validator. The junit5 extractor (internal/custom/java/junit5.go) captures @Test methods for the junit5 framework tag. Tests for bean-validation handlers are linked via the same JUnit 5 test-method extraction path used by other Java frameworks (e.g. Jakarta EE, Spring Boot — see #2996, #2991).",
             "verified_at": "2026-05-29"
           }
@@ -32319,30 +32379,32 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; Kotlin trailing-lambda route DSL proven by TestKotlinJavalin_Routes_Issue3274",
             "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; handler attribution proven by TestKotlinJavalin_Routes_Issue3274",
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/kotlin_port_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274",
             "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies"
           }
         },
@@ -32360,8 +32422,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "app.before() and app.after() global/path-scoped middleware — Kotlin Javalin trailing lambda matches same regex"
           }
         },
@@ -33568,69 +33631,69 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @Transactional (JTA/Spring) on Kotlin proven by TestKotlinTransactional_Quarkus_Issue3274 (JTA path covers micronaut too)",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; propagation capture via transactional.go txFrameworks[\"micronaut\"]",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; rollbackFor rules parsed by transactional.go txFrameworks[\"micronaut\"]",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/micronaut_aop.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; Micronaut @Around/@InterceptorBean on Kotlin proven by TestKotlinMicronautAOP_Interceptor_Issue3274",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/micronaut_aop.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; Micronaut interceptor/aspect extraction proven by TestKotlinMicronautAOP_Interceptor_Issue3274",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/micronaut_aop.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; proven by TestKotlinMicronautAOP_Interceptor_Issue3274",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; SLF4J/@Slf4j on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 (obsFrameworks[\"micronaut\"]=true)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; Micrometer @Timed on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 (obsFrameworks[\"micronaut\"]=true)",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274",
             "verified_at": "2026-05-30"
           }
@@ -33849,69 +33912,69 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; Jakarta @Transactional on Kotlin quarkus class proven by TestKotlinTransactional_Quarkus_Issue3274",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; txFrameworks[\"quarkus\"]=true in transactional.go",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; txFrameworks[\"quarkus\"]=true in transactional.go",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin (cdiFrameworks[\"quarkus\"]=true); @Interceptor/@AroundInvoke on Kotlin proven by TestKotlinCDIInterceptors_Issue3274",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; CDI interceptor aspect extraction proven by TestKotlinCDIInterceptors_Issue3274",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/cdi_interceptors.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; proven by TestKotlinCDIInterceptors_Issue3274",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; obsFrameworks[\"quarkus\"]=true; SLF4J/@Slf4j proven by TestKotlinObservability_Slf4j_Issue3274",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @Timed Micrometer proven by TestKotlinObservability_Micrometer_Issue3274",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @WithSpan OTel proven by TestKotlinObservability_OTel_Issue3274",
             "verified_at": "2026-05-30"
           }
@@ -34329,83 +34392,92 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_boot.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Kotlin Spring Boot @Service/@Repository/@Component stereotypes + @Bean methods; value-asserted by TestKotlinSpringBoot_DI_BindingNames_3435 (stereotype=service/repository, bean_method=passwordEncoder/config_class=AppConfig)",
             "verified_at": "2026-05-30"
           },
           "di_injection_point": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_boot.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Kotlin primary-constructor injection (class Foo @Autowired constructor(private val x: Bar)) + @Autowired lateinit var props now captured (new Kotlin-gated regexes in spring_boot.go); injected_type+injection_kind asserted by TestKotlinSpringBoot_DI_ConstructorInjection_3435 and _PrimaryCtorNoAnnotation_3435",
             "verified_at": "2026-05-30"
           },
           "di_scope_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_boot.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@RequestScope/@Scope(\"prototype\") on Kotlin classes; spring_scope value asserted by TestKotlinSpringBoot_DI_ScopeValues_3435 (request, prototype)",
             "verified_at": "2026-05-30"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Transactional on Kotlin fun/class; method/class boundary names asserted by TestKotlinTransactional_Attributes_3435 (getOrders, processPayment, reconcile)",
             "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "propagation=Propagation.REQUIRES_NEW captured + asserted by TestKotlinTransactional_Attributes_3435; readOnly=true also asserted",
             "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Kotlin rollbackFor=[X::class]/noRollbackFor + isolation captured (txClassRefRE now accepts ::class); rollback_for=PaymentException, no_rollback_for=WarnException, isolation=SERIALIZABLE asserted by TestKotlinTransactional_Attributes_3435",
             "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Before/@Around advice on Kotlin fun; advice_type (before/around) + method names asserted by TestKotlinSpringAOP_Attributes_3435",
             "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Aspect on Kotlin class; aspect name=LoggingAspect asserted by TestKotlinSpringAOP_Attributes_3435",
             "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "@Pointcut expression + advice-\u003enamed-pointcut REFERENCES edge asserted by TestKotlinSpringAOP_Attributes_3435 (execution(* com.example.service.*.*(..)))",
             "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @Slf4j and SLF4J logger on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @Timed Micrometer on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "3274",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274",
             "verified_at": "2026-05-30"
           }
@@ -34593,16 +34665,16 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Recording win: hibernate.go ExtractHibernate() accepts ctx.Language==\"kotlin\" — @Entity/@Table on Kotlin data classes matched identically to Java. Partial because Kotlin-specific JPA idioms (constructor-param columns, data class shorthand) may not all be captured."
           }
         },
         "Relationships": {
           "association_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Recording win: hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne/@OneToOne/@ManyToMany before Kotlin 'var/val' properties. jpa_fk_lazy.go ExtractJPAFKAndLazy also runs on Kotlin (language gate: java or kotlin). Partial because collection types differ from Java generics."
           },
@@ -34622,7 +34694,7 @@
           },
           "relationship_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/kotlin_port_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "3274",
             "notes": "java extractor language-gated to kotlin; @OneToMany/@ManyToOne/@ManyToMany on Kotlin proved by TestKotlinHibernate_Issue3274",
             "verified_at": "2026-05-30"
@@ -34823,16 +34895,16 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "missing",
             "cites": ["internal/custom/java/hibernate.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "Recording win: hibernate.go accepts kotlin language with spring_data_jpa framework. Spring Data JPA entities use the same @Entity/@Table annotations as Hibernate — regex patterns match Kotlin data class declarations. spring_ecosystem.go is Java-only but the JPA schema layer is shared."
           }
         },
         "Relationships": {
           "association_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Recording win: same as orm.hibernate — hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne on Kotlin Spring Data JPA entities. @JoinColumn / @ForeignKey handled by jpa_fk_lazy.go ExtractJPAFKAndLazy."
           },
@@ -34852,7 +34924,7 @@
           },
           "relationship_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go","internal/custom/java/kotlin_port_test.go"],
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
             "issue": "3274",
             "notes": "java extractor language-gated to kotlin; @OneToMany/@ManyToOne on Kotlin Spring Data entities covered by hibernate.go hibAssociationRE",
             "verified_at": "2026-05-30"


### PR DESCRIPTION
Closes #3585 (epic #3584). **REGISTRY-ONLY integrity fix. DEPLOY-DEFERRED.**

The Java `internal/custom/java/` pattern-extractor layer — 35 `Extract*(PatternContext)PatternResult` funcs across 34 files — has **zero non-test callers** and is never wired into the live indexer. 270 registry cells cited those orphan files as evidence of coverage the indexer never produces. This corrects the registry so it stops claiming that coverage.

### What changed (`docs/coverage/registry.json` + regenerated docs)
- **248 cells → `missing`** + `issue: #3586` — orphan-only cells (cites were exclusively orphan `.go` / `_test.go` / fixtures). **56 of these were false-`full`**, 192 were false-`partial`.
- **37 co-cite cells** — kept status, dropped the orphan + test cites; the live extractor cite is retained.
- **22 `not_applicable` cells** left as-is per #3585 (genuinely N/A — not a coverage claim).

### Orphan-set discipline
Excluded the 6 live self-registering ORM extractors (`jooq`/`mybatis`/`ebean`/`eclipselink`/`dynamodb`/`neo4j` via `extreg.Register("custom_java_...")`) and `jpa_fk_lazy.go::ExtractJPAFKAndLazy` (called by `ebean`/`eclipselink`/`hibernate`/`spring_ecosystem`). Classification was by actual cite path, not record language — hence kotlin records citing java orphans are included.

### Per-record breakdown

| Record | Cells downgraded | full→missing | Co-cites trimmed |
|---|---|---|---|
| `lang.java.framework.akka-http` | 9 | 0 | 2 |
| `lang.java.framework.android-jetpack` | 9 | 0 | 0 |
| `lang.java.framework.android-sdk` | 9 | 0 | 0 |
| `lang.java.framework.dropwizard` | 14 | 0 | 0 |
| `lang.java.framework.gwt` | 4 | 0 | 0 |
| `lang.java.framework.helidon` | 13 | 0 | 1 |
| `lang.java.framework.jakarta-ee` | 14 | 0 | 0 |
| `lang.java.framework.javalin` | 9 | 0 | 2 |
| `lang.java.framework.jaxrs` | 14 | 10 | 0 |
| `lang.java.framework.langchain4j` | 3 | 0 | 0 |
| `lang.java.framework.micronaut` | 14 | 10 | 2 |
| `lang.java.framework.microprofile` | 15 | 0 | 0 |
| `lang.java.framework.play` | 7 | 0 | 1 |
| `lang.java.framework.quarkus` | 13 | 0 | 2 |
| `lang.java.framework.spring-boot` | 14 | 10 | 0 |
| `lang.java.framework.spring-webflux` | 15 | 10 | 1 |
| `lang.java.framework.struts` | 9 | 0 | 0 |
| `lang.java.framework.vaadin` | 4 | 0 | 0 |
| `lang.java.framework.vertx` | 8 | 0 | 1 |
| `lang.java.orm.hibernate` | 2 | 0 | 3 |
| `lang.java.orm.jpa` | 2 | 0 | 3 |
| `lang.java.orm.panache` | 0 | 0 | 3 |
| `lang.java.orm.spring-data-cassandra` | 1 | 1 | 2 |
| `lang.java.orm.spring-data-elastic` | 1 | 1 | 2 |
| `lang.java.orm.spring-data-jpa` | 2 | 0 | 3 |
| `lang.java.orm.spring-data-mongo` | 1 | 1 | 2 |
| `lang.java.orm.spring-data-redis` | 1 | 1 | 2 |
| `lang.java.validation.bean-validation` | 4 | 2 | 1 |
| `lang.kotlin.framework.javalin` | 5 | 1 | 0 |
| `lang.kotlin.framework.micronaut` | 9 | 0 | 0 |
| `lang.kotlin.framework.quarkus` | 9 | 0 | 0 |
| `lang.kotlin.framework.spring-boot` | 12 | 9 | 0 |
| `lang.kotlin.orm.hibernate` | 1 | 0 | 2 |
| `lang.kotlin.orm.spring-data` | 1 | 0 | 2 |
| **TOTAL** | **248** | **56** | **37** |

### Verification
- `coverage validate`: **0 errors** (warnings dropped 7647 → 7466 as false-`full` cells lost their phantom mapping requirement).
- `coverage fmt --check`: canonical.
- `coverage gen`: docs regenerated; java/kotlin by-language pages now show honest 🔴/🟡 on the dead cells. Unrelated infra detail-page drift reverted.
- `go test ./tools/coverage/`: pass.

### Re-wiring tracked by #3586
This is the integrity correction only. Wiring the extractor layer into the live indexer is **follow-up #3586**; the downgraded cells carry that issue link. **DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
