### PR TITLE
fix(mongo-agg-py): resolve collection-name constant receiver — real _get_me_inspections $lookups now anchor on the real collection node

### DIFF
--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -338,7 +338,18 @@ func mongoAggPyFollowCollBinding(src, ident string, usePos int) string {
 			return m[1] // quoted collection name
 		}
 		if m[2] != "" {
-			return m[2] // bare constant identifier (e.g. INSPECTIONS)
+			// Bare constant identifier (e.g. `get_collection(INSPECTIONS)`) — the
+			// legacy idiom where a collection-name constant stands in for the
+			// quoted name. The constant NAME is NOT the collection name: the
+			// migration parity oracle (and every string-literal viewset form)
+			// anchors the join on the COLLECTION, so we must resolve the constant
+			// to its string VALUE. Without this, `INSPECTIONS` flows straight into
+			// capitalisedSingular which leaves the all-caps token unchanged
+			// (`Class:INSPECTIONS`), a phantom node that never matches the real
+			// `Class:Inspection` collection node the literal `"inspections"`
+			// produces — so the task-file joins orphan and vanish from the graph
+			// while ~57 string-literal viewset aggregations extract fine.
+			return mongoAggPyResolveCollConst(src, m[2])
 		}
 	}
 	// db["c"] / db['c'] subscript anywhere in the RHS.
@@ -354,6 +365,44 @@ func mongoAggPyFollowCollBinding(src, ident string, usePos int) string {
 		}
 	}
 	return ""
