### PR TITLE
Deepen SwiftUI extractor: NAVIGATES_TO + USES edges; add swiftui coverage record

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 209 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 14 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 1
+**Total**: 210 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 14 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 2
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -189,6 +189,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 21/21 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 19/19 | |
+| [swift](../by-language/swift.md) | [SwiftUI](../detail/lang.swift.framework.swiftui.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/21 | 🟡 3/8 | |
 
 
 ## Meta Framework

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # swift
 
-**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 2 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -27,6 +27,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+
+
+### UI Frontend
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [SwiftUI](../detail/lang.swift.framework.swiftui.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/21 | 🟡 3/8 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.swift.framework.swiftui.md
+++ b/docs/coverage/detail/lang.swift.framework.swiftui.md
@@ -1,0 +1,90 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.swift.framework.swiftui` — SwiftUI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [swift](../by-language/swift.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 33
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | ✅ `full` | `2026-06-01` | — | `internal/custom/swift/extractors_test.go`<br>`internal/custom/swift/swiftui.go` | struct/class conforming to View -> SCOPE.UIComponent (framework=swiftui, provenance INFERRED_FROM_SWIFTUI_VIEW); SwiftUI builtin views skipped. Regex/heuristic but catches the canonical View idiom; value-asserting tests TestSwiftUIView/TestSwiftUIBuiltinSkipped. |
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Data fetching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Prop extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | 🟢 `partial` | `2026-06-01` | [link](https://github.com/cajasmota/archigraph/issues/3577) | `internal/custom/swift/extractors_test.go`<br>`internal/custom/swift/swiftui.go` | @StateObject/@ObservedObject/@EnvironmentObject -> USES edge View->type:<Observable> (via observable_object); @State/@Binding kept as local SCOPE.Pattern props (no edge, by design). PARTIAL: NavigationLink(value:) destinations resolve cross-file via .navigationDestination(for:) (confidence 0.6, partial prop) and observable type declarations are cross-file (synthetic type:/view: stubs linker-resolved); no in-file destination/observable body resolution. Tests: ProfileView USES type:ProfileViewModel/SettingsStore/AppState; TestSwiftUIStateNoEdge asserts @State emits no USES. |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | ✅ `full` | `2026-06-01` | — | `internal/custom/swift/extractors_test.go`<br>`internal/custom/swift/swiftui.go` | NavigationLink(destination:) and .sheet/.fullScreenCover { DestView() } -> NAVIGATES_TO edge enclosingView->view:<Dest> (via navigation_link / modal_sheet / modal_fullScreenCover). Plus standalone nav:/navdest: SCOPE.Operation entities. Value-asserting tests: ContentView NAVIGATES_TO view:DetailView, HomeView->SettingsView (sheet), RootView->OnboardingView (fullScreenCover). |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.swift.framework.swiftui ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -55854,6 +55854,168 @@
       }
     },
     {
+      "id": "lang.swift.framework.swiftui",
+      "category": "http_framework",
+      "subcategory": "ui_frontend",
+      "language": "swift",
+      "label": "SwiftUI",
+      "capabilities": {
+        "Structure": {
+          "component_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/swift/extractors_test.go","internal/custom/swift/swiftui.go"],
+            "notes": "struct/class conforming to View -\u003e SCOPE.UIComponent (framework=swiftui, provenance INFERRED_FROM_SWIFTUI_VIEW); SwiftUI builtin views skipped. Regex/heuristic but catches the canonical View idiom; value-asserting tests TestSwiftUIView/TestSwiftUIBuiltinSkipped.",
+            "verified_at": "2026-06-01"
+          },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "data_fetching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "prop_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "partial",
+            "cites": ["internal/custom/swift/extractors_test.go","internal/custom/swift/swiftui.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3577",
+            "notes": "@StateObject/@ObservedObject/@EnvironmentObject -\u003e USES edge View-\u003etype:\u003cObservable\u003e (via observable_object); @State/@Binding kept as local SCOPE.Pattern props (no edge, by design). PARTIAL: NavigationLink(value:) destinations resolve cross-file via .navigationDestination(for:) (confidence 0.6, partial prop) and observable type declarations are cross-file (synthetic type:/view: stubs linker-resolved); no in-file destination/observable body resolution. Tests: ProfileView USES type:ProfileViewModel/SettingsStore/AppState; TestSwiftUIStateNoEdge asserts @State emits no USES.",
+            "verified_at": "2026-06-01"
+          }
+        },
+        "Navigation": {
+          "router_pattern": {
+            "status": "full",
+            "cites": ["internal/custom/swift/extractors_test.go","internal/custom/swift/swiftui.go"],
+            "notes": "NavigationLink(destination:) and .sheet/.fullScreenCover { DestView() } -\u003e NAVIGATES_TO edge enclosingView-\u003eview:\u003cDest\u003e (via navigation_link / modal_sheet / modal_fullScreenCover). Plus standalone nav:/navdest: SCOPE.Operation entities. Value-asserting tests: ContentView NAVIGATES_TO view:DetailView, HomeView-\u003eSettingsView (sheet), RootView-\u003eOnboardingView (fullScreenCover).",
+            "verified_at": "2026-06-01"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.swift.framework.vapor",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 209 · **ORMs**: 152 · **Tools**: 110 · **Other**: 124
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 210 · **ORMs**: 152 · **Tools**: 110 · **Other**: 124
 
 ## Coverage by language
 
@@ -20,8 +20,8 @@
 | [scala](by-language/scala.md) | 14 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 0 |
+| [swift](by-language/swift.md) | 2 | 1 | 0 | 0 |
 | [dart](by-language/dart.md) | 1 | 1 | 0 | 0 |
-| [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 4 |
 | [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 209 frameworks · 110 tools · 152 ORMs · 124 other
+Total: 210 frameworks · 110 tools · 152 ORMs · 124 other

--- a/internal/custom/swift/extractors_test.go
+++ b/internal/custom/swift/extractors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
 
 	_ "github.com/cajasmota/archigraph/internal/custom/swift"
 )
@@ -171,5 +172,176 @@ func TestSwiftUINoMatch(t *testing.T) {
 	ents := extract(t, "custom_swift_swiftui", fi("imports.swift", "swift", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SwiftUI edges (navigation + state) — value-asserting
+// ---------------------------------------------------------------------------
+
+// extractFull returns the raw EntityRecords (with relationships) for edge tests.
+func extractFull(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+// hasEdge reports whether some entity named fromName emits an edge of kind to
+// ToID. fromName "" matches any source.
+func hasEdge(ents []types.EntityRecord, fromName, kind, toID string) bool {
+	for _, e := range ents {
+		if fromName != "" && e.Name != fromName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func edgeProp(ents []types.EntityRecord, fromName, kind, toID, key string) (string, bool) {
+	for _, e := range ents {
+		if fromName != "" && e.Name != fromName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == toID {
+				v, ok := r.Properties[key]
+				return v, ok
+			}
+		}
+	}
+	return "", false
+}
+
+func TestSwiftUINavigatesToEdge(t *testing.T) {
+	src := `
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            NavigationLink(destination: DetailView()) { Text("Go") }
+        }
+    }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("ContentView.swift", "swift", src))
+	// ContentView NAVIGATES_TO DetailView (via the synthetic view: stub).
+	if !hasEdge(ents, "ContentView", "NAVIGATES_TO", "view:DetailView") {
+		t.Fatal("expected ContentView NAVIGATES_TO view:DetailView")
+	}
+	if v, _ := edgeProp(ents, "ContentView", "NAVIGATES_TO", "view:DetailView", "via"); v != "navigation_link" {
+		t.Errorf("expected via=navigation_link, got %q", v)
+	}
+}
+
+func TestSwiftUINavigatesValueEdge(t *testing.T) {
+	src := `
+struct ListView: View {
+    var body: some View {
+        NavigationStack {
+            NavigationLink(value: route) { Text("Open") }
+        }
+    }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("ListView.swift", "swift", src))
+	if !hasEdge(ents, "ListView", "NAVIGATES_TO", "navvalue:route") {
+		t.Fatal("expected ListView NAVIGATES_TO navvalue:route")
+	}
+	if v, _ := edgeProp(ents, "ListView", "NAVIGATES_TO", "navvalue:route", "via"); v != "navigation_link_value" {
+		t.Errorf("expected via=navigation_link_value, got %q", v)
+	}
+}
+
+func TestSwiftUIModalNavigatesEdge(t *testing.T) {
+	src := `
+struct HomeView: View {
+    @State var showing = false
+    var body: some View {
+        Text("Home")
+            .sheet(isPresented: $showing) { SettingsView() }
+    }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("HomeView.swift", "swift", src))
+	if !hasEdge(ents, "HomeView", "NAVIGATES_TO", "view:SettingsView") {
+		t.Fatal("expected HomeView NAVIGATES_TO view:SettingsView (sheet)")
+	}
+	if v, _ := edgeProp(ents, "HomeView", "NAVIGATES_TO", "view:SettingsView", "via"); v != "modal_sheet" {
+		t.Errorf("expected via=modal_sheet, got %q", v)
+	}
+}
+
+func TestSwiftUIFullScreenCoverNavigatesEdge(t *testing.T) {
+	src := `
+struct RootView: View {
+    var body: some View {
+        Text("Root")
+            .fullScreenCover(isPresented: $flag) { OnboardingView() }
+    }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("RootView.swift", "swift", src))
+	if !hasEdge(ents, "RootView", "NAVIGATES_TO", "view:OnboardingView") {
+		t.Fatal("expected RootView NAVIGATES_TO view:OnboardingView (fullScreenCover)")
+	}
+	if v, _ := edgeProp(ents, "RootView", "NAVIGATES_TO", "view:OnboardingView", "via"); v != "modal_fullScreenCover" {
+		t.Errorf("expected via=modal_fullScreenCover, got %q", v)
+	}
+}
+
+func TestSwiftUIUsesViewModelEdge(t *testing.T) {
+	src := `
+struct ProfileView: View {
+    @StateObject var vm = ProfileViewModel()
+    @ObservedObject var settings: SettingsStore
+    @EnvironmentObject var appState: AppState
+    var body: some View { Text("Profile") }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("ProfileView.swift", "swift", src))
+	// ProfileView USES ProfileViewModel / SettingsStore / AppState.
+	if !hasEdge(ents, "ProfileView", "USES", "type:SettingsStore") {
+		t.Fatal("expected ProfileView USES type:SettingsStore")
+	}
+	if !hasEdge(ents, "ProfileView", "USES", "type:AppState") {
+		t.Fatal("expected ProfileView USES type:AppState")
+	}
+	// @StateObject var vm = ProfileViewModel() — type comes from initializer; the
+	// shared regex captures the RHS type token.
+	if !hasEdge(ents, "ProfileView", "USES", "type:ProfileViewModel") {
+		t.Fatal("expected ProfileView USES type:ProfileViewModel")
+	}
+	if v, _ := edgeProp(ents, "ProfileView", "USES", "type:AppState", "property_wrapper"); v != "@EnvironmentObject" {
+		t.Errorf("expected property_wrapper=@EnvironmentObject, got %q", v)
+	}
+}
+
+func TestSwiftUIStateNoEdge(t *testing.T) {
+	// @State / @Binding are local value state — entity props, NOT edges.
+	src := `
+struct Counter: View {
+    @State var count: Int = 0
+    @Binding var on: Bool
+    var body: some View { Text("\(count)") }
+}
+`
+	ents := extractFull(t, "custom_swift_swiftui", fi("Counter.swift", "swift", src))
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "USES" {
+				t.Errorf("@State/@Binding must not emit USES edge, got %s -> %s", e.Name, r.ToID)
+			}
+		}
 	}
 }

