### PR TITLE
Raw-SQL table topology: ACCESSES_TABLE for Python/Go/Java raw drivers

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13839,9 +13839,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/dbmap/extractor_test.go","internal/extractors/cross/dbmap/orms.go"],
+            "notes": "Raw db.Query/Exec(\"…\") SQL resolves table topology: dbmap.detectGoSQLDriver (import-gated on github.com/go-sql-driver/mysql, lib/pq, go-sqlite3, jackc/pgx, jmoiron/sqlx) parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb. Value-asserting tests TestGoSQLDriverLibPQSelect + TestGoSQLDriverNoDoubleEmitWithDatabaseSQL (#3644).",
             "verified_at": "2026-06-02"
           }
         },
@@ -13992,10 +13992,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/sqlite_go.yaml"],
-            "issue": "3214",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/sqlite_go.yaml","internal/extractors/cross/dbmap/orms.go"],
+            "notes": "Raw db.Query/Exec(\"…\") SQL resolves table topology: dbmap.detectGoSQLDriver (import-gated on github.com/mattn/go-sqlite3) parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -18159,11 +18159,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
-            "issue": "3214",
-            "notes": "Exec/Query/QueryRow/Get/Select/NamedExec call sites + SQL literal content captured; cannot bind a call site to a specific model without data-flow analysis",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/extractors/cross/dbmap/extractor_test.go","internal/extractors/cross/dbmap/orms.go"],
+            "notes": "Exec/Query/QueryRow/Get/Select/NamedExec call sites captured; raw SQL literal table topology now resolved by dbmap.detectGoSQLDriver (import-gated on github.com/jackc/pgx) which parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -18274,11 +18273,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
-            "issue": "3214",
-            "notes": "Exec/Query/QueryRow/Get/Select/NamedExec call sites + SQL literal content captured; cannot bind a call site to a specific model without data-flow analysis",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/extractors/cross/dbmap/extractor_test.go","internal/extractors/cross/dbmap/orms.go"],
+            "notes": "Exec/Query/QueryRow/Get/Select/NamedExec call sites captured; raw SQL literal table topology now resolved by dbmap.detectGoSQLDriver (import-gated on github.com/jmoiron/sqlx) which parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -24101,10 +24099,10 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_other.go","internal/engine/orm_queries_test.go"],
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_other.go","internal/engine/orm_queries_test.go","internal/extractors/cross/dbmap/extractor_test.go","internal/extractors/cross/dbmap/orms.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3096",
-            "notes": "Engine pass scanJavaORM handles EntityManager.find/persist/remove/merge and Spring Data repository call patterns (findByX, save, etc.); emits QUERIES edges with orm=jpa or orm=spring_data; inline JPQL string content and @NamedQuery body text not parsed",
-            "verified_at": "2026-05-29"
+            "notes": "Engine pass scanJavaORM handles EntityManager.find/persist/remove/merge and Spring Data repository call patterns; emits QUERIES edges with orm=jpa or orm=spring_data. Plain JDBC raw SQL (Statement.executeQuery/executeUpdate(\"…\")) table topology now resolved by dbmap.detectJDBC (import-gated on java.sql/javax.sql) which parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb; value-asserting tests TestJDBCExecuteQueryReadsTable + TestJDBCJoinYieldsBothTables (#3644). Inline JPQL string content still unparsed for engine QUERIES edges.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -42037,9 +42035,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/cross/dbmap/orms.go","internal/extractors/python/raw_sql_db_calls.go"],
+            "notes": "Raw cursor.execute(\"…\") SQL now resolves table topology: dbmap.detectPyDBAPI (import-gated on pymysql/mysqlclient) parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb. Value-asserting test TestPyDBAPIPymysqlInsertWritesOrders. Dynamic/concatenated SQL → no fabricated table (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -42146,9 +42145,9 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-            "issue": "3060",
-            "verified_at": "2026-05-29"
+            "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/cross/dbmap/orms.go","internal/extractors/python/raw_sql_db_calls.go"],
+            "notes": "Raw cursor.execute(\"…\") SQL resolves table topology: dbmap.detectPyDBAPI/detectPsycopg2 (asyncpg/psycopg2 import-gated) parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -42247,9 +42246,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/cross/dbmap/orms.go","internal/extractors/python/raw_sql_db_calls.go"],
+            "notes": "Raw cursor.execute(\"…\") SQL now resolves table topology: dbmap.detectPyDBAPI (import-gated on sqlite3/aiosqlite) parses FROM/INTO/UPDATE/JOIN and emits SCOPE.DataAccess + ACCESSES_TABLE edges with read/write verb. Value-asserting tests TestPyDBAPISqlite3SelectReadsUsers + negative TestPyDBAPIDynamicSQLNoFabricatedTable (#3644).",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {

--- a/internal/extractors/cross/dbmap/extractor_test.go
+++ b/internal/extractors/cross/dbmap/extractor_test.go
@@ -639,3 +639,166 @@ func ListAdults(db *gorm.DB) {
 		t.Errorf("edge function_qname=%q, want ListAdults", edge.Properties["function_qname"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Raw-SQL table topology for high-traffic drivers (#3644)
+// Python DB-API (sqlite3/pymysql/...), Go raw driver, plain JDBC.
+// ---------------------------------------------------------------------------
+
+// findEdge returns the ACCESSES_TABLE edge on rec (fatals if absent).
+func findEdge(t *testing.T, rec types.EntityRecord) types.RelationshipRecord {
+	t.Helper()
+	for _, rel := range rec.Relationships {
+		if rel.Kind == RelAccessesTable {
+			return rel
+		}
+	}
+	t.Fatalf("no ACCESSES_TABLE edge on entity: %+v", rec)
+	return types.RelationshipRecord{}
+}
+
+// --- Python stdlib sqlite3: cursor.execute("SELECT id FROM users WHERE x=1")
+func TestPyDBAPISqlite3SelectReadsUsers(t *testing.T) {
+	src := `import sqlite3
+def load(db):
+    cur = db.cursor()
+    cur.execute("SELECT id FROM users WHERE x=1")`
+	recs := runExtract(t, "load.py", "python", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	if r.Properties["orm"] != "dbapi" {
+		t.Errorf("orm=%q, want dbapi", r.Properties["orm"])
+	}
+	edge := findEdge(t, r)
+	if edge.Properties["table"] != "users" {
+		t.Errorf("edge table=%q, want users", edge.Properties["table"])
+	}
+	if edge.Properties["operation"] != OpSelect {
+		t.Errorf("edge operation=%q, want %s", edge.Properties["operation"], OpSelect)
+	}
+	if edge.Properties["function_qname"] != "load" {
+		t.Errorf("edge function_qname=%q, want load", edge.Properties["function_qname"])
+	}
+}
+
+// --- Python pymysql write: INSERT INTO orders -> table orders (write/INSERT)
+func TestPyDBAPIPymysqlInsertWritesOrders(t *testing.T) {
+	src := `import pymysql
+def add(conn):
+    cur = conn.cursor()
+    cur.execute("INSERT INTO orders (id) VALUES (1)")`
+	recs := runExtract(t, "add.py", "python", src)
+	r := findByOpTable(t, recs, OpInsert, "orders")
+	edge := findEdge(t, r)
+	if edge.Properties["table"] != "orders" || edge.Properties["operation"] != OpInsert {
+		t.Errorf("edge=%v, want table=orders op=INSERT", edge.Properties)
+	}
+}
+
+// --- Negative: dynamic/concatenated SQL must not fabricate a table.
+func TestPyDBAPIDynamicSQLNoFabricatedTable(t *testing.T) {
+	src := `import sqlite3
+def run(db, q):
+    db.cursor().execute(q)`
+	recs := runExtract(t, "dyn.py", "python", src)
+	for _, r := range recs {
+		if r.Kind == KindDataAccess && r.Properties["table"] != UnknownTable && r.Properties["table"] != "" {
+			t.Errorf("fabricated table %q from dynamic SQL", r.Properties["table"])
+		}
+	}
+}
+
+// --- Negative: a Python file with no recognised driver import emits nothing.
+func TestPyDBAPINoDriverImportSkipped(t *testing.T) {
+	src := `def run(cur):
+    cur.execute("SELECT id FROM users")`
+	recs := runExtract(t, "nodriver.py", "python", src)
+	if len(recs) != 0 {
+		t.Errorf("expected no records without a driver import, got %d: %+v", len(recs), recs)
+	}
+}
+
+// --- Go raw driver imported directly (lib/pq), no "database/sql" token.
+func TestGoSQLDriverLibPQSelect(t *testing.T) {
+	src := `package main
+import _ "github.com/lib/pq"
+func Fetch(db *DB) {
+    db.Query("SELECT name FROM accounts WHERE id = $1")
+}`
+	recs := runExtract(t, "fetch.go", "go", src)
+	r := findByOpTable(t, recs, OpSelect, "accounts")
+	if r.Properties["orm"] != "go_sql_driver" {
+		t.Errorf("orm=%q, want go_sql_driver", r.Properties["orm"])
+	}
+	edge := findEdge(t, r)
+	if edge.Properties["table"] != "accounts" {
+		t.Errorf("edge table=%q, want accounts", edge.Properties["table"])
+	}
+}
+
+// --- Go: importing BOTH database/sql and a driver must not double-emit.
+func TestGoSQLDriverNoDoubleEmitWithDatabaseSQL(t *testing.T) {
+	src := `package main
+import (
+    "database/sql"
+    _ "github.com/lib/pq"
+)
+func Fetch(db *sql.DB) { db.Query("SELECT name FROM accounts") }`
+	recs := runExtract(t, "both.go", "go", src)
+	count := 0
+	for _, r := range recs {
+		if r.Kind == KindDataAccess && r.Properties["table"] == "accounts" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 accounts access, got %d: %+v", count, recs)
+	}
+}
+
+// --- Java plain JDBC: stmt.executeQuery("SELECT ... FROM t")
+func TestJDBCExecuteQueryReadsTable(t *testing.T) {
+	src := `import java.sql.Connection;
+import java.sql.Statement;
+class Dao {
+    void load(Connection c) throws Exception {
+        Statement st = c.createStatement();
+        st.executeQuery("SELECT id FROM employees WHERE active = 1");
+    }
+}`
+	recs := runExtract(t, "Dao.java", "java", src)
+	r := findByOpTable(t, recs, OpSelect, "employees")
+	if r.Properties["orm"] != "jdbc" {
+		t.Errorf("orm=%q, want jdbc", r.Properties["orm"])
+	}
+	edge := findEdge(t, r)
+	if edge.Properties["table"] != "employees" || edge.Properties["operation"] != OpSelect {
+		t.Errorf("edge=%v, want table=employees op=SELECT", edge.Properties)
+	}
+}
+
+// --- Java JDBC write + JOIN: INSERT writes, JOIN yields both tables.
+func TestJDBCJoinYieldsBothTables(t *testing.T) {
+	src := `import java.sql.Statement;
+class Rep {
+    void j(Statement st) throws Exception {
+        st.executeQuery("SELECT * FROM orders JOIN customers ON orders.cid = customers.id");
+    }
+}`
+	recs := runExtract(t, "Rep.java", "java", src)
+	findByOpTable(t, recs, OpSelect, "orders")
+	findByOpTable(t, recs, OpSelect, "customers")
+}
+
+// --- Negative: JDBC dynamic SQL string variable -> no fabricated table.
+func TestJDBCDynamicSQLNoFabricatedTable(t *testing.T) {
+	src := `import java.sql.Statement;
+class D {
+    void run(Statement st, String q) throws Exception { st.executeQuery(q); }
+}`
+	recs := runExtract(t, "D.java", "java", src)
+	for _, r := range recs {
+		if r.Kind == KindDataAccess && r.Properties["table"] != UnknownTable && r.Properties["table"] != "" {
+			t.Errorf("fabricated table %q from dynamic JDBC SQL", r.Properties["table"])
+		}
+	}
+}

--- a/internal/extractors/cross/dbmap/orms.go
+++ b/internal/extractors/cross/dbmap/orms.go
@@ -40,6 +40,21 @@ var importCallRE = regexp.MustCompile(
 	`(?mi)\b(?:require|import)\s*\(\s*["']([\w@][\w\-./:]*)["']\s*\)`,
 )
 
+// quotedImportRE captures quoted import paths inside Go-style grouped/blank
+// import blocks where the token does not directly follow the `import`
+// keyword:
+//
+//	import (
+//	    _ "github.com/lib/pq"
+//	    "database/sql"
+//	)
+//
+// It deliberately requires the path to contain a `/` or `.` so it does not
+// match arbitrary string literals (e.g. SQL fragments) — only module paths.
+var quotedImportRE = regexp.MustCompile(
+	`(?m)^\s*(?:import\s+)?(?:[\w.]+\s+)?"([\w@][\w\-]*[./][\w\-./:]*)"\s*$`,
+)
+
 // extractImportTokens returns the lower-cased set of import tokens found in source.
 func extractImportTokens(source string) map[string]bool {
 	out := map[string]bool{}
@@ -59,6 +74,11 @@ func extractImportTokens(source string) map[string]bool {
 		}
 	}
 	for _, m := range importCallRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 2 {
+			add(m[1])
+		}
+	}
+	for _, m := range quotedImportRE.FindAllStringSubmatch(source, -1) {
 		if len(m) >= 2 {
 			add(m[1])
 		}
@@ -566,6 +586,46 @@ func detectJPA(source string) []access {
 }
 
 // ---------------------------------------------------------------------------
+// Java — plain JDBC (java.sql)
+// ---------------------------------------------------------------------------
+
+// JDBC raw SQL is passed as a string literal to Statement.executeQuery /
+// executeUpdate / execute / Connection.prepareStatement / prepareCall.
+// We reuse the shared raw-SQL table scanner (FROM/INTO/UPDATE/JOIN) over the
+// whole source — it already handles double-quoted SELECT/INSERT/UPDATE/DELETE
+// literals — and retag the hits as orm=jdbc. Files reach this detector only
+// when a java.sql / javax.sql import gate matched (see ormOrder), so the
+// scan is import-gated like every other driver.
+//
+// Honest-partial: dynamically built SQL ("SELECT * FROM " + tbl) is not a
+// single literal and resolves to no table (no fabricated edge).
+func detectJDBC(source string) []access {
+	return retagRaw(detectRawSQL(source), "jdbc")
+}
+
+// ---------------------------------------------------------------------------
+// Python — raw stdlib / third-party DB-API drivers (sqlite3, pymysql,
+// mysql.connector, cx_Oracle/oracledb, pyodbc, asyncpg, aiosqlite, MySQLdb).
+// These hand raw SQL strings to cursor.execute(...)/conn.execute(...). The
+// shared raw-SQL scanner resolves the table(s); we retag as orm=dbapi.
+// ---------------------------------------------------------------------------
+
+func detectPyDBAPI(source string) []access {
+	return retagRaw(detectRawSQL(source), "dbapi")
+}
+
+// ---------------------------------------------------------------------------
+// Go — raw database/sql drivers imported directly (lib/pq, go-sql-driver,
+// go-sqlite3, jackc/pgx, jmoiron/sqlx). Files using sqlx or a driver via a
+// blank import may never import "database/sql" by that literal token, so we
+// gate on the driver import as well and reuse the shared raw-SQL scanner.
+// ---------------------------------------------------------------------------
+
+func detectGoSQLDriver(source string) []access {
+	return retagRaw(detectRawSQL(source), "go_sql_driver")
+}
+
+// ---------------------------------------------------------------------------
 // Ruby — ActiveRecord
 // ---------------------------------------------------------------------------
 
@@ -969,6 +1029,41 @@ var ormOrder = []ormEntry{
 		detect:      detectPsycopg2,
 	},
 	{
+		// Raw Python DB-API drivers (stdlib + third-party). Reuses the
+		// shared raw-SQL table scanner. psycopg2/sqlalchemy keep their own
+		// entries above so their orm tags are preserved.
+		name: "dbapi",
+		importHints: []string{
+			"sqlite3", "aiosqlite",
+			"pymysql", "mysql.connector", "mysqldb", "mysqlclient",
+			"oracledb", "cx_oracle",
+			"pyodbc", "asyncpg",
+		},
+		detect: detectPyDBAPI,
+	},
+	{
+		// Raw Go SQL drivers imported directly (driver token, sqlx, pgx).
+		// database/sql keeps its own entry above; this catches files that
+		// import only the driver / sqlx wrapper.
+		name: "go_sql_driver",
+		importHints: []string{
+			"github.com/lib/pq",
+			"github.com/go-sql-driver/mysql",
+			"github.com/mattn/go-sqlite3",
+			"github.com/jackc/pgx",
+			"github.com/jmoiron/sqlx",
+		},
+		detect: detectGoSQLDriver,
+	},
+	{
+		// Plain JDBC (java.sql / javax.sql). Hibernate/JPA keep their own
+		// entry below; this catches Statement.executeQuery("SELECT … FROM t")
+		// style raw SQL.
+		name:        "jdbc",
+		importHints: []string{"java.sql", "javax.sql"},
+		detect:      detectJDBC,
+	},
+	{
 		name:        "hibernate",
 		importHints: []string{"javax.persistence", "jakarta.persistence", "hibernate"},
 		detect:      detectJPA,
@@ -1017,6 +1112,35 @@ func selectORMs(tokens map[string]bool) []ormEntry {
 		if matchesAnyImport(tokens, ormOrder[i].importHints) {
 			out = append(out, ormOrder[i])
 		}
+	}
+	// The "database_sql" and "go_sql_driver" entries both run the shared
+	// raw-SQL scanner over the same source; when a file matches both (e.g.
+	// imports "database/sql" and "github.com/lib/pq") keep only the first
+	// so the SCOPE.DataAccess entities are not duplicated under two orm tags.
+	out = dropDuplicateRawScanner(out, "database_sql", "go_sql_driver")
+	return out
+}
+
+// dropDuplicateRawScanner removes the `drop` entry from sel when `keep` is
+// also present — both delegate to detectRawSQL and would otherwise emit
+// identical table edges differing only by the orm tag.
+func dropDuplicateRawScanner(sel []ormEntry, keep, drop string) []ormEntry {
+	hasKeep := false
+	for i := range sel {
+		if sel[i].name == keep {
+			hasKeep = true
+			break
+		}
+	}
+	if !hasKeep {
+		return sel
+	}
+	out := sel[:0]
+	for i := range sel {
+		if sel[i].name == drop {
+			continue
+		}
+		out = append(out, sel[i])
 	}
 	return out
 }


### PR DESCRIPTION
## Closes #3644 (epic #3625)

The meta-audit (#3628 area #3/#10) found `ACCESSES_TABLE` came from only 2 sources (cross/dbmap ORMs + cobol); the high-traffic raw drivers emitted query operations but never resolved the tables they touch.

The `_cross_dbmap` raw-SQL scanner (`detectRawSQL`) already parses `FROM`/`INTO`/`UPDATE`/`JOIN` and emits the canonical `SCOPE.DataAccess` + `ACCESSES_TABLE` shape — it was just import-gated to a narrow ORM set. This PR enables that proven, cross-language-consistent emitter for the dominant raw drivers (rather than porting divergent per-language logic).

### Langs now emitting ACCESSES_TABLE from raw SQL
- **Python** — `detectPyDBAPI`, gated on `sqlite3`/`aiosqlite`/`pymysql`/`mysql.connector`/`mysqlclient`/`oracledb`/`cx_oracle`/`pyodbc`/`asyncpg` (psycopg2/sqlalchemy keep their own tags).
- **Go** — `detectGoSQLDriver`, gated on `lib/pq`, `go-sql-driver/mysql`, `mattn/go-sqlite3`, `jackc/pgx`, `jmoiron/sqlx`; deduped against `database/sql` so a file importing both does not double-emit.
- **Java** — `detectJDBC`, gated on `java.sql`/`javax.sql` (plain `Statement.executeQuery("SELECT … FROM t")`).

Also taught `extractImportTokens` to read quoted import paths inside Go grouped/blank import blocks (`import ( _ "github.com/lib/pq" )`), which the keyword-anchored token regex missed.

All paths emit the table entity + `ACCESSES_TABLE` edge with the read/write verb, matching the existing cross-language entity/edge shape. Honest-partial: dynamic/concatenated SQL resolves to no fabricated table.

### Table edges asserted (value-asserting, not len>0)
- `cursor.execute("SELECT id FROM users WHERE x=1")` (sqlite3) → table `users` (SELECT/read), edge fn `load`
- `cursor.execute("INSERT INTO orders …")` (pymysql) → table `orders` (INSERT/write)
- `db.Query("SELECT name FROM accounts …")` (lib/pq) → table `accounts`
- `st.executeQuery("SELECT id FROM employees …")` (JDBC) → table `employees`
- JDBC `SELECT * FROM orders JOIN customers …` → both `orders` + `customers`
- **Negatives:** dynamic `execute(q)` / `executeQuery(q)` → no fabricated table (Python + Java); no driver import → no records
- **Guard:** `database/sql` + `lib/pq` in one file → exactly one `accounts` access

### Records
`query_attribution` → **full** for `go.driver.mysql` (was `missing`/#3644), `go.driver.sqlite`, `go.orm.pgx`, `go.orm.sqlx`, `python.driver.sqlite`, `python.driver.mysql` (were `partial`); dbmap cite added to `python.driver.postgres` and `java.orm.jpa` (JDBC path). Reverses relevant #3635 downgrades.

### Verification
`go test` targeted green (dbmap + engine + types + tools/coverage); `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

**DEPLOY-DEFERRED** — graph effect lands on the next live-daemon rebuild + reindex; not run here (sandbox-isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)