### PR TITLE
mobile(compose): emit NAVIGATES_TO + USES edges from Jetpack Compose extractor

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31556,7 +31556,8 @@
           "navigation_extraction": {
             "status": "partial",
             "cites": ["internal/custom/kotlin/compose.go"],
-            "verified_at": "2026-05-30"
+            "notes": "compose.go (#3576) emits screen-\u003eroute NAVIGATES_TO edges: navController.navigate(\"detail/42\") inside an enclosing @Composable produces HomeScreen -NAVIGATES_TO-\u003e route:detail/{id}, with concrete path-arg segments (numbers/$var/${expr}) normalized back to the declared {id} template; constant routes (\"home\") pass through unchanged. Value-asserted in compose_edges_test.go (TestComposeNavigatesToEdge asserts HomeScreen NAVIGATES_TO route:detail/{id} and DetailScreen NAVIGATES_TO route:home). Edges leave FromID empty so the resolver substitutes the enclosing composable's host ID at assembly. PARTIAL: sealed-class Screen.X.route indirection emits a NAVIGATES_TO edge marked unresolved=true (TestComposeNavigatesToRouteConstPartial) because the literal route string lives in another file and cannot be resolved in-file.",
+            "verified_at": "2026-06-02"
           },
           "screen_detection": {
             "status": "partial",
@@ -31587,7 +31588,8 @@
           "state_management": {
             "status": "partial",
             "cites": ["internal/custom/kotlin/compose.go"],
-            "verified_at": "2026-05-30"
+            "notes": "compose.go emits StateFlow/MutableStateFlow/collectAsState state entities, plus (#3576) view-\u003eviewmodel USES edges: val vm: HomeViewModel = viewModel() / hiltViewModel() / koinViewModel\u003cT\u003e() inside an enclosing @Composable produces HomeScreen -USES-\u003e HomeViewModel (the ViewModel type is already an entity via kotlin extraction; the edge wires the screen to it). Value-asserted in compose_edges_test.go (TestComposeUsesViewModelEdge asserts HomeScreen USES HomeViewModel, ProfileScreen USES ProfileViewModel, SettingsScreen USES SettingsViewModel, and the negative no-cross-screen-leak case). Partial: cross-file StateFlow ownership and dynamic state holders remain unmodeled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -33105,7 +33107,8 @@
           "navigation_extraction": {
             "status": "partial",
             "cites": ["internal/custom/kotlin/compose.go"],
-            "verified_at": "2026-05-30"
+            "notes": "compose.go (#3576) runs on all Kotlin including KMP shared modules and emits screen-\u003eroute NAVIGATES_TO edges from navController.navigate(\"route\") call sites attributed to the enclosing @Composable, with concrete path-arg segments normalized to {id}. Value-asserted in compose_edges_test.go (TestComposeNavigatesToEdge). PARTIAL: sealed-class Screen.X.route route-constant indirection emits an edge marked unresolved=true (cross-file constant, not resolvable in-file).",
+            "verified_at": "2026-06-02"
           },
           "screen_detection": {
             "status": "partial",
@@ -33136,7 +33139,8 @@
           "state_management": {
             "status": "partial",
             "cites": ["internal/custom/kotlin/compose.go"],
-            "verified_at": "2026-05-30"
+            "notes": "compose.go emits StateFlow/collectAsState state entities plus (#3576) view-\u003eviewmodel USES edges (HomeScreen -USES-\u003e HomeViewModel) from viewModel()/hiltViewModel()/koinViewModel\u003cT\u003e() injection inside an enclosing @Composable; runs on KMP shared Kotlin identically. Value-asserted in compose_edges_test.go (TestComposeUsesViewModelEdge). Partial: cross-file state ownership unmodeled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {

--- a/internal/custom/kotlin/compose.go
+++ b/internal/custom/kotlin/compose.go
@@ -3,6 +3,7 @@ package kotlin
 import (
 	"context"
 	"regexp"
+	"strconv"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -35,10 +36,26 @@ var (
 		`navigation\s*\(\s*(?:route\s*=\s*)?["']([^"']+)["']`,
 	)
 	reViewModelGeneric = regexp.MustCompile(
-		`\b(?:viewModel|hiltViewModel)\s*<([A-Z][A-Za-z0-9_]*)>\s*\(`,
+		`\b(?:viewModel|hiltViewModel|koinViewModel)\s*<([A-Z][A-Za-z0-9_]*)>\s*\(`,
 	)
 	reViewModelAssign = regexp.MustCompile(
-		`val\s+\w+\s*:\s*([A-Z][A-Za-z0-9_]*)\s*=\s*(?:viewModel|hiltViewModel)\s*\(`,
+		`val\s+\w+\s*:\s*([A-Z][A-Za-z0-9_]*)\s*=\s*(?:viewModel|hiltViewModel|koinViewModel)\s*\(`,
+	)
+
+	// Navigation transition: navController.navigate("route") /
+	// navController.navigate("detail/42") / navController.navigate(Screen.Detail.route).
+	// Group 1 = string-literal route (in-file resolvable); group 2 = bare
+	// expression route (e.g. Screen.Detail.route — cross-file indirection).
+	reNavNavigateLiteral = regexp.MustCompile(
+		`\.navigate\s*\(\s*["']([^"']+)["']`,
+	)
+	reNavNavigateExpr = regexp.MustCompile(
+		`\.navigate\s*\(\s*([A-Z][A-Za-z0-9_.]*\.route)\b`,
+	)
+	// Enclosing @Composable function header (name capture) used to attribute
+	// navigate(...) / viewModel() call sites to the screen that contains them.
+	reComposableHeader = regexp.MustCompile(
+		`@Composable\s+(?:(?:private|internal|public)\s+)?fun\s+([A-Z][A-Za-z0-9_]*)\s*\(`,
 	)
 
 	// State management: StateFlow<T>, MutableStateFlow<T>, collectAsState, collectAsStateWithLifecycle
@@ -284,8 +301,178 @@ func (e *composeExtractor) Extract(ctx context.Context, file extractor.FileInput
 		entities = append(entities, ent)
 	}
 
+	// ---------------------------------------------------------------------
+	// Edges (issue #3576). Both NAVIGATES_TO and USES are emitted as embedded
+	// relationships with an empty FromID so the resolver substitutes the host
+	// entity ID (the enclosing @Composable) at edge-assembly time. ToID is a
+	// bare name that the name-keyed resolver matches against the declared
+	// route / ViewModel entity.
+	//
+	// relsByComposable groups every edge by the name of the @Composable that
+	// owns the call site; attached to that composable's entity record below.
+	spans := composableSpans(src)
+	relsByComposable := make(map[string][]types.RelationshipRecord)
+	edgeSeen := make(map[string]bool)
+
+	// 10. Navigation transitions -> NAVIGATES_TO (screen -> route).
+	// navController.navigate("detail/42") inside HomeScreen{} emits
+	// HomeScreen -NAVIGATES_TO-> route:detail/{id}.
+	emitNav := func(rawRoute, via string, off int) {
+		from := enclosingComposable(spans, off)
+		if from == "" {
+			return // navigate() outside any @Composable — unattributable
+		}
+		route := normalizeRoute(rawRoute)
+		key := "nav|" + from + "|" + route + "|" + via
+		if edgeSeen[key] {
+			return
+		}
+		edgeSeen[key] = true
+		props := map[string]string{
+			"route":     route,
+			"via":       via,
+			"caller":    from,
+			"framework": "compose",
+			"line":      strconv.Itoa(lineOf(src, off)),
+		}
+		if via == "navigate_route_const" {
+			// Sealed-class Screen.X.route indirection: the literal route string
+			// lives in another file, so the target is partial/unresolved here.
+			props["unresolved"] = "true"
+		}
+		relsByComposable[from] = append(relsByComposable[from], types.RelationshipRecord{
+			ToID:       "route:" + route,
+			Kind:       "NAVIGATES_TO",
+			Properties: props,
+		})
+	}
+	for _, m := range reNavNavigateLiteral.FindAllStringSubmatchIndex(src, -1) {
+		emitNav(src[m[2]:m[3]], "navigate_call", m[0])
+	}
+	for _, m := range reNavNavigateExpr.FindAllStringSubmatchIndex(src, -1) {
+		emitNav(src[m[2]:m[3]], "navigate_route_const", m[0])
+	}
+
+	// 11. view -> viewmodel -> USES (composable -> ViewModel type).
+	// val vm: MyViewModel = viewModel() inside HomeScreen{} emits
+	// HomeScreen -USES-> MyViewModel.
+	emitUses := func(vmType, via string, off int) {
+		from := enclosingComposable(spans, off)
+		if from == "" {
+			return
+		}
+		key := "uses|" + from + "|" + vmType
+		if edgeSeen[key] {
+			return
+		}
+		edgeSeen[key] = true
+		relsByComposable[from] = append(relsByComposable[from], types.RelationshipRecord{
+			ToID: vmType,
+			Kind: "USES",
+			Properties: map[string]string{
+				"viewmodel": vmType,
+				"via":       via,
+				"caller":    from,
+				"framework": "compose",
+				"line":      strconv.Itoa(lineOf(src, off)),
+			},
+		})
+	}
+	for _, m := range reViewModelGeneric.FindAllStringSubmatchIndex(src, -1) {
+		emitUses(src[m[2]:m[3]], "viewmodel", m[0])
+	}
+	for _, m := range reViewModelAssign.FindAllStringSubmatchIndex(src, -1) {
+		emitUses(src[m[2]:m[3]], "viewmodel_assign", m[0])
+	}
+
+	// Attach collected edges to their owning composable entity record.
+	if len(relsByComposable) > 0 {
+		for i := range entities {
+			if rels, ok := relsByComposable[entities[i].Name]; ok &&
+				entities[i].Kind == "SCOPE.UIComponent" {
+				entities[i].Relationships = append(entities[i].Relationships, rels...)
+			}
+		}
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// composableSpan records the byte range owned by one @Composable function so
+// call sites (navigate(...), viewModel()) can be attributed to the enclosing
+// screen. The span runs from the function header to the close of its body's
+// top-level brace block.
+type composableSpan struct {
+	name       string
+	start, end int
+}
+
+// composableSpans returns the byte ranges of every @Composable function in src,
+// in source order. Used to attribute navigate(...) / viewModel() call sites to
+// their enclosing composable.
+func composableSpans(src string) []composableSpan {
+	var spans []composableSpan
+	for _, m := range reComposableHeader.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// Body block starts at the first '{' after the header's '('.
+		bodyStart := -1
+		for i := m[1]; i < len(src); i++ {
+			if src[i] == '{' {
+				bodyStart = i
+				break
+			}
+			if src[i] == '=' { // single-expression composable, no brace body
+				break
+			}
+		}
+		end := len(src)
+		if bodyStart != -1 {
+			depth := 0
+			for i := bodyStart; i < len(src); i++ {
+				switch src[i] {
+				case '{':
+					depth++
+				case '}':
+					depth--
+					if depth == 0 {
+						end = i + 1
+						i = len(src) // break outer
+					}
+				}
+			}
+		}
+		spans = append(spans, composableSpan{name: name, start: m[0], end: end})
+	}
+	return spans
+}
+
+// enclosingComposable returns the name of the composable whose span contains
+// off, or "" if none. Inner (later-starting) spans win so nested call sites are
+// attributed to the closest enclosing screen.
+func enclosingComposable(spans []composableSpan, off int) string {
+	best := ""
+	bestStart := -1
+	for _, s := range spans {
+		if off >= s.start && off < s.end && s.start > bestStart {
+			best = s.name
+			bestStart = s.start
+		}
+	}
+	return best
+}
+
+// reRouteParamSeg matches a single concrete path segment that is a navigation
+// argument value (a bare number, a $var, or a ${expr} interpolation) so it can
+// be normalised back to the declared {id}-style template param.
+var reRouteParamSeg = regexp.MustCompile(`/(?:\d+|\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*)`)
+
+// normalizeRoute rewrites a concrete navigate("detail/42") destination into the
+// declared route template "detail/{id}" by replacing value segments with {id}.
+// Already-templated routes (detail/{id}) and constant routes (home) pass
+// through unchanged.
+func normalizeRoute(route string) string {
+	return reRouteParamSeg.ReplaceAllString(route, "/{id}")
 }
 
 // extractBraceBlock returns the content of the balanced brace block starting at or after start.

--- a/internal/custom/kotlin/compose_edges_test.go
+++ b/internal/custom/kotlin/compose_edges_test.go
@@ -1,0 +1,191 @@
+package kotlin_test
+
+// ---------------------------------------------------------------------------
+// Compose edge tests (issue #3576): NAVIGATES_TO (screen -> route) and
+// USES (composable -> ViewModel). These assert the SPECIFIC edge endpoints,
+// not len>0.
+// ---------------------------------------------------------------------------
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractRels runs the named extractor and returns the raw entity records so
+// embedded Relationships are inspectable (the shared entitySummary helper
+// drops them).
+func extractRels(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+// hasEdge reports whether some entity named fromName carries a relationship of
+// the given kind whose ToID equals wantToID.
+func hasEdge(ents []types.EntityRecord, fromName, kind, wantToID string) bool {
+	for _, e := range ents {
+		if e.Name != fromName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == wantToID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestComposeNavigatesToEdge asserts the screen->route NAVIGATES_TO edge with a
+// normalized {id} param: composable "home"'s screen navigates to detail/{id}.
+func TestComposeNavigatesToEdge(t *testing.T) {
+	src := `
+@Composable
+fun HomeScreen(navController: NavController) {
+    Button(onClick = { navController.navigate("detail/42") }) {
+        Text("Open")
+    }
+}
+
+@Composable
+fun DetailScreen(navController: NavController) {
+    Button(onClick = { navController.navigate("home") }) {
+        Text("Back")
+    }
+}
+`
+	ents := extractRels(t, "custom_kotlin_compose", fi("Nav.kt", "kotlin", src))
+
+	// HomeScreen -NAVIGATES_TO-> route:detail/{id} (42 normalized to {id})
+	if !hasEdge(ents, "HomeScreen", "NAVIGATES_TO", "route:detail/{id}") {
+		t.Errorf("expected HomeScreen NAVIGATES_TO route:detail/{id}; edges=%v", dumpEdges(ents))
+	}
+	// DetailScreen -NAVIGATES_TO-> route:home (constant route, unchanged)
+	if !hasEdge(ents, "DetailScreen", "NAVIGATES_TO", "route:home") {
+		t.Errorf("expected DetailScreen NAVIGATES_TO route:home; edges=%v", dumpEdges(ents))
+	}
+	// Negative: HomeScreen must NOT own DetailScreen's edge.
+	if hasEdge(ents, "HomeScreen", "NAVIGATES_TO", "route:home") {
+		t.Error("HomeScreen should not own DetailScreen's NAVIGATES_TO route:home edge")
+	}
+}
+
+// TestComposeNavigatesToRouteConstPartial asserts that sealed-class route
+// indirection (Screen.Detail.route) still emits a NAVIGATES_TO edge, marked
+// unresolved (honest-partial for cross-file constant resolution).
+func TestComposeNavigatesToRouteConstPartial(t *testing.T) {
+	src := `
+@Composable
+fun HomeScreen(navController: NavController) {
+    Button(onClick = { navController.navigate(Screen.Detail.route) }) {
+        Text("Open")
+    }
+}
+`
+	ents := extractRels(t, "custom_kotlin_compose", fi("NavConst.kt", "kotlin", src))
+	if !hasEdge(ents, "HomeScreen", "NAVIGATES_TO", "route:Screen.Detail.route") {
+		t.Fatalf("expected HomeScreen NAVIGATES_TO route:Screen.Detail.route; edges=%v", dumpEdges(ents))
+	}
+	// Assert it carries the unresolved marker.
+	for _, e := range ents {
+		if e.Name != "HomeScreen" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "NAVIGATES_TO" && r.ToID == "route:Screen.Detail.route" {
+				if r.Properties["unresolved"] != "true" {
+					t.Errorf("expected unresolved=true on route-const edge, got %q", r.Properties["unresolved"])
+				}
+			}
+		}
+	}
+}
+
+// TestComposeUsesViewModelEdge asserts the composable->ViewModel USES edge for
+// each injection form (viewModel(), hiltViewModel(), koinViewModel()).
+func TestComposeUsesViewModelEdge(t *testing.T) {
+	src := `
+@Composable
+fun HomeScreen() {
+    val vm: HomeViewModel = viewModel()
+    Text("Home")
+}
+
+@Composable
+fun ProfileScreen() {
+    val pvm: ProfileViewModel = hiltViewModel()
+    Text("Profile")
+}
+
+@Composable
+fun SettingsScreen() {
+    val svm = koinViewModel<SettingsViewModel>()
+    Text("Settings")
+}
+`
+	ents := extractRels(t, "custom_kotlin_compose", fi("Screens.kt", "kotlin", src))
+
+	if !hasEdge(ents, "HomeScreen", "USES", "HomeViewModel") {
+		t.Errorf("expected HomeScreen USES HomeViewModel; edges=%v", dumpEdges(ents))
+	}
+	if !hasEdge(ents, "ProfileScreen", "USES", "ProfileViewModel") {
+		t.Errorf("expected ProfileScreen USES ProfileViewModel; edges=%v", dumpEdges(ents))
+	}
+	if !hasEdge(ents, "SettingsScreen", "USES", "SettingsViewModel") {
+		t.Errorf("expected SettingsScreen USES SettingsViewModel; edges=%v", dumpEdges(ents))
+	}
+	// Negative: HomeScreen must not USE ProfileViewModel.
+	if hasEdge(ents, "HomeScreen", "USES", "ProfileViewModel") {
+		t.Error("HomeScreen should not USE ProfileViewModel (cross-screen leak)")
+	}
+}
+
+// TestComposeEdgesFromIDEmpty confirms emitted edges leave FromID empty so the
+// resolver substitutes the host (enclosing composable) entity ID at assembly.
+func TestComposeEdgesFromIDEmpty(t *testing.T) {
+	src := `
+@Composable
+fun HomeScreen(navController: NavController) {
+    val vm: HomeViewModel = viewModel()
+    navController.navigate("detail/1")
+}
+`
+	ents := extractRels(t, "custom_kotlin_compose", fi("Home.kt", "kotlin", src))
+	count := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "NAVIGATES_TO" || r.Kind == "USES" {
+				count++
+				if r.FromID != "" {
+					t.Errorf("expected empty FromID on %s edge, got %q", r.Kind, r.FromID)
+				}
+			}
+		}
+	}
+	if count == 0 {
+		t.Fatal("expected at least one NAVIGATES_TO/USES edge")
+	}
+}
+
+func dumpEdges(ents []types.EntityRecord) string {
+	out := ""
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			out += "\n  " + e.Name + " -" + r.Kind + "-> " + r.ToID
+		}
+	}
+	if out == "" {
+		return "(none)"
+	}
+	return out
+}


### PR DESCRIPTION
Closes #3576 (epic #3571).

The Jetpack Compose extractor (`internal/custom/kotlin/compose.go`) was entities-only per the mobile audit. This PR deepens it with **navigation (screen→screen)** and **view→viewmodel** edges while preserving all existing entity emission.

## Edges now emitted

Both are embedded relationships with an empty `FromID`, so the resolver substitutes the enclosing `@Composable` host ID at edge-assembly time (the established convention — see `canMigrate` in `internal/resolve/imports.go`). `ToID` is a bare name the name-keyed resolver matches against the declared route / ViewModel entity.

### `NAVIGATES_TO` (screen → route)
`navController.navigate("detail/42")` inside a `@Composable` emits `HomeScreen -NAVIGATES_TO-> route:detail/{id}`. Concrete path-arg segments (numbers, `$var`, `${expr}`) are normalized back to the declared `{id}` template; constant routes (`"home"`) pass through unchanged. Call sites are attributed to their enclosing composable via balanced-brace span tracking.
- **FULL** for in-file literal routes.
- **PARTIAL**: sealed-class `Screen.X.route` indirection still emits a `NAVIGATES_TO` edge, marked `unresolved=true`, because the literal route string lives in another file and cannot be resolved in-file.

### `USES` (composable → ViewModel)
`val vm: MyViewModel = viewModel()` / `hiltViewModel()` / `koinViewModel<T>()` emits `HomeScreen -USES-> MyViewModel`. ViewModel types are already entities via kotlin extraction. **FULL.**

## Value-asserting tests (`compose_edges_test.go`)
Assert the **specific** edge endpoints (not `len>0`):
- `HomeScreen NAVIGATES_TO route:detail/{id}` and `DetailScreen NAVIGATES_TO route:home` (+ negative: HomeScreen does not own DetailScreen's edge)
- route-const `Screen.Detail.route` edge carries `unresolved=true`
- `HomeScreen USES HomeViewModel`, `ProfileScreen USES ProfileViewModel`, `SettingsScreen USES SettingsViewModel` (+ negative: no cross-screen leak)
- emitted edges leave `FromID` empty

## Coverage
Updated `lang.kotlin.framework.compose` and `lang.kotlin.framework.kmp` — `navigation_extraction` + `state_management` cells (still **partial** due to route-const indirection), citing `compose.go`. `coverage validate` 0 errors, `coverage fmt --check` canonical.

## Checks
- `go test ./internal/custom/kotlin/... ./internal/engine/ ./internal/types/ ./tools/coverage/` green
- `gofmt -l` empty, `go vet` clean
- No unrelated drift

**DEPLOY-DEFERRED**: indexer/daemon rebuild + reindex required to surface these edges on live graphs; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)