--- a/internal/custom/swift/swiftui.go
+++ b/internal/custom/swift/swiftui.go
@@ -3,6 +3,7 @@ package swift
 import (
 	"context"
 	"regexp"
+	"strconv"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -30,8 +31,21 @@ var (
 	reSwiftUINavLink = regexp.MustCompile(
 		`NavigationLink\s*\(\s*(?:destination:\s*)?([A-Z][A-Za-z0-9_]*)`,
 	)
+	// NavigationLink(value: …) { Text("Detail") } — value-based navigation
+	// whose concrete destination is declared elsewhere via
+	// .navigationDestination(for:). The destination View is not statically
+	// resolvable in-file, so we record the value type as the nav target.
+	reSwiftUINavLinkValue = regexp.MustCompile(
+		`NavigationLink\s*\(\s*value:\s*([A-Za-z_][A-Za-z0-9_.]*)`,
+	)
 	reSwiftUINavDestination = regexp.MustCompile(
 		`\.navigationDestination\s*\(for:\s*(\w+)\.self`,
+	)
+	// .sheet(isPresented: …) { DetailView() } / .fullScreenCover(...) { … }
+	// modal navigation transitions whose presented View we capture as the
+	// destination of a NAVIGATES_TO edge.
+	reSwiftUIModalPresent = regexp.MustCompile(
+		`\.(sheet|fullScreenCover)\s*\([^)]*\)\s*\{\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+in\s*)?([A-Z][A-Za-z0-9_]*)\s*\(`,
 	)
 	reSwiftUIState = regexp.MustCompile(
 		`@State\s+(?:private\s+)?var\s+(\w+)\s*:`,
@@ -39,8 +53,11 @@ var (
 	reSwiftUIBinding = regexp.MustCompile(
 		`@Binding\s+var\s+(\w+)\s*:`,
 	)
+	// Matches both the type-annotated form (`@ObservedObject var x: Vm`) and the
+	// initializer form (`@StateObject var x = Vm()`). Exactly one of the type
+	// (group 2) or the init-type (group 3) is populated per match.
 	reSwiftUIObservedObject = regexp.MustCompile(
-		`@(?:ObservedObject|EnvironmentObject|StateObject)\s+var\s+(\w+)\s*:\s*(\w+)`,
+		`@(?:ObservedObject|EnvironmentObject|StateObject)\s+var\s+(\w+)\s*(?::\s*(\w+)|=\s*([A-Z]\w*)\s*\()`,
 	)
 	reSwiftUIEnvironment = regexp.MustCompile(
 		`@Environment\s*\(\s*\\\.(\w+)\s*\)\s+var\s+(\w+)`,
@@ -94,6 +111,17 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		entities = append(entities, ent)
 	}
 
+	// viewSpans records each emitted View struct's start offset + entity ID so
+	// edges (navigation, observable USES) can be attributed to the enclosing
+	// View. A match at offset O belongs to the View with the greatest start
+	// offset <= O.
+	type viewSpan struct {
+		start int
+		id    string
+		name  string
+	}
+	var viewSpans []viewSpan
+
 	// 1. struct/class conforming to View -> SCOPE.UIComponent
 	for _, m := range reSwiftUIViewConformance.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
@@ -103,6 +131,33 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		ent := makeEntity(name, "SCOPE.UIComponent", "component", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "swiftui", "provenance", "INFERRED_FROM_SWIFTUI_VIEW")
 		add(ent)
+		viewSpans = append(viewSpans, viewSpan{start: m[0], id: ent.ID, name: name})
+	}
+
+	// enclosingView returns the (id, name) of the View whose declaration most
+	// closely precedes offset, or ("","") if none — used as the FromID of
+	// navigation / USES edges.
+	enclosingView := func(offset int) (string, string) {
+		id, name := "", ""
+		best := -1
+		for _, vs := range viewSpans {
+			if vs.start <= offset && vs.start > best {
+				best = vs.start
+				id, name = vs.id, vs.name
+			}
+		}
+		return id, name
+	}
+
+	// relsByView buffers relationships keyed by the source View's entity ID;
+	// they are flushed onto the entities after all emission completes (so slice
+	// growth from later add() calls can't invalidate pointers).
+	relsByView := make(map[string][]types.RelationshipRecord)
+	attach := func(id string, rel types.RelationshipRecord) {
+		if id == "" {
+			return
+		}
+		relsByView[id] = append(relsByView[id], rel)
 	}
 
 	// 2. NavigationStack -> signals navigation context
@@ -112,7 +167,7 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		add(ent)
 	}
 
-	// 3. NavigationLink destinations -> SCOPE.Operation/endpoint
+	// 3. NavigationLink destinations -> SCOPE.Operation/endpoint + NAVIGATES_TO
 	for _, m := range reSwiftUINavLink.FindAllStringSubmatchIndex(src, -1) {
 		dest := src[m[2]:m[3]]
 		if swiftUIBuiltinViews[dest] {
@@ -122,6 +177,72 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		setProps(&ent, "framework", "swiftui", "provenance", "INFERRED_FROM_SWIFTUI_NAV_LINK",
 			"destination", dest)
 		add(ent)
+
+		// NAVIGATES_TO: enclosing View -> destination View. ToID is a synthetic
+		// "view:<Dest>" stub the linker resolves against the destination's
+		// SCOPE.UIComponent (cross-file resolution happens in the engine).
+		if fromID, fromName := enclosingView(m[0]); fromID != "" {
+			attach(fromID, types.RelationshipRecord{
+				FromID: fromID,
+				ToID:   "view:" + dest,
+				Kind:   "NAVIGATES_TO",
+				Properties: map[string]string{
+					"framework":   "swiftui",
+					"destination": dest,
+					"from_view":   fromName,
+					"line":        itoa(lineOf(src, m[0])),
+					"via":         "navigation_link",
+				},
+			})
+		}
+	}
+
+	// 3b. NavigationLink(value:) -> NAVIGATES_TO (value-based; concrete
+	// destination declared via .navigationDestination(for:), not in-file).
+	for _, m := range reSwiftUINavLinkValue.FindAllStringSubmatchIndex(src, -1) {
+		val := src[m[2]:m[3]]
+		if fromID, fromName := enclosingView(m[0]); fromID != "" {
+			attach(fromID, types.RelationshipRecord{
+				FromID: fromID,
+				ToID:   "navvalue:" + val,
+				Kind:   "NAVIGATES_TO",
+				// Honest-partial: the destination View backing this value type is
+				// resolved elsewhere via .navigationDestination(for:) and cannot
+				// be followed in-file.
+				Confidence: 0.6,
+				Properties: map[string]string{
+					"framework": "swiftui",
+					"value":     val,
+					"from_view": fromName,
+					"line":      itoa(lineOf(src, m[0])),
+					"via":       "navigation_link_value",
+					"partial":   "destination_resolved_via_navigationDestination",
+				},
+			})
+		}
+	}
+
+	// 3c. .sheet / .fullScreenCover -> NAVIGATES_TO (modal transitions).
+	for _, m := range reSwiftUIModalPresent.FindAllStringSubmatchIndex(src, -1) {
+		kind := src[m[2]:m[3]]
+		dest := src[m[4]:m[5]]
+		if swiftUIBuiltinViews[dest] {
+			continue
+		}
+		if fromID, fromName := enclosingView(m[0]); fromID != "" {
+			attach(fromID, types.RelationshipRecord{
+				FromID: fromID,
+				ToID:   "view:" + dest,
+				Kind:   "NAVIGATES_TO",
+				Properties: map[string]string{
+					"framework":   "swiftui",
+					"destination": dest,
+					"from_view":   fromName,
+					"line":        itoa(lineOf(src, m[0])),
+					"via":         "modal_" + kind,
+				},
+			})
+		}
 	}
 
 	// 4. .navigationDestination -> SCOPE.Operation/endpoint
@@ -151,14 +272,47 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		add(ent)
 	}
 
-	// 7. @ObservedObject/@EnvironmentObject -> SCOPE.Component
+	// 7. @ObservedObject/@EnvironmentObject/@StateObject -> SCOPE.Component
+	//    + USES edge: enclosing View -> observable type (view model / app state).
 	for _, m := range reSwiftUIObservedObject.FindAllStringSubmatchIndex(src, -1) {
 		varName := src[m[2]:m[3]]
-		vmType := src[m[4]:m[5]]
+		vmType := ""
+		if m[4] >= 0 { // `: Type` annotation form
+			vmType = src[m[4]:m[5]]
+		} else if m[6] >= 0 { // `= Type(...)` initializer form
+			vmType = src[m[6]:m[7]]
+		}
+		if vmType == "" {
+			continue
+		}
 		ent := makeEntity(varName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "swiftui", "provenance", "INFERRED_FROM_SWIFTUI_OBSERVED_OBJECT",
 			"view_model_type", vmType)
 		add(ent)
+
+		// USES: View -> observable type. The wrapper token (@StateObject etc.)
+		// is recorded for traceability. ToID is a synthetic "type:<Vm>" stub the
+		// linker resolves to the observable's declaration (often cross-file).
+		wrapper := "@ObservedObject"
+		if idx := indexBackWrapper(src, m[0]); idx != "" {
+			wrapper = idx
+		}
+		if fromID, fromName := enclosingView(m[0]); fromID != "" {
+			attach(fromID, types.RelationshipRecord{
+				FromID: fromID,
+				ToID:   "type:" + vmType,
+				Kind:   "USES",
+				Properties: map[string]string{
+					"framework":        "swiftui",
+					"observable_type":  vmType,
+					"property":         varName,
+					"property_wrapper": wrapper,
+					"from_view":        fromName,
+					"line":             itoa(lineOf(src, m[0])),
+					"via":              "observable_object",
+				},
+			})
+		}
 	}
 
 	// 8. @Environment -> SCOPE.Pattern
@@ -170,6 +324,44 @@ func (e *swiftUIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		add(ent)
 	}
 
+	// Flush buffered relationships onto their source View entities. Done after
+	// all add() calls so slice growth cannot invalidate references.
+	if len(relsByView) > 0 {
+		for i := range entities {
+			if rels, ok := relsByView[entities[i].ID]; ok {
+				entities[i].Relationships = append(entities[i].Relationships, rels...)
+			}
+		}
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// indexBackWrapper looks back from offset (the start of an @Observed/State/...
+// match) to recover which property wrapper token was used. The shared regex
+// matches three alternatives without capturing which one, so we re-scan the
+// matched prefix.
+func indexBackWrapper(src string, offset int) string {
+	// The match begins at the '@'; read "@" + the wrapper identifier.
+	if offset >= len(src) || src[offset] != '@' {
+		return ""
+	}
+	end := offset + 1
+	for end < len(src) && isIdentByte(src[end]) {
+		end++
+	}
+	if end > offset+1 {
+		return src[offset:end]
+	}
+	return ""
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }


### PR DESCRIPTION
Closes #3577 (epic #3571).

## What
Deepens the existing SwiftUI extractor (`internal/custom/swift/swiftui.go`, previously entities-only) with navigation + state edges, and adds the missing `lang.swift.framework.swiftui` coverage registry record. Swift previously documented **vapor only** even though a live SwiftUI extractor existed — the same doc-gap class as Flutter #3572.

## Edges (attributed to the enclosing View struct)
All edges set `FromID` to the enclosing `struct/class … : View` (nearest preceding View declaration); `ToID` is a synthetic stub the linker resolves cross-file.

**NAVIGATES_TO** (full):
- `NavigationLink(destination: DetailView())` → `view:DetailView` (`via=navigation_link`)
- `.sheet(isPresented:){ SettingsView() }` → `view:SettingsView` (`via=modal_sheet`)
- `.fullScreenCover(isPresented:){ OnboardingView() }` → `view:OnboardingView` (`via=modal_fullScreenCover`)
- `NavigationLink(value: route)` → `navvalue:route` (`via=navigation_link_value`, **confidence 0.6 honest-partial** — concrete destination resolves cross-file via `.navigationDestination(for:)`)

**USES** (partial):
- `@StateObject var vm = ProfileViewModel()` / `@ObservedObject var x: SettingsStore` / `@EnvironmentObject var s: AppState` → `type:<Observable>` (`via=observable_object`); supports both `: Type` and `= Type()` forms.
- `@State`/`@Binding` remain local `SCOPE.Pattern` props — **no edge, by design** (asserted by `TestSwiftUIStateNoEdge`).

## Coverage record
New `lang.swift.framework.swiftui` (`http_framework` / `ui_frontend`, mirrors flutter/react). Honest stamps citing `swiftui.go` + tests:
- `component_extraction` = **full** (View → SCOPE.UIComponent, existing entities, tested)
- `router_pattern` = **full** (nav edges, tested)
- `state_management` = **partial** (USES edges + cross-file resolution caveat)
- remaining cells **missing**

Fixes the swift doc-gap: `docs/coverage/by-language/swift.md` now lists **Vapor + SwiftUI** (was vapor-only).

## Value-asserting tests
`internal/custom/swift/extractors_test.go` — assert specific edges, not `len>0`:
- `ContentView NAVIGATES_TO view:DetailView`
- `ListView NAVIGATES_TO navvalue:route`
- `HomeView NAVIGATES_TO view:SettingsView` (sheet)
- `RootView NAVIGATES_TO view:OnboardingView` (fullScreenCover)
- `ProfileView USES type:ProfileViewModel / type:SettingsStore / type:AppState`
- `@State`/`@Binding` emit no USES edge

## Verification
`go test ./internal/custom/swift/... ./internal/engine/ ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean. (capability-map "no mapping entry" warnings on the new full/partial cells match the established norm for flutter's custom-extractor record.)

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)