### PR TITLE
feat(csharp): HotChocolate GraphQL server endpoint synthesis

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 212 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 14 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
+**Total**: 213 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -29,6 +29,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🔴 0/7 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C#
 
-**Frameworks**: 15 · **Tools**: 7 · **ORMs**: 14 · **Other**: 0
+**Frameworks**: 16 · **Tools**: 7 · **ORMs**: 14 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -30,6 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Carter](../detail/lang.csharp.framework.carter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🔴 0/7 | |
 | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 

--- a/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
+++ b/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.hotchocolate` — HotChocolate (GraphQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | synthesizeHotChocolate emits http:GRAPHQL:/graphql/<Query|Mutation|Subscription>/<field> per public resolver method — EXACT canonical shape as gqlgen (Go) / Strawberry (Python) / Apollo (JS) / Absinthe so client links (#3667) + cross-repo linker join. Field name = HotChocolate default: leading Get stripped + first letter lower-cased (GetUser->user, GetUsersByTeam->usersByTeam, CreateUser->createUser). Recognises [QueryType]/[MutationType]/[SubscriptionType] markers, [ExtendObjectType(typeof(Query))] extensions, and same-file fluent .AddQueryType<T>() registrations. Value-asserting tests assert the EXACT endpoint ids. |
+| Handler attribution | ✅ `full` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | Each endpoint carries source_handler=SCOPE.Operation:<Class>.<Method> (same naming as the C# extractor buildOperation), which ResolveHTTPEndpointHandlers rebinds to the resolver method — HANDLES edge endpoint->method. Value-asserting tests assert source_handler=SCOPE.Operation:Query.GetUser / Mutation.CreateUser / UserQueries.GetUserByEmail. |
+| Route extraction | 🟢 `partial` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | Root-type registration recovered from marker attributes, [ExtendObjectType] extensions, or SAME-FILE fluent .AddQueryType<T>(). PARTIAL (honest): a resolver class registered fluently in a DIFFERENT file than its declaration, descriptor.Field() runtime fluent field definitions, and SDL schema-first .graphqls binding are not resolved. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.hotchocolate ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -8259,6 +8259,186 @@
       }
     },
     {
+      "id": "lang.csharp.framework.hotchocolate",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "csharp",
+      "label": "HotChocolate (GraphQL)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_hotchocolate.go","internal/engine/http_endpoint_hotchocolate_test.go"],
+            "issue": "3617",
+            "notes": "synthesizeHotChocolate emits http:GRAPHQL:/graphql/\u003cQuery|Mutation|Subscription\u003e/\u003cfield\u003e per public resolver method — EXACT canonical shape as gqlgen (Go) / Strawberry (Python) / Apollo (JS) / Absinthe so client links (#3667) + cross-repo linker join. Field name = HotChocolate default: leading Get stripped + first letter lower-cased (GetUser-\u003euser, GetUsersByTeam-\u003eusersByTeam, CreateUser-\u003ecreateUser). Recognises [QueryType]/[MutationType]/[SubscriptionType] markers, [ExtendObjectType(typeof(Query))] extensions, and same-file fluent .AddQueryType\u003cT\u003e() registrations. Value-asserting tests assert the EXACT endpoint ids.",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_hotchocolate.go","internal/engine/http_endpoint_hotchocolate_test.go"],
+            "issue": "3617",
+            "notes": "Each endpoint carries source_handler=SCOPE.Operation:\u003cClass\u003e.\u003cMethod\u003e (same naming as the C# extractor buildOperation), which ResolveHTTPEndpointHandlers rebinds to the resolver method — HANDLES edge endpoint-\u003emethod. Value-asserting tests assert source_handler=SCOPE.Operation:Query.GetUser / Mutation.CreateUser / UserQueries.GetUserByEmail.",
+            "verified_at": "2026-06-02"
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_hotchocolate.go","internal/engine/http_endpoint_hotchocolate_test.go"],
+            "issue": "3617",
+            "notes": "Root-type registration recovered from marker attributes, [ExtendObjectType] extensions, or SAME-FILE fluent .AddQueryType\u003cT\u003e(). PARTIAL (honest): a resolver class registered fluently in a DIFFERENT file than its declaration, descriptor.Field() runtime fluent field definitions, and SDL schema-first .graphqls binding are not resolved.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.csharp.framework.nancyfx",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 212 · **ORMs**: 152 · **Tools**: 110 · **Other**: 125
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 213 · **ORMs**: 152 · **Tools**: 110 · **Other**: 125
 
 ## Coverage by language
 
@@ -13,7 +13,7 @@
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
-| [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
+| [C#](by-language/csharp.md) | 16 | 7 | 14 | 0 |
 | [php](by-language/php.md) | 15 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 14 | 5 | 10 | 2 |
 | [rust](by-language/rust.md) | 14 | 6 | 15 | 3 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 212 frameworks · 110 tools · 152 ORMs · 125 other
+Total: 213 frameworks · 110 tools · 152 ORMs · 125 other

--- a/internal/engine/http_endpoint_hotchocolate.go
+++ b/internal/engine/http_endpoint_hotchocolate.go
@@ -1,0 +1,307 @@
+// http_endpoint_hotchocolate.go — HotChocolate (C#/.NET) GraphQL server
+// → http_endpoint_definition synthesis.
+//
+// HotChocolate is the dominant .NET GraphQL framework. The canonical,
+// code-first style declares the three GraphQL root types as plain C#
+// classes whose public methods become root fields:
+//
+//	[QueryType]
+//	public class Query
+//	{
+//	    public User GetUser(int id) => ...;   // → field `user`
+//	    public IEnumerable<User> GetUsers() => ...;  // → field `users`
+//	}
+//
+//	[MutationType]
+//	public class Mutation
+//	{
+//	    public User CreateUser(string name) => ...;  // → field `createUser`
+//	}
+//
+// The root classes are recognised three ways:
+//
+//   - the `[QueryType]` / `[MutationType]` / `[SubscriptionType]` marker
+//     attributes (HotChocolate ≥ v13 annotation-based registration);
+//   - `[ExtendObjectType(typeof(Query))]` / `[ExtendObjectType("Query")]`
+//     type extensions that contribute additional root fields;
+//   - classes registered fluently in Program.cs / Startup via
+//     `.AddQueryType<Query>()` / `.AddMutationType<Mutation>()` /
+//     `.AddSubscriptionType<Subscription>()`.
+//
+// Each public resolver method is mapped to the SAME canonical endpoint shape
+// the JS (synthesizeGraphQLResolvers), Python (synthesizeStrawberry), Go
+// (gqlgen) and Elixir (synthesizeAbsinthe) GraphQL servers emit:
+//
+//	http:GRAPHQL:/graphql/<Query|Mutation|Subscription>/<field>
+//
+// The field name follows HotChocolate's default naming convention: the
+// leading `Get` prefix is stripped and the first letter is lower-cased
+// (`GetUser` → `user`, `GetUsersByTeam` → `usersByTeam`, `CreateUser`
+// → `createUser`). This matches the cross-stack endpoint shape so the
+// GraphQL client links (#3667) + cross-repo linker join to these endpoints.
+//
+// Handler attribution mirrors synthesizeASPNetCore (#2692): each endpoint
+// carries `source_handler=SCOPE.Operation:<Class>.<Method>`, which the C#
+// extractor names identically (buildOperation in
+// internal/extractors/csharp/csharp.go), so ResolveHTTPEndpointHandlers
+// rebinds source_file / start_line to the resolver method — producing the
+// HANDLES edge endpoint → resolver method.
+//
+// Detection is gated on a HotChocolate file-signal (`HotChocolate` import or
+// `.AddGraphQLServer()`) so the synthesizer is a no-op on plain ASP.NET Core
+// / gRPC / Blazor C# files. The root-type registration is `honest-partial`
+// where it is indirect (fluent `.AddQueryType<T>()` in a *different* file
+// than the resolver class): in that case the marker-attribute path or the
+// same-file `.AddQueryType<T>()` recovers the class→root mapping; a resolver
+// class with neither marker nor same-file registration is not emitted.
+//
+// Refs #3617 (epic #3607).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// hotChocolateHasSignal reports whether a C# file shows any sign of a
+// HotChocolate GraphQL server. Used as a fast pre-filter so the regex
+// machinery doesn't run on every C# file in the index.
+func hotChocolateHasSignal(content string) bool {
+	return strings.Contains(content, "HotChocolate") ||
+		strings.Contains(content, ".AddGraphQLServer()") ||
+		strings.Contains(content, ".AddGraphQLServer(")
+}
+
+// hcRootMarker is the canonical GraphQL root-type name a registration maps to.
+type hcRootMarker = string
+
+const (
+	hcQuery        hcRootMarker = "Query"
+	hcMutation     hcRootMarker = "Mutation"
+	hcSubscription hcRootMarker = "Subscription"
+)
+
+// hcMarkerAttrRe captures a HotChocolate root-type marker attribute
+// (`[QueryType]` / `[MutationType]` / `[SubscriptionType]`, optionally
+// fully-qualified or with parentheses) immediately preceding a class
+// declaration (allowing intervening attributes between the marker and the
+// `class` line).
+//
+// Capture groups:
+//
+//	1 = root kind (Query | Mutation | Subscription)
+//	2 = class name
+var hcMarkerAttrRe = regexp.MustCompile(
+	`\[\s*(Query|Mutation|Subscription)Type\s*(?:\([^)]*\))?\s*\]` +
+		`\s*[\r\n]+(?:\s*\[[^\]\r\n]+\]\s*[\r\n]+)*` +
+		`\s*(?:public|internal|sealed|abstract|partial|static|\s)*` +
+		`class\s+([A-Za-z_]\w*)`,
+)
+
+// hcExtendObjectRe captures an `[ExtendObjectType(typeof(Query))]` or
+// `[ExtendObjectType("Query")]` (or `OperationType.Query`) type-extension
+// attribute and the class it decorates. The extension contributes its
+// public methods as additional fields on the named root type.
+//
+// Capture groups:
+//
+//	1 = root type referenced (Query | Mutation | Subscription)
+//	2 = class name
+var hcExtendObjectRe = regexp.MustCompile(
+	`\[\s*ExtendObjectType\s*\(\s*` +
+		`(?:typeof\s*\(\s*(Query|Mutation|Subscription)\s*\)` +
+		`|"(?:Query|Mutation|Subscription)"` +
+		`|OperationType\.(Query|Mutation|Subscription))` +
+		`[^)]*\)\s*\]` +
+		`\s*[\r\n]+(?:\s*\[[^\]\r\n]+\]\s*[\r\n]+)*` +
+		`\s*(?:public|internal|sealed|abstract|partial|static|\s)*` +
+		`class\s+([A-Za-z_]\w*)`,
+)
+
+// hcFluentRegRe captures a fluent root-type registration in Program.cs /
+// Startup: `.AddQueryType<Query>()` / `.AddMutationType<Mutation>()` /
+// `.AddSubscriptionType<Subscription>()`. The type argument is the resolver
+// class name; when that class lives in the same file its methods are mapped.
+//
+// Capture groups:
+//
+//	1 = root kind (Query | Mutation | Subscription)
+//	2 = class name (the generic type argument)
+var hcFluentRegRe = regexp.MustCompile(
+	`\.Add(Query|Mutation|Subscription)Type\s*<\s*([A-Za-z_][\w.]*)\s*>\s*\(`,
+)
+
+// hcResolverMethodRe matches a public resolver method inside a class body.
+// HotChocolate resolver methods must be `public` (non-public methods are not
+// exposed as fields). The return-type chunk `[\w<>\[\],.\s?]+?` matches
+// `User`, `Task<User>`, `IEnumerable<User>`, `IQueryable<User?>`, etc.
+//
+// Capture group 1 = method name.
+var hcResolverMethodRe = regexp.MustCompile(
+	`(?m)^\s*(?:\[[^\]\r\n]+\]\s*)*\s*public\s+` +
+		`(?:static\s+|virtual\s+|override\s+|async\s+|sealed\s+)*` +
+		`[\w<>\[\],.\s?]+?\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// hcFieldName converts a HotChocolate resolver method name to its default
+// GraphQL field name: strip a leading `Get` prefix (only when followed by an
+// upper-case letter, so `Get`/`Gettable` are not mangled) and lower-case the
+// first letter.
+//
+//	GetUser        -> user
+//	GetUsersByTeam -> usersByTeam
+//	CreateUser     -> createUser
+//	User           -> user
+//	Get            -> get        (no upper-case follow → not a prefix)
+func hcFieldName(method string) string {
+	name := method
+	if strings.HasPrefix(name, "Get") && len(name) > 3 {
+		r := name[3]
+		if r >= 'A' && r <= 'Z' {
+			name = name[3:]
+		}
+	}
+	if name == "" {
+		return name
+	}
+	return strings.ToLower(name[:1]) + name[1:]
+}
+
+// hcClassBody returns the brace-delimited body of the class whose declaration
+// ends at or after byte offset `declEnd`. It scans forward for the first `{`
+// and returns the substring up to its matching `}` (exclusive of the braces).
+// Returns "" when no balanced body is found.
+func hcClassBody(content string, declEnd int) string {
+	open := strings.IndexByte(content[declEnd:], '{')
+	if open < 0 {
+		return ""
+	}
+	open += declEnd
+	close := findMatchingBrace(content, open)
+	if close < 0 {
+		return ""
+	}
+	return content[open+1 : close]
+}
+
+// hcEmitClassFields emits one GRAPHQL endpoint per public resolver method in
+// the given class body, attributing each to root `rootKind`. Already-emitted
+// (root, field) pairs are de-duplicated via `seen`.
+func hcEmitClassFields(content string, declEnd int, className, rootKind string, seen map[string]bool, emit emitFn) {
+	body := hcClassBody(content, declEnd)
+	if body == "" {
+		return
+	}
+	for _, mm := range hcResolverMethodRe.FindAllStringSubmatch(body, -1) {
+		method := mm[1]
+		// Skip constructors (method name == class name) and lifecycle/ctor-ish.
+		if method == className {
+			continue
+		}
+		field := hcFieldName(method)
+		key := rootKind + "/" + field
+		if field == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		path := "/graphql/" + rootKind + "/" + field
+		// FrameworkFastAPI canonicalisation preserves the path verbatim
+		// (collapsing only redundant slashes) — identical to the shape the
+		// Strawberry / Absinthe / gqlgen / JS GraphQL servers emit.
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+		// SCOPE.Operation:<Class>.<Method> matches the C# extractor's naming
+		// (buildOperation), so the resolver rebinds to the resolver method
+		// (HANDLES edge endpoint → method).
+		emit("GRAPHQL", canonical, "hotchocolate", "SCOPE.Operation", className+"."+method)
+	}
+}
+
+// synthesizeHotChocolate scans a C# source file for HotChocolate GraphQL
+// server root types and emits one `http:GRAPHQL:/graphql/<Root>/<field>`
+// synthetic per public resolver method, with a HANDLES edge to the resolver
+// method. Gated on a HotChocolate file-signal so it no-ops on other C# files.
+func synthesizeHotChocolate(content string, emit emitFn) {
+	if !hotChocolateHasSignal(content) {
+		return
+	}
+
+	// (className → rootKind) for classes registered fluently in this file via
+	// `.AddQueryType<Query>()` etc. The bare generic type argument may be
+	// namespace-qualified (`Types.Query`); key on the final segment.
+	fluentRoots := map[string]string{}
+	for _, fm := range hcFluentRegRe.FindAllStringSubmatch(content, -1) {
+		rootKind := fm[1]
+		arg := fm[2]
+		if i := strings.LastIndexByte(arg, '.'); i >= 0 {
+			arg = arg[i+1:]
+		}
+		if arg != "" {
+			fluentRoots[arg] = rootKind
+		}
+	}
+
+	// De-dup of emitted (root, field) pairs across all recognition paths so a
+	// class that is BOTH marker-annotated and fluent-registered, or a field
+	// that recurs across a base + extension, is emitted once.
+	seen := map[string]bool{}
+
+	// 1) Marker-attribute classes: [QueryType] / [MutationType] / [SubscriptionType].
+	for _, m := range hcMarkerAttrRe.FindAllStringSubmatchIndex(content, -1) {
+		rootKind := content[m[2]:m[3]]
+		className := content[m[4]:m[5]]
+		hcEmitClassFields(content, m[1], className, rootKind, seen, emit)
+	}
+
+	// 2) [ExtendObjectType(typeof(Query))] type-extension classes.
+	for _, m := range hcExtendObjectRe.FindAllStringSubmatchIndex(content, -1) {
+		// Group 1 (typeof) OR group 2 (OperationType.) carries the root kind;
+		// the quoted-string alternative has no capture, so recover from text.
+		rootKind := ""
+		if m[2] >= 0 {
+			rootKind = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			rootKind = content[m[4]:m[5]]
+		} else {
+			// "Query" | "Mutation" | "Subscription" quoted-string form.
+			seg := content[m[0]:m[1]]
+			switch {
+			case strings.Contains(seg, `"Query"`):
+				rootKind = hcQuery
+			case strings.Contains(seg, `"Mutation"`):
+				rootKind = hcMutation
+			case strings.Contains(seg, `"Subscription"`):
+				rootKind = hcSubscription
+			}
+		}
+		if rootKind == "" {
+			continue
+		}
+		className := content[m[6]:m[7]]
+		hcEmitClassFields(content, m[1], className, rootKind, seen, emit)
+	}
+
+	// 3) Fluent-registered classes declared in THIS file. The class declaration
+	// itself carries no marker, so find each `class <Name>` whose name appears
+	// in fluentRoots and map its methods to the registered root kind.
+	if len(fluentRoots) > 0 {
+		for _, cm := range hcPlainClassRe.FindAllStringSubmatchIndex(content, -1) {
+			className := content[cm[2]:cm[3]]
+			rootKind, ok := fluentRoots[className]
+			if !ok {
+				continue
+			}
+			hcEmitClassFields(content, cm[1], className, rootKind, seen, emit)
+		}
+	}
+}
+
+// hcPlainClassRe matches any class declaration (no marker required). Used to
+// locate fluent-registered resolver classes by name.
+//
+// Capture group 1 = class name.
+var hcPlainClassRe = regexp.MustCompile(
+	`(?m)^\s*(?:public|internal|sealed|abstract|partial|static|\s)*` +
+		`class\s+([A-Za-z_]\w*)`,
+)