+}
+
+// mongoAggPyConstAssignRe matches a module-level constant assignment
+// `NAME = "value"` / `NAME = 'value'` at column 0 (top-level, not indented),
+// capturing the string value. Used to resolve a collection-name constant
+// (`INSPECTIONS = "inspections"`) to its value when defined in the same file.
+var mongoAggPyConstAssignReCache = map[string]*regexp.Regexp{}
+
+func mongoAggPyConstAssignRe(name string) *regexp.Regexp {
+	if re, ok := mongoAggPyConstAssignReCache[name]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s*=\s*['"]([a-zA-Z_][\w$.]*)['"]`)
+	mongoAggPyConstAssignReCache[name] = re
+	return re
+}
+
+// mongoAggPyResolveCollConst turns a bare collection-name constant identifier
+// (e.g. `INSPECTIONS`) into the collection token used to anchor the join.
+//
+//  1. Same-file definition: if `NAME = "value"` exists at module scope in this
+//     file, return the literal value ("inspections") — exact, matches a quoted
+//     receiver.
+//  2. Cross-module import (the real `_get_me_inspections` case — `INSPECTIONS`
+//     comes from `core.mongodb_collections`): the value isn't in this file, so
+//     fall back to the constant NAME LOWERCASED. UPPER_SNAKE collection
+//     constants are conventionally the upper-cased collection name, so
+//     lowercasing recovers a token that canonicalises (via capitalisedSingular)
+//     to the SAME node as the string literal would: `INSPECTIONS` → `inspections`
+//     → `Class:Inspection`, identical to the 57 working viewset forms. This is
+//     the honest-partial: we don't fabricate a value, we normalise the name so
+//     the edge lands on the real collection node instead of a phantom all-caps
+//     one.
+func mongoAggPyResolveCollConst(src, name string) string {
+	if m := mongoAggPyConstAssignRe(name).FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	return strings.ToLower(name)
 }
 
 // mongoAggPyCollSubscriptRe matches a `db["coll"]` / `db['coll']` subscript

--- a/internal/engine/orm_queries_python_mongo_agg_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_test.go
@@ -153,8 +153,12 @@ def _get_me_inspections():
 		if j == nil {
 			t.Fatalf("expected JOINS_COLLECTION edge to %s; rels=%+v", coll, rels)
 		}
-		if j.FromID != "Class:"+capitalisedSingular("INSPECTIONS") {
-			t.Errorf("join to %s from = %q, want aggregating collection INSPECTIONS", coll, j.FromID)
+		// The `INSPECTIONS` constant receiver (imported cross-module, no in-file
+		// value) must resolve to the SAME canonical collection node as the
+		// string-literal `"inspections"` viewset forms: Class:Inspection, NOT a
+		// phantom Class:INSPECTIONS. This is the real-vs-fixture fix.
+		if j.FromID != "Class:"+capitalisedSingular("inspections") {
+			t.Errorf("join to %s from = %q, want aggregating collection Class:Inspection", coll, j.FromID)
 		}
 		if j.Properties["stage"] != "lookup" {
 			t.Errorf("join to %s stage = %q, want lookup", coll, j.Properties["stage"])
@@ -181,6 +185,180 @@ def _get_me_inspections():
 		if got[i] != want[i] {
 			t.Fatalf("stage[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
 		}
+	}
+}
+
+// REAL-FORM regression — verbatim copy of the production
+// `core.tasks.maintenance_evaluation_notifications._get_me_inspections`
+// pipeline (multiline stage objects, nested `let`/`pipeline`/`$project` on
+// their OWN lines, `$first` accessor, `True` Python literals). The earlier
+// #3567 fixture collapsed each `$lookup` onto ONE line, which hid a stage-split
+// failure that occurs on the real multiline form. Must emit the 3 correlated
+// joins (inspection_groups, m_devices, m_buildings) and the full 8-stage order.
+func TestMongoAggPy_RealForm_GetMeInspections(t *testing.T) {
+	src := `
+import logging
+from core.helper.mongo_helper import MongoDBConnection
+from core.mongodb_collections import INSPECTIONS
+
+
+def _get_me_inspections():
+    inspections_cls = MongoDBConnection.get_collection(INSPECTIONS)
+    pipeline = [
+        {
+            "$project": {
+                "device_id": 1,
+                "inspectionGroupId": 1,
+                "status": 1,
+                "checklist_id": {"$first": "$inspection_checklists.id"},
+                "checklist_type": {"$first": "$inspection_checklists.type"},
+            }
+        },
+        {"$match": {"checklist_type": 4, "status": {"$in": ["Results Reviewed", "Assembling Report"]}}},
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "let": {"inspections_group_id": "$inspectionGroupId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$_id", "$$inspections_group_id"]}}},
+                    {"$project": {"_id": 1, "buildingId": 1, "groupId": 1}},
+                ],
+                "as": "inspections_group",
+            }
+        },
+        {"$unwind": {"path": "$inspections_group", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_devices",
+                "let": {"device_id": "$device_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$device_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                ],
+                "as": "device",
+            }
+        },
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_buildings",
+                "let": {"building_id": "$inspections_group.buildingId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$building_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                ],
+                "as": "building",
+            }
+        },
+        {"$unwind": {"path": "$building", "preserveNullAndEmptyArrays": True}},
+    ]
+    return list(inspections_cls.aggregate(pipeline))
+`
+	ents, rels := runMongoAggPy(t, src)
+
+	// The 3 correlated joins to the SPECIFIC from-collections.
+	wantTo := []string{"inspection_groups", "m_devices", "m_buildings"}
+	for _, coll := range wantTo {
+		j := pyFindJoinTo(rels, capitalisedSingular(coll))
+		if j == nil {
+			t.Fatalf("expected JOINS_COLLECTION edge to %s; rels=%+v", coll, rels)
+		}
+		// Cross-module `INSPECTIONS` constant resolves to the canonical
+		// Class:Inspection node — identical to the string-literal viewset forms.
+		if j.FromID != "Class:"+capitalisedSingular("inspections") {
+			t.Errorf("join to %s from = %q, want aggregating collection Class:Inspection", coll, j.FromID)
+		}
+		if j.Properties["stage"] != "lookup" {
+			t.Errorf("join to %s stage = %q, want lookup", coll, j.Properties["stage"])
+		}
+	}
+	if n := len(rels); n != 3 {
+		t.Fatalf("expected exactly 3 join edges, got %d: %+v", n, rels)
+	}
+
+	jg := pyFindJoinTo(rels, capitalisedSingular("inspection_groups"))
+	if jg.Properties["as"] != "inspections_group" {
+		t.Errorf("inspection_groups join as = %q, want inspections_group", jg.Properties["as"])
+	}
+
+	// 8 stages, order preserved: project, match, lookup, unwind, lookup, unwind,
+	// lookup, unwind.
+	got := pyStageSubtypesInOrder(ents)
+	want := []string{"$project", "$match", "$lookup", "$unwind", "$lookup", "$unwind", "$lookup", "$unwind"}
+	if len(got) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stage[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// Same-file constant definition: `INSPECTIONS = "inspections"` at module scope,
+// then `get_collection(INSPECTIONS)`. The constant must resolve to its literal
+// VALUE "inspections" → Class:Inspection, exactly as a quoted receiver would.
+func TestMongoAggPy_CollConstResolvedToValue_SameFile(t *testing.T) {
+	src := `
+import pymongo
+from core.helper.mongo_helper import MongoDBConnection
+
+INSPECTIONS = "inspections"
+
+
+def run():
+    inspections_cls = MongoDBConnection.get_collection(INSPECTIONS)
+    pipeline = [
+        {"$lookup": {"from": "m_devices", "localField": "device_id", "foreignField": "_id", "as": "device"}},
+    ]
+    return list(inspections_cls.aggregate(pipeline))
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 join edge, got %d: %+v", len(rels), rels)
+	}
+	if rels[0].FromID != "Class:"+capitalisedSingular("inspections") {
+		t.Errorf("join from = %q, want Class:Inspection (constant resolved to value)", rels[0].FromID)
+	}
+	if len(ents) == 0 || ents[0].Properties["collection"] != "inspections" {
+		t.Errorf("stage collection = %q, want inspections", ents[0].Properties["collection"])
+	}
+}
+
+// REGRESSION GUARD for the 57 string-literal viewset aggregations: a quoted
+// `get_collection("inspections")` receiver via the same variable-binding follow
+// must keep producing Class:Inspection. The constant-resolution change must not
+// touch this path.
+func TestMongoAggPy_ViewsetStringLiteralReceiver_Unchanged(t *testing.T) {
+	src := `
+from core.helper.mongo_helper import MongoDBConnection
+
+
+def get_inspection_details(self):
+    inspections_group_cln = MongoDBConnection.get_collection("inspection_groups")
+    pipeline = [
+        {"$lookup": {"from": "inspections", "localField": "_id", "foreignField": "inspectionGroupId", "as": "inspections"}},
+        {"$lookup": {"from": "m_buildings", "localField": "buildingId", "foreignField": "postgresql_id", "as": "building"}},
+    ]
+    return inspections_group_cln.aggregate(pipeline)
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 join edges, got %d: %+v", len(rels), rels)
+	}
+	for _, r := range rels {
+		if r.FromID != "Class:"+capitalisedSingular("inspection_groups") {
+			t.Errorf("join from = %q, want aggregating collection Class:Inspection_group", r.FromID)
+		}
+	}
+	if pyFindJoinTo(rels, capitalisedSingular("inspections")) == nil {
+		t.Errorf("expected join to inspections; rels=%+v", rels)
+	}
+	if pyFindJoinTo(rels, capitalisedSingular("m_buildings")) == nil {
+		t.Errorf("expected join to m_buildings; rels=%+v", rels)
+	}
+	if len(ents) != 2 {
+		t.Fatalf("expected 2 stage entities, got %d", len(ents))
 	}
 }
 


### PR DESCRIPTION
## Residual Mongo `\$lookup` fix (real form, not a fixture)

The real `core.tasks.maintenance_evaluation_notifications._get_me_inspections` emitted ZERO usable `SCOPE.DataAccess` stages / JOINS_COLLECTION edges on the LIVE graph, while ~57 string-literal viewset aggregations extract fine. The earlier #3567 fix used a synthetic fixture that **also asserted the broken FROM-side**, so it passed without fixing reality.

### Real-vs-fixture root cause
The extraction pass itself was correct — the bug is the **receiver**.

- Viewsets: `get_collection("inspections")` → `capitalisedSingular` → `Class:Inspection` (real node).
- Task: `from core.mongodb_collections import INSPECTIONS` then `get_collection(INSPECTIONS)`. The bare constant `INSPECTIONS` flowed straight into `capitalisedSingular`, which leaves an all-caps token unchanged → **`Class:INSPECTIONS`**: a phantom node. The 3 `\$lookup` join edges anchored on it, orphaned, and the cluster was unusable on the served graph.

### Fix
`mongoAggPyResolveCollConst` resolves a bare collection-name constant receiver:
1. **Same-file** `NAME = "value"` module-scope def → the literal value.
2. **Cross-module** import (the real case) → honest-partial: lowercase the UPPER_SNAKE constant name. `INSPECTIONS` → `inspections` → `capitalisedSingular` → `Class:Inspection`, **identical to the viewset string-literal forms**. No fabricated value; the edge lands on the real collection node.

Verified against the verbatim production source: `_get_me_inspections` now emits all 3 joins from `Class:Inspection` → `Class:Inspection_group` / `Class:M_device` / `Class:M_building`.

### Tests (value-asserting)
- `TestMongoAggPy_RealForm_GetMeInspections` — verbatim multiline production pipeline (nested `let`/`pipeline`/`\$project`, `\$first`, `True`); asserts the 3 specific joins, 8-stage order, and corrected `Class:Inspection` FROM-side.
- `TestMongoAggPy_CollConstResolvedToValue_SameFile` — same-file constant resolves to value.
- `TestMongoAggPy_ViewsetStringLiteralReceiver_Unchanged` — regression guard mirroring a viewset form (the 57 working aggregations stay green).
- Updated `TestMongoAggPy_VariableBound_CorrelatedLookups` to assert the corrected canonical FROM-side.

`go test ./internal/engine/` green · `gofmt -l` empty · `go vet` clean.

**DEPLOY-DEFERRED**: indexer change only; needs a coordinated live-daemon rebuild + reindex of upvate to take effect on the served graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)