### PR TITLE
feat(go): gqlgen GraphQL server operation-endpoint extraction (#3613)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 212 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 14 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
+**Total**: 213 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 14 · **go**: 18 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -57,6 +57,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # go
 
-**Frameworks**: 17 · **Tools**: 8 · **ORMs**: 17 · **Other**: 0
+**Frameworks**: 18 · **Tools**: 8 · **ORMs**: 17 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -40,6 +40,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🔴 0/7 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.gqlgen` — gqlgen (GraphQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml` | Resolver method on generated *queryResolver/*mutationResolver/*subscriptionResolver -> http:GRAPHQL:/graphql/<Root>/<field>; source_handler=SCOPE.Operation:<receiver>.<Method> rebinds to a HANDLES edge. |
+| Route extraction | 🟢 `partial` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml`<br>`internal/extractors/graphql/graphql.go` | Operation endpoints synthesised from Go resolver receivers; SDL schema types parsed by the shared graphql extractor. Field-name mapping is gqlgen default lowerCamel and does not yet read gqlgen.yml overrides or @goField directives. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3613 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3613 | — | — |
+| Request validation | 🔴 `missing` | — | 3613 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3613 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3613 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3613 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3613 | — | — |
+| Type extraction | 🔴 `missing` | — | 3613 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3613 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3613 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3613 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3613 | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | 3613 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3613 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3613 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3613 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3613 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3613 | — | — |
+| Fs effect | 🔴 `missing` | — | 3613 | — | — |
+| HTTP effect | 🔴 `missing` | — | 3613 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 3613 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3613 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3613 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3613 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3613 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3613 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3613 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3613 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3613 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3613 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3613 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3613 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3613 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.gqlgen ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15830,6 +15830,185 @@
       }
     },
     {
+      "id": "lang.go.framework.gqlgen",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "go",
+      "label": "gqlgen (GraphQL)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/gqlgen_go.yaml"],
+            "issue": "3613",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/gqlgen_go.yaml"],
+            "issue": "3613",
+            "notes": "Resolver method on generated *queryResolver/*mutationResolver/*subscriptionResolver -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e; source_handler=SCOPE.Operation:\u003creceiver\u003e.\u003cMethod\u003e rebinds to a HANDLES edge.",
+            "verified_at": "2026-06-02"
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/gqlgen_go.yaml","internal/extractors/graphql/graphql.go"],
+            "issue": "3613",
+            "notes": "Operation endpoints synthesised from Go resolver receivers; SDL schema types parsed by the shared graphql extractor. Field-name mapping is gqlgen default lowerCamel and does not yet read gqlgen.yml overrides or @goField directives.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3613"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3613"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.go.framework.hertz",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 212 · **ORMs**: 152 · **Tools**: 110 · **Other**: 125
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 213 · **ORMs**: 152 · **Tools**: 110 · **Other**: 125
 
 ## Coverage by language
 
@@ -11,7 +11,7 @@
 | [python](by-language/python.md) | 21 | 15 | 17 | 6 |
 | [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 4 |
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
-| [go](by-language/go.md) | 17 | 8 | 17 | 0 |
+| [go](by-language/go.md) | 18 | 8 | 17 | 0 |
 | [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
 | [php](by-language/php.md) | 15 | 6 | 14 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 212 frameworks · 110 tools · 152 ORMs · 125 other
+Total: 213 frameworks · 110 tools · 152 ORMs · 125 other

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -722,6 +722,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeGorillaMux(string(content), emitDef)
 		synthesizeNetHTTPStdlib(string(content), emitDef)
 		synthesizeHuma(string(content), emitDef)
+		// Producer side (#3613): gqlgen GraphQL server. Maps Go resolver
+		// methods on the generated *queryResolver/*mutationResolver/
+		// *subscriptionResolver receivers to the canonical
+		// http:GRAPHQL:/graphql/<Root>/<field> operation-endpoint shape shared
+		// with the JS/TS GraphQL server (synthesizeGraphQLResolvers) and the
+		// Python Strawberry server — so GraphQL client links (#3667) and the
+		// cross-repo linker join to them. Gated on a gqlgen file-signal so it
+		// no-ops on every other Go file.
+		synthesizeGqlgen(string(content), emitDef)
 		// Consumer side (#721 wave 2a): net/http, resty, fasthttp.
 		synthesizeGoClientWithRuntime(string(content), emitClientRuntime)
 	case "kotlin":
@@ -3182,6 +3191,139 @@ func synthesizeStrawberry(content string, emit emitDefFn) {
 			handlerRef := rootType + "." + methodName
 			emit("GRAPHQL", canonical, "strawberry-graphql", "SCOPE.Operation", handlerRef, defLine)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gqlgen (Go) — #3613 (epic #3607)
+// ---------------------------------------------------------------------------
+//
+// gqlgen is the dominant schema-first GraphQL server for Go
+// (github.com/99designs/gqlgen). The SDL schema (`type Query { users: [User!]! }`,
+// in `*.graphqls`) is compiled to a generated `Resolver` root whose root-type
+// fields are implemented by user-edited Go methods on the generated receiver
+// types `*queryResolver`, `*mutationResolver`, and `*subscriptionResolver`
+// (canonically in `graph/schema.resolvers.go`):
+//
+//	func (r *queryResolver) Users(ctx context.Context) ([]*model.User, error) { ... }
+//	func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) (*model.User, error) { ... }
+//	func (r *subscriptionResolver) UserAdded(ctx context.Context) (<-chan *model.User, error) { ... }
+//
+// gqlgen derives the GraphQL field name from the resolver method by lower-casing
+// the leading run of the exported Go method name (Go's `Users` ↔ schema field
+// `users`, `CreateUser` ↔ `createUser`, `URL` ↔ `url`). We map each resolver
+// method to the SAME operation-endpoint shape emitted by the JS/TS GraphQL
+// server (synthesizeGraphQLResolvers) and the Python Strawberry server:
+//
+//	http:GRAPHQL:/graphql/<RootType>/<field>
+//
+// where RootType is Query / Mutation / Subscription. Emitting the identical id
+// shape is what lets the GraphQL client-link synthesizer (#3667) and the
+// cross-repo linker join Go GraphQL servers to their consumers.
+//
+// Handler attribution: the resolver method is the handler, referenced as
+// `SCOPE.Operation:<receiverType>.<Method>` (e.g.
+// `SCOPE.Operation:queryResolver.Users`). The Phase-2 resolver rebinds this
+// `source_handler` ref into a HANDLES edge to the Go method symbol.
+//
+// Detection is gated on a gqlgen file-signal (a `github.com/99designs/gqlgen`
+// import or one of the generated receiver types) so the synthesizer is a no-op
+// on every other Go file.
+
+// gqlgenResolverMethodRe matches a Go method declared on one of gqlgen's
+// generated root resolver receiver types, capturing the receiver type and the
+// exported method name.
+//
+// Capture groups:
+//
+//	1 = receiver type (queryResolver | mutationResolver | subscriptionResolver)
+//	2 = method (exported field implementation, e.g. Users / CreateUser)
+var gqlgenResolverMethodRe = regexp.MustCompile(
+	`(?m)^func\s*\(\s*\w+\s+\*?(queryResolver|mutationResolver|subscriptionResolver)\s*\)\s+([A-Z]\w*)\s*\(`,
+)
+
+// gqlgenReceiverToRoot maps a gqlgen generated receiver type to its GraphQL
+// root operation type.
+var gqlgenReceiverToRoot = map[string]string{
+	"queryResolver":        "Query",
+	"mutationResolver":     "Mutation",
+	"subscriptionResolver": "Subscription",
+}
+
+// gqlgenFieldName lower-cases the leading run of capitals of an exported Go
+// method name to recover the GraphQL field name, matching gqlgen's default
+// name-mapping (`Users` → `users`, `CreateUser` → `createUser`, `URL` → `url`,
+// `ID` → `id`). A single leading capital lower-cases just that letter; a run of
+// N>1 capitals lower-cases all but the last when the last is followed by a
+// lowercase (Go's standard initialism handling), otherwise the whole run.
+func gqlgenFieldName(method string) string {
+	if method == "" {
+		return method
+	}
+	r := []rune(method)
+	// Count the leading run of upper-case letters.
+	n := 0
+	for n < len(r) && r[n] >= 'A' && r[n] <= 'Z' {
+		n++
+	}
+	if n <= 1 {
+		// Simple case: lower-case the single leading capital.
+		r[0] = r[0] - 'A' + 'a'
+		return string(r)
+	}
+	// Initialism run (e.g. URL, ID). If the run is the whole identifier
+	// (URL → url) lower-case all of it; otherwise the final capital starts
+	// the next word (HTTPServer → httpServer) so keep it upper.
+	end := n
+	if n < len(r) {
+		end = n - 1
+	}
+	for i := 0; i < end; i++ {
+		r[i] = r[i] - 'A' + 'a'
+	}
+	return string(r)
+}
+
+func synthesizeGqlgen(content string, emit emitDefFn) {
+	// File-signal gate: require a gqlgen marker so this no-ops on every other
+	// Go file. The generated receiver types are gqlgen-specific; the import is
+	// the canonical project signal.
+	if !strings.Contains(content, "github.com/99designs/gqlgen") &&
+		!strings.Contains(content, "queryResolver") &&
+		!strings.Contains(content, "mutationResolver") &&
+		!strings.Contains(content, "subscriptionResolver") {
+		return
+	}
+
+	seen := map[string]bool{}
+	for _, m := range gqlgenResolverMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		receiver := content[m[2]:m[3]]
+		method := content[m[4]:m[5]]
+		root, ok := gqlgenReceiverToRoot[receiver]
+		if !ok {
+			continue
+		}
+		field := gqlgenFieldName(method)
+		if field == "" {
+			continue
+		}
+		dedupKey := root + "." + field
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+
+		defLine := lineOfOffset(content, m[0])
+		path := "/graphql/" + root + "/" + field
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGqlgen, path)
+		// Handler ref points at the resolver method symbol. The Phase-2
+		// resolver rebinds `SCOPE.Operation:<receiver>.<Method>` into a HANDLES
+		// edge against the extracted Go method entity.
+		handlerRef := receiver + "." + method
+		emit("GRAPHQL", canonical, "gqlgen", "SCOPE.Operation", handlerRef, defLine)
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go
+++ b/internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestSynth_Gqlgen_Query covers a gqlgen schema.resolvers.go Query resolver.
+// Asserts the EXACT operation-endpoint shape shared with the JS/TS GraphQL
+// server (synthesizeGraphQLResolvers) and the Python Strawberry server, plus
+// the framework label and the resolver-method handler attribution that the
+// Phase-2 resolver rebinds into a HANDLES edge. #3613.
+func TestSynth_Gqlgen_Query(t *testing.T) {
+	src := `package graph
+
+import "context"
+
+// github.com/99designs/gqlgen generated resolver glue.
+
+func (r *queryResolver) Users(ctx context.Context) ([]*User, error) {
+	return nil, nil
+}
+
+func (r *queryResolver) User(ctx context.Context, id string) (*User, error) {
+	return nil, nil
+}
+`
+	got, res := runDetect(t, "go", "graph/schema.resolvers.go", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Query/user",
+	}
+	requireContains(t, got, want, "gqlgen Query")
+
+	// EXACT shape + framework + handler attribution → HANDLES edge.
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/users")
+	if e == nil {
+		t.Fatalf("gqlgen Query: missing http:GRAPHQL:/graphql/Query/users")
+	}
+	if e.Properties["framework"] != "gqlgen" {
+		t.Errorf("gqlgen Query: framework = %q, want gqlgen", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:queryResolver.Users" {
+		t.Errorf("gqlgen Query: source_handler = %q, want SCOPE.Operation:queryResolver.Users",
+			e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("gqlgen Query: StartLine not stamped on Users resolver")
+	}
+}
+
+// TestSynth_Gqlgen_Mutation covers a gqlgen Mutation resolver and asserts the
+// CreateUser → createUser field-name mapping (gqlgen lower-cases the leading
+// capital). #3613.
+func TestSynth_Gqlgen_Mutation(t *testing.T) {
+	src := `package graph
+
+import "context"
+
+func (r *mutationResolver) CreateUser(ctx context.Context, input NewUser) (*User, error) {
+	return nil, nil
+}
+
+func (r *mutationResolver) DeleteUser(ctx context.Context, id string) (bool, error) {
+	return true, nil
+}
+`
+	got, res := runDetect(t, "go", "graph/schema.resolvers.go", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+		"http:GRAPHQL:/graphql/Mutation/deleteUser",
+	}
+	requireContains(t, got, want, "gqlgen Mutation")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Mutation/createUser")
+	if e == nil {
+		t.Fatalf("gqlgen Mutation: missing http:GRAPHQL:/graphql/Mutation/createUser")
+	}
+	if e.Properties["framework"] != "gqlgen" {
+		t.Errorf("gqlgen Mutation: framework = %q, want gqlgen", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:mutationResolver.CreateUser" {
+		t.Errorf("gqlgen Mutation: source_handler = %q, want SCOPE.Operation:mutationResolver.CreateUser",
+			e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Gqlgen_Subscription covers a gqlgen Subscription resolver returning
+// a channel. #3613.
+func TestSynth_Gqlgen_Subscription(t *testing.T) {
+	src := `package graph
+
+import "context"
+
+func (r *subscriptionResolver) UserAdded(ctx context.Context) (<-chan *User, error) {
+	return nil, nil
+}
+`
+	got, res := runDetect(t, "go", "graph/schema.resolvers.go", src)
+	want := []string{"http:GRAPHQL:/graphql/Subscription/userAdded"}
+	requireContains(t, got, want, "gqlgen Subscription")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Subscription/userAdded")
+	if e == nil {
+		t.Fatalf("gqlgen Subscription: missing http:GRAPHQL:/graphql/Subscription/userAdded")
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:subscriptionResolver.UserAdded" {
+		t.Errorf("gqlgen Subscription: source_handler = %q, want SCOPE.Operation:subscriptionResolver.UserAdded",
+			e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Gqlgen_InitialismFieldName asserts gqlgen's initialism name-mapping:
+// a leading run of capitals where the last begins a new word keeps that capital
+// (HTTPServer → httpServer), and an all-caps identifier lower-cases fully
+// (URL → url). #3613.
+func TestSynth_Gqlgen_InitialismFieldName(t *testing.T) {
+	src := `package graph
+
+import "context"
+
+func (r *queryResolver) HTTPServer(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (r *queryResolver) URL(ctx context.Context) (string, error) {
+	return "", nil
+}
+`
+	got, _ := runDetect(t, "go", "graph/schema.resolvers.go", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/httpServer",
+		"http:GRAPHQL:/graphql/Query/url",
+	}
+	requireContains(t, got, want, "gqlgen initialism field name")
+}
+
+// TestSynth_Gqlgen_NoOpOnPlainGo asserts the gqlgen synthesizer does not fire on
+// a plain net/http Go file (no gqlgen signal). #3613.
+func TestSynth_Gqlgen_NoOpOnPlainGo(t *testing.T) {
+	src := `package main
+
+import "net/http"
+
+func main() {
+	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {})
+	http.ListenAndServe(":8080", nil)
+}
+`
+	_, res := runDetect(t, "go", "main.go", src)
+	for _, ent := range res.Entities {
+		if ent.Properties["framework"] == "gqlgen" {
+			t.Errorf("gqlgen synthesizer fired on plain Go file, emitted: %s", ent.ID)
+		}
+	}
+}
+
+// TestSynth_Gqlgen_IgnoresFieldResolvers asserts that resolver methods on
+// per-type field-resolver receivers (e.g. *userResolver) are NOT mapped to root
+// operation endpoints — only the three GraphQL root types are operations. #3613.
+func TestSynth_Gqlgen_IgnoresFieldResolvers(t *testing.T) {
+	src := `package graph
+
+import "context"
+
+// Field resolver for User.friends — NOT a root operation.
+func (r *userResolver) Friends(ctx context.Context, obj *User) ([]*User, error) {
+	return nil, nil
+}
+
+func (r *queryResolver) Users(ctx context.Context) ([]*User, error) {
+	return nil, nil
+}
+`
+	got, _ := runDetect(t, "go", "graph/schema.resolvers.go", src)
+	for _, id := range got {
+		if id == "http:GRAPHQL:/graphql/Query/friends" ||
+			id == "http:GRAPHQL:/graphql/User/friends" {
+			t.Errorf("gqlgen: field resolver should not be emitted as a root operation, got %q", id)
+		}
+	}
+	requireContains(t, got, []string{"http:GRAPHQL:/graphql/Query/users"}, "gqlgen field-resolver skip")
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -154,6 +154,13 @@ const (
 	// normalised by canonicalizeColonParams (a literal nginx path has no `:`
 	// segments, so it passes through unchanged save for slash normalisation).
 	FrameworkOpenResty = "openresty"
+	// FrameworkGqlgen (#3613) — gqlgen is the dominant schema-first GraphQL
+	// server for Go. Operation endpoints are synthesised as the canonical
+	// `/graphql/<RootType>/<field>` path shared with the JS/TS GraphQL server
+	// (synthesizeGraphQLResolvers) and the Python Strawberry server. The path
+	// carries no framework-specific parameter syntax, so canonicalisation is
+	// identity + slash normalisation (default case).
+	FrameworkGqlgen = "gqlgen"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical


### PR DESCRIPTION
## Summary

gqlgen is the dominant schema-first GraphQL server for Go and previously had **zero** extraction (only a detection YAML). This adds `synthesizeGqlgen` to the Go branch of the HTTP-endpoint synthesizer.

Each user-edited resolver method on gqlgen's generated `*queryResolver` / `*mutationResolver` / `*subscriptionResolver` receivers is mapped to the canonical operation-endpoint shape:

```
http:GRAPHQL:/graphql/<RootType>/<field>
```

### Endpoint-shape parity (the load-bearing requirement)

This is the **EXACT** id shape emitted by:
- the JS/TS GraphQL server — `synthesizeGraphQLResolvers` (`/graphql/<Root>/<field>`)
- the Python Strawberry server — `synthesizeStrawberry`
- the GraphQL **client**-link synthesizer (#3667), whose tests already assert `http:GRAPHQL:/graphql/Mutation/createUser` etc.

Because the Go server now emits the identical id, the GraphQL client links (#3667) and the cross-repo linker join Go GraphQL servers to their consumers.

The GraphQL field name is recovered from the Go method name via gqlgen's default lowerCamel/initialism mapping: `Users → users`, `CreateUser → createUser`, `URL → url`, `HTTPServer → httpServer`.

### Asserted endpoint + resolver edge

For `func (r *queryResolver) Users(ctx context.Context) ([]*User, error)`:
- endpoint id: **`http:GRAPHQL:/graphql/Query/users`**
- framework: `gqlgen`
- `source_handler` = **`SCOPE.Operation:queryResolver.Users`** → the Phase-2 resolver rebinds this into a **HANDLES** edge to the resolver method symbol.

### Scope / honesty
- File-signal gated on the `github.com/99designs/gqlgen` import or one of the generated receiver types — no-op on every other Go file.
- Per-type field resolvers (e.g. `*userResolver`) are intentionally NOT emitted as root operations.
- Field-name mapping is the gqlgen default; `gqlgen.yml` field overrides / `@goField` directives are not yet read — tracked as `route_extraction: partial`.

### Tests (value-asserting, not `len>0`)
Query / Mutation / Subscription exact-id + framework + handler-ref assertions, initialism field-name mapping, plain-Go no-op, and field-resolver skip. Targeted suites green; `coverage validate` 0 errors; `fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

### Coverage
Adds `lang.go.framework.gqlgen`: Routing `endpoint_synthesis` + `handler_attribution` **full**, `route_extraction` **partial**. Remaining lanes honestly backfilled as gaps tracking #3613.

Closes #3613 (epic #3607).

**DEPLOY-DEFERRED** — no daemon rebuild/reindex performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)