### PR TITLE
feat(engine): persist deplinker dependency hygiene into the graph (#3640)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -59,13 +59,14 @@ const (
 	PassEventFlow     = "event-flow"     // Pass 7.5: event-flow pub/sub walk (#1944 Phase 1)
 	PassModuleAgg     = "module-agg"     // Pass 8: module-level aggregation (#1383)
 	PassCommitCouple  = "commit-couple"  // Pass 8.5: VCS-derived COMMIT_COUPLED soft edges (#21)
+	PassDepHygiene    = "dep-hygiene"    // Pass 8.7: persist deplinker used/unused status onto deps (#3640)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassDepHygiene, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1528,6 +1529,26 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				"archigraph: commit-couple commits=%d candidate_pairs=%d files=%d edges=%d oversize_skipped=%d\n",
 				ccStats.TotalCommits, ccStats.CandidatePairs, ccStats.FileEntities,
 				ccStats.CoupledEdges, ccStats.SkippedOversizeCommits)
+		}
+	}
+
+	// Pass 8.7 — dependency-hygiene annotation (#3640, epic #3625). Runs
+	// AFTER the document is assembled (manifest external_dependency entities +
+	// import DEPENDS_ON edges are all present) so the deplinker analysis sees
+	// the same graph the dashboard would. Persists usage_status=used|unused
+	// onto each declared dependency entity (and its DEPENDS_ON edge), promoting
+	// the previously dashboard-only deplinker signal into the graph so
+	// find/neighbors/agents can read dependency hygiene. The dashboard keeps
+	// calling AnalyzeGroup independently; this pass annotates entities in place
+	// (no new entities, no double-emit). Skippable via --skip-pass=dep-hygiene.
+	if !i.skipPasses[PassDepHygiene] {
+		dhStats := engine.ApplyDependencyHygiene(doc)
+		if verbose() || dhStats.EntitiesAnnotated > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: dep-hygiene declared=%d used=%d unused=%d phantom=%d "+
+					"entities_annotated=%d edges_annotated=%d\n",
+				dhStats.Declared, dhStats.Used, dhStats.Unused, dhStats.Phantom,
+				dhStats.EntitiesAnnotated, dhStats.EdgesAnnotated)
 		}
 	}
 

