### PR TITLE
Deepen .NET MAUI extractor: Shell-routing, MVVM, and DI edges

### DIFF
--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | Application.Current global context, DependencyService.Get<T>() service resolution, and IServiceProvider/MauiAppBuilder usages emitted as SCOPE.Component/context_extraction. |
+| Context extraction | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_maui_edges_test.go`<br>`internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | Application.Current global context, DependencyService.Get<T>() resolution, IServiceProvider/MauiAppBuilder usages as SCOPE.Component/context_extraction. MauiProgram.cs DI registrations emit binding edges: builder.Services.AddSingleton/AddScoped<IFoo,Foo>() -> BINDS impl:Foo (interface->impl, with lifetime prop); AddSingleton/AddTransient/AddScoped<XViewModel>() -> REGISTERS impl:XViewModel (self-binding). Cross-file impl resolution is partial. |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Deep link extraction | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | Shell.Current.GoToAsync() deep-link routes, [QueryProperty] shell parameter bindings, and AppLinks.RegisterRoute/AppendAppLink registrations emitted as SCOPE.Pattern/deep_link_extraction. |
-| Navigation extraction | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | Navigation.PushAsync/PopAsync/PushModalAsync/PopModalAsync stack operations, Shell.GoToAsync route-based navigation, and NavigationPage/TabbedPage/FlyoutPage constructor usages detected. |
+| Navigation extraction | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_maui_edges_test.go`<br>`internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | Navigation.PushAsync/PopAsync/PushModalAsync stack ops, NavigationPage/TabbedPage/FlyoutPage ctors detected. Shell routing emits NAVIGATES_TO edges to synthetic route:<path> stubs: Routing.RegisterRoute("r", typeof(Page)) and <ShellContent Route="r" ContentTemplate="{DataTemplate Page}"/> (route tables, target_page resolved in-file), plus Shell.Current.GoToAsync("//r") and GoToAsync(nameof(Page)) call sites (route normalized). Cross-file route->page resolution is partial. |
 | Screen detection | 🟢 `partial` | — | — | `internal/custom/csharp/mobile_platform.go`<br>`internal/custom/csharp/mobile_platform_test.go` | ContentPage/Shell/TabbedPage/FlyoutPage/NavigationPage/MasterDetailPage subclass declarations emitted as SCOPE.UIComponent/screen_detection. |
 
 ### Platform
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | 🟢 `partial` | — | — | `internal/custom/csharp/blazor_dataflow.go` | Device.RuntimePlatform/DeviceInfo.Platform platform conditionals + code if() branches detected via reBDFPlatformBranch/reBDFDeviceInfo/reBDFCodeIf |
-| State management | 🟢 `partial` | — | — | `internal/custom/csharp/blazor_dataflow.go` | MAUI BindableProperty.Create/SetValue + INotifyPropertyChanged callbacks detected via reBDFSetValue/reBDFPropertyChanged/reBDFBindableProperty |
+| State management | 🟢 `partial` | — | — | `internal/custom/csharp/blazor_dataflow.go`<br>`internal/custom/csharp/mobile_maui_edges_test.go`<br>`internal/custom/csharp/mobile_platform.go` | MAUI BindableProperty.Create/SetValue + INotifyPropertyChanged callbacks (blazor_dataflow.go). MVVM view<->viewmodel wiring emits USES edges page->viewmodel:<VM>: BindingContext = new XViewModel() and DI-injected XViewModel ctor params on a ContentPage. CommunityToolkit.Mvvm [ObservableProperty]/[RelayCommand] mark a class as a ViewModel (viewmodel:<name> marker) and [RelayCommand] methods become command:<name> entities (mobile_platform.go). |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -8466,8 +8466,8 @@
         "Structure": {
           "context_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/csharp/mobile_platform.go","internal/custom/csharp/mobile_platform_test.go"],
