### PR TITLE
feat(go/neo4j): GRAPH_RELATES graph-schema topology from Cypher (#3612)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13476,10 +13476,10 @@
             "notes": "No lazy/eager loading; queries are explicit."
           },
           "relationship_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/golang/neo4j.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/neo4j.yaml"],
-            "issue": "3214",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/golang/neo4j.go","internal/custom/golang/neo4j_test.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/neo4j.yaml"],
+            "notes": "Cypher relationship patterns promoted to GRAPH_RELATES edges between node-label entities (reCypherTriple); statically-resolvable topology full, dynamic/untyped relations honest-partial. Completes Neo4j GRAPH_RELATES set java(#3663)+py/jsts(#3670)+go(#3612); reverses #3635 downgrade.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {

--- a/internal/custom/golang/neo4j.go
+++ b/internal/custom/golang/neo4j.go
@@ -22,14 +22,19 @@ import (
 //                    (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a
 //                    soft schema (a node may carry any labels at runtime) and
 //                    are recovered from a query string by regex, hence partial.
-//   - Relationships— partial. Relationship types in Cypher patterns
+//   - Relationships— full (topology). Relationship types in Cypher patterns
 //                    (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as
 //                    SCOPE.Schema entities with subtype "relationship" (there
-//                    is no dedicated SCOPE.Relation kind). This is the
-//                    first-class graph case — but the endpoints of the relation
-//                    are not always statically resolvable from the query text,
-//                    so the relation type is recorded without proven endpoint
-//                    binding: partial.
+//                    is no dedicated SCOPE.Relation kind). When BOTH endpoints
+//                    of the pattern carry a static node label and the relation
+//                    a static type — (a:Person)-[:ACTED_IN]->(m:Movie) — the
+//                    graph-schema topology is additionally promoted to a
+//                    traversable GRAPH_RELATES edge between the node-label
+//                    entities (Person ─GRAPH_RELATES(ACTED_IN)→ Movie), the
+//                    graph-DB analogue of Mongo's JOINS_COLLECTION and the Java
+//                    SDN @Relationship edge (#3612, epic #3606). Parameterised
+//                    / dynamic relations (no static type, or built by string
+//                    concatenation) stay type-only — honest-partial.
 //   - Queries      — partial. `session.Run("CYPHER")` / `ExecuteQuery(...,
 //                    "CYPHER")` / `tx.Run("CYPHER")` call sites are captured
 //                    with a coarse verb sniffed from the leading Cypher clause.
@@ -65,6 +70,32 @@ var (
 
 	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
 	reCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+
+	// A full directed relationship triple inside a Cypher pattern:
+	//
+	//   (a:LeftLabel) -[ rvar :REL_TYPE ]-> (b:RightLabel)
+	//   (a:LeftLabel) <-[ rvar :REL_TYPE ]-  (b:RightLabel)
+	//
+	// Both endpoints must carry a statically-resolvable node label and the
+	// relationship must carry a statically-resolvable type for an edge to be
+	// emitted. The arrow head (-> vs <-) determines GRAPH_RELATES direction:
+	// the OUTGOING source is the label the arrow points away from.
+	//
+	// Captures:
+	//   1 = left node label
+	//   2 = optional left-arrow head ("<" when the relation points left)
+	//   3 = relationship type
+	//   4 = optional right-arrow head (">" when the relation points right)
+	//   5 = right node label
+	//
+	// A bare relationship with no type (-[r]-> / -[]->) or a parameterised /
+	// dynamic type (-[:$relType]-> built via string concat) does NOT match the
+	// type group, so no edge is emitted — honest-partial.
+	reCypherTriple = regexp.MustCompile(
+		`\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^()]*\)\s*` +
+			`(<)?-\[\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^\]]*\]-(>)?` +
+			`\s*\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)`,
+	)
 )
 
 func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -98,6 +129,13 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		entities = append(entities, ent)
 	}
 
+	// nodeIdx maps a node label to the index, in `entities`, of its
+	// SCOPE.Schema node entity. Used by the GRAPH_RELATES pass to hang the
+	// graph-topology edge off the *source* node-label entity (the graph
+	// "table"), mirroring the Java SDN @Node owner and the Mongo
+	// JOINS_COLLECTION source collection.
+	nodeIdx := make(map[string]int)
+
 	for _, m := range reNeo4jRun.FindAllStringSubmatchIndex(src, -1) {
 		cypher := submatch(src, m, 2) // backtick form
 		if cypher == "" {
@@ -124,7 +162,13 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, file.Language, line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
+			before := len(entities)
 			add(n)
+			// Record the node entity's index the first time it is emitted.
+			// add() dedupes, so only register when it was actually appended.
+			if len(entities) == before+1 {
+				nodeIdx["node:"+label] = before
+			}
 		}
 
 		// Relationships: relationship types in the Cypher pattern (first-class).
@@ -140,6 +184,63 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"rel_type", relType)
 			add(r)
