### PR TITLE
feat(mcp): test_only_referenced dead-code class — auto-detect production-dead-but-test-covered symbols (#3657)

### DIFF
--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -377,6 +377,68 @@ func isLiveCodeKind(kind string) bool {
 	return true
 }
 
+// isTestFileMCP reports whether a source-file path matches a recognised
+// test-file convention. It is a local copy of internal/graph/coverage.go's
+// (unexported) isTestFile, kept in this package to avoid widening the graph
+// package's exported surface and to keep the mcp → graph layering one-way and
+// data-only — the same convention the rest of this file follows for the
+// link-pass edge-kind / framework-seed sets.
+//
+// Recognised conventions (mirror coverage.go exactly):
+//   - any /test/, /tests/, /__tests__/, /spec/ path segment
+//   - Go:        *_test.go
+//   - Python:    test_*.py, *_test.py            (plus conftest.py below)
+//   - JS/TS:     *.test.{js,ts,jsx,tsx}, *.spec.*
+//   - Ruby:      *_spec.rb
+//   - Java/Kt/C#: *Test, *Tests, *Spec stems
+//
+// conftest.py is added on top of coverage.go's set because pytest fixtures
+// defined there are test-only callers for dead-code purposes.
+func isTestFileMCP(path string) bool {
+	if path == "" {
+		return false
+	}
+	lowerPath := strings.ToLower(strings.ReplaceAll(path, "\\", "/"))
+	slashed := "/" + lowerPath
+	for _, seg := range []string{"/test/", "/tests/", "/__tests__/", "/spec/"} {
+		if strings.Contains(slashed, seg) {
+			return true
+		}
+	}
+
+	base := lowerPath
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	if base == "conftest.py" {
+		return true
+	}
+	ext := ""
+	if i := strings.LastIndexByte(base, '.'); i >= 0 {
+		ext = base[i:]
+	}
+	stem := strings.TrimSuffix(base, ext)
+
+	switch ext {
+	case ".go":
+		return strings.HasSuffix(stem, "_test")
+	case ".py":
+		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
+	case ".ts", ".tsx", ".js", ".jsx":
+		return strings.HasSuffix(stem, ".test") ||
+			strings.HasSuffix(stem, ".spec") ||
+			strings.Contains(base, ".test.") ||
+			strings.Contains(base, ".spec.")
+	case ".rb":
+		return strings.HasSuffix(stem, "_spec")
+	case ".java", ".kt", ".cs":
+		return strings.HasSuffix(stem, "test") ||
+			strings.HasSuffix(stem, "tests") ||
+			strings.HasSuffix(stem, "spec")
+	}
+	return false
+}
+
 // matchesBareKind reports whether entity kind matches a user-supplied
 // bare-kind filter ("function", "class", …). Empty filter passes.
 func matchesBareKind(kind, filter string) bool {

--- a/internal/mcp/dead_code_test_only_test.go
+++ b/internal/mcp/dead_code_test_only_test.go
@@ -1,0 +1,191 @@
+package mcp
+
+// dead_code_test_only_test.go — value-asserting validation corpus for the
+// test_only_referenced dead-code class (#3657, epic #3648).
+//
+// The fixture is a synthetic graph modelled on the real #3650-3656 orphans:
+// production symbols whose ONLY callers live in *_test.go files. The class must
+// FLAG those and SPARE the wired siblings (production-called, cmd-wired,
+// framework-registered, cross-repo-imported). Assertions are value-based — they
+// name the exact symbols that must / must not appear — not len>0.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// buildTestOnlyDoc models the validation corpus from the #3657 spec.
+//
+// Production entities (production source files):
+//   - enrichOrphan        : called ONLY from enricher_test.go        → FLAG
+//   - ReferenceExtractor.Extract : called ONLY via a TESTS edge      → FLAG
+//   - TryClone            : called ONLY from clone_test.go           → FLAG
+//   - applyDjangoSignalPubSub : wired from cmd/index.go (production) → SPARE
+//   - bothCaller          : called from prod AND test               → SPARE
+//   - registeredHandler   : framework handler, only test caller      → SPARE (exclusion)
+//   - exportedAPI         : imported cross-repo, only test caller    → SPARE (exclusion)
+//
+// Test entities (live in *_test.go — callers, never flagged themselves):
+//   - enricherTest, refTest, cloneTest, handlerTest, apiTest, bothTest
+func buildTestOnlyDoc() *graph.Document {
+	ents := []graph.Entity{
+		// ---- production operations ----
+		{ID: "enrichOrphan", Name: "enrichOrphan", Kind: "Function", SourceFile: "internal/enrichers/orphan.go"},
+		{ID: "refExtract", Name: "ReferenceExtractor.Extract", Kind: "Method", SourceFile: "internal/extractors/references/extractor.go"},
+		{ID: "tryClone", Name: "TryClone", Kind: "Function", SourceFile: "daemon/clone/clone.go"},
+		{ID: "applyDjango", Name: "applyDjangoSignalPubSub", Kind: "Function", SourceFile: "internal/passes/django.go"},
+		{ID: "bothCaller", Name: "computeStuff", Kind: "Function", SourceFile: "internal/svc/compute.go"},
+		{ID: "registeredHandler", Name: "handleEvent", Kind: "Function", SourceFile: "internal/svc/handler.go"},
+		{ID: "exportedAPI", Name: "ReadSecretValue", Kind: "Function", SourceFile: "internal/api/secrets.go"},
+		// production callers
+		{ID: "indexMain", Name: "indexMain", Kind: "Function", SourceFile: "cmd/index.go"},
+		{ID: "prodCaller", Name: "prodCaller", Kind: "Function", SourceFile: "internal/svc/runner.go"},
+
+		// ---- test entities (live in *_test.go) ----
+		{ID: "enricherTest", Name: "TestEnrich", Kind: "Function", SourceFile: "internal/enrichers/orphan_test.go"},
+		{ID: "refTest", Name: "TestRef", Kind: "Function", SourceFile: "internal/extractors/references/extractor_test.go"},
+		{ID: "cloneTest", Name: "TestClone", Kind: "Function", SourceFile: "daemon/clone/clone_test.go"},
+		{ID: "handlerTest", Name: "TestHandler", Kind: "Function", SourceFile: "internal/svc/handler_test.go"},
+		{ID: "apiTest", Name: "TestAPI", Kind: "Function", SourceFile: "internal/api/secrets_test.go"},
+		{ID: "bothTest", Name: "TestBoth", Kind: "Function", SourceFile: "internal/svc/compute_test.go"},
+
+		// cross-repo consumer marker: an IMPORTS edge carrying imported_name
+		// keeps exportedAPI alive as public surface.
+		{ID: "extConsumer", Name: "extConsumer", Kind: "File", SourceFile: "other/consumer.go"},
+	}
+
+	rels := []graph.Relationship{
+		// enrichOrphan: ONLY a test caller → test_only_referenced
+		{FromID: "enricherTest", ToID: "enrichOrphan", Kind: "CALLS"},
+		// ReferenceExtractor.Extract: ONLY a TESTS edge → test_only_referenced
+		{FromID: "refTest", ToID: "refExtract", Kind: "TESTS"},
+		// TryClone: ONLY a test caller → test_only_referenced
+		{FromID: "cloneTest", ToID: "tryClone", Kind: "CALLS"},
+
+		// applyDjangoSignalPubSub: wired from cmd/index.go (production) → SPARE
+		{FromID: "indexMain", ToID: "applyDjango", Kind: "CALLS"},
+
+		// computeStuff: a production caller AND a test caller → SPARE
+		{FromID: "prodCaller", ToID: "bothCaller", Kind: "CALLS"},
+		{FromID: "bothTest", ToID: "bothCaller", Kind: "CALLS"},
+
+		// handleEvent: ONLY a test caller, but it is a framework handler
+		// (name "handle*") → honest exclusion → SPARE
+		{FromID: "handlerTest", ToID: "registeredHandler", Kind: "CALLS"},
+
+		// ReadSecretValue: ONLY a test caller, but imported cross-repo → SPARE
+		{FromID: "apiTest", ToID: "exportedAPI", Kind: "CALLS"},
+		{FromID: "extConsumer", ToID: "exportedAPI", Kind: "IMPORTS",
+			Properties: map[string]string{"imported_name": "ReadSecretValue"}},
+	}
+	return minDoc(ents, rels)
+}
+
+func TestFindDeadCode_TestOnlyReferenced(t *testing.T) {
+	srv := newTestServer(t, buildTestOnlyDoc())
+
+	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{
+		"group": "test",
+		"limit": float64(500),
+	})
+
+	dead, ok := out["dead_code"].([]any)
+	if !ok {
+		t.Fatalf("dead_code not an array: %T", out["dead_code"])
+	}
+
+	// Index flagged symbols by name → reason.
+	flaggedReason := map[string]string{}
+	for _, it := range dead {
+		m := it.(map[string]any)
+		flaggedReason[m["name"].(string)], _ = m["reason"].(string)
+	}
+
+	const testOnlyTag = "test_only_referenced"
+
+	// MUST be flagged as test_only_referenced (the known orphans).
+	mustFlag := []string{"enrichOrphan", "ReferenceExtractor.Extract", "TryClone"}
+	for _, name := range mustFlag {
+		reason, present := flaggedReason[name]
+		if !present {
+			t.Errorf("expected %q to be flagged test_only_referenced, but it was not flagged at all", name)
+			continue
+		}
+		if !contains(reason, testOnlyTag) {
+			t.Errorf("expected %q flagged with reason %q, got reason %q", name, testOnlyTag, reason)
+		}
+	}
+
+	// MUST NOT be flagged (wired siblings + honest exclusions).
+	mustNotFlag := map[string]string{
+		"applyDjangoSignalPubSub": "wired from cmd/index.go (production caller)",
+		"computeStuff":            "has a production caller in addition to a test caller",
+		"handleEvent":             "framework handler (honest exclusion)",
+		"ReadSecretValue":         "imported cross-repo (live public API)",
+	}
+	for name, why := range mustNotFlag {
+		if _, present := flaggedReason[name]; present {
+			t.Errorf("FALSE POSITIVE: %q (%s) must not be flagged, but it was: reason=%q",
+				name, why, flaggedReason[name])
+		}
+	}
+
+	// Test entities themselves are never flagged.
+	for _, name := range []string{"TestEnrich", "TestRef", "TestClone", "TestHandler"} {
+		if _, present := flaggedReason[name]; present {
+			t.Errorf("FALSE POSITIVE: test entity %q must never be flagged", name)
+		}
+	}
+}
+
+// TestIsTestFileMCP guards the per-language test-file predicate.
+func TestIsTestFileMCP(t *testing.T) {
+	testFiles := []string{
+		"internal/enrichers/orphan_test.go",
+		"pkg/foo_test.go",
+		"app/test_views.py",
+		"app/views_test.py",
+		"conftest.py",
+		"src/components/Button.test.tsx",
+		"src/components/Button.spec.ts",
+		"spec/models/user_spec.rb",
+		"src/test/java/com/x/FooTest.java",
+		"src/test/kotlin/FooSpec.kt",
+		"Foo.Tests.cs",
+		"some/__tests__/helper.js",
+		"a/tests/b.go",
+	}
+	for _, f := range testFiles {
+		if !isTestFileMCP(f) {
+			t.Errorf("expected %q to be a test file", f)
+		}
+	}
+	prodFiles := []string{
+		"internal/enrichers/orphan.go",
+		"cmd/index.go",
+		"app/views.py",
+		"src/components/Button.tsx",
+		"daemon/clone/clone.go",
+		"",                            // empty path is not a test file
+		"internal/testutil/helper.go", // 'test' substring but not a test-file convention
+	}
+	for _, f := range prodFiles {
+		if isTestFileMCP(f) {
+			t.Errorf("expected %q to NOT be a test file", f)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -1301,6 +1301,17 @@ func isOperationKind(e *graph.Entity) bool {
 //     helper that other repos may call) — we deliberately do NOT flag the
 //     latter to keep precision high.
 //
+//  3. test_only_referenced (#3657) — a production operation whose ONLY inbound
+//     reference edges originate in test files (or are TESTS edges). It is
+//     reachable in the full graph (so the classic caller-count check thinks it
+//     is live) yet UNREACHABLE in a production-only pass that drops test-source
+//     callers. This is the recurring "unwired code" class — orphaned enrichers,
+//     test-only extractors, framework patterns wired only from *_test.go — that
+//     a plain reachability BFS misses because it counts test callers as
+//     references. The same honest exclusions as class 2 apply (route handlers,
+//     framework lifecycle hooks, constructors, cross-repo imports) so we do not
+//     false-positive on reflectively-invoked or externally-consumed symbols.
+//
 // Supports optional filters: kind_filter, repo_filter, limit.
 func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	_, lg, errRes := s.resolveAndGroup(req)
@@ -1334,12 +1345,20 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			continue
 		}
 
-		// Build set of entities that are project (non-stdlib) code.
+		// Build set of entities that are project (non-stdlib) code, plus the
+		// per-entity test-file predicate (#3657). testEntity[id] is true when
+		// the entity's source file matches a recognised test-file convention —
+		// used to drop test-file callers from the production-only reachability
+		// pass.
 		projectEntities := map[string]bool{}
+		testEntity := map[string]bool{}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
 			if !isStdlibEntity(e) {
 				projectEntities[e.ID] = true
+			}
+			if isTestFileMCP(e.SourceFile) {
+				testEntity[e.ID] = true
 			}
 		}
 
@@ -1348,7 +1367,16 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 		// live. CONTAINS is excluded (every entity is contained by its module,
 		// so it carries no usage signal). Cross-repo references are handled
 		// separately via the imported-name set.
+		//
+		// #3657: we keep TWO counts. inRef is the full count (any caller,
+		// including tests) — an entity with inRef>0 is NOT classic dead code.
+		// inRefProd drops edges whose source is a test entity (FromID in a test
+		// file) AND drops the TESTS edge kind itself (a test→target relation is
+		// by definition a test caller). An operation that is reachable in the
+		// full graph (inRef>0) but UNREACHABLE production-only (inRefProd==0) is
+		// production-dead-but-test-covered: the `test_only_referenced` class.
 		inRef := map[string]int{}
+		inRefProd := map[string]int{}
 		for i := range r.Doc.Relationships {
 			rel := &r.Doc.Relationships[i]
 			if !projectEntities[rel.FromID] || !projectEntities[rel.ToID] {
@@ -1359,6 +1387,12 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			}
 			if inboundRefKinds[rel.Kind] {
 				inRef[rel.ToID]++
+				// Production-only edge: source is not a test entity, and the
+				// edge is not a TESTS relation. These are the edges that keep a
+				// symbol alive in production.
+				if rel.Kind != "TESTS" && !testEntity[rel.FromID] {
+					inRefProd[rel.ToID]++
+				}
 			}
 		}
 
@@ -1384,20 +1418,23 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			if !isOperationKind(e) {
 				continue
 			}
-			// An operation that is called/referenced/tested/routed/etc. is
-			// live.
-			if inRef[e.ID] > 0 {
-				continue
-			}
 			// Exclude non-code "operation" entities (Dockerfile CMD, SQL DDL).
 			if nonCodeLanguages[strings.ToLower(e.Language)] {
 				continue
 			}
-			if strings.Contains(strings.ToLower(e.SourceFile), "test") {
+			// The TARGET being a test entity is never dead production code — a
+			// test helper called only by other tests is wired-as-intended. We
+			// only flag PRODUCTION symbols. Both the legacy class and the new
+			// test_only_referenced class require the target to live in
+			// production code.
+			if testEntity[e.ID] || strings.Contains(strings.ToLower(e.SourceFile), "test") {
 				continue
 			}
 			// Route handlers, framework lifecycle hooks, event listeners, and
-			// constructors are reachable without an explicit call edge.
+			// constructors are reachable without an explicit call edge. These
+			// are honest exclusions shared by BOTH classes — a symbol invoked
+			// reflectively / by the framework / as an entry point is not dead
+			// even with zero in-graph production callers.
 			if isFrameworkOrHandler(e) {
 				continue
 			}
@@ -1410,29 +1447,54 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			if j := strings.LastIndexByte(leaf, '.'); j >= 0 {
 				leaf = leaf[j+1:]
 			}
-			// An unreferenced operation is flagged as dead code only when it
-			// carries a conventional dead-code marker (legacy/deprecated/
-			// obsolete/dead/unused/old) in its name. The marker is the
-			// precision gate that separates genuine dead code from a
-			// legitimate-but-currently-unused public API export or a symbol
-			// reachable only via reflection/config. Without it, a merely
-			// zero-caller operation (extremely common on real per-repo graphs,
-			// where cross-repo usage lives in the group links file rather than
-			// in per-repo edges) is NOT flagged, keeping false positives near
-			// zero.
-			if !deadMarkerRe.MatchString(leaf) {
-				continue
+
+			switch {
+			case inRef[e.ID] > 0:
+				// Has callers in the full graph. Classic dead-code detection
+				// treats this as live. BUT #3657: if EVERY caller is a test
+				// (inRefProd == 0), the symbol is production-unreachable while
+				// test-covered — the recurring "unwired code" class (orphaned
+				// enrichers, test-only extractors, Java patterns wired only from
+				// *_test.go). Flag it as test_only_referenced. Otherwise it has
+				// at least one real production caller and is genuinely live.
+				if inRefProd[e.ID] == 0 {
+					out = append(out, item{
+						EntityID:   prefixedID(r.Repo, e.ID),
+						Name:       e.Name,
+						Kind:       stripScopePrefix(e.Kind),
+						Repo:       r.Repo,
+						SourceFile: e.SourceFile,
+						StartLine:  e.StartLine,
+						Reason:     "test_only_referenced: reachable only from test files (0 production callers, not imported, not a route/handler/entrypoint) — production-dead but test-covered",
+						Confidence: 0.8,
+					})
+				}
+				// else: real production caller → live, not flagged.
+			default:
+				// Zero callers of any kind. Flagged as dead code only when it
+				// carries a conventional dead-code marker (legacy/deprecated/
+				// obsolete/dead/unused/old) in its name. The marker is the
+				// precision gate that separates genuine dead code from a
+				// legitimate-but-currently-unused public API export or a symbol
+				// reachable only via reflection/config. Without it, a merely
+				// zero-caller operation (extremely common on real per-repo
+				// graphs, where cross-repo usage lives in the group links file
+				// rather than in per-repo edges) is NOT flagged, keeping false
+				// positives near zero.
+				if !deadMarkerRe.MatchString(leaf) {
+					continue
+				}
+				out = append(out, item{
+					EntityID:   prefixedID(r.Repo, e.ID),
+					Name:       e.Name,
+					Kind:       stripScopePrefix(e.Kind),
+					Repo:       r.Repo,
+					SourceFile: e.SourceFile,
+					StartLine:  e.StartLine,
+					Reason:     "unreferenced operation with dead-code marker (0 callers, not imported, not a route/handler/entrypoint)",
+					Confidence: 0.85,
+				})
 			}
-			out = append(out, item{
-				EntityID:   prefixedID(r.Repo, e.ID),
-				Name:       e.Name,
-				Kind:       stripScopePrefix(e.Kind),
-				Repo:       r.Repo,
-				SourceFile: e.SourceFile,
-				StartLine:  e.StartLine,
-				Reason:     "unreferenced operation with dead-code marker (0 callers, not imported, not a route/handler/entrypoint)",
-				Confidence: 0.85,
-			})
 		}
 	}
 
@@ -1452,7 +1514,7 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 		"count":     len(out),
 		"total":     total,
 		"truncated": total > len(out),
-		"note":      "Dead code candidates. Class 1 (confidence 0.6): isolated entities with no edges — may be an extraction gap. Class 2 (confidence 0.85): unreferenced public operations carrying a dead-code marker. Verify before deletion — some entry points are invoked via reflection or config.",
+		"note":      "Dead code candidates. Class 1 (confidence 0.6): isolated entities with no edges — may be an extraction gap. Class 2 (confidence 0.85): unreferenced public operations carrying a dead-code marker (reason='unreferenced operation…'). Class 3 (confidence 0.8): test_only_referenced — operations reachable ONLY from test files (0 production callers; reason='test_only_referenced…'). These are production-dead but test-covered: the recurring unwired-code class (orphaned helpers, test-only extractors/enrichers) the classic caller-count BFS misses because it counts test callers as references. Verify before deletion — some entry points are invoked via reflection or config.",
 	}), nil
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -827,7 +827,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_impact_radius", s.handleImpactRadius))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_dead_code",
-		mcpapi.WithDescription("Entities with no project edges — dead code or extraction gap candidates."),
+		mcpapi.WithDescription("Dead/unwired code: isolated, marked-unused, or test_only_referenced symbols."),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("kind_filter"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),


### PR DESCRIPTION
Closes #3657 (epic #3648).

## What & why
Adds a third class, **`test_only_referenced`** (confidence 0.8), to `archigraph_find_dead_code`. It flags production operations that are reachable ONLY from test files — production-unreachable but test-covered.

The existing dead-code logic treats *any* inbound reference edge as "live", so a symbol whose only callers are in `_test.go` (or arrive via a `TESTS` edge) looks alive when it is actually production-dead. This is the recurring **unwired-code class** — orphaned `internal/enrichers/*` funcs, the `internal/extractors/references` ReferenceExtractor, `daemon/clone.TryClone`, framework patterns wired only from tests (the #3650-3656 orphans) — that a plain reachability BFS misses. This change makes **archigraph self-detect** that class.

## How the production-only pass works
Per repo we keep two inbound-reference counts:
- `inRef` — the full count (any caller, incl. tests). `inRef>0` → not classic dead code.
- `inRefProd` — production-only: drops edges whose `FromID` is a **test entity** (source file matches a test-file convention) AND drops the `TESTS` edge kind itself.

An operation with `inRef>0` but `inRefProd==0` is reachable in the full graph yet unreachable production-only → flagged `test_only_referenced`. An operation with at least one real production caller stays live.

A per-language test-file predicate `isTestFileMCP` (a local copy of `internal/graph/coverage.go`'s `isTestFile`, keeping the `mcp→graph` layering data-only) recognises: Go `_test.go`; Python `test_*.py`/`*_test.py`/`conftest.py`; JS/TS `*.test.*`/`*.spec.*`/`__tests__`; Ruby `*_spec.rb`; Java/Kotlin/C# `*Test`/`*Tests`/`*Spec`; and `/test/`,`/tests/`,`/spec/` path segments.

## Honest exclusions (shared with the marker class — no false positives)
Route handlers / framework lifecycle hooks / constructors (`isFrameworkOrHandler`), cross-repo imports (`isExternallyConsumed`), the test entity itself (we only flag production symbols), and non-code languages are all spared — so reflectively-invoked / registered / externally-consumed symbols are not flagged.

## Validation corpus (value-asserting, not `len>0`)
`TestFindDeadCode_TestOnlyReferenced` builds a synthetic graph modelled on the #3657 spec and asserts exact symbols:

**Flags** (test-only):
- `enrichOrphan` — called only from `enricher_test.go`
- `ReferenceExtractor.Extract` — reached only via a `TESTS` edge
- `TryClone` — called only from `clone_test.go`

**Spares**:
- `applyDjangoSignalPubSub` — wired from `cmd/index.go` (production caller)
- `computeStuff` — has a production caller *and* a test caller
- `handleEvent` — framework handler (honest exclusion)
- `ReadSecretValue` — imported cross-repo (live public API)
- the test entities themselves are never flagged

`TestIsTestFileMCP` guards the per-language predicate across all supported languages and negative cases (`internal/testutil/helper.go` is not a test file).

## Quality gates
- Targeted tests green: `go test ./internal/mcp/... ./internal/graph/... ./internal/engine/`
- `gofmt -l` clean on touched files; `go vet ./internal/mcp/` clean
- Existing dead-code classes (isolated 0.6, dead-marker 0.85) unchanged and still passing.
- Budget test passing (tool description kept under the 80-char ceiling).

## Deploy
**DEPLOY-DEFERRED** — code + tests only; no daemon rebuild / reindex performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)