--- a/internal/engine/http_endpoint_hotchocolate_test.go
+++ b/internal/engine/http_endpoint_hotchocolate_test.go
@@ -1,0 +1,176 @@
+package engine
+
+import "testing"
+
+// TestHotChocolate_MarkerRootTypes asserts that HotChocolate's annotation-based
+// root types ([QueryType] / [MutationType] / [SubscriptionType]) map each
+// public resolver method to the canonical cross-stack GraphQL endpoint shape
+// `http:GRAPHQL:/graphql/<Root>/<field>` — Get-prefix stripped + lowerCamel,
+// IDENTICAL to gqlgen (Go) / Strawberry (Python) / Apollo (JS) — with a
+// HANDLES edge (source_handler) to the C# resolver method.
+func TestHotChocolate_MarkerRootTypes(t *testing.T) {
+	src := `
+using HotChocolate;
+using HotChocolate.Types;
+
+namespace Demo.GraphQL;
+
+[QueryType]
+public class Query
+{
+    public User GetUser(int id) => _repo.Find(id);
+    public IEnumerable<User> GetUsers() => _repo.All();
+    private User Internal() => null;            // non-public → NOT a field
+}
+
+[MutationType]
+public class Mutation
+{
+    public User CreateUser(string name) => _repo.Add(name);
+}
+
+[SubscriptionType]
+public class Subscription
+{
+    public User OnUserAdded() => null;
+}
+`
+	ids, res := runDetect(t, "csharp", "GraphQL/Types.cs", src)
+
+	// EXACT shape parity with gqlgen/JS: `GetUser` → field `user`,
+	// `GetUsers` → `users`, `CreateUser` → `createUser` (no Get strip),
+	// `OnUserAdded` → `onUserAdded`.
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/user",
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+		"http:GRAPHQL:/graphql/Subscription/onUserAdded",
+	}
+	requireContains(t, ids, want, "hotchocolate-marker")
+
+	// The private method must NOT become an endpoint.
+	for _, bad := range []string{
+		"http:GRAPHQL:/graphql/Query/internal",
+	} {
+		for _, id := range ids {
+			if id == bad {
+				t.Errorf("hotchocolate: non-public method wrongly emitted as %s", bad)
+			}
+		}
+	}
+
+	// HANDLES edge: the `user` endpoint carries source_handler pointing at the
+	// C# resolver method Query.GetUser (SCOPE.Operation:<Class>.<Method>), the
+	// same convention the C# extractor's buildOperation produces — which the
+	// resolver consumes to materialise the endpoint → method HANDLES edge.
+	assertHandler(t, res, "http:GRAPHQL:/graphql/Query/user",
+		"hotchocolate", "SCOPE.Operation:Query.GetUser")
+	assertHandler(t, res, "http:GRAPHQL:/graphql/Mutation/createUser",
+		"hotchocolate", "SCOPE.Operation:Mutation.CreateUser")
+}
+
+// TestHotChocolate_ExtendObjectType asserts that an [ExtendObjectType(typeof(
+// Query))] type extension contributes its public methods as additional fields
+// on the Query root, in the same canonical shape.
+func TestHotChocolate_ExtendObjectType(t *testing.T) {
+	src := `
+using HotChocolate.Types;
+
+[ExtendObjectType(typeof(Query))]
+public class UserQueries
+{
+    public User GetUserByEmail(string email) => _repo.ByEmail(email);
+}
+
+[ExtendObjectType(OperationType.Mutation)]
+public class UserMutations
+{
+    public bool DeleteUser(int id) => _repo.Remove(id);
+}
+`
+	ids, res := runDetect(t, "csharp", "GraphQL/Extensions.cs", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/userByEmail",
+		"http:GRAPHQL:/graphql/Mutation/deleteUser",
+	}
+	requireContains(t, ids, want, "hotchocolate-extend")
+
+	assertHandler(t, res, "http:GRAPHQL:/graphql/Query/userByEmail",
+		"hotchocolate", "SCOPE.Operation:UserQueries.GetUserByEmail")
+}
+
+// TestHotChocolate_FluentRegistration asserts that a class registered fluently
+// via `.AddQueryType<Query>()` in the same file (Program.cs-style) — with NO
+// marker attribute on the class — still has its resolver methods mapped.
+func TestHotChocolate_FluentRegistration(t *testing.T) {
+	src := `
+using HotChocolate;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services
+    .AddGraphQLServer()
+    .AddQueryType<Query>()
+    .AddMutationType<Mutation>();
+
+public class Query
+{
+    public Product GetProduct(int id) => _repo.Find(id);
+}
+
+public class Mutation
+{
+    public Product AddProduct(string sku) => _repo.Add(sku);
+}
+`
+	ids, res := runDetect(t, "csharp", "Program.cs", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/product",
+		"http:GRAPHQL:/graphql/Mutation/addProduct",
+	}
+	requireContains(t, ids, want, "hotchocolate-fluent")
+
+	assertHandler(t, res, "http:GRAPHQL:/graphql/Query/product",
+		"hotchocolate", "SCOPE.Operation:Query.GetProduct")
+}
+
+// TestHotChocolate_NoSignalNoOp asserts the synthesizer is a no-op on a plain
+// ASP.NET Core C# file with no HotChocolate signal — proving the file-signal
+// gate prevents false GraphQL endpoints on the rest of the C# index.
+func TestHotChocolate_NoSignalNoOp(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetWidget() => Ok();
+}
+`
+	ids, _ := runDetect(t, "csharp", "WidgetsController.cs", src)
+	for _, id := range ids {
+		if len(id) >= 13 && id[:13] == "http:GRAPHQL:" {
+			t.Errorf("hotchocolate: emitted GraphQL endpoint %q on a non-HotChocolate file", id)
+		}
+	}
+}
+
+// assertHandler asserts the synthetic endpoint with id `wantID` exists, is
+// tagged framework=`wantFW`, and carries source_handler=`wantHandler`.
+func assertHandler(t *testing.T, res *DetectResult, wantID, wantFW, wantHandler string) {
+	t.Helper()
+	for _, e := range res.Entities {
+		if e.ID != wantID {
+			continue
+		}
+		if e.Properties["framework"] != wantFW {
+			t.Errorf("%s: framework=%q, want %q", wantID, e.Properties["framework"], wantFW)
+		}
+		if e.Properties["source_handler"] != wantHandler {
+			t.Errorf("%s: source_handler=%q, want %q", wantID, e.Properties["source_handler"], wantHandler)
+		}
+		return
+	}
+	t.Errorf("missing synthetic endpoint %q", wantID)
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -749,6 +749,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Producer side (#2692): ASP.NET Core attribute routing —
 		// [HttpGet/Post/...] + class-level [Route("/api/[controller]")].
 		synthesizeASPNetCore(string(content), emit)
+		// Producer side (#3617): HotChocolate GraphQL server. Maps the three
+		// root types ([QueryType]/[MutationType]/[SubscriptionType] markers,
+		// [ExtendObjectType(...)] extensions, or fluent .AddQueryType<T>()
+		// registrations) to http:GRAPHQL:/graphql/<Root>/<field> synthetics —
+		// the SAME canonical shape the JS / Python / Go / Elixir GraphQL
+		// servers emit — with a HANDLES edge to each C# resolver method.
+		// Gated on a HotChocolate file-signal so it no-ops on other C# files.
+		synthesizeHotChocolate(string(content), emit)
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	case "rust":


### PR DESCRIPTION
Closes #3617 (epic #3607).

Adds C# **HotChocolate** GraphQL server extraction — the dominant .NET GraphQL framework, previously zero coverage. Parallels the just-merged gqlgen work (#3613/#3669) under the same endpoint-shape requirement.

## What it does
`synthesizeHotChocolate` (new `internal/engine/http_endpoint_hotchocolate.go`, wired into the `csharp` case of the synthesis dispatcher) emits, per public resolver method:

```
http:GRAPHQL:/graphql/<Query|Mutation|Subscription>/<field>
```

plus a `source_handler=SCOPE.Operation:<Class>.<Method>` property that `ResolveHTTPEndpointHandlers` rebinds to the resolver method — the **HANDLES edge** endpoint → method.

### Endpoint-shape parity (cross-repo links form)
The id is byte-for-byte the SAME canonical shape the gqlgen (Go), Strawberry (Python), Apollo (JS) and Absinthe (Elixir) servers emit, so the GraphQL client links (#3667) + the cross-repo linker join to it. Field name = HotChocolate default convention: leading `Get` stripped + first letter lower-cased.

| C# resolver | endpoint |
|---|---|
| `Query.GetUser` | `http:GRAPHQL:/graphql/Query/user` |
| `Query.GetUsers` | `http:GRAPHQL:/graphql/Query/users` |
| `Mutation.CreateUser` | `http:GRAPHQL:/graphql/Mutation/createUser` |
| `Subscription.OnUserAdded` | `http:GRAPHQL:/graphql/Subscription/onUserAdded` |

### Root-type recognition
- `[QueryType]`/`[MutationType]`/`[SubscriptionType]` marker attributes
- `[ExtendObjectType(typeof(Query))]` / `OperationType.Mutation` type extensions
- same-file fluent `.AddQueryType<Query>()` / `.AddMutationType<Mutation>()`

Gated on a HotChocolate file-signal (`HotChocolate` import / `.AddGraphQLServer()`) so it no-ops on plain ASP.NET Core / gRPC / Blazor C# files.

## Honest-partial
Indirect root-type registration — a resolver class registered fluently in a *different* file than its declaration, runtime `descriptor.Field("x")` fluent fields, and SDL schema-first `.graphqls` binding — is not resolved. Recorded as `route_extraction: partial`.

## Tests (value-asserting, not len>0)
- `TestHotChocolate_MarkerRootTypes` — asserts the EXACT four endpoint ids above + `source_handler=SCOPE.Operation:Query.GetUser`/`Mutation.CreateUser`; proves a private method is NOT emitted.
- `TestHotChocolate_ExtendObjectType` — `GetUserByEmail`→`userByEmail`, `OperationType.Mutation` `DeleteUser`→`deleteUser` + HANDLES edge.
- `TestHotChocolate_FluentRegistration` — marker-less classes registered via `.AddQueryType<Query>()` + HANDLES edge.
- `TestHotChocolate_NoSignalNoOp` — a plain `[ApiController]` file emits zero GraphQL endpoints (gate proof).

## Coverage record
`lang.csharp.framework.hotchocolate` (graphql): `endpoint_synthesis` + `handler_attribution` **full**, `route_extraction` **partial**; remaining taxonomy lanes backfilled. `coverage validate` 0 errors, `fmt --check` canonical.

## Checks
- `go test ./internal/custom/csharp/... ./internal/engine/ ./internal/extractors/graphql/... ./internal/types/ ./tools/coverage/` — all green
- `gofmt -l` empty, `go vet ./internal/engine/` clean

**DEPLOY-DEFERRED** — extractor change requires a coordinated live-daemon rebuild+reindex; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)