### PR TITLE
Restore endpoint→DTO edges for FastAPI/Flask/ASP.NET (#3629)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -6697,8 +6697,9 @@
         "Validation": {
           "dto_extraction": {
             "status": "full",
-            "cites": ["internal/custom/csharp/validation.go","internal/custom/csharp/validation_test.go"],
-            "notes": "DTO types inferred from FluentValidation AbstractValidator\u003cT\u003e type arg and DataAnnotation model classes; heuristic"
+            "cites": ["internal/custom/csharp/aspnet_request_response.go","internal/custom/csharp/extractors_test.go","internal/custom/csharp/validation.go","internal/custom/csharp/validation_test.go"],
+            "notes": "DTO types inferred from FluentValidation AbstractValidator\u003cT\u003e type arg and DataAnnotation model classes. aspnet_request_response.go ALSO emits traversable endpoint→DTO graph edges (#3629): an action SCOPE.Operation entity with ACCEPTS_INPUT → [FromBody] request DTO and RETURNS → ActionResult\u003cT\u003e/concrete response DTO (Class:\u003cName\u003e structural ref; FromID=action entity). Previously these extractors emitted DTO entities only, so expand/traces/payload_drift could not follow endpoint→DTO; now they can, restoring parity with Java Spring. Tests: TestAspNetReqRespAcceptsInputAndReturnsEdges, TestAspNetReqRespEdgeHasFromID, TestAspNetReqRespPrimitiveParamNoEdge.",
+            "verified_at": "2026-06-02"
           },
           "request_validation": {
             "status": "full",
@@ -42452,8 +42453,8 @@
           "dto_extraction": {
             "status": "full",
             "cites": ["internal/custom/python/fastapi.go","internal/custom/python/fastapi_reqresp.go"],
-            "notes": "fastapi_reqresp.go extracts Pydantic BaseModel body params (ACCEPTS_INPUT), response_model= kwarg (RETURNS), and return type annotations for all FastAPI route decorators; fastapi.go extracts APIRouter, Depends(), and per-route metadata. Fixture test TestFastAPIReqResp_FullFixture proves CreateOrderRequest/UpdateOrderRequest body params + OrderResponse response_model and annotation returns. Pydantic v1/v2 unwrapping via unwrapType. Depends/Query/Path injection tokens skipped.",
-            "verified_at": "2026-05-30"
+            "notes": "fastapi_reqresp.go extracts Pydantic BaseModel body params and response_model=/return annotations for all FastAPI route decorators AND emits traversable endpoint→DTO graph edges (#3629): each endpoint SCOPE.Operation carries ACCEPTS_INPUT → request DTO (body param) and RETURNS → response DTO (response_model= or return annotation), ToID=Class:\u003cName\u003e structural ref the resolver binds by name. Previously DTO entities were emitted but no edges, so expand/traces/payload_drift could not follow endpoint→DTO; now they can (parity with Java Spring). fastapi.go extracts APIRouter, Depends(), per-route metadata. Pydantic v1/v2 unwrapping via unwrapType; Depends/Query/Path injection tokens skipped. Tests: TestFastAPIReqResp_AcceptsInputEdge, TestFastAPIReqResp_ReturnsEdgeResponseModel, TestFastAPIReqResp_ReturnsEdgeAnnotation, TestFastAPIReqResp_PrimitiveParamNoEdge, TestFastAPIReqResp_FullFixture.",
+            "verified_at": "2026-06-02"
           },
           "request_validation": {
             "status": "full",
@@ -42692,8 +42693,8 @@
           "dto_extraction": {
             "status": "full",
             "cites": ["internal/custom/python/flask.go","internal/custom/python/flask_reqresp.go"],
-            "notes": "flask_reqresp.go extracts marshmallow Schema.load() call sites in route handler bodies (ACCEPTS_INPUT), and return type annotations (RETURNS). flask.go emits FlaskForm/class entities as schema-level DTOs. canonicalSchemaName converts snake_case schema vars to PascalCase. Tests: TestFlaskReqResp_SchemaLoad, TestFlaskReqResp_Returns, TestFlaskReqResp_PascalCaseSchema, TestFlask_FlaskForm.",
-            "verified_at": "2026-05-30"
+            "notes": "flask_reqresp.go extracts marshmallow Schema.load() call sites (request DTO) and return annotations (response DTO) AND emits traversable endpoint→DTO graph edges (#3629): the endpoint SCOPE.Operation carries ACCEPTS_INPUT → schema (statically-resolvable schema.load()) and RETURNS → return-annotation type, ToID=Class:\u003cName\u003e. Honest-partial by design: dynamic/untyped request.get_json() bodies and runtime-serialized responses stay edge-less (only statically resolvable DTOs get edges). Previously entity-only; edges now restore endpoint→DTO traversal for expand/traces/payload_drift. flask.go emits FlaskForm/class entities; canonicalSchemaName converts snake_case vars to PascalCase. Tests: TestFlaskReqResp_AcceptsInputEdge, TestFlaskReqResp_ReturnsEdge, TestFlaskReqResp_UntypedNoEdge, TestFlaskReqResp_PascalCaseSchema.",
+            "verified_at": "2026-06-02"
           },
           "request_validation": {
             "status": "partial",

--- a/internal/custom/csharp/aspnet_request_response.go
+++ b/internal/custom/csharp/aspnet_request_response.go
@@ -3,6 +3,7 @@ package csharp
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -29,6 +30,11 @@ var (
 	)
 	reActionResultUnwrap = regexp.MustCompile(
 		`ActionResult<([^>]+)>`,
+	)
+	// Action-method signature: captures the return-type clause and the action
+	// method name so endpoint→DTO edges (#3629) can anchor on the action.
+	reActionMethod = regexp.MustCompile(
+		`(?m)public\s+(?:async\s+)?(?:Task<)?(ActionResult<[^>]+>|IActionResult|[A-Z][A-Za-z0-9_]*)\s*>?\s+(\w+)\s*\(`,
 	)
 )
 
@@ -99,6 +105,102 @@ func (e *aspnetReqRespExtractor) Extract(ctx context.Context, file extractor.Fil
 		add(ent)
 	}
 
+	// 3. Endpoint→DTO edges (#3629). Anchor an action operation entity per
+	//    action method and emit:
+	//      ACCEPTS_INPUT : action -> [FromBody] request DTO
+	//      RETURNS       : action -> ActionResult<T> / concrete response DTO
+	//    Mirrors the Java Spring extractor so expand/traces/payload_drift can
+	//    traverse endpoint→DTO. FromID is set explicitly to the action entity
+	//    ID (C# computes entity IDs eagerly); ToID is a Class:<Name> structural
+	//    ref the intra-repo resolver binds to the real DTO class by name.
+	for _, m := range reActionMethod.FindAllStringSubmatchIndex(src, -1) {
+		returnClause := src[m[2]:m[3]]
+		methodName := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+
+		// Balanced-paren parameter block for this action.
+		params, _ := aspnetParamsBlock(src, m[1])
+
+		var rels []types.RelationshipRecord
+
+		// ACCEPTS_INPUT: [FromBody] Dto param.
+		if bm := reFromBody.FindStringSubmatch(params); bm != nil {
+			dtoType := aspnetUnwrapGeneric(bm[1])
+			if dtoType != "" && !csharpPrimitives[dtoType] {
+				rels = append(rels, types.RelationshipRecord{
+					ToID:       "Class:" + dtoType,
+					Kind:       string(types.RelationshipKindAcceptsInput),
+					Properties: map[string]string{"framework": "aspnet_core", "match_source": "from_body_param", "dto_type": dtoType},
+				})
+			}
+		}
+
+		// RETURNS: ActionResult<T> or concrete type return clause.
+		if um := reActionResultUnwrap.FindStringSubmatch(returnClause); um != nil {
+			returnClause = um[1]
+		}
+		retType := aspnetUnwrapGeneric(returnClause)
+		if retType != "" && !csharpPrimitives[retType] {
+			rels = append(rels, types.RelationshipRecord{
+				ToID:       "Class:" + retType,
+				Kind:       string(types.RelationshipKindReturns),
+				Properties: map[string]string{"framework": "aspnet_core", "match_source": "action_return_type", "dto_type": retType},
+			})
+		}
+
+		if len(rels) == 0 {
+			continue
+		}
+		action := makeEntity(methodName, "SCOPE.Operation", "endpoint", file.Path, file.Language, line)
+		setProps(&action, "framework", "aspnet_core", "pattern_type", "action_endpoint")
+		action.Relationships = rels
+		for i := range action.Relationships {
+			action.Relationships[i].FromID = action.ID
+		}
+		add(action)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// aspnetParamsBlock returns the text between the opening paren (whose end
+// offset is openParenEnd) and its matching close paren.
+func aspnetParamsBlock(src string, openParenEnd int) (string, int) {
+	depth := 1
+	i := openParenEnd
+	for i < len(src) && depth > 0 {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return "", openParenEnd
+	}
+	return src[openParenEnd : i-1], i - 1
+}
+
+// aspnetUnwrapGeneric strips a single generic wrapper (e.g. List<Order> ->
+// Order, IEnumerable<Dto> -> Dto) and returns the base type name. Returns the
+// bare type when there is no wrapper. Returns "" when the inner type is empty.
+func aspnetUnwrapGeneric(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if lt := strings.IndexByte(raw, '<'); lt >= 0 {
+		base := strings.TrimSpace(raw[:lt])
+		gt := strings.LastIndexByte(raw, '>')
+		if gt > lt {
+			inner := strings.TrimSpace(raw[lt+1 : gt])
+			// Collection/wrapper bases unwrap to their element type.
+			if csharpPrimitives[base] {
+				return aspnetUnwrapGeneric(inner)
+			}
+			return base
+		}
+		return base
+	}
+	return raw
 }

--- a/internal/custom/csharp/extractors_test.go
+++ b/internal/custom/csharp/extractors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
 
 	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
 )
@@ -149,6 +150,67 @@ func TestAspNetReqRespNoMatch(t *testing.T) {
 	ents := extract(t, "custom_csharp_aspnet_reqresp", fi("Helper.cs", "csharp", src))
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// hasEdge reports whether any entity carries an edge of (kind -> toID). #3629.
+func hasEdge(ents []types.EntityRecord, kind, toID string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// #3629: [FromBody] OrderDto emits an ACCEPTS_INPUT edge to the request DTO,
+// and ActionResult<OrderResult> emits a RETURNS edge to the response DTO.
+func TestAspNetReqRespAcceptsInputAndReturnsEdges(t *testing.T) {
+	src := `
+public class OrdersController : ControllerBase {
+    [HttpPost]
+    public async Task<ActionResult<OrderResult>> Create([FromBody] OrderDto dto) => Ok();
+}
+`
+	ents := extractFull(t, "custom_csharp_aspnet_reqresp", fi("OrdersController.cs", "csharp", src))
+	if !hasEdge(ents, "ACCEPTS_INPUT", "Class:OrderDto") {
+		t.Errorf("expected ACCEPTS_INPUT -> Class:OrderDto edge, got %+v", ents)
+	}
+	if !hasEdge(ents, "RETURNS", "Class:OrderResult") {
+		t.Errorf("expected RETURNS -> Class:OrderResult edge, got %+v", ents)
+	}
+}
+
+// #3629: edges must anchor on a non-empty FromID (the action operation entity)
+// so expand/traces can traverse endpoint→DTO.
+func TestAspNetReqRespEdgeHasFromID(t *testing.T) {
+	src := `public ActionResult<UserDto> Get([FromBody] UserQuery q) => Ok();`
+	ents := extractFull(t, "custom_csharp_aspnet_reqresp", fi("UsersController.cs", "csharp", src))
+	var checked int
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.FromID == "" {
+				t.Errorf("edge %s -> %s has empty FromID", r.Kind, r.ToID)
+			}
+			if r.FromID != e.ID {
+				t.Errorf("edge FromID %q != owning entity ID %q", r.FromID, e.ID)
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Fatal("expected at least one endpoint→DTO edge")
+	}
+}
+
+// #3629 negative: a primitive [FromBody] param emits no DTO edge.
+func TestAspNetReqRespPrimitiveParamNoEdge(t *testing.T) {
+	src := `public IActionResult Delete([FromBody] int id) => Ok();`
+	ents := extractFull(t, "custom_csharp_aspnet_reqresp", fi("Controller.cs", "csharp", src))
+	if hasEdge(ents, "ACCEPTS_INPUT", "Class:int") {
+		t.Error("primitive [FromBody] int should not emit an ACCEPTS_INPUT edge")
 	}
 }
 

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1810,6 +1810,108 @@ func TestFastAPIReqResp_NoMatch(t *testing.T) {
 	}
 }
 
+// hasRel reports whether any entity carries an edge of (kind -> toID). #3629.
+func hasRel(ents []extractResult, kind, toID string) bool {
+	for _, e := range ents {
+		for _, r := range e.Rels {
+			if r.Kind == kind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// #3629: FastAPI body param emits an ACCEPTS_INPUT edge to the request DTO.
+func TestFastAPIReqResp_AcceptsInputEdge(t *testing.T) {
+	src := `@app.post("/users")
+def create_user(user: UserCreate):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasRel(ents, "ACCEPTS_INPUT", "Class:UserCreate") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:UserCreate edge from create_user")
+	}
+}
+
+// #3629: FastAPI response_model= emits a RETURNS edge to the response DTO.
+func TestFastAPIReqResp_ReturnsEdgeResponseModel(t *testing.T) {
+	src := `@app.get("/users", response_model=UserOut)
+def list_users():
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasRel(ents, "RETURNS", "Class:UserOut") {
+		t.Fatal("expected RETURNS -> Class:UserOut edge from response_model")
+	}
+}
+
+// #3629: FastAPI return annotation emits a RETURNS edge (generic-unwrapped).
+func TestFastAPIReqResp_ReturnsEdgeAnnotation(t *testing.T) {
+	src := `@app.get("/users")
+def list_users() -> List[UserOut]:
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasRel(ents, "RETURNS", "Class:UserOut") {
+		t.Fatal("expected RETURNS -> Class:UserOut edge from return annotation")
+	}
+}
+
+// #3629 negative: a primitive/path param emits no DTO edge.
+func TestFastAPIReqResp_PrimitiveParamNoEdge(t *testing.T) {
+	src := `@app.get("/items/{item_id}")
+def get_item(item_id: int):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	for _, e := range ents {
+		if len(e.Rels) != 0 {
+			t.Fatalf("expected no DTO edges for primitive param, got %+v", e.Rels)
+		}
+	}
+}
+
+// #3629: Flask marshmallow schema.load() emits ACCEPTS_INPUT to the schema.
+func TestFlaskReqResp_AcceptsInputEdge(t *testing.T) {
+	src := `@app.route("/orders", methods=["POST"])
+def create_order():
+    data = OrderSchema().load(request.json)
+    return jsonify(data)
+`
+	ents := extract(t, "python_flask_reqresp", src)
+	if !hasRel(ents, "ACCEPTS_INPUT", "Class:OrderSchema") {
+		t.Fatalf("expected ACCEPTS_INPUT -> Class:OrderSchema edge, got %+v", ents)
+	}
+}
+
+// #3629: Flask return annotation emits a RETURNS edge to the response type.
+func TestFlaskReqResp_ReturnsEdge(t *testing.T) {
+	src := `@app.get("/orders")
+def list_orders() -> OrderResponse:
+    pass
+`
+	ents := extract(t, "python_flask_reqresp", src)
+	if !hasRel(ents, "RETURNS", "Class:OrderResponse") {
+		t.Fatalf("expected RETURNS -> Class:OrderResponse edge, got %+v", ents)
+	}
+}
+
+// #3629 negative: a Flask handler with no typed schema/return emits no edge.
+func TestFlaskReqResp_UntypedNoEdge(t *testing.T) {
+	src := `@app.route("/ping")
+def ping():
+    data = request.get_json()
+    return jsonify({"ok": True})
+`
+	ents := extract(t, "python_flask_reqresp", src)
+	for _, e := range ents {
+		if len(e.Rels) != 0 {
+			t.Fatalf("expected no edges for untyped Flask handler, got %+v", e.Rels)
+		}
+	}
+}
+
 // TestFastAPIReqResp_FullFixture exercises fastapi_reqresp.go against the
 // testdata/fastapi_reqresp_fixture.py fixture. It proves that:
 //   - Pydantic body parameters are emitted as dto + accepts_input entities

--- a/internal/custom/python/fastapi_reqresp.go
+++ b/internal/custom/python/fastapi_reqresp.go
@@ -94,8 +94,17 @@ func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.Fi
 				continue
 			}
 			emitDTO(dtoName, line, "dto")
-			out = append(out, entity(handlerName+":accepts:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
-				map[string]string{"framework": "fastapi", "pattern_type": "accepts_input", "param_name": paramName, "dto_type": dtoName}))
+			ep := entity(handlerName+":accepts:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
+				map[string]string{"framework": "fastapi", "pattern_type": "accepts_input", "param_name": paramName, "dto_type": dtoName})
+			// ACCEPTS_INPUT edge: endpoint -> request DTO type (#3629).
+			// FromID is left empty so graph assembly binds it to this endpoint
+			// entity; ToID is the structural ref to the real Pydantic class.
+			ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+				ToID:       "Class:" + dtoName,
+				Kind:       string(types.RelationshipKindAcceptsInput),
+				Properties: map[string]string{"framework": "fastapi", "match_source": "body_param_annotation", "param_name": paramName, "dto_type": dtoName},
+			})
+			out = append(out, ep)
 		}
 
 		// RETURNS: response_model= kwarg
@@ -103,8 +112,14 @@ func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.Fi
 			dtoName := unwrapType(rm[1])
 			if dtoName != "" {
 				emitDTO(dtoName, line, "response")
-				out = append(out, entity(handlerName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
-					map[string]string{"framework": "fastapi", "pattern_type": "returns", "dto_type": dtoName, "match_source": "response_model_decorator"}))
+				ep := entity(handlerName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
+					map[string]string{"framework": "fastapi", "pattern_type": "returns", "dto_type": dtoName, "match_source": "response_model_decorator"})
+				ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+					ToID:       "Class:" + dtoName,
+					Kind:       string(types.RelationshipKindReturns),
+					Properties: map[string]string{"framework": "fastapi", "match_source": "response_model_decorator", "dto_type": dtoName},
+				})
+				out = append(out, ep)
 			}
 		}
 
@@ -114,8 +129,14 @@ func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.Fi
 			dtoName := unwrapType(strings.TrimSpace(ret[1]))
 			if dtoName != "" {
 				emitDTO(dtoName, line, "response")
-				out = append(out, entity(handlerName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
-					map[string]string{"framework": "fastapi", "pattern_type": "returns", "dto_type": dtoName, "match_source": "return_type_annotation"}))
+				ep := entity(handlerName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
+					map[string]string{"framework": "fastapi", "pattern_type": "returns", "dto_type": dtoName, "match_source": "return_type_annotation"})
+				ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+					ToID:       "Class:" + dtoName,
+					Kind:       string(types.RelationshipKindReturns),
+					Properties: map[string]string{"framework": "fastapi", "match_source": "return_type_annotation", "dto_type": dtoName},
+				})
+				out = append(out, ep)
 			}
 		}
 	}

