### PR TITLE
[di] NestJS dependency-injection graph (BINDS / INJECTED_INTO / USES)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -27817,6 +27817,31 @@
             "verified_at": "2026-05-29"
           }
         }
+      },
+      "framework_specific": {
+        "DI": {
+          "di_binding_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/javascript/nestjs.go","internal/custom/javascript/nestjs_di.go","internal/custom/javascript/nestjs_di_test.go"],
+            "issue": "3647",
+            "notes": "NestJS-unique DI/IoC graph (recorded under framework_specific because most http_backend frameworks have no DI container). @Module wiring → BINDS (module→provider/controller/import with an exported flag) and object-form provider tokens {provide, useClass/useValue/useFactory/useExisting} → token BINDS impl; class- and method-level @UseGuards/@UseInterceptors/@UsePipes → USES (controller/handler→guard/interceptor/pipe). Value-asserting tests prove specific edges: UsersModule BINDS UsersService; token CONFIG BINDS ConfigService; AdminController USES JwtAuthGuard; GET getSecret USES RolesGuard. Partial: token→impl BINDS resolves cross-file only when an entity with the matching token/class name exists in another file (regex single-file pass).",
+            "verified_at": "2026-06-02"
+          },
+          "di_injection_point": {
+            "status": "partial",
+            "cites": ["internal/custom/javascript/nestjs_di.go","internal/custom/javascript/nestjs_di_test.go"],
+            "issue": "3647",
+            "notes": "Constructor injection → INJECTED_INTO (provider→injecting class), including @Inject(TOKEN) string-literal and identifier custom tokens. Value-asserting tests prove UsersService INJECTED_INTO UsersController, @Inject('CONFIG_TOKEN') normalisation, and reject primitive params / cross-class leakage. Partial: the edge carries the bare type/token name; cross-file binding of that name to its declaring provider entity is the resolver's job and is not proven for cross-file fixtures here.",
+            "verified_at": "2026-06-02"
+          },
+          "di_scope_resolution": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/nestjs.go","internal/custom/javascript/nestjs_di.go","internal/custom/javascript/nestjs_di_test.go"],
+            "issue": "3647",
+            "notes": "@Injectable({ scope: Scope.REQUEST }) → di_scope property on the provider entity; @Injectable() classes tagged di_provider=true. Value-asserted by TestNestDIInjectableScope.",
+            "verified_at": "2026-06-02"
+          }
+        }
       }
     },
     {

--- a/internal/custom/javascript/nestjs.go
+++ b/internal/custom/javascript/nestjs.go
@@ -149,11 +149,21 @@ func (e *nestjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		addEntity(ent)
 	}
 
-	// @Injectable
+	// @Injectable — provider. Capture the DI scope when declared via
+	// @Injectable({ scope: Scope.REQUEST }) so the oracle knows the provider's
+	// lifecycle (#3628 area #5).
+	scopeByClass := map[string]string{}
+	for _, m := range reNestInjectableScope.FindAllStringSubmatch(src, -1) {
+		scopeByClass[m[2]] = m[1]
+	}
 	for _, m := range reNestInjectable.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Component", "service", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "nestjs", "provenance", "INFERRED_FROM_NESTJS_INJECTABLE")
+		setProps(&ent, "framework", "nestjs", "provenance", "INFERRED_FROM_NESTJS_INJECTABLE",
+			"di_provider", "true")
+		if s := scopeByClass[name]; s != "" {
+			setProps(&ent, "di_scope", s)
+		}
 		addEntity(ent)
 	}
 
