### PR TITLE
Restore consumes_api as wired Pass-3 cross extractor (CONSUMES_API)

### DIFF
--- a/internal/extractors/cross/consumes_api/extractor.go
+++ b/internal/extractors/cross/consumes_api/extractor.go
@@ -1,0 +1,347 @@
+// Package consumes_api implements the cross-language API-consumption extractor.
+//
+// It restores the previously-orphaned consumes_api enricher (Python
+// `consumes_api_enricher.py`, ported but unwired in internal/enrichers/) as a
+// registered Pass-3 cross extractor that emits CONSUMES_API edges from an HTTP
+// client call site to the server endpoint it consumes.
+//
+// What it emits
+// -------------
+//
+//	CONSUMES_API : caller stub ("scope:component:http_caller:<file>")
+//	             → endpoint entity ("scope:endpoint:<file>#<VERB>:<path>")
+//
+// for every HTTP client call in a file whose (verb, path) matches a server
+// endpoint declared in the SAME file. This is the co-located client+server
+// shape — BFFs, API gateways, Django views that call their own API,
+// integration-test harnesses — where the consumption is statically
+// determinable without crossing a file boundary.
+//
+// Why same-file only
+// ------------------
+// The cross-extractor contract (internal/extractor.Extractor) is strictly
+// per-file: Extract sees one file at a time and has no group-wide / multi-repo
+// view. The original enricher's same-org client→endpoint join across repos is
+// therefore owned by the cross-repo link layer (internal/links/http_pass.go,
+// which fires only for groups of ≥2 repos via synthetic http_endpoint
+// entities). This extractor deliberately covers the complementary case the
+// link layer never touches: consumption that lives entirely inside one file.
+// Because both sides live in the same file they are by construction the same
+// org / repo, so the original enricher's cross-org guard is trivially
+// satisfied here.
+//
+// Complementary, not duplicate
+// ----------------------------
+//   - _cross_httpclient emits CALLS → SCOPE.ExternalAPI(url). That is the raw
+//     outbound-call fact; it does not know which endpoint the URL resolves to.
+//   - _cross_endpoint emits SCOPE.Operation endpoint entities + SERVES edges to
+//     handlers. That is the server-side route catalog.
+//   - internal/links/http_pass emits cross-repo MethodHTTP links between repos.
+//
+// CONSUMES_API is the *consumption* join the three above never produce: a
+// direct caller → endpoint-identity edge. To avoid double-emitting the
+// underlying entities, this extractor reuses the existing _cross_httpclient and
+// _cross_endpoint extractors to discover calls and endpoints and emits ONLY the
+// new CONSUMES_API relationship (carried on a thin, deduplicated entity record);
+// it never re-emits the ExternalAPI / endpoint entities those extractors own.
+//
+// Registration key: "_cross_consumes_api"
+package consumes_api
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/cross/endpoint"
+	"github.com/cajasmota/archigraph/internal/extractors/cross/httpclient"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("_cross_consumes_api", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for same-file API consumption.
+type Extractor struct {
+	// clientExtractor / endpointExtractor are reused to discover the call and
+	// endpoint facts without duplicating any detection regexes. Both are
+	// stateless, so a shared instance is safe for concurrent Extract calls.
+	clientExtractor   httpclient.Extractor
+	endpointExtractor endpoint.Extractor
+}
+
+// Language returns the registration key.
+func (e *Extractor) Language() string { return "_cross_consumes_api" }
+
+// ---------------------------------------------------------------------------
+// Path / method matching — ported from internal/enrichers/consumes_api_enricher.go
+// ---------------------------------------------------------------------------
+
+// pathParamRe matches every path-parameter placeholder style so a client call
+// path and a server endpoint path can be compared structurally regardless of
+// the parameter-syntax each side spelled:
+//   - {id}, {userId}      curly-brace (FastAPI / DRF router / endpoint canonical)
+//   - :id, :userId        colon prefix (Express / Rails / endpoint canonical)
+//   - <int:id>, <id>      angle bracket (Django / Flask)
+//   - ${id}, {*}          JS template-literal / wildcard sentinels (httpclient)
+var pathParamRe = regexp.MustCompile(`\$\{[^}]*\}|\{[^}]*\}|:[A-Za-z_]\w*|<[^>]+>`)
+
+// extractURLPath extracts the path component from a raw URL or URL pattern.
+// Absolute URLs ("https://host/x") yield "/x"; root-relative URLs ("/x") yield
+// "/x" unchanged. Returns "" when no usable path can be recovered.
+//
+// Ported from ExtractURLPath in the orphaned enricher, hardened for the
+// root-relative case (url.Parse keeps the leading slash there) and for
+// template-literal URLs whose "${...}" segments would otherwise confuse the
+// host/path split.
+func extractURLPath(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	// Root-relative paths parse with an empty Host; keep them verbatim.
+	if strings.HasPrefix(rawURL, "/") {
+		if i := strings.IndexAny(rawURL, "?#"); i >= 0 {
+			return rawURL[:i]
+		}
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Path == "" {
+		return ""
+	}
+	return parsed.Path
+}
+
+// normalizePath canonicalises a path for cross-side comparison: every parameter
+// placeholder collapses to the sentinel {*}, the result is lower-cased, and a
+// trailing slash (other than the bare root) is stripped. Mirrors the
+// normalisation the endpoint extractor and links/http_pass apply so that
+// "/api/users/{id}" (server) and "/api/users/123"-style template calls compare
+// equal once the dynamic segment is a placeholder.
+func normalizePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	path = pathParamRe.ReplaceAllString(path, "{*}")
+	path = strings.ToLower(path)
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+	return path
+}
+
+// methodMatches returns true when the client call's verb is compatible with the
+// endpoint's verb. An empty endpoint verb or the wildcard "*"/"ANY" matches any
+// call; an empty call verb never matches a specific endpoint verb (we refuse to
+// guess). Ported from MethodMatches in the orphaned enricher, extended to treat
+// "ANY" (Django ViewSet) as a wildcard.
+func methodMatches(callMethod, endpointMethod string) bool {
+	em := strings.ToUpper(strings.TrimSpace(endpointMethod))
+	if em == "" || em == "*" || em == "ANY" {
+		return true
+	}
+	if callMethod == "" {
+		return false
+	}
+	return strings.EqualFold(callMethod, em)
+}
+
+// ---------------------------------------------------------------------------
+// Fact harvesting from the reused extractors
+// ---------------------------------------------------------------------------
+
+// clientCall is one outbound HTTP call site recovered from the httpclient
+// extractor's CALLS edges.
+type clientCall struct {
+	callerRef string // the http_caller stub ID (FromID of the CALLS edge)
+	method    string // HTTP verb (may be empty when the client form omits it)
+	url       string // raw URL / pattern
+	path      string // normalised path key for matching
+}
+
+// serverEndpoint is one server endpoint recovered from the endpoint extractor.
+type serverEndpoint struct {
+	entityID string // canonical endpoint entity ID (ToID of the CONSUMES_API edge)
+	method   string // HTTP verb / "ANY" / "*"
+	path     string // normalised path key for matching
+	rawPath  string // canonical (non-normalised) path, for traceability props
+}
+
+// harvestClientCalls runs the reused httpclient extractor and lifts each
+// CALLS(kind=external_http_call) edge into a clientCall. The httpclient
+// extractor embeds the CALLS edge on the ExternalAPI entity it owns; we read it
+// without re-emitting that entity.
+func (e *Extractor) harvestClientCalls(ctx context.Context, file extractor.FileInput) []clientCall {
+	recs, err := e.clientExtractor.Extract(ctx, file)
+	if err != nil {
+		return nil
+	}
+	var out []clientCall
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if !strings.EqualFold(rel.Kind, "CALLS") {
+				continue
+			}
+			if rel.Properties["kind"] != "external_http_call" {
+				continue
+			}
+			rawURL := rel.Properties["url"]
+			p := normalizePath(extractURLPath(rawURL))
+			if p == "" {
+				continue
+			}
+			out = append(out, clientCall{
+				callerRef: rel.FromID,
+				method:    strings.ToUpper(strings.TrimSpace(rel.Properties["http_method"])),
+				url:       rawURL,
+				path:      p,
+			})
+		}
+	}
+	return out
+}
+
+// harvestServerEndpoints runs the reused endpoint extractor and lifts each
+// emitted SCOPE.Operation router endpoint into a serverEndpoint.
+func (e *Extractor) harvestServerEndpoints(ctx context.Context, file extractor.FileInput) []serverEndpoint {
+	recs, err := e.endpointExtractor.Extract(ctx, file)
+	if err != nil {
+		return nil
+	}
+	var out []serverEndpoint
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Operation" || r.Properties["provenance"] != "INFERRED_FROM_FRAMEWORK_ROUTER" {
+			continue
+		}
+		rawPath := r.Properties["path"]
+		p := normalizePath(rawPath)
+		if p == "" {
+			continue
+		}
+		out = append(out, serverEndpoint{
+			entityID: r.Properties["ref"],
+			method:   r.Properties["method"],
+			path:     p,
+			rawPath:  rawPath,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Extract implements extractor.Extractor
+// ---------------------------------------------------------------------------
+
+// consumesEntityID builds the stable identity for the thin carrier entity that
+// holds a file's CONSUMES_API edges. One per file keeps the edge set
+// deduplicated and avoids colliding with the ExternalAPI / endpoint entities
+// the reused extractors own.
+func consumesEntityID(filePath string) string {
+	return "scope:consumes_api:" + filePath
+}
+
+// Extract discovers HTTP client calls and server endpoints in the file (by
+// reusing the httpclient + endpoint extractors) and emits one CONSUMES_API edge
+// for every (call, endpoint) pair whose verb is compatible and whose normalised
+// path is identical. Files with no client call OR no endpoint produce nothing.
+func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("extractor._cross_consumes_api")
+	ctx, span := tracer.Start(ctx, "indexer.consumes_api_enricher.enrich")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("file_path", file.Path),
+		attribute.String("language", file.Language),
+	)
+
+	if len(file.Content) == 0 {
+		span.SetAttributes(attribute.Int("consumes_api_edges", 0))
+		return nil, nil
+	}
+
+	calls := e.harvestClientCalls(ctx, file)
+	endpoints := e.harvestServerEndpoints(ctx, file)
+	if len(calls) == 0 || len(endpoints) == 0 {
+		span.SetAttributes(
+			attribute.Int("client_calls", len(calls)),
+			attribute.Int("server_endpoints", len(endpoints)),
+			attribute.Int("consumes_api_edges", 0),
+		)
+		return nil, nil
+	}
+
+	// Index endpoints by normalised path for an O(calls + endpoints) join.
+	byPath := map[string][]serverEndpoint{}
+	for _, ep := range endpoints {
+		byPath[ep.path] = append(byPath[ep.path], ep)
+	}
+
+	carrierID := consumesEntityID(file.Path)
+	rec := types.EntityRecord{
+		Name:       file.Path,
+		Kind:       "SCOPE.Component",
+		Subtype:    "consumes_api",
+		SourceFile: file.Path,
+		Language:   file.Language,
+		Properties: map[string]string{
+			"ref":        carrierID,
+			"provenance": "INFERRED_FROM_HTTP_CLIENT_CALL",
+		},
+		QualityScore: 0.8,
+	}
+
+	// Deterministic edge emission + per-(caller,endpoint,method) dedup so two
+	// call sites in the same file to the same endpoint do not double-emit.
+	seen := map[string]bool{}
+	for _, c := range calls {
+		matches := byPath[c.path]
+		// Stable ordering so re-runs produce identical graph.json.
+		sort.SliceStable(matches, func(i, j int) bool {
+			return matches[i].entityID < matches[j].entityID
+		})
+		for _, ep := range matches {
+			if !methodMatches(c.method, ep.method) {
+				continue
+			}
+			dedupKey := c.callerRef + "\x00" + ep.entityID + "\x00" + c.method
+			if seen[dedupKey] {
+				continue
+			}
+			seen[dedupKey] = true
+			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+				FromID: c.callerRef,
+				ToID:   ep.entityID,
+				Kind:   string(types.RelationshipKindConsumesAPI),
+				Properties: map[string]string{
+					"method":        c.method,
+					"matched_url":   c.url,
+					"matched_path":  c.path,
+					"endpoint_path": ep.rawPath,
+					"via":           "same_file_http_consumption",
+					"provenance":    "INFERRED_FROM_HTTP_CLIENT_CALL",
+				},
+			})
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Int("client_calls", len(calls)),
+		attribute.Int("server_endpoints", len(endpoints)),
+		attribute.Int("consumes_api_edges", len(rec.Relationships)),
+	)
+
+	if len(rec.Relationships) == 0 {
+		return nil, nil
+	}
+	return []types.EntityRecord{rec}, nil
+}

