### PR TITLE
fix(extractors): wire 20 orphaned Ruby+PHP framework extractors to dispatch

### DIFF
--- a/internal/custom/php/data_extractors_test.go
+++ b/internal/custom/php/data_extractors_test.go
@@ -25,7 +25,7 @@ class User
     private string $email;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("User.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("User.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "username") {
 		t.Error("expected username column schema")
 	}
@@ -46,7 +46,7 @@ class Order
     private Collection $items;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Order.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Order.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "relation:ManyToOne") {
 		t.Error("expected ManyToOne relation component")
 	}
@@ -65,7 +65,7 @@ class OrderItem
     private Order $order;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("OrderItem.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("OrderItem.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "join_column") {
 		t.Error("expected join_column FK entity")
 	}
@@ -80,7 +80,7 @@ class Product
     private Collection $reviews;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Product.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Product.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "fetch:LAZY") {
 		t.Error("expected fetch:LAZY pattern entity")
 	}
@@ -103,7 +103,7 @@ class Version20230101120000 extends AbstractMigration
     }
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Version20230101120000.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Version20230101120000.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Operation", "Version20230101120000") {
 		t.Error("expected migration class entity")
 	}
@@ -117,7 +117,7 @@ class Version20230101120000 extends AbstractMigration
 
 func TestDoctrineNoMatch(t *testing.T) {
 	src := `<?php echo "hello doctrine";`
-	ents := extract(t, "php_doctrine_orm_data", fi("plain.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
@@ -153,7 +153,7 @@ class User
     private bool $active;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("User.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("User.php", "php", src))
 
 	// Entity class name must be emitted as SCOPE.Schema/entity.
 	if !containsEntity(ents, "SCOPE.Schema", "User") {
@@ -189,7 +189,7 @@ class Post
     private $body;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Post.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Post.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Schema", "title") {
 		t.Error("expected title column from @ORM\\Column annotation")
@@ -219,7 +219,7 @@ class Post
     private ?Profile $profile;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Post.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Post.php", "php", src))
 
 	// All four relation types must produce SCOPE.Component/relation entities.
 	for _, relType := range []string{"OneToMany", "ManyToOne", "ManyToMany", "OneToOne"} {
@@ -245,7 +245,7 @@ class Order
     private ?Address $shippingAddress;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Order.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Order.php", "php", src))
 
 	// FK entities are named "fk:<column_name>" when name= is present.
 	if !containsEntity(ents, "SCOPE.Schema", "fk:customer_id") {
@@ -268,7 +268,7 @@ class Article
     private Collection $tags;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Article.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Article.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Schema", "join_table") {
 		t.Error("expected join_table foreign_key entity from #[ORM\\JoinTable]")
@@ -289,7 +289,7 @@ class Invoice
     private Collection $tags;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Invoice.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Invoice.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Pattern", "fetch:EAGER") {
 		t.Error("expected fetch:EAGER lazy_loading pattern entity")
@@ -320,7 +320,7 @@ class Version20240115000000 extends AbstractMigration
     }
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Version20240115000000.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Version20240115000000.php", "php", src))
 
 	// Migration class and methods.
 	if !containsEntity(ents, "SCOPE.Operation", "Version20240115000000") {
@@ -384,7 +384,7 @@ class Order
     private Collection $coupons;
 }
 `
-	ents := extract(t, "php_doctrine_orm_data", fi("Order.php", "php", src))
+	ents := extract(t, "custom_php_doctrine_orm_data", fi("Order.php", "php", src))
 
 	// Entity class.
 	if !containsEntity(ents, "SCOPE.Schema", "Order") {
@@ -441,7 +441,7 @@ class Post extends Model
     ];
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Post.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Post.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "title") {
 		t.Error("expected title column schema from fillable")
 	}
@@ -464,7 +464,7 @@ class Comment extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Comment.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Comment.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "post") {
 		t.Error("expected post belongsTo relation")
 	}
@@ -493,7 +493,7 @@ class CreatePostsTable extends Migration
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("2023_01_01_create_posts_table.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("2023_01_01_create_posts_table.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Operation", "create:posts") {
 		t.Error("expected create:posts migration entity")
 	}
@@ -512,7 +512,7 @@ class User extends Model
     protected $with = ['profile', 'roles'];
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("User.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("User.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "eager_with") {
 		t.Error("expected eager_with lazy/eager loading pattern")
 	}
@@ -540,7 +540,7 @@ class User extends Model
     ];
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("app/Models/User.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("app/Models/User.php", "php", src))
 
 	// model class entity
 	if !containsEntity(ents, "SCOPE.Schema", "User") {
@@ -590,7 +590,7 @@ class Post extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Post.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Post.php", "php", src))
 
 	// Each relationship method must produce a SCOPE.Component/relation entity.
 	for _, rel := range []string{"author", "comments", "thumbnail", "tags", "history"} {
@@ -619,7 +619,7 @@ class Post extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Polymorphic.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Polymorphic.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Component", "imageable") {
 		t.Error("expected imageable morphTo relation entity")
@@ -645,7 +645,7 @@ class Comment extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Comment.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Comment.php", "php", src))
 
 	// Conventional FKs: post → post_id; postAuthor → post_author_id
 	if !containsEntity(ents, "SCOPE.Schema", "fk:post_id") {
@@ -668,7 +668,7 @@ class Profile extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Profile.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Profile.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Schema", "fk:owner_id") {
 		t.Error("expected fk:owner_id from explicit 2nd arg in belongsTo")
@@ -701,7 +701,7 @@ return new class extends Migration
     }
 };
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("database/migrations/2024_create_posts.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("database/migrations/2024_create_posts.php", "php", src))
 
 	// Migration operation entities
 	if !containsEntity(ents, "SCOPE.Operation", "create:posts") {
@@ -740,7 +740,7 @@ class Article extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Article.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Article.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Pattern", "lazy:default") {
 		t.Error("expected lazy:default pattern — Eloquent is lazy by default when no $with is set")
@@ -780,7 +780,7 @@ class Post extends Model
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("Post.php", "php", src2))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("Post.php", "php", src2))
 
 	if !containsEntity(ents, "SCOPE.Pattern", "eager_load:with") {
 		t.Error("expected eager_load:with entity from ->with() call")
@@ -816,7 +816,7 @@ class AddStatusToOrdersTable extends Migration
     }
 }
 `
-	ents := extract(t, "php_eloquent_orm_data", fi("2024_add_status_to_orders.php", "php", src))
+	ents := extract(t, "custom_php_eloquent_orm_data", fi("2024_add_status_to_orders.php", "php", src))
 
 	if !containsEntity(ents, "SCOPE.Operation", "alter:orders") {
 		t.Error("expected alter:orders from Schema::table")
@@ -856,7 +856,7 @@ class User
     private string $name;
 }
 `
-	ents := extract(t, "php_cycleorm_data", fi("User.php", "php", src))
+	ents := extract(t, "custom_php_cycleorm_data", fi("User.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "User") {
 		t.Error("expected User entity model")
 	}
@@ -883,7 +883,7 @@ class Post
     private User $author;
 }
 `
-	ents := extract(t, "php_cycleorm_data", fi("Post.php", "php", src))
+	ents := extract(t, "custom_php_cycleorm_data", fi("Post.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "relation:HasMany") {
 		t.Error("expected HasMany relation")
 	}
@@ -902,7 +902,7 @@ class UserRepository
     }
 }
 `
-	ents := extract(t, "php_cycleorm_data", fi("UserRepository.php", "php", src))
+	ents := extract(t, "custom_php_cycleorm_data", fi("UserRepository.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Operation", "query:findOne") {
 		t.Error("expected query:findOne entity")
 	}
@@ -923,7 +923,7 @@ class UserTableMap extends TableMap
     const COL_EMAIL = 'user.email';
 }
 `
-	ents := extract(t, "php_propel_orm_data", fi("UserTableMap.php", "php", src))
+	ents := extract(t, "custom_php_propel_orm_data", fi("UserTableMap.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "UserTableMap") {
 		t.Error("expected UserTableMap schema entity")
 	}
@@ -943,7 +943,7 @@ class BookTableMap extends TableMap
     }
 }
 `
-	ents := extract(t, "php_propel_orm_data", fi("BookTableMap.php", "php", src))
+	ents := extract(t, "custom_php_propel_orm_data", fi("BookTableMap.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "relation:Author") {
 		t.Error("expected relation:Author component")
 	}
@@ -960,7 +960,7 @@ $users = UserQuery::create()
 
 $book = BookQuery::create()->findOne();
 `
-	ents := extract(t, "php_propel_orm_data", fi("list.php", "php", src))
+	ents := extract(t, "custom_php_propel_orm_data", fi("list.php", "php", src))
 	if len(ents) == 0 {
 		t.Error("expected Propel query entities from UserQuery::create()")
 	}
@@ -978,7 +978,7 @@ $product->name = 'Widget';
 $product->price = 9.99;
 R::store($product);
 `
-	ents := extract(t, "php_redbeanphp_data", fi("store.php", "php", src))
+	ents := extract(t, "custom_php_redbeanphp_data", fi("store.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "product") {
 		t.Error("expected product table schema from R::dispense")
 	}
@@ -989,7 +989,7 @@ func TestRedBeanRelation(t *testing.T) {
 R::associate($product, $category);
 $related = R::related($product, 'category');
 `
-	ents := extract(t, "php_redbeanphp_data", fi("relate.php", "php", src))
+	ents := extract(t, "custom_php_redbeanphp_data", fi("relate.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "relation:associate") {
 		t.Error("expected relation:associate component")
 	}
@@ -1003,7 +1003,7 @@ func TestRedBeanFind(t *testing.T) {
 $products = R::find('product', ' price > ? ', [10]);
 $user = R::findOne('user', ' email = ? ', [$email]);
 `
-	ents := extract(t, "php_redbeanphp_data", fi("query.php", "php", src))
+	ents := extract(t, "custom_php_redbeanphp_data", fi("query.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "product") {
 		t.Error("expected product schema from R::find")
 	}
@@ -1014,7 +1014,7 @@ $user = R::findOne('user', ' email = ? ', [$email]);
 
 func TestRedBeanNoMatch(t *testing.T) {
 	src := `<?php class Plain { public function run() {} }`
-	ents := extract(t, "php_redbeanphp_data", fi("Plain.php", "php", src))
+	ents := extract(t, "custom_php_redbeanphp_data", fi("Plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
@@ -1035,7 +1035,7 @@ $pdo->exec("
     )
 ");
 `
-	ents := extract(t, "php_sql_driver_schema", fi("setup.php", "php", src))
+	ents := extract(t, "custom_php_sql_driver_schema", fi("setup.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "users") {
 		t.Error("expected users table schema")
 	}
@@ -1053,7 +1053,7 @@ $db->exec('CREATE TABLE orders (
     status TEXT DEFAULT "pending"
 )');
 `
-	ents := extract(t, "php_sql_driver_schema", fi("init.php", "php", src))
+	ents := extract(t, "custom_php_sql_driver_schema", fi("init.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "orders") {
 		t.Error("expected orders table schema")
 	}
@@ -1061,7 +1061,7 @@ $db->exec('CREATE TABLE orders (
 
 func TestPHPSQLDriverNoMatch(t *testing.T) {
 	src := `<?php echo "no driver here";`
-	ents := extract(t, "php_sql_driver_schema", fi("plain.php", "php", src))
+	ents := extract(t, "custom_php_sql_driver_schema", fi("plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
@@ -1087,7 +1087,7 @@ func TestBehatFeature(t *testing.T) {
     When I fill in "email" with "bad@example.com"
     Then I should see "Invalid credentials"
 `
-	ents := extract(t, "php_behat_test", fi("login.feature", "gherkin", src))
+	ents := extract(t, "custom_php_behat_test", fi("login.feature", "gherkin", src))
 	if !containsEntity(ents, "SCOPE.Operation", "feature:User login") {
 		t.Error("expected feature entity")
 	}
@@ -1120,7 +1120,7 @@ class FeatureContext implements Context
     public function iFillIn($field, $value) {}
 }
 `
-	ents := extract(t, "php_behat_test", fi("FeatureContext.php", "php", src))
+	ents := extract(t, "custom_php_behat_test", fi("FeatureContext.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "FeatureContext") {
 		t.Error("expected FeatureContext context class entity")
 	}
@@ -1128,7 +1128,7 @@ class FeatureContext implements Context
 
 func TestBehatNoMatch(t *testing.T) {
 	src := `<?php class NoBehatHere {}`
-	ents := extract(t, "php_behat_test", fi("plain.php", "php", src))
+	ents := extract(t, "custom_php_behat_test", fi("plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
@@ -1158,7 +1158,7 @@ class UserLoginCest
     }
 }
 `
-	ents := extract(t, "php_codeception_test", fi("UserLoginCest.php", "php", src))
+	ents := extract(t, "custom_php_codeception_test", fi("UserLoginCest.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "UserLoginCest") {
 		t.Error("expected UserLoginCest test suite")
 	}
@@ -1184,7 +1184,7 @@ class ApiCest
     }
 }
 `
-	ents := extract(t, "php_codeception_test", fi("ApiCest.php", "php", src))
+	ents := extract(t, "custom_php_codeception_test", fi("ApiCest.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Component", "Codeception\\Module\\Laravel") {
 		t.Error("expected Laravel module dependency")
 	}
@@ -1192,7 +1192,7 @@ class ApiCest
 
 func TestCodeceptionNoMatch(t *testing.T) {
 	src := `<?php class NoCept {}`
-	ents := extract(t, "php_codeception_test", fi("plain.php", "php", src))
+	ents := extract(t, "custom_php_codeception_test", fi("plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
@@ -1221,7 +1221,7 @@ describe('Authentication', function () {
     });
 });
 `
-	ents := extract(t, "php_pest_test", fi("UserTest.php", "php", src))
+	ents := extract(t, "custom_php_pest_test", fi("UserTest.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Operation", "can create a user") {
 		t.Error("expected 'can create a user' test case")
 	}
@@ -1247,7 +1247,7 @@ it('validates emails', function (string $email) {
     expect($email)->toBeEmail();
 })->with('emails');
 `
-	ents := extract(t, "php_pest_test", fi("EmailTest.php", "php", src))
+	ents := extract(t, "custom_php_pest_test", fi("EmailTest.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Schema", "dataset:emails") {
 		t.Error("expected dataset:emails entity")
 	}
@@ -1265,7 +1265,7 @@ afterEach(function () {
     // cleanup
 });
 `
-	ents := extract(t, "php_pest_test", fi("HookTest.php", "php", src))
+	ents := extract(t, "custom_php_pest_test", fi("HookTest.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "hook:beforeEach") {
 		t.Error("expected hook:beforeEach pattern")
 	}
@@ -1276,7 +1276,7 @@ afterEach(function () {
 
 func TestPestNoMatch(t *testing.T) {
 	src := `<?php echo "no pest here";`
-	ents := extract(t, "php_pest_test", fi("plain.php", "php", src))
+	ents := extract(t, "custom_php_pest_test", fi("plain.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}

--- a/internal/custom/php/driver_sql.go
+++ b/internal/custom/php/driver_sql.go
@@ -27,12 +27,12 @@ import (
 )
 
 func init() {
-	extractor.Register("php_sql_driver_schema", &phpSQLDriverSchemaExtractor{})
+	extractor.Register("custom_php_sql_driver_schema", &phpSQLDriverSchemaExtractor{})
 }
 
 type phpSQLDriverSchemaExtractor struct{}
 
-func (e *phpSQLDriverSchemaExtractor) Language() string { return "php_sql_driver_schema" }
+func (e *phpSQLDriverSchemaExtractor) Language() string { return "custom_php_sql_driver_schema" }
 
 var (
 	// phpDriverGateRe gates the extractor: must contain a recognised PHP SQL

--- a/internal/custom/php/observability.go
+++ b/internal/custom/php/observability.go
@@ -35,7 +35,7 @@
 // therefore remain `partial`, matching the honesty discipline established
 // by the Java, Python, and Ruby extractors.
 //
-// Extractor key: "phpObs_laravel_symfony" — registered as a dedicated
+// Extractor key: "custom_php_obs_laravel_symfony" — registered as a dedicated
 // extractor. The coarse custom_php_observability stub in frameworks.go
 // continues to run for the remaining PHP frameworks; this extractor
 // deepens detection specifically for Laravel + Symfony call-sites.
@@ -57,12 +57,12 @@ import (
 )
 
 func init() {
-	extractor.Register("phpObs_laravel_symfony", &phpObsExtractor{})
+	extractor.Register("custom_php_obs_laravel_symfony", &phpObsExtractor{})
 }
 
 type phpObsExtractor struct{}
 
-func (e *phpObsExtractor) Language() string { return "phpObs_laravel_symfony" }
+func (e *phpObsExtractor) Language() string { return "custom_php_obs_laravel_symfony" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes — log_extraction

--- a/internal/custom/php/observability_test.go
+++ b/internal/custom/php/observability_test.go
@@ -1,4 +1,4 @@
-// observability_test.go — value-asserting tests for the phpObs_laravel_symfony
+// observability_test.go — value-asserting tests for the custom_php_obs_laravel_symfony
 // extractor. Each test verifies that a concrete call-site pattern emits the
 // expected entity (Kind + Name). Tests intentionally use realistic PHP
 // snippets; no test forces a "full" status — detection is call-site heuristic.
@@ -30,7 +30,7 @@ class UserController extends Controller
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Http/Controllers/UserController.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Http/Controllers/UserController.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Log::info") {
 		t.Error("expected Log::info log_statement entity")
 	}
@@ -41,7 +41,7 @@ func TestPHPObsLaravelLogFacadeError(t *testing.T) {
 	src := `<?php
 Log::error('Payment failed', ['order_id' => $orderId, 'reason' => $e->getMessage()]);
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/PaymentService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Services/PaymentService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Log::error") {
 		t.Error("expected Log::error log_statement entity")
 	}
@@ -55,7 +55,7 @@ Log::debug('Processing item', ['id' => $id]);
 Log::warning('Item is deprecated', ['item' => $name]);
 Log::critical('Database connection failed');
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Jobs/ProcessItem.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Jobs/ProcessItem.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Log::debug") {
 		t.Error("expected Log::debug entity")
 	}
@@ -74,7 +74,7 @@ func TestPHPObsLaravelLogChannel(t *testing.T) {
 Log::channel('slack')->critical('Server is down', ['host' => $host]);
 Log::channel('daily')->info('Scheduled job completed');
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Console/Commands/HealthCheck.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Console/Commands/HealthCheck.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Log::channel(slack)") {
 		t.Error("expected Log::channel(slack) entity")
 	}
@@ -94,7 +94,7 @@ public function store(Request $request): JsonResponse
     return response()->json($order);
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Http/Controllers/OrderController.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Http/Controllers/OrderController.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "logger()->info") {
 		t.Error("expected logger()->info entity")
 	}
@@ -110,7 +110,7 @@ func TestPHPObsLaravelBackslashLogFacade(t *testing.T) {
 \Log::info('Starting import job');
 \Log::warning('Import row skipped', ['row' => $rowNumber]);
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Jobs/ImportJob.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Jobs/ImportJob.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Log::info") {
 		t.Error("expected Log::info entity for \\Log::info call")
 	}
@@ -141,7 +141,7 @@ class OrderService
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "$logger->info") {
 		t.Error("expected $logger->info Monolog call-site entity")
 	}
@@ -161,7 +161,7 @@ class AppBootstrap
     private Logger $logger;
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/app.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("bootstrap/app.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Monolog\\Logger") {
 		t.Error("expected Monolog\\Logger use-declaration entity")
 	}
@@ -184,7 +184,7 @@ class NotificationService
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/NotificationService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Service/NotificationService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "$logger->info") {
 		t.Error("expected $logger->info PSR-3 entity for Symfony injected logger")
 	}
@@ -206,7 +206,7 @@ class Calculator
     public function add(int $a, int $b): int { return $a + $b; }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Calculator.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Calculator.php", "php", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no observability entities for plain PHP, got %d", len(ents))
 	}
@@ -232,7 +232,7 @@ class MetricsService
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/MetricsService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Service/MetricsService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "new Counter") {
 		t.Error("expected new Counter metric entity")
 	}
@@ -251,7 +251,7 @@ use Prometheus\Histogram;
 $gauge = new Gauge('memory_usage_bytes', 'Current memory usage');
 $histogram = new Histogram('request_duration_seconds', 'Request duration', ['endpoint']);
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Metrics/AppMetrics.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Metrics/AppMetrics.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "new Gauge") {
 		t.Error("expected new Gauge metric entity")
 	}
@@ -274,7 +274,7 @@ class PrometheusBootstrap
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/metrics.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("bootstrap/metrics.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Prometheus") {
 		t.Error("expected Prometheus use-declaration entity")
 	}
@@ -294,7 +294,7 @@ $statsd = new StatsD();
 $statsd->increment('page.views');
 $statsd->gauge('queue.depth', $depth);
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracking/PageTracker.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Tracking/PageTracker.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "page.views") {
 		t.Error("expected page.views StatsD metric entity")
 	}
@@ -314,7 +314,7 @@ class StatsHelper
     public function __construct(private StatsD $statsd) {}
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/StatsHelper.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/StatsHelper.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "StatsD") {
 		t.Error("expected StatsD use-declaration entity")
 	}
@@ -327,7 +327,7 @@ func TestPHPObsLaravelMetrics(t *testing.T) {
 Metrics::counter('orders_placed');
 Metrics::gauge('active_users', $count);
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Observers/OrderObserver.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Observers/OrderObserver.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Metrics::counter") {
 		t.Error("expected Metrics::counter entity")
 	}
@@ -363,7 +363,7 @@ class OrderService
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "order.create") {
 		t.Error("expected order.create span entity from spanBuilder")
 	}
@@ -378,7 +378,7 @@ $span = $tracer->startSpan('payment.process');
 $span->setAttribute('amount', $amount);
 $span->end();
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Payment/Processor.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Payment/Processor.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "payment.process") {
 		t.Error("expected payment.process span entity from startSpan")
 	}
@@ -396,7 +396,7 @@ $span->addEvent('auth.success');
 $span->setStatus(StatusCode::STATUS_OK);
 $span->end();
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Auth/AuthService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Auth/AuthService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "$span->setAttribute") {
 		t.Error("expected $span->setAttribute lifecycle entity")
 	}
@@ -417,7 +417,7 @@ use OpenTelemetry\API\Globals;
 $tracerProvider = Globals::tracerProvider();
 $tracer = $tracerProvider->getTracer('my-app');
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/otel.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("bootstrap/otel.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Globals::tracerProvider()") {
 		t.Error("expected Globals::tracerProvider() bootstrap entity")
 	}
@@ -434,7 +434,7 @@ class TracingBootstrap
     public function __construct(private TracerInterface $tracer) {}
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracing/Bootstrap.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Tracing/Bootstrap.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "OpenTelemetry") {
 		t.Error("expected OpenTelemetry use-declaration entity")
 	}
@@ -463,7 +463,7 @@ class DataImportService
     }
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/DataImportService.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Service/DataImportService.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "data.import") {
 		t.Error("expected data.import Stopwatch trace_span entity")
 	}
@@ -482,7 +482,7 @@ foreach ($items as $item) {
 }
 $stopwatch->stop('batch.processing');
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Batch/Processor.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Batch/Processor.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "batch.processing") {
 		t.Error("expected batch.processing Stopwatch entity")
 	}
@@ -499,7 +499,7 @@ class ProfilerHelper
     public function __construct(private Stopwatch $stopwatch) {}
 }
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Profiler/Helper.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Profiler/Helper.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Stopwatch") {
 		t.Error("expected Stopwatch use-declaration entity")
 	}
@@ -520,7 +520,7 @@ func TestPHPObsDDTrace(t *testing.T) {
     $span->name = 'user.repo.find';
 });
 `
-	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracing/DatadogTracing.php", "php", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("src/Tracing/DatadogTracing.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "DDTrace\\trace_function") {
 		t.Error("expected DDTrace\\trace_function entity")
 	}
@@ -537,7 +537,7 @@ func TestPHPObsDDTrace(t *testing.T) {
 // non-php language files.
 func TestPHPObsIgnoresNonPHP(t *testing.T) {
 	src := `Log::info('This is PHP-like code but in a JS file');`
-	ents := extract(t, "phpObs_laravel_symfony", fi("frontend/app.js", "javascript", src))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("frontend/app.js", "javascript", src))
 	if len(ents) != 0 {
 		t.Errorf("expected 0 entities for non-php file, got %d", len(ents))
 	}
@@ -545,7 +545,7 @@ func TestPHPObsIgnoresNonPHP(t *testing.T) {
 
 // TestPHPObsIgnoresEmptyFile verifies empty files return no entities.
 func TestPHPObsIgnoresEmptyFile(t *testing.T) {
-	ents := extract(t, "phpObs_laravel_symfony", fi("app/Empty.php", "php", ""))
+	ents := extract(t, "custom_php_obs_laravel_symfony", fi("app/Empty.php", "php", ""))
 	if len(ents) != 0 {
 		t.Errorf("expected 0 entities for empty file, got %d", len(ents))
 	}

--- a/internal/custom/php/orm_data.go
+++ b/internal/custom/php/orm_data.go
@@ -34,11 +34,11 @@ import (
 )
 
 func init() {
-	extractor.Register("php_doctrine_orm_data", &doctrineORMDataExtractor{})
-	extractor.Register("php_eloquent_orm_data", &eloquentORMDataExtractor{})
-	extractor.Register("php_cycleorm_data", &cycleORMDataExtractor{})
-	extractor.Register("php_propel_orm_data", &propelORMDataExtractor{})
-	extractor.Register("php_redbeanphp_data", &redBeanPHPDataExtractor{})
+	extractor.Register("custom_php_doctrine_orm_data", &doctrineORMDataExtractor{})
+	extractor.Register("custom_php_eloquent_orm_data", &eloquentORMDataExtractor{})
+	extractor.Register("custom_php_cycleorm_data", &cycleORMDataExtractor{})
+	extractor.Register("custom_php_propel_orm_data", &propelORMDataExtractor{})
+	extractor.Register("custom_php_redbeanphp_data", &redBeanPHPDataExtractor{})
 }
 
 // ============================================================================
@@ -61,7 +61,7 @@ func ormAdd(seen map[string]bool, entities *[]types.EntityRecord, ent types.Enti
 
 type doctrineORMDataExtractor struct{}
 
-func (e *doctrineORMDataExtractor) Language() string { return "php_doctrine_orm_data" }
+func (e *doctrineORMDataExtractor) Language() string { return "custom_php_doctrine_orm_data" }
 
 var (
 	// dctColumnAttrRe matches PHP8 attribute #[ORM\Column(...)] directly before the
@@ -313,7 +313,7 @@ func (e *doctrineORMDataExtractor) Extract(ctx context.Context, file extractor.F
 
 type eloquentORMDataExtractor struct{}
 
-func (e *eloquentORMDataExtractor) Language() string { return "php_eloquent_orm_data" }
+func (e *eloquentORMDataExtractor) Language() string { return "custom_php_eloquent_orm_data" }
 
 var (
 	// eloquentFillableRe matches $fillable or $guarded arrays (schema columns)
@@ -644,7 +644,7 @@ func (e *eloquentORMDataExtractor) Extract(ctx context.Context, file extractor.F
 
 type cycleORMDataExtractor struct{}
 
-func (e *cycleORMDataExtractor) Language() string { return "php_cycleorm_data" }
+func (e *cycleORMDataExtractor) Language() string { return "custom_php_cycleorm_data" }
 
 var (
 	// cycleEntityRe detects #[Entity] or #[Cycle\Annotated\Annotation\Entity]
@@ -790,7 +790,7 @@ func (e *cycleORMDataExtractor) Extract(ctx context.Context, file extractor.File
 
 type propelORMDataExtractor struct{}
 
-func (e *propelORMDataExtractor) Language() string { return "php_propel_orm_data" }
+func (e *propelORMDataExtractor) Language() string { return "custom_php_propel_orm_data" }
 
 var (
 	// propelTableMapRe detects Propel TableMap class (schema reflection)
@@ -917,7 +917,7 @@ func (e *propelORMDataExtractor) Extract(ctx context.Context, file extractor.Fil
 
 type redBeanPHPDataExtractor struct{}
 
-func (e *redBeanPHPDataExtractor) Language() string { return "php_redbeanphp_data" }
+func (e *redBeanPHPDataExtractor) Language() string { return "custom_php_redbeanphp_data" }
 
 var (
 	// rbDispenseRe detects R::dispense('tablename') — implicit schema creation

--- a/internal/custom/php/test_data.go
+++ b/internal/custom/php/test_data.go
@@ -24,9 +24,9 @@ import (
 )
 
 func init() {
-	extractor.Register("php_behat_test", &behatTestExtractor{})
-	extractor.Register("php_codeception_test", &codeceptionTestExtractor{})
-	extractor.Register("php_pest_test", &pestTestExtractor{})
+	extractor.Register("custom_php_behat_test", &behatTestExtractor{})
+	extractor.Register("custom_php_codeception_test", &codeceptionTestExtractor{})
+	extractor.Register("custom_php_pest_test", &pestTestExtractor{})
 }
 
 // ============================================================================
@@ -35,7 +35,7 @@ func init() {
 
 type behatTestExtractor struct{}
 
-func (e *behatTestExtractor) Language() string { return "php_behat_test" }
+func (e *behatTestExtractor) Language() string { return "custom_php_behat_test" }
 
 var (
 	// behatFeatureRe matches "Feature: <name>" lines in .feature files
@@ -153,7 +153,7 @@ func (e *behatTestExtractor) Extract(ctx context.Context, file extractor.FileInp
 
 type codeceptionTestExtractor struct{}
 
-func (e *codeceptionTestExtractor) Language() string { return "php_codeception_test" }
+func (e *codeceptionTestExtractor) Language() string { return "custom_php_codeception_test" }
 
 var (
 	// codeceptionCestRe detects Cest class declarations
@@ -270,7 +270,7 @@ func (e *codeceptionTestExtractor) Extract(ctx context.Context, file extractor.F
 
 type pestTestExtractor struct{}
 
-func (e *pestTestExtractor) Language() string { return "php_pest_test" }
+func (e *pestTestExtractor) Language() string { return "custom_php_pest_test" }
 
 var (
 	// pestTestRe matches it('...') / it("...") or test('...') / test("...") declarations.

--- a/internal/custom/ruby/auth.go
+++ b/internal/custom/ruby/auth.go
@@ -32,13 +32,13 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_auth", &rubyAuthExtractor{})
+	extractor.Register("custom_ruby_auth", &rubyAuthExtractor{})
 }
 
 // rubyAuthExtractor detects auth patterns across Ruby source files.
 type rubyAuthExtractor struct{}
 
-func (e *rubyAuthExtractor) Language() string { return "ruby_auth" }
+func (e *rubyAuthExtractor) Language() string { return "custom_ruby_auth" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/auth_deep_test.go
+++ b/internal/custom/ruby/auth_deep_test.go
@@ -20,9 +20,9 @@ import (
 // extractAuth returns full EntityRecord slice from the ruby_auth extractor.
 func extractAuth(t *testing.T, path, src string) []types.EntityRecord {
 	t.Helper()
-	e, ok := extreg.Get("ruby_auth")
+	e, ok := extreg.Get("custom_ruby_auth")
 	if !ok {
-		t.Fatal("ruby_auth extractor not registered")
+		t.Fatal("custom_ruby_auth extractor not registered")
 	}
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
 		Path: path, Language: "ruby", Content: []byte(src),

--- a/internal/custom/ruby/auth_test.go
+++ b/internal/custom/ruby/auth_test.go
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
 end
 `
-	ents := extract(t, "ruby_auth", fi("config/routes.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("config/routes.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "devise_for:users") {
 		t.Error("expected devise_for:users entity")
 	}
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/application_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/application_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "authenticate_user!") {
 		t.Error("expected authenticate_user! entity")
 	}
@@ -43,7 +43,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/models/user.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/models/user.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "devise_modules") {
 		t.Error("expected devise_modules entity")
 	}
@@ -55,7 +55,7 @@ class PostsController < ApplicationController
   before_filter :require_login
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "require_login") {
 		t.Error("expected require_login entity")
 	}
@@ -77,7 +77,7 @@ def decode_token(token)
   JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/lib/jwt_helper.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/lib/jwt_helper.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "JWT.encode") {
 		t.Error("expected JWT.encode entity")
 	}
@@ -88,7 +88,7 @@ end
 
 func TestRubyAuthJWTRequireOnly(t *testing.T) {
 	src := `require 'jwt'`
-	ents := extract(t, "ruby_auth", fi("lib/auth.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("lib/auth.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "jwt") {
 		t.Error("expected jwt require entity")
 	}
@@ -107,7 +107,7 @@ use Warden::Manager do |manager|
   }
 end
 `
-	ents := extract(t, "ruby_auth", fi("config.ru", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("config.ru", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Warden::Manager") {
 		t.Error("expected Warden::Manager entity")
 	}
@@ -119,7 +119,7 @@ def current_user
   @current_user ||= env['warden'].user
 end
 `
-	ents := extract(t, "ruby_auth", fi("lib/auth_helper.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("lib/auth_helper.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "env.warden") {
 		t.Error("expected env.warden entity")
 	}
@@ -138,7 +138,7 @@ class ArticlesController < ApplicationController
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "authorize!") {
 		t.Error("expected authorize! entity")
 	}
@@ -150,7 +150,7 @@ class PostsController < ApplicationController
   load_and_authorize_resource
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "load_and_authorize_resource") {
 		t.Error("expected load_and_authorize_resource entity")
 	}
@@ -167,7 +167,7 @@ class Ability
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/models/ability.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/models/ability.rb", "ruby", src))
 	if len(ents) == 0 {
 		t.Error("expected CanCanCan ability entities")
 	}
@@ -193,7 +193,7 @@ class ArticlesController < ApplicationController
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "authorize") {
 		t.Error("expected Pundit authorize entity")
 	}
@@ -209,7 +209,7 @@ class ArticlePolicy < ApplicationPolicy
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/policies/article_policy.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/policies/article_policy.rb", "ruby", src))
 	if len(ents) == 0 {
 		t.Error("expected at least one Pundit entity")
 	}
@@ -229,7 +229,7 @@ class ApiController < ApplicationController
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("app/controllers/api_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("app/controllers/api_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "doorkeeper_authorize!") {
 		t.Error("expected doorkeeper_authorize! entity")
 	}
@@ -248,7 +248,7 @@ use Rack::Auth::Basic, "Protected Area" do |username, password|
   )
 end
 `
-	ents := extract(t, "ruby_auth", fi("config.ru", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("config.ru", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Rack::Auth::Basic") {
 		t.Error("expected Rack::Auth::Basic entity")
 	}
@@ -261,7 +261,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_ID'], ENV['GOOGLE_SECRET']
 end
 `
-	ents := extract(t, "ruby_auth", fi("config/initializers/omniauth.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("config/initializers/omniauth.rb", "ruby", src))
 	if len(ents) == 0 {
 		t.Error("expected OmniAuth entities")
 	}
@@ -279,7 +279,7 @@ class Calculator
   end
 end
 `
-	ents := extract(t, "ruby_auth", fi("lib/calculator.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_auth", fi("lib/calculator.rb", "ruby", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}

--- a/internal/custom/ruby/cuba_routing.go
+++ b/internal/custom/ruby/cuba_routing.go
@@ -48,12 +48,12 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_cuba_routing", &cubaSynthesisExtractor{})
+	extractor.Register("custom_ruby_cuba_routing", &cubaSynthesisExtractor{})
 }
 
 type cubaSynthesisExtractor struct{}
 
-func (e *cubaSynthesisExtractor) Language() string { return "ruby_cuba_routing" }
+func (e *cubaSynthesisExtractor) Language() string { return "custom_ruby_cuba_routing" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/cuba_routing_test.go
+++ b/internal/custom/ruby/cuba_routing_test.go
@@ -9,7 +9,7 @@ import (
 
 func cubaExtract(t *testing.T, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_cuba_routing", fi("app.rb", "ruby", src))
+	return extract(t, "custom_ruby_cuba_routing", fi("app.rb", "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/ruby/dry_types.go
+++ b/internal/custom/ruby/dry_types.go
@@ -31,12 +31,12 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_dry_types", &dryTypesExtractor{})
+	extractor.Register("custom_ruby_dry_types", &dryTypesExtractor{})
 }
 
 type dryTypesExtractor struct{}
 
-func (e *dryTypesExtractor) Language() string { return "ruby_dry_types" }
+func (e *dryTypesExtractor) Language() string { return "custom_ruby_dry_types" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/dry_types_test.go
+++ b/internal/custom/ruby/dry_types_test.go
@@ -9,7 +9,7 @@ import (
 
 func dryExtract(t *testing.T, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_dry_types", fi("types.rb", "ruby", src))
+	return extract(t, "custom_ruby_dry_types", fi("types.rb", "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/ruby/grape_deep.go
+++ b/internal/custom/ruby/grape_deep.go
@@ -43,12 +43,12 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_grape_deep", &grapeDeepExtractor{})
+	extractor.Register("custom_ruby_grape_deep", &grapeDeepExtractor{})
 }
 
 type grapeDeepExtractor struct{}
 
-func (e *grapeDeepExtractor) Language() string { return "ruby_grape_deep" }
+func (e *grapeDeepExtractor) Language() string { return "custom_ruby_grape_deep" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/grape_deep_test.go
+++ b/internal/custom/ruby/grape_deep_test.go
@@ -24,9 +24,9 @@ import (
 
 func grapeDeepExtract(t *testing.T, path, src string) []types.EntityRecord {
 	t.Helper()
-	e, ok := extreg.Get("ruby_grape_deep")
+	e, ok := extreg.Get("custom_ruby_grape_deep")
 	if !ok {
-		t.Fatal("ruby_grape_deep extractor not registered")
+		t.Fatal("custom_ruby_grape_deep extractor not registered")
 	}
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
 		Path: path, Language: "ruby", Content: []byte(src),

--- a/internal/custom/ruby/middleware.go
+++ b/internal/custom/ruby/middleware.go
@@ -47,12 +47,12 @@ import (
 func itoa(n int) string { return strconv.Itoa(n) }
 
 func init() {
-	extractor.Register("ruby_middleware", &rubyMiddlewareExtractor{})
+	extractor.Register("custom_ruby_middleware", &rubyMiddlewareExtractor{})
 }
 
 type rubyMiddlewareExtractor struct{}
 
-func (e *rubyMiddlewareExtractor) Language() string { return "ruby_middleware" }
+func (e *rubyMiddlewareExtractor) Language() string { return "custom_ruby_middleware" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/middleware_test.go
+++ b/internal/custom/ruby/middleware_test.go
@@ -13,9 +13,9 @@ import (
 // mwExtractRaw returns raw EntityRecord values so tests can inspect Properties.
 func mwExtractRaw(t *testing.T, path, src string) []interface{ GetName() string } {
 	t.Helper()
-	e, ok := extreg.Get("ruby_middleware")
+	e, ok := extreg.Get("custom_ruby_middleware")
 	if !ok {
-		t.Fatal("ruby_middleware extractor not registered")
+		t.Fatal("custom_ruby_middleware extractor not registered")
 	}
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
 		Path: path, Language: "ruby", Content: []byte(src),
@@ -31,9 +31,9 @@ func mwExtractRaw(t *testing.T, path, src string) []interface{ GetName() string 
 // mwExtractProps returns raw entities so callers can access Properties.
 func mwExtractProps(t *testing.T, path, src string) []map[string]string {
 	t.Helper()
-	e, ok := extreg.Get("ruby_middleware")
+	e, ok := extreg.Get("custom_ruby_middleware")
 	if !ok {
-		t.Fatal("ruby_middleware extractor not registered")
+		t.Fatal("custom_ruby_middleware extractor not registered")
 	}
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
 		Path: path, Language: "ruby", Content: []byte(src),
@@ -66,7 +66,7 @@ func findByName(props []map[string]string, name string) map[string]string {
 
 func mwExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_middleware", fi(path, "ruby", src))
+	return extract(t, "custom_ruby_middleware", fi(path, "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/ruby/observability.go
+++ b/internal/custom/ruby/observability.go
@@ -16,7 +16,7 @@
 // extractors (internal/custom/java/observability.go,
 // internal/custom/python/observability.go).
 //
-// A single extractor key "ruby_observability" is registered; the extractor
+// A single extractor key "custom_ruby_observability" is registered; the extractor
 // runs on any Ruby file regardless of framework.
 //
 // Part of issues #3282, #3343.
@@ -35,14 +35,14 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_observability", &rubyObservabilityExtractor{})
+	extractor.Register("custom_ruby_observability", &rubyObservabilityExtractor{})
 }
 
 // rubyObservabilityExtractor detects log, metric, and trace instrumentation
 // across Ruby source files.
 type rubyObservabilityExtractor struct{}
 
-func (e *rubyObservabilityExtractor) Language() string { return "ruby_observability" }
+func (e *rubyObservabilityExtractor) Language() string { return "custom_ruby_observability" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/observability_test.go
+++ b/internal/custom/ruby/observability_test.go
@@ -36,7 +36,7 @@ class PostsController < ApplicationController
   end
 end
 `
-	ents := extract(t, "ruby_observability", fi("app/controllers/posts_controller.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("app/controllers/posts_controller.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Rails.logger.info") {
 		t.Error("expected Rails.logger.info entity")
 	}
@@ -51,7 +51,7 @@ require 'logger'
 logger = Logger.new(STDOUT)
 logger.info "Application started"
 `
-	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/initializer.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Logger.new") {
 		t.Error("expected Logger.new entity")
 	}
@@ -62,7 +62,7 @@ func TestRubyObsSemanticLogger(t *testing.T) {
 require 'semantic_logger'
 SemanticLogger.add_appender(file_name: 'development.log', formatter: :color)
 `
-	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/initializer.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "SemanticLogger") {
 		t.Error("expected SemanticLogger entity")
 	}
@@ -70,7 +70,7 @@ SemanticLogger.add_appender(file_name: 'development.log', formatter: :color)
 
 func TestRubyObsLoggerRequireOnly(t *testing.T) {
 	src := `require 'logger'`
-	ents := extract(t, "ruby_observability", fi("lib/app.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/app.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "logger") {
 		t.Error("expected logger require entity")
 	}
@@ -87,7 +87,7 @@ prometheus = Prometheus::Client.registry
 counter = Prometheus::Client::Counter.new(:http_requests, docstring: 'A counter')
 gauge = Prometheus::Client::Gauge.new(:cpu_usage, docstring: 'CPU gauge')
 `
-	ents := extract(t, "ruby_observability", fi("lib/metrics.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/metrics.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Prometheus::Client::Counter") {
 		t.Error("expected Prometheus::Client::Counter entity")
 	}
@@ -103,7 +103,7 @@ statsd = Datadog::Statsd.new('localhost', 8125)
 statsd.increment('page.views', tags: ['page:home'])
 statsd.gauge('account.balance', 1000.0)
 `
-	ents := extract(t, "ruby_observability", fi("lib/metrics.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/metrics.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Datadog::Statsd.new") {
 		t.Error("expected Datadog::Statsd.new entity")
 	}
@@ -115,7 +115,7 @@ require 'yabeda'
 Yabeda.counter(:http_requests_total, comment: "Total HTTP requests")
 Yabeda.histogram(:request_duration, comment: "Duration", buckets: [0.1, 0.5, 1.0])
 `
-	ents := extract(t, "ruby_observability", fi("config/metrics.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/metrics.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Yabeda.counter") {
 		t.Error("expected Yabeda.counter entity")
 	}
@@ -129,7 +129,7 @@ func TestRubyObsStatsDRuby(t *testing.T) {
 StatsD.measure('request.time') { do_work }
 StatsD.increment('request.count')
 `
-	ents := extract(t, "ruby_observability", fi("lib/tracking.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/tracking.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "StatsD.measure") {
 		t.Error("expected StatsD.measure entity")
 	}
@@ -153,7 +153,7 @@ tracer.in_span("process_order") do |span|
   span.set_attribute('order.id', order_id)
 end
 `
-	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/initializer.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "process_order") {
 		t.Error("expected process_order trace_span entity from in_span")
 	}
@@ -169,7 +169,7 @@ Datadog.configure do |c|
   c.service = 'my-service'
 end
 `
-	ents := extract(t, "ruby_observability", fi("config/ddtrace.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/ddtrace.rb", "ruby", src))
 	if len(ents) == 0 {
 		t.Error("expected at least one trace entity from ddtrace")
 	}
@@ -182,7 +182,7 @@ Skylight.instrument(title: "perform_query") do
   run_query
 end
 `
-	ents := extract(t, "ruby_observability", fi("lib/query.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/query.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Skylight.instrument") {
 		t.Error("expected Skylight.instrument entity")
 	}
@@ -195,7 +195,7 @@ OpenTracing.start_active_span('operation_name') do |scope|
   scope.span.set_tag('user', user_id)
 end
 `
-	ents := extract(t, "ruby_observability", fi("lib/tracing.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("lib/tracing.rb", "ruby", src))
 	if len(ents) == 0 {
 		t.Error("expected at least one entity from opentracing")
 	}
@@ -215,7 +215,7 @@ class ApplicationController < ActionController::Base
   end
 end
 `
-	ents := extractFull(t, "ruby_observability", fi("app/controllers/application_controller.rb", "ruby", src))
+	ents := extractFull(t, "custom_ruby_observability", fi("app/controllers/application_controller.rb", "ruby", src))
 	found := false
 	for _, e := range ents {
 		if e.Properties["kind"] == "tagged_block" && e.Properties["library"] == "rails_tagged_logging" {
@@ -234,7 +234,7 @@ require 'active_support/tagged_logging'
 logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 logger.tagged("BCX") { logger.info "Stuff" }
 `
-	ents := extract(t, "ruby_observability", fi("config/application.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/application.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "ActiveSupport::TaggedLogging") {
 		t.Error("expected ActiveSupport::TaggedLogging entity")
 	}
@@ -248,7 +248,7 @@ Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Json.new
 end
 `
-	ents := extractFull(t, "ruby_observability", fi("config/initializers/lograge.rb", "ruby", src))
+	ents := extractFull(t, "custom_ruby_observability", fi("config/initializers/lograge.rb", "ruby", src))
 	// Expect at least the require entity or config entity
 	found := false
 	for _, e := range ents {
@@ -278,7 +278,7 @@ Yabeda.configure do
   end
 end
 `
-	ents := extract(t, "ruby_observability", fi("config/initializers/yabeda.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("config/initializers/yabeda.rb", "ruby", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "Yabeda.configure") {
 		t.Error("expected Yabeda.configure entity with kind=configure_block")
 	}
@@ -298,7 +298,7 @@ class OrderService
   end
 end
 `
-	ents := extractFull(t, "ruby_observability", fi("app/services/order_service.rb", "ruby", src))
+	ents := extractFull(t, "custom_ruby_observability", fi("app/services/order_service.rb", "ruby", src))
 	found := false
 	for _, e := range ents {
 		if e.Name == "process_order.order_service" {
@@ -325,7 +325,7 @@ ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, fin
   Rails.logger.debug "SQL: #{payload[:sql]}"
 end
 `
-	ents := extractFull(t, "ruby_observability", fi("config/initializers/notifications.rb", "ruby", src))
+	ents := extractFull(t, "custom_ruby_observability", fi("config/initializers/notifications.rb", "ruby", src))
 	found := false
 	for _, e := range ents {
 		if e.Name == "sql.active_record" {
@@ -350,7 +350,7 @@ class PaymentController < ApplicationController
   end
 end
 `
-	ents := extractFull(t, "ruby_observability", fi("app/controllers/payment_controller.rb", "ruby", src))
+	ents := extractFull(t, "custom_ruby_observability", fi("app/controllers/payment_controller.rb", "ruby", src))
 	found := false
 	for _, e := range ents {
 		if e.Name == "Rails.logger.error" {
@@ -380,7 +380,7 @@ class User
   end
 end
 `
-	ents := extract(t, "ruby_observability", fi("app/models/user.rb", "ruby", src))
+	ents := extract(t, "custom_ruby_observability", fi("app/models/user.rb", "ruby", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}

--- a/internal/custom/ruby/routes.go
+++ b/internal/custom/ruby/routes.go
@@ -51,8 +51,8 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_routes", &rubyRoutesExtractor{})
-	extractor.Register("ruby_driver_schema", &rubyDriverSchemaExtractor{})
+	extractor.Register("custom_ruby_routes", &rubyRoutesExtractor{})
+	extractor.Register("custom_ruby_driver_schema", &rubyDriverSchemaExtractor{})
 }
 
 // ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@ func init() {
 
 type rubyRoutesExtractor struct{}
 
-func (e *rubyRoutesExtractor) Language() string { return "ruby_routes" }
+func (e *rubyRoutesExtractor) Language() string { return "custom_ruby_routes" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes — Routes
@@ -358,7 +358,7 @@ func (e *rubyRoutesExtractor) Extract(ctx context.Context, file extractor.FileIn
 
 type rubyDriverSchemaExtractor struct{}
 
-func (e *rubyDriverSchemaExtractor) Language() string { return "ruby_driver_schema" }
+func (e *rubyDriverSchemaExtractor) Language() string { return "custom_ruby_driver_schema" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes — Driver Schema

--- a/internal/custom/ruby/routes_test.go
+++ b/internal/custom/ruby/routes_test.go
@@ -9,12 +9,12 @@ import (
 
 func routeExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_routes", fi(path, "ruby", src))
+	return extract(t, "custom_ruby_routes", fi(path, "ruby", src))
 }
 
 func driverSchemaExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_driver_schema", fi(path, "ruby", src))
+	return extract(t, "custom_ruby_driver_schema", fi(path, "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/ruby/sinatra_deep.go
+++ b/internal/custom/ruby/sinatra_deep.go
@@ -44,12 +44,12 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_sinatra_deep", &sinatraDeepExtractor{})
+	extractor.Register("custom_ruby_sinatra_deep", &sinatraDeepExtractor{})
 }
 
 type sinatraDeepExtractor struct{}
 
-func (e *sinatraDeepExtractor) Language() string { return "ruby_sinatra_deep" }
+func (e *sinatraDeepExtractor) Language() string { return "custom_ruby_sinatra_deep" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes — Sinatra deep

--- a/internal/custom/ruby/sinatra_deep_test.go
+++ b/internal/custom/ruby/sinatra_deep_test.go
@@ -9,7 +9,7 @@ import (
 
 func sinatraDeepExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_sinatra_deep", fi(path, "ruby", src))
+	return extract(t, "custom_ruby_sinatra_deep", fi(path, "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/ruby/validation.go
+++ b/internal/custom/ruby/validation.go
@@ -14,7 +14,7 @@
 // patterns but does NOT perform cross-file dataflow, so all cells are set to
 // `partial`.  This is consistent with the observability and auth extractors.
 //
-// A single extractor key "ruby_validation" is registered; it runs on any Ruby
+// A single extractor key "custom_ruby_validation" is registered; it runs on any Ruby
 // file regardless of framework.
 //
 // Part of issue #3282.
@@ -35,14 +35,14 @@ import (
 )
 
 func init() {
-	extractor.Register("ruby_validation", &rubyValidationExtractor{})
+	extractor.Register("custom_ruby_validation", &rubyValidationExtractor{})
 }
 
 // rubyValidationExtractor detects validation and DTO-like patterns across Ruby
 // source files.
 type rubyValidationExtractor struct{}
 
-func (e *rubyValidationExtractor) Language() string { return "ruby_validation" }
+func (e *rubyValidationExtractor) Language() string { return "custom_ruby_validation" }
 
 // ---------------------------------------------------------------------------
 // Compiled regexes

--- a/internal/custom/ruby/validation_deep_test.go
+++ b/internal/custom/ruby/validation_deep_test.go
@@ -22,9 +22,9 @@ import (
 // valExtractRaw extracts raw EntityRecord values from the ruby_validation extractor.
 func valExtractRaw(t *testing.T, path, src string) []types.EntityRecord {
 	t.Helper()
-	e, ok := extreg.Get("ruby_validation")
+	e, ok := extreg.Get("custom_ruby_validation")
 	if !ok {
-		t.Fatal("ruby_validation extractor not registered")
+		t.Fatal("custom_ruby_validation extractor not registered")
 	}
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
 		Path:     path,

--- a/internal/custom/ruby/validation_test.go
+++ b/internal/custom/ruby/validation_test.go
@@ -9,7 +9,7 @@ import (
 
 func valExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
-	return extract(t, "ruby_validation", fi(path, "ruby", src))
+	return extract(t, "custom_ruby_validation", fi(path, "ruby", src))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/extractors/custom_dispatch_smoke_test.go
+++ b/internal/extractors/custom_dispatch_smoke_test.go
@@ -1,0 +1,133 @@
+package extractors
+
+import (
+	"context"
+	"testing"
+)
+
+// hasEntity reports whether any record in recs has the given Kind and Name.
+func hasEntity(recs []entityNameKind, kind, name string) bool {
+	for _, e := range recs {
+		if e.kind == kind && e.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+type entityNameKind struct{ kind, name string }
+
+// runSmoke dispatches the full custom-extractor pass for a language+file
+// through the REAL registry (populated by custom_registry.go's blank imports)
+// and returns the flattened (kind,name) pairs of every emitted entity.
+//
+// Crucially this exercises CustomExtractorsFor → prefix selection, exactly the
+// path that silently dropped the bare-stem Ruby/PHP extractors before #3587/
+// #3592. If an extractor is not wired to a dispatch prefix it contributes
+// nothing here, so a specific-entity assertion fails — proving live wiring.
+func runSmoke(t *testing.T, language, path, content string) []entityNameKind {
+	t.Helper()
+	ents, errs := RunCustomExtractors(context.Background(), FileInput{
+		Path:     path,
+		Language: language,
+		Content:  []byte(content),
+	})
+	for _, err := range errs {
+		t.Fatalf("custom dispatch returned error for %s/%s: %v", language, path, err)
+	}
+	out := make([]entityNameKind, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entityNameKind{kind: e.Kind, name: e.Name})
+	}
+	return out
+}
+
+// TestSmokeRubyOrphansFireViaDispatch proves that the previously-orphaned Ruby
+// framework extractors are now selected by language dispatch AND actually emit
+// their expected entities when run through RunCustomExtractors("ruby", …).
+func TestSmokeRubyOrphansFireViaDispatch(t *testing.T) {
+	// ruby_auth (custom_ruby_auth): devise_for route auth pattern.
+	authSrc := `
+Rails.application.routes.draw do
+  devise_for :users
+end
+`
+	got := runSmoke(t, "ruby", "config/routes.rb", authSrc)
+	if !hasEntity(got, "SCOPE.Pattern", "devise_for:users") {
+		t.Errorf("custom_ruby_auth did not fire via dispatch: expected SCOPE.Pattern devise_for:users, got %v", got)
+	}
+
+	// ruby_routes (custom_ruby_routes): Grape resource component.
+	routesSrc := `
+class UsersAPI < Grape::API
+  resource :users do
+    get do
+      User.all
+    end
+  end
+end
+`
+	got = runSmoke(t, "ruby", "app/api/users_api.rb", routesSrc)
+	if !hasEntity(got, "SCOPE.Component", "grape_resource:users") {
+		t.Errorf("custom_ruby_routes did not fire via dispatch: expected SCOPE.Component grape_resource:users, got %v", got)
+	}
+
+	// ruby_validation (custom_ruby_validation): strong-params request validation.
+	valSrc := `
+class ArticlesController < ApplicationController
+  def article_params
+    params.require(:article).permit(:title, :body, :published)
+  end
+end
+`
+	got = runSmoke(t, "ruby", "app/controllers/articles_controller.rb", valSrc)
+	if !hasEntity(got, "SCOPE.Pattern", "strong_params:params.require(:article)") {
+		t.Errorf("custom_ruby_validation did not fire via dispatch: expected strong_params request_validation pattern, got %v", got)
+	}
+}
+
+// TestSmokePhpOrphansFireViaDispatch proves the previously-orphaned PHP
+// framework extractors are now selected by dispatch AND emit expected entities
+// via RunCustomExtractors("php", …).
+func TestSmokePhpOrphansFireViaDispatch(t *testing.T) {
+	// php_doctrine_orm_data (custom_php_doctrine_orm_data): ORM column schema.
+	doctrineSrc := `<?php
+namespace App\Entity;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+class User
+{
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $username;
+
+    #[ORM\Column(type: 'string', unique: true)]
+    private string $email;
+}
+`
+	got := runSmoke(t, "php", "User.php", doctrineSrc)
+	if !hasEntity(got, "SCOPE.Schema", "username") {
+		t.Errorf("custom_php_doctrine_orm_data did not fire via dispatch: expected SCOPE.Schema username column, got %v", got)
+	}
+	if !hasEntity(got, "SCOPE.Schema", "email") {
+		t.Errorf("custom_php_doctrine_orm_data did not fire via dispatch: expected SCOPE.Schema email column, got %v", got)
+	}
+
+	// php_pest_test (custom_php_pest_test): Pest test-case operations.
+	pestSrc := `<?php
+uses(Tests\TestCase::class);
+
+it('can create a user', function () {
+    $user = User::factory()->create();
+    expect($user->id)->toBeInt();
+});
+
+test('user email is unique', function () {
+    // ...
+});
+`
+	got = runSmoke(t, "php", "UserTest.php", pestSrc)
+	if !hasEntity(got, "SCOPE.Operation", "can create a user") {
+		t.Errorf("custom_php_pest_test did not fire via dispatch: expected SCOPE.Operation 'can create a user', got %v", got)
+	}
+}

--- a/internal/extractors/dispatch_parity_test.go
+++ b/internal/extractors/dispatch_parity_test.go
@@ -1,0 +1,168 @@
+package extractors
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// TestEveryRegisteredCustomKeyDispatches is the dispatch-parity guard.
+//
+// Background (CORE #3587 / #3592): custom framework extractors register into
+// the global registry under a language-encoding key prefix and are selected at
+// runtime by CustomExtractorsFor via strings.HasPrefix against the prefix in
+// customPrefixForLanguage. Their unit tests call .Extract() directly, so an
+// extractor registered under a prefix that no language maps to (e.g. the bare
+// `ruby_*` / `php_*` stems the Ruby and PHP framework extractors used to use)
+// passes every unit test yet is NEVER invoked by the live pipeline — silently
+// producing zero entities in production.
+//
+// This guard enumerates EVERY key in the real, fully-populated registry (the
+// custom sub-packages are blank-imported by custom_registry.go) and asserts
+// that every key which looks like a custom/framework extractor key dispatches
+// under exactly one mapped prefix. Any key that does not is reported as a
+// FAILURE listing the orphaned key, so a future mis-registration is caught at
+// CI time instead of in production.
+//
+// It deliberately does NOT call cleanRegistry: the assertion is against the
+// production registry contents, not a synthetic fixture set.
+//
+// Pre-fix, this test would have FAILED listing all 20 Ruby+PHP orphans (and it
+// also covers the Lua framework keys — #3548 — which dispatch under the bare
+// `lua_` prefix that customPrefixForLanguage maps explicitly).
+func TestEveryRegisteredCustomKeyDispatches(t *testing.T) {
+	// All dispatch prefixes that customPrefixForLanguage can select with.
+	// Deduplicated because several languages share a prefix (e.g. js/ts).
+	prefixSet := map[string]struct{}{}
+	for _, prefix := range customPrefixForLanguage {
+		prefixSet[prefix] = struct{}{}
+	}
+	prefixes := make([]string, 0, len(prefixSet))
+	for p := range prefixSet {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+
+	// dispatches reports whether a key would be selected by CustomExtractorsFor
+	// for at least one language: it must HasPrefix some mapped prefix AND be
+	// strictly longer than that prefix (mirroring the len(k) > len(prefix) guard
+	// in CustomExtractorsFor, which excludes the bare base-language key).
+	dispatches := func(key string) bool {
+		for _, p := range prefixes {
+			if strings.HasPrefix(key, p) && len(key) > len(p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Authoritative classification of every registered key, derived from the
+	// registry itself rather than a hand-maintained prefix list:
+	//
+	//   - A BASE language extractor registers under a bare language identifier
+	//     (e.g. "go", "ruby", "php", "python", "lua", "typescript"). These are
+	//     intentionally NON-dispatching and must be excluded.
+	//   - A FRAMEWORK / custom extractor registers under "<baseLang>_<suffix>"
+	//     (e.g. "custom_php_pest_test" under base "custom"? no — under a
+	//     language stem). Concretely: its key starts with some *other*
+	//     registered base key followed by "_". Every such key MUST dispatch.
+	//
+	// This catches the exact bug class of #3587/#3592 (Ruby/PHP framework
+	// extractors that registered under bare "ruby_*"/"php_*" stems — which
+	// start with the registered base keys "ruby"/"php" + "_" — yet matched no
+	// dispatch prefix) AND #3548 (Lua), independent of the prefix-mapping
+	// details. Pre-fix it would report all 20 orphans.
+	registered := map[string]bool{}
+	for _, k := range extractor.List() {
+		registered[k] = true
+	}
+
+	// Known legitimate non-dispatching compound base extractors: keys of the
+	// form "<baseLang>_<suffix>" that are themselves base/manifest extractors
+	// (not framework dispatch targets). swift_package is the package-manifest
+	// extractor, registered alongside the bare "swift" grammar extractor.
+	nonDispatchingBaseAllow := map[string]bool{
+		"swift_package": true,
+	}
+
+	// isCustomLooking reports whether key is a framework/custom extractor that
+	// must dispatch: it begins with some *other* registered base key + "_" and
+	// is not an allow-listed compound base extractor.
+	isCustomLooking := func(key string) bool {
+		if nonDispatchingBaseAllow[key] {
+			return false
+		}
+		for base := range registered {
+			if base != key && strings.HasPrefix(key, base+"_") {
+				return true
+			}
+		}
+		return false
+	}
+
+	var orphans []string
+	for _, key := range extractor.List() {
+		if isCustomLooking(key) && !dispatches(key) {
+			orphans = append(orphans, key)
+		}
+	}
+	sort.Strings(orphans)
+
+	if len(orphans) > 0 {
+		t.Fatalf("dispatch-parity violation: %d custom extractor key(s) register "+
+			"under a prefix no language maps to in customPrefixForLanguage and "+
+			"are therefore NEVER invoked by the live pipeline (unit tests calling "+
+			".Extract() directly do not catch this):\n  %s\n"+
+			"Fix: either add the prefix to customPrefixForLanguage or rename the "+
+			"key to an existing mapped prefix (e.g. custom_<lang>_*).",
+			len(orphans), strings.Join(orphans, "\n  "))
+	}
+}
+
+// TestRubyAndPhpOrphansNowDispatch is a focused regression assertion for the
+// exact 20 keys fixed in #3587 / #3592: every previously-orphaned Ruby and PHP
+// framework extractor must now be selected by CustomExtractorsFor for its
+// language. This pins the fix so a future rename cannot silently re-orphan them.
+func TestRubyAndPhpOrphansNowDispatch(t *testing.T) {
+	cases := map[string][]string{
+		"ruby": {
+			"custom_ruby_auth",
+			"custom_ruby_cuba_routing",
+			"custom_ruby_dry_types",
+			"custom_ruby_grape_deep",
+			"custom_ruby_middleware",
+			"custom_ruby_observability",
+			"custom_ruby_routes",
+			"custom_ruby_driver_schema",
+			"custom_ruby_sinatra_deep",
+			"custom_ruby_validation",
+		},
+		"php": {
+			"custom_php_sql_driver_schema",
+			"custom_php_obs_laravel_symfony",
+			"custom_php_doctrine_orm_data",
+			"custom_php_eloquent_orm_data",
+			"custom_php_cycleorm_data",
+			"custom_php_propel_orm_data",
+			"custom_php_redbeanphp_data",
+			"custom_php_behat_test",
+			"custom_php_codeception_test",
+			"custom_php_pest_test",
+		},
+	}
+
+	for lang, wantKeys := range cases {
+		selected := map[string]bool{}
+		for _, e := range CustomExtractorsFor(lang) {
+			selected[e.Language()] = true
+		}
+		for _, k := range wantKeys {
+			if !selected[k] {
+				t.Errorf("%s: previously-orphaned extractor %q is not selected by "+
+					"CustomExtractorsFor(%q) — it would never run live", lang, k, lang)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #3587
Closes #3592

## Problem

`custom_dispatch.go::customPrefixForLanguage` maps `ruby → "custom_ruby_"` and `php → "custom_php_"`, and `CustomExtractorsFor` selects extractors via `strings.HasPrefix(key, prefix)`. 20 complete, fully-tested Ruby and PHP framework extractors registered under **bare stems** that match no dispatch prefix, so they were **silently dropped at runtime**. Their unit tests call `.Extract()` directly, so they stayed green while the extractors never ran in the live pipeline — producing zero entities in production. This PR **restores** that lost coverage.

## Fix

Renamed each orphan's `extractor.Register(...)` key **and** its `Language()` return value to a dispatching `custom_<lang>_*` key (keys remain unique; every reference in source + tests updated).

### Key rename table

| # | Old key | New key |
|---|---------|---------|
| 1 | `ruby_auth` | `custom_ruby_auth` |
| 2 | `ruby_cuba_routing` | `custom_ruby_cuba_routing` |
| 3 | `ruby_dry_types` | `custom_ruby_dry_types` |
| 4 | `ruby_grape_deep` | `custom_ruby_grape_deep` |
| 5 | `ruby_middleware` | `custom_ruby_middleware` |
| 6 | `ruby_observability` | `custom_ruby_observability` |
| 7 | `ruby_routes` | `custom_ruby_routes` |
| 8 | `ruby_driver_schema` | `custom_ruby_driver_schema` |
| 9 | `ruby_sinatra_deep` | `custom_ruby_sinatra_deep` |
| 10 | `ruby_validation` | `custom_ruby_validation` |
| 11 | `php_sql_driver_schema` | `custom_php_sql_driver_schema` |
| 12 | `phpObs_laravel_symfony` | `custom_php_obs_laravel_symfony` |
| 13 | `php_doctrine_orm_data` | `custom_php_doctrine_orm_data` |
| 14 | `php_eloquent_orm_data` | `custom_php_eloquent_orm_data` |
| 15 | `php_cycleorm_data` | `custom_php_cycleorm_data` |
| 16 | `php_propel_orm_data` | `custom_php_propel_orm_data` |
| 17 | `php_redbeanphp_data` | `custom_php_redbeanphp_data` |
| 18 | `php_behat_test` | `custom_php_behat_test` |
| 19 | `php_codeception_test` | `custom_php_codeception_test` |
| 20 | `php_pest_test` | `custom_php_pest_test` |

> Note: the ticket listed `php_cycleorm_orm_data` / `php_redbeanphp_orm_data`; the actual registered keys are `php_cycleorm_data` / `php_redbeanphp_data` — the real keys were used. `validation_deep.go` / `activerecord_deep.go` are reachable only via these registered extractors and are now live again.

## Tests

Two new regression tests in `internal/extractors/` (run against the **real**, blank-import-populated registry — not a synthetic fixture set):

- **`dispatch_parity_test.go` — dispatch-parity guard.** Enumerates every registered key and fails listing any framework/custom key that dispatches under no mapped prefix. Classification is derived from the registry itself (a key is custom-looking iff it starts with another registered base key + `_`), so it is robust to prefix-mapping details. **Pre-fix it would have FAILED listing all 20 Ruby+PHP orphans.** Verified locally that re-orphaning a single key makes it fail. **It also guards the Lua framework keys (#3548)** under the bare `lua_` stem.
- **`custom_dispatch_smoke_test.go` — value-asserting smoke test.** Drives `RunCustomExtractors("ruby"/"php", …)` and asserts specific emitted entities: Ruby auth (`devise_for:users`), routes (`grape_resource:users`), validation (strong-params pattern); PHP Doctrine ORM column schema (`username`/`email`), Pest test cases (`can create a user`). Proves end-to-end wiring, not just registration.

## Verification

- Targeted tests green: `internal/custom/ruby`, `internal/custom/php`, `internal/extractors`, `internal/engine`, `internal/types`, `tools/coverage`.
- `coverage validate`: 0 errors. `coverage fmt --check`: registry.json canonical. Registry untouched (no cite path changed).
- `gofmt -l` empty on all changed/new files; `go vet` clean.

## Deploy

**DEPLOY-DEFERRED** — wiring + test-only change; requires a coordinated daemon rebuild + reindex to take effect on live graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)