### PR TITLE
RN deepening: native-module bridge entities + Expo sdkVersion (#3580)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -25011,7 +25011,8 @@
             "status": "full",
             "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/expo_config/app.json"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2879",
-            "verified_at": "2026-05-29"
+            "notes": "parseExpoManifest mines app.json / app.config.{js,ts} Expo manifest → expo_name, expo_slug, expo_version, expo_sdk_version, expo_scheme, expo_plugins. #3580 added sdkVersion (expo_sdk_version), value-asserted in TestDiscover_MobileFixtures (51.0.0).",
+            "verified_at": "2026-06-02"
           },
           "expo_router_specifics": {
             "status": "full",
@@ -25024,6 +25025,12 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
+          },
+          "native_module_bridge": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/issue3580_native_bridge_test.go","internal/extractors/javascript/mobile_navigation.go","internal/extractors/javascript/testdata/mobile_react_native/NativeBridge.tsx"],
+            "issue": "3580",
+            "notes": "Shared mobile_navigation.go emitNativeBridgeEntities pass (RN-and-Expo). Expo modules-core requireNativeModule('ExpoBattery') → SCOPE.External native_module entity 'ExpoBattery' + DEPENDS_ON edge; same path also covers TurboModuleRegistry/codegenNativeComponent/requireNativeComponent/NativeModules-destructuring. Value-asserting test issue3580_native_bridge_test.go."
           }
         }
       }
@@ -29110,6 +29117,12 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
+          },
+          "native_module_bridge": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/issue3580_native_bridge_test.go","internal/extractors/javascript/mobile_navigation.go","internal/extractors/javascript/testdata/mobile_react_native/NativeBridge.tsx"],
+            "issue": "3580",
+            "notes": "emitNativeBridgeEntities materialises the JS↔native boundary as first-class SCOPE.External entities (subtype native_module | native_component) + DEPENDS_ON edges from the file entity, beyond the #2860 summary native_modules property. Value-asserting test proves: const {BiometricAuth}=NativeModules → native_module 'BiometricAuth'; TurboModuleRegistry.getEnforcing('RNDeviceInfo') → native_module 'RNDeviceInfo' (new arch); requireNativeComponent('RCTMapView') → native_component 'RCTMapView'; codegenNativeComponent('RCTWebView') → native_component 'RCTWebView' (Fabric); requireNativeModule('ExpoBattery') → native_module 'ExpoBattery'. via property records the bridge mechanism."
           }
         }
       }

