### PR TITLE
fix(mcp): make find work on groups indexed at a non-HEAD ref (#3648)

### DIFF
--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -365,6 +365,60 @@ func FindGraphFile(repoPath string) (path string, modtime int64) {
 	return findGraphFileInDir(stateDir)
 }
 
+// FindGraphFileAnyRef resolves a queryable graph file for repoPath, preferring
+// the current HEAD ref's per-ref directory but falling back to the newest
+// graph.fb/graph.json found under ANY indexed ref for the repo.
+//
+// Why this exists (#3648): a group registered via `group add --index` is
+// indexed ONCE, at the repo's HEAD ref at that moment, and — unless watchers
+// were installed (they default to OFF for `group add`, ON for the interactive
+// wizard) — nothing reindexes when HEAD subsequently moves. When the MCP server
+// later resolves the per-ref state dir from the *current* HEAD ref it lands on
+// an empty (never-indexed) ref directory, so FindGraphFile returns "" and the
+// repo's Doc stays nil. Every repo-scoped tool (find/inspect/expand/…) then
+// reports "no repos loaded for this group" even though a fully-indexed graph
+// exists one ref-directory over. The wizard/install path avoids this only
+// incidentally, because its watchers keep the current-ref dir fresh.
+//
+// Resolution order:
+//  1. The current HEAD ref's dir (fast path; matches FindGraphFile exactly).
+//  2. The newest graph file across all sibling refs/<ref>/ dirs for the repo.
+//
+// The fallback is freshness-safe for a read-only query surface: it serves the
+// most recently indexed graph the repo has, rather than nothing. Returns
+// ("", 0) when no ref directory holds a graph file. The returned path's parent
+// directory is the state dir the caller should read sidecars from.
+func FindGraphFileAnyRef(repoPath string) (path string, modtime int64) {
+	if repoPath == "" {
+		return "", 0
+	}
+	// 1. Current-ref fast path.
+	if p, mt := findGraphFileInDir(StateDirForRepo(repoPath)); p != "" {
+		return p, mt
+	}
+	// 2. Scan every indexed ref dir and keep the newest graph file.
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	abs = filepath.Clean(abs)
+	refsDir := filepath.Join(repoBaseDir(abs), "refs")
+	entries, rdErr := os.ReadDir(refsDir)
+	if rdErr != nil {
+		return "", 0
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		p, mt := findGraphFileInDir(filepath.Join(refsDir, e.Name()))
+		if p != "" && mt > modtime {
+			path, modtime = p, mt
+		}
+	}
+	return path, modtime
+}
+
 // WarnCaseCollisions scans the store directory for store slots whose
 // directory name (slug-hash) does not match the hash derived from the
 // canonical fleet repo path. This detects legacy store dirs created

--- a/internal/daemon/state_path_ref_test.go
+++ b/internal/daemon/state_path_ref_test.go
@@ -335,3 +335,79 @@ func TestStateDirForRepo_AlwaysUnderBaseAndHasRefs(t *testing.T) {
 		t.Errorf("StateDirForRepo path %q does not contain '/refs/'", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// FindGraphFileAnyRef: cross-ref fallback (#3648)
+// ---------------------------------------------------------------------------
+
+// TestFindGraphFileAnyRef_FallsBackToOtherRef reproduces the #3648 bug: a group
+// registered via `group add --index` is indexed once at the then-HEAD ref and,
+// with watchers off, nothing reindexes when HEAD moves. The current-ref state
+// dir is then empty, so the current-ref-only FindGraphFile returns "" and the
+// MCP server reports "no repos loaded for this group". FindGraphFileAnyRef must
+// fall back to the graph under the ref it was actually indexed at.
+func TestFindGraphFileAnyRef_FallsBackToOtherRef(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	// Non-git temp path → current HEAD ref resolves to the "_unknown" ref dir,
+	// which we deliberately leave EMPTY (simulating HEAD having moved away from
+	// the ref the graph was indexed at).
+	repoPath := t.TempDir()
+
+	// Index artifacts live ONLY under a different ref dir.
+	indexedRefDir := StateDirForRepoRef(repoPath, "feat/indexed-at")
+	writeFakeGraph(t, indexedRefDir, "feat/indexed-at")
+
+	// Bug: current-ref-only discovery finds nothing.
+	if p, _ := FindGraphFile(repoPath); p != "" {
+		t.Fatalf("precondition: current-ref FindGraphFile should be empty, got %q", p)
+	}
+
+	// Fix: AnyRef falls back to the indexed ref's graph.
+	got, mt := FindGraphFileAnyRef(repoPath)
+	if got == "" {
+		t.Fatal("FindGraphFileAnyRef returned empty; expected fallback to indexed ref")
+	}
+	if mt == 0 {
+		t.Errorf("FindGraphFileAnyRef returned zero modtime for %q", got)
+	}
+	if filepath.Dir(got) != filepath.Clean(indexedRefDir) {
+		t.Errorf("FindGraphFileAnyRef found %q; want a graph under %q", got, indexedRefDir)
+	}
+}
+
+// TestFindGraphFileAnyRef_PrefersCurrentRef ensures the fast path still wins:
+// when the current HEAD ref dir has a graph, AnyRef returns it without scanning
+// siblings (matching FindGraphFile exactly so the watcher/wizard path is
+// unaffected).
+func TestFindGraphFileAnyRef_PrefersCurrentRef(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	repoPath := t.TempDir()
+
+	// Non-git path → current ref is "_unknown". Put a graph there AND under a
+	// newer sibling ref; AnyRef must return the current-ref one.
+	curDir := StateDirForRepo(repoPath)
+	writeFakeGraph(t, curDir, "")
+
+	want, _ := FindGraphFile(repoPath)
+	if want == "" {
+		t.Fatal("setup: current-ref graph not discoverable")
+	}
+	got, _ := FindGraphFileAnyRef(repoPath)
+	if got != want {
+		t.Errorf("FindGraphFileAnyRef = %q; want current-ref %q", got, want)
+	}
+}
+
+// TestFindGraphFileAnyRef_NoGraphAnywhere returns empty when no ref dir holds a
+// graph (no false positives that would mask a genuinely un-indexed repo).
+func TestFindGraphFileAnyRef_NoGraphAnywhere(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	repoPath := t.TempDir()
+	if got, mt := FindGraphFileAnyRef(repoPath); got != "" || mt != 0 {
+		t.Errorf("FindGraphFileAnyRef = (%q,%d); want empty", got, mt)
+	}
+}

--- a/internal/mcp/find_anyref_3648_test.go
+++ b/internal/mcp/find_anyref_3648_test.go
@@ -1,0 +1,80 @@
+// find_anyref_3648_test.go reproduces and guards the #3648 fix: archigraph_find
+// (and every other repo-scoped tool) must work on a group whose graph was
+// indexed at a ref that is no longer HEAD — the failure mode for groups
+// registered via `archigraph group add --index` with watchers off, which index
+// once at the then-HEAD ref and never reindex when HEAD subsequently moves.
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+)
+
+// writeGraphAtRef writes doc into the per-ref state dir for (repoDir, ref),
+// rather than the current-HEAD ref dir writeGraph targets. This simulates an
+// indexed graph stranded under a ref that is no longer HEAD.
+func writeGraphAtRef(t *testing.T, repoDir, ref string, doc *struct{ raw []byte }) string {
+	t.Helper()
+	dir := daemon.StateDirForRepoRef(repoDir, ref)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "graph.json")
+	if err := os.WriteFile(path, doc.raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestFind_AnyRefFallback_NoReposLoadedRegression is the end-to-end guard. A
+// repo registered the `group add --index` way has its graph under a non-HEAD
+// ref dir; find must still resolve it and return a hit, not the
+// "# no repos loaded for this group" sentinel.
+func TestFind_AnyRefFallback_NoReposLoadedRegression(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+
+	repoPath := filepath.Join(dir, "scriptable-repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Serialize the shared fixture and stash it ONLY under a non-HEAD ref dir.
+	// repoPath is a plain (non-git) dir, so the MCP server's current-ref
+	// resolution lands on the "_unknown" ref dir — which we leave empty.
+	raw, err := json.MarshalIndent(fixtureDoc("scriptable-repo"), "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeGraphAtRef(t, repoPath, "feature/indexed-long-ago", &struct{ raw []byte }{raw})
+
+	// Sanity: nothing under the current (HEAD) ref dir.
+	if p, _ := daemon.FindGraphFile(repoPath); p != "" {
+		t.Fatalf("precondition: current-ref graph should be empty, got %q", p)
+	}
+
+	regPath := makeRegistry(t, dir, map[string]map[string]string{
+		"scriptable": {"scriptable-repo": repoPath},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	res := callTool(t, srv, "archigraph_find", map[string]any{
+		"group": "scriptable",
+		"query": "rareUniqueWidget",
+	})
+	out := resultText(res)
+	if strings.Contains(out, "no repos loaded") {
+		t.Fatalf("find returned the #3648 sentinel; AnyRef fallback did not engage:\n%s", out)
+	}
+	if !strings.Contains(out, "rareUniqueWidget") {
+		t.Fatalf("find did not surface the indexed entity; got:\n%s", out)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -611,10 +611,21 @@ func (s *State) reloadLocked() (int, bool, error) {
 				// If stat failed (file removed) fall through to full discovery below.
 			}
 			if graphPath == "" {
-				// Use FindGraphFile to discover graph.fb (preferred) or graph.json,
-				// fixing issue #1374 item #1: repos that only have graph.fb were
-				// silently dropped because the old os.Stat always targeted graph.json.
-				graphPath, modtimeNs = daemon.FindGraphFile(rEntry.Path)
+				// Use FindGraphFileAnyRef to discover graph.fb (preferred) or
+				// graph.json, fixing issue #1374 item #1: repos that only have
+				// graph.fb were silently dropped because the old os.Stat always
+				// targeted graph.json.
+				//
+				// #3648: AnyRef falls back to the newest graph under ANY indexed
+				// ref when the current HEAD ref's dir is empty. A group registered
+				// via `group add --index` (watchers default OFF) is indexed once at
+				// the then-HEAD ref; when HEAD later moves the current-ref dir is
+				// empty and the old current-ref-only FindGraphFile returned "",
+				// leaving Doc nil and every repo-scoped tool reporting
+				// "no repos loaded for this group". Serving the most-recent indexed
+				// ref keeps find/inspect/expand working regardless of how the group
+				// was registered.
+				graphPath, modtimeNs = daemon.FindGraphFileAnyRef(rEntry.Path)
 			}
 
 			if graphPath == "" {
@@ -633,7 +644,13 @@ func (s *State) reloadLocked() (int, bool, error) {
 			// Update GraphFile in case .fb appeared after initial load.
 			lr.GraphFile = graphPath
 			fileMtime := time.Unix(0, modtimeNs)
-			stateDir := daemon.StateDirForRepo(rEntry.Path)
+			// #3648: derive the state dir from the directory the graph file was
+			// actually discovered in (graphPath may live under a non-HEAD ref dir
+			// when AnyRef fell back), NOT from the current-HEAD per-ref dir. The
+			// graph.fb mmap reader and the embeddings.bin / graph.json sidecars
+			// below must all read from the SAME dir as the parsed Document, or a
+			// fallback-discovered graph would be paired with a stale/empty sidecar.
+			stateDir := filepath.Dir(lr.GraphFile)
 			if !(fileMtime.Equal(lr.mtime) && lr.Doc != nil) {
 				// #3377 content-hash skip: the live indexer rewrites graph.fb on
 				// every reindex, bumping mtime even when the bytes are identical


### PR DESCRIPTION
Part of epic #3648 (MCP correctness).

## Symptom
`archigraph_find` (BM25/semantic search) — and in fact every repo-scoped MCP tool — returned `# no repos loaded for this group` on the `archigraph` group (registered via `archigraph group add archigraph --repo ... --index`, fully indexed = 62K entities), while working on the `upvate`/`upvate-v2` groups (registered via the interactive wizard/install). The primary semantic-search tool was dead for groups added the scriptable way.

## Root cause (the differential vs the wizard path)
- `archigraph group add` defaults **watchers OFF** (`internal/cli/group.go`, `--watchers` default `false`); the interactive wizard installs them.
- With `--index`, the group is indexed **once**, at the repo's HEAD ref *at that moment*, writing `graph.fb` to `store/<repo>/refs/<ref>/`.
- With no watchers, nothing reindexes when HEAD subsequently moves — and the archigraph repo is under constant development, so HEAD moves often.
- At query time the MCP reload (`internal/mcp/state.go`) resolves the per-ref state dir from the **current** HEAD ref (`StateDirForRepo` → `gitmeta.Capture`), lands on an empty, never-indexed `refs/<current-ref>/` dir, so `FindGraphFile` returns `""`, the repo's `Doc` stays `nil`, and `reposToConsider` (which requires `Doc != nil`) filters it out → `no repos loaded for this group`.
- The wizard groups avoid this only **incidentally**: their watchers keep the current-ref dir continuously reindexed.

So the BM25 index was never the problem — it is built lazily from `Doc` and `Doc` was simply never loaded. The missing step on the `group add --index` path is the watcher that keeps the current-ref graph fresh; the durable fix is to not depend on the current ref being the indexed one.

## Fix
- New `daemon.FindGraphFileAnyRef(repoPath)`: prefers the current-HEAD ref dir (fast path, byte-identical behaviour to `FindGraphFile`, so the watcher/wizard path is unchanged) and **falls back to the newest `graph.fb`/`graph.json` across any `refs/<ref>/` dir** for the repo. Serving the most-recently-indexed graph keeps find/inspect/expand working regardless of how the group was registered or where HEAD has wandered.
- The MCP reload path now uses `FindGraphFileAnyRef` and derives the state dir from the **discovered file's directory** (`filepath.Dir(GraphFile)`), so the `graph.fb` mmap reader and the `embeddings.bin` / `graph.json` sidecars all read from the SAME dir as the parsed `Document` — never pairing a fallback graph with a stale current-ref sidecar.

## Tests
- `internal/daemon/state_path_ref_test.go`: `FindGraphFileAnyRef` falls back to a non-HEAD ref, prefers the current ref when it has a graph, and returns empty when no ref dir holds a graph.
- `internal/mcp/find_anyref_3648_test.go`: end-to-end regression — a repo whose graph lives **only** under a non-HEAD ref dir yields a queryable `archigraph_find` (returns the entity, not the sentinel). **Verified to FAIL** with the exact `# no repos loaded for this group` output when the reload path is reverted to current-ref-only `FindGraphFile`.

## Validation
- `go test ./internal/mcp/...` green; touched `internal/daemon` path/state tests green.
- `gofmt -l` empty on touched files; `go vet` clean.
- The only failing `internal/daemon` tests are pre-existing daemon-**process** integration tests (`daemon never became ready ... socket missing`) that require binding a unix socket — confirmed to fail identically on the untouched base tree; they are sandbox-environment failures unrelated to this change.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)