--- a/internal/custom/python/flask_reqresp.go
+++ b/internal/custom/python/flask_reqresp.go
@@ -102,8 +102,17 @@ func (e *FlaskReqRespExtractor) Extract(ctx context.Context, file extractor.File
 			dtoName := unwrapType(strings.TrimSpace(ret[1]))
 			if dtoName != "" && !flrrSkipTypes[dtoName] {
 				emitSchema(dtoName, line, "response")
-				out = append(out, entity(h.funcName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
-					map[string]string{"framework": "flask", "pattern_type": "returns", "schema_type": dtoName, "match_source": "return_type_annotation"}))
+				ep := entity(h.funcName+":returns:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
+					map[string]string{"framework": "flask", "pattern_type": "returns", "schema_type": dtoName, "match_source": "return_type_annotation"})
+				// RETURNS edge: endpoint -> response schema/DTO type (#3629).
+				// Only emitted for the statically-resolvable return annotation;
+				// dynamically-serialized responses stay edge-less (honest-partial).
+				ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+					ToID:       "Class:" + dtoName,
+					Kind:       string(types.RelationshipKindReturns),
+					Properties: map[string]string{"framework": "flask", "match_source": "return_type_annotation", "schema_type": dtoName},
+				})
+				out = append(out, ep)
 			}
 		}
 
