### PR TITLE
Honest-downgrade 60 false datastore cells + add cite-validity guard (Closes #3635)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -6252,10 +6252,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6303,10 +6303,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6354,10 +6354,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6405,10 +6405,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6454,10 +6454,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6503,10 +6503,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6552,10 +6552,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6601,10 +6601,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -6650,10 +6650,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
-            "issue": "3262",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -9820,9 +9820,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -9868,9 +9869,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -9916,9 +9918,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -9964,9 +9967,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -10012,9 +10016,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -10060,9 +10065,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -10108,9 +10114,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -10156,9 +10163,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -13400,9 +13408,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -22944,9 +22953,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -23038,10 +23048,10 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "missing",
@@ -23074,10 +23084,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -23098,10 +23108,10 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "missing",
@@ -23134,10 +23144,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -23223,10 +23233,10 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "missing",
@@ -23259,10 +23269,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -23283,10 +23293,10 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "missing",
@@ -23319,10 +23329,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-            "issue": "3095",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36290,9 +36300,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36338,9 +36349,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36386,9 +36398,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36434,9 +36447,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36484,9 +36498,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36532,9 +36547,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36582,9 +36598,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36630,9 +36647,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -36680,9 +36698,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -40198,9 +40217,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -40246,9 +40266,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -40294,9 +40315,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -40393,9 +40415,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -45359,9 +45382,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -45479,9 +45503,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -45997,9 +46022,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46045,9 +46071,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46095,9 +46122,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46143,9 +46171,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46191,9 +46220,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46239,9 +46269,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46287,9 +46318,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -46335,9 +46367,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48191,9 +48224,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48357,9 +48391,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48405,9 +48440,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48453,9 +48489,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48501,9 +48538,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48549,9 +48587,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48597,9 +48636,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48645,9 +48685,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48693,9 +48734,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -48741,9 +48783,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
+            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {

--- a/tools/coverage/datastore_cite_guard_test.go
+++ b/tools/coverage/datastore_cite_guard_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// datastoreCiteGuardCapabilities is the set of capability keys whose
+// "full"/"partial" claim asserts that the engine extracts real query /
+// model topology from source — i.e. a key/collection/table/index/label
+// out of a datastore *driver* call site. A cell in this class CANNOT be
+// legitimately backed by a detection-only rule YAML (one whose
+// `source_patterns` and `relationship_rules` are both empty), because
+// such a YAML only proves the driver is *present*; it extracts zero
+// topology. The dead `custom_extractors` Python block these YAMLs carry
+// is never executed by the Go engine (internal/engine/schema.go), so it
+// is not evidence either.
+var datastoreCiteGuardCapabilities = map[string]struct{}{
+	"query_attribution": {},
+	"model_extraction":  {},
+}
+
+// datastoreStoreAliases maps a driver record's trailing store token (the
+// last dot-segment of `lang.<lang>.driver.<store>`) to the identifier
+// substrings a native Go extractor would mention. Used by the "is there a
+// real Go extractor?" escape hatch so the guard fires ONLY on the genuine
+// false class (no backing of any kind), not on the separate "under-cited"
+// class where a real Go extractor exists but the cell cites the wrong file.
+var datastoreStoreAliases = map[string][]string{
+	"redis":     {"redis"},
+	"redix":     {"redis"},
+	"mongodb":   {"mongo"},
+	"mongo":     {"mongo"},
+	"cassandra": {"cassandra"},
+	"xandra":    {"cassandra", "xandra"},
+	"dynamodb":  {"dynamo"},
+	"elastic":   {"elastic"},
+	"neo4j":     {"neo4j", "cypher"},
+	"mysql":     {"mysql"},
+	"myxql":     {"mysql"},
+	"postgres":  {"postgres", "pgx"},
+	"postgrex":  {"postgres", "pgx"},
+	"npgsql":    {"npgsql", "postgres"},
+	"sqlite":    {"sqlite"},
+}
+
+// yamlRuleExtractsTopology reports whether the cited YAML rule file at the
+// repo-relative path performs any live extraction the Go engine honours: a
+// non-empty `source_patterns` OR a non-empty `relationship_rules` (both are
+// executed by the declarative rule loader). A missing file or a
+// detection-only YAML (both lists empty/absent) returns false.
+func yamlRuleExtractsTopology(t *testing.T, repoRoot, rel string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot, rel))
+	if err != nil {
+		// A missing cite is never positive evidence; validate.go reports
+		// the cite-exists failure separately.
+		return false
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("parse rule YAML %s: %v", rel, err)
+	}
+	return nodeHasNonEmptyList(&root, "source_patterns") ||
+		nodeHasNonEmptyList(&root, "relationship_rules")
+}
+
+// nodeHasNonEmptyList walks a YAML node tree and reports whether any
+// mapping carries the named key bound to a non-empty sequence. This is
+// resilient to the wrapper nesting the rule files use (e.g. the keys may
+// live at the top level or under an `orms_database:` wrapper).
+func nodeHasNonEmptyList(n *yaml.Node, key string) bool {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			if nodeHasNonEmptyList(c, key) {
+				return true
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+			if k.Value == key && v.Kind == yaml.SequenceNode && len(v.Content) > 0 {
+				return true
+			}
+			if nodeHasNonEmptyList(v, key) {
+				return true
+			}
+		}
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			if nodeHasNonEmptyList(c, key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// citeIsValidTopologyBacking reports whether a single cite is acceptable
+// backing for a datastore topology cell: a Go extractor source file, or a
+// rule YAML that actually extracts (non-empty source_patterns /
+// relationship_rules). Anything else (a detection-only YAML, a doc, a dead
+// module ref) is not.
+func citeIsValidTopologyBacking(t *testing.T, repoRoot, cite string) bool {
+	t.Helper()
+	if strings.HasSuffix(cite, ".go") {
+		return true
+	}
+	if strings.HasSuffix(cite, ".yaml") || strings.HasSuffix(cite, ".yml") {
+		return yamlRuleExtractsTopology(t, repoRoot, cite)
+	}
+	return false
+}
+
+// nativeGoExtractorExists reports whether a per-language native Go driver
+// extractor for the store exists under internal/custom/<lang>/ — the
+// "under-cited, not false" escape hatch (audit rule #3625): a topology cell
+// whose cite is merely wrong but whose extractor genuinely exists is NOT
+// the false class this guard polices (that is tracked by the re-cite ticket
+// #3637). The guard only fails when NO per-language extractor exists.
+//
+// The scan is deliberately confined to the LANGUAGE-SPECIFIC custom dir. The
+// shared internal/engine/ tree carries cross-language *synthesis* passes
+// (e.g. redis_pubsub_edges.go, mongo agg) that mention every store but do
+// NOT constitute per-driver query-topology extraction — including it would
+// excuse the very false cells this guard exists to catch.
+func nativeGoExtractorExists(t *testing.T, repoRoot, lang, store string) bool {
+	t.Helper()
+	tokens := datastoreStoreAliases[store]
+	if len(tokens) == 0 {
+		tokens = []string{store}
+	}
+	dir := filepath.Join(repoRoot, "internal", "custom", lang)
+	return mentionsTokenInGoSources(t, dir, tokens)
+}
+
+// mentionsTokenInGoSources scans non-test .go files directly under dir for
+// any of the (lower-cased) tokens. Shallow by design: native driver
+// extractors live one level under internal/custom/<lang>/.
+func mentionsTokenInGoSources(t *testing.T, dir string, tokens []string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(raw))
+		for _, tok := range tokens {
+			if strings.Contains(lower, strings.ToLower(tok)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestDatastoreCiteValidityGuard is the permanent guard against the
+// false-datastore-coverage class found by the #3625 datastore audit and
+// remediated in #3635. For every datastore *driver* record
+// (`lang.<lang>.driver.<store>`), every full/partial query_attribution /
+// model_extraction cell MUST either:
+//
+//   - cite at least one .go file OR a rule YAML whose
+//     source_patterns/relationship_rules is non-empty (valid backing), OR
+//   - have a native Go extractor that mentions the datastore (the
+//     "under-cited not false" escape hatch — that re-cite is #3637's job).
+//
+// A driver topology cell stamped full/partial with NEITHER — backed solely
+// by a detection-only YAML and with no extractor anywhere — is a false
+// claim and fails this test, listing every offender. Before the #3635
+// downgrades this test failed on the audited false cells; after them it
+// passes. It complements the dispatch-parity guard.
+func TestDatastoreCiteValidityGuard(t *testing.T) {
+	root := repoRoot(t)
+	reg, err := loadRegistry(filepath.Join(root, defaultRegistryPath))
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+
+	var offenders []string
+	for _, rec := range reg.Records {
+		lang, store, ok := parseDriverRecordID(rec.ID)
+		if !ok {
+			continue
+		}
+		visit := func(group string, caps map[string]Capability) {
+			for capKey, cell := range caps {
+				if _, watched := datastoreCiteGuardCapabilities[capKey]; !watched {
+					continue
+				}
+				if cell.Status != StatusFull && cell.Status != StatusPartial {
+					continue
+				}
+				backed := false
+				for _, cite := range cell.Cites {
+					if citeIsValidTopologyBacking(t, root, cite) {
+						backed = true
+						break
+					}
+				}
+				if !backed && nativeGoExtractorExists(t, root, lang, store) {
+					backed = true // under-cited, not false — see #3637
+				}
+				if !backed {
+					loc := rec.ID + "." + capKey
+					if group != "" {
+						loc = rec.ID + ".[" + group + "]." + capKey
+					}
+					offenders = append(offenders, loc+" cites="+strings.Join(cell.Cites, ","))
+				}
+			}
+		}
+		if rec.IsGrouped() {
+			for g, caps := range rec.Groups {
+				visit(g, caps)
+			}
+		} else {
+			visit("", rec.Capabilities)
+		}
+		for g, caps := range rec.FrameworkSpecific {
+			visit(g, caps)
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("found %d datastore driver topology cell(s) stamped full/partial with no valid backing "+
+			"(must cite a .go file OR a rule YAML with non-empty source_patterns/relationship_rules, "+
+			"or have a native Go extractor for the store); a detection-only YAML / dead module ref is "+
+			"not evidence:\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+// parseDriverRecordID extracts (lang, store) from a driver record id of the
+// shape `lang.<lang>.driver.<store>`. Returns ok=false for any other id.
+func parseDriverRecordID(id string) (lang, store string, ok bool) {
+	parts := strings.Split(id, ".")
+	if len(parts) != 4 || parts[0] != "lang" || parts[2] != "driver" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
+}
+
+// TestDatastoreCiteValidityGuard_DetectsDetectionOnlyYAML proves the guard's
+// cite-validity helper actually catches the false-coverage class: a cell
+// citing a detection-only rule YAML (empty source_patterns/relationship_rules)
+// is rejected, while the same cell citing a Go file or an extracting YAML is
+// accepted. This keeps the guard honest if its helpers are ever refactored.
+func TestDatastoreCiteValidityGuard_DetectsDetectionOnlyYAML(t *testing.T) {
+	root := t.TempDir()
+
+	// A detection-only rule YAML: driver present, but zero topology.
+	detectionOnly := "internal/engine/rules/fixture/detection_only.yaml"
+	writeRuleFixture(t, root, detectionOnly, ""+
+		"orms_database:\n"+
+		"  name: Fixture Driver\n"+
+		"  detection:\n"+
+		"    import_patterns:\n"+
+		"    - import fixture\n"+
+		"source_patterns: []\n"+
+		"relationship_rules: []\n")
+
+	// An extracting rule YAML: non-empty source_patterns.
+	extracting := "internal/engine/rules/fixture/extracting.yaml"
+	writeRuleFixture(t, root, extracting, ""+
+		"orms_database:\n"+
+		"  name: Fixture Driver\n"+
+		"source_patterns:\n"+
+		"- pattern: \"FROM (\\\\w+)\"\n"+
+		"  emits: table\n"+
+		"relationship_rules: []\n")
+
+	goCite := "internal/custom/fixture/extractor.go"
+	writeRuleFixture(t, root, goCite, "package fixture\n")
+
+	if citeIsValidTopologyBacking(t, root, detectionOnly) {
+		t.Error("detection-only YAML (empty source_patterns/relationship_rules) wrongly accepted as backing")
+	}
+	if !citeIsValidTopologyBacking(t, root, extracting) {
+		t.Error("extracting YAML (non-empty source_patterns) wrongly rejected as backing")
+	}
+	if !citeIsValidTopologyBacking(t, root, goCite) {
+		t.Error(".go cite wrongly rejected as backing")
+	}
+	if citeIsValidTopologyBacking(t, root, "internal/engine/rules/fixture/missing.yaml") {
+		t.Error("missing YAML wrongly accepted as backing")
+	}
+}
+
+// TestDatastoreCiteValidityGuard_EscapeHatchForUnderCited proves the
+// "under-cited not false" escape hatch: when a native Go extractor for the
+// store exists, the guard must NOT flag the cell (re-citing it is #3637's
+// job), but it MUST flag a store with no extractor at all.
+func TestDatastoreCiteValidityGuard_EscapeHatchForUnderCited(t *testing.T) {
+	root := t.TempDir()
+	writeRuleFixture(t, root, "internal/custom/python/redis.go",
+		"package python\n\n// RedisExtractor extracts redis ops.\ntype RedisExtractor struct{}\n")
+
+	if !nativeGoExtractorExists(t, root, "python", "redis") {
+		t.Error("under-cited python/redis cell wrongly flagged: a native redis.go extractor exists")
+	}
+	if nativeGoExtractorExists(t, root, "rust", "cassandra") {
+		t.Error("false rust/cassandra cell wrongly excused: no native extractor exists for it")
+	}
+}
+
+// writeRuleFixture materialises a fixture file under root for the guard
+// self-tests.
+func writeRuleFixture(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}


### PR DESCRIPTION
Closes #3635 (epic #3625).

## What
Honest-downgrade datastore `query_attribution` / `model_extraction` cells stamped `full`/`partial` whose ONLY backing is a dead `custom_extractors` Python ref or a rule YAML with empty `source_patterns` **and** `relationship_rules` (detection-only) — these extract **zero** live query topology in Go, so the coverage claim is FALSE. Plus a permanent registry-lint guard so the class cannot recur.

## Downgraded: 60 cells (full/partial → missing)
Each verified against its cited YAML (empty `source_patterns`+`relationship_rules`) **and** the Go tree (no native per-language extractor). Dead YAML cites dropped; each routed to the rebuild ticket for its datastore type:

| Rebuild ticket | datastore class | cells |
|---|---|---|
| #3643 | redis key-topology | 7 |
| #3644 | raw-SQL table-topology | 15 |
| #3645 | mongo/cassandra/dynamodb/elasticsearch/neo4j | 38 |
| **total** | | **60** |

Breakdown: 48 `lang.*.driver.*` driver cells + 12 non-driver (java `spring-data-{cassandra,elastic,mongo,redis}` ×2 each = 8, ODM `query_attribution` for beanie/mongoengine/mongoid = 3, `java.orm.neo4j` `query_attribution` = 1 — the last per #3637's "move to #3635 scope" note).

This covers the #3635 charter (44 NoSQL/cache/search/graph + 13 raw-SQL = 57) **plus 3 same-class elixir raw-driver cells the enumeration missed** (`myxql`, `postgrex`, `redix` — verified: no native Go extractor; `ecto.go` only attributes Ecto ORM `Repo.*` calls, not raw driver call sites).

**Untouched (correctly):** under-cited cells that have a real Go extractor and merely cite the wrong file (e.g. `python.driver.redis` → `internal/custom/python/redis.go`; the named ORMs jpa/prisma/diesel/doctrine/…). Those are #3637's job. No detail-page / doc drift; registry diff is exactly 60 `status→missing` changes, 0 others.

## Guard: `tools/coverage/datastore_cite_guard_test.go`
`TestDatastoreCiteValidityGuard` — every `full`/`partial` `query_attribution`/`model_extraction` cell on a `lang.*.driver.*` record MUST either:
- cite a `.go` file **OR** a rule YAML with non-empty `source_patterns`/`relationship_rules`, **or**
- have a per-language native Go extractor under `internal/custom/<lang>/` mentioning the store (the "under-cited, not false" escape hatch — the shared `internal/engine/` synthesis tree is intentionally excluded so it cannot excuse a false cell).

A detection-only YAML / dead module ref is **not** evidence. **Fails on `main`** listing **29 driver offenders**; **passes** after these downgrades. Two self-tests cover the detection-only / extracting-YAML / `.go` / missing-file cases and the escape-hatch (excuses under-cited, flags genuinely-false).

## Discipline
- `coverage validate`: 0 errors
- `coverage fmt --check`: canonical
- `go test ./tools/coverage/`: green (incl. the new guard + self-tests)
- `gofmt -l` / `go vet`: clean on the changed files

**DEPLOY-DEFERRED** — registry + dev-tool test only; no daemon/indexer/MCP change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)