-            "notes": "Application.Current global context, DependencyService.Get\u003cT\u003e() service resolution, and IServiceProvider/MauiAppBuilder usages emitted as SCOPE.Component/context_extraction."
+            "cites": ["internal/custom/csharp/mobile_maui_edges_test.go","internal/custom/csharp/mobile_platform.go","internal/custom/csharp/mobile_platform_test.go"],
+            "notes": "Application.Current global context, DependencyService.Get\u003cT\u003e() resolution, IServiceProvider/MauiAppBuilder usages as SCOPE.Component/context_extraction. MauiProgram.cs DI registrations emit binding edges: builder.Services.AddSingleton/AddScoped\u003cIFoo,Foo\u003e() -\u003e BINDS impl:Foo (interface-\u003eimpl, with lifetime prop); AddSingleton/AddTransient/AddScoped\u003cXViewModel\u003e() -\u003e REGISTERS impl:XViewModel (self-binding). Cross-file impl resolution is partial."
           }
         },
         "Navigation": {
@@ -8478,8 +8478,8 @@
           },
           "navigation_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/csharp/mobile_platform.go","internal/custom/csharp/mobile_platform_test.go"],
-            "notes": "Navigation.PushAsync/PopAsync/PushModalAsync/PopModalAsync stack operations, Shell.GoToAsync route-based navigation, and NavigationPage/TabbedPage/FlyoutPage constructor usages detected."
+            "cites": ["internal/custom/csharp/mobile_maui_edges_test.go","internal/custom/csharp/mobile_platform.go","internal/custom/csharp/mobile_platform_test.go"],
+            "notes": "Navigation.PushAsync/PopAsync/PushModalAsync stack ops, NavigationPage/TabbedPage/FlyoutPage ctors detected. Shell routing emits NAVIGATES_TO edges to synthetic route:\u003cpath\u003e stubs: Routing.RegisterRoute(\"r\", typeof(Page)) and \u003cShellContent Route=\"r\" ContentTemplate=\"{DataTemplate Page}\"/\u003e (route tables, target_page resolved in-file), plus Shell.Current.GoToAsync(\"//r\") and GoToAsync(nameof(Page)) call sites (route normalized). Cross-file route-\u003epage resolution is partial."
           },
           "screen_detection": {
             "status": "partial",
@@ -8509,8 +8509,8 @@
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/custom/csharp/blazor_dataflow.go"],
-            "notes": "MAUI BindableProperty.Create/SetValue + INotifyPropertyChanged callbacks detected via reBDFSetValue/reBDFPropertyChanged/reBDFBindableProperty"
+            "cites": ["internal/custom/csharp/blazor_dataflow.go","internal/custom/csharp/mobile_maui_edges_test.go","internal/custom/csharp/mobile_platform.go"],
+            "notes": "MAUI BindableProperty.Create/SetValue + INotifyPropertyChanged callbacks (blazor_dataflow.go). MVVM view\u003c-\u003eviewmodel wiring emits USES edges page-\u003eviewmodel:\u003cVM\u003e: BindingContext = new XViewModel() and DI-injected XViewModel ctor params on a ContentPage. CommunityToolkit.Mvvm [ObservableProperty]/[RelayCommand] mark a class as a ViewModel (viewmodel:\u003cname\u003e marker) and [RelayCommand] methods become command:\u003cname\u003e entities (mobile_platform.go)."
           }
         },
         "Type System": {

--- a/internal/custom/csharp/mobile_maui_edges_test.go
+++ b/internal/custom/csharp/mobile_maui_edges_test.go
@@ -1,0 +1,246 @@
+package csharp_test
+
+// ---------------------------------------------------------------------------
+// .NET MAUI edge extraction (#3579):
+//   - Shell-routing NAVIGATES_TO (RegisterRoute / ShellContent / GoToAsync)
+//   - MVVM view↔viewmodel USES (BindingContext / DI ctor / CommunityToolkit)
+//   - DI registration BINDS / REGISTERS (AddSingleton<IFoo,Foo> / AddTransient<X>)
+//
+// These assert SPECIFIC edges (ToID + Kind + owning props), not len>0.
+// extractFull / fi are shared helpers from the csharp_test package.
+// ---------------------------------------------------------------------------
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mauiEdgeOwner returns the first entity carrying an edge {toID, kind}, or nil.
+func mauiEdgeOwner(ents []types.EntityRecord, toID, kind string) *types.EntityRecord {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.ToID == toID && r.Kind == kind {
+				return &ents[i]
+			}
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Shell routing → NAVIGATES_TO
+// ---------------------------------------------------------------------------
+
+func TestMauiEdges_RegisterRoute_NavigatesTo(t *testing.T) {
+	src := `
+public partial class AppShell : Shell
+{
+    public AppShell()
+    {
+        Routing.RegisterRoute("details", typeof(DetailsPage));
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("AppShell.xaml.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "route:details", "NAVIGATES_TO")
+	if owner == nil {
+		t.Fatalf("expected NAVIGATES_TO route:details from RegisterRoute")
+	}
+	if owner.Subtype != "navigation_extraction" {
+		t.Errorf("expected subtype navigation_extraction, got %q", owner.Subtype)
+	}
+	if owner.Properties["target_page"] != "DetailsPage" {
+		t.Errorf("expected target_page=DetailsPage, got %q", owner.Properties["target_page"])
+	}
+}
+
+func TestMauiEdges_ShellContentXaml_NavigatesTo(t *testing.T) {
+	src := `
+<ShellContent Route="home" ContentTemplate="{DataTemplate local:HomePage}" />
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("AppShell.xaml", "csharp", src))
+	owner := mauiEdgeOwner(ents, "route:home", "NAVIGATES_TO")
+	if owner == nil {
+		t.Fatalf("expected NAVIGATES_TO route:home from <ShellContent>")
+	}
+	if owner.Properties["target_page"] != "HomePage" {
+		t.Errorf("expected target_page=HomePage from ContentTemplate, got %q", owner.Properties["target_page"])
+	}
+}
+
+func TestMauiEdges_GoToAsyncString_NavigatesTo(t *testing.T) {
+	src := `
+public async Task Open()
+{
+    await Shell.Current.GoToAsync("//details");
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MainPage.xaml.cs", "csharp", src))
+	// "//details" must normalize to route:details (leading slashes stripped).
+	if mauiEdgeOwner(ents, "route:details", "NAVIGATES_TO") == nil {
+		t.Fatalf("expected normalized NAVIGATES_TO route:details from GoToAsync(\"//details\")")
+	}
+}
+
+func TestMauiEdges_GoToAsyncNameof_NavigatesTo(t *testing.T) {
+	src := `
+public async Task Open()
+{
+    await Shell.Current.GoToAsync(nameof(DetailsPage));
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MainPage.xaml.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "route:DetailsPage", "NAVIGATES_TO")
+	if owner == nil {
+		t.Fatalf("expected NAVIGATES_TO route:DetailsPage from GoToAsync(nameof(DetailsPage))")
+	}
+	if owner.Properties["target_page"] != "DetailsPage" {
+		t.Errorf("expected target_page=DetailsPage, got %q", owner.Properties["target_page"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MVVM view↔viewmodel → USES
+// ---------------------------------------------------------------------------
+
+func TestMauiEdges_BindingContextNew_Uses(t *testing.T) {
+	src := `
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+        BindingContext = new MainViewModel();
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MainPage.xaml.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "viewmodel:MainViewModel", "USES")
+	if owner == nil {
+		t.Fatalf("expected MainPage USES viewmodel:MainViewModel")
+	}
+	if owner.Properties["view"] != "MainPage" {
+		t.Errorf("expected view=MainPage on USES edge, got %q", owner.Properties["view"])
+	}
+}
+
+func TestMauiEdges_CtorInjectedViewModel_Uses(t *testing.T) {
+	src := `
+public partial class ProductPage : ContentPage
+{
+    public ProductPage(ProductViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("ProductPage.xaml.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "viewmodel:ProductViewModel", "USES")
+	if owner == nil {
+		t.Fatalf("expected ProductPage USES viewmodel:ProductViewModel via ctor injection")
+	}
+	if owner.Properties["view"] != "ProductPage" {
+		t.Errorf("expected view=ProductPage, got %q", owner.Properties["view"])
+	}
+}
+
+func TestMauiEdges_CommunityToolkitViewModel_And_RelayCommand(t *testing.T) {
+	src := `
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+public partial class CounterViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int count;
+
+    [RelayCommand]
+    private void Increment() => Count++;
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("CounterViewModel.cs", "csharp", src))
+	foundVM := false
+	foundCmd := false
+	for i := range ents {
+		e := ents[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "state_management" && e.Name == "viewmodel:CounterViewModel" {
+			foundVM = true
+		}
+		if e.Name == "command:Increment" && e.Subtype == "state_management" {
+			foundCmd = true
+		}
+	}
+	if !foundVM {
+		t.Errorf("expected viewmodel:CounterViewModel marker entity")
+	}
+	if !foundCmd {
+		t.Errorf("expected command:Increment entity from [RelayCommand]")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DI registration → BINDS / REGISTERS
+// ---------------------------------------------------------------------------
+
+func TestMauiEdges_AddSingletonTwoArg_Binds(t *testing.T) {
+	src := `
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.Services.AddSingleton<IDataService, DataService>();
+        return builder.Build();
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MauiProgram.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "impl:DataService", "BINDS")
+	if owner == nil {
+		t.Fatalf("expected BINDS impl:DataService from AddSingleton<IDataService,DataService>")
+	}
+	if owner.Properties["interface"] != "IDataService" {
+		t.Errorf("expected interface=IDataService, got %q", owner.Properties["interface"])
+	}
+	if owner.Properties["lifetime"] != "Singleton" {
+		t.Errorf("expected lifetime=Singleton, got %q", owner.Properties["lifetime"])
+	}
+}
+
+func TestMauiEdges_AddTransientOneArg_Registers(t *testing.T) {
+	src := `
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.Services.AddTransient<MainViewModel>();
+        return builder.Build();
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MauiProgram.cs", "csharp", src))
+	owner := mauiEdgeOwner(ents, "impl:MainViewModel", "REGISTERS")
+	if owner == nil {
+		t.Fatalf("expected REGISTERS impl:MainViewModel from AddTransient<MainViewModel>")
+	}
+	if owner.Properties["lifetime"] != "Transient" {
+		t.Errorf("expected lifetime=Transient, got %q", owner.Properties["lifetime"])
+	}
+}
+
+// Two-arg form must NOT also emit a one-arg self-registration edge.
+func TestMauiEdges_NoDoubleEmit_TwoArgVsOneArg(t *testing.T) {
+	src := `
+builder.Services.AddScoped<IRepo, Repo>();
+`
+	ents := extractFull(t, "custom_csharp_mobile_platform", fi("MauiProgram.cs", "csharp", src))
+	if mauiEdgeOwner(ents, "impl:IRepo", "REGISTERS") != nil {
+		t.Errorf("two-arg AddScoped must not emit a self REGISTERS edge for the interface")
+	}
+	if mauiEdgeOwner(ents, "impl:Repo", "BINDS") == nil {
+		t.Errorf("expected BINDS impl:Repo from AddScoped<IRepo,Repo>")
+	}
+}

--- a/internal/custom/csharp/mobile_platform.go
+++ b/internal/custom/csharp/mobile_platform.go
@@ -52,6 +52,7 @@ package csharp
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -229,7 +230,86 @@ var (
 	reMPSetProperty = regexp.MustCompile(
 		`SetProperty\s*\(\s*ref\s+\w`,
 	)
+
+	// Navigation/navigation_extraction — Shell routing edges (#3579) -----------
+
+	// Routing.RegisterRoute("details", typeof(DetailsPage)) — route→page mapping
+	reMPRegisterRoute = regexp.MustCompile(
+		`Routing\.RegisterRoute\s*\(\s*["']([^"']+)["']\s*,\s*typeof\s*\(\s*(\w+)\s*\)`,
+	)
+
+	// <ShellContent Route="home" ...> — XAML route declaration. Optionally a
+	// ContentTemplate="{DataTemplate local:HomePage}" naming the target page.
+	reMPShellContentRoute = regexp.MustCompile(
+		`<ShellContent\b[^>]*\bRoute\s*=\s*["']([^"']+)["']`,
+	)
+
+	// ContentTemplate="{DataTemplate local:HomePage}" — page reference within a
+	// ShellContent / Tab / FlyoutItem element.
+	reMPContentTemplatePage = regexp.MustCompile(
+		`ContentTemplate\s*=\s*["']\{\s*DataTemplate\s+(?:[\w:]+:)?(\w+)\s*\}`,
+	)
+
+	// Shell.Current.GoToAsync(nameof(DetailsPage)) — nameof-style route target
+	reMPGoToAsyncNameof = regexp.MustCompile(
+		`(?:Shell(?:\.Current)?)?\.?GoToAsync\s*\(\s*nameof\s*\(\s*(\w+)\s*\)`,
+	)
+
+	// MVVM view↔viewmodel — USES edges (#3579) ---------------------------------
+
+	// BindingContext = new ProductViewModel(...) — explicit VM wiring
+	reMPBindingContextNew = regexp.MustCompile(
+		`BindingContext\s*=\s*new\s+(\w+)\s*\(`,
+	)
+
+	// public MainPage(MainViewModel vm) — DI-injected ViewModel ctor parameter.
+	// Captured against the enclosing ContentPage class (resolved separately).
+	reMPViewModelCtorParam = regexp.MustCompile(
+		`\b(\w+ViewModel)\s+\w+\s*[,)]`,
+	)
+
+	// [ObservableProperty] / [RelayCommand] — CommunityToolkit.Mvvm markers that
+	// identify a class as a ViewModel.
+	reMPObservableProperty = regexp.MustCompile(
+		`\[ObservableProperty\b`,
+	)
+
+	// [RelayCommand] private void/Task Save() — command method declaration
+	reMPRelayCommand = regexp.MustCompile(
+		`(?s)\[RelayCommand[^\]]*\]\s*(?:public|private|protected|internal)?\s*` +
+			`(?:async\s+)?(?:partial\s+)?(?:void|Task|ValueTask|IAsyncRelayCommand|\w+)\s+(\w+)\s*\(`,
+	)
+
+	// DI registration — BINDS edges (#3579) ------------------------------------
+
+	// builder.Services.AddSingleton<IFoo, Foo>() — interface→impl binding
+	reMPDITwoTypeArgs = regexp.MustCompile(
+		`\.Add(Singleton|Transient|Scoped)\s*<\s*(\w+(?:<[^>]+>)?)\s*,\s*(\w+(?:<[^>]+>)?)\s*>\s*\(`,
+	)
+
+	// builder.Services.AddTransient<XViewModel>() — single-type self registration
+	reMPDIOneTypeArg = regexp.MustCompile(
+		`\.Add(Singleton|Transient|Scoped)\s*<\s*(\w+(?:<[^>]+>)?)\s*>\s*\(`,
+	)
+
+	// class XViewModel { ... } — any class declaration (used to name the
+	// CommunityToolkit.Mvvm ViewModel when no ContentPage subclass is present,
+	// e.g. a partial ViewModel-only file).
+	reMPMvvmClass = regexp.MustCompile(
+		`(?m)\bclass\s+(\w+)\b`,
+	)
 )
+
+// normalizeMauiRoute strips Shell's "//" and "/" routing prefixes so that
+// GoToAsync("//details"), GoToAsync("details") and RegisterRoute("details", ...)
+// all resolve to the same synthetic "route:details" stub.
+func normalizeMauiRoute(route string) string {
+	r := route
+	for len(r) > 0 && r[0] == '/' {
+		r = r[1:]
+	}
+	return r
+}
 
 // ---------------------------------------------------------------------------
 // Extract
@@ -528,6 +608,288 @@ func (e *mobilePlatformExtractor) Extract(ctx context.Context, file extractor.Fi
 		add(ent)
 	}
 
+	// -------------------------------------------------------------------------
+	// Navigation/navigation_extraction — Shell routing NAVIGATES_TO edges (#3579)
+	//
+	// Three Shell-routing surfaces become NAVIGATES_TO edges to a synthetic
+	// "route:<path>" stub (mirroring the JS/TS Angular/Expo route convention):
+	//   1. Routing.RegisterRoute("details", typeof(DetailsPage))   [route table]
+	//   2. <ShellContent Route="home" ...>                          [route table]
+	//   3. Shell.Current.GoToAsync("//details") / GoToAsync(nameof(DetailsPage))
+	//      [imperative call site]
+	// Cross-file resolution of the route→page identity is honest-partial: it is
+	// resolved within a file when RegisterRoute / ContentTemplate names the page.
+	// -------------------------------------------------------------------------
+
+	for _, m := range reMPRegisterRoute.FindAllStringSubmatchIndex(src, -1) {
+		route := normalizeMauiRoute(src[m[2]:m[3]])
+		pageType := src[m[4]:m[5]]
+		if route == "" {
+			continue
+		}
+		ent := makeEntity("route_register:"+route, "SCOPE.Operation", "navigation_extraction",
+			file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_REGISTER_ROUTE",
+			"route", route, "target_page", pageType)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "route:" + route,
+			Kind: string(types.RelationshipKindNavigatesTo),
+			Properties: map[string]string{
+				"route":       route,
+				"via":         "register_route",
+				"target_page": pageType,
+				"framework":   "maui",
+				"line":        itoa(lineOf(src, m[0])),
+			},
+		})
+		add(ent)
+	}
+
+	// <ShellContent Route="home" ContentTemplate="{DataTemplate local:HomePage}">
+	// Pair each Route= with the nearest following ContentTemplate page (if any).
+	contentTemplates := reMPContentTemplatePage.FindAllStringSubmatchIndex(src, -1)
+	for _, m := range reMPShellContentRoute.FindAllStringSubmatchIndex(src, -1) {
+		route := normalizeMauiRoute(src[m[2]:m[3]])
+		if route == "" {
+			continue
+		}
+		targetPage := ""
+		for _, cm := range contentTemplates {
+			// The ContentTemplate belongs to the same element when it appears
+			// shortly after the Route= attribute on the opening tag.
+			if cm[0] >= m[0] && cm[0]-m[1] < 200 {
+				targetPage = src[cm[2]:cm[3]]
+				break
+			}
+		}
+		ent := makeEntity("shell_content:"+route, "SCOPE.Operation", "navigation_extraction",
+			file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_SHELL_CONTENT",
+			"route", route)
+		props := map[string]string{
+			"route":     route,
+			"via":       "shell_content",
+			"framework": "maui",
+			"line":      itoa(lineOf(src, m[0])),
+		}
+		if targetPage != "" {
+			setProps(&ent, "target_page", targetPage)
+			props["target_page"] = targetPage
+		}
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID:       "route:" + route,
+			Kind:       string(types.RelationshipKindNavigatesTo),
+			Properties: props,
+		})
+		add(ent)
+	}
+
+	// Shell.Current.GoToAsync("//details") — string-literal imperative nav.
+	for _, m := range reMPShellGoToAsync.FindAllStringSubmatchIndex(src, -1) {
+		route := normalizeMauiRoute(src[m[2]:m[3]])
+		if route == "" {
+			continue
+		}
+		ent := makeEntity("goto:"+route+":"+file.Path+":"+itoa(lineOf(src, m[0])),
+			"SCOPE.Operation", "navigation_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_GO_TO_ASYNC",
+			"route", route)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "route:" + route,
+			Kind: string(types.RelationshipKindNavigatesTo),
+			Properties: map[string]string{
+				"route":     route,
+				"via":       "goto_async",
+				"framework": "maui",
+				"line":      itoa(lineOf(src, m[0])),
+			},
+		})
+		add(ent)
+	}
+
+	// Shell.Current.GoToAsync(nameof(DetailsPage)) — nameof target == page == route.
+	for _, m := range reMPGoToAsyncNameof.FindAllStringSubmatchIndex(src, -1) {
+		page := src[m[2]:m[3]]
+		ent := makeEntity("goto:nameof:"+page+":"+file.Path+":"+itoa(lineOf(src, m[0])),
+			"SCOPE.Operation", "navigation_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_GO_TO_ASYNC_NAMEOF",
+			"route", page, "target_page", page)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "route:" + page,
+			Kind: string(types.RelationshipKindNavigatesTo),
+			Properties: map[string]string{
+				"route":       page,
+				"via":         "goto_nameof",
+				"target_page": page,
+				"framework":   "maui",
+				"line":        itoa(lineOf(src, m[0])),
+			},
+		})
+		add(ent)
+	}
+
+	// -------------------------------------------------------------------------
+	// Data Flow/state_management — MVVM view↔viewmodel USES edges (#3579)
+	//
+	// A ContentPage that wires a ViewModel — via BindingContext = new XViewModel()
+	// or a DI-injected XViewModel ctor parameter — emits a USES edge
+	// page→"viewmodel:XViewModel". [ObservableProperty]/[RelayCommand] mark the
+	// class as a ViewModel; [RelayCommand] methods become command entities.
+	// -------------------------------------------------------------------------
+
+	// Resolve the enclosing page/class name (first ContentPage-style subclass in
+	// the file) so the USES edge has a meaningful caller property.
+	enclosingPage := ""
+	if pm := reMPContentPage.FindStringSubmatchIndex(src); pm != nil {
+		enclosingPage = src[pm[2]:pm[3]]
+	}
+
+	emitViewModelUses := func(vm string, via string, line int) {
+		if vm == "" {
+			return
+		}
+		ent := makeEntity("view_binds:"+enclosingPage+":"+vm, "SCOPE.UIComponent", "state_management",
+			file.Path, "csharp", line)
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_MVVM_BINDING",
+			"view", enclosingPage, "viewmodel", vm, "binding", via)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "viewmodel:" + vm,
+			Kind: string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"viewmodel": vm,
+				"view":      enclosingPage,
+				"via":       via,
+				"framework": "maui",
+				"line":      itoa(line),
+			},
+		})
+		add(ent)
+	}
+
+	for _, m := range reMPBindingContextNew.FindAllStringSubmatchIndex(src, -1) {
+		emitViewModelUses(src[m[2]:m[3]], "binding_context_new", lineOf(src, m[0]))
+	}
+	// DI-injected ViewModel ctor param: only meaningful inside a page class.
+	if enclosingPage != "" {
+		for _, m := range reMPViewModelCtorParam.FindAllStringSubmatchIndex(src, -1) {
+			emitViewModelUses(src[m[2]:m[3]], "ctor_injection", lineOf(src, m[0]))
+		}
+	}
+
+	// CommunityToolkit.Mvvm ViewModel marker: [ObservableProperty]/[RelayCommand].
+	if reMPObservableProperty.MatchString(src) || reMPRelayCommand.MatchString(src) {
+		// Tag the enclosing class as a ViewModel so the "viewmodel:<name>" stub
+		// emitted by USES edges has a concrete endpoint within the same file.
+		vmName := enclosingPage
+		if vm := reMPMvvmClass.FindStringSubmatchIndex(src); vm != nil {
+			vmName = src[vm[2]:vm[3]]
+		}
+		if vmName != "" {
+			ent := makeEntity("viewmodel:"+vmName, "SCOPE.Component", "state_management",
+				file.Path, "csharp", 1)
+			setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_MVVM_TOOLKIT",
+				"viewmodel", vmName)
+			add(ent)
+		}
+	}
+
+	// [RelayCommand] methods → command entities (cheap; aids USES targeting).
+	for _, m := range reMPRelayCommand.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		ent := makeEntity("command:"+method, "SCOPE.Operation", "state_management",
+			file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_RELAY_COMMAND",
+			"command", method)
+		add(ent)
+	}
+
+	// -------------------------------------------------------------------------
+	// Structure/context_extraction — DI registration BINDS edges (#3579)
+	//
+	// MauiProgram.cs service registrations:
+	//   builder.Services.AddSingleton<IFoo, Foo>()  → BINDS  iface:IFoo → impl:Foo
+	//   builder.Services.AddTransient<XViewModel>() → REGISTERS self-binding
+	// Mirrors how DI bindings are modeled elsewhere (interface→impl edge).
+	// -------------------------------------------------------------------------
+
+	for _, m := range reMPDITwoTypeArgs.FindAllStringSubmatchIndex(src, -1) {
+		lifetime := src[m[2]:m[3]]
+		iface := src[m[4]:m[5]]
+		impl := src[m[6]:m[7]]
+		ent := makeEntity("di:"+iface+"->"+impl, "SCOPE.Component", "context_extraction",
+			file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_DI_REGISTRATION",
+			"interface", iface, "implementation", impl, "lifetime", lifetime)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "impl:" + impl,
+			Kind: string(types.RelationshipKindBinds),
+			Properties: map[string]string{
+				"interface":      iface,
+				"implementation": impl,
+				"lifetime":       lifetime,
+				"framework":      "maui",
+				"line":           itoa(lineOf(src, m[0])),
+			},
+		})
+		add(ent)
+	}
+
+	// Single-type-arg registrations (self-binding); skip those already captured
+	// as the two-arg form (the one-arg regex also matches "<IFoo, Foo>" prefix).
+	for _, m := range reMPDIOneTypeArg.FindAllStringSubmatchIndex(src, -1) {
+		// Guard: the two-type-arg regex is a superset; re-check there is no comma
+		// between the angle brackets for this match to avoid double emission.
+		seg := src[m[0]:m[1]]
+		if commaInTypeArgs(seg) {
+			continue
+		}
+		lifetime := src[m[2]:m[3]]
+		svc := src[m[4]:m[5]]
+		ent := makeEntity("di:self:"+svc, "SCOPE.Component", "context_extraction",
+			file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "maui", "provenance", "INFERRED_FROM_DI_SELF_REGISTRATION",
+			"service", svc, "lifetime", lifetime)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "impl:" + svc,
+			Kind: string(types.RelationshipKindRegisters),
+			Properties: map[string]string{
+				"service":   svc,
+				"lifetime":  lifetime,
+				"framework": "maui",
+				"line":      itoa(lineOf(src, m[0])),
+			},
+		})
+		add(ent)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// commaInTypeArgs reports whether the matched Add{Singleton,…}<...>( segment
+// contains a top-level comma between its angle brackets — i.e. it is the
+// two-type-arg interface→impl form, which the dedicated two-arg pass already
+// handles. Used to keep the one-arg self-registration pass from double-emitting.
+func commaInTypeArgs(seg string) bool {
+	open := strings.IndexByte(seg, '<')
+	if open < 0 {
+		return false
+	}
+	depth := 0
+	for i := open; i < len(seg); i++ {
+		switch seg[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+			if depth == 0 {
+				return false
+			}
+		case ',':
+			if depth == 1 {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Closes #3579 (epic #3571).

The C# mobile extractor (`internal/custom/csharp/mobile_platform.go`) was **entities-only** per the mobile audit. This deepens it with **value-asserting edges** for .NET MAUI, keeping all existing entity emission intact.

## Edges emitted

### Shell routing → `NAVIGATES_TO` (`navigation_extraction` cell) — full in-file, partial cross-file
- `Routing.RegisterRoute("details", typeof(DetailsPage))` → `route:details` (route table, `target_page` resolved in-file)
- `<ShellContent Route="home" ContentTemplate="{DataTemplate local:HomePage}"/>` (XAML) → `route:home` (pairs nearest `ContentTemplate` page)
- `Shell.Current.GoToAsync("//details")` → `route:details` (leading `//`/`/` normalized away)
- `Shell.Current.GoToAsync(nameof(DetailsPage))` → `route:DetailsPage`

### MVVM view↔viewmodel → `USES` (`state_management` cell)
- `BindingContext = new XViewModel()` → page `USES viewmodel:XViewModel`
- DI-injected `XViewModel` ctor param on a `ContentPage` → page `USES viewmodel:XViewModel`
- CommunityToolkit.Mvvm `[ObservableProperty]`/`[RelayCommand]` → `viewmodel:<name>` marker entity; `[RelayCommand]` methods → `command:<name>` entities

### DI registration → `BINDS` / `REGISTERS` (`context_extraction` cell)
- `builder.Services.AddSingleton/AddScoped<IFoo,Foo>()` → `BINDS impl:Foo` (interface→impl, with `lifetime` prop)
- `Add{Singleton,Transient,Scoped}<XViewModel>()` → `REGISTERS impl:XViewModel` (self-binding); the two-arg form is guarded against double-emit.

## Honest-partial
Cross-file route→page and interface→impl resolution remains `partial`; full where an in-file mapping (`RegisterRoute` / `ContentTemplate`) names the target. The three coverage cells stay `partial`, now cited with the new edge test.

## Xamarin
Xamarin is EOL — no new Xamarin-specific edges. The existing entity-only Xamarin patterns (`DependencyService`, `Device.RuntimePlatform`, `MasterDetailPage`, etc.) are unchanged; the new edges target MAUI surfaces (Shell, CommunityToolkit.Mvvm, `builder.Services`).

## Tests (value-asserting — assert specific ToID+Kind+props, not `len>0`)
`internal/custom/csharp/mobile_maui_edges_test.go` — 10 tests covering each edge above, including route normalization, ctor-injection resolution, `target_page` resolution, and the two-arg/one-arg DI no-double-emit guard.

`go test ./internal/custom/csharp/... ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## DEPLOY-DEFERRED
Extractor + coverage record only. No daemon rebuild / reindex performed (live daemon serves the rewrite agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)