### PR TITLE
feat(neo4j-java): emit Neo4j graph schema as traversable GRAPH_RELATES edges

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -22911,10 +22911,10 @@
             "notes": "Neo4j Spring Data has no lazy-loading concept equivalent to relational ORMs; not applicable"
           },
           "relationship_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/neo4j.go"],
-            "issue": "3098",
-            "notes": "Neo4j graph relationships require @Relationship annotation extraction from Spring Data Neo4j; no extractor exists."
+            "status": "full",
+            "cites": ["internal/custom/java/neo4j.go","internal/custom/java/neo4j_test.go"],
+            "issue": "3611",
+            "notes": "@Relationship(type=,direction=) fields are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-@Node -\u003e target-@Node (mirrors JOINS_COLLECTION for graph DBs); the app's domain graph topology is now a navigable subgraph rather than opaque string props. Full for same-file @Node targets (value-asserting test TestNeo4jGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN)-\u003e Movie); cross-file target resolution is honest-partial (deferred to the resolver / future cross-file pass, kept as target_node props only)."
           }
         },
         "Queries": {

--- a/internal/custom/java/neo4j.go
+++ b/internal/custom/java/neo4j.go
@@ -89,10 +89,16 @@ var (
 	// Extract direction= from @Relationship attributes.
 	neo4jRelDirRE = regexp.MustCompile(`\bdirection\s*=\s*(?:Direction\.)?(\w+)`)
 
-	// Field declaration following @Relationship.
+	// Field declaration following @Relationship. Captures:
+	//   group 1 = generic type param (e.g. Person in List<Person>), if present
+	//   group 2 = the declared (outer) type token (e.g. List, or Movie for a
+	//             non-collection field)
+	//   group 3 = the field name
+	// For a collection field the target node type is group 1; for a plain field
+	// it is group 2.
 	neo4jRelFieldRE = regexp.MustCompile(
 		`(?:private|protected|public|)\s+(?:(?:final|transient)\s+)*` +
-			`(?:\w+(?:<(\w+)>)?|(\w+))\s+(\w+)\s*;`)
+			`(\w+)(?:<(\w+)>)?\s+(\w+)\s*;`)
 )
 
 func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
@@ -124,8 +130,13 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		name   string
 		label  string
 		offset int
+		idx    int // index into `entities` of the emitted node entity
 	}
 	var nodes []nodeInfo
