### PR TITLE
feat(python/redis): extract key/channel/stream topology (#3643)

### DIFF
--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ✅ `full` | `2026-05-29` | 3060 | `internal/engine/rules/python/orms/redis_py.yaml` | — |
+| Query attribution | ✅ `full` | `2026-06-02` | 3643 | `internal/custom/python/redis.go` | Key/channel/stream topology extracted: concrete keys, prefix globs (user:*) from concat and f-strings; READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Matches JS scanJSRedis shape (#3643). |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -40509,9 +40509,10 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
-            "issue": "3060",
-            "verified_at": "2026-05-29"
+            "cites": ["internal/custom/python/redis.go"],
+            "issue": "3643",
+            "notes": "Key/channel/stream topology extracted: concrete keys, prefix globs (user:*) from concat and f-strings; READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Matches JS scanJSRedis shape (#3643).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1412,6 +1412,149 @@ r.hset("hash", "field", "value")
 	}
 }
 
+// findCacheOpAtLine returns the cache_op entity on a given source line.
+func findCacheOpAtLine(t *testing.T, ents []extractResult, line int) extractResult {
+	t.Helper()
+	for _, e := range ents {
+		if e.Subtype == "cache_op" && e.StartLine == line {
+			return e
+		}
+	}
+	t.Fatalf("no cache_op found on line %d", line)
+	return extractResult{}
+}
+
+func hasRel(rels []relResult, kind, toID string) bool {
+	for _, r := range rels {
+		if r.Kind == kind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+func findKeyspace(ents []extractResult, label string) (extractResult, bool) {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Props["keyspace"] == label {
+			return e, true
+		}
+	}
+	return extractResult{}, false
+}
+
+// TestRedis_CacheOp_LiteralKey asserts the SPECIFIC key `session:abc` is
+// captured as a read access target with a READS_FROM edge.
+func TestRedis_CacheOp_LiteralKey(t *testing.T) {
+	src := `r.get("session:abc")
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key"] != "session:abc" {
+		t.Fatalf("expected key=session:abc, got key=%q", op.Props["key"])
+	}
+	if !hasRel(op.Rels, "READS_FROM", "Datastore:redis:session:abc") {
+		t.Fatalf("expected READS_FROM edge to Datastore:redis:session:abc, got %+v", op.Rels)
+	}
+	ks, ok := findKeyspace(ents, "session:abc")
+	if !ok {
+		t.Fatal("expected keyspace entity for session:abc")
+	}
+	if ks.Props["key_type"] != "key" {
+		t.Fatalf("expected key_type=key, got %q", ks.Props["key_type"])
+	}
+}
+
+// TestRedis_CacheOp_SetWritesTo asserts a write verb emits WRITES_TO.
+func TestRedis_CacheOp_SetWritesTo(t *testing.T) {
+	src := `r.set("user:42", value)
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key"] != "user:42" {
+		t.Fatalf("expected key=user:42, got %q", op.Props["key"])
+	}
+	if !hasRel(op.Rels, "WRITES_TO", "Datastore:redis:user:42") {
+		t.Fatalf("expected WRITES_TO edge to Datastore:redis:user:42, got %+v", op.Rels)
+	}
+}
+
+// TestRedis_CacheOp_ConcatPrefix asserts `r.set("user:" + id, v)` yields a
+// key-prefix `user:*`, not a fabricated concrete key.
+func TestRedis_CacheOp_ConcatPrefix(t *testing.T) {
+	src := `r.set("user:" + id, v)
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key_prefix"] != "user:*" {
+		t.Fatalf("expected key_prefix=user:*, got %q", op.Props["key_prefix"])
+	}
+	if op.Props["key"] != "" {
+		t.Fatalf("expected no concrete key, got key=%q", op.Props["key"])
+	}
+	if !hasRel(op.Rels, "WRITES_TO", "Datastore:redis:user:*") {
+		t.Fatalf("expected WRITES_TO edge to Datastore:redis:user:*, got %+v", op.Rels)
+	}
+}
+
+// TestRedis_CacheOp_FStringPrefix asserts `r.get(f"session:{sid}")` yields a
+// key-prefix `session:*`.
+func TestRedis_CacheOp_FStringPrefix(t *testing.T) {
+	src := `r.get(f"session:{sid}")
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key_prefix"] != "session:*" {
+		t.Fatalf("expected key_prefix=session:*, got %q", op.Props["key_prefix"])
+	}
+	if !hasRel(op.Rels, "READS_FROM", "Datastore:redis:session:*") {
+		t.Fatalf("expected READS_FROM edge to Datastore:redis:session:*, got %+v", op.Rels)
+	}
+}
+
+// TestRedis_CacheOp_DynamicKey is the negative case: a fully-dynamic key
+// (variable only) must emit the op with NO key edge and NO fabricated key.
+func TestRedis_CacheOp_DynamicKey(t *testing.T) {
+	src := `r.get(k)
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key"] != "" {
+		t.Fatalf("expected no concrete key for dynamic key, got %q", op.Props["key"])
+	}
+	if op.Props["key_prefix"] != "" {
+		t.Fatalf("expected no key_prefix for dynamic key, got %q", op.Props["key_prefix"])
+	}
+	if len(op.Rels) != 0 {
+		t.Fatalf("expected no access edge for fully-dynamic key, got %+v", op.Rels)
+	}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected no keyspace target for dynamic key, got %q", e.Props["keyspace"])
+		}
+	}
+}
+
+// TestRedis_CacheOp_FStringNoStaticHead asserts an f-string whose first token
+// is an interpolation (`f"{tenant}:cfg"`) is marked dynamic with no edge and
+// no fabricated keyspace — the key arg matched but could not be resolved.
+func TestRedis_CacheOp_FStringNoStaticHead(t *testing.T) {
+	src := `r.get(f"{tenant}:cfg")
+`
+	ents := extract(t, "python_redis", src)
+	op := findCacheOpAtLine(t, ents, 1)
+	if op.Props["key"] != "<dynamic>" {
+		t.Fatalf("expected key=<dynamic>, got %q", op.Props["key"])
+	}
+	if len(op.Rels) != 0 {
+		t.Fatalf("expected no edge for unresolved f-string, got %+v", op.Rels)
+	}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected no keyspace node, got %q", e.Props["keyspace"])
+		}
+	}
+}
+
 func TestRedis_PubSub(t *testing.T) {
 	src := `r.publish("channel", "message")
 `
@@ -1424,6 +1567,87 @@ func TestRedis_PubSub(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected pubsub entity")
+	}
+}
+
+// TestRedis_PubSub_Channel asserts `r.publish("events", m)` captures channel
+// `events` with a PUBLISHES_TO edge.
+func TestRedis_PubSub_Channel(t *testing.T) {
+	src := `r.publish("events", m)
+`
+	ents := extract(t, "python_redis", src)
+	var op extractResult
+	for _, e := range ents {
+		if e.Subtype == "pubsub" && e.StartLine == 1 {
+			op = e
+		}
+	}
+	if op.Props["channel"] != "events" {
+		t.Fatalf("expected channel=events, got %q", op.Props["channel"])
+	}
+	if !hasRel(op.Rels, "PUBLISHES_TO", "Datastore:redis:events") {
+		t.Fatalf("expected PUBLISHES_TO edge to Datastore:redis:events, got %+v", op.Rels)
+	}
+	ks, ok := findKeyspace(ents, "events")
+	if !ok || ks.Props["key_type"] != "channel" {
+		t.Fatalf("expected channel keyspace events, got %+v", ks)
+	}
+}
+
+// TestRedis_PubSub_Subscribe asserts subscribe emits SUBSCRIBES_TO.
+func TestRedis_PubSub_Subscribe(t *testing.T) {
+	src := `pubsub.subscribe("notifications")
+`
+	ents := extract(t, "python_redis", src)
+	var op extractResult
+	for _, e := range ents {
+		if e.Subtype == "pubsub" && e.StartLine == 1 {
+			op = e
+		}
+	}
+	if op.Props["channel"] != "notifications" {
+		t.Fatalf("expected channel=notifications, got %q", op.Props["channel"])
+	}
+	if !hasRel(op.Rels, "SUBSCRIBES_TO", "Datastore:redis:notifications") {
+		t.Fatalf("expected SUBSCRIBES_TO edge, got %+v", op.Rels)
+	}
+}
+
+// TestRedis_Stream_Key asserts `r.xadd("orders", ...)` captures stream
+// `orders` with a WRITES_TO edge.
+func TestRedis_Stream_Key(t *testing.T) {
+	src := `r.xadd("orders", {"id": 1})
+`
+	ents := extract(t, "python_redis", src)
+	var op extractResult
+	for _, e := range ents {
+		if e.Subtype == "stream_op" && e.StartLine == 1 {
+			op = e
+		}
+	}
+	if op.Props["stream"] != "orders" {
+		t.Fatalf("expected stream=orders, got %q", op.Props["stream"])
+	}
+	if !hasRel(op.Rels, "WRITES_TO", "Datastore:redis:orders") {
+		t.Fatalf("expected WRITES_TO edge to Datastore:redis:orders, got %+v", op.Rels)
+	}
+}
+
+// TestRedis_Keyspace_Dedup asserts two ops on the same key converge on a
+// single keyspace target node.
+func TestRedis_Keyspace_Dedup(t *testing.T) {
+	src := `r.set("cart:1", v)
+r.get("cart:1")
+`
+	ents := extract(t, "python_redis", src)
+	count := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Props["keyspace"] == "cart:1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 keyspace node for cart:1, got %d", count)
 	}
 }
 

--- a/internal/custom/python/redis.go
+++ b/internal/custom/python/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -18,6 +19,21 @@ func init() {
 
 // RedisExtractor extracts Redis usage patterns: client connections, cache
 // operations, pub/sub, streams, Lua scripts, queue patterns, and rate limiting.
+//
+// Beyond detecting the operation *category* (get/set/publish/xadd/…) it also
+// extracts the KEY / channel / stream the call touches — the crown-jewel
+// data-access detail (#3643, epic #3625). For each keyed op it emits a
+// SCOPE.Datastore keyspace target entity and an access edge (READS_FROM /
+// WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO) from the operation to that target,
+// mirroring the JS driver-layer shape (scanJSRedis in
+// internal/engine/orm_queries_jsts_drivers.go) so the data-access graph is
+// traversable and cross-language consistent.
+//
+// Key topology:
+//   - literal key          r.get("session:abc")    -> key "session:abc"
+//   - string-concat prefix  r.set("user:" + id, v)  -> key_prefix "user:*"
+//   - f-string prefix       r.get(f"session:{sid}") -> key_prefix "session:*"
+//   - fully-dynamic key     r.get(k)                -> op only, no key (honest partial)
 type RedisExtractor struct{}
 
 func (e *RedisExtractor) Language() string { return "python_redis" }
@@ -35,7 +51,130 @@ var (
 		`(?:\.|->)(?:eval|evalsha|script_load|register_script)\s*\(`)
 	rdRateLimitRe = regexp.MustCompile(
 		`(?:incr|INCR)\s*\([^)]*\).*(?:expire|EXPIRE)\s*\(`)
+
+	// rdCacheKeyRe captures the command verb (group 1) and its first string-
+	// literal key argument (group 2). The verb drives the read/write edge
+	// direction; the key is the data-access target.
+	rdCacheKeyRe = regexp.MustCompile(
+		`(?:\.|->)(get|set|hget|hset|hgetall|hmset|hmget|setex|setnx|getset|mget|mset|expire|ttl|pttl|persist|delete|exists|incr|decr|incrby|decrby|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zrank)\s*\(\s*` + rdKeyArg)
+
+	// rdPubSubKeyRe captures the pub/sub verb (group 1) and the channel
+	// literal (group 2).
+	rdPubSubKeyRe = regexp.MustCompile(
+		`(?:\.|->)(publish|subscribe|psubscribe)\s*\(\s*` + rdKeyArg)
+
+	// rdStreamKeyRe captures the stream verb (group 1) and the stream key
+	// literal (group 2).
+	rdStreamKeyRe = regexp.MustCompile(
+		`(?i)(?:\.|->)(xadd|xread|xreadgroup|xack|xlen|xrange|xrevrange|xtrim|xdel|xclaim|xpending)\s*\(\s*` + rdKeyArg)
 )
+
+// rdKeyArg matches a Redis key/channel/stream first-argument literal and
+// captures the literal body in group 2 (relative to the verb capture in
+// group 1). It accepts:
+//   - a plain string literal          "session:abc"   /  'events'
+//   - an f-string                     f"user:{uid}"
+//
+// The surrounding quote style is normalised away; prefix/dynamic handling is
+// done by normaliseRedisKey.
+const rdKeyArg = `(f?["'])([^"']*)["']`
+
+// redisKeyAccess captures the resolved key topology for one keyed op.
+type redisKeyAccess struct {
+	key       string // concrete key when fully literal, else ""
+	keyPrefix string // "user:*" style namespace when prefixed/dynamic-suffix
+	dynamic   bool   // true when no static key/prefix could be resolved
+}
+
+// normaliseRedisKey turns a captured first-argument literal (and the raw
+// source window after it) into a redisKeyAccess.
+//
+//	"session:abc"            -> key "session:abc"
+//	"user:" (followed by +x) -> key_prefix "user:*"
+//	f"session:{sid}"         -> key_prefix "session:*"  (literal head before {)
+//	f"{tenant}:cfg"          -> dynamic (no static head)
+//	""                       -> dynamic
+func normaliseRedisKey(quote, literal, after string) redisKeyAccess {
+	isFString := strings.HasPrefix(quote, "f")
+
+	if isFString {
+		// f-string: take the static head before the first interpolation `{`.
+		// A literal with no `{` is effectively a constant key.
+		if i := strings.IndexByte(literal, '{'); i >= 0 {
+			head := literal[:i]
+			if head == "" {
+				return redisKeyAccess{dynamic: true}
+			}
+			return redisKeyAccess{keyPrefix: keyspaceGlob(head)}
+		}
+		if literal == "" {
+			return redisKeyAccess{dynamic: true}
+		}
+		return redisKeyAccess{key: literal}
+	}
+
+	if literal == "" {
+		return redisKeyAccess{dynamic: true}
+	}
+
+	// Plain string literal. If the very next non-space source token is a `+`
+	// concatenation, this literal is a key *prefix* (`"user:" + id`).
+	rest := strings.TrimLeft(after, " \t")
+	if strings.HasPrefix(rest, "+") {
+		return redisKeyAccess{keyPrefix: keyspaceGlob(literal)}
+	}
+	return redisKeyAccess{key: literal}
+}
+
+// keyspaceGlob renders a key prefix as a `prefix*` glob, collapsing a trailing
+// separator so `"user:"` -> `user:*` and `"user"` -> `user*`.
+func keyspaceGlob(prefix string) string {
+	return prefix + "*"
+}
+
+// rdReadVerbs is the set of cache/list/set/hash verbs that only read.
+var rdReadVerbs = map[string]bool{
+	"get": true, "hget": true, "hgetall": true, "hmget": true, "getset": true,
+	"mget": true, "ttl": true, "pttl": true, "exists": true, "lrange": true,
+	"llen": true, "smembers": true, "sismember": true, "zrange": true,
+	"zrangebyscore": true, "zrank": true, "lpop": true, "rpop": true,
+}
+
+// cacheEdgeKind returns READS_FROM for pure-read verbs, WRITES_TO otherwise.
+func cacheEdgeKind(verb string) string {
+	if rdReadVerbs[strings.ToLower(verb)] {
+		return string(types.RelationshipKindReadsFrom)
+	}
+	return string(types.RelationshipKindWritesTo)
+}
+
+// pubsubEdgeKind maps publish -> PUBLISHES_TO, (p)subscribe -> SUBSCRIBES_TO.
+func pubsubEdgeKind(verb string) string {
+	if strings.HasPrefix(strings.ToLower(verb), "sub") || strings.HasPrefix(strings.ToLower(verb), "psub") {
+		return string(types.RelationshipKindSubscribesTo)
+	}
+	return string(types.RelationshipKindPublishesTo)
+}
+
+// streamEdgeKind maps producing stream verbs to WRITES_TO and consuming/
+// inspecting verbs to READS_FROM.
+func streamEdgeKind(verb string) string {
+	switch strings.ToLower(verb) {
+	case "xadd":
+		return string(types.RelationshipKindWritesTo)
+	case "xtrim", "xdel", "xack", "xclaim":
+		return string(types.RelationshipKindWritesTo)
+	default:
+		// xread, xreadgroup, xlen, xrange, xrevrange, xinfo, xpending
+		return string(types.RelationshipKindReadsFrom)
+	}
+}
+
+// redisKeyspaceRef builds the stable ToID for a keyspace/channel/stream target
+// node so multiple call-sites that touch the same key converge on one node.
+func redisKeyspaceRef(keyspace string) string {
+	return fmt.Sprintf("Datastore:redis:%s", keyspace)
+}
 
 func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("custom.python_redis")
@@ -50,12 +189,32 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 	source := string(file.Content)
 	var out []types.EntityRecord
 	seenLines := make(map[string]map[int]bool)
+	seenKeyspace := make(map[string]bool)
 
 	getSeen := func(cat string) map[int]bool {
 		if seenLines[cat] == nil {
 			seenLines[cat] = make(map[int]bool)
 		}
 		return seenLines[cat]
+	}
+
+	// emitKeyspace adds one SCOPE.Datastore target node per distinct keyspace
+	// (deduplicated across the file). Returns the ToID for the access edge.
+	emitKeyspace := func(label, keyType string, line int) string {
+		ref := redisKeyspaceRef(label)
+		if !seenKeyspace[ref] {
+			seenKeyspace[ref] = true
+			out = append(out, entity(ref,
+				"SCOPE.Datastore", keyType, file.Path, line,
+				map[string]string{
+					"framework":    "redis",
+					"pattern_type": "keyspace",
+					"keyspace":     label,
+					"key_type":     keyType,
+					"language":     "python",
+				}))
+		}
+		return ref
 	}
 
 	// 1. Client connections
@@ -71,7 +230,8 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			map[string]string{"framework": "redis", "pattern_type": "client", "language": "python"}))
 	}
 
-	// 2. Cache operations
+	// 2. Cache operations (with key topology)
+	keyedCache := keyedRedisOps(source, rdCacheKeyRe)
 	for _, idx := range allMatchesIndex(rdCacheOpRe, source) {
 		line := lineOf(source, idx[0])
 		seen := getSeen("cache")
@@ -79,12 +239,31 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			continue
 		}
 		seen[line] = true
-		out = append(out, entity(fmt.Sprintf("redis_cache:%s:%d", file.Path, line),
-			"SCOPE.Operation", "cache_op", file.Path, line,
-			map[string]string{"framework": "redis", "pattern_type": "cache_op", "language": "python"}))
+		props := map[string]string{"framework": "redis", "pattern_type": "cache_op", "language": "python"}
+		ent := entity(fmt.Sprintf("redis_cache:%s:%d", file.Path, line),
+			"SCOPE.Operation", "cache_op", file.Path, line, props)
+		if op, ok := keyedCache[line]; ok {
+			label := applyKeyProps(props, op.access)
+			if label != "" {
+				keyType := "key"
+				if op.access.keyPrefix != "" {
+					keyType = "key_prefix"
+				}
+				ref := emitKeyspace(label, keyType, line)
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID: ref,
+					Kind: cacheEdgeKind(op.verb),
+					Properties: map[string]string{
+						"framework": "redis", "op": strings.ToLower(op.verb), "keyspace": label,
+					},
+				})
+			}
+		}
+		out = append(out, ent)
 	}
 
-	// 3. Pub/Sub
+	// 3. Pub/Sub (with channel topology)
+	keyedPubSub := keyedRedisOps(source, rdPubSubKeyRe)
 	for _, idx := range allMatchesIndex(rdPubSubRe, source) {
 		line := lineOf(source, idx[0])
 		seen := getSeen("pubsub")
@@ -92,12 +271,31 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			continue
 		}
 		seen[line] = true
-		out = append(out, entity(fmt.Sprintf("redis_pubsub:%s:%d", file.Path, line),
-			"SCOPE.Operation", "pubsub", file.Path, line,
-			map[string]string{"framework": "redis", "pattern_type": "pubsub", "language": "python"}))
+		props := map[string]string{"framework": "redis", "pattern_type": "pubsub", "language": "python"}
+		ent := entity(fmt.Sprintf("redis_pubsub:%s:%d", file.Path, line),
+			"SCOPE.Operation", "pubsub", file.Path, line, props)
+		if op, ok := keyedPubSub[line]; ok {
+			label := applyChannelProps(props, op.access)
+			if label != "" {
+				keyType := "channel"
+				if op.access.keyPrefix != "" {
+					keyType = "channel_prefix"
+				}
+				ref := emitKeyspace(label, keyType, line)
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID: ref,
+					Kind: pubsubEdgeKind(op.verb),
+					Properties: map[string]string{
+						"framework": "redis", "op": strings.ToLower(op.verb), "channel": label,
+					},
+				})
+			}
+		}
+		out = append(out, ent)
 	}
 
-	// 4. Streams
+	// 4. Streams (with stream topology)
+	keyedStream := keyedRedisOps(source, rdStreamKeyRe)
 	for _, idx := range allMatchesIndex(rdStreamRe, source) {
 		line := lineOf(source, idx[0])
 		seen := getSeen("stream")
@@ -105,9 +303,27 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			continue
 		}
 		seen[line] = true
-		out = append(out, entity(fmt.Sprintf("redis_stream:%s:%d", file.Path, line),
-			"SCOPE.Operation", "stream_op", file.Path, line,
-			map[string]string{"framework": "redis", "pattern_type": "stream_op", "language": "python"}))
+		props := map[string]string{"framework": "redis", "pattern_type": "stream_op", "language": "python"}
+		ent := entity(fmt.Sprintf("redis_stream:%s:%d", file.Path, line),
+			"SCOPE.Operation", "stream_op", file.Path, line, props)
+		if op, ok := keyedStream[line]; ok {
+			label := applyStreamProps(props, op.access)
+			if label != "" {
+				keyType := "stream"
+				if op.access.keyPrefix != "" {
+					keyType = "stream_prefix"
+				}
+				ref := emitKeyspace(label, keyType, line)
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID: ref,
+					Kind: streamEdgeKind(op.verb),
+					Properties: map[string]string{
+						"framework": "redis", "op": strings.ToLower(op.verb), "stream": label,
+					},
+				})
+			}
+		}
+		out = append(out, ent)
 	}
 
 	// 5. Lua scripts
@@ -138,4 +354,90 @@ func (e *RedisExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// keyedOp pairs a resolved key access with its command verb, keyed by line.
+type keyedOp struct {
+	verb   string
+	access redisKeyAccess
+}
+
+// keyedRedisOps runs a key-capturing regex over the source and returns a
+// line -> keyedOp map (first keyed op per line wins, matching the per-line
+// dedup of the category scan).
+func keyedRedisOps(source string, re *regexp.Regexp) map[int]keyedOp {
+	res := make(map[int]keyedOp)
+	for _, m := range re.FindAllStringSubmatchIndex(source, -1) {
+		// groups: 0-1 full, 2-3 verb, 4-5 quote, 6-7 literal
+		if len(m) < 8 {
+			continue
+		}
+		line := lineOf(source, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb := source[m[2]:m[3]]
+		quote := source[m[4]:m[5]]
+		literal := ""
+		if m[6] >= 0 {
+			literal = source[m[6]:m[7]]
+		}
+		after := ""
+		if m[1] < len(source) {
+			end := m[1] + 8
+			if end > len(source) {
+				end = len(source)
+			}
+			after = source[m[1]:end]
+		}
+		access := normaliseRedisKey(quote, literal, after)
+		res[line] = keyedOp{verb: verb, access: access}
+	}
+	return res
+}
+
+// applyKeyProps writes key / key_prefix props for cache ops and returns the
+// keyspace label (concrete key or glob), or "" when fully dynamic.
+func applyKeyProps(props map[string]string, a redisKeyAccess) string {
+	switch {
+	case a.key != "":
+		props["key"] = a.key
+		return a.key
+	case a.keyPrefix != "":
+		props["key_prefix"] = a.keyPrefix
+		return a.keyPrefix
+	default:
+		props["key"] = "<dynamic>"
+		return ""
+	}
+}
+
+// applyChannelProps writes channel / channel_prefix props for pub/sub ops.
+func applyChannelProps(props map[string]string, a redisKeyAccess) string {
+	switch {
+	case a.key != "":
+		props["channel"] = a.key
+		return a.key
+	case a.keyPrefix != "":
+		props["channel_prefix"] = a.keyPrefix
+		return a.keyPrefix
+	default:
+		props["channel"] = "<dynamic>"
+		return ""
+	}
+}
+
+// applyStreamProps writes stream / stream_prefix props for stream ops.
+func applyStreamProps(props map[string]string, a redisKeyAccess) string {
+	switch {
+	case a.key != "":
+		props["stream"] = a.key
+		return a.key
+	case a.keyPrefix != "":
+		props["stream_prefix"] = a.keyPrefix
+		return a.keyPrefix
+	default:
+		props["stream"] = "<dynamic>"
+		return ""
+	}
 }


### PR DESCRIPTION
Closes #3643 (epic #3625 datastore audit).

## What changed
`python_redis` previously detected operation *categories* (GET/SET/PUBLISH/XADD/…) and emitted `SCOPE.Operation` with **no key name** — the crown-jewel data-access detail was missing. This ports the JS driver-layer pattern (`scanJSRedis` in `internal/engine/orm_queries_jsts_drivers.go`) to Python so each Redis call records the actual key / channel / stream it touches.

## Key topology now emitted (FULL)
For each keyed op we emit a `SCOPE.Datastore` keyspace target node (one per distinct keyspace, deduplicated) plus an access edge from the operation to it:

| Source | Captured | Edge |
|---|---|---|
| `r.get("session:abc")` | key `session:abc` | `READS_FROM` |
| `r.set("user:42", v)` | key `user:42` | `WRITES_TO` |
| `r.set("user:" + id, v)` | key_prefix `user:*` | `WRITES_TO` |
| `r.get(f"session:{sid}")` | key_prefix `session:*` | `READS_FROM` |
| `r.publish("events", m)` | channel `events` | `PUBLISHES_TO` |
| `pubsub.subscribe("notifications")` | channel `notifications` | `SUBSCRIBES_TO` |
| `r.xadd("orders", …)` | stream `orders` | `WRITES_TO` |

Target ToID is `Datastore:redis:<keyspace>` so multiple call-sites touching the same key converge on one node.

## Honest-partial
A fully-dynamic key (`r.get(k)`, or an f-string with no static head like `f"{tenant}:cfg"`) emits the operation with **no key and no fabricated edge/keyspace** — same as before for the unresolvable case.

## Matches the JS driver shape
Same read/write/pub/sub edge semantics and prefix-glob convention as `scanJSRedis` (key prefix → `prefix*`), keeping the data-access graph traversable and **cross-language consistent**. This is the template for the csharp / php / ruby / rust redis extractors next (they're currently `partial` on `query_attribution`).

## Records
Re-stamped `lang.python.driver.redis` `query_attribution` → `full`, now citing `internal/custom/python/redis.go` (real key extraction). This reverses the #3635 downgrade for python redis specifically, now that it's genuine key topology rather than category-only detection.

## Tests (value-asserting)
New tests assert the **specific** key/channel/stream and edge direction — e.g. `r.get("session:abc")` → READS_FROM `Datastore:redis:session:abc`; `r.set("user:"+id,…)` → key_prefix `user:*`; `r.publish("events",…)` → channel `events` PUBLISHES_TO. Negative: fully-dynamic key emits op with no key/edge/keyspace. Keyspace dedup covered. Not `len>0` assertions.

## Verification
- `go test ./internal/custom/python/... ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `go vet` clean, `gofmt -l` empty
- `coverage validate` 0 errors, `coverage fmt --check` canonical, docs regenerated

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)