+		}
+
+		// --- GRAPH_RELATES edges (#3612, epic #3606) ---
+		// Promote the graph-schema topology encoded in a Cypher relationship
+		// pattern — (a:Person)-[:ACTED_IN]->(m:Movie) — into a traversable
+		// edge between the node-label entities (the graph "tables"), the
+		// graph-DB analogue of the Mongo JOINS_COLLECTION and the Java SDN
+		// @Relationship GRAPH_RELATES. The edge hangs off the OUTGOING source
+		// node entity; the arrow head decides which endpoint that is:
+		//
+		//   (a:A)-[:R]->(b:B)   →  A ─GRAPH_RELATES(R, OUTGOING)→ node:B
+		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
+		//
+		// The resolver fills FromID from the owning node entity and resolves
+		// ToID ("node:<label>") to the target node entity by name. Only emitted
+		// when BOTH endpoints carry a static label AND the relation a static
+		// type; dynamic / parameterised relations don't match and stay
+		// label/type-only — honest-partial.
+		for _, tm := range reCypherTriple.FindAllStringSubmatch(cypher, -1) {
+			leftLabel, relType, rightLabel := tm[1], tm[3], tm[5]
+			pointsRight := tm[4] == ">"
+			pointsLeft := tm[2] == "<"
+			if relType == "" || leftLabel == "" || rightLabel == "" {
+				continue
+			}
+			// Determine OUTGOING source / target from the arrow head. A
+			// pattern with no head on either side is undirected; Neo4j stores
+			// every relationship with a concrete direction, so we treat the
+			// written left→right order as the source for the edge and record
+			// direction=UNDIRECTED.
+			srcLabel, dstLabel, direction := leftLabel, rightLabel, "OUTGOING"
+			switch {
+			case pointsRight && !pointsLeft:
+				srcLabel, dstLabel = leftLabel, rightLabel
+			case pointsLeft && !pointsRight:
+				srcLabel, dstLabel = rightLabel, leftLabel
+			default:
+				direction = "UNDIRECTED"
+			}
+
+			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			if !ok {
+				continue
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "node:" + dstLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neo4j",
+						"rel_type":   relType,
+						"direction":  direction,
+						"provenance": "INFERRED_FROM_NEO4J_CYPHER",
+					},
+				},
+			)
 		}
 	}
 