@@ -312,6 +322,31 @@ func (e *nestjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		ent := makeEntity(name, "SCOPE.Pattern", "param_decorator", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "nestjs", "provenance", "INFERRED_FROM_NESTJS_PARAM_DECORATOR")
 		addEntity(ent)
+	}
+
+	// Dependency-injection graph (#3628 area #5): merge INJECTED_INTO / BINDS /
+	// USES edges onto their file-local owning entity. The owner key is the bare
+	// entity Name (consumer class, controller, route operation, or module).
+	diEdges := extractNestDIEdges(src)
+	if len(diEdges) > 0 {
+		byName := make(map[string]int, len(entities))
+		for i := range entities {
+			// First entity wins per name (controllers/services are unique by
+			// class name within a file; route ops are unique by "<VERB> <m>").
+			if _, ok := byName[entities[i].Name]; !ok {
+				byName[entities[i].Name] = i
+			}
+		}
+		edgeCount := 0
+		for owner, rels := range diEdges {
+			idx, ok := byName[owner]
+			if !ok {
+				continue
+			}
+			entities[idx].Relationships = append(entities[idx].Relationships, rels...)
+			edgeCount += len(rels)
+		}
+		span.SetAttributes(attribute.Int("di_edge_count", edgeCount))
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/javascript/nestjs_di.go
+++ b/internal/custom/javascript/nestjs_di.go
@@ -1,0 +1,630 @@
+package javascript
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// NestJS dependency-injection extraction (#3628 area #5).
+//
+// The base nestjsExtractor emits entities (controllers, services, modules,
+// guards, …) but no DI edges, so the rewrite-parity oracle cannot resolve
+// "what provider satisfies this constructor param" or "what guard protects this
+// endpoint". This file adds the DI graph by emitting:
+//
+//   INJECTED_INTO : provider/token → the class whose constructor injects it.
+//                   Mirrors the Angular DI convention (angular.go): FromID is
+//                   the injected provider (type name or @Inject token), ToID is
+//                   the consuming class. Property via=nestjs_constructor.
+//
+//   BINDS         : a NestJS @Module → each provider/controller it declares,
+//                   each module it imports, and each provider it exports; and a
+//                   DI token → its implementation for the object-form provider
+//                   shapes {provide: TOKEN, useClass/useValue/useFactory/
+//                   useExisting: Impl}. Mirrors the Helm BINDS shape (token →
+//                   impl). Property binding_kind distinguishes the sub-shape.
+//
+//   USES          : a controller class (class-level @UseGuards/@UseInterceptors/
+//                   @UsePipes) or a route handler operation (method-level) → the
+//                   guard / interceptor / pipe it applies. This is what the
+//                   oracle needs to resolve auth on an endpoint. Property
+//                   di_role records guard|interceptor|pipe.
+//
+// All edges use bare class / token names for FromID/ToID, matching the Angular
+// path; the cross-file resolver binds them to the declaring entity. Token →
+// impl bindings whose token is a string literal resolve cross-file only when an
+// {provide:} site names the same token, so the coverage record marks
+// module-wiring/di-binding "partial" for cross-file token resolution.
+
+var (
+	// reNestInjectableScope captures the Scope.X enum from
+	// @Injectable({ scope: Scope.REQUEST }).
+	reNestInjectableScope = regexp.MustCompile(
+		`@Injectable\s*\(\s*\{[^}]*\bscope\s*:\s*Scope\.(\w+)[^}]*\}\s*\)\s*(?:export\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
+	)
+
+	// reNestClassDecl captures a (possibly decorated) class declaration head so
+	// the constructor / @UseGuards scan can be anchored to its class name. The
+	// class name is group 1. The decorator block preceding the class is consumed
+	// loosely so @UseGuards at class level falls within the matched span when we
+	// re-scan from the class start.
+	reNestClassDecl = regexp.MustCompile(`class\s+([A-Z][A-Za-z0-9_]*)`)
+
+	// reNestConstructor captures the parameter list of a class constructor.
+	reNestConstructor = regexp.MustCompile(`constructor\s*\(`)
+
+	// reNestModuleDecorator captures a @Module({...}) decorator's object body
+	// (group 1) and the class it decorates (group 2).
+	reNestModuleDecorator = regexp.MustCompile(
+		`@Module\s*\(\s*(\{[\s\S]*?\})\s*\)\s*(?:export\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
+	)
+
+	// reNestUseDecorator captures class- or method-level @UseGuards /
+	// @UseInterceptors / @UsePipes and their argument list (group 2).
+	reNestUseDecorator = regexp.MustCompile(
+		`@Use(Guards|Interceptors|Pipes)\s*\(([^)]*)\)`,
+	)
+
+	// reNestIdent matches a bare PascalCase identifier (a class reference).
+	reNestIdent = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\b`)
+
+	// reNestProvideObject matches an object-literal provider entry
+	// {provide: TOKEN, useClass|useValue|useFactory|useExisting: Impl}. Group 1
+	// is the raw token expression, group 2 the binding keyword, group 3 the impl
+	// expression (best-effort up to the next comma/brace).
+	reNestProvideObject = regexp.MustCompile(
+		`provide\s*:\s*([^,]+?)\s*,\s*(useClass|useValue|useFactory|useExisting)\s*:\s*([^,}]+)`,
+	)
+)
+
+var nestUseRoleMap = map[string]string{
+	"Guards":       "guard",
+	"Interceptors": "interceptor",
+	"Pipes":        "pipe",
+}
+
+// extractNestDIEdges scans a NestJS source file and returns the DI edges grouped
+// by the bare entity name they should attach to (the FromID side for
+// INJECTED_INTO/USES on a class, the module name for BINDS). The caller merges
+// these onto the matching emitted entity's Relationships slice.
+//
+// edgesByOwner key is the bare Name of the file-local entity the edge should
+// hang off (so the resolver always finds a real source entity). The edge's
+// FromID/ToID still carry the semantic provider/consumer/token names, mirroring
+// angular.go where INJECTED_INTO has FromID=provider, ToID=consumer but the
+// edge is attached to the consumer class entity present in the file.
+//
+//	INJECTED_INTO : owner = consumer class (FromID=provider, ToID=consumer)
+//	USES (class)  : owner = controller class
+//	USES (handler): owner = "<HTTP_METHOD> <method>" operation
+//	BINDS (module): owner = module class
+//	BINDS (token) : owner = module class (token entity may be cross-file)
+func extractNestDIEdges(src string) map[string][]types.RelationshipRecord {
+	out := map[string][]types.RelationshipRecord{}
+	add := func(owner string, r types.RelationshipRecord) {
+		out[owner] = append(out[owner], r)
+	}
+
+	// ---- Constructor injection: provider INJECTED_INTO consumer ----------
+	for _, c := range nestClasses(src) {
+		params := nestConstructorParams(src, c.bodyStart)
+		for _, p := range params {
+			provider := p.token
+			if provider == "" {
+				continue
+			}
+			add(c.name, types.RelationshipRecord{
+				FromID: provider,
+				ToID:   c.name,
+				Kind:   string(types.RelationshipKindInjectedInto),
+				Properties: map[string]string{
+					"consumer":  c.name,
+					"provider":  provider,
+					"framework": "nestjs",
+					"via":       "nestjs_constructor",
+					"di_role":   p.role,
+				},
+			})
+		}
+		// ---- Class-level @UseGuards/@UseInterceptors/@UsePipes ----------
+		for _, u := range nestUseDecoratorsIn(src[c.declStart:c.bodyStart]) {
+			add(c.name, types.RelationshipRecord{
+				FromID: c.name,
+				ToID:   u.target,
+				Kind:   string(types.RelationshipKindUses),
+				Properties: map[string]string{
+					"framework": "nestjs",
+					"di_role":   u.role,
+					"di_scope":  "class",
+					"via":       "nestjs_use_decorator",
+				},
+			})
+		}
+	}
+
+	// ---- Method-level @UseGuards on route handlers -----------------------
+	// The route handler operation entity is named "<HTTP_METHOD> <method>" by
+	// the base extractor; we attach the USES edge to that operation so the
+	// oracle can answer "what guard protects this endpoint". We re-scan each
+	// HTTP-verb decorator block and look backwards for a sibling @UseGuards
+	// applied to the same handler.
+	for _, h := range nestRouteHandlers(src) {
+		for _, u := range nestUseDecoratorsIn(h.decoratorBlock) {
+			owner := h.opName
+			add(owner, types.RelationshipRecord{
+				FromID: owner,
+				ToID:   u.target,
+				Kind:   string(types.RelationshipKindUses),
+				Properties: map[string]string{
+					"framework":   "nestjs",
+					"di_role":     u.role,
+					"di_scope":    "handler",
+					"method_name": h.methodName,
+					"via":         "nestjs_use_decorator",
+				},
+			})
+		}
+	}
+
+	// ---- @Module wiring: BINDS -------------------------------------------
+	for _, mm := range reNestModuleDecorator.FindAllStringSubmatch(src, -1) {
+		body := mm[1]
+		module := mm[2]
+		sections := nestModuleSections(body)
+		// Collapse to one BINDS edge per (module → target): a member that is
+		// both a provider and an export yields a single edge tagged
+		// binding_kind=provider with exported=true, rather than two
+		// (module,target)-identical edges. Precedence: controller > provider >
+		// import (each names a distinct member kind; export is a flag).
+		type bindInfo struct {
+			kind     string
+			exported bool
+			order    int // emission order to keep output stable
+		}
+		binds := map[string]*bindInfo{}
+		var order []string
+		ensure := func(name string) *bindInfo {
+			b, ok := binds[name]
+			if !ok {
+				b = &bindInfo{}
+				binds[name] = b
+				order = append(order, name)
+			}
+			return b
+		}
+		rank := map[string]int{"controller": 3, "provider": 2, "import": 1}
+		for kind, names := range sections {
+			for _, n := range names {
+				b := ensure(n)
+				if kind == "export" {
+					b.exported = true
+					if b.kind == "" {
+						// Exported-but-not-locally-declared (re-export): record
+						// the export membership so it is still queryable.
+						b.kind = "export"
+					}
+					continue
+				}
+				if rank[kind] > rank[b.kind] {
+					b.kind = kind
+				}
+			}
+		}
+		for _, n := range order {
+			b := binds[n]
+			props := map[string]string{
+				"framework":    "nestjs",
+				"binding_kind": b.kind, // provider|controller|import|export
+				"module":       module,
+				"via":          "nestjs_module",
+			}
+			if b.exported {
+				props["exported"] = "true"
+			}
+			add(module, types.RelationshipRecord{
+				FromID:     module,
+				ToID:       n,
+				Kind:       string(types.RelationshipKindBinds),
+				Properties: props,
+			})
+		}
+		// Object-form provider tokens: {provide: TOKEN, useClass: Impl} → the
+		// token BINDS its implementation (token → impl), mirroring Helm BINDS.
+		for _, pm := range reNestProvideObject.FindAllStringSubmatch(body, -1) {
+			token := nestNormaliseToken(pm[1])
+			useKind := pm[2]
+			impl := nestImplName(pm[3], useKind)
+			if token == "" || impl == "" {
+				continue
+			}
+			add(module, types.RelationshipRecord{
+				FromID: token,
+				ToID:   impl,
+				Kind:   string(types.RelationshipKindBinds),
+				Properties: map[string]string{
+					"framework":    "nestjs",
+					"binding_kind": strings.ToLower(useKind[:1]) + useKind[1:], // useClass etc.
+					"token":        token,
+					"module":       module,
+					"via":          "nestjs_provider_token",
+				},
+			})
+		}
+	}
+
+	return out
+}
+
+// nestClassInfo describes a class declaration span within a file.
+type nestClassInfo struct {
+	name      string
+	declStart int // index of the `class` keyword (after decorators are scanned back)
+	bodyStart int // index of the opening `{` of the class body
+}
+
+// nestClasses returns every PascalCase class in the file with the byte offsets
+// needed to scope the constructor / decorator scans.
+func nestClasses(src string) []nestClassInfo {
+	var out []nestClassInfo
+	for _, m := range reNestClassDecl.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		declStart := m[0]
+		// Walk back over a preceding decorator block so class-level @UseGuards
+		// is included in [declStart, bodyStart). We move declStart back to the
+		// start of the contiguous decorator/export prefix.
+		ds := declStart
+		// Find the body open brace.
+		brace := strings.IndexByte(src[m[1]:], '{')
+		if brace < 0 {
+			continue
+		}
+		bodyStart := m[1] + brace
+		// Expand declStart backwards across a decorator span: scan up to ~400
+		// bytes before the class for the nearest preceding blank line / `}` /
+		// `;` boundary so class-level decorators are captured.
+		lo := ds - 600
+		if lo < 0 {
+			lo = 0
+		}
+		prefix := src[lo:ds]
+		if idx := nestDecoratorPrefixStart(prefix); idx >= 0 {
+			ds = lo + idx
+		}
+		out = append(out, nestClassInfo{name: name, declStart: ds, bodyStart: bodyStart})
+	}
+	return out
+}
+
+// nestDecoratorPrefixStart returns the offset within prefix where the contiguous
+// trailing decorator block begins, or -1 when the text immediately before the
+// class is not a decorator. It walks back over lines that are blank, `export`,
+// or start with `@`, stopping at the first non-decorator code line.
+func nestDecoratorPrefixStart(prefix string) int {
+	lines := strings.Split(prefix, "\n")
+	// Find the index of the last line that is a decorator/export so we can keep
+	// the contiguous trailing run.
+	start := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		t := strings.TrimSpace(lines[i])
+		if t == "" || t == "export" || t == "export default" {
+			continue
+		}
+		if strings.HasPrefix(t, "@") {
+			start = i
+			continue
+		}
+		break
+	}
+	if start < 0 {
+		return -1
+	}
+	// Compute byte offset of line `start`.
+	off := 0
+	for i := 0; i < start; i++ {
+		off += len(lines[i]) + 1
+	}
+	return off
+}
+
+// nestCtorParam is one constructor injection target.
+type nestCtorParam struct {
+	token string // injected provider: the @Inject token, else the param type
+	role  string // "token" when @Inject(...) custom token, else "type"
+}
+
+// nestConstructorParams parses the constructor parameter list of the class
+// whose body opens at bodyStart and returns the injected providers. It handles:
+//
+//	constructor(private readonly userService: UserService)        → UserService
+//	constructor(@Inject('CONFIG') private cfg: ConfigShape)       → CONFIG (token)
+//	constructor(@Inject(TOKEN) private x: X)                      → TOKEN  (token)
+func nestConstructorParams(src string, bodyStart int) []nestCtorParam {
+	// Search for the constructor within the class body.
+	body := src[bodyStart:]
+	loc := reNestConstructor.FindStringIndex(body)
+	if loc == nil {
+		return nil
+	}
+	open := bodyStart + loc[1] - 1 // index of '('
+	params := nestBalanced(src, open, '(', ')')
+	if params == "" {
+		return nil
+	}
+	var out []nestCtorParam
+	for _, raw := range nestSplitParams(params) {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue
+		}
+		// @Inject(token) custom token wins over the declared type.
+		if tok := nestInjectToken(p); tok != "" {
+			out = append(out, nestCtorParam{token: tok, role: "token"})
+			continue
+		}
+		if t := nestParamType(p); t != "" {
+			out = append(out, nestCtorParam{token: t, role: "type"})
+		}
+	}
+	return out
+}
+
+var reNestInject = regexp.MustCompile(`@Inject\s*\(\s*([^)]*?)\s*\)`)
+
+// nestInjectToken extracts the token from an @Inject(...) parameter decorator,
+// normalising a string-literal token to its bare value.
+func nestInjectToken(param string) string {
+	m := reNestInject.FindStringSubmatch(param)
+	if m == nil {
+		return ""
+	}
+	return nestNormaliseToken(m[1])
+}
+
+// nestParamType returns the leaf type identifier of a constructor parameter
+// (the part after the last `:`), rejecting primitives and lowercase shapes.
+func nestParamType(param string) string {
+	idx := strings.LastIndex(param, ":")
+	if idx < 0 {
+		return ""
+	}
+	t := strings.TrimSpace(param[idx+1:])
+	// Strip default value / trailing tokens.
+	if eq := strings.IndexByte(t, '='); eq >= 0 {
+		t = strings.TrimSpace(t[:eq])
+	}
+	// Take the leaf identifier before any generic / union / array marker.
+	if i := strings.IndexAny(t, "<|&[ \t"); i >= 0 {
+		t = t[:i]
+	}
+	t = strings.TrimSpace(t)
+	switch t {
+	case "", "string", "number", "boolean", "any", "void", "object",
+		"unknown", "never", "symbol", "bigint":
+		return ""
+	}
+	if t[0] < 'A' || t[0] > 'Z' {
+		return ""
+	}
+	return t
+}
+
+// nestUse is a resolved @Use* decorator application.
+type nestUse struct {
+	role   string // guard|interceptor|pipe
+	target string // the referenced class name
+}
+
+// nestUseDecoratorsIn returns every guard/interceptor/pipe referenced by a
+// @UseGuards/@UseInterceptors/@UsePipes decorator within the given text span.
+// Each PascalCase identifier in the decorator's argument list becomes a target
+// (NestJS allows multiple per decorator, e.g. @UseGuards(A, B)).
+func nestUseDecoratorsIn(span string) []nestUse {
+	var out []nestUse
+	seen := map[string]bool{}
+	for _, m := range reNestUseDecorator.FindAllStringSubmatch(span, -1) {
+		role := nestUseRoleMap[m[1]]
+		for _, idm := range reNestIdent.FindAllStringSubmatch(m[2], -1) {
+			target := idm[1]
+			key := role + ":" + target
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, nestUse{role: role, target: target})
+		}
+	}
+	return out
+}
+
+// nestRouteHandler describes a decorated HTTP route handler method.
+type nestRouteHandler struct {
+	opName         string // matches the base extractor's "<HTTP_METHOD> <method>" entity name
+	methodName     string
+	decoratorBlock string // the contiguous decorator text preceding the handler
+}
+
+var reNestRouteHandler = regexp.MustCompile(
+	`@(Get|Post|Put|Delete|Patch|Options|Head|All)\s*\(([^)]*)\)\s*(?:async\s+)?(\w+)\s*\(`,
+)
+
+// nestRouteHandlers returns each HTTP route handler with the decorator block
+// immediately preceding it (so method-level @UseGuards can be associated).
+func nestRouteHandlers(src string) []nestRouteHandler {
+	var out []nestRouteHandler
+	for _, m := range reNestRouteHandler.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		methodName := src[m[6]:m[7]]
+		httpMethod := nestHTTPVerbMap[verb]
+		// Decorator block: walk back from the @Verb decorator across the
+		// contiguous decorator run (other @Use*/@Verb decorators on the same
+		// handler appear directly above or below; NestJS allows either order).
+		lo := m[0] - 400
+		if lo < 0 {
+			lo = 0
+		}
+		// Extend forward to the handler's opening paren so a @UseGuards placed
+		// *between* @Get and the method name is captured too.
+		hi := m[1]
+		block := src[lo:hi]
+		if idx := nestDecoratorPrefixStart(src[lo:m[0]]); idx >= 0 {
+			block = src[lo+idx : hi]
+		} else {
+			block = src[m[0]:hi]
+		}
+		out = append(out, nestRouteHandler{
+			opName:         httpMethod + " " + methodName,
+			methodName:     methodName,
+			decoratorBlock: block,
+		})
+	}
+	return out
+}
+
+// nestModuleSections parses a @Module({...}) object body and returns the
+// PascalCase identifiers declared under providers/controllers/imports/exports.
+// The returned map keys are binding_kind values (singular): provider,
+// controller, import, export. Object-form provider entries ({provide: …}) are
+// skipped here (handled separately as token→impl BINDS) but their useClass impl
+// is still surfaced as a provider membership so module→impl is queryable.
+func nestModuleSections(body string) map[string][]string {
+	out := map[string][]string{}
+	for key, kind := range map[string]string{
+		"providers":   "provider",
+		"controllers": "controller",
+		"imports":     "import",
+		"exports":     "export",
+	} {
+		arr := nestArrayFor(body, key)
+		if arr == "" {
+			continue
+		}
+		seen := map[string]bool{}
+		// Bare identifiers (UsersService) and object-form impls (useClass: X).
+		for _, idm := range reNestIdent.FindAllStringSubmatch(arr, -1) {
+			id := idm[1]
+			// Skip object-literal keyword identifiers.
+			switch id {
+			case "Inject", "Scope":
+				continue
+			}
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			out[kind] = append(out[kind], id)
+		}
+	}
+	return out
+}
+
+// nestArrayFor returns the raw text inside the `[...]` value of `key:` within a
+// module-decorator object body, or "" when the key is absent.
+func nestArrayFor(body, key string) string {
+	re := regexp.MustCompile(`\b` + key + `\s*:\s*\[`)
+	loc := re.FindStringIndex(body)
+	if loc == nil {
+		return ""
+	}
+	open := loc[1] - 1 // index of '['
+	return nestBalanced(body, open, '[', ']')
+}
+
+// nestBalanced returns the substring strictly inside the balanced bracket pair
+// that opens at index `open` (src[open]==openCh). Returns "" on imbalance.
+func nestBalanced(src string, open int, openCh, closeCh byte) string {
+	if open < 0 || open >= len(src) || src[open] != openCh {
+		return ""
+	}
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case openCh:
+			depth++
+		case closeCh:
+			depth--
+			if depth == 0 {
+				return src[open+1 : i]
+			}
+		}
+	}
+	return ""
+}
+
+// nestSplitParams splits a constructor parameter list on top-level commas,
+// respecting nested (), [], {}, <> so generics and @Inject(...) args don't
+// break a parameter in two.
+func nestSplitParams(params string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(params); i++ {
+		switch params[i] {
+		case '(', '[', '{', '<':
+			depth++
+		case ')', ']', '}', '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, params[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(params) {
+		out = append(out, params[start:])
+	}
+	return out
+}
+
+// nestNormaliseToken strips quotes/whitespace from a DI token expression. A
+// string-literal token 'CONFIG' becomes CONFIG; an identifier token TOKEN is
+// returned as-is. Returns "" for empty/unparseable tokens.
+func nestNormaliseToken(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// String literal → bare value.
+	if (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) ||
+		(strings.HasPrefix(s, "`") && strings.HasSuffix(s, "`")) {
+		return strings.Trim(s, "'\"`")
+	}
+	// Identifier token (possibly InjectionToken constant) — keep leaf.
+	if i := strings.IndexAny(s, " <([{"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
+// nestImplName extracts the implementation identifier bound to a token for the
+// given use-kind. For useClass/useExisting it is a class identifier; for
+// useValue it may be any expression (we keep the leaf identifier when it is
+// PascalCase, else ""); for useFactory it is a function reference.
+func nestImplName(expr, useKind string) string {
+	expr = strings.TrimSpace(expr)
+	switch useKind {
+	case "useClass", "useExisting", "useFactory":
+		if i := strings.IndexAny(expr, " <([{,"); i >= 0 {
+			expr = expr[:i]
+		}
+		expr = strings.TrimSpace(expr)
+		if expr == "" {
+			return ""
+		}
+		return expr
+	case "useValue":
+		// A useValue may be a class/const reference (PascalCase) or a literal.
+		if i := strings.IndexAny(expr, " <([{,"); i >= 0 {
+			expr = expr[:i]
+		}
+		expr = strings.TrimSpace(expr)
+		if expr == "" || expr[0] < 'A' || expr[0] > 'Z' {
+			return ""
+		}
+		return expr
+	}
+	return ""
+}

--- a/internal/custom/javascript/nestjs_di_test.go
+++ b/internal/custom/javascript/nestjs_di_test.go
@@ -1,0 +1,334 @@
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// extractNest runs the NestJS extractor and returns the full entity records
+// (with Relationships) so the DI-edge tests can assert specific edges.
+func extractNest(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	return extractFull(t, "custom_js_nestjs", fi("file.ts", "typescript", src))
+}
+
+// hasEdge returns true when some entity named `ownerName` carries a relationship
+// of the given Kind with the given FromID and ToID. ownerName may be "" to skip
+// the owner check.
+func hasEdge(ents []types.EntityRecord, ownerName, kind, fromID, toID string) bool {
+	for _, e := range ents {
+		if ownerName != "" && e.Name != ownerName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// edgeProp returns the value of property `key` on the first matching edge, or "".
+func edgeProp(ents []types.EntityRecord, kind, fromID, toID, key string) string {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+				return r.Properties[key]
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Constructor injection → INJECTED_INTO
+// ---------------------------------------------------------------------------
+
+func TestNestDIConstructorInjection(t *testing.T) {
+	src := `
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  @Get()
+  list() { return this.usersService.findAll(); }
+}
+`
+	ents := extractNest(t, src)
+	// UsersService INJECTED_INTO UsersController
+	if !hasEdge(ents, "UsersController", "INJECTED_INTO", "UsersService", "UsersController") {
+		t.Error("expected UsersService INJECTED_INTO UsersController")
+	}
+	// LoggerService INJECTED_INTO UsersController
+	if !hasEdge(ents, "UsersController", "INJECTED_INTO", "LoggerService", "UsersController") {
+		t.Error("expected LoggerService INJECTED_INTO UsersController")
+	}
+	if v := edgeProp(ents, "INJECTED_INTO", "UsersService", "UsersController", "via"); v != "nestjs_constructor" {
+		t.Errorf("expected via=nestjs_constructor, got %q", v)
+	}
+}
+
+func TestNestDIInjectCustomToken(t *testing.T) {
+	src := `
+import { Injectable, Inject } from '@nestjs/common';
+
+@Injectable()
+export class ConfigConsumer {
+  constructor(
+    @Inject('CONFIG_TOKEN') private readonly cfg: ConfigShape,
+    @Inject(DATA_SOURCE) private readonly ds: DataSource,
+  ) {}
+}
+`
+	ents := extractNest(t, src)
+	// String-literal token normalised to its bare value.
+	if !hasEdge(ents, "ConfigConsumer", "INJECTED_INTO", "CONFIG_TOKEN", "ConfigConsumer") {
+		t.Error("expected token CONFIG_TOKEN INJECTED_INTO ConfigConsumer")
+	}
+	// Identifier token preserved.
+	if !hasEdge(ents, "ConfigConsumer", "INJECTED_INTO", "DATA_SOURCE", "ConfigConsumer") {
+		t.Error("expected token DATA_SOURCE INJECTED_INTO ConfigConsumer")
+	}
+	if v := edgeProp(ents, "INJECTED_INTO", "CONFIG_TOKEN", "ConfigConsumer", "di_role"); v != "token" {
+		t.Errorf("expected di_role=token, got %q", v)
+	}
+}
+
+// Negative: a constructor in class A must NOT inject into unrelated class B.
+func TestNestDINoCrossClassInjection(t *testing.T) {
+	src := `
+@Injectable()
+export class ServiceA {
+  constructor(private readonly repo: RepoA) {}
+}
+
+@Injectable()
+export class ServiceB {
+  constructor(private readonly other: RepoB) {}
+}
+`
+	ents := extractNest(t, src)
+	if !hasEdge(ents, "ServiceA", "INJECTED_INTO", "RepoA", "ServiceA") {
+		t.Error("expected RepoA INJECTED_INTO ServiceA")
+	}
+	if !hasEdge(ents, "ServiceB", "INJECTED_INTO", "RepoB", "ServiceB") {
+		t.Error("expected RepoB INJECTED_INTO ServiceB")
+	}
+	// RepoA must not be injected into ServiceB (no cross-class leakage).
+	if hasEdge(ents, "", "INJECTED_INTO", "RepoA", "ServiceB") {
+		t.Error("unexpected cross-class injection RepoA INTO ServiceB")
+	}
+	if hasEdge(ents, "", "INJECTED_INTO", "RepoB", "ServiceA") {
+		t.Error("unexpected cross-class injection RepoB INTO ServiceA")
+	}
+}
+
+// Primitive-typed constructor params must not produce an injection edge.
+func TestNestDIRejectsPrimitiveParams(t *testing.T) {
+	src := `
+@Injectable()
+export class TokenService {
+  constructor(private readonly secret: string, private readonly ttl: number) {}
+}
+`
+	ents := extractNest(t, src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "INJECTED_INTO" {
+				t.Errorf("unexpected INJECTED_INTO edge for primitive params: %+v", r)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// @Module wiring → BINDS
+// ---------------------------------------------------------------------------
+
+func TestNestDIModuleBinds(t *testing.T) {
+	src := `
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [SharedModule, AuthModule],
+  controllers: [UsersController],
+  providers: [UsersService, UsersRepository],
+  exports: [UsersService],
+})
+export class UsersModule {}
+`
+	ents := extractNest(t, src)
+	// @Module providers:[UsersService] → UsersModule BINDS UsersService
+	if !hasEdge(ents, "UsersModule", "BINDS", "UsersModule", "UsersService") {
+		t.Error("expected UsersModule BINDS UsersService (provider)")
+	}
+	if v := edgeProp(ents, "BINDS", "UsersModule", "UsersService", "binding_kind"); v != "provider" {
+		t.Errorf("expected binding_kind=provider, got %q", v)
+	}
+	// controllers
+	if !hasEdge(ents, "UsersModule", "BINDS", "UsersModule", "UsersController") {
+		t.Error("expected UsersModule BINDS UsersController (controller)")
+	}
+	if v := edgeProp(ents, "BINDS", "UsersModule", "UsersController", "binding_kind"); v != "controller" {
+		t.Errorf("expected binding_kind=controller, got %q", v)
+	}
+	// imports
+	if !hasEdge(ents, "UsersModule", "BINDS", "UsersModule", "SharedModule") {
+		t.Error("expected UsersModule BINDS SharedModule (import)")
+	}
+	if v := edgeProp(ents, "BINDS", "UsersModule", "SharedModule", "binding_kind"); v != "import" {
+		t.Errorf("expected binding_kind=import, got %q", v)
+	}
+	// exports: UsersService is both a provider and exported → a single BINDS
+	// edge tagged binding_kind=provider with exported=true (no duplicate edge).
+	if v := edgeProp(ents, "BINDS", "UsersModule", "UsersService", "exported"); v != "true" {
+		t.Errorf("expected exported=true on UsersService binding, got %q", v)
+	}
+	usersServiceBinds := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "BINDS" && r.FromID == "UsersModule" && r.ToID == "UsersService" {
+				usersServiceBinds++
+			}
+		}
+	}
+	if usersServiceBinds != 1 {
+		t.Errorf("expected exactly 1 BINDS edge to UsersService, got %d", usersServiceBinds)
+	}
+}
+
+func TestNestDIModuleProviderTokenBinds(t *testing.T) {
+	src := `
+@Module({
+  providers: [
+    { provide: 'CONFIG', useClass: ConfigService },
+    { provide: CACHE_TOKEN, useExisting: RedisCache },
+  ],
+})
+export class CoreModule {}
+`
+	ents := extractNest(t, src)
+	// {provide:'CONFIG', useClass: ConfigService} → token CONFIG BINDS ConfigService
+	if !hasEdge(ents, "CoreModule", "BINDS", "CONFIG", "ConfigService") {
+		t.Error("expected token CONFIG BINDS ConfigService")
+	}
+	if v := edgeProp(ents, "BINDS", "CONFIG", "ConfigService", "binding_kind"); v != "useClass" {
+		t.Errorf("expected binding_kind=useClass, got %q", v)
+	}
+	// useExisting alias
+	if !hasEdge(ents, "CoreModule", "BINDS", "CACHE_TOKEN", "RedisCache") {
+		t.Error("expected token CACHE_TOKEN BINDS RedisCache")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// @UseGuards / @UseInterceptors / @UsePipes → USES
+// ---------------------------------------------------------------------------
+
+func TestNestDIClassLevelGuard(t *testing.T) {
+	src := `
+import { Controller, UseGuards } from '@nestjs/common';
+
+@UseGuards(JwtAuthGuard)
+@Controller('admin')
+export class AdminController {}
+`
+	ents := extractNest(t, src)
+	// @UseGuards(JwtAuthGuard) on controller → AdminController USES JwtAuthGuard
+	if !hasEdge(ents, "AdminController", "USES", "AdminController", "JwtAuthGuard") {
+		t.Error("expected AdminController USES JwtAuthGuard")
+	}
+	if v := edgeProp(ents, "USES", "AdminController", "JwtAuthGuard", "di_role"); v != "guard" {
+		t.Errorf("expected di_role=guard, got %q", v)
+	}
+}
+
+func TestNestDIHandlerLevelGuard(t *testing.T) {
+	src := `
+import { Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @UseGuards(RolesGuard)
+  @UseInterceptors(LoggingInterceptor)
+  @Get('secret')
+  getSecret() { return 42; }
+}
+`
+	ents := extractNest(t, src)
+	// @UseGuards(RolesGuard) on a route → endpoint "GET getSecret" USES RolesGuard
+	if !hasEdge(ents, "GET getSecret", "USES", "GET getSecret", "RolesGuard") {
+		t.Error("expected endpoint GET getSecret USES RolesGuard")
+	}
+	if v := edgeProp(ents, "USES", "GET getSecret", "RolesGuard", "di_scope"); v != "handler" {
+		t.Errorf("expected di_scope=handler, got %q", v)
+	}
+	// Interceptor on the same handler.
+	if !hasEdge(ents, "GET getSecret", "USES", "GET getSecret", "LoggingInterceptor") {
+		t.Error("expected endpoint GET getSecret USES LoggingInterceptor")
+	}
+	if v := edgeProp(ents, "USES", "GET getSecret", "LoggingInterceptor", "di_role"); v != "interceptor" {
+		t.Errorf("expected di_role=interceptor, got %q", v)
+	}
+}
+
+func TestNestDIMultipleGuards(t *testing.T) {
+	src := `
+@UseGuards(AuthGuard, RolesGuard)
+@Controller('x')
+export class XController {}
+`
+	ents := extractNest(t, src)
+	if !hasEdge(ents, "XController", "USES", "XController", "AuthGuard") {
+		t.Error("expected XController USES AuthGuard")
+	}
+	if !hasEdge(ents, "XController", "USES", "XController", "RolesGuard") {
+		t.Error("expected XController USES RolesGuard")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// @Injectable scope
+// ---------------------------------------------------------------------------
+
+func TestNestDIInjectableScope(t *testing.T) {
+	src := `
+import { Injectable, Scope } from '@nestjs/common';
+
+@Injectable({ scope: Scope.REQUEST })
+export class RequestScopedService {}
+`
+	ents := extractNest(t, src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "RequestScopedService" {
+			found = true
+			if e.Properties["di_scope"] != "REQUEST" {
+				t.Errorf("expected di_scope=REQUEST, got %q", e.Properties["di_scope"])
+			}
+			if e.Properties["di_provider"] != "true" {
+				t.Errorf("expected di_provider=true, got %q", e.Properties["di_provider"])
+			}
+		}
+	}
+	if !found {
+		t.Error("RequestScopedService entity not emitted")
+	}
+}
+
+// No DI edges leak out of a plain non-NestJS file.
+func TestNestDINoMatch(t *testing.T) {
+	ents := extractNest(t, "const x = 1;")
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3647 (child of epic #3628, meta-audit area #5 — DI/IoC edges).

## Problem
The NestJS extractor (`internal/custom/javascript/nestjs.go`) emitted entities but **zero relationships**, so the rewrite-parity oracle could not resolve providers, module wiring, or endpoint guards. NestJS is the rewrite **target**, yet DI/IoC edges existed only for Angular and Helm.

## What this emits
New DI pass (`internal/custom/javascript/nestjs_di.go`), wired into the existing extractor:

| Edge | Shape | Status |
|---|---|---|
| `INJECTED_INTO` | constructor injection: provider / `@Inject(TOKEN)` → injecting class (mirrors Angular's FromID=provider, ToID=consumer) | **partial** (cross-file token→provider resolution is the resolver's job) |
| `BINDS` (module) | `@Module` wiring: module → provider / controller / import (`exported` flag) | **full** for in-file membership |
| `BINDS` (token) | `{provide: TOKEN, useClass/useValue/useFactory/useExisting: Impl}` → token BINDS impl (mirrors Helm token→impl) | **partial** (cross-file token resolution) |
| `USES` | class- and method-level `@UseGuards/@UseInterceptors/@UsePipes` → guard/interceptor/pipe (`di_role`, `di_scope`) | **full** in-file |
| `@Injectable` scope | `@Injectable({ scope: Scope.REQUEST })` → `di_scope` prop; `di_provider=true` | **full** |

Reuses existing edge Kinds (`INJECTED_INTO`, `BINDS`, `USES`) — no new Kinds.

## Tests (value-asserting, not `len>0`)
`nestjs_di_test.go` asserts specific edges:
- `UsersService INJECTED_INTO UsersController`; `@Inject('CONFIG_TOKEN')` normalisation; `@Inject(DATA_SOURCE)` identifier token
- `UsersModule BINDS UsersService` (single edge, `exported=true`); `BINDS` for controllers/imports
- token `CONFIG BINDS ConfigService` (`useClass`); `CACHE_TOKEN BINDS RedisCache` (`useExisting`)
- `AdminController USES JwtAuthGuard` (class-level); `GET getSecret USES RolesGuard` + `USES LoggingInterceptor` (handler-level); multi-guard
- `@Injectable({ scope: Scope.REQUEST })` → `di_scope=REQUEST`
- **negatives**: no cross-class injection leakage; primitive-typed params rejected

## Records
Adds a `framework_specific` `DI` block (`di_binding_extraction`, `di_injection_point`, `di_scope_resolution`) to the NestJS coverage record. Recorded under `framework_specific` rather than the shared `http_backend` taxonomy because DI is NestJS-unique (most http_backend frameworks have no DI container) — keeps the change to one record. `coverage validate` 0 errors, `coverage fmt --check` canonical.

## Verification
- `go test ./internal/extractors/javascript/... ./internal/engine/ ./internal/types/ ./tools/coverage/ ./internal/custom/javascript/` — all pass
- `gofmt -l` clean on changed files; `go vet` clean
- `coverage validate` 0 errors; `coverage fmt --check` canonical

Unblocks the rewrite parity oracle's provider/guard resolution. **DEPLOY-DEFERRED** (no daemon rebuild in this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)