### PR TITLE
fix(java): synthesise edge carriers so jaxrs DI + nested-@Valid edges materialise

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -20720,25 +20720,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/jakarta_ee.go","internal/extractors/custom_java_patterns_smoke_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3589",
-            "notes": "CDI/EJB bean entities (SCOPE.Service/Component) emit live for jaxrs files carrying jakarta_ee markers; the @EJB/@Inject DEPENDS_ON injection edge is dropped by the no-carrier policy in patternResultToRecords.",
-            "verified_at": "2026-06-01"
+            "status": "full",
+            "cites": ["internal/custom/java/jakarta_ee.go","internal/custom/java/patterns_dispatch.go","internal/extractors/java_edge_carrier_reverify_test.go"],
+            "notes": "#3605 (epic #3584): CDI/EJB bean entities emit live AND the @EJB/@Inject DEPENDS_ON injection edge now materialises — patternResultToRecords synthesises the injecting-class carrier (SCOPE.Class) for the previously carrier-less SourceRef. TestReverifyJaxrsInjectionPointCarrier asserts the DEPENDS_ON UserResource-\u003eUserService (kind=ejb_inject) edge live.",
+            "verified_at": "2026-06-02"
           },
           "di_injection_point": {
-            "status": "missing",
-            "cites": ["internal/custom/java/jakarta_ee.go","internal/extractors/custom_java_patterns_smoke_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3589",
-            "notes": "@Inject/@EJB injection DEPENDS_ON edges are constructed but DROPPED live: their SourceRef (scope:dependency:jakarta:...) has no carrier entity in patternResultToRecords, so the edge never reaches the graph. Genuinely not produced.",
-            "verified_at": "2026-06-01"
+            "status": "full",
+            "cites": ["internal/custom/java/jakarta_ee.go","internal/custom/java/patterns_dispatch.go","internal/extractors/java_edge_carrier_reverify_test.go"],
+            "notes": "#3605 (epic #3584): the @Inject/@EJB injection DEPENDS_ON edge now reaches the graph — patternResultToRecords synthesises a SCOPE.Class carrier for its SourceRef (scope:dependency:jakarta:...) instead of dropping it, and surfaces edge-only PatternResults. TestReverifyJaxrsInjectionPointCarrier asserts the materialised carrier + DEPENDS_ON edge live.",
+            "verified_at": "2026-06-02"
           },
           "di_scope_resolution": {
-            "status": "partial",
-            "cites": ["internal/custom/java/jakarta_ee.go","internal/custom/java/java_di_scope_deepen.go","internal/extractors/custom_java_patterns_smoke_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3589",
-            "notes": "CDI scope components (@RequestScoped/@ConversationScoped) emit live with cdi_scope/scope props; no DEPENDS_ON injection wiring (that edge is dropped).",
-            "verified_at": "2026-06-01"
+            "status": "full",
+            "cites": ["internal/custom/java/jakarta_ee.go","internal/custom/java/java_di_scope_deepen.go","internal/custom/java/patterns_dispatch.go","internal/extractors/java_edge_carrier_reverify_test.go"],
+            "notes": "#3605 (epic #3584): CDI scope components emit live AND the DEPENDS_ON injection wiring into them now materialises via the synthesised injecting-class carrier (no longer dropped). TestReverifyJaxrsInjectionPointCarrier proves the injection edge reaches the graph.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -24633,11 +24630,10 @@
       "capabilities": {
         "Schema": {
           "nested_model_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/bean_validation.go","internal/extractors/custom_java_patterns_smoke_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3589",
-            "notes": "Nested @Valid field schema entities emit live; the VALIDATES edge (owner class -\u003e nested type) is dropped by the no-carrier policy because its SourceRef (scope:class:bean_validation:...) has no carrier entity.",
-            "verified_at": "2026-06-01"
+            "status": "full",
+            "cites": ["internal/custom/java/bean_validation.go","internal/custom/java/patterns_dispatch.go","internal/extractors/java_edge_carrier_reverify_test.go"],
+            "notes": "#3605 (epic #3584): nested @Valid field schema entities emit live AND the VALIDATES edge (owner DTO -\u003e nested type) now materialises — patternResultToRecords synthesises the owning-DTO carrier (SCOPE.Class) for its SourceRef (scope:class:bean_validation:...) instead of dropping it. TestReverifyBeanValidationNestedValidCarrier asserts the VALIDATES OrderRequest-\u003eAddress (field=shippingAddress, via=valid_annotation) edge live.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "full",

--- a/internal/custom/java/patterns_dispatch.go
+++ b/internal/custom/java/patterns_dispatch.go
@@ -278,11 +278,19 @@ func (e *javaPatternsExtractor) Extract(ctx context.Context, file extreg.FileInp
 // custom extractors emit edges (ToID = target structural ref, FromID implicit
 // from the carrying entity; the resolver pass binds the ref later).
 //
-// Relationships whose SourceRef does not correspond to an emitted entity are
-// dropped (the same silent-drop policy the django extractor uses for unresolved
-// edges) — there is no carrier entity to hang them on.
+// Relationships whose SourceRef does not correspond to an emitted entity used to
+// be dropped (the django silent-drop policy), but several real Java edges encode
+// their carrier purely in the SourceRef and never emit a standalone entity for it
+// — the jaxrs/CDI di_injection_point edge (`scope:dependency:jakarta:…`, owner =
+// the injecting class) and the bean-validation nested-@Valid VALIDATES edge
+// (`scope:class:bean_validation:…`, owner = the DTO class). For those, #3605
+// SYNTHESISES a minimal carrier entity from the structured SourceRef so the edge
+// materialises and stays traversable, mirroring how the spring DI edges already
+// hang off a materialised injection-point entity. The synthesis is idempotent and
+// only fires when no real entity claims the SourceRef, so it never duplicates an
+// emitted carrier nor fabricates phantoms for refs a relationship does not use.
 func patternResultToRecords(res *PatternResult, filePath string) []types.EntityRecord {
-	if res == nil || len(res.Entities) == 0 {
+	if res == nil || (len(res.Entities) == 0 && len(res.Relationships) == 0) {
 		return nil
 	}
 
@@ -311,11 +319,19 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 		records = append(records, rec)
 	}
 
-	// Attach relationships to their carrier (source) entity.
+	// Attach relationships to their carrier (source) entity. When no emitted
+	// entity claims the SourceRef, synthesise a minimal carrier from the
+	// structured ref so the edge materialises instead of being dropped (#3605).
 	for _, r := range res.Relationships {
 		idx, ok := byRef[r.SourceRef]
 		if !ok {
-			continue // no carrier entity for this edge — drop, like django.
+			synth, made := synthesizeCarrier(r.SourceRef, filePath)
+			if !made {
+				continue // ref not structurally parseable — cannot carry the edge.
+			}
+			idx = len(records)
+			byRef[r.SourceRef] = idx
+			records = append(records, synth)
 		}
 		rr := types.RelationshipRecord{
 			ToID:       r.TargetRef,
@@ -330,6 +346,60 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 	}
 
 	return records
+}
+
+// synthesizeCarrier builds a minimal carrier EntityRecord for an edge whose
+// SourceRef encodes its owner structurally but never emitted a standalone entity
+// (the di_injection_point and nested-@Valid edges). Pattern refs follow the shape
+// `scope:<kind>:<namespace>:<filePath>:<name>` — the second field names the SCOPE
+// kind and the trailing field names the owner symbol. We materialise an entity at
+// that ref so the resolver can bind the edge's FromID. Returns (record, true) when
+// the ref is a parseable `scope:`-prefixed ref; (zero, false) otherwise — an
+// unparseable ref cannot carry an edge and is left dropped.
+//
+// Only refs that an actual Relationship.SourceRef references reach this function,
+// so it never fabricates phantom carriers for unrelated refs.
+func synthesizeCarrier(sourceRef, filePath string) (types.EntityRecord, bool) {
+	const prefix = "scope:"
+	if !strings.HasPrefix(sourceRef, prefix) {
+		return types.EntityRecord{}, false
+	}
+	rest := sourceRef[len(prefix):]
+	// rest == "<kind>:<namespace>:<filePath>:<name>" — kind is the first field,
+	// name is the last field (filePath may itself be empty but contains no ':' on
+	// the platforms we index, so the last ':' segment is the owner symbol).
+	firstColon := strings.IndexByte(rest, ':')
+	if firstColon <= 0 {
+		return types.EntityRecord{}, false
+	}
+	kindSeg := rest[:firstColon]
+	lastColon := strings.LastIndexByte(rest, ':')
+	if lastColon < firstColon {
+		return types.EntityRecord{}, false
+	}
+	name := rest[lastColon+1:]
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	rec := makeEntity(name, carrierKindFor(kindSeg), "", filePath, "java", 0)
+	rec.Properties["ref"] = sourceRef
+	rec.Properties["provenance"] = "INFERRED_FROM_EDGE_CARRIER"
+	rec.Properties["synthesized_carrier"] = "true"
+	return rec, true
+}
+
+// carrierKindFor maps the structural ref's kind segment onto a valid SCOPE.* kind
+// for a synthesised carrier. The injection-point owner refs use the `dependency`
+// segment and the nested-@Valid owner refs use the `class` segment; both denote a
+// concrete owning class, so they map to SCOPE.Class. Any other parseable segment
+// falls back to SCOPE.Component (a generic structural node) rather than guessing.
+func carrierKindFor(kindSeg string) string {
+	switch kindSeg {
+	case "dependency", "class":
+		return "SCOPE.Class"
+	default:
+		return "SCOPE.Component"
+	}
 }
 
 // fileOr returns primary if non-empty, else fallback.

--- a/internal/extractors/java_edge_carrier_reverify_test.go
+++ b/internal/extractors/java_edge_carrier_reverify_test.go
@@ -1,0 +1,181 @@
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// java_edge_carrier_reverify_test.go — live-path re-verification for #3605 (epic
+// #3584).
+//
+// #3589 had to leave the jaxrs/CDI di_injection_point cell `missing` and the
+// bean-validation nested_model_extraction cell `partial` because the dispatcher
+// (`patternResultToRecords` in internal/custom/java/patterns_dispatch.go) DROPPED
+// any Relationship whose SourceRef had no emitted carrier entity. The
+// di_injection_point DEPENDS_ON edge (SourceRef `scope:dependency:jakarta:…`, the
+// injecting class) and the nested-@Valid VALIDATES edge (SourceRef
+// `scope:class:bean_validation:…`, the owning DTO) both encode their carrier
+// purely in the ref and never emit a standalone entity, so both edges vanished.
+//
+// #3605 synthesises a minimal carrier from the structured SourceRef. These tests
+// drive the FULL live dispatch (RunCustomExtractors → CustomExtractorsFor("java")
+// → custom_java_patterns.Extract) and assert the SPECIFIC restored edge now
+// materialises with a real carrier — never len > 0.
+
+// relWithProp reports whether rec carries a relationship of the given kind to the
+// given ToID whose property key==val.
+func relWithProp(rec *types.EntityRecord, kind, toID, key, val string) bool {
+	if rec == nil {
+		return false
+	}
+	for _, r := range rec.Relationships {
+		if r.Kind == kind && r.ToID == toID && r.Properties[key] == val {
+			return true
+		}
+	}
+	return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JAX-RS / CDI — DI.di_injection_point
+// (cite: internal/custom/java/jakarta_ee.go @EJB / @Resource injection;
+//  carrier synthesised by internal/custom/java/patterns_dispatch.go #3605)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestReverifyJaxrsInjectionPointCarrier(t *testing.T) {
+	path := "src/main/java/com/example/api/UserResource.java"
+	src := `
+package com.example.api;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.GET;
+import jakarta.ejb.EJB;
+
+@Path("/users")
+public class UserResource {
+
+    @EJB
+    private UserService userService;
+
+    @GET
+    public String list() {
+        return userService.findAll();
+    }
+}
+`
+	recs := runJavaPatterns(t, path, src)
+
+	// The injecting class is the carrier: the @EJB DEPENDS_ON edge's SourceRef is
+	// scope:dependency:jakarta:<fp>:UserResource, which #3605 now materialises as a
+	// SCOPE.Class carrier so the edge survives instead of being dropped.
+	carrierRef := "scope:dependency:jakarta:" + path + ":UserResource"
+	carrier := findByKindProp(recs, "SCOPE.Class", "ref", carrierRef)
+	if carrier == nil {
+		t.Fatalf("expected a synthesised SCOPE.Class carrier at ref %q for the @EJB injection point; got %v",
+			carrierRef, names(recs))
+	}
+	if got := carrier.Name; got != "UserResource" {
+		t.Errorf("carrier Name = %q, want UserResource", got)
+	}
+	if got := carrier.Properties["synthesized_carrier"]; got != "true" {
+		t.Errorf("carrier synthesized_carrier = %q, want true", got)
+	}
+
+	// The restored di_injection_point edge: DEPENDS_ON from UserResource to the
+	// injected UserService bean, tagged kind=ejb_inject.
+	targetRef := "scope:dependency:jakarta:" + path + ":UserService"
+	if !relWithProp(carrier, "DEPENDS_ON", targetRef, "kind", "ejb_inject") {
+		t.Fatalf("expected restored di_injection_point DEPENDS_ON edge "+
+			"UserResource -> UserService (kind=ejb_inject); got rels %v", carrier.Relationships)
+	}
+	if !hasRel(carrier, "DEPENDS_ON", targetRef) {
+		t.Errorf("carrier missing DEPENDS_ON ToID %q", targetRef)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bean Validation — Validation.nested_model_extraction
+// (cite: internal/custom/java/bean_validation.go @Valid recursion;
+//  carrier synthesised by internal/custom/java/patterns_dispatch.go #3605)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestReverifyBeanValidationNestedValidCarrier(t *testing.T) {
+	path := "src/main/java/com/example/dto/OrderRequest.java"
+	src := `
+package com.example.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public class OrderRequest {
+
+    @NotNull
+    private String orderId;
+
+    @Valid
+    @NotNull
+    private Address shippingAddress;
+}
+`
+	recs := runJavaPatterns(t, path, src)
+
+	// The owning DTO is the carrier: the nested @Valid VALIDATES edge's SourceRef
+	// is scope:class:bean_validation:<fp>:OrderRequest, which #3605 now materialises
+	// as a SCOPE.Class carrier so the VALIDATES edge survives.
+	carrierRef := "scope:class:bean_validation:" + path + ":OrderRequest"
+	carrier := findByKindProp(recs, "SCOPE.Class", "ref", carrierRef)
+	if carrier == nil {
+		t.Fatalf("expected a synthesised SCOPE.Class carrier at ref %q for the nested @Valid edge; got %v",
+			carrierRef, names(recs))
+	}
+	if got := carrier.Name; got != "OrderRequest" {
+		t.Errorf("carrier Name = %q, want OrderRequest", got)
+	}
+
+	// The restored nested_model_extraction edge: VALIDATES from OrderRequest to the
+	// nested Address type via the @Valid annotation on shippingAddress.
+	targetRef := "scope:dependency:bean_validation:" + path + ":Address"
+	if !relWithProp(carrier, "VALIDATES", targetRef, "via", "valid_annotation") {
+		t.Fatalf("expected restored nested_model_extraction VALIDATES edge "+
+			"OrderRequest -> Address (via=valid_annotation); got rels %v", carrier.Relationships)
+	}
+	if !relWithProp(carrier, "VALIDATES", targetRef, "field", "shippingAddress") {
+		t.Errorf("VALIDATES edge missing field=shippingAddress; got rels %v", carrier.Relationships)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Negative — no phantom carrier for unrelated refs.
+//
+// A source whose only framework signal yields entities but NO edge with an
+// unmaterialised SourceRef must not gain any synthesised carrier. Synthesis fires
+// ONLY for a SourceRef an actual Relationship references.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestReverifyNoPhantomCarrierForUnrelatedRefs(t *testing.T) {
+	path := "src/main/java/com/example/dto/SimpleDto.java"
+	src := `
+package com.example.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class SimpleDto {
+
+    @NotNull
+    @Size(min = 1, max = 64)
+    private String name;
+}
+`
+	recs := runJavaPatterns(t, path, src)
+
+	// No @Valid here, so no VALIDATES edge and therefore no bean_validation class
+	// carrier should ever be synthesised.
+	for i := range recs {
+		if recs[i].Properties["synthesized_carrier"] == "true" {
+			t.Fatalf("synthesised a phantom carrier %q (%s) for a source with no carrier-less edge; got %v",
+				recs[i].Name, recs[i].Properties["ref"], names(recs))
+		}
+	}
+}


### PR DESCRIPTION
Closes #3605 (epic #3584).

## The bug

The `custom_java_patterns` dispatcher (`internal/custom/java/patterns_dispatch.go`, `patternResultToRecords`) attached each `Relationship` to the entity whose `Ref == SourceRef` and **dropped** any edge whose `SourceRef` had no emitted carrier entity (the django silent-drop policy). Two real Java edges encode their carrier purely in the `SourceRef` and never emit a standalone entity, so both vanished — which is why #3589 had to leave the cells `missing`/`partial`:

- **jaxrs/CDI `di_injection_point`** — the `@EJB`/`@Inject` `DEPENDS_ON` edge, `SourceRef = scope:dependency:jakarta:<fp>:<ownerClass>` (the injecting class).
- **bean-validation `nested_model_extraction`** — the nested `@Valid` `VALIDATES` edge, `SourceRef = scope:class:bean_validation:<fp>:<ownerClass>` (the owning DTO).

A second facet: `patternResultToRecords` early-returned for entity-empty results, discarding edge-only `PatternResult`s entirely.

## How the carrier synthesis works

In `patternResultToRecords`, when an edge's `SourceRef` has no emitted carrier, `synthesizeCarrier` parses the structured ref `scope:<kind>:<ns>:<fp>:<name>` — taking the second field as the SCOPE kind and the trailing field as the owner symbol — and materialises a minimal carrier `EntityRecord` at that ref (`dependency`/`class` → `SCOPE.Class`, else `SCOPE.Component`), tagged `synthesized_carrier=true`/`provenance=INFERRED_FROM_EDGE_CARRIER`. The edge then attaches and the resolver can bind its `FromID` — mirroring how the working spring DI edges already hang off a materialised injection-point entity.

Synthesis is **idempotent** and fires **only** for a ref an actual `Relationship` references, so it never duplicates an emitted carrier nor fabricates phantoms for unrelated refs. The entities-empty early return now also keeps edge-only `PatternResult`s.

## Edges now materialising (value-asserting live-dispatch tests)

Driven through the LIVE path (`RunCustomExtractors` → `CustomExtractorsFor("java")` → `custom_java_patterns.Extract`), asserting the SPECIFIC edge — never `len > 0`:

- `TestReverifyJaxrsInjectionPointCarrier` — synthesised `SCOPE.Class UserResource` carrier + `DEPENDS_ON UserResource → UserService` (`kind=ejb_inject`).
- `TestReverifyBeanValidationNestedValidCarrier` — synthesised `SCOPE.Class OrderRequest` carrier + `VALIDATES OrderRequest → Address` (`field=shippingAddress`, `via=valid_annotation`).
- `TestReverifyNoPhantomCarrierForUnrelatedRefs` — negative: no carrier synthesised when no carrier-less edge exists.

## Cells re-flipped (honest; #3586/#3589 issue tag dropped)

| Record | Capability | Before → After |
|---|---|---|
| `lang.java.framework.jaxrs` | `DI.di_injection_point` | missing → **full** |
| `lang.java.framework.jaxrs` | `DI.di_binding_extraction` | partial → **full** |
| `lang.java.framework.jaxrs` | `DI.di_scope_resolution` | partial → **full** |
| `lang.java.validation.bean-validation` | `Schema.nested_model_extraction` | partial → **full** |

Each flip is proven by a value-asserting live test (the injection edge satisfies the previously-cited "injection wiring dropped" gap in all three jaxrs DI cells).

## Checks

- `go test ./internal/custom/java/... ./internal/extractors/ ./tools/coverage/` — green.
- `coverage validate` — 0 errors (only pre-existing `no mapping entry` warnings); `fmt --check` canonical.
- `gofmt -l` + `go vet` clean on the changed files.

## DEPLOY-DEFERRED

Requires a coordinated live-daemon rebuild + upvate reindex to surface the restored edges in the served graph; not done here to avoid disturbing the live rewrite daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)