@@ -133,8 +142,17 @@ func (e *FlaskReqRespExtractor) Extract(ctx context.Context, file extractor.File
 				continue
 			}
 			emitSchema(canonical, line, "schema")
-			out = append(out, entity(h.funcName+":accepts:"+canonical, "SCOPE.Operation", "endpoint", file.Path, line,
-				map[string]string{"framework": "flask", "pattern_type": "accepts_input", "schema_var": schemaVar, "schema_type": canonical}))
+			ep := entity(h.funcName+":accepts:"+canonical, "SCOPE.Operation", "endpoint", file.Path, line,
+				map[string]string{"framework": "flask", "pattern_type": "accepts_input", "schema_var": schemaVar, "schema_type": canonical})
+			// ACCEPTS_INPUT edge: endpoint -> marshmallow schema resolved from a
+			// statically-detectable schema.load() call (#3629). Dynamic /
+			// request.get_json() untyped bodies stay edge-less (honest-partial).
+			ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+				ToID:       "Class:" + canonical,
+				Kind:       string(types.RelationshipKindAcceptsInput),
+				Properties: map[string]string{"framework": "flask", "match_source": "marshmallow_schema_load", "schema_var": schemaVar, "schema_type": canonical},
+			})
+			out = append(out, ep)
 		}
 	}
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -256,6 +256,13 @@ const (
 	// Documented-but-previously-undocumented relationship kinds (Issue #77):
 	RelationshipKindRenders RelationshipKind = "RENDERS"
 	RelationshipKindReturns RelationshipKind = "RETURNS"
+	// #3629: endpoint→request-DTO edge. Emitted by the request/response
+	// extractors (Spring already emits ACCEPTS_INPUT/RETURNS as string
+	// literals; FastAPI, Flask and ASP.NET now mirror it) from a handler/
+	// endpoint operation entity → the request body DTO/schema type. Partner
+	// to RETURNS so `expand`/`traces`/`payload_drift` can traverse
+	// endpoint→DTO in both directions.
+	RelationshipKindAcceptsInput RelationshipKind = "ACCEPTS_INPUT"
 	// Issue #86: surfaced by the producer-boundary validator scan. Emitted
 	// by the OpenAPI pattern extractor to associate operations with their
 	// tag entities.
@@ -635,6 +642,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindWritesTo,
 		RelationshipKindRenders,
 		RelationshipKindReturns,
+		// #3629:
+		RelationshipKindAcceptsInput,
 		RelationshipKindTaggedAs,
 		// ADR-0018 pattern edge kinds:
 		RelationshipKindExemplar,


### PR DESCRIPTION
Closes #3629 (epic #3625).

## Problem
The #3625 framework audit found FastAPI, Flask, and ASP.NET request/response extractors emit DTO **entities** but no traversable `ACCEPTS_INPUT`/`RETURNS` **edges** (REIMPL-SHALLOWER vs the Java Spring parity bar, which does emit them). Without edges, `expand`/`traces`/`payload_drift` cannot follow endpoint→DTO.

## Fix
Ports the Spring pattern (`internal/custom/java/spring_request_response.go`) to the three non-JVM stacks. Each edge attaches to the endpoint/action `SCOPE.Operation` entity; `ToID` is a `Class:<Name>` structural ref the intra-repo resolver binds to the real DTO class by name (same convention as `django.go` REGISTERS/HANDLES_SIGNAL). Existing entity emission is unchanged.

### Per-framework — what edges now emit
- **FastAPI (full)** — `ACCEPTS_INPUT` → Pydantic body-param DTO; `RETURNS` → `response_model=` kwarg and `-> ReturnType` annotation (generic-unwrapped). `internal/custom/python/fastapi_reqresp.go`.
- **Flask (honest-partial)** — `ACCEPTS_INPUT` → statically-resolvable marshmallow `schema.load()`; `RETURNS` → return annotation. Dynamic/untyped `request.get_json()` bodies and runtime-serialized responses stay edge-less by design. `internal/custom/python/flask_reqresp.go`.
- **ASP.NET (full)** — `ACCEPTS_INPUT` → `[FromBody]` DTO; `RETURNS` → `ActionResult<T>`/concrete return type. Anchors a new action `SCOPE.Operation` entity; `FromID` set explicitly (C# computes IDs eagerly). `internal/custom/csharp/aspnet_request_response.go`.

Adds `RelationshipKindAcceptsInput` (`"ACCEPTS_INPUT"`) to `internal/types/kinds.go` and `AllRelationshipKinds` (reuses existing `RETURNS`). This **restores endpoint→DTO traversal** for the 3 stacks so `expand`/`traces`/`payload_drift` work the same as Java Spring.

### Records
Note-corrects the fastapi/flask/aspnet-core `dto_extraction` coverage cells — prior notes implied `ACCEPTS_INPUT`/`RETURNS` but were entity-only; they are now graph-traversable. Partner to #3631. `coverage validate` 0 errors, `fmt --check` canonical.

### Tests (value-asserting, not len>0)
- FastAPI: `create_user(user: UserCreate)` → `ACCEPTS_INPUT Class:UserCreate`; `response_model=UserOut` → `RETURNS Class:UserOut`; `-> List[UserOut]` → `RETURNS Class:UserOut`; negative: `get_item(item_id: int)` emits no edge.
- Flask: `OrderSchema().load(...)` → `ACCEPTS_INPUT Class:OrderSchema`; `-> OrderResponse` → `RETURNS Class:OrderResponse`; negative: untyped handler emits no edge.
- ASP.NET: `[FromBody] OrderDto` → `ACCEPTS_INPUT Class:OrderDto`; `ActionResult<OrderResult>` → `RETURNS Class:OrderResult`; FromID anchors on the action entity; negative: `[FromBody] int` emits no edge.

`gofmt -l` empty, `go vet` clean, targeted `go test` green.

**DEPLOY-DEFERRED** — graph/extractor change; requires a coordinated daemon rebuild + reindex before the new edges appear in served graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)