--- a/internal/extractors/cross/consumes_api/extractor_test.go
+++ b/internal/extractors/cross/consumes_api/extractor_test.go
@@ -1,0 +1,256 @@
+package consumes_api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func runExtract(t *testing.T, path, lang, source string) []types.EntityRecord {
+	t.Helper()
+	e := &Extractor{}
+	recs, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(source),
+		Language: lang,
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	return recs
+}
+
+// consumesEdges flattens every CONSUMES_API relationship across the returned
+// records.
+func consumesEdges(recs []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == string(types.RelationshipKindConsumesAPI) {
+				out = append(out, rel)
+			}
+		}
+	}
+	return out
+}
+
+// findConsumesTo returns the CONSUMES_API edge whose ToID is the given endpoint
+// id, failing the test when absent.
+func findConsumesTo(t *testing.T, recs []types.EntityRecord, toID string) types.RelationshipRecord {
+	t.Helper()
+	for _, rel := range consumesEdges(recs) {
+		if rel.ToID == toID {
+			return rel
+		}
+	}
+	t.Fatalf("no CONSUMES_API edge to %q; edges=%+v", toID, consumesEdges(recs))
+	return types.RelationshipRecord{}
+}
+
+// ---------------------------------------------------------------------------
+// Interface / registration
+// ---------------------------------------------------------------------------
+
+func TestLanguageKey(t *testing.T) {
+	e := &Extractor{}
+	if got := e.Language(); got != "_cross_consumes_api" {
+		t.Errorf("Language()=%q, want _cross_consumes_api", got)
+	}
+}
+
+func TestRegisteredInExtractorRegistry(t *testing.T) {
+	ext, ok := extractor.Get("_cross_consumes_api")
+	if !ok {
+		t.Fatal("_cross_consumes_api not registered in extractor registry")
+	}
+	if ext.Language() != "_cross_consumes_api" {
+		t.Errorf("registered extractor Language()=%q", ext.Language())
+	}
+}
+
+func TestConsumesAPIIsValidRelationshipKind(t *testing.T) {
+	if !types.IsValidRelationshipKind(string(types.RelationshipKindConsumesAPI)) {
+		t.Fatal("CONSUMES_API is not registered in AllRelationshipKinds — producer-kind validator would reject it")
+	}
+}
+
+func TestEmptyFileReturnsNil(t *testing.T) {
+	if recs := runExtract(t, "empty.js", "javascript", ""); len(recs) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(recs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure matcher units (ported semantics)
+// ---------------------------------------------------------------------------
+
+func TestExtractURLPath(t *testing.T) {
+	cases := map[string]string{
+		"https://api.example.com/api/users/123": "/api/users/123",
+		"/api/users/123":                        "/api/users/123",
+		"/api/users/123?expand=1":               "/api/users/123",
+		"":                                      "",
+		"://bad-host":                           "",
+	}
+	for in, want := range cases {
+		if got := extractURLPath(in); got != want {
+			t.Errorf("extractURLPath(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizePathCollapsesParamStyles(t *testing.T) {
+	// Server (:id / {id} / <int:id>) and client (${id} / {*}) param styles must
+	// all collapse to the same key.
+	want := "/api/users/{*}"
+	for _, in := range []string{
+		"/api/users/:id",
+		"/api/users/{id}",
+		"/api/users/<int:id>",
+		"/api/users/${userId}",
+		"/api/users/{*}",
+		"/api/Users/{id}/", // case + trailing slash
+	} {
+		if got := normalizePath(in); got != want {
+			t.Errorf("normalizePath(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMethodMatches(t *testing.T) {
+	if !methodMatches("GET", "GET") {
+		t.Error("GET should match GET")
+	}
+	if !methodMatches("get", "GET") {
+		t.Error("case-insensitive verb match expected")
+	}
+	if !methodMatches("POST", "ANY") {
+		t.Error("ANY endpoint verb is a wildcard")
+	}
+	if !methodMatches("DELETE", "*") {
+		t.Error("* endpoint verb is a wildcard")
+	}
+	if methodMatches("GET", "POST") {
+		t.Error("GET must NOT match a POST endpoint")
+	}
+	if methodMatches("", "GET") {
+		t.Error("empty call verb must NOT match a specific endpoint verb")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VALUE assertion: a specific CONSUMES_API edge is emitted for a same-file
+// client GET → server GET endpoint, param-normalized.
+// ---------------------------------------------------------------------------
+
+// expressBFF is a co-located client+server file: it both SERVES the route
+// `GET /api/users/:id` (Express) and CALLS `GET /api/users/123` (axios). The
+// extractor must join them into exactly one CONSUMES_API edge.
+const expressBFF = `
+import express from 'express';
+import axios from 'axios';
+
+const app = express();
+
+// server: declares the endpoint
+app.get('/api/users/:id', async (req, res) => {
+  res.json({ id: req.params.id });
+});
+
+// client: consumes its own endpoint (template-literal id → {*} param)
+async function fetchUser(id) {
+  return axios.get(` + "`" + `https://gateway.internal/api/users/${id}` + "`" + `);
+}
+`
+
+func TestEmitsSpecificConsumesAPIEdge(t *testing.T) {
+	recs := runExtract(t, "bff/users.js", "javascript", expressBFF)
+
+	edges := consumesEdges(recs)
+	if len(edges) != 1 {
+		t.Fatalf("expected exactly 1 CONSUMES_API edge, got %d: %+v", len(edges), edges)
+	}
+
+	// The endpoint extractor canonicalises `:id` → `{id}`, so the endpoint ID is
+	// scope:endpoint:<file>#GET:/api/users/{id}. Assert the edge targets exactly
+	// that endpoint identity and originates from the http_caller stub.
+	wantEndpoint := "scope:endpoint:bff/users.js#GET:/api/users/{id}"
+	rel := findConsumesTo(t, recs, wantEndpoint)
+
+	if rel.FromID != "scope:component:http_caller:bff/users.js" {
+		t.Errorf("CONSUMES_API FromID=%q, want the http_caller stub", rel.FromID)
+	}
+	if rel.Properties["method"] != "GET" {
+		t.Errorf("edge method=%q, want GET", rel.Properties["method"])
+	}
+	if rel.Properties["matched_path"] != "/api/users/{*}" {
+		t.Errorf("edge matched_path=%q, want /api/users/{*}", rel.Properties["matched_path"])
+	}
+	if rel.Properties["endpoint_path"] != "/api/users/{id}" {
+		t.Errorf("edge endpoint_path=%q, want /api/users/{id}", rel.Properties["endpoint_path"])
+	}
+	if rel.Properties["via"] != "same_file_http_consumption" {
+		t.Errorf("edge via=%q, want same_file_http_consumption", rel.Properties["via"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE: no edge when the verb mismatches (client POST, server GET only).
+// ---------------------------------------------------------------------------
+
+const expressVerbMismatch = `
+import express from 'express';
+import axios from 'axios';
+const app = express();
+app.get('/api/users/:id', handler);
+async function f(){ return axios.post(` + "`" + `https://h/api/users/${id}` + "`" + `); }
+`
+
+func TestNoEdgeOnVerbMismatch(t *testing.T) {
+	recs := runExtract(t, "bff/mismatch.js", "javascript", expressVerbMismatch)
+	if edges := consumesEdges(recs); len(edges) != 0 {
+		t.Fatalf("expected 0 CONSUMES_API edges on verb mismatch, got %d: %+v", len(edges), edges)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE: no edge when the path does not match (different route).
+// ---------------------------------------------------------------------------
+
+const expressPathMismatch = `
+import express from 'express';
+import axios from 'axios';
+const app = express();
+app.get('/api/orders/:id', handler);
+async function f(){ return axios.get(` + "`" + `https://h/api/users/${id}` + "`" + `); }
+`
+
+func TestNoEdgeOnPathMismatch(t *testing.T) {
+	recs := runExtract(t, "bff/pathmiss.js", "javascript", expressPathMismatch)
+	if edges := consumesEdges(recs); len(edges) != 0 {
+		t.Fatalf("expected 0 CONSUMES_API edges on path mismatch, got %d: %+v", len(edges), edges)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE: a file with only a client call (no server endpoint) — the cross-repo
+// case owned by links/http_pass — must NOT emit a CONSUMES_API edge here.
+// ---------------------------------------------------------------------------
+
+const clientOnly = `
+import axios from 'axios';
+async function f(){ return axios.get('https://h/api/users/9'); }
+`
+
+func TestNoEdgeWhenNoServerEndpointInFile(t *testing.T) {
+	recs := runExtract(t, "client.js", "javascript", clientOnly)
+	if edges := consumesEdges(recs); len(edges) != 0 {
+		t.Fatalf("expected 0 CONSUMES_API edges when no server endpoint co-located, got %d: %+v", len(edges), edges)
+	}
+}

--- a/internal/extractors/cross/cross.go
+++ b/internal/extractors/cross/cross.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/extractor"
 
 	_ "github.com/cajasmota/archigraph/internal/extractors/cross/abibridge"
+	_ "github.com/cajasmota/archigraph/internal/extractors/cross/consumes_api"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cross/dbmap"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cross/deprecation"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cross/endpoint"
@@ -45,6 +46,9 @@ var names = []string{
 	"ormlink",
 	"react_props",
 	"endpoint",
+	// consumes_api runs after httpclient + endpoint: it reuses their detection
+	// to join same-file client calls → server endpoints into CONSUMES_API edges.
+	"consumes_api",
 	"manifest",
 	"testmap",
 	"deprecation",

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -610,6 +610,30 @@ const (
 	//   "parent_path"   : the dotted path in the parent values tree
 	// Append-only — never modifies existing entities or edges.
 	RelationshipKindOverrides RelationshipKind = "OVERRIDES"
+
+	// #3632 (epic #3625): API-consumption edge. Emitted by the
+	// internal/extractors/cross/consumes_api Pass-3 cross extractor for every
+	// HTTP client call site whose (verb, path) matches a server endpoint
+	// declared in the SAME source file (co-located client + server — BFFs, API
+	// gateways, Django views that call their own API, integration-test
+	// harnesses). The edge goes from the consuming caller stub
+	// ("scope:component:http_caller:<file>") → the canonical endpoint entity ID
+	// ("scope:endpoint:<file>#<VERB>:<canonical-path>") emitted by the
+	// _cross_endpoint extractor. Properties:
+	//   "method"        : the HTTP verb of the client call
+	//   "matched_url"   : the raw client URL/pattern that produced the match
+	//   "matched_path"  : the path component used for the join
+	//   "endpoint_path" : the server endpoint's canonical path
+	//   "via"           : "same_file_http_consumption" (capability tag)
+	//   "provenance"    : "INFERRED_FROM_HTTP_CLIENT_CALL"
+	// This is the *consumption* semantic — it is complementary to, not a
+	// duplicate of, the CALLS→ExternalAPI edge emitted by _cross_httpclient and
+	// the cross-repo MethodHTTP links emitted by internal/links/http_pass.go
+	// (which only fires for groups of ≥2 repos via synthetic http_endpoint
+	// entities). Cross-org / cross-repo consumption stays owned by the links
+	// layer; this extractor never crosses a file boundary, so its org guard is
+	// trivially satisfied. Append-only — never modifies existing entities/edges.
+	RelationshipKindConsumesAPI RelationshipKind = "CONSUMES_API"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -718,6 +742,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindIncludes,
 		// #3552 Helm parent-chart values override edge:
 		RelationshipKindOverrides,
+		// #3632 API-consumption edge (same-file client→endpoint):
+		RelationshipKindConsumesAPI,
 	}
 }
 


### PR DESCRIPTION
Closes #3632 (epic #3625).

## What this does
Wires the previously-**orphaned** `consumes_api` enricher (`internal/enrichers/consumes_api_enricher.go`, imported by zero production code) into a **live, registered Pass-3 cross extractor** at `internal/extractors/cross/consumes_api/`, reachable from `cross.AllExtractors()` (the registry the indexer's Pass 3 iterates in `internal/daemon/extract/subproc.go`).

## What CONSUMES_API edges now emit
For every HTTP client call site whose `(verb, normalized-path)` matches a server endpoint declared **in the same source file**, emit:

```
CONSUMES_API : scope:component:http_caller:<file>  →  scope:endpoint:<file>#<VERB>:<path>
```

with properties `method`, `matched_url`, `matched_path`, `endpoint_path`, `via=same_file_http_consumption`, `provenance=INFERRED_FROM_HTTP_CLIENT_CALL`.

This is the co-located client+server shape — BFFs, API gateways, self-calling Django views, integration-test harnesses.

## How it complements (does NOT duplicate) existing cross_links
The cross-extractor contract (`extractor.Extractor.Extract`) is strictly **per-file** — it has no multi-repo view, so a true cross-repo same-org join is structurally impossible inside it. That join is already owned by **`internal/links/http_pass.go`** (cross-repo `MethodHTTP` links, fires only for groups of ≥2 repos via synthetic `http_endpoint` entities).

- `_cross_httpclient` → `CALLS → SCOPE.ExternalAPI(url)` (raw outbound fact, no endpoint resolution)
- `_cross_endpoint` → `SCOPE.Operation` endpoint catalog + `SERVES`
- `internal/links/http_pass` → cross-repo `MethodHTTP` links

`CONSUMES_API` is the **consumption join none of them produce**: a direct caller→endpoint-identity edge. To avoid double-emit, the extractor **reuses** `_cross_httpclient` + `_cross_endpoint` to discover the call/endpoint facts and emits **only** the new relationship — it never re-emits the ExternalAPI / endpoint entities those extractors own. Cross-repo/cross-org consumption is deliberately left to the links layer; because both sides here live in one file, the original enricher's same-org guard is trivially satisfied.

## Changes
- `internal/types/kinds.go`: add `RelationshipKindConsumesAPI` ("CONSUMES_API") + register in `AllRelationshipKinds()` (producer-kind validator would otherwise reject it).
- `internal/extractors/cross/cross.go`: blank import + `"consumes_api"` in `names` (after `httpclient`/`endpoint`).
- Ports `ExtractURLPath` / `MethodMatches` / path-normalization from the orphaned enricher; extends `ANY`→wildcard and `{*}`/`${}` param-style collapse.

## Tests (value-asserting)
- **Positive**: same-file `axios.get(\`.../api/users/${id}\`)` → asserts exactly one edge to `scope:endpoint:bff/users.js#GET:/api/users/{id}` from `scope:component:http_caller:bff/users.js`, method GET, param-normalized.
- **Negatives**: verb mismatch (client POST / server GET) → 0 edges; path mismatch (`/api/users` vs `/api/orders`) → 0 edges; client-only-no-endpoint → 0 edges.
- Registry + kind-validity + reachability-from-Pass assertions.

## Verification
- `go test ./internal/extractors/cross/... ./internal/enrichers/... ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `gofmt -l` empty; `go vet` clean
- `coverage validate` 0 errors; `coverage fmt --check` canonical (registry untouched — no cell falsely cited the orphaned code, so nothing to repair)

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)