--- a/internal/custom/golang/neo4j_test.go
+++ b/internal/custom/golang/neo4j_test.go
@@ -1,0 +1,235 @@
+package golang_test
+
+// neo4j_test.go — tests for the custom_go_neo4j extractor's GRAPH_RELATES
+// graph-schema topology (#3612, epic #3606). Completes the Neo4j topology set
+// alongside Java (#3663) and Python+JS (#3670).
+//
+// Go's Neo4j access is driver-based (github.com/neo4j/neo4j-go-driver) with no
+// OGM decorators, so the graph schema lives in the Cypher query text. The
+// extractor parses relationship patterns —
+//   (a:Person)-[:ACTED_IN]->(m:Movie)
+// — and promotes them to traversable GRAPH_RELATES edges between the
+// node-label entities, the graph-DB analogue of Mongo's JOINS_COLLECTION.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractNeo4jRaw runs the custom_go_neo4j extractor and returns the raw
+// EntityRecords (with their Relationships intact, which the entitySummary
+// helper strips).
+func extractNeo4jRaw(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_go_neo4j")
+	if !ok {
+		t.Fatal("custom_go_neo4j not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "store.go",
+		Language: "go",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findGoGraphRelates returns the GRAPH_RELATES edge from the node entity named
+// "node:<fromLabel>" to ToID "node:<toLabel>", or nil if absent.
+func findGoGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// anyGraphRelates reports whether ANY GRAPH_RELATES edge exists in the set.
+func anyGraphRelates(ents []types.EntityRecord) bool {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// neo4jImport is the driver import line every fixture carries so the extractor
+// gate fires.
+const neo4jImport = "\t\"github.com/neo4j/neo4j-go-driver/v5/neo4j\"\n"
+
+// ---------------------------------------------------------------------------
+// Headline: MATCH (p:Person)-[:ACTED_IN]->(m:Movie) →
+//           Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ node:Movie
+// ---------------------------------------------------------------------------
+
+func TestNeo4jGoGraphRelatesEdge(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+
+	edge := findGoGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES→ node:Movie edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "ACTED_IN" {
+		t.Errorf("rel_type: want ACTED_IN, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["framework"] != "neo4j" {
+		t.Errorf("framework: want neo4j, got %q", edge.Properties["framework"])
+	}
+
+	// The OUTGOING source node is the edge owner; the reverse edge must NOT
+	// exist (direction is a property, not an endpoint swap).
+	if findGoGraphRelates(ents, "Movie", "Person") != nil {
+		t.Error("did not expect a reverse Movie ─GRAPH_RELATES→ Person edge")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Arrow direction: (m:Movie)<-[:DIRECTED]-(d:Director) — the head points LEFT,
+// so the OUTGOING source is the RIGHT endpoint (Director), not the written
+// left endpoint.
+// ---------------------------------------------------------------------------
+
+func TestNeo4jGoGraphRelatesIncomingArrow(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (m:Movie)<-[:DIRECTED]-(d:Director) RETURN m`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+
+	edge := findGoGraphRelates(ents, "Director", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Director ─GRAPH_RELATES→ node:Movie edge (left-arrow), got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "DIRECTED" {
+		t.Errorf("rel_type: want DIRECTED, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	// The written-left endpoint must NOT be the source.
+	if findGoGraphRelates(ents, "Movie", "Director") != nil {
+		t.Error("did not expect Movie ─GRAPH_RELATES→ Director for a left-pointing arrow")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE / MERGE patterns carry the same topology as MATCH.
+// ---------------------------------------------------------------------------
+
+func TestNeo4jGoGraphRelatesCreateMerge(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`CREATE (u:User)-[:FOLLOWS]->(t:Team)`, nil)\n" +
+		"\tsession.Run(`MERGE (a:Account)-[:OWNS]->(w:Wallet)`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+
+	if e := findGoGraphRelates(ents, "User", "Team"); e == nil || e.Properties["rel_type"] != "FOLLOWS" {
+		t.Errorf("expected User ─GRAPH_RELATES(FOLLOWS)→ Team from CREATE, got %+v", ents)
+	}
+	if e := findGoGraphRelates(ents, "Account", "Wallet"); e == nil || e.Properties["rel_type"] != "OWNS" {
+		t.Errorf("expected Account ─GRAPH_RELATES(OWNS)→ Wallet from MERGE, got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Undirected pattern (a:A)-[:R]-(b:B): Neo4j stores a concrete direction, so
+// the written left→right order seeds the edge but direction=UNDIRECTED.
+// ---------------------------------------------------------------------------
+
+func TestNeo4jGoGraphRelatesUndirected(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (a:Person)-[:KNOWS]-(b:Person) RETURN a, b`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+
+	edge := findGoGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person ─GRAPH_RELATES(KNOWS)→ Person self-edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "KNOWS" {
+		t.Errorf("rel_type: want KNOWS, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "UNDIRECTED" {
+		t.Errorf("direction: want UNDIRECTED, got %q", edge.Properties["direction"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives / honest-partial
+// ---------------------------------------------------------------------------
+
+// A single-node MATCH (no relationship) emits the node entity but NO edge.
+func TestNeo4jGoSingleNodeNoEdge(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (p:Person) RETURN p`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+	if anyGraphRelates(ents) {
+		t.Errorf("single-node MATCH must not emit GRAPH_RELATES, got %+v", ents)
+	}
+}
+
+// A relationship whose type is dynamic/parameterised (-[r]-> with no static
+// type) is honest-partial: no GRAPH_RELATES edge, the labels stay as node
+// schema only.
+func TestNeo4jGoDynamicRelTypeNoEdge(t *testing.T) {
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (p:Person)-[r]->(m:Movie) RETURN type(r)`, nil)\n" +
+		"}\n"
+
+	ents := extractNeo4jRaw(t, src)
+	if anyGraphRelates(ents) {
+		t.Errorf("untyped relationship must not emit GRAPH_RELATES (honest-partial), got %+v", ents)
+	}
+	// The node labels are still surfaced as schema (partial coverage holds).
+	foundPerson := false
+	for i := range ents {
+		if ents[i].Name == "node:Person" {
+			foundPerson = true
+		}
+	}
+	if !foundPerson {
+		t.Errorf("expected node:Person schema entity to survive, got %+v", ents)
+	}
+}
+
+// Gate: a file without the neo4j-go-driver import produces nothing.
+func TestNeo4jGoImportGate(t *testing.T) {
+	src := "package store\n\nconst q = `MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p`\n"
+	ents := extractNeo4jRaw(t, src)
+	if len(ents) != 0 {
+		t.Errorf("neo4j extractor must not fire without the driver import, got %+v", ents)
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -5369,18 +5369,28 @@ records:
       Relationships:
         relationship_extraction:
           # Relationship types in Cypher patterns (-[:ACTED_IN]->, -[r:KNOWS]-)
-          # => SCOPE.Schema subtype=relationship (reCypherRelType). The one driver
-          # in this slice where relationships are first-class. Endpoints are not
-          # always statically resolvable from the query text, so partial.
-          status: partial
+          # => SCOPE.Schema subtype=relationship (reCypherRelType). When BOTH
+          # endpoints carry a static node label and the relation a static type
+          # ((a:Person)-[:ACTED_IN]->(m:Movie)), the graph-schema topology is
+          # additionally promoted to a traversable GRAPH_RELATES edge between the
+          # node-label entities (reCypherTriple), the graph-DB analogue of Mongo's
+          # JOINS_COLLECTION and the Java SDN @Relationship edge. The arrow head
+          # decides the OUTGOING source endpoint; undirected patterns record
+          # direction=UNDIRECTED. Dynamic / parameterised relations (untyped
+          # -[r]->, string-concat) stay type-only — honest-partial — but the
+          # statically-resolvable topology is now full. Completes the Neo4j
+          # GRAPH_RELATES set: java (#3663) + python/jsts (#3670) + go (#3612).
+          # Reverses the #3635 downgrade.
+          status: full
           symbols:
             - file: internal/engine/rules/go/orms/neo4j.yaml
             - file: internal/custom/golang/neo4j.go
               functions: [Extract]
           tests:
             - file: internal/custom/golang/nosql_drivers_test.go
-          issues_implemented: ["3214"]
-          verified_at: "2026-05-30"
+            - file: internal/custom/golang/neo4j_test.go
+          issues_implemented: ["3214", "3612"]
+          verified_at: "2026-06-02"
       Queries:
         query_attribution:
           # session.Run("CYPHER") / tx.Run / ExecuteQuery call sites;


### PR DESCRIPTION
Closes #3612 (epic #3606).

Extends the Neo4j `GRAPH_RELATES` graph-schema topology to **Go**, completing the set: Neo4j topology now spans **java** (#3663) + **python/jsts** (#3670) + **go** (#3612).

## What

Go's Neo4j access is driver-based (`github.com/neo4j/neo4j-go-driver`) with no OGM decorators like neomodel — the graph schema lives in the **Cypher query text**. The `custom_go_neo4j` extractor now parses relationship patterns and promotes the statically-resolvable topology to traversable `GRAPH_RELATES` edges between the node-label entities (the graph "tables"), the graph-DB analogue of Mongo's `JOINS_COLLECTION` and the Java SDN `@Relationship` edge.

### Cypher → GRAPH_RELATES edges

| Cypher pattern | Emitted edge |
|---|---|
| `MATCH (p:Person)-[:ACTED_IN]->(m:Movie)` | `node:Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ node:Movie` |
| `MATCH (m:Movie)<-[:DIRECTED]-(d:Director)` | `node:Director ─GRAPH_RELATES(DIRECTED, OUTGOING)→ node:Movie` (arrow head flips the source) |
| `MATCH (a:Person)-[:KNOWS]-(b:Person)` | `node:Person ─GRAPH_RELATES(KNOWS, UNDIRECTED)→ node:Person` |
| `CREATE/MERGE (u:User)-[:FOLLOWS]->(t:Team)` | `node:User ─GRAPH_RELATES(FOLLOWS, OUTGOING)→ node:Team` |

The edge hangs off the OUTGOING **source** node entity (`reCypherTriple`); the arrow head decides which endpoint that is. ToID is `node:<label>`, resolved by name to the target node entity.

**Honest-partial:** untyped (`-[r]->`) and dynamic / string-concat relations don't match the static-type group, so no edge is emitted — labels stay as node schema only. A single-node `MATCH (p:Person)` emits no edge.

## Records

`lang.go.driver.neo4j` relationship_extraction **partial → full** (reverses the #3635 downgrade), cited to `internal/custom/golang/neo4j.go` + the new test. Updated in both `capability-map.yaml` and `docs/coverage/registry.json` (canonical, `fmt --check` clean, `validate` 0 errors).

## Tests (value-asserting, not len>0)

- Headline edge with `rel_type=ACTED_IN`, `direction=OUTGOING`, `framework=neo4j`; reverse edge asserted absent.
- Left-arrow flips the source endpoint.
- Undirected records `direction=UNDIRECTED`.
- CREATE/MERGE carry the same topology.
- Negatives: single-node MATCH and untyped relationship emit **no** `GRAPH_RELATES` (honest-partial); node labels still survive as schema.
- Import gate.

`go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/` green; `gofmt -l` clean (mine); `go vet` clean; `coverage validate` 0 errors + `fmt --check` canonical.

## DEPLOY-DEFERRED

Live daemon rebuild + reindex deferred (live daemon serves the rewrite agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)