+	// knownNodes lets the @Relationship pass resolve a field's target type to a
+	// same-file @Node class (honest-partial: cross-file targets are unresolved
+	// and their GRAPH_RELATES edge is deferred — only string props are kept).
+	knownNodes := make(map[string]bool)
 
 	emitNode := func(className, label string, offset int) {
 		if label == "" {
@@ -135,8 +146,13 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		setProps(&ent, "framework", "neo4j",
 			"node_label", label,
 			"provenance", "INFERRED_FROM_NEO4J_NODE")
+		idx := len(entities)
 		add(ent)
-		nodes = append(nodes, nodeInfo{name: className, label: label, offset: offset})
+		// add() dedupes; only record the node if the entity was actually appended.
+		if len(entities) == idx+1 {
+			nodes = append(nodes, nodeInfo{name: className, label: label, offset: offset, idx: idx})
+			knownNodes[className] = true
+		}
 	}
 
 	// Spring Data Neo4j @Node.
@@ -163,6 +179,18 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		for _, n := range nodes {
 			if n.offset <= offset {
 				best = n.name
+			}
+		}
+		return best
+	}
+
+	// owningNodeIdx returns the index into `entities` of the @Node entity whose
+	// declaration most closely precedes offset (-1 if none).
+	owningNodeIdx := func(offset int) int {
+		best := -1
+		for _, n := range nodes {
+			if n.offset <= offset {
+				best = n.idx
 			}
 		}
 		return best
@@ -238,12 +266,15 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		if fm == nil {
 			continue
 		}
-		// Capture generic type param or plain type, and field name.
+		// The target node type is the generic param (group 2) for a collection
+		// field (e.g. List<Person> → Person), otherwise the declared outer type
+		// (group 1) for a plain field (e.g. Movie movie → Movie). Field name is
+		// group 3.
 		var targetType, fieldName string
-		if fm[2] >= 0 {
-			targetType = rest[fm[2]:fm[3]]
-		} else if fm[4] >= 0 {
+		if fm[4] >= 0 {
 			targetType = rest[fm[4]:fm[5]]
+		} else if fm[2] >= 0 {
+			targetType = rest[fm[2]:fm[3]]
 		}
 		fieldName = rest[fm[6]:fm[7]]
 
@@ -270,6 +301,36 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		}
 		setProps(&ent, kvs...)
 		add(ent)
+
+		// --- GRAPH_RELATES edge (#3611, epic #3606) ---
+		// Mirror the JOINS_COLLECTION model: emit the domain graph schema as a
+		// traversable edge owner-@Node ──GRAPH_RELATES──▶ target-@Node, instead
+		// of leaving the topology encoded only as `target_node` string props on
+		// the relationship Component above. The edge hangs off the owner @Node
+		// entity (the graph "table"); the resolver fills FromID from it and
+		// resolves ToID via its byName index ("Class:<TargetType>" matches the
+		// target @Node's SCOPE.Schema entity, same convention as the Django
+		// model cross-refs). Only emitted when the owner is an @Node and the
+		// target type resolves to a known same-file @Node class — cross-file
+		// targets are honest-partial and stay as props only.
+		ownerIdx := owningNodeIdx(m[0])
+		if ownerIdx >= 0 && targetType != "" && knownNodes[targetType] {
+			relProps := map[string]string{
+				"framework":  "neo4j",
+				"rel_type":   relType,
+				"direction":  direction,
+				"field_name": fieldName,
+				"provenance": "INFERRED_FROM_NEO4J_RELATIONSHIP",
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID:       "Class:" + targetType,
+					Kind:       string(types.RelationshipKindGraphRelates),
+					Properties: relProps,
+				},
+			)
+		}
 	}
 
 	return entities, nil

