### PR TITLE
Add mobile HTTP-client extraction -> outbound cross_links (#3574)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9648,8 +9648,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "data_fetching": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_dart_client.go","internal/engine/http_endpoint_dart_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Dio (dio.get/post/put/delete) and package:http (http.get(Uri.parse(...))) outbound calls -\u003e one http_endpoint_call (consumer) per call site + FETCHES from the enclosing function; host stripped, $id/${expr} -\u003e {id}/{param} to match server-route normalisation. Value-asserted in http_endpoint_dart_client_test.go (e.g. dio.post(\"/auth/login\") -\u003e POST /auth/login, http.get(Uri.parse(\".../v1/users\")) -\u003e GET /v1/users)."
           },
           "prop_extraction": {
             "status": "missing",
@@ -9726,8 +9727,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_dart_client.go","internal/engine/http_endpoint_dart_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Each Dio / package:http call is recorded as an outbound HTTP effect (verb + canonical path) emitted with the SAME http_endpoint_call entity shape as the backend producer side, so the cross-repo linker pairs the Flutter screen with the backend route on reindex. Value-asserted in http_endpoint_dart_client_test.go."
           },
           "import_resolution_quality": {
             "status": "missing",
@@ -55849,6 +55851,334 @@
             "status": "full",
             "cites": ["internal/custom/scala/orm_extractors.go"],
             "notes": "slickMigrationRe captures schema.create / schema.createIfNotExists / DBIO.seq DDL patterns; full SQL migration file parsing not applicable (use Flyway)"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.swift.framework.alamofire",
+      "category": "http_framework",
+      "subcategory": "mobile",
+      "language": "swift",
+      "label": "Alamofire (HTTP client)",
+      "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "navigation_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "screen_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Platform": {
+          "platform_branching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_swift_client.go","internal/engine/http_endpoint_swift_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Alamofire AF.request(\"...\", method: .verb) / session.request(...) outbound calls -\u003e one http_endpoint_call (consumer) per call site + FETCHES from the enclosing func; host stripped, \\(expr) -\u003e {param}; verb from method: .verb (default GET). Same entity shape as the backend producer so the cross-repo linker pairs the iOS screen with the backend route on reindex. Value-asserted in http_endpoint_swift_client_test.go (AF.request(\"/auth/login\", method: .post) -\u003e POST /auth/login)."
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.swift.framework.urlsession",
+      "category": "http_framework",
+      "subcategory": "mobile",
+      "language": "swift",
+      "label": "URLSession (HTTP client)",
+      "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "navigation_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "screen_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Platform": {
+          "platform_branching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_swift_client.go","internal/engine/http_endpoint_swift_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "URLSession via URL(string: \"...\") + request.httpMethod = \"VERB\" (default GET) -\u003e one http_endpoint_call (consumer) per URL site + FETCHES from the enclosing func; host stripped, \\(expr) -\u003e {param}. Same entity shape as the backend producer so the cross-repo linker pairs the iOS screen with the backend route on reindex. Value-asserted in http_endpoint_swift_client_test.go (URL(string: \".../v1/users\") -\u003e GET /v1/users; httpMethod=\"POST\" + URL(string:\"/auth/login\") -\u003e POST /auth/login)."
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/internal/engine/http_endpoint_dart_client.go
+++ b/internal/engine/http_endpoint_dart_client.go
@@ -1,0 +1,182 @@
+// Dart / Flutter consumer-side HTTP client synthesis (#3574, epic #3571).
+//
+// Flutter mobile screens reach their backend through one of two dominant Dart
+// HTTP clients:
+//
+//   - Dio (https://pub.dev/packages/dio) — the de-facto Flutter networking lib:
+//     dio.get("/users"), dio.post("/auth/login", data: body)
+//     dio.put("/users/$id"), dio.delete("/users/${user.id}")
+//     _dio.get("https://api.example.com/v1/users")
+//
+//   - package:http (https://pub.dev/packages/http) — the lower-level client:
+//     http.get(Uri.parse("https://api.example.com/v1/users"))
+//     http.post(Uri.parse("/auth/login"), body: payload)
+//     client.get(Uri.parse("/users/$id"))
+//
+// Before this pass a Flutter app that called a downstream API produced no
+// http_endpoint_call entity and no cross-repo FETCHES edge — the mobile side of
+// the cross-link graph was invisible, so a backend route served by the Upvate
+// API had no consumer edge from the mobile screen that calls it.
+//
+// This emits one synthetic http_endpoint_call per detected Dio / http verb call
+// site (via the shared emitClientRuntime from applyHTTPEndpointSynthesis), so
+// the existing cross-repo linker pairs them with producer-side route
+// definitions by canonical path Name. The entity shape is IDENTICAL to the
+// scala/elixir/kotlin client synthesizers (kind=http_endpoint_call,
+// id=http:<VERB>:<path>, FETCHES edge from the enclosing function) — the
+// cross-repo join depends on that identical shape.
+//
+// The URL host is stripped (the producer serves "/v1/users" without the host);
+// Dart string-interpolation markers `$id` / `${expr}` become `{id}` / `{param}`
+// placeholders to match server-route normalisation. The enclosing
+// `<ret> name(...)` / `Future<...> name(...) async` is attributed as the
+// calling reference.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// dartDioVerbRe matches a Dio verb call whose first positional argument is a
+// double-quoted or single-quoted string literal:
+//
+//	dio.get("/users")            _dio.post('/auth/login')
+//	apiClient.dio.put("/x/$id")  client.delete("...")
+//
+// Receiver allow-list (left side of the `.`): dio, _dio, client, _client,
+// apiClient, httpClient, http (the `http` form is also matched by the http.get
+// + Uri.parse pattern below; the side-scoped dedup collapses the duplicate ID).
+// Group 1 = verb, group 2 = double-quoted body, group 3 = single-quoted body.
+var dartDioVerbRe = regexp.MustCompile(
+	`\b(?:dio|_dio|client|_client|apiClient|httpClient|http)\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*(?:"([^"\n\r]+)"|'([^'\n\r]+)')`,
+)
+
+// dartHttpUriVerbRe matches the package:http form where the URL is wrapped in
+// `Uri.parse(...)`:
+//
+//	http.get(Uri.parse("https://api.example.com/v1/users"))
+//	http.post(Uri.parse('/auth/login'), body: payload)
+//	client.get(Uri.parse("/users/$id"))
+//
+// Group 1 = verb, group 2 = double-quoted body, group 3 = single-quoted body.
+var dartHttpUriVerbRe = regexp.MustCompile(
+	`\b(?:http|client|_client)\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*Uri\s*\.\s*parse\s*\(\s*(?:"([^"\n\r]+)"|'([^'\n\r]+)')`,
+)
+
+// dartInterpRe rewrites a Dart string-interpolation marker (`$id` or
+// `${expr}`) into a `{id}` / `{param}` placeholder so the canonical path is
+// stable across call sites and matches the server-route normalisation.
+var dartInterpRe = regexp.MustCompile(`\$\{[^}]*\}|\$[A-Za-z_]\w*`)
+
+// dartEnclosingFuncRe captures Dart function / method declarations for caller
+// attribution. Handles bare functions, async functions, and methods with a
+// return type:
+//
+//	Future<List<User>> fetchUsers() async { ... }
+//	void createUser(User u) { ... }
+//	login(String email) async { ... }
+//
+// The return type (if any) is optional; group 1 is the declared name. The
+// trailing `(` anchors it to a callable declaration (not a field). Dart
+// keywords that can precede a method (`static`, `Future`, `void`, etc.) are
+// absorbed by the optional type prefix.
+var dartEnclosingFuncRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:(?:static|final|external|abstract)\s+)*(?:[\w<>,\[\]?.]+\s+)?([A-Za-z_]\w*)\s*\([^;{]*\)\s*(?:async\s*\*?\s*)?\{`,
+)
+
+// dartClientEmitFn is the runtime-aware emitter type for the Dart client.
+type dartClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeDartClientWithRuntime is the package-level entry point referenced
+// from applyHTTPEndpointSynthesis. Emits one outbound http_endpoint_call per
+// Dio / http verb call site + a FETCHES edge from the enclosing function.
+func synthesizeDartClientWithRuntime(content string, emit dartClientEmitFn) {
+	if !strings.Contains(content, "dio") && !strings.Contains(content, "Dio") &&
+		!strings.Contains(content, "http.") && !strings.Contains(content, "Uri.parse") &&
+		!strings.Contains(content, ".get(") && !strings.Contains(content, ".post(") {
+		return
+	}
+
+	funcs := indexDartFuncs(content)
+
+	emitMatch := func(m []int, verbG, dqG, sqG int, framework string) {
+		verb := strings.ToUpper(content[m[verbG]:m[verbG+1]])
+		raw := ""
+		if m[dqG] >= 0 {
+			raw = content[m[dqG]:m[dqG+1]]
+		} else if m[sqG] >= 0 {
+			raw = content[m[sqG]:m[sqG+1]]
+		}
+		if raw == "" {
+			return
+		}
+		runtimeDynamic := strings.Contains(raw, "$")
+		raw = canonicalizeDartInterpolation(raw)
+		path, ok := normalizeRawClientPath(raw)
+		if !ok {
+			return
+		}
+		caller := enclosingDartFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, path)
+		emit(verb, canonical, framework, "Function", caller, runtimeDynamic)
+	}
+
+	// package:http via Uri.parse runs FIRST: `http.get(Uri.parse("..."))`
+	// overlaps the bare `http.get("...")` receiver shape, so claiming the ID
+	// here stamps the correct `http` framework label; the side-scoped dedup in
+	// applyHTTPEndpointSynthesis then suppresses the Dio re-emission.
+	for _, m := range dartHttpUriVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		emitMatch(m, 2, 4, 6, "http_dart")
+	}
+
+	// Dio verb calls.
+	for _, m := range dartDioVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		emitMatch(m, 2, 4, 6, "dio")
+	}
+}
+
+// canonicalizeDartInterpolation rewrites Dart `$x` / `${expr}` interpolation
+// markers inside a URL-literal body to `{param}` placeholders.
+func canonicalizeDartInterpolation(raw string) string {
+	return dartInterpRe.ReplaceAllStringFunc(raw, func(tok string) string {
+		if strings.HasPrefix(tok, "${") {
+			return "{param}"
+		}
+		name := strings.TrimPrefix(tok, "$")
+		return "{" + name + "}"
+	})
+}
+
+// indexDartFuncs builds a sorted (offset, name) list for every Dart
+// function / method declaration in the file, for enclosing-fn attribution.
+func indexDartFuncs(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range dartEnclosingFuncRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		// Skip control-flow keywords the loose return-type prefix can capture
+		// when a block follows (`if (...) {`, `for (...) {`, etc.).
+		switch name {
+		case "if", "for", "while", "switch", "catch", "return":
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: name})
+	}
+	return out
+}
+
+// enclosingDartFuncAt returns the nearest preceding function name for a call site.
+func enclosingDartFuncAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_dart_client_test.go
+++ b/internal/engine/http_endpoint_dart_client_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import "testing"
+
+// TestDartClient_DioLiteralGetPost covers the canonical Dio forms
+// `dio.get("/users")` and `dio.post("/auth/login")`, asserting the SPECIFIC
+// canonical paths + verbs and the FETCHES edges from the enclosing functions
+// (value-asserting; not len>0).
+func TestDartClient_DioLiteralGetPost(t *testing.T) {
+	src := `
+import 'package:dio/dio.dart';
+
+class ApiClient {
+  final Dio dio = Dio();
+
+  Future<List<User>> fetchUsers() async {
+    return dio.get("/users");
+  }
+
+  Future<Token> login(String email) async {
+    return dio.post("/auth/login", data: {"email": email});
+  }
+}
+`
+	ids, rels := runDetectWithRels(t, "dart", "lib/api_client.dart", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:POST:/auth/login",
+	}, "dio-literal")
+	requireFetches(t, rels, "http:GET:/users", "dio-literal")
+	requireFetches(t, rels, "http:POST:/auth/login", "dio-literal")
+}
+
+// TestDartClient_DioInterpolatedPath covers a Dio path with a Dart
+// string-interpolation `$id` → `{id}` placeholder, asserting the exact path
+// /inspections/{id} (matching the backend route normalisation).
+func TestDartClient_DioInterpolatedPath(t *testing.T) {
+	src := `
+import 'package:dio/dio.dart';
+
+Future<Inspection> getInspection(String id) async {
+  return dio.get("/inspections/$id");
+}
+
+Future<void> updateUser(User user) async {
+  await dio.put("/users/${user.id}");
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/inspections.dart", src)
+	requireContains(t, ids, []string{
+		"http:GET:/inspections/{id}",
+		"http:PUT:/users/{param}",
+	}, "dio-interp")
+}
+
+// TestDartClient_HttpUriParse covers the package:http form
+// `http.get(Uri.parse("https://api.example.com/v1/users"))` and a POST,
+// asserting that the host is stripped to leave the producer route /v1/users.
+func TestDartClient_HttpUriParse(t *testing.T) {
+	src := `
+import 'package:http/http.dart' as http;
+
+Future<void> loadProfile() async {
+  final res = await http.get(Uri.parse("https://api.example.com/v1/users"));
+}
+
+Future<void> signIn(String email) async {
+  await http.post(Uri.parse("/auth/login"), body: {"email": email});
+}
+`
+	ids, rels := runDetectWithRels(t, "dart", "lib/http_api.dart", src)
+	requireContains(t, ids, []string{
+		"http:GET:/v1/users",
+		"http:POST:/auth/login",
+	}, "http-uriparse")
+	requireFetches(t, rels, "http:GET:/v1/users", "http-uriparse")
+}
+
+// TestDartClient_NoMatch asserts a Dart file with no HTTP-client call produces
+// no http synthetic.
+func TestDartClient_NoMatch(t *testing.T) {
+	src := `
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Text("hello");
+  }
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/home_screen.dart", src)
+	for _, id := range ids {
+		if len(id) >= 5 && id[:5] == "http:" {
+			t.Errorf("dio-no-match: unexpected http synthetic %q", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_swift_client.go
+++ b/internal/engine/http_endpoint_swift_client.go
@@ -1,0 +1,224 @@
+// Swift (iOS) consumer-side HTTP client synthesis (#3574, epic #3571).
+//
+// iOS mobile screens reach their backend through one of two dominant Swift
+// HTTP clients:
+//
+//   - URLSession (Foundation, first-party):
+//     URLSession.shared.dataTask(with: URL(string: "https://api.example.com/v1/users"))
+//     var request = URLRequest(url: URL(string: "/auth/login")!); request.httpMethod = "POST"
+//
+//   - Alamofire (https://github.com/Alamofire/Alamofire) — the de-facto 3rd-party lib:
+//     AF.request("https://api.example.com/v1/users")
+//     AF.request("/auth/login", method: .post)
+//     session.request("/users/\(id)", method: .put)
+//
+// Before this pass an iOS app that called a downstream API produced no
+// http_endpoint_call entity and no cross-repo FETCHES edge — the iOS side of
+// the cross-link graph was invisible.
+//
+// This emits one synthetic http_endpoint_call per detected URLSession /
+// Alamofire call site (via the shared emitClientRuntime from
+// applyHTTPEndpointSynthesis), so the existing cross-repo linker pairs them
+// with producer-side route definitions by canonical path Name. The entity shape
+// is IDENTICAL to the scala/elixir/kotlin/dart client synthesizers
+// (kind=http_endpoint_call, id=http:<VERB>:<path>, FETCHES edge from the
+// enclosing function) — the cross-repo join depends on that identical shape.
+//
+// The URL host is stripped; Swift string-interpolation markers `\(expr)` become
+// `{param}` placeholders to match server-route normalisation. The enclosing
+// `func name(...)` is attributed as the calling reference.
+//
+// Verb resolution:
+//   - URLSession defaults to GET unless an adjacent `httpMethod = "VERB"`
+//     assignment is found within a forward window of the URL site.
+//   - Alamofire defaults to GET unless a `method: .verb` argument is present on
+//     the same request call.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// swiftURLStringRe matches a `URL(string: "...")` / `URL(string: "...")!`
+// constructor whose argument is a string literal. Group 1 = the URL body.
+var swiftURLStringRe = regexp.MustCompile(
+	`URL\s*\(\s*string\s*:\s*"([^"\n\r]+)"`,
+)
+
+// swiftAlamofireRequestRe matches an Alamofire request whose first positional
+// argument is a string-literal URL, optionally followed by `method: .verb`:
+//
+//	AF.request("https://.../path")
+//	AF.request("/path", method: .post)
+//	session.request("/path", method: .put)
+//
+// Group 1 = the URL body. The verb is resolved separately by scanning the
+// request call's argument list for `method: .<verb>` (swiftAFMethodRe).
+var swiftAlamofireRequestRe = regexp.MustCompile(
+	`\b(?:AF|session|_session|manager|sessionManager)\s*\.\s*request\s*\(\s*"([^"\n\r]+)"`,
+)
+
+// swiftAFMethodRe captures an Alamofire `method: .get` / `.post` argument.
+var swiftAFMethodRe = regexp.MustCompile(
+	`method\s*:\s*\.\s*(get|post|put|patch|delete|head|options)\b`,
+)
+
+// swiftHTTPMethodAssignRe captures `request.httpMethod = "POST"` (URLSession /
+// URLRequest verb assignment). Group 1 = the verb string.
+var swiftHTTPMethodAssignRe = regexp.MustCompile(
+	`\.\s*httpMethod\s*=\s*"([A-Za-z]+)"`,
+)
+
+// swiftInterpRe rewrites a Swift string-interpolation marker `\(expr)` into a
+// `{param}` placeholder so the canonical path is stable across call sites.
+var swiftInterpRe = regexp.MustCompile(`\\\([^)]*\)`)
+
+// swiftEnclosingFuncRe captures Swift function / method declarations for caller
+// attribution:
+//
+//	func fetchUsers() async throws -> [User] { ... }
+//	private func login(_ email: String) { ... }
+//	@objc func reload() { ... }
+var swiftEnclosingFuncRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:@\w+\s+)*(?:(?:public|private|internal|fileprivate|open|static|final|override|class|mutating|nonisolated)\s+)*func\s+([A-Za-z_]\w*)\s*[\(<]`,
+)
+
+// swiftClientEmitFn is the runtime-aware emitter type for the Swift client.
+type swiftClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeSwiftClientWithRuntime is the package-level entry point referenced
+// from applyHTTPEndpointSynthesis. Emits one outbound http_endpoint_call per
+// URLSession / Alamofire call site + a FETCHES edge from the enclosing func.
+func synthesizeSwiftClientWithRuntime(content string, emit swiftClientEmitFn) {
+	if !strings.Contains(content, "URL(string:") && !strings.Contains(content, "URL(string :") &&
+		!strings.Contains(content, ".request(") && !strings.Contains(content, "URLSession") &&
+		!strings.Contains(content, "AF.") {
+		return
+	}
+
+	funcs := indexSwiftFuncs(content)
+
+	doEmit := func(siteOffset int, rawURL, verb, framework string) {
+		runtimeDynamic := strings.Contains(rawURL, `\(`)
+		rawURL = canonicalizeSwiftInterpolation(rawURL)
+		path, ok := normalizeRawClientPath(rawURL)
+		if !ok {
+			return
+		}
+		caller := enclosingSwiftFuncAt(funcs, siteOffset)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, path)
+		emit(verb, canonical, framework, "Function", caller, runtimeDynamic)
+	}
+
+	// Alamofire FIRST: `AF.request("...")` does not wrap the URL in
+	// URL(string:), so its sites are disjoint from URLSession; ordering only
+	// matters for label correctness on the rare overlap.
+	for _, m := range swiftAlamofireRequestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		rawURL := content[m[2]:m[3]]
+		verb := swiftResolveAlamofireVerb(content, m[1])
+		doEmit(m[0], rawURL, verb, "alamofire")
+	}
+
+	// URLSession / URLRequest via URL(string: "...").
+	urlSites := swiftURLStringRe.FindAllStringSubmatchIndex(content, -1)
+	for i, m := range urlSites {
+		if len(m) < 4 {
+			continue
+		}
+		rawURL := content[m[2]:m[3]]
+		// Clamp the httpMethod search window to the neighbouring URL(string:)
+		// sites so a verb assignment belonging to a DIFFERENT request (a later
+		// function) can't leak back onto this URL. The configuration of a
+		// URLRequest follows its URL construction, so we look forward up to the
+		// next URL(string:) site (or 512 bytes, whichever is closer).
+		windowEnd := len(content)
+		if i+1 < len(urlSites) {
+			windowEnd = urlSites[i+1][0]
+		}
+		verb := swiftResolveURLSessionVerb(content, m[1], windowEnd)
+		doEmit(m[0], rawURL, verb, "urlsession")
+	}
+}
+
+// swiftResolveAlamofireVerb scans the `.request(...)` argument list (bounded by
+// the balanced closing paren, capped at 200 bytes) for a `method: .verb`
+// argument; defaults to GET. Bounding to the call's own arg list prevents a
+// `method:` belonging to a LATER request call from being attributed here.
+func swiftResolveAlamofireVerb(content string, pos int) string {
+	end := swiftCallArgEnd(content, pos, 200)
+	if mm := swiftAFMethodRe.FindStringSubmatch(content[pos:end]); len(mm) >= 2 {
+		return strings.ToUpper(mm[1])
+	}
+	return "GET"
+}
+
+// swiftCallArgEnd returns the offset just past the balanced `)` that closes the
+// argument list whose opening `(` precedes `pos` (depth starts at 1 because the
+// caller's match consumed the opening paren and the first string arg). Capped
+// at pos+maxLen so a missing close paren can't run to EOF.
+func swiftCallArgEnd(content string, pos, maxLen int) int {
+	limit := pos + maxLen
+	if limit > len(content) {
+		limit = len(content)
+	}
+	depth := 1
+	for i := pos; i < limit; i++ {
+		switch content[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return limit
+}
+
+// swiftResolveURLSessionVerb scans forward from the URL(string:) site up to
+// windowEnd (the next URL site or EOF) for a `.httpMethod = "VERB"` assignment;
+// defaults to GET. The request var is configured AFTER its URL is constructed,
+// so a forward-only, neighbour-clamped scan attributes the verb correctly.
+func swiftResolveURLSessionVerb(content string, pos, windowEnd int) string {
+	if windowEnd > len(content) {
+		windowEnd = len(content)
+	}
+	if windowEnd <= pos {
+		return "GET"
+	}
+	if mm := swiftHTTPMethodAssignRe.FindStringSubmatch(content[pos:windowEnd]); len(mm) >= 2 {
+		return strings.ToUpper(mm[1])
+	}
+	return "GET"
+}
+
+// canonicalizeSwiftInterpolation rewrites Swift `\(expr)` interpolation markers
+// inside a URL-literal body to `{param}` placeholders.
+func canonicalizeSwiftInterpolation(raw string) string {
+	return swiftInterpRe.ReplaceAllString(raw, "{param}")
+}
+
+// indexSwiftFuncs builds a sorted (offset, name) list for every Swift
+// function / method declaration in the file, for enclosing-fn attribution.
+func indexSwiftFuncs(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range swiftEnclosingFuncRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingSwiftFuncAt returns the nearest preceding func name for a call site.
+func enclosingSwiftFuncAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_swift_client_test.go
+++ b/internal/engine/http_endpoint_swift_client_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import "testing"
+
+// TestSwiftClient_AlamofireRequest covers Alamofire `AF.request("...")` (GET
+// default) and `AF.request("...", method: .post)`, asserting the SPECIFIC
+// canonical paths + verbs and FETCHES edges (value-asserting; host stripped).
+func TestSwiftClient_AlamofireRequest(t *testing.T) {
+	src := `
+import Alamofire
+
+func fetchUsers() {
+    AF.request("https://api.example.com/v1/users")
+}
+
+func login(email: String) {
+    AF.request("/auth/login", method: .post)
+}
+`
+	ids, rels := runDetectWithRels(t, "swift", "Sources/ApiClient.swift", src)
+	requireContains(t, ids, []string{
+		"http:GET:/v1/users",
+		"http:POST:/auth/login",
+	}, "alamofire")
+	requireFetches(t, rels, "http:GET:/v1/users", "alamofire")
+	requireFetches(t, rels, "http:POST:/auth/login", "alamofire")
+}
+
+// TestSwiftClient_AlamofireInterpolated covers an Alamofire path with a Swift
+// `\(id)` interpolation → `{param}` placeholder and a PUT verb, asserting the
+// exact path /inspections/{param}.
+func TestSwiftClient_AlamofireInterpolated(t *testing.T) {
+	src := `
+import Alamofire
+
+func updateInspection(id: String) {
+    session.request("/inspections/\(id)", method: .put)
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "Sources/Inspections.swift", src)
+	requireContains(t, ids, []string{"http:PUT:/inspections/{param}"}, "alamofire-interp")
+}
+
+// TestSwiftClient_URLSession covers URLSession via `URL(string: "...")` with a
+// `request.httpMethod = "POST"` assignment, asserting POST /auth/login (host
+// stripped) and a GET default for a bare dataTask URL.
+func TestSwiftClient_URLSession(t *testing.T) {
+	src := `
+import Foundation
+
+func loadUsers() {
+    let url = URL(string: "https://api.example.com/v1/users")!
+    URLSession.shared.dataTask(with: url).resume()
+}
+
+func signIn(email: String) {
+    var request = URLRequest(url: URL(string: "/auth/login")!)
+    request.httpMethod = "POST"
+    URLSession.shared.dataTask(with: request).resume()
+}
+`
+	ids, rels := runDetectWithRels(t, "swift", "Sources/Networking.swift", src)
+	requireContains(t, ids, []string{
+		"http:GET:/v1/users",
+		"http:POST:/auth/login",
+	}, "urlsession")
+	requireFetches(t, rels, "http:POST:/auth/login", "urlsession")
+}
+
+// TestSwiftClient_NoMatch asserts a Swift file with no HTTP-client call produces
+// no http synthetic.
+func TestSwiftClient_NoMatch(t *testing.T) {
+	src := `
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("hello")
+    }
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "Sources/ContentView.swift", src)
+	for _, id := range ids {
+		if len(id) >= 5 && id[:5] == "http:" {
+			t.Errorf("urlsession-no-match: unexpected http synthetic %q", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -107,6 +107,12 @@ func synthesisSupportsLanguage(lang string) bool {
 	// through for the client synthesizer; files without sttp markers are no-ops.
 	case "scala":
 		return true
+	// #3574: mobile consumer-side HTTP client extraction (epic #3571). Dart
+	// (Dio / package:http) and Swift (URLSession / Alamofire) have no compiled
+	// YAML rules for their outbound calls; allow them through so the mobile
+	// client synthesizers run. Files without client markers are no-ops.
+	case "dart", "swift":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -198,6 +204,9 @@ func isTestSourceFile(filePath string) bool {
 	case ".php":
 		// PHP: FooTest.php
 		return strings.HasSuffix(stem, "test")
+	case ".dart":
+		// Dart: foo_test.dart (the package:test / flutter_test convention).
+		return strings.HasSuffix(stem, "_test")
 	case ".rs":
 		// Rust tests live in modules within production files; file-level
 		// exclusion is not meaningful. Return false and rely on the testmap
@@ -811,6 +820,20 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// combinators with uri"..." literals) outbound HTTP client. The Scala
 		// producer side is handled by the custom_scala_* framework extractors.
 		synthesizeScalaClientWithRuntime(string(content), emitClientRuntime)
+	case "dart":
+		// Consumer side (#3574, epic #3571): Flutter mobile HTTP clients —
+		// Dio (`dio.get("/path")`) and package:http
+		// (`http.get(Uri.parse("..."))`). Emits outbound http_endpoint_call
+		// entities + FETCHES edges so the cross-repo linker pairs mobile
+		// screens with backend routes.
+		synthesizeDartClientWithRuntime(string(content), emitClientRuntime)
+	case "swift":
+		// Consumer side (#3574, epic #3571): iOS mobile HTTP clients —
+		// URLSession (`URL(string: "...")` + `httpMethod`) and Alamofire
+		// (`AF.request("...", method: .post)`). Emits outbound
+		// http_endpoint_call entities + FETCHES edges. The Swift PRODUCER
+		// side (Vapor) is handled by the custom_swift_* extractors.
+		synthesizeSwiftClientWithRuntime(string(content), emitClientRuntime)
 	}
 
 	// #722 — response/request shape extraction. Mutates Properties on


### PR DESCRIPTION
Closes #3574 (epic #3571). Highest-leverage mobile ticket: extends the rewrite-parity oracle to mobile clients so Flutter (Dart) and iOS (Swift) screens link to backend endpoints.

## What
Mirrors the scala sttp client (#3554) EXACTLY. Each detected outbound mobile HTTP call emits one `http_endpoint_call` entity (`kind=http_endpoint_call`, `id=http:<VERB>:<path>`, `pattern_type=http_endpoint_client_synthesis`) plus a `FETCHES` edge from the enclosing function — the SAME entity shape the backend producer side emits. The existing cross-repo linker joins consumer call sites to producer routes by the canonical path `Name`, so **mobile -> backend links form on reindex with no new matching code**.

New synthesizers (wired into `synthesisSupportsLanguage` + `applyHTTPEndpointSynthesis`):
- `internal/engine/http_endpoint_dart_client.go` — Dart/Flutter
- `internal/engine/http_endpoint_swift_client.go` — Swift/iOS

Also: `.dart` case added to `isTestSourceFile`.

## Clients + status
- **Dio (Dart) — full**: `dio.get/post/put/patch/delete("/path")`. `$id`/`${expr}` -> `{id}`/`{param}`, host stripped.
- **package:http (Dart) — full**: `http.get(Uri.parse("https://.../v1/users"))`, host stripped.
- **Alamofire (Swift) — full**: `AF.request("...", method: .verb)` / `session.request(...)`; verb from `method: .verb` (default GET), bounded to the call's own arg list. `\(expr)` -> `{param}`.
- **URLSession (Swift) — full**: `URL(string: "...")` + `request.httpMethod = "VERB"` (default GET, neighbour-clamped forward scan). `\(expr)` -> `{param}`.

Dynamic/non-literal URLs carry `runtime_dynamic=true` via the shared runtime emitter (interpolated paths counted as full where the literal prefix + verb are statically asserted).

## Entity-shape confirmation (cross-repo linker)
The synthesizers route through the shared `emitClientRuntime` -> `emitClient` path, emitting `kind=http_endpoint_call` with `id=http:<VERB>:<path>` and a `FETCHES` edge — byte-identical to the scala/elixir/kotlin client shape and to the producer-side `http:<VERB>:<path>` synthetic ID. Tests assert the exact synthetic IDs, so a cross-repo link WILL form on reindex.

## Records
- `lang.dart.framework.flutter`: `Data Flow/data_fetching` + `Substrate/http_effect` -> full.
- New `lang.swift.framework.alamofire` + `lang.swift.framework.urlsession` (subcategory `mobile`): `Substrate/http_effect` -> full; taxonomy backfilled.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.

## Tests assert these specific path+verb pairs (value-asserting, not len>0)
Dart (`http_endpoint_dart_client_test.go`):
- `dio.get("/users")` -> GET `/users`; `dio.post("/auth/login")` -> POST `/auth/login` (+ FETCHES)
- `dio.get("/inspections/$id")` -> GET `/inspections/{id}`; `dio.put("/users/${user.id}")` -> PUT `/users/{param}`
- `http.get(Uri.parse(".../v1/users"))` -> GET `/v1/users` (host stripped, + FETCHES); `http.post(Uri.parse("/auth/login"))` -> POST `/auth/login`

Swift (`http_endpoint_swift_client_test.go`):
- `AF.request(".../v1/users")` -> GET `/v1/users` (+ FETCHES); `AF.request("/auth/login", method: .post)` -> POST `/auth/login` (+ FETCHES)
- `session.request("/inspections/\(id)", method: .put)` -> PUT `/inspections/{param}`
- `URL(string:".../v1/users")` -> GET `/v1/users`; `httpMethod="POST"` + `URL(string:"/auth/login")` -> POST `/auth/login` (+ FETCHES)

## Verification
Targeted tests green: `./internal/engine/` (full pkg), `./internal/types/`, `./tools/coverage/`, `./internal/custom/...` (incl. dart + swift). `gofmt -l` empty, `go vet ./internal/engine/` clean. No unrelated detail-page drift.

DEPLOY-DEFERRED: takes effect on the next live-daemon rebuild + reindex.