--- a/internal/extractors/config/discover.go
+++ b/internal/extractors/config/discover.go
@@ -1771,11 +1771,12 @@ func parseExpoManifest(props map[string]string, content []byte) {
 		manifest = wrapper.Expo
 	}
 	var expo struct {
-		Name    string          `json:"name"`
-		Slug    string          `json:"slug"`
-		Version string          `json:"version"`
-		Scheme  json.RawMessage `json:"scheme"`
-		Plugins json.RawMessage `json:"plugins"`
+		Name       string          `json:"name"`
+		Slug       string          `json:"slug"`
+		Version    string          `json:"version"`
+		SDKVersion string          `json:"sdkVersion"`
+		Scheme     json.RawMessage `json:"scheme"`
+		Plugins    json.RawMessage `json:"plugins"`
 	}
 	if err := json.Unmarshal(manifest, &expo); err != nil {
 		return
@@ -1788,6 +1789,9 @@ func parseExpoManifest(props map[string]string, content []byte) {
 	}
 	if expo.Version != "" {
 		props["expo_version"] = expo.Version
+	}
+	if expo.SDKVersion != "" {
+		props["expo_sdk_version"] = expo.SDKVersion
 	}
 	if scheme := decodeStringOrArray(expo.Scheme); len(scheme) > 0 {
 		sort.Strings(scheme)

--- a/internal/extractors/config/discover_test.go
+++ b/internal/extractors/config/discover_test.go
@@ -978,6 +978,9 @@ func TestDiscover_MobileFixtures(t *testing.T) {
 	if expo.Properties["expo_scheme"] != "fixtureapp" {
 		t.Errorf("expo_scheme=%q", expo.Properties["expo_scheme"])
 	}
+	if expo.Properties["expo_sdk_version"] != "51.0.0" {
+		t.Errorf("expo_sdk_version=%q want 51.0.0", expo.Properties["expo_sdk_version"])
+	}
 	if !strings.Contains(expo.Properties["expo_plugins"], "expo-router") ||
 		!strings.Contains(expo.Properties["expo_plugins"], "expo-build-properties") {
 		t.Errorf("expo_plugins wrong: %q", expo.Properties["expo_plugins"])

--- a/internal/extractors/config/testdata/mobile/expo_config/app.json
+++ b/internal/extractors/config/testdata/mobile/expo_config/app.json
@@ -3,6 +3,7 @@
     "name": "FixtureMobileApp",
     "slug": "fixture-mobile-app",
     "version": "1.0.0",
+    "sdkVersion": "51.0.0",
     "scheme": "fixtureapp",
     "platforms": ["ios", "android"],
     "plugins": [

--- a/internal/extractors/javascript/issue3580_native_bridge_test.go
+++ b/internal/extractors/javascript/issue3580_native_bridge_test.go
@@ -1,0 +1,98 @@
+// Package javascript_test — issue #3580 React Native native-bridge deepening
+// (epic #3571).
+//
+// The pre-existing #2860 pass recorded native-bridge access as a summary
+// `native_modules` property string on the file entity. This pass makes the
+// JS↔native boundary first-class: each distinct native module / native
+// component reached across the bridge becomes a SCOPE.External entity (subtype
+// native_module | native_component) with a DEPENDS_ON edge from the file
+// entity. New-architecture (TurboModuleRegistry, codegenNativeComponent) and
+// legacy (NativeModules destructuring, requireNativeComponent) surfaces, plus
+// Expo modules-core (requireNativeModule), are all covered.
+//
+// Every assertion names a SPECIFIC module/component (value-asserting), proving
+// the Native Bridge coverage cell for react-native / expo.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// nativeBridgeEntity returns the SCOPE.External entity with the given name and
+// subtype, or nil.
+func nativeBridgeEntity(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == "SCOPE.External" && e.Name == name && e.Subtype == subtype &&
+			e.Properties["native_bridge"] == "1" {
+			return e
+		}
+	}
+	return nil
+}
+
+// hasDependsOnNative asserts the file entity has a DEPENDS_ON edge to the named
+// native module/component carrying the expected subtype.
+func hasDependsOnNative(fe *types.EntityRecord, name, subtype string) bool {
+	for _, r := range fe.Relationships {
+		if r.Kind == "DEPENDS_ON" && r.ToID == "native_module:"+name &&
+			r.Properties["subtype"] == subtype && r.Properties["native_bridge"] == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNativeBridge_ReactNative_ModulesAndComponents(t *testing.T) {
+	ents := extractFixtureTSX(t, "mobile_react_native/NativeBridge.tsx")
+	fe := fileEntity(t, ents)
+
+	cases := []struct {
+		name    string
+		subtype string
+	}{
+		{"BiometricAuth", "native_module"}, // const { BiometricAuth } = NativeModules
+		{"RNDeviceInfo", "native_module"},  // TurboModuleRegistry.getEnforcing('RNDeviceInfo')
+		{"ExpoBattery", "native_module"},   // requireNativeModule('ExpoBattery')
+		{"RCTMapView", "native_component"}, // requireNativeComponent('RCTMapView')
+		{"RCTWebView", "native_component"}, // codegenNativeComponent('RCTWebView')
+	}
+	for _, tc := range cases {
+		if nativeBridgeEntity(ents, tc.name, tc.subtype) == nil {
+			t.Errorf("expected SCOPE.External native-bridge entity %q subtype %q", tc.name, tc.subtype)
+		}
+		if !hasDependsOnNative(fe, tc.name, tc.subtype) {
+			t.Errorf("expected DEPENDS_ON native_module:%s subtype=%s on file entity", tc.name, tc.subtype)
+		}
+	}
+
+	// The discovery `via` is recorded on the entity so the bridge mechanism is
+	// queryable (legacy NativeModules vs new-arch TurboModuleRegistry vs codegen).
+	if e := nativeBridgeEntity(ents, "RNDeviceInfo", "native_module"); e != nil {
+		if e.Properties["via"] != "TurboModuleRegistry.getEnforcing" {
+			t.Errorf("RNDeviceInfo via=%q, want TurboModuleRegistry.getEnforcing", e.Properties["via"])
+		}
+	}
+	if e := nativeBridgeEntity(ents, "RCTWebView", "native_component"); e != nil {
+		if e.Properties["via"] != "codegenNativeComponent" {
+			t.Errorf("RCTWebView via=%q, want codegenNativeComponent", e.Properties["via"])
+		}
+	}
+}
+
+// The original #2860 RN fixture uses the destructured NativeModules form; prove
+// the named module is now surfaced as a bridge entity there too (regression-
+// proofs the destructuring path against real fixture shape).
+func TestNativeBridge_ReactNative_DestructuredFromAppNavigator(t *testing.T) {
+	ents := extractFixtureTSX(t, "mobile_react_native/AppNavigator.tsx")
+	fe := fileEntity(t, ents)
+
+	if nativeBridgeEntity(ents, "BiometricAuth", "native_module") == nil {
+		t.Error("expected SCOPE.External native_module entity BiometricAuth from AppNavigator destructuring")
+	}
+	if !hasDependsOnNative(fe, "BiometricAuth", "native_module") {
+		t.Error("expected DEPENDS_ON native_module:BiometricAuth on AppNavigator file entity")
+	}
+}

--- a/internal/extractors/javascript/mobile_navigation.go
+++ b/internal/extractors/javascript/mobile_navigation.go
@@ -115,6 +115,37 @@ var nativeBridgeCallees = map[string]bool{
 	"requireNativeComponent": true,
 	"requireNativeModule":    true, // Expo modules core
 	"NativeEventEmitter":     true,
+	"codegenNativeComponent": true, // RN new-arch (Fabric) component spec
+	"codegenNativeCommands":  true, // RN new-arch native commands spec
+}
+
+// nativeBridgeKindForCallee maps a native-bridge call-expression callee to the
+// subtype recorded on the emitted SCOPE.External native-boundary entity. A
+// component callee yields "native_component"; a module/registry callee yields
+// "native_module".
+var nativeBridgeKindForCallee = map[string]string{
+	"requireNativeComponent": "native_component",
+	"codegenNativeComponent": "native_component",
+	"codegenNativeCommands":  "native_component",
+	"requireNativeModule":    "native_module",
+}
+
+// turboModuleRegistryGetters are the TurboModuleRegistry methods whose string
+// argument names the requested TurboModule (RN new architecture).
+var turboModuleRegistryGetters = map[string]bool{
+	"get":          true,
+	"getEnforcing": true,
+}
+
+// nativeBridgeDep is a discovered JS↔native boundary dependency: a native
+// module or native component the JS code reaches across the bridge. `name` is
+// the module/component name (e.g. "BiometricAuth", "RCTMapView"); `subtype` is
+// "native_module" or "native_component"; `via` records how it was discovered.
+type nativeBridgeDep struct {
+	name    string
+	subtype string
+	via     string
+	line    int
 }
 
 // platformBranchReceivers are receiver identifiers whose member-comparison is a
@@ -208,6 +239,7 @@ func isNativeModuleSpecifier(spec string) bool {
 // on the matching IMPORTS edge (no new edge kind).
 func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.EntityRecord) {
 	var mods []string
+	var deps []nativeBridgeDep
 
 	// 1. Native package imports — both the IMPORTS edges already on the file
 	//    entity and the raw import bindings (importByLocal) are inspected.
@@ -237,18 +269,82 @@ func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.En
 	}
 
 	// 2. Member access: NativeModules.Foo / TurboModuleRegistry.get('Foo').
+	//    A bare `NativeModules.BiometricAuth` names the module "BiometricAuth";
+	//    `TurboModuleRegistry.get('Foo')` / `.getEnforcing('Foo')` names the
+	//    requested TurboModule via its string argument.
 	for _, mem := range findAllNodes(root, "member_expression") {
 		obj := mem.ChildByFieldName("object")
 		prop := mem.ChildByFieldName("property")
 		if obj == nil || prop == nil {
 			continue
 		}
-		if nativeBridgeMembers[x.nodeText(obj)] {
-			mods = append(mods, x.nodeText(obj)+"."+x.nodeText(prop))
+		recv := x.nodeText(obj)
+		if !nativeBridgeMembers[recv] {
+			continue
+		}
+		member := x.nodeText(prop)
+		mods = append(mods, recv+"."+member)
+		switch recv {
+		case "NativeModules":
+			// NativeModules.BiometricAuth — `member` is the native module name.
+			deps = append(deps, nativeBridgeDep{
+				name: member, subtype: "native_module",
+				via: "NativeModules", line: int(mem.StartPoint().Row) + 1,
+			})
+		case "TurboModuleRegistry":
+			// TurboModuleRegistry.get('Foo') / .getEnforcing('Foo') — the name is
+			// the string argument of the enclosing call, not `member` itself.
+			if turboModuleRegistryGetters[member] {
+				if call := enclosingCall(mem); call != nil {
+					if name := stringArg(x, call); name != "" {
+						deps = append(deps, nativeBridgeDep{
+							name: name, subtype: "native_module",
+							via:  "TurboModuleRegistry." + member,
+							line: int(mem.StartPoint().Row) + 1,
+						})
+					}
+				}
+			}
 		}
 	}
 
-	// 3. Native-bridge calls: requireNativeComponent('X'), new NativeEventEmitter().
+	// 2b. Destructured native modules: `const { BiometricAuth } = NativeModules`
+	//     — the idiomatic RN form. Each destructured binding names a module.
+	for _, decl := range findAllNodes(root, "variable_declarator") {
+		val := decl.ChildByFieldName("value")
+		if val == nil || val.Type() != "identifier" || x.nodeText(val) != "NativeModules" {
+			continue
+		}
+		nameNode := decl.ChildByFieldName("name")
+		if nameNode == nil || nameNode.Type() != "object_pattern" {
+			continue
+		}
+		for i := 0; i < int(nameNode.ChildCount()); i++ {
+			c := nameNode.Child(i)
+			if c == nil {
+				continue
+			}
+			var local string
+			switch c.Type() {
+			case "shorthand_property_identifier_pattern", "shorthand_property_identifier":
+				local = x.nodeText(c)
+			case "pair_pattern":
+				local = strings.Trim(x.nodeText(c.ChildByFieldName("key")), `"'`+"`")
+			}
+			if local == "" {
+				continue
+			}
+			mods = append(mods, "NativeModules."+local)
+			deps = append(deps, nativeBridgeDep{
+				name: local, subtype: "native_module",
+				via: "NativeModules", line: int(decl.StartPoint().Row) + 1,
+			})
+		}
+	}
+
+	// 3. Native-bridge calls: requireNativeComponent('RCTFoo'), new
+	//    NativeEventEmitter(), codegenNativeComponent('RCTFoo') (RN new arch),
+	//    requireNativeModule('ExpoFoo') (Expo modules core).
 	for _, call := range findAllNodes(root, "call_expression", "new_expression") {
 		fn := call.ChildByFieldName("function")
 		var callee string
@@ -267,6 +363,12 @@ func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.En
 			arg := stringArg(x, call)
 			if arg != "" {
 				mods = append(mods, callee+"('"+arg+"')")
+				if subtype, ok := nativeBridgeKindForCallee[callee]; ok {
+					deps = append(deps, nativeBridgeDep{
+						name: arg, subtype: subtype,
+						via: callee, line: int(call.StartPoint().Row) + 1,
+					})
+				}
 			} else {
 				mods = append(mods, callee+"()")
 			}
@@ -277,6 +379,88 @@ func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.En
 		ensureProps(fileEnt)
 		fileEnt.Properties["native_modules"] = joinSorted(mods)
 	}
+
+	x.emitNativeBridgeEntities(fileEnt, deps)
+}
+
+// enclosingCall walks up from a member_expression to the call_expression that
+// invokes it (so TurboModuleRegistry.get('Foo') resolves from the .get member
+// to the call carrying the 'Foo' argument), or returns nil.
+func enclosingCall(mem *sitter.Node) *sitter.Node {
+	for n := mem.Parent(); n != nil; n = n.Parent() {
+		switch n.Type() {
+		case "call_expression":
+			// Confirm `mem` is the function being called, not an argument.
+			if fn := n.ChildByFieldName("function"); fn != nil &&
+				fn.StartByte() <= mem.StartByte() && fn.EndByte() >= mem.EndByte() {
+				return n
+			}
+			return nil
+		case "arguments", "statement_block", "program":
+			return nil
+		}
+	}
+	return nil
+}
+
+// emitNativeBridgeEntities materialises one SCOPE.External entity per distinct
+// JS↔native boundary dependency (native module / native component) and a
+// DEPENDS_ON edge from the file entity to it. This makes the bridge boundary
+// first-class and queryable (vs. the summary `native_modules` property). The
+// edge ToID uses the `native_module:<name>` synthetic form mirrored by
+// addFileNavEdge's `route:` convention so the resolver binds it by name.
+func (x *extractor) emitNativeBridgeEntities(fileEnt *types.EntityRecord, deps []nativeBridgeDep) {
+	seen := make(map[string]bool, len(deps))
+	var ents []types.EntityRecord
+	// Append every DEPENDS_ON edge to the file entity FIRST, then append the
+	// SCOPE.External entities. Appending entities to x.entities may reallocate
+	// its backing array and invalidate the fileEnt pointer, so all writes
+	// through fileEnt must complete before x.entities grows.
+	for _, d := range deps {
+		if d.name == "" {
+			continue
+		}
+		key := d.subtype + ":" + d.name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		fileEnt.Relationships = append(fileEnt.Relationships, types.RelationshipRecord{
+			ToID: "native_module:" + d.name,
+			Kind: string(types.RelationshipKindDependsOn),
+			Properties: map[string]string{
+				"native_bridge": "1",
+				"native_name":   d.name,
+				"subtype":       d.subtype,
+				"via":           d.via,
+				"line":          strconv.Itoa(d.line),
+			},
+		})
+
+		ent := types.EntityRecord{
+			Name:          d.name,
+			QualifiedName: x.qualify(d.name),
+			Kind:          string(types.EntityKindExternal),
+			SourceFile:    x.filePath,
+			StartLine:     d.line,
+			EndLine:       d.line,
+			Language:      x.language,
+			Subtype:       d.subtype,
+			Properties: map[string]string{
+				"kind":          string(types.EntityKindExternal),
+				"subtype":       d.subtype,
+				"native_bridge": "1",
+				"native_name":   d.name,
+				"via":           d.via,
+			},
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     1.0,
+		}
+		ent.ID = ent.ComputeID()
+		ents = append(ents, ent)
+	}
+	x.entities = append(x.entities, ents...)
 }
 
 func ensurePropsRel(rel *types.RelationshipRecord) {

--- a/internal/extractors/javascript/testdata/mobile_react_native/NativeBridge.tsx
+++ b/internal/extractors/javascript/testdata/mobile_react_native/NativeBridge.tsx
@@ -1,0 +1,34 @@
+// React Native native-bridge (JS↔native boundary) fixture (#3580).
+//
+// Exercises the new-architecture + legacy bridge surfaces that emit
+// SCOPE.External native-boundary entities + DEPENDS_ON edges:
+//   - const { BiometricAuth } = NativeModules        → native_module "BiometricAuth"
+//   - TurboModuleRegistry.getEnforcing('RNDeviceInfo') → native_module "RNDeviceInfo"
+//   - requireNativeComponent('RCTMapView')           → native_component "RCTMapView"
+//   - codegenNativeComponent<Props>('RCTWebView')    → native_component "RCTWebView"
+//   - requireNativeModule('ExpoBattery')             → native_module "ExpoBattery"
+import { NativeModules, TurboModuleRegistry, requireNativeComponent } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import { requireNativeModule } from 'expo-modules-core';
+
+const { BiometricAuth } = NativeModules;
+
+const deviceInfo = TurboModuleRegistry.getEnforcing('RNDeviceInfo');
+
+export const MapView = requireNativeComponent('RCTMapView');
+
+export const WebView = codegenNativeComponent<{ src: string }>('RCTWebView');
+
+const Battery = requireNativeModule('ExpoBattery');
+
+export async function authenticate() {
+  return BiometricAuth.prompt('Confirm identity');
+}
+
+export function model(): string {
+  return deviceInfo.getModel();
+}
+
+export function level(): number {
+  return Battery.getLevel();
+}


### PR DESCRIPTION
Closes #3580 (epic #3571). Long-tail deepening of the best-covered mobile platform — kept tight (S-M). RN navigation/deep-links/platform-branching/native-module-imports and Expo app.json config were already `full`; this adds the genuine gaps.

## Added — Native bridge (JS↔native boundary) — `full`
`internal/extractors/javascript/mobile_navigation.go` `emitNativeBridgeEntities`. The #2860 pass only recorded a summary `native_modules` property string. This materialises the boundary as **first-class entities + edges**: one `SCOPE.External` entity (subtype `native_module` | `native_component`) + a `DEPENDS_ON` edge from the file entity per distinct module/component. Reuses existing kinds only — no schema change.

Value-asserted (`issue3580_native_bridge_test.go`, fixture `NativeBridge.tsx`):
- `const { BiometricAuth } = NativeModules` → native_module **BiometricAuth** (destructuring; also re-proven against the real #2860 `AppNavigator.tsx` fixture)
- `TurboModuleRegistry.getEnforcing('RNDeviceInfo')` → native_module **RNDeviceInfo** (new arch; `via=TurboModuleRegistry.getEnforcing`)
- `requireNativeComponent('RCTMapView')` → native_component **RCTMapView**
- `codegenNativeComponent<Props>('RCTWebView')` → native_component **RCTWebView** (Fabric; `via=codegenNativeComponent`)
- `requireNativeModule('ExpoBattery')` → native_module **ExpoBattery** (Expo modules-core)

`via` records the bridge mechanism so legacy vs new-arch is queryable.

## Added — Expo config — `full`
`internal/extractors/config/discover.go` `parseExpoManifest`: `sdkVersion` → `expo_sdk_version` (alongside existing name/slug/version/scheme/plugins). Asserted in `TestDiscover_MobileFixtures` (`51.0.0`).

## Not changed (already covered, confirmed)
expo-router file routes / app.config.{js,ts} / EAS / metro / native-link / Linking deep-links / `NavigationContainer` screens — all pre-existing `full`. Did not duplicate.

## Records
`native_module_bridge` (full) under react-native + expo `framework_specific` Internals; `expo_config_extraction` note updated. (Native Bridge taxonomy group only permits `native_module_imports`, so the new capability lives in framework_specific.)

## Discipline
Targeted suites green (`javascript`, `engine`, `types` incl. producer-kinds guardrail, `config`, `tools/coverage`); `coverage validate` 0 errors; `coverage fmt` canonical; gofmt/vet clean. No unrelated detail-page drift.

## DEPLOY-DEFERRED
Extractor change requires a coordinated live-daemon rebuild + reindex; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)