--- a/internal/custom/java/neo4j_test.go
+++ b/internal/custom/java/neo4j_test.go
@@ -11,8 +11,9 @@ import (
 	"context"
 	"testing"
 
-	extreg "github.com/cajasmota/archigraph/internal/extractor"
 	_ "github.com/cajasmota/archigraph/internal/custom/java"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -194,6 +195,192 @@ public class UserNode {
 	}
 	if !hasSub(ents, "relationship") {
 		t.Errorf("expected relationship entity from OGM @Relationship, got %v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAPH_RELATES — graph-schema domain topology as a traversable edge (#3611)
+// ---------------------------------------------------------------------------
+
+// findGraphRelates returns the GRAPH_RELATES edge from the @Node entity named
+// `fromNode` to the structural ref "Class:<toType>", or nil if absent.
+func findGraphRelates(ents []types.EntityRecord, fromNode, toType string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "node" && ents[i].Name == fromNode) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "Class:"+toType {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// TestNeo4jGraphRelatesEdge proves the headline capability: an @Node owning an
+// @Relationship field to another same-file @Node type emits a traversable
+// GRAPH_RELATES edge carrying the Neo4j rel_type and direction — the graph-DB
+// analogue of JOINS_COLLECTION.  Person ──GRAPH_RELATES(ACTED_IN)──▶ Movie.
+func TestNeo4jGraphRelatesEdge(t *testing.T) {
+	ctx := context.Background()
+	e, _ := extreg.Get("custom_java_neo4j")
+
+	src := `
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.schema.Relationship.Direction;
+
+@Node("Movie")
+public class Movie {
+    @org.springframework.data.neo4j.core.schema.Id
+    private Long id;
+}
+
+@Node("Person")
+public class Person {
+    @org.springframework.data.neo4j.core.schema.Id
+    private Long id;
+
+    @Relationship(type = "ACTED_IN", direction = Direction.OUTGOING)
+    private Movie movie;
+}
+`
+	ents, err := e.Extract(ctx, extreg.FileInput{Path: "Graph.java", Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	edge := findGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Movie edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["field_name"] != "movie" {
+		t.Errorf("field_name: want movie, got %q", edge.Properties["field_name"])
+	}
+	if edge.Properties["framework"] != "neo4j" {
+		t.Errorf("framework: want neo4j, got %q", edge.Properties["framework"])
+	}
+
+	// The owner @Node entity is the source ("table"); the reverse edge must NOT
+	// exist (direction is encoded as a property, not by swapping endpoints).
+	if findGraphRelates(ents, "Movie", "Person") != nil {
+		t.Error("did not expect a reverse Movie ─GRAPH_RELATES→ Person edge")
+	}
+}
+
+// TestNeo4jGraphRelatesGenericCollection proves the edge resolves through a
+// generic collection field: @Relationship List<Person> on Person → self-edge
+// Person ─GRAPH_RELATES(KNOWS)→ Person.
+func TestNeo4jGraphRelatesGenericCollection(t *testing.T) {
+	ctx := context.Background()
+	e, _ := extreg.Get("custom_java_neo4j")
+
+	src := `
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import java.util.List;
+
+@Node
+public class Person {
+    @org.springframework.data.neo4j.core.schema.Id
+    private Long id;
+
+    @Relationship(type = "KNOWS", direction = Relationship.Direction.OUTGOING)
+    private List<Person> friends;
+}
+`
+	ents, err := e.Extract(ctx, extreg.FileInput{Path: "Person.java", Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edge := findGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Person self-edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "KNOWS" {
+		t.Errorf("rel_type: want KNOWS, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestNeo4jGraphRelatesCrossFileDeferred proves honest-partial behaviour: when
+// the @Relationship target type is NOT a same-file @Node (cross-file), no
+// GRAPH_RELATES edge is emitted — the topology stays as `target_node` props on
+// the relationship Component only. (ActorEntity/DirectorEntity are referenced
+// but never declared @Node here.)
+func TestNeo4jGraphRelatesCrossFileDeferred(t *testing.T) {
+	ctx := context.Background()
+	e, _ := extreg.Get("custom_java_neo4j")
+
+	src := `
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.schema.Relationship.Direction;
+import java.util.List;
+
+@Node("Movie")
+public class MovieEntity {
+    @org.springframework.data.neo4j.core.schema.Id
+    private Long id;
+
+    @Relationship(type = "ACTED_IN", direction = Direction.INCOMING)
+    private List<ActorEntity> actors;
+}
+`
+	ents, err := e.Extract(ctx, extreg.FileInput{Path: "MovieEntity.java", Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("expected NO GRAPH_RELATES edge for cross-file target, got %+v", r)
+			}
+		}
+	}
+}
+
+// TestNeo4jGraphRelatesNonRelationshipFieldNoEdge proves the negative: a plain
+// @Property field (no @Relationship) on an @Node emits no GRAPH_RELATES edge.
+func TestNeo4jGraphRelatesNonRelationshipFieldNoEdge(t *testing.T) {
+	ctx := context.Background()
+	e, _ := extreg.Get("custom_java_neo4j")
+
+	src := `
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+
+@Node("Movie")
+public class Movie {
+    @org.springframework.data.neo4j.core.schema.Id
+    private Long id;
+}
+
+@Node("Person")
+public class Person {
+    @Property("name")
+    private String name;
+
+    private Movie favourite;
+}
+`
+	ents, err := e.Extract(ctx, extreg.FileInput{Path: "Graph.java", Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("plain field must not emit GRAPH_RELATES, got %+v", r)
+			}
+		}
 	}
 }
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -295,6 +295,16 @@ const (
 	// pattern_type.
 	RelationshipKindJoinsCollection RelationshipKind = "JOINS_COLLECTION"
 
+	// #3611 (epic #3606): Neo4j graph-schema domain-topology edge. Emitted from
+	// an @Node-annotated owner node-label entity → the target @Node entity named
+	// by an @Relationship(type=…, direction=…) field. Mirrors JOINS_COLLECTION
+	// for graph databases: encodes the application's domain graph schema
+	// (e.g. (:Person)-[:ACTED_IN]->(:Movie)) as a traversable subgraph rather
+	// than as opaque string props on a relationship component. Properties on the
+	// edge: rel_type (the Neo4j relationship type), direction (OUTGOING/INCOMING),
+	// field_name, framework, provenance.
+	RelationshipKindGraphRelates RelationshipKind = "GRAPH_RELATES"
+
 	// #721: Consumer-side HTTP fetch edge. Emitted from a calling
 	// function/method entity → the synthetic http_endpoint entity that
 	// represents the URL the client invokes. Lets the process-flow BFS
@@ -674,6 +684,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #723:
 		RelationshipKindQueries,
 		RelationshipKindJoinsCollection,
+		// #3611 (epic #3606):
+		RelationshipKindGraphRelates,
 		// #721:
 		RelationshipKindFetches,
 		// #726 wave 1:


### PR DESCRIPTION
Closes #3611 (epic #3606).

## What

The crown-jewel gap from the Neo4j audit (#3606): **no language emitted `(:A)-[:REL]->(:B)` as a traversable graph edge**, despite `JOINS_COLLECTION` (Mongo) being the proven model. The deepest existing Neo4j extractor — `custom_java_neo4j` (Spring Data Neo4j) — already parsed `@Node`/`@Relationship(type=,direction=)` but encoded the relationship target as **string props** (`target_node`) on a `SCOPE.Component/relationship` entity — topology-blind.

This PR makes the Neo4j **domain graph schema a traversable subgraph**, mirroring `JOINS_COLLECTION` for graph databases.

## Changes

- **`internal/types/kinds.go`** — new `RelationshipKindGraphRelates` (`"GRAPH_RELATES"`), registered in `AllRelationshipKinds` (producer-kind validator green).
- **`internal/custom/java/neo4j.go`** — for each `@Relationship(type=REL, direction=DIR)` field on an `@Node` class whose target type resolves to a **same-file `@Node`**, emit a real `GRAPH_RELATES` edge from the owner node-label entity → the target node-label entity, with props `rel_type`, `direction`, `field_name`, `framework`, `provenance`. Node-label entities stay the graph "tables"; existing entity emission is kept (edge is **added**). Cross-file targets are honest-partial (kept as `target_node` props, deferred to the resolver / a future cross-file pass).
  - Also fixes the `@Relationship` field-type regex so a non-collection field (`Movie movie`) resolves its target type, not only generic collections (`List<Person>`).

## Tests (value-asserting)

- `Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING, field_name=movie)→ Class:Movie` — the headline edge, asserting the **specific** node→node relationship and that no reverse edge is emitted.
- `List<Person>` self-edge → `Person ─GRAPH_RELATES(KNOWS)→ Person`.
- **Negative**: cross-file target (`List<ActorEntity>` with no same-file `@Node`) emits no edge; a plain non-`@Relationship` field emits no edge.

`go test ./internal/custom/java/... ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` clean on changed files; `go vet` clean.

## Registry

`lang.java.orm.neo4j` → `relationship_extraction` **partial → full** (cites neo4j.go + the edge test); cross-file resolution noted as honest-partial.

## Note

This is the **template for the other-language Neo4j `GRAPH_RELATES` tickets** (#3609 / #3610 / #3612 …).

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)