--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -6,96 +6,96 @@
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
-| Language | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [Catch2](../detail/test.catch2.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | 🔴 | |
-| [C#](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | — | — | 🔴 | |
-| [C#](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | 🟢 | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | 🟢 | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | 🟢 | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
-| [C#](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | 🟢 | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
-| [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | 🟢 | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
-| [elixir](../by-language/elixir.md) | [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | ✅ | |
-| [go](../by-language/go.md) | [Ginkgo](../detail/test.ginkgo.md) | 🟢 | — | — | ✅ | |
-| [go](../by-language/go.md) | [Gomega](../detail/test.gomega.md) | 🟢 | — | — | ✅ | |
-| [go](../by-language/go.md) | [Mage](../detail/build.mage.md) | ✅ | — | — | ✅ | |
-| [go](../by-language/go.md) | [Task (taskfile.dev)](../detail/build.task.md) | ✅ | — | — | ✅ | |
-| [go](../by-language/go.md) | [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | ✅ | |
-| [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | ✅ | |
-| [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ✅ | — | — | ✅ | |
-| [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | 🔴 | — | — | 🔴 | |
-| [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | 🔴 | — | — | 🔴 | |
-| [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | ✅ | |
-| [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | 🟢 | — | — | 🟢 | |
-| [java](../by-language/java.md) | [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | ✅ | |
-| [java](../by-language/java.md) | [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | ✅ | |
-| [java](../by-language/java.md) | [Mockito](../detail/test.mockito.md) | 🔴 | — | — | 🔴 | |
-| [java](../by-language/java.md) | [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | 🔴 | |
-| [java](../by-language/java.md) | [TestNG](../detail/test.testng.md) | 🔴 | — | — | 🟢 | |
-| [JS/TS](../by-language/jsts.md) | [AVA](../detail/test.ava.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Cypress](../detail/test.cypress.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Jasmine](../detail/test.jasmine.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Jest](../detail/test.jest.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Lerna](../detail/build.lerna.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Mocha](../detail/test.mocha.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Nx (monorepo)](../detail/build.nx.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Parcel](../detail/build.parcel.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Playwright](../detail/test.playwright.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Rollup](../detail/build.rollup.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Turborepo](../detail/build.turborepo.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Vite](../detail/build.vite.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Vitest](../detail/test.vitest.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Webpack](../detail/build.webpack.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Yarn](../detail/build.yarn.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [esbuild](../detail/build.esbuild.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [npm](../detail/build.npm.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [pnpm](../detail/build.pnpm.md) | ✅ | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [tap / node:test](../detail/test.tap.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
-| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
-| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [Pipenv](../detail/build.pipenv.md) | 🟢 | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Poetry](../detail/build.poetry.md) | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [doctest (stdlib)](../detail/test.doctest.md) | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [nose2](../detail/test.nose2.md) | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [pytest](../detail/test.pytest.md) | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | — | — | 🟢 | |
-| [python](../by-language/python.md) | [unittest (stdlib)](../detail/test.unittest.md) | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [uv (Astral)](../detail/build.uv.md) | ✅ | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Cucumber](../detail/test.cucumber.md) | 🔴 | — | — | 🔴 | |
-| [ruby](../by-language/ruby.md) | [Minitest](../detail/test.minitest.md) | 🟢 | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [RSpec](../detail/test.rspec.md) | ✅ | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Rake](../detail/build.rake.md) | 🔴 | — | — | 🟢 | |
-| [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ✅ | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ✅ | — | — | ✅ | |
-| [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | — | — | 🔴 | |
-| [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | — | — | ✅ | |
+| Language | Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | — | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [Catch2](../detail/test.catch2.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | — | 🔴 | |
+| [C#](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | — | — | — | 🔴 | |
+| [C#](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | 🟢 | — | — | — | 🟢 | |
+| [C#](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | 🟢 | — | — | — | 🟢 | |
+| [C#](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | 🟢 | — | — | — | 🟢 | |
+| [C#](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | — | ✅ | |
+| [C#](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | 🟢 | — | — | — | 🟢 | |
+| [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | — | ✅ | |
+| [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | 🟢 | — | — | — | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | — | ✅ | |
+| [elixir](../by-language/elixir.md) | [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [Ginkgo](../detail/test.ginkgo.md) | 🟢 | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [Gomega](../detail/test.gomega.md) | 🟢 | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [Mage](../detail/build.mage.md) | ✅ | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [Task (taskfile.dev)](../detail/build.task.md) | ✅ | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | — | ✅ | |
+| [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ✅ | — | — | — | ✅ | |
+| [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | 🔴 | — | — | — | 🔴 | |
+| [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | 🔴 | — | — | — | 🔴 | |
+| [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | — | ✅ | |
+| [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | 🟢 | — | — | — | 🟢 | |
+| [java](../by-language/java.md) | [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | — | ✅ | |
+| [java](../by-language/java.md) | [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | — | ✅ | |
+| [java](../by-language/java.md) | [Mockito](../detail/test.mockito.md) | 🔴 | — | — | — | 🔴 | |
+| [java](../by-language/java.md) | [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | — | 🔴 | |
+| [java](../by-language/java.md) | [TestNG](../detail/test.testng.md) | 🔴 | — | — | — | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [AVA](../detail/test.ava.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Cypress](../detail/test.cypress.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Jasmine](../detail/test.jasmine.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Jest](../detail/test.jest.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Lerna](../detail/build.lerna.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Mocha](../detail/test.mocha.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Nx (monorepo)](../detail/build.nx.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Parcel](../detail/build.parcel.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Playwright](../detail/test.playwright.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Rollup](../detail/build.rollup.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Turborepo](../detail/build.turborepo.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Vite](../detail/build.vite.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Vitest](../detail/test.vitest.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Webpack](../detail/build.webpack.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Yarn](../detail/build.yarn.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [esbuild](../detail/build.esbuild.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [npm](../detail/build.npm.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [pnpm](../detail/build.pnpm.md) | ✅ | — | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [tap / node:test](../detail/test.tap.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | — | — | — | 🟢 | |
+| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | — | — | — | 🟢 | |
+| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | — | — | — | 🟢 | |
+| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | — | — | — | ✅ | |
+| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | — | ✅ | |
+| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | — | 🔴 | |
+| [python](../by-language/python.md) | [Pipenv](../detail/build.pipenv.md) | 🟢 | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [Poetry](../detail/build.poetry.md) | ✅ | — | — | — | ✅ | |
+| [python](../by-language/python.md) | [doctest (stdlib)](../detail/test.doctest.md) | — | — | — | — | 🔴 | |
+| [python](../by-language/python.md) | [nose2](../detail/test.nose2.md) | — | — | — | — | 🔴 | |
+| [python](../by-language/python.md) | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | — | ✅ | |
+| [python](../by-language/python.md) | [pytest](../detail/test.pytest.md) | ✅ | — | — | — | ✅ | |
+| [python](../by-language/python.md) | [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [unittest (stdlib)](../detail/test.unittest.md) | ✅ | — | — | — | ✅ | |
+| [python](../by-language/python.md) | [uv (Astral)](../detail/build.uv.md) | ✅ | — | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Cucumber](../detail/test.cucumber.md) | 🔴 | — | — | — | 🔴 | |
+| [ruby](../by-language/ruby.md) | [Minitest](../detail/test.minitest.md) | 🟢 | — | — | — | 🟢 | |
+| [ruby](../by-language/ruby.md) | [RSpec](../detail/test.rspec.md) | ✅ | — | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Rake](../detail/build.rake.md) | 🔴 | — | — | — | 🟢 | |
+| [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ✅ | — | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ✅ | — | — | — | ✅ | |
+| [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | — | — | — | 🔴 | |
+| [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | — | — | — | ✅ | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,29 +1,30 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 19 records · **C/C++**: 4 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **go**: 1 · **java**: 2 · **JS/TS**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 20 records · **C/C++**: 4 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **go**: 1 · **java**: 2 · **JS/TS**: 1 · **multi**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
-| Language | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | 🟢 | — | |
-| [C/C++](../by-language/c-cpp.md) | [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | 🔴 | 🔴 | — | |
-| [C/C++](../by-language/c-cpp.md) | [build2](../detail/lang.c-cpp.tool.build2.md) | — | 🔴 | 🔴 | — | |
-| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🟢 | 🟢 | — | |
-| [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ✅ | ✅ | — | |
-| [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | 🔴 | ✅ | — | |
-| [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | — | |
-| [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | 🔴 | 🔴 | — | |
-| [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | — | |
-| [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | ✅ | ✅ | — | |
-| [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | — | |
-| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | — | |
-| [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | — | |
-| [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | 🔴 | ✅ | — | |
-| [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | — | |
-| [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | 🔴 | — | |
-| [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | 🔴 | — | |
+| Language | Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | — | 🟢 | — | |
+| [C/C++](../by-language/c-cpp.md) | [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | — | 🔴 | 🔴 | — | |
+| [C/C++](../by-language/c-cpp.md) | [build2](../detail/lang.c-cpp.tool.build2.md) | — | — | 🔴 | 🔴 | — | |
+| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | — | 🟢 | 🟢 | — | |
+| [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | — | ✅ | ✅ | — | |
+| [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | — | 🔴 | ✅ | — | |
+| [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | — | 🔴 | — | |
+| [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | — | ✅ | ✅ | — | |
+| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🔴 | — | |
+| [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | — | ✅ | — | |
+| [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | — | ✅ | ✅ | — | |
+| [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | — | ✅ | — | — | — | |
+| [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | — | ✅ | ✅ | — | |
+| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | — | 🟢 | 🟢 | — | |
+| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | — | 🟢 | ✅ | — | |
+| [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | — | ✅ | — | |
+| [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | — | 🔴 | ✅ | — | |
+| [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | — | 🔴 | ✅ | — | |
+| [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | — | 🔴 | — | |
+| [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | — | 🔴 | — | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -67,24 +67,24 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | 🔴 | |
-| [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | 🔴 | |
-| [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | 🟢 | |
-| [Catch2](../detail/test.catch2.md) | 🔴 | — | — | 🔴 | |
-| [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | 🟢 | — | |
-| [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | 🔴 | |
-| [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | 🔴 | |
-| [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | 🔴 | |
-| [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | — | — | 🔴 | |
-| [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | 🔴 | 🔴 | — | |
-| [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | — | — | 🔴 | |
-| [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | 🔴 | |
-| [build2](../detail/lang.c-cpp.tool.build2.md) | — | 🔴 | 🔴 | — | |
-| [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | 🔴 | |
-| [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🟢 | 🟢 | — | |
-| [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | 🔴 | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | — | 🔴 | |
+| [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | — | 🔴 | |
+| [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | — | 🟢 | |
+| [Catch2](../detail/test.catch2.md) | 🔴 | — | — | — | 🔴 | |
+| [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | — | 🟢 | — | |
+| [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | — | 🔴 | |
+| [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | — | 🔴 | |
+| [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | — | 🔴 | |
+| [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | — | — | — | 🔴 | |
+| [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | — | 🔴 | 🔴 | — | |
+| [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | — | — | — | 🔴 | |
+| [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | — | 🔴 | |
+| [build2](../detail/lang.c-cpp.tool.build2.md) | — | — | 🔴 | 🔴 | — | |
+| [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | — | 🔴 | |
+| [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | — | 🟢 | 🟢 | — | |
+| [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | — | 🔴 | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -69,15 +69,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [.csproj / packages.config](../detail/pkg.csproj.md) | — | ✅ | ✅ | — | |
-| [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | — | — | 🔴 | |
-| [MSTest](../detail/test.mstest.md) | 🟢 | — | — | 🟢 | |
-| [NUnit](../detail/test.nunit.md) | 🟢 | — | — | 🟢 | |
-| [NuGet](../detail/build.nuget.md) | 🟢 | — | — | 🟢 | |
-| [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
-| [xUnit](../detail/test.xunit.md) | 🟢 | — | — | 🟢 | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [.csproj / packages.config](../detail/pkg.csproj.md) | — | — | ✅ | ✅ | — | |
+| [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | — | — | — | 🔴 | |
+| [MSTest](../detail/test.mstest.md) | 🟢 | — | — | — | 🟢 | |
+| [NUnit](../detail/test.nunit.md) | 🟢 | — | — | — | 🟢 | |
+| [NuGet](../detail/build.nuget.md) | 🟢 | — | — | — | 🟢 | |
+| [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | — | ✅ | |
+| [xUnit](../detail/test.xunit.md) | 🟢 | — | — | — | 🟢 | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -31,6 +31,6 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [pubspec.yaml](../detail/pkg.pubspec.md) | — | 🔴 | ✅ | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [pubspec.yaml](../detail/pkg.pubspec.md) | — | — | 🔴 | ✅ | — | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -56,13 +56,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
-| [Hex](../detail/build.hex.md) | 🟢 | — | — | 🟢 | |
-| [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
-| [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | ✅ | |
-| [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [ExUnit](../detail/test.exunit.md) | ✅ | — | — | — | ✅ | |
+| [Hex](../detail/build.hex.md) | 🟢 | — | — | — | 🟢 | |
+| [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | — | ✅ | |
+| [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | — | ✅ | |
+| [mix.exs](../detail/pkg.mix.md) | — | — | — | 🔴 | — | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -59,16 +59,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Ginkgo](../detail/test.ginkgo.md) | 🟢 | — | — | ✅ | |
-| [Gomega](../detail/test.gomega.md) | 🟢 | — | — | ✅ | |
-| [Mage](../detail/build.mage.md) | ✅ | — | — | ✅ | |
-| [Task (taskfile.dev)](../detail/build.task.md) | ✅ | — | — | ✅ | |
-| [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | ✅ | |
-| [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | ✅ | |
-| [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | — | |
-| [testify](../detail/test.testify.md) | ✅ | — | — | ✅ | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Ginkgo](../detail/test.ginkgo.md) | 🟢 | — | — | — | ✅ | |
+| [Gomega](../detail/test.gomega.md) | 🟢 | — | — | — | ✅ | |
+| [Mage](../detail/build.mage.md) | ✅ | — | — | — | ✅ | |
+| [Task (taskfile.dev)](../detail/build.task.md) | ✅ | — | — | — | ✅ | |
+| [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | — | ✅ | |
+| [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | — | ✅ | |
+| [go.mod](../detail/pkg.go-mod.md) | — | — | ✅ | ✅ | — | |
+| [testify](../detail/test.testify.md) | ✅ | — | — | — | ✅ | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/groovy.md
+++ b/docs/coverage/by-language/groovy.md
@@ -21,6 +21,6 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Spock](../detail/test.spock.md) | 🔴 | — | — | 🔴 | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Spock](../detail/test.spock.md) | 🔴 | — | — | — | 🔴 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -73,18 +73,18 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [AssertJ](../detail/test.assertj.md) | 🔴 | — | — | 🔴 | |
-| [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | ✅ | |
-| [JUnit 4](../detail/test.junit4.md) | 🟢 | — | — | 🟢 | |
-| [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | ✅ | |
-| [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | ✅ | |
-| [Mockito](../detail/test.mockito.md) | 🔴 | — | — | 🔴 | |
-| [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | 🔴 | |
-| [TestNG](../detail/test.testng.md) | 🔴 | — | — | 🟢 | |
-| [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | 🔴 | 🔴 | — | |
-| [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [AssertJ](../detail/test.assertj.md) | 🔴 | — | — | — | 🔴 | |
+| [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | — | ✅ | |
+| [JUnit 4](../detail/test.junit4.md) | 🟢 | — | — | — | 🟢 | |
+| [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | — | ✅ | |
+| [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | — | ✅ | |
+| [Mockito](../detail/test.mockito.md) | 🔴 | — | — | — | 🔴 | |
+| [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | — | 🔴 | |
+| [TestNG](../detail/test.testng.md) | 🔴 | — | — | — | 🟢 | |
+| [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🔴 | — | |
+| [pom.xml](../detail/pkg.pom.md) | — | — | — | ✅ | — | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -96,29 +96,29 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [AVA](../detail/test.ava.md) | ✅ | — | — | ✅ | |
-| [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | — | — | ✅ | |
-| [Cypress](../detail/test.cypress.md) | ✅ | — | — | ✅ | |
-| [Jasmine](../detail/test.jasmine.md) | ✅ | — | — | ✅ | |
-| [Jest](../detail/test.jest.md) | ✅ | — | — | ✅ | |
-| [Lerna](../detail/build.lerna.md) | ✅ | — | — | ✅ | |
-| [Mocha](../detail/test.mocha.md) | ✅ | — | — | ✅ | |
-| [Nx (monorepo)](../detail/build.nx.md) | ✅ | — | — | ✅ | |
-| [Parcel](../detail/build.parcel.md) | ✅ | — | — | ✅ | |
-| [Playwright](../detail/test.playwright.md) | ✅ | — | — | ✅ | |
-| [Rollup](../detail/build.rollup.md) | ✅ | — | — | ✅ | |
-| [Turborepo](../detail/build.turborepo.md) | ✅ | — | — | ✅ | |
-| [Vite](../detail/build.vite.md) | ✅ | — | — | ✅ | |
-| [Vitest](../detail/test.vitest.md) | ✅ | — | — | ✅ | |
-| [Webpack](../detail/build.webpack.md) | ✅ | — | — | ✅ | |
-| [Yarn](../detail/build.yarn.md) | ✅ | — | — | ✅ | |
-| [esbuild](../detail/build.esbuild.md) | ✅ | — | — | ✅ | |
-| [npm](../detail/build.npm.md) | ✅ | — | — | ✅ | |
-| [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | ✅ | ✅ | — | |
-| [pnpm](../detail/build.pnpm.md) | ✅ | — | — | ✅ | |
-| [tap / node:test](../detail/test.tap.md) | ✅ | — | — | ✅ | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [AVA](../detail/test.ava.md) | ✅ | — | — | — | ✅ | |
+| [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | — | — | — | ✅ | |
+| [Cypress](../detail/test.cypress.md) | ✅ | — | — | — | ✅ | |
+| [Jasmine](../detail/test.jasmine.md) | ✅ | — | — | — | ✅ | |
+| [Jest](../detail/test.jest.md) | ✅ | — | — | — | ✅ | |
+| [Lerna](../detail/build.lerna.md) | ✅ | — | — | — | ✅ | |
+| [Mocha](../detail/test.mocha.md) | ✅ | — | — | — | ✅ | |
+| [Nx (monorepo)](../detail/build.nx.md) | ✅ | — | — | — | ✅ | |
+| [Parcel](../detail/build.parcel.md) | ✅ | — | — | — | ✅ | |
+| [Playwright](../detail/test.playwright.md) | ✅ | — | — | — | ✅ | |
+| [Rollup](../detail/build.rollup.md) | ✅ | — | — | — | ✅ | |
+| [Turborepo](../detail/build.turborepo.md) | ✅ | — | — | — | ✅ | |
+| [Vite](../detail/build.vite.md) | ✅ | — | — | — | ✅ | |
+| [Vitest](../detail/test.vitest.md) | ✅ | — | — | — | ✅ | |
+| [Webpack](../detail/build.webpack.md) | ✅ | — | — | — | ✅ | |
+| [Yarn](../detail/build.yarn.md) | ✅ | — | — | — | ✅ | |
+| [esbuild](../detail/build.esbuild.md) | ✅ | — | — | — | ✅ | |
+| [npm](../detail/build.npm.md) | ✅ | — | — | — | ✅ | |
+| [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | — | ✅ | ✅ | — | |
+| [pnpm](../detail/build.pnpm.md) | ✅ | — | — | — | ✅ | |
+| [tap / node:test](../detail/test.tap.md) | ✅ | — | — | — | ✅ | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -45,14 +45,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Behat](../detail/test.behat.md) | 🟢 | — | — | 🟢 | |
-| [Codeception](../detail/test.codeception.md) | 🟢 | — | — | 🟢 | |
-| [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
-| [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
-| [Pest](../detail/test.pest.md) | 🟢 | — | — | 🟢 | |
-| [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Behat](../detail/test.behat.md) | 🟢 | — | — | — | 🟢 | |
+| [Codeception](../detail/test.codeception.md) | 🟢 | — | — | — | 🟢 | |
+| [Composer](../detail/build.composer.md) | ✅ | — | — | — | ✅ | |
+| [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | — | ✅ | |
+| [Pest](../detail/test.pest.md) | 🟢 | — | — | — | 🟢 | |
+| [composer.json](../detail/pkg.composer.md) | — | — | ✅ | ✅ | — | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -63,23 +63,23 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Flit](../detail/build.flit.md) | 🟢 | — | — | 🟢 | |
-| [Hatch](../detail/build.hatch.md) | 🟢 | — | — | 🟢 | |
-| [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | 🔴 | |
-| [Pipenv](../detail/build.pipenv.md) | 🟢 | — | — | 🟢 | |
-| [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | — | |
-| [Poetry](../detail/build.poetry.md) | ✅ | — | — | ✅ | |
-| [doctest (stdlib)](../detail/test.doctest.md) | — | — | — | 🔴 | |
-| [nose2](../detail/test.nose2.md) | — | — | — | 🔴 | |
-| [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | ✅ | |
-| [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | — | |
-| [pytest](../detail/test.pytest.md) | ✅ | — | — | ✅ | |
-| [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | — | |
-| [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | — | — | 🟢 | |
-| [unittest (stdlib)](../detail/test.unittest.md) | ✅ | — | — | ✅ | |
-| [uv (Astral)](../detail/build.uv.md) | ✅ | — | — | ✅ | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Flit](../detail/build.flit.md) | 🟢 | — | — | — | 🟢 | |
+| [Hatch](../detail/build.hatch.md) | 🟢 | — | — | — | 🟢 | |
+| [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | — | 🔴 | |
+| [Pipenv](../detail/build.pipenv.md) | 🟢 | — | — | — | 🟢 | |
+| [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | — | 🟢 | 🟢 | — | |
+| [Poetry](../detail/build.poetry.md) | ✅ | — | — | — | ✅ | |
+| [doctest (stdlib)](../detail/test.doctest.md) | — | — | — | — | 🔴 | |
+| [nose2](../detail/test.nose2.md) | — | — | — | — | 🔴 | |
+| [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | — | ✅ | |
+| [pyproject.toml](../detail/pkg.pyproject.md) | — | — | 🟢 | ✅ | — | |
+| [pytest](../detail/test.pytest.md) | ✅ | — | — | — | ✅ | |
+| [requirements.txt](../detail/pkg.requirements.md) | — | — | — | ✅ | — | |
+| [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | — | — | — | 🟢 | |
+| [unittest (stdlib)](../detail/test.unittest.md) | ✅ | — | — | — | ✅ | |
+| [uv (Astral)](../detail/build.uv.md) | ✅ | — | — | — | ✅ | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -38,14 +38,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | ✅ | |
-| [Cucumber](../detail/test.cucumber.md) | 🔴 | — | — | 🔴 | |
-| [Gemfile](../detail/pkg.gemfile.md) | — | 🔴 | ✅ | — | |
-| [Minitest](../detail/test.minitest.md) | 🟢 | — | — | 🟢 | |
-| [RSpec](../detail/test.rspec.md) | ✅ | — | — | ✅ | |
-| [Rake](../detail/build.rake.md) | 🔴 | — | — | 🟢 | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | — | ✅ | |
+| [Cucumber](../detail/test.cucumber.md) | 🔴 | — | — | — | 🔴 | |
+| [Gemfile](../detail/pkg.gemfile.md) | — | — | 🔴 | ✅ | — | |
+| [Minitest](../detail/test.minitest.md) | 🟢 | — | — | — | 🟢 | |
+| [RSpec](../detail/test.rspec.md) | ✅ | — | — | — | ✅ | |
+| [Rake](../detail/build.rake.md) | 🔴 | — | — | — | 🟢 | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -50,14 +50,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | ✅ | |
-| [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | — | |
-| [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | ✅ | |
-| [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | ✅ | |
-| [mockall](../detail/test.mockall.md) | ✅ | — | — | ✅ | |
-| [proptest](../detail/test.proptest.md) | ✅ | — | — | ✅ | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | — | ✅ | |
+| [Cargo.toml](../detail/pkg.cargo.md) | — | — | 🔴 | ✅ | — | |
+| [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | — | ✅ | |
+| [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | — | ✅ | |
+| [mockall](../detail/test.mockall.md) | ✅ | — | — | — | ✅ | |
+| [proptest](../detail/test.proptest.md) | ✅ | — | — | — | ✅ | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -56,11 +56,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Mill](../detail/build.mill.md) | 🔴 | — | — | 🔴 | |
-| [SBT](../detail/build.sbt.md) | ✅ | — | — | ✅ | |
-| [build.sbt](../detail/pkg.sbt.md) | — | — | 🔴 | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Mill](../detail/build.mill.md) | 🔴 | — | — | — | 🔴 | |
+| [SBT](../detail/build.sbt.md) | ✅ | — | — | — | ✅ | |
+| [build.sbt](../detail/pkg.sbt.md) | — | — | — | 🔴 | — | |
 
 ## ORMs
 

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -46,6 +46,6 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Tools
 
-| Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|
-| [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | 🔴 | — | |
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | — | 🔴 | — | |

--- a/docs/coverage/detail/analysis.dependency-hygiene.md
+++ b/docs/coverage/detail/analysis.dependency-hygiene.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `analysis.dependency-hygiene` — Dependency hygiene (used / unused / phantom)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency usage status | ✅ `full` | `2026-06-02` | — | `cmd/archigraph/index.go`<br>`internal/engine/dependency_hygiene.go`<br>`internal/engine/dependency_hygiene_test.go`<br>`internal/extractors/cross/deplinker/extractor.go` | deplinker used/unused/phantom classification is now PERSISTED into the graph (issue #3640, epic #3625). The Pass 8.7 engine pass engine.ApplyDependencyHygiene reuses deplinker.Analyze over the assembled graph.Document and writes usage_status=used|unused onto each external_dependency entity (manifest extractor) and its DEPENDS_ON(kind=external_dependency) edge, so find/neighbors/agents read dependency hygiene directly. Phantom imports (imported, not declared) are reported as a stat but not synthesised as entities to avoid double-counting the manifest inventory; phantom listing remains the dashboard's job. The dashboard handler keeps calling AnalyzeGroup independently (no double-emit). Honest-partial: classification fidelity tracks deplinker's manifest+import inputs. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update analysis.dependency-hygiene ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2,6 +2,20 @@
   "$schema_version": 1,
   "records": [
     {
+      "id": "analysis.dependency-hygiene",
+      "category": "package_manager",
+      "language": "multi",
+      "label": "Dependency hygiene (used / unused / phantom)",
+      "capabilities": {
+        "dependency_usage_status": {
+          "status": "full",
+          "cites": ["cmd/archigraph/index.go","internal/engine/dependency_hygiene.go","internal/engine/dependency_hygiene_test.go","internal/extractors/cross/deplinker/extractor.go"],
+          "notes": "deplinker used/unused/phantom classification is now PERSISTED into the graph (issue #3640, epic #3625). The Pass 8.7 engine pass engine.ApplyDependencyHygiene reuses deplinker.Analyze over the assembled graph.Document and writes usage_status=used|unused onto each external_dependency entity (manifest extractor) and its DEPENDS_ON(kind=external_dependency) edge, so find/neighbors/agents read dependency hygiene directly. Phantom imports (imported, not declared) are reported as a stat but not synthesised as entities to avoid double-counting the manifest inventory; phantom listing remains the dashboard's job. The dashboard handler keeps calling AnalyzeGroup independently (no double-emit). Honest-partial: classification fidelity tracks deplinker's manifest+import inputs.",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "build.bazel",
       "category": "build_system",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 212 · **ORMs**: 152 · **Tools**: 110 · **Other**: 125
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 212 · **ORMs**: 152 · **Tools**: 111 · **Other**: 125
 
 ## Coverage by language
 
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 212 frameworks · 110 tools · 152 ORMs · 125 other
+Total: 212 frameworks · 111 tools · 152 ORMs · 125 other

--- a/internal/engine/dependency_hygiene.go
+++ b/internal/engine/dependency_hygiene.go
@@ -1,0 +1,185 @@
+// Package engine — dependency-hygiene annotation pass (#3640, epic #3625).
+//
+// This pass promotes the deplinker dependency analysis from a dashboard-only
+// query into a PERSISTED graph signal. Previously deplinker.AnalyzeGroup was
+// called solely by the dashboard handler (internal/dashboard/handlers_
+// dependencies.go); its used/unused/phantom classification never reached the
+// graph, so `find`/`neighbors`/agents could not see dependency hygiene.
+//
+// ApplyDependencyHygiene runs the SAME deplinker.Analyze logic over the
+// assembled graph.Document and writes the classification back onto the graph:
+//
+//   - Each external_dependency entity (emitted by the manifest extractor) gets
+//     a usage_status=used|unused property.
+//   - The entity's embedded DEPENDS_ON(kind=external_dependency) edge — when
+//     present — gets the same usage_status property, so edge-oriented queries
+//     (neighbors) surface hygiene without a second entity lookup.
+//   - Phantom imports (imported but not declared in any manifest) are surfaced
+//     as a doc-level stat. We deliberately do NOT synthesise new entities for
+//     phantoms here: the import edges already exist in the graph and inventing
+//     dependency entities for them would double-count against the manifest
+//     extractor's declared-dep inventory. Phantom visibility remains the
+//     dashboard's job; the persisted layer annotates declared deps only.
+//
+// The dashboard path is unchanged and keeps calling AnalyzeGroup — this pass
+// adds the persisted layer without removing the on-demand one (no double
+// emit: this mutates existing entities in place, it does not append).
+//
+// Honest-partial: when manifest data or import edges are incomplete the
+// classification is only as good as deplinker's input. A declared dep with no
+// observed import edge is marked "unused" exactly as the dashboard reports it;
+// callers reading usage_status should treat it with the same confidence as the
+// dashboard's dependency panel.
+package engine
+
+import (
+	"github.com/cajasmota/archigraph/internal/extractors/cross/deplinker"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// DependencyHygieneStats summarises one ApplyDependencyHygiene run.
+type DependencyHygieneStats struct {
+	// Declared is the number of external_dependency entities considered.
+	Declared int
+	// Used is the count annotated usage_status=used.
+	Used int
+	// Unused is the count annotated usage_status=unused.
+	Unused int
+	// Phantom is the count of imported-but-undeclared packages deplinker
+	// detected. Not persisted as entities (see package doc); reported for
+	// parity with the dashboard summary.
+	Phantom int
+	// EntitiesAnnotated is the number of entities that received a
+	// usage_status property (== Used + Unused for matched declared deps).
+	EntitiesAnnotated int
+	// EdgesAnnotated is the number of embedded DEPENDS_ON edges that
+	// received a usage_status property.
+	EdgesAnnotated int
+}
+
+// usageStatusProp is the entity/edge property key carrying the deplinker
+// classification. Kept in one place so queries and tests agree on the name.
+const usageStatusProp = "usage_status"
+
+// ApplyDependencyHygiene classifies every declared external dependency in doc
+// as used or unused (via deplinker.Analyze) and writes usage_status onto the
+// dependency entities and their DEPENDS_ON edges in place.
+//
+// Reuses deplinker.Analyze — the classification logic is NOT reimplemented
+// here. Safe to call on a doc with no manifest data (returns zero stats).
+func ApplyDependencyHygiene(doc *graph.Document) DependencyHygieneStats {
+	stats := DependencyHygieneStats{}
+	if doc == nil {
+		return stats
+	}
+
+	// Reuse the dashboard's analysis logic verbatim.
+	report := deplinker.Analyze(doc)
+	stats.Declared = report.Declared
+	stats.Used = report.Used
+	stats.Unused = report.Unused
+	stats.Phantom = report.Phantom
+
+	if report.Declared == 0 {
+		return stats
+	}
+
+	// Index the classification by the canonical "<pm>:<name>" key so we can
+	// match it back to entities. deplinker keys declared deps the same way
+	// (package_manager + name), so this round-trips exactly.
+	statusByKey := make(map[string]deplinker.DependencyStatus, len(report.Packages))
+	for _, p := range report.Packages {
+		// Phantom packages have no package_manager and no declared entity to
+		// annotate; skip them (their import edges already live in the graph).
+		if p.Status == deplinker.StatusPhantom {
+			continue
+		}
+		statusByKey[depKey(p.PackageManager, p.Name)] = p.Status
+	}
+
+	// Walk entities once, annotating external_dependency entities (and their
+	// embedded DEPENDS_ON edges) with the matched status.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "external_dependency" {
+			continue
+		}
+		if e.Properties == nil {
+			continue
+		}
+		pm := e.Properties["package_manager"]
+		if pm == "" {
+			continue
+		}
+		status, ok := statusByKey[depKey(pm, e.Name)]
+		if !ok {
+			continue
+		}
+		e.Properties[usageStatusProp] = string(status)
+		stats.EntitiesAnnotated++
+	}
+
+	// Annotate the standalone DEPENDS_ON(kind=external_dependency) edges that
+	// the manifest extractor emits. These live in doc.Relationships after the
+	// document is assembled. We match on the edge's ToID, which the manifest
+	// extractor builds as "scope:component:external_dep:<pm>:<name>".
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "DEPENDS_ON" {
+			continue
+		}
+		if r.Properties == nil || r.Properties["kind"] != "external_dependency" {
+			continue
+		}
+		pm := r.Properties["package_manager"]
+		name := depNameFromExternalRef(r.ToID)
+		if pm == "" || name == "" {
+			continue
+		}
+		status, ok := statusByKey[depKey(pm, name)]
+		if !ok {
+			continue
+		}
+		r.Properties[usageStatusProp] = string(status)
+		stats.EdgesAnnotated++
+	}
+
+	return stats
+}
+
+// depKey builds the canonical "<pm>:<name>" lookup key, matching the keying
+// deplinker uses internally for declared dependencies.
+func depKey(pm, name string) string {
+	return pm + ":" + name
+}
+
+// externalDepRefPrefix is the ToID prefix the manifest extractor uses for the
+// DEPENDS_ON edge target: "scope:component:external_dep:<pm>:<name>".
+const externalDepRefPrefix = "scope:component:external_dep:"
+
+// depNameFromExternalRef extracts the bare package name from a manifest
+// dependency ref of the form "scope:component:external_dep:<pm>:<name>".
+// Returns "" when ref is not in that form. The package name may itself
+// contain ':' (e.g. Maven "group:artifact"), so we strip only the prefix and
+// the leading "<pm>:" segment.
+func depNameFromExternalRef(ref string) string {
+	rest, ok := cutPrefix(ref, externalDepRefPrefix)
+	if !ok {
+		return ""
+	}
+	// rest == "<pm>:<name>"; drop the first segment (the package manager).
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == ':' {
+			return rest[i+1:]
+		}
+	}
+	return ""
+}
+
+// cutPrefix is strings.CutPrefix, inlined to avoid an import churn diff.
+func cutPrefix(s, prefix string) (string, bool) {
+	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+		return s[len(prefix):], true
+	}
+	return "", false
+}

--- a/internal/engine/dependency_hygiene_test.go
+++ b/internal/engine/dependency_hygiene_test.go
@@ -1,0 +1,205 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// depEntity builds an external_dependency entity the way the manifest
+// extractor does, including the embedded DEPENDS_ON edge target ref.
+func depEntity(name, pm string) graph.Entity {
+	return graph.Entity{
+		ID:         "ent:" + pm + ":" + name,
+		Name:       name,
+		Kind:       "SCOPE.Component",
+		Subtype:    "external_dependency",
+		SourceFile: "package.json",
+		Properties: map[string]string{
+			"package_manager":     pm,
+			"external_dependency": "true",
+			"dependency_kind":     "runtime",
+		},
+	}
+}
+
+// importEdge mimics the cross/imports DEPENDS_ON(kind=import) edge.
+func importEdge(fromFile, pkg string) graph.Relationship {
+	return graph.Relationship{
+		ID:     fromFile + "->import:" + pkg,
+		FromID: fromFile,
+		ToID:   "scope:component:import:external:" + pkg,
+		Kind:   "DEPENDS_ON",
+		Properties: map[string]string{
+			"kind": "import",
+		},
+	}
+}
+
+// dependsOnEdge mimics the manifest DEPENDS_ON(kind=external_dependency) edge
+// whose ToID is the canonical dependency ref.
+func dependsOnEdge(pm, name string) graph.Relationship {
+	ref := "scope:component:external_dep:" + pm + ":" + name
+	return graph.Relationship{
+		ID:     "proj->" + ref,
+		FromID: "scope:component:project:package.json",
+		ToID:   ref,
+		Kind:   "DEPENDS_ON",
+		Properties: map[string]string{
+			"kind":            "external_dependency",
+			"package_manager": pm,
+		},
+	}
+}
+
+// TestApplyDependencyHygiene_UsedUnusedPhantom is the core value-asserting
+// test for #3640. Fixture:
+//
+//	A (express)  — declared AND imported  → usage_status=used
+//	B (lodash)   — declared, NOT imported → usage_status=unused
+//	C (axios)    — imported, NOT declared → phantom (stat only, no entity)
+//
+// Asserts the SPECIFIC usage_status property persisted on each declared
+// dependency entity AND on its DEPENDS_ON edge.
+func TestApplyDependencyHygiene_UsedUnusedPhantom(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			depEntity("express", "npm"), // A: used
+			depEntity("lodash", "npm"),  // B: unused
+		},
+		Relationships: []graph.Relationship{
+			// manifest DEPENDS_ON edges for declared deps A and B
+			dependsOnEdge("npm", "express"),
+			dependsOnEdge("npm", "lodash"),
+			// import edges: express (A) is imported, axios (C) is phantom
+			importEdge("src/app.js", "express"),
+			importEdge("src/http.js", "axios"),
+		},
+	}
+
+	stats := ApplyDependencyHygiene(doc)
+
+	// --- doc-level stats -------------------------------------------------
+	if stats.Declared != 2 {
+		t.Errorf("Declared=%d want 2", stats.Declared)
+	}
+	if stats.Used != 1 {
+		t.Errorf("Used=%d want 1", stats.Used)
+	}
+	if stats.Unused != 1 {
+		t.Errorf("Unused=%d want 1", stats.Unused)
+	}
+	if stats.Phantom != 1 {
+		t.Errorf("Phantom=%d want 1 (axios)", stats.Phantom)
+	}
+	if stats.EntitiesAnnotated != 2 {
+		t.Errorf("EntitiesAnnotated=%d want 2", stats.EntitiesAnnotated)
+	}
+	if stats.EdgesAnnotated != 2 {
+		t.Errorf("EdgesAnnotated=%d want 2", stats.EdgesAnnotated)
+	}
+
+	// --- entity props: SPECIFIC status, not len>0 ------------------------
+	got := map[string]string{}
+	for _, e := range doc.Entities {
+		if e.Subtype == "external_dependency" {
+			got[e.Name] = e.Properties[usageStatusProp]
+		}
+	}
+	if got["express"] != "used" {
+		t.Errorf("express usage_status=%q want \"used\"", got["express"])
+	}
+	if got["lodash"] != "unused" {
+		t.Errorf("lodash usage_status=%q want \"unused\"", got["lodash"])
+	}
+
+	// --- phantom (axios) must NOT become a declared dep entity -----------
+	for _, e := range doc.Entities {
+		if e.Name == "axios" {
+			t.Errorf("phantom axios should not be synthesised as an entity, found %+v", e)
+		}
+	}
+
+	// --- edge props mirror the entity status -----------------------------
+	edgeStatus := map[string]string{}
+	for _, r := range doc.Relationships {
+		if r.Kind == "DEPENDS_ON" && r.Properties["kind"] == "external_dependency" {
+			name := depNameFromExternalRef(r.ToID)
+			edgeStatus[name] = r.Properties[usageStatusProp]
+		}
+	}
+	if edgeStatus["express"] != "used" {
+		t.Errorf("express edge usage_status=%q want \"used\"", edgeStatus["express"])
+	}
+	if edgeStatus["lodash"] != "unused" {
+		t.Errorf("lodash edge usage_status=%q want \"unused\"", edgeStatus["lodash"])
+	}
+}
+
+// TestApplyDependencyHygiene_GoModulePrefix verifies a Go-style import path
+// that extends the declared module (gin/ginS) classifies the declared module
+// as used — exercising deplinker's prefix match through the persisted layer.
+func TestApplyDependencyHygiene_GoModulePrefix(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			depEntity("github.com/gin-gonic/gin", "go_modules"),
+		},
+		Relationships: []graph.Relationship{
+			dependsOnEdge("go_modules", "github.com/gin-gonic/gin"),
+			importEdge("cmd/main.go", "github.com/gin-gonic/gin/ginS"),
+		},
+	}
+
+	ApplyDependencyHygiene(doc)
+
+	if got := doc.Entities[0].Properties[usageStatusProp]; got != "used" {
+		t.Errorf("gin usage_status=%q want \"used\" (prefix match)", got)
+	}
+}
+
+// TestApplyDependencyHygiene_NoManifest is the honest-partial guard: a doc
+// with no external_dependency entities yields zero annotations and no panic.
+func TestApplyDependencyHygiene_NoManifest(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "Foo", Kind: "SCOPE.Function", SourceFile: "a.go"},
+		},
+		Relationships: []graph.Relationship{
+			importEdge("a.go", "axios"),
+		},
+	}
+
+	stats := ApplyDependencyHygiene(doc)
+
+	if stats.EntitiesAnnotated != 0 {
+		t.Errorf("EntitiesAnnotated=%d want 0 (no declared deps)", stats.EntitiesAnnotated)
+	}
+	// axios is still a phantom even with no declared deps.
+	if stats.Phantom != 1 {
+		t.Errorf("Phantom=%d want 1", stats.Phantom)
+	}
+}
+
+// TestApplyDependencyHygiene_NilDoc must not panic.
+func TestApplyDependencyHygiene_NilDoc(t *testing.T) {
+	if got := ApplyDependencyHygiene(nil); got.Declared != 0 {
+		t.Errorf("nil doc Declared=%d want 0", got.Declared)
+	}
+}
+
+// TestDepNameFromExternalRef covers the ref parser, including Maven-style
+// names that themselves contain ':' (group:artifact).
+func TestDepNameFromExternalRef(t *testing.T) {
+	cases := map[string]string{
+		"scope:component:external_dep:npm:express":               "express",
+		"scope:component:external_dep:go_modules:github.com/x/y": "github.com/x/y",
+		"scope:component:external_dep:maven:org.example:my-lib":  "org.example:my-lib",
+		"not-a-dep-ref":                    "",
+		"scope:component:external_dep:npm": "",
+	}
+	for ref, want := range cases {
+		if got := depNameFromExternalRef(ref); got != want {
+			t.Errorf("depNameFromExternalRef(%q)=%q want %q", ref, got, want)
+		}
+	}
+}

--- a/tools/coverage/buckets_test.go
+++ b/tools/coverage/buckets_test.go
@@ -49,7 +49,7 @@ func TestBucketCapabilityKeys(t *testing.T) {
 
 	// Tools: union of build_system + package_manager.
 	got = bucketCapabilityKeys(BucketTools)
-	want = []string{"dependency_graph", "lockfile_parsing", "manifest_parsing", "target_extraction"}
+	want = []string{"dependency_graph", "dependency_usage_status", "lockfile_parsing", "manifest_parsing", "target_extraction"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Tools keys = %v, want %v", got, want)
 	}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -61,7 +61,7 @@ categories:
   build_system:
     capabilities: [target_extraction, dependency_graph]
   package_manager:
-    capabilities: [manifest_parsing, lockfile_parsing]
+    capabilities: [manifest_parsing, lockfile_parsing, dependency_usage_status]
   databases:
     capabilities: [resource_extraction, dependency_attribution]
   platform:

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -20,6 +20,27 @@
 
 records:
 
+  analysis.dependency-hygiene:
+    capabilities:
+      dependency_usage_status:
+        # Pass 8.7 (engine.ApplyDependencyHygiene) reuses deplinker.Analyze
+        # over the assembled graph.Document and persists usage_status=
+        # used|unused onto each external_dependency entity + its DEPENDS_ON
+        # edge. Promotes the previously dashboard-only deplinker signal into
+        # the graph (issue #3640, epic #3625). Invoked from cmd/archigraph/
+        # index.go gated on --skip-pass=dep-hygiene.
+        status: full
+        symbols:
+          - file: internal/engine/dependency_hygiene.go
+            functions: [ApplyDependencyHygiene, depKey, depNameFromExternalRef, cutPrefix]
+          - file: internal/extractors/cross/deplinker/extractor.go
+            functions: [Analyze, analyzeEntities]
+        tests:
+          - file: internal/engine/dependency_hygiene_test.go
+            functions: [TestApplyDependencyHygiene_UsedUnusedPhantom, TestApplyDependencyHygiene_GoModulePrefix, TestApplyDependencyHygiene_NoManifest, TestDepNameFromExternalRef]
+        issues_implemented: ["3640"]
+        verified_at: "2026-06-02"
+
   lang.cobol.runtime.ibm-enterprise:
     capabilities:
       core_extraction:


### PR DESCRIPTION
Closes #3640 (epic #3625).

## What

Promotes the `deplinker` used/unused/phantom dependency analysis from a **dashboard-only** query into a **PERSISTED graph signal**. Previously `deplinker.AnalyzeGroup` was called only by the dashboard handler (`internal/dashboard/handlers_dependencies.go`); the classification never reached the graph, so `find`/`neighbors`/agents could not see dependency hygiene.

## How

New **Pass 8.7** engine pass `engine.ApplyDependencyHygiene` (`internal/engine/dependency_hygiene.go`) **reuses `deplinker.Analyze`** (no reimplementation) over the assembled `graph.Document` and writes the classification back in place:

- `usage_status=used|unused` onto each `external_dependency` entity (emitted by the manifest extractor)
- the same `usage_status` onto the entity's standalone `DEPENDS_ON(kind=external_dependency)` edge

Wired into `cmd/archigraph/index.go` after document assembly (manifest entities + import edges all present), gated on `--skip-pass=dep-hygiene`.

### No double-emit
The dashboard keeps calling `AnalyzeGroup` independently. This pass **mutates existing entities in place** — it appends no entities. Phantom imports (imported, not declared) are reported as a stat but deliberately NOT synthesised as entities, to avoid double-counting the manifest extractor's declared-dep inventory; phantom listing stays the dashboard's job.

### Honest-partial
Classification fidelity tracks deplinker's manifest + import inputs; a declared dep with no observed import edge is `unused` exactly as the dashboard reports it.

## usage_status props asserted (value-asserting test)

Fixture declares **A** `express` (imported), **B** `lodash` (declared-not-imported), **C** `axios` (imported-not-declared). `TestApplyDependencyHygiene_UsedUnusedPhantom` asserts the SPECIFIC values:

- entity `express.usage_status == "used"`
- entity `lodash.usage_status == "unused"`
- `axios` → `phantom` (stat only, asserted NOT synthesised as an entity)
- the `DEPENDS_ON` edges for express/lodash mirror `used`/`unused`

Plus `GoModulePrefix` (gin/ginS prefix match → used), `NoManifest`/`NilDoc` honest-partial guards, and `TestDepNameFromExternalRef` (incl. Maven `group:artifact` names).

## Records

- New `dependency_usage_status` capability under the `package_manager` category (dictionary).
- New `analysis.dependency-hygiene` record, `status=full`, cites the now-persisting path; capability-map traceability entry added.
- `coverage validate` 0 errors, `fmt --check` canonical, docs regenerated deterministically.

## Verification
- `go test ./internal/extractors/cross/... ./internal/engine/ ./internal/types/ ./tools/coverage/` green
- `gofmt -l` empty, `go vet` clean, `go build ./...` clean

## DEPLOY-DEFERRED
Requires a daemon rebuild + reindex to populate `usage_status` on existing graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)