### PR TITLE
feat(neo4j): GRAPH_RELATES topology for neomodel (py) + neogma (jsts)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -23687,38 +23687,41 @@
       "category": "orm",
       "subcategory": "orm_mapper",
       "language": "jsts",
-      "label": "neo4j-driver (JS)",
+      "label": "neo4j-driver (JS) / neogma OGM",
       "capabilities": {
         "Models": {
           "model_extraction": {
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "issue": "3069",
-            "notes": "Raw driver binding executes SQL/query strings directly; no ORM model layer, no schema declarations, no associations, no FK definitions, no lazy-loading. N/A per issue #3069."
+            "status": "partial",
+            "cites": ["internal/custom/javascript/neogma.go","internal/custom/javascript/neogma_test.go"],
+            "issue": "3610",
+            "notes": "neogma OGM (not just the raw driver): each ModelFactory({ label, schema, relationships }) call is extracted as a SCOPE.Schema/node keyed on its Neo4j `label`. Regex over the balanced config object; partial (schema field types not individually emitted).",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "not_applicable",
-            "issue": "3069",
-            "notes": "Raw driver binding executes SQL/query strings directly; no ORM model layer, no schema declarations, no associations, no FK definitions, no lazy-loading. N/A per issue #3069."
+            "status": "partial",
+            "cites": ["internal/custom/javascript/neogma.go"],
+            "issue": "3610",
+            "notes": "neogma relationships.\u003ckey\u003e entries are extracted as SCOPE.Component/relationship entities carrying relation_type, direction, and target_model/target_node."
           },
           "foreign_key_extraction": {
             "status": "not_applicable",
-            "issue": "3069",
-            "notes": "Raw driver binding executes SQL/query strings directly; no ORM model layer, no schema declarations, no associations, no FK definitions, no lazy-loading. N/A per issue #3069."
+            "notes": "graph DB — no foreign-key concept"
           },
           "lazy_loading_recognition": {
             "status": "not_applicable",
-            "issue": "3069",
-            "notes": "Raw driver binding executes SQL/query strings directly; no ORM model layer, no schema declarations, no associations, no FK definitions, no lazy-loading. N/A per issue #3069."
+            "notes": "graph DB — no lazy-loading concept"
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "issue": "3069",
-            "notes": "Raw driver binding executes SQL/query strings directly; no ORM model layer, no schema declarations, no associations, no FK definitions, no lazy-loading. N/A per issue #3069."
+            "status": "full",
+            "cites": ["internal/custom/javascript/neogma.go","internal/custom/javascript/neogma_test.go"],
+            "issue": "3610",
+            "notes": "neogma ModelFactory relationships ({ model: Target, name: 'REL_TYPE', direction: 'out'|'in' }) are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-node -\u003e target-node (mirrors the Java SDN template #3663 / JOINS_COLLECTION for graph DBs); the domain graph topology is a navigable subgraph rather than opaque string props. Full for same-file ModelFactory `model:` bindings (value-asserting test TestNeogmaGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; direction 'in' -\u003e INCOMING). Cross-file model references are honest-partial (kept as target_model props only). Reverses the #3635 datastore-pass downgrade for this OGM.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {
@@ -40420,33 +40423,41 @@
       "category": "orm",
       "subcategory": "orm_mapper",
       "language": "python",
-      "label": "neo4j (Python driver)",
+      "label": "neo4j (Python driver) / neomodel OGM",
       "capabilities": {
         "Models": {
           "model_extraction": {
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "notes": "NoSQL driver — no relational schema model"
+            "status": "partial",
+            "cites": ["internal/custom/python/neo4j_neomodel.go","internal/custom/python/neo4j_neomodel_test.go"],
+            "issue": "3609",
+            "notes": "neomodel OGM (not just the raw driver): each StructuredNode subclass is extracted as a SCOPE.Schema/node (the graph node label) and each *Property() attribute as a SCOPE.Schema/property. Regex over class bodies; partial (no inheritance/mixin StructuredNode resolution).",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship model"
+            "status": "partial",
+            "cites": ["internal/custom/python/neo4j_neomodel.go"],
+            "issue": "3609",
+            "notes": "neomodel RelationshipTo/RelationshipFrom attributes are extracted as SCOPE.Component/relationship entities carrying relation_type, direction, and target_node."
           },
           "foreign_key_extraction": {
             "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship model"
+            "notes": "graph DB — no foreign-key concept"
           },
           "lazy_loading_recognition": {
             "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship model"
+            "notes": "graph DB — no lazy-loading concept"
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship model"
+            "status": "full",
+            "cites": ["internal/custom/python/neo4j_neomodel.go","internal/custom/python/neo4j_neomodel_test.go"],
+            "issue": "3609",
+            "notes": "neomodel RelationshipTo/RelationshipFrom('Target','REL_TYPE') fields are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-node -\u003e target-node (mirrors the Java SDN template #3663 / JOINS_COLLECTION for graph DBs); the domain graph topology is a navigable subgraph rather than opaque string props. Full for same-file StructuredNode targets (value-asserting test TestNeomodelGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; RelationshipFrom -\u003e INCOMING). Cross-file target labels are honest-partial (kept as target_node props only). Reverses the #3635 datastore-pass downgrade for this OGM.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {

--- a/internal/custom/javascript/neogma.go
+++ b/internal/custom/javascript/neogma.go
@@ -1,0 +1,281 @@
+package javascript
+
+// neogma.go — custom extractor for neogma (Neo4j JS/TS OGM) graph schema
+// mappings.
+//
+// neogma maps JS/TS model objects to Neo4j graph nodes and relationships via
+// ModelFactory:
+//
+//	import { ModelFactory } from 'neogma';
+//
+//	const Person = ModelFactory({
+//	  label: 'Person',
+//	  schema: { name: { type: 'string', required: true } },
+//	  relationships: {
+//	    actedIn: { model: Movie, name: 'ACTED_IN', direction: 'out' },
+//	  },
+//	}, neogma);
+//
+//	const Movie = ModelFactory({ label: 'Movie', schema: { ... } }, neogma);
+//
+// Each ModelFactory(...) call is a graph "node" (the analogue of a SQL table)
+// whose label comes from `label:`; the `relationships:` block declares typed,
+// directed edges to other node models.
+//
+// Extracted entities
+// ------------------
+//	SCOPE.Schema / node          — one per ModelFactory call (label = node label)
+//	SCOPE.Component / relationship — one per relationships.<key> entry
+//
+// GRAPH_RELATES topology (#3610, epic #3606)
+// ------------------------------------------
+// Mirroring the Java Spring-Data-Neo4j template (#3663), every relationship
+// whose `model:` reference resolves to a same-file ModelFactory binding also
+// emits a traversable GRAPH_RELATES edge hanging off the owner node entity:
+//
+//	Person ──GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)──▶ Class:Movie
+//
+// direction 'out' → OUTGOING, 'in' → INCOMING, 'none'/absent → preserved as-is
+// (defaulting OUTGOING). The ToID uses the "Class:<Label>" convention so the
+// intra-repo resolver's byName index links it to the target node entity (same
+// convention as the Java SDN / neomodel templates). Cross-file `model:`
+// targets are honest-partial: no edge is emitted; topology stays as the
+// `target_model` prop on the relationship Component.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_neogma", &neogmaExtractor{})
+}
+
+type neogmaExtractor struct{}
+
+func (e *neogmaExtractor) Language() string { return "custom_js_neogma" }
+
+var (
+	// Gate: the file must reference neogma / ModelFactory.
+	neogmaMarkerRe = regexp.MustCompile(`\bneogma\b|\bModelFactory\b`)
+
+	// const Person = ModelFactory({ ... }, neogma)
+	// Captures group 1 = binding variable (the model handle other models
+	// reference via `model:`).
+	neogmaModelAssignRe = regexp.MustCompile(
+		`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?=\s*ModelFactory\s*\(`)
+
+	// label: 'Person'  (within a ModelFactory config object)
+	neogmaLabelRe = regexp.MustCompile(`\blabel\s*:\s*['"]([A-Za-z_][\w]*)['"]`)
+
+	// A relationships.<key> entry. Captures:
+	//   group1 relationship key (field name)
+	//   group2 target model binding (the `model:` reference)
+	//   group3 rel name literal (the `name:`)
+	//   group4 direction literal (the `direction:`), optional
+	// model / name / direction may appear in any order; we capture name &
+	// direction independently below to stay order-tolerant, but the common
+	// canonical order is matched here for the model+name pairing.
+	neogmaRelKeyRe = regexp.MustCompile(
+		`([A-Za-z_$][\w$]*)\s*:\s*\{([^{}]*)\}`)
+
+	neogmaRelModelRe = regexp.MustCompile(`\bmodel\s*:\s*([A-Za-z_$][\w$]*)`)
+	neogmaRelNameRe  = regexp.MustCompile(`\bname\s*:\s*['"]([^'"]+)['"]`)
+	neogmaRelDirRe   = regexp.MustCompile(`\bdirection\s*:\s*['"](out|in|none)['"]`)
+
+	// relationships: { ... } block locator (to scope rel-key scanning).
+	neogmaRelBlockRe = regexp.MustCompile(`\brelationships\s*:\s*\{`)
+)
+
+// matchedBrace returns the body between the brace at openIdx (which must point
+// at '{') and its matching close brace, plus the index just past the close.
+func matchedBrace(s string, openIdx int) (string, int) {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '{' {
+		return "", openIdx
+	}
+	depth := 0
+	for i := openIdx; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[openIdx+1 : i], i + 1
+			}
+		}
+	}
+	return s[openIdx+1:], len(s)
+}
+
+func (e *neogmaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.neogma_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neogma"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+	if !neogmaMarkerRe.MatchString(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) int {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return -1
+		}
+		seen[key] = true
+		out = append(out, ent)
+		return len(out) - 1
+	}
+
+	// --- ModelFactory node models (the graph "nodes") ---
+	type modelInfo struct {
+		binding string // the const variable (referenced by `model:`)
+		label   string // the Neo4j node label
+		body    string // the ModelFactory config object body
+		idx     int    // index into out of the node entity
+	}
+	var models []modelInfo
+	// bindingToLabel resolves a `model:` reference (a binding variable) to the
+	// target node label so GRAPH_RELATES ToID uses the label, not the var.
+	bindingToLabel := make(map[string]string)
+
+	for _, m := range neogmaModelAssignRe.FindAllStringSubmatchIndex(src, -1) {
+		binding := src[m[2]:m[3]]
+		// The config object starts at the '(' just past the match; find the
+		// first '{' after the ModelFactory( and read the balanced object body.
+		callOpen := m[1] - 1 // index of the '(' captured by the regex tail
+		braceOpen := strings.IndexByte(src[callOpen:], '{')
+		if braceOpen < 0 {
+			continue
+		}
+		braceOpen += callOpen
+		body, _ := matchedBrace(src, braceOpen)
+
+		label := binding
+		if lm := neogmaLabelRe.FindStringSubmatch(body); lm != nil {
+			label = lm[1]
+		}
+		ent := makeEntity(label, "SCOPE.Schema", "node", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "neogma",
+			"node_label", label,
+			"binding", binding,
+			"provenance", "INFERRED_FROM_NEO4J_NEOGMA_NODE")
+		idx := add(ent)
+		if idx >= 0 {
+			models = append(models, modelInfo{binding: binding, label: label, body: body, idx: idx})
+			bindingToLabel[binding] = label
+		}
+	}
+
+	// --- relationships within each ModelFactory ---
+	for _, owner := range models {
+		// Locate the relationships: { ... } block within this model's body.
+		bm := neogmaRelBlockRe.FindStringIndex(owner.body)
+		if bm == nil {
+			continue
+		}
+		braceOpen := strings.IndexByte(owner.body[bm[1]-1:], '{')
+		if braceOpen < 0 {
+			continue
+		}
+		braceOpen += bm[1] - 1
+		relsBody, _ := matchedBrace(owner.body, braceOpen)
+
+		for _, km := range neogmaRelKeyRe.FindAllStringSubmatch(relsBody, -1) {
+			fieldName := km[1]
+			cfg := km[2]
+
+			targetBinding := ""
+			if mm := neogmaRelModelRe.FindStringSubmatch(cfg); mm != nil {
+				targetBinding = mm[1]
+			}
+			relType := ""
+			if nm := neogmaRelNameRe.FindStringSubmatch(cfg); nm != nil {
+				relType = nm[1]
+			}
+			direction := "OUTGOING"
+			if dm := neogmaRelDirRe.FindStringSubmatch(cfg); dm != nil {
+				switch dm[1] {
+				case "in":
+					direction = "INCOMING"
+				case "none":
+					direction = "NONE"
+				default:
+					direction = "OUTGOING"
+				}
+			}
+			// A relationship entry must carry at least a model: reference.
+			if targetBinding == "" {
+				continue
+			}
+
+			name := relType
+			if name == "" {
+				name = fieldName
+			}
+			name = owner.label + "." + name
+
+			targetLabel := bindingToLabel[targetBinding] // "" if cross-file
+			relEnt := makeEntity(name, "SCOPE.Component", "relationship", file.Path, file.Language, lineOf(src, 0))
+			props := []string{
+				"framework", "neogma",
+				"relation_type", relType,
+				"direction", direction,
+				"field_name", fieldName,
+				"owner_node", owner.label,
+				"target_model", targetBinding,
+				"provenance", "INFERRED_FROM_NEO4J_NEOGMA_RELATIONSHIP",
+			}
+			if targetLabel != "" {
+				props = append(props, "target_node", targetLabel)
+			}
+			setProps(&relEnt, props...)
+			add(relEnt)
+
+			// --- GRAPH_RELATES edge (#3610, epic #3606) ---
+			// Only when the `model:` reference resolves to a same-file
+			// ModelFactory binding — cross-file targets are honest-partial.
+			if targetLabel != "" {
+				out[owner.idx].Relationships = append(out[owner.idx].Relationships,
+					types.RelationshipRecord{
+						ToID: "Class:" + targetLabel,
+						Kind: string(types.RelationshipKindGraphRelates),
+						Properties: map[string]string{
+							"framework":  "neogma",
+							"rel_type":   relType,
+							"direction":  direction,
+							"field_name": fieldName,
+							"provenance": "INFERRED_FROM_NEO4J_NEOGMA_RELATIONSHIP",
+						},
+					})
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/javascript/neogma_test.go
+++ b/internal/custom/javascript/neogma_test.go
@@ -1,0 +1,252 @@
+package javascript_test
+
+// neogma_test.go — tests for the custom_js_neogma extractor (#3610, epic #3606).
+//
+// Covers neogma (Neo4j JS/TS OGM) ModelFactory graph-schema extraction and the
+// headline GRAPH_RELATES topology edge: an owner node model whose
+// relationships.<key>.model resolves to a same-file ModelFactory binding emits
+// a traversable owner ──GRAPH_RELATES(rel_type,direction)──▶ Class:<TargetLabel>
+// edge. Mirrors the Java SDN template (#3663).
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findNeogmaGraphRelates returns the GRAPH_RELATES edge from the node entity
+// labelled fromLabel to "Class:<toLabel>", or nil.
+func findNeogmaGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "node" && ents[i].Name == fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "Class:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func runNeogma(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_neogma")
+	if !ok {
+		t.Fatal("custom_js_neogma not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "graph.ts", Language: "typescript", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// hasNodeLabel returns true if a SCOPE.Schema/node entity named label exists.
+func hasNodeLabel(ents []types.EntityRecord, label string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "node" && e.Name == label {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// node extraction — ModelFactory label
+// ---------------------------------------------------------------------------
+
+func TestNeogmaNodeExtracted(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string', required: true } },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+	if !hasNodeLabel(ents, "Person") {
+		t.Fatalf("expected Person node entity (label), got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAPH_RELATES — the headline node→node topology edge
+// ---------------------------------------------------------------------------
+
+// TestNeogmaGraphRelatesEdge proves Person ─GRAPH_RELATES(ACTED_IN,OUTGOING)→
+// Class:Movie when relationships.actedIn.model resolves to a same-file Movie
+// ModelFactory binding.
+func TestNeogmaGraphRelatesEdge(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+
+const Movie = ModelFactory({
+  label: 'Movie',
+  schema: { title: { type: 'string' } },
+}, neogma);
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string' } },
+  relationships: {
+    actedIn: { model: Movie, name: 'ACTED_IN', direction: 'out' },
+  },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+
+	edge := findNeogmaGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Movie edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["field_name"] != "actedIn" {
+		t.Errorf("field_name: want actedIn, got %q", edge.Properties["field_name"])
+	}
+	if edge.Properties["framework"] != "neogma" {
+		t.Errorf("framework: want neogma, got %q", edge.Properties["framework"])
+	}
+
+	// direction is a property, not endpoint-swapping: no reverse edge.
+	if findNeogmaGraphRelates(ents, "Movie", "Person") != nil {
+		t.Error("did not expect a reverse Movie ─GRAPH_RELATES→ Person edge")
+	}
+}
+
+// TestNeogmaGraphRelatesIncoming proves direction 'in' → INCOMING.
+func TestNeogmaGraphRelatesIncoming(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string' } },
+}, neogma);
+
+const Movie = ModelFactory({
+  label: 'Movie',
+  schema: { title: { type: 'string' } },
+  relationships: {
+    actors: { model: Person, name: 'ACTED_IN', direction: 'in' },
+  },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+	edge := findNeogmaGraphRelates(ents, "Movie", "Person")
+	if edge == nil {
+		t.Fatalf("expected Movie ─GRAPH_RELATES→ Class:Person edge, got %+v", ents)
+	}
+	if edge.Properties["direction"] != "INCOMING" {
+		t.Errorf("direction: want INCOMING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestNeogmaGraphRelatesSelfEdge proves a self-referential model edge resolves:
+// Person ─GRAPH_RELATES(KNOWS)→ Person.
+func TestNeogmaGraphRelatesSelfEdge(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string' } },
+  relationships: {
+    friends: { model: Person, name: 'KNOWS', direction: 'out' },
+  },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+	edge := findNeogmaGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Person self-edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "KNOWS" {
+		t.Errorf("rel_type: want KNOWS, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestNeogmaGraphRelatesCrossFileDeferred proves honest-partial: a model:
+// reference that is NOT a same-file ModelFactory binding emits no edge — the
+// topology stays only as the target_model prop on the relationship Component.
+func TestNeogmaGraphRelatesCrossFileDeferred(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+import { Movie } from './movie';
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string' } },
+  relationships: {
+    actedIn: { model: Movie, name: 'ACTED_IN', direction: 'out' },
+  },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("expected NO GRAPH_RELATES edge for cross-file model, got %+v", r)
+			}
+		}
+	}
+	// The relationship Component must still record the deferred target as a prop.
+	foundProp := false
+	for _, e := range ents {
+		if e.Subtype == "relationship" && e.Properties["target_model"] == "Movie" {
+			foundProp = true
+		}
+	}
+	if !foundProp {
+		t.Errorf("expected relationship Component with target_model=Movie prop, got %+v", ents)
+	}
+}
+
+// TestNeogmaPlainSchemaFieldNoEdge proves the negative: a model with only a
+// schema (no relationships block) emits no GRAPH_RELATES edge.
+func TestNeogmaPlainSchemaFieldNoEdge(t *testing.T) {
+	src := `
+import { ModelFactory } from 'neogma';
+
+const Person = ModelFactory({
+  label: 'Person',
+  schema: { name: { type: 'string' }, favouriteMovie: { type: 'string' } },
+}, neogma);
+`
+	ents := runNeogma(t, src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("plain schema must not emit GRAPH_RELATES, got %+v", r)
+			}
+		}
+	}
+}
+
+// TestNeogmaSkipsNonNeogmaSource proves the gate: non-neogma source produces
+// nothing.
+func TestNeogmaSkipsNonNeogmaSource(t *testing.T) {
+	src := `
+import mongoose from 'mongoose';
+const Person = new mongoose.Schema({ name: String });
+`
+	ents := runNeogma(t, src)
+	if len(ents) != 0 {
+		t.Errorf("neogma extractor must not fire on mongoose source, got %+v", ents)
+	}
+}

--- a/internal/custom/python/neo4j_neomodel.go
+++ b/internal/custom/python/neo4j_neomodel.go
@@ -1,0 +1,262 @@
+package python
+
+// neo4j_neomodel.go — custom extractor for neomodel (Neo4j Python OGM) graph
+// schema mappings.
+//
+// neomodel maps Python classes to Neo4j graph nodes and relationships:
+//
+//	from neomodel import StructuredNode, RelationshipTo, RelationshipFrom
+//
+//	class Person(StructuredNode):
+//	    name   = StringProperty()
+//	    movies = RelationshipTo('Movie', 'ACTED_IN')
+//
+//	class Movie(StructuredNode):
+//	    title = StringProperty()
+//
+// A subclass of StructuredNode is the graph "node" (the analogue of a SQL
+// table); each RelationshipTo/RelationshipFrom class attribute declares a
+// typed, directed edge to another node label.
+//
+// Extracted entities
+// ------------------
+//	SCOPE.Schema / node          — one per StructuredNode subclass
+//	SCOPE.Schema / property      — one per *Property() class attribute
+//	SCOPE.Component / relationship — one per RelationshipTo/From attribute
+//
+// GRAPH_RELATES topology (#3609, epic #3606)
+// ------------------------------------------
+// Mirroring the Java Spring-Data-Neo4j template (#3663), every relationship
+// whose target node label resolves to a same-file StructuredNode subclass also
+// emits a traversable GRAPH_RELATES edge that hangs off the owner node entity:
+//
+//	Person ──GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)──▶ Class:Movie
+//
+// RelationshipTo → direction OUTGOING; RelationshipFrom → direction INCOMING.
+// The target label is the first string argument ('Movie'); the rel_type is the
+// second string argument ('ACTED_IN'). The ToID uses the "Class:<Label>"
+// convention so the intra-repo resolver's byName index links it to the target
+// node entity (same convention as the Django model cross-refs and the Java
+// SDN template). Cross-file target labels are honest-partial: no edge is
+// emitted, the topology stays only as a `target_node` prop on the relationship
+// Component.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_neomodel", &NeomodelExtractor{})
+}
+
+// NeomodelExtractor emits graph-schema entities and GRAPH_RELATES topology for
+// neomodel StructuredNode classes.
+type NeomodelExtractor struct{}
+
+func (e *NeomodelExtractor) Language() string { return "python_neomodel" }
+
+var (
+	// Gate: the file must import neomodel.
+	neomodelImportRe = regexp.MustCompile(
+		`(?m)^\s*(?:from\s+neomodel(?:\.\w+)*\s+import|import\s+neomodel)\b`)
+
+	// class Person(StructuredNode): / class Rel(StructuredRel):
+	// Captures group 1 = class name. Only StructuredNode subclasses are nodes.
+	neomodelNodeClassRe = regexp.MustCompile(
+		`(?m)^[ \t]*class\s+(\w+)\s*\(([^)]*)\)\s*:`)
+
+	// A *Property() class attribute (StringProperty, IntegerProperty, …).
+	//   name = StringProperty()
+	neomodelPropertyRe = regexp.MustCompile(
+		`(?m)^[ \t]+(\w+)\s*=\s*(\w*Property)\s*\(`)
+
+	// RelationshipTo / RelationshipFrom / Relationship attribute.
+	//   movies = RelationshipTo('Movie', 'ACTED_IN')
+	//   movies = RelationshipFrom("Movie", "ACTED_IN", cardinality=ZeroOrMore)
+	// Captures: group1 field name, group2 To|From|"" (plain Relationship),
+	// group3 target-label literal, group4 rel-type literal (optional).
+	neomodelRelRe = regexp.MustCompile(
+		`(?m)^[ \t]+(\w+)\s*=\s*Relationship(To|From|)\s*\(\s*` +
+			`['"]([A-Za-z_][\w.]*)['"]` +
+			`(?:\s*,\s*['"]([^'"]+)['"])?`)
+)
+
+// neomodelLabel returns the short node label for a (possibly dotted) target
+// reference such as 'myapp.models.Movie' → 'Movie'.
+func neomodelLabel(ref string) string {
+	if dot := strings.LastIndex(ref, "."); dot >= 0 {
+		return ref[dot+1:]
+	}
+	return ref
+}
+
+func (e *NeomodelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_neomodel")
+	_, span := tracer.Start(ctx, "custom.python_neomodel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !neomodelImportRe.MatchString(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) int {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return -1
+		}
+		seen[key] = true
+		out = append(out, ent)
+		return len(out) - 1
+	}
+
+	// --- StructuredNode subclasses (the graph "nodes") ---
+	type nodeInfo struct {
+		name   string
+		offset int
+		idx    int // index into out of the node entity
+	}
+	var nodes []nodeInfo
+	knownNodes := make(map[string]bool)
+
+	for _, m := range neomodelNodeClassRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		bases := src[m[4]:m[5]]
+		// Only StructuredNode subclasses are graph nodes. StructuredRel models
+		// the relationship's own properties — not a node — so it is skipped as a
+		// node (its props are still captured below as generic properties of
+		// nothing; we just don't treat it as an edge endpoint).
+		if !strings.Contains(bases, "StructuredNode") {
+			continue
+		}
+		ent := entity(className, "SCOPE.Schema", "node", file.Path, lineOf(src, m[0]),
+			map[string]string{
+				"framework":  "neomodel",
+				"node_label": className,
+				"provenance": "INFERRED_FROM_NEO4J_NEOMODEL_NODE",
+			})
+		idx := add(ent)
+		if idx >= 0 {
+			nodes = append(nodes, nodeInfo{name: className, offset: m[0], idx: idx})
+			knownNodes[className] = true
+		}
+	}
+
+	// owningNode / owningNodeIdx resolve the StructuredNode whose class
+	// declaration most closely precedes a class-body offset.
+	owningNode := func(offset int) string {
+		best := ""
+		for _, n := range nodes {
+			if n.offset <= offset {
+				best = n.name
+			}
+		}
+		return best
+	}
+	owningNodeIdx := func(offset int) int {
+		best := -1
+		for _, n := range nodes {
+			if n.offset <= offset {
+				best = n.idx
+			}
+		}
+		return best
+	}
+
+	// --- *Property() attributes (schema_extraction — properties) ---
+	for _, m := range neomodelPropertyRe.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		propType := src[m[4]:m[5]]
+		owner := owningNode(m[0])
+		if owner == "" {
+			continue
+		}
+		ent := entity(owner+"."+fieldName, "SCOPE.Schema", "property", file.Path, lineOf(src, m[0]),
+			map[string]string{
+				"framework":     "neomodel",
+				"property_name": fieldName,
+				"property_type": propType,
+				"owner_node":    owner,
+				"provenance":    "INFERRED_FROM_NEO4J_NEOMODEL_PROPERTY",
+			})
+		add(ent)
+	}
+
+	// --- RelationshipTo/From attributes (relationship_extraction + topology) ---
+	for _, m := range neomodelRelRe.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		toFrom := src[m[4]:m[5]] // "To", "From", or ""
+		targetRef := src[m[6]:m[7]]
+		relType := ""
+		if m[8] >= 0 {
+			relType = src[m[8]:m[9]]
+		}
+		targetLabel := neomodelLabel(targetRef)
+
+		direction := "OUTGOING"
+		if toFrom == "From" {
+			direction = "INCOMING"
+		}
+
+		owner := owningNode(m[0])
+		if owner == "" {
+			continue
+		}
+		name := relType
+		if name == "" {
+			name = fieldName
+		}
+		name = owner + "." + name
+
+		relEnt := entity(name, "SCOPE.Component", "relationship", file.Path, lineOf(src, m[0]),
+			map[string]string{
+				"framework":     "neomodel",
+				"relation_type": relType,
+				"direction":     direction,
+				"field_name":    fieldName,
+				"owner_node":    owner,
+				"target_node":   targetLabel,
+				"provenance":    "INFERRED_FROM_NEO4J_NEOMODEL_RELATIONSHIP",
+			})
+		add(relEnt)
+
+		// --- GRAPH_RELATES edge (#3609, epic #3606) ---
+		// Emit the domain graph schema as a traversable edge owner-node
+		// ──GRAPH_RELATES──▶ target-node carrying rel_type + direction, instead
+		// of leaving the topology encoded only as the `target_node` string prop.
+		// Only when the target label resolves to a same-file StructuredNode
+		// subclass — cross-file targets stay honest-partial (props only).
+		ownerIdx := owningNodeIdx(m[0])
+		if ownerIdx >= 0 && knownNodes[targetLabel] {
+			out[ownerIdx].Relationships = append(out[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "Class:" + targetLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neomodel",
+						"rel_type":   relType,
+						"direction":  direction,
+						"field_name": fieldName,
+						"provenance": "INFERRED_FROM_NEO4J_NEOMODEL_RELATIONSHIP",
+					},
+				})
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/neo4j_neomodel_test.go
+++ b/internal/custom/python/neo4j_neomodel_test.go
@@ -1,0 +1,244 @@
+package python_test
+
+// neo4j_neomodel_test.go — tests for the python_neomodel extractor (#3609,
+// epic #3606).
+//
+// Covers neomodel (Neo4j Python OGM) StructuredNode graph-schema extraction and
+// the headline GRAPH_RELATES topology edge: a StructuredNode owning a
+// RelationshipTo/RelationshipFrom to another same-file StructuredNode subclass
+// emits a traversable owner ──GRAPH_RELATES(rel_type,direction)──▶
+// Class:<TargetLabel> edge. Mirrors the Java SDN template (#3663).
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runNeomodel(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("python_neomodel")
+	if !ok {
+		t.Fatal("python_neomodel not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extractor.FileInput{Path: "models.py", Language: "python", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findNeomodelGraphRelates returns the GRAPH_RELATES edge from the node entity
+// named fromNode to "Class:<toNode>", or nil.
+func findNeomodelGraphRelates(ents []types.EntityRecord, fromNode, toNode string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "node" && ents[i].Name == fromNode) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "Class:"+toNode {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func hasNeomodelNode(ents []types.EntityRecord, name string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "node" && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// node + property extraction
+// ---------------------------------------------------------------------------
+
+func TestNeomodelNodeAndProperty(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty, IntegerProperty
+
+class Movie(StructuredNode):
+    title = StringProperty(unique_index=True)
+    released = IntegerProperty()
+`
+	ents := runNeomodel(t, src)
+	if !hasNeomodelNode(ents, "Movie") {
+		t.Fatalf("expected Movie node entity, got %+v", ents)
+	}
+	var foundTitle bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "property" && e.Name == "Movie.title" {
+			foundTitle = true
+			if e.Properties["property_type"] != "StringProperty" {
+				t.Errorf("Movie.title property_type: want StringProperty, got %q", e.Properties["property_type"])
+			}
+		}
+	}
+	if !foundTitle {
+		t.Errorf("expected Movie.title property entity, got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAPH_RELATES — the headline node→node topology edge
+// ---------------------------------------------------------------------------
+
+// TestNeomodelGraphRelatesEdge proves Person ─GRAPH_RELATES(ACTED_IN,OUTGOING)→
+// Class:Movie for a RelationshipTo('Movie','ACTED_IN').
+func TestNeomodelGraphRelatesEdge(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty, RelationshipTo
+
+class Movie(StructuredNode):
+    title = StringProperty()
+
+class Person(StructuredNode):
+    name = StringProperty()
+    movies = RelationshipTo('Movie', 'ACTED_IN')
+`
+	ents := runNeomodel(t, src)
+
+	edge := findNeomodelGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Movie edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["field_name"] != "movies" {
+		t.Errorf("field_name: want movies, got %q", edge.Properties["field_name"])
+	}
+	if edge.Properties["framework"] != "neomodel" {
+		t.Errorf("framework: want neomodel, got %q", edge.Properties["framework"])
+	}
+
+	// direction is a property, not endpoint-swapping: no reverse edge.
+	if findNeomodelGraphRelates(ents, "Movie", "Person") != nil {
+		t.Error("did not expect a reverse Movie ─GRAPH_RELATES→ Person edge")
+	}
+}
+
+// TestNeomodelGraphRelatesFromIncoming proves RelationshipFrom → INCOMING.
+func TestNeomodelGraphRelatesFromIncoming(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty, RelationshipFrom
+
+class Person(StructuredNode):
+    name = StringProperty()
+
+class Movie(StructuredNode):
+    title = StringProperty()
+    actors = RelationshipFrom('Person', 'ACTED_IN')
+`
+	ents := runNeomodel(t, src)
+	edge := findNeomodelGraphRelates(ents, "Movie", "Person")
+	if edge == nil {
+		t.Fatalf("expected Movie ─GRAPH_RELATES→ Class:Person edge, got %+v", ents)
+	}
+	if edge.Properties["direction"] != "INCOMING" {
+		t.Errorf("direction: want INCOMING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestNeomodelGraphRelatesSelfEdge proves a self-referential RelationshipTo
+// resolves: Person ─GRAPH_RELATES(KNOWS)→ Person.
+func TestNeomodelGraphRelatesSelfEdge(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty, RelationshipTo
+
+class Person(StructuredNode):
+    name = StringProperty()
+    friends = RelationshipTo('Person', 'KNOWS')
+`
+	ents := runNeomodel(t, src)
+	edge := findNeomodelGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ Class:Person self-edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "KNOWS" {
+		t.Errorf("rel_type: want KNOWS, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestNeomodelGraphRelatesCrossFileDeferred proves honest-partial: a target
+// label that is NOT a same-file StructuredNode emits no edge — the topology
+// stays only as the target_node prop on the relationship Component.
+func TestNeomodelGraphRelatesCrossFileDeferred(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty, RelationshipTo
+
+class Person(StructuredNode):
+    name = StringProperty()
+    movies = RelationshipTo('Movie', 'ACTED_IN')
+`
+	ents := runNeomodel(t, src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("expected NO GRAPH_RELATES edge for cross-file target, got %+v", r)
+			}
+		}
+	}
+	foundProp := false
+	for _, e := range ents {
+		if e.Subtype == "relationship" && e.Properties["target_node"] == "Movie" {
+			foundProp = true
+		}
+	}
+	if !foundProp {
+		t.Errorf("expected relationship Component with target_node=Movie prop, got %+v", ents)
+	}
+}
+
+// TestNeomodelPlainPropertyNoEdge proves the negative: a plain *Property field
+// (no Relationship) on a StructuredNode emits no GRAPH_RELATES edge.
+func TestNeomodelPlainPropertyNoEdge(t *testing.T) {
+	src := `
+from neomodel import StructuredNode, StringProperty
+
+class Movie(StructuredNode):
+    title = StringProperty()
+
+class Person(StructuredNode):
+    name = StringProperty()
+    favourite = StringProperty()
+`
+	ents := runNeomodel(t, src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("plain property must not emit GRAPH_RELATES, got %+v", r)
+			}
+		}
+	}
+}
+
+// TestNeomodelSkipsNonNeomodelSource proves the gate: a plain SQLAlchemy/Django
+// model file produces nothing.
+func TestNeomodelSkipsNonNeomodelSource(t *testing.T) {
+	src := `
+from django.db import models
+
+class Movie(models.Model):
+    title = models.CharField(max_length=200)
+`
+	ents := runNeomodel(t, src)
+	if len(ents) != 0 {
+		t.Errorf("neomodel extractor must not fire on non-neomodel source, got %+v", ents)
+	}
+}


### PR DESCRIPTION
Extends the Neo4j `GRAPH_RELATES` graph-schema topology — landed for Java Spring Data Neo4j in #3663 — to the two remaining Neo4j OGMs, emitting real traversable node→node edges instead of opaque target string props.

## Python — neomodel (`internal/custom/python/neo4j_neomodel.go`, key `python_neomodel`)
- `class X(StructuredNode)` → `SCOPE.Schema/node` (graph node label)
- `*Property()` attribute → `SCOPE.Schema/property`
- `RelationshipTo/From('Target','REL_TYPE')` → `SCOPE.Component/relationship` **and** a `GRAPH_RELATES` edge owner-node → `Class:<Target>` with `rel_type` + `direction` (`To`→OUTGOING, `From`→INCOMING)

## JS/TS — neogma (`internal/custom/javascript/neogma.go`, key `custom_js_neogma`)
- `ModelFactory({ label, schema, relationships }, neogma)` → `SCOPE.Schema/node` keyed on the Neo4j `label`
- `relationships.<key>: { model, name, direction }` → `SCOPE.Component/relationship` **and** a `GRAPH_RELATES` edge owner-node → `Class:<TargetLabel>` (`'out'`→OUTGOING, `'in'`→INCOMING) when `model:` resolves to a same-file `ModelFactory` binding

Both **honest-partial**: cross-file targets stay as `target_node`/`target_model` props only — no edge. ToID uses the `Class:<Label>` convention so the intra-repo resolver's byName index links the edge to the target node entity (same as the Django / Java SDN templates). Wiring is automatic via the `python_` / `custom_js_` dispatch prefixes.

## Specific edges asserted (value-asserting tests)
- neomodel `Person.movies = RelationshipTo('Movie','ACTED_IN')` → `Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ Class:Movie` (`TestNeomodelGraphRelatesEdge`); `RelationshipFrom` → INCOMING; self-edge `KNOWS`
- neogma `actedIn: { model: Movie, name: 'ACTED_IN', direction: 'out' }` → `Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ Class:Movie` (`TestNeogmaGraphRelatesEdge`); `'in'` → INCOMING; self-edge `KNOWS`
- Negatives: plain `*Property()` / schema-only model emits **no** edge; cross-file target deferred (props only); non-OGM source gated out

## Registry
`lang.python.driver.neo4j` + `lang.jsts.driver.neo4j`: `relationship_extraction` → **full**, `schema_extraction` / `association_extraction` → **partial**, citing the new extractors. Reverses the #3635 datastore-pass downgrade for these OGMs. `coverage validate` 0 errors, `fmt --check` canonical.

## Verification
`go test` (custom/python, custom/javascript, engine, types, tools/coverage) green; `gofmt -l` clean on changed files; `go vet` clean; datastore cite guard passes.

**DEPLOY-DEFERRED**: requires a coordinated live-daemon rebuild + reindex; not deployed in this change.

Closes #3609
Closes #3610

🤖 Generated with [Claude Code](https://claude.com/claude-code)