### PR TITLE
[realtime] WebSocket/SSE/SignalR/Phoenix Channels endpoint extraction

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 31 records · **C/C++**: 3 · **elixir**: 1 · **JS/TS**: 1 · **multi**: 20 · **python**: 3 · **ruby**: 1 · **rust**: 2
+**Total**: 33 records · **C/C++**: 3 · **elixir**: 2 · **JS/TS**: 1 · **multi**: 21 · **python**: 3 · **ruby**: 1 · **rust**: 2
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -11,6 +11,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | 🟢 | 🔴 | |
 | [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
@@ -30,6 +31,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [SignalR](../detail/msg.signalr.md) | 🔴 | ✅ | — | 🔴 | |
 | [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # elixir
 
-**Frameworks**: 14 · **Tools**: 5 · **ORMs**: 10 · **Other**: 2
+**Frameworks**: 14 · **Tools**: 5 · **ORMs**: 10 · **Other**: 3
 
 Back to [summary](../summary.md).
 
@@ -88,4 +88,5 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Category | Status | Notes |
 |---|---|---|---|
 | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+| [Phoenix Channels](../detail/msg.phoenix-channels.md) | [message_broker](../by-category/message_broker.md) | 🔴 | |
 | [Ueberauth (Elixir OAuth)](../detail/lang.elixir.framework.ueberauth.md) | [security](../by-category/security.md) | 🔴 | |

--- a/docs/coverage/detail/msg.phoenix-channels.md
+++ b/docs/coverage/detail/msg.phoenix-channels.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.phoenix-channels` — Phoenix Channels
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🔴 `missing` | — | 3682 | — | Client-side Phoenix channel.join() extraction not yet implemented; producer-side endpoints land in #3682. |
+| Producer extraction | ✅ `full` | `2026-06-02` | — | `internal/engine/realtime_endpoint_synthesis.go`<br>`internal/engine/realtime_endpoint_synthesis_test.go` | #3682 (epic #3628 area #7): Phoenix 'channel "topic:*", XChannel' declarations in a Phoenix.Socket module emit endpoint-shaped http_endpoint_definition entities http:WS:<topic> (transport=channels) with a HANDLES edge Class:XChannel -> endpoint. Honest-partial: topic wildcards (room:*) are kept verbatim as the route_path; per-message handle_in event extraction is deferred. |
+| Topic attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/realtime_endpoint_synthesis.go` | Topic pattern captured verbatim as route_path (room:*); wildcard segments not expanded. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.phoenix-channels ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.signalr.md
+++ b/docs/coverage/detail/msg.signalr.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.signalr` — SignalR
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🔴 `missing` | — | 3682 | — | Client-side SignalR (HubConnectionBuilder().WithUrl) extraction not yet implemented; producer-side endpoints land in #3682. |
+| Producer extraction | ✅ `full` | `2026-06-02` | — | `internal/engine/realtime_endpoint_synthesis.go`<br>`internal/engine/realtime_endpoint_synthesis_test.go` | #3682 (epic #3628 area #7): SignalR Hubs emit endpoint-shaped http_endpoint_definition entities. Each client-invokable public Task/void method on a 'class XHub : Hub' becomes a realtime endpoint http:WS:<base>/<Method> (transport=signalr) with a HANDLES edge Class:Hub.Method -> endpoint; app.MapHub<XHub>("/path") rebinds the base path, else default /<hub-without-suffix>. Lifecycle overrides (OnConnectedAsync/OnDisconnectedAsync/Dispose) excluded. Honest: hub method discovery is regex-scoped to the class body; no cross-assembly client-invoke verification. |
+| Topic attribution | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.signalr ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.sse.md
+++ b/docs/coverage/detail/msg.sse.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Consumer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/sse_edges.go` | — |
-| Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/sse_edges.go` | — |
+| Producer extraction | ✅ `full` | `2026-06-02` | — | `internal/engine/realtime_endpoint_synthesis.go`<br>`internal/engine/sse_edges.go` | #3682 (epic #3628 area #7): in addition to Stream + STREAMS_TO edges, the producer side now ALSO emits endpoint-shaped http_endpoint_definition entities (verb=SSE, route_path, realtime=true, transport=sse) with a HANDLES edge to the handler, so endpoints/find surface SSE endpoints. Frameworks: NestJS @Sse('path'), FastAPI sse-starlette EventSourceResponse / StreamingResponse(text/event-stream) on an @app.get handler. Honest-partial for dynamic paths. |
 | Topic attribution | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/msg.websocket.md
+++ b/docs/coverage/detail/msg.websocket.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Consumer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/websocket_edges.go` | — |
-| Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/websocket_edges.go` | — |
+| Producer extraction | ✅ `full` | `2026-06-02` | — | `internal/engine/realtime_endpoint_synthesis.go`<br>`internal/engine/websocket_edges.go` | #3682 (epic #3628 area #7): in addition to ChannelEvent + WS_SUBSCRIBES_TO/WS_EMITS edges, the producer side now ALSO emits endpoint-shaped http_endpoint_definition entities (verb=WS, route_path, realtime=true, transport=websocket) with a HANDLES edge to the handler, so the endpoints/find tools surface WS endpoints alongside REST and they cross-link on the shared http:WS:<path> synthetic ID. Frameworks: NestJS @WebSocketGateway+@SubscribeMessage, socket.io socket.on, bare ws WebSocketServer, FastAPI @app.websocket. Honest-partial where the channel/path is fully dynamic. |
 | Topic attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/websocket_edges.go` | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -59064,6 +59064,31 @@
       }
     },
     {
+      "id": "msg.phoenix-channels",
+      "category": "message_broker",
+      "language": "elixir",
+      "label": "Phoenix Channels",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "missing",
+          "issue": "3682",
+          "notes": "Client-side Phoenix channel.join() extraction not yet implemented; producer-side endpoints land in #3682."
+        },
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/realtime_endpoint_synthesis.go","internal/engine/realtime_endpoint_synthesis_test.go"],
+          "notes": "#3682 (epic #3628 area #7): Phoenix 'channel \"topic:*\", XChannel' declarations in a Phoenix.Socket module emit endpoint-shaped http_endpoint_definition entities http:WS:\u003ctopic\u003e (transport=channels) with a HANDLES edge Class:XChannel -\u003e endpoint. Honest-partial: topic wildcards (room:*) are kept verbatim as the route_path; per-message handle_in event extraction is deferred.",
+          "verified_at": "2026-06-02"
+        },
+        "topic_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/realtime_endpoint_synthesis.go"],
+          "notes": "Topic pattern captured verbatim as route_path (room:*); wildcard segments not expanded.",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "msg.sidekiq",
       "category": "message_broker",
       "language": "ruby",
@@ -59074,6 +59099,28 @@
         },
         "producer_extraction": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "msg.signalr",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "SignalR",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "missing",
+          "issue": "3682",
+          "notes": "Client-side SignalR (HubConnectionBuilder().WithUrl) extraction not yet implemented; producer-side endpoints land in #3682."
+        },
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/realtime_endpoint_synthesis.go","internal/engine/realtime_endpoint_synthesis_test.go"],
+          "notes": "#3682 (epic #3628 area #7): SignalR Hubs emit endpoint-shaped http_endpoint_definition entities. Each client-invokable public Task/void method on a 'class XHub : Hub' becomes a realtime endpoint http:WS:\u003cbase\u003e/\u003cMethod\u003e (transport=signalr) with a HANDLES edge Class:Hub.Method -\u003e endpoint; app.MapHub\u003cXHub\u003e(\"/path\") rebinds the base path, else default /\u003chub-without-suffix\u003e. Lifecycle overrides (OnConnectedAsync/OnDisconnectedAsync/Dispose) excluded. Honest: hub method discovery is regex-scoped to the class body; no cross-assembly client-invoke verification.",
+          "verified_at": "2026-06-02"
+        },
+        "topic_attribution": {
+          "status": "not_applicable"
         }
       }
     },
@@ -59090,8 +59137,9 @@
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/realtime_endpoint_synthesis.go","internal/engine/sse_edges.go"],
+          "notes": "#3682 (epic #3628 area #7): in addition to Stream + STREAMS_TO edges, the producer side now ALSO emits endpoint-shaped http_endpoint_definition entities (verb=SSE, route_path, realtime=true, transport=sse) with a HANDLES edge to the handler, so endpoints/find surface SSE endpoints. Frameworks: NestJS @Sse('path'), FastAPI sse-starlette EventSourceResponse / StreamingResponse(text/event-stream) on an @app.get handler. Honest-partial for dynamic paths.",
+          "verified_at": "2026-06-02"
         },
         "topic_attribution": {
           "status": "not_applicable"
@@ -59134,8 +59182,9 @@
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/realtime_endpoint_synthesis.go","internal/engine/websocket_edges.go"],
+          "notes": "#3682 (epic #3628 area #7): in addition to ChannelEvent + WS_SUBSCRIBES_TO/WS_EMITS edges, the producer side now ALSO emits endpoint-shaped http_endpoint_definition entities (verb=WS, route_path, realtime=true, transport=websocket) with a HANDLES edge to the handler, so the endpoints/find tools surface WS endpoints alongside REST and they cross-link on the shared http:WS:\u003cpath\u003e synthetic ID. Frameworks: NestJS @WebSocketGateway+@SubscribeMessage, socket.io socket.on, bare ws WebSocketServer, FastAPI @app.websocket. Honest-partial where the channel/path is fully dynamic.",
+          "verified_at": "2026-06-02"
         },
         "topic_attribution": {
           "status": "partial",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 126
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 128
 
 ## Coverage by language
 
@@ -15,7 +15,7 @@
 | [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
 | [C#](by-language/csharp.md) | 16 | 7 | 14 | 0 |
 | [php](by-language/php.md) | 15 | 6 | 14 | 0 |
-| [elixir](by-language/elixir.md) | 14 | 5 | 10 | 2 |
+| [elixir](by-language/elixir.md) | 14 | 5 | 10 | 3 |
 | [rust](by-language/rust.md) | 14 | 6 | 15 | 3 |
 | [scala](by-language/scala.md) | 14 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
@@ -33,13 +33,13 @@
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
 | [Platform / k8s](by-category/platform.md) | 26 | 19 | 7 | 0 |
-| [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
+| [Message Brokers](by-category/message_broker.md) | 21 | 9 | 9 | 3 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 100 | 39 | 35 | 26 |
+| **Total** | 101 | 39 | 35 | 27 |
 
 ## Languages with extractor support, no records yet
 
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 216 frameworks · 111 tools · 152 ORMs · 126 other
+Total: 216 frameworks · 111 tools · 152 ORMs · 128 other

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -712,6 +712,13 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	applyPass(applyWebSocketSynthesis)
 	applyPass(applySSESynthesis)
 	applyPass(applyGraphQLSubscriptionSynthesis)
+	// #3682 (epic #3628 area #7): realtime-endpoint synthesis. Emits the
+	// endpoint-shaped, queryable, cross-linkable view of WebSocket / SSE /
+	// SignalR / Phoenix Channels handlers — http_endpoint_definition entities
+	// with verb=WS|SSE + route_path + a HANDLES edge to the handler — so the
+	// `endpoints` / `find` tools surface realtime endpoints alongside REST
+	// routes. Additive on top of the ChannelEvent/Stream passes above.
+	applyPass(applyRealtimeEndpointSynthesis)
 	// #728: Scheduled-job entry-point detection. Emits SCOPE.ScheduledJob
 	// entities + TRIGGERS edges for every major scheduler framework across
 	// Python, Node, Java/Kotlin, Go; plus Kubernetes CronJob YAML and

--- a/internal/engine/realtime_endpoint_synthesis.go
+++ b/internal/engine/realtime_endpoint_synthesis.go
@@ -1,0 +1,508 @@
+// Realtime-endpoint synthesis (#3682, epic #3628 area #7).
+//
+// The pre-existing realtime passes (websocket_edges.go, sse_edges.go,
+// graphql_subscriptions.go) model realtime traffic as *edge annotations*
+// onto bespoke `ChannelEvent` / `Stream` / `Subscription` entities. Those
+// entities are NOT endpoint-shaped: they carry no `verb` + `route_path`
+// identity, are not classified by the `endpoints` / `find` MCP tools, and
+// cannot be cross-linked the way HTTP routes are.
+//
+// This pass adds the endpoint-shaped, queryable, cross-linkable view on
+// top — it does NOT replace the channel/stream passes. For every realtime
+// handler the extractor can statically identify on the PRODUCER side it
+// emits a synthetic entity that is shaped exactly like an HTTP route:
+//
+//   - Kind = `http_endpoint_definition` (the same kind HTTP routes use) so
+//     `endpoints` / `find` surface realtime endpoints with zero MCP-layer
+//     changes. The `realtime=true` + `transport=...` properties let callers
+//     filter realtime endpoints apart from REST when they want to.
+//   - `verb` = `WS` (websocket / socket.io / signalr / channels) or `SSE`.
+//   - `path` = the channel / route / event path, canonicalised.
+//   - Synthetic ID `http:WS:<path>` / `http:SSE:<path>` built with the same
+//     httproutes.SyntheticID the HTTP synthesizer uses, so a server's
+//     `WS /ws/notifications` and a browser's `new WebSocket(".../ws/notifications")`
+//     collapse onto one identity for the cross-repo linker (the WS client
+//     side is still recorded as a WS_CONNECTS edge by websocket_edges.go;
+//     the shared synthetic-ID path is the cross-stack pivot).
+//   - A HANDLES edge from the handler symbol → the realtime endpoint entity,
+//     mirroring the GraphQL operation-endpoint shape (spring_graphql.go).
+//     The handler FromID uses the same `Function:<name>` / `Class:<name>`
+//     convention the WS/SSE edge passes already emit, so the standard
+//     resolve pass binds it to the stamped handler entity.
+//
+// Frameworks covered (producer side):
+//
+//   - JS/TS  NestJS  `@WebSocketGateway()` class + `@SubscribeMessage('evt')`
+//     methods → `WS /<evt>` + HANDLES to the gateway method.
+//     NestJS  `@Sse('path')` → `SSE /path` + HANDLES to the method.
+//     socket.io `socket.on('evt', ...)` → `WS /<evt>`.
+//     bare ws  `new WebSocketServer(...)` → `WS /ws` (or the literal
+//     `path:` option when present).
+//   - Python FastAPI `@app.websocket("/ws/...")` → `WS /ws/...` + HANDLES.
+//     FastAPI/Starlette SSE: `EventSourceResponse(...)` (sse-starlette)
+//     or `StreamingResponse(..., media_type="text/event-stream")`
+//     returned from an `@app.get("/path")` handler → `SSE /path`.
+//   - C#     SignalR `class ChatHub : Hub` invokable methods → `WS /<hub>/<method>`;
+//     `app.MapHub<ChatHub>("/chat")` rebinds the hub's base path
+//     so `ChatHub.SendMessage` mapped at `/chat` becomes
+//     `WS /chat/SendMessage`.
+//   - Elixir Phoenix `channel "room:*", RoomChannel` → `WS room:*` + HANDLES
+//     to the channel module.
+//
+// Honest-partial: when a path/channel is fully dynamic (interpolated at
+// runtime) the endpoint is emitted only if a stable literal segment can be
+// derived; otherwise it is skipped rather than guessed.
+//
+// Refs #3682.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// realtimeVerbWS / realtimeVerbSSE are the synthetic HTTP "verbs" used to
+// distinguish realtime endpoints from REST routes while keeping them inside
+// the http_endpoint_definition kind so `endpoints` / `find` surface them.
+const (
+	realtimeVerbWS  = "WS"
+	realtimeVerbSSE = "SSE"
+)
+
+// applyRealtimeEndpointSynthesis is the per-file entry point. Append-only:
+// it never modifies or removes existing entities/edges. No-op for content
+// that contains none of the per-framework anchors.
+func applyRealtimeEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	src := string(content)
+
+	seen := map[string]bool{}
+
+	// emitEndpoint appends one realtime endpoint entity (deduped per file by
+	// synthetic ID) and a HANDLES edge from the handler symbol to it. The
+	// handlerRef is a kind-qualified reference (`Function:foo` / `Class:Bar`)
+	// that the standard resolve pass binds to the stamped handler entity; an
+	// empty handlerRef emits the entity with no HANDLES edge (honest: no
+	// statically-addressable handler).
+	emitEndpoint := func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string) {
+		canonical := canonicalizeRealtimePath(transport, rawPath)
+		if canonical == "" {
+			return
+		}
+		id := httproutes.SyntheticID(verb, canonical)
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+
+		props := map[string]string{
+			"verb":         verb,
+			"path":         canonical,
+			"framework":    framework,
+			"realtime":     "true",
+			"transport":    transport,
+			"pattern_type": "realtime_endpoint_synthesis",
+		}
+		for k, v := range extra {
+			if v != "" {
+				props[k] = v
+			}
+		}
+		if handlerRef != "" {
+			props["source_handler"] = handlerRef
+		}
+		entities = append(entities, types.EntityRecord{
+			ID:                 id,
+			Name:               id,
+			QualifiedName:      id,
+			Kind:               httpEndpointDefinitionKind,
+			SourceFile:         path,
+			Language:           lang,
+			Properties:         props,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+
+		if handlerRef != "" {
+			relationships = append(relationships, types.RelationshipRecord{
+				FromID: handlerRef,
+				ToID:   id,
+				Kind:   string(types.RelationshipKindHandles),
+				Properties: map[string]string{
+					"framework":    framework,
+					"transport":    transport,
+					"pattern_type": "realtime_endpoint_synthesis",
+				},
+			})
+		}
+	}
+
+	switch lang {
+	case "javascript", "typescript":
+		synthNestWebSocketGateway(src, emitEndpoint)
+		synthNestSse(src, emitEndpoint)
+		synthSocketIORealtimeEndpoints(src, emitEndpoint)
+		synthBareWSRealtimeEndpoint(src, emitEndpoint)
+	case "python":
+		synthFastAPIRealtimeWS(src, emitEndpoint)
+		synthPythonSSEEndpoint(src, emitEndpoint)
+	case "csharp":
+		synthSignalRRealtimeEndpoints(src, emitEndpoint)
+	case "elixir":
+		synthPhoenixChannelEndpoints(src, emitEndpoint)
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// canonicalizeRealtimePath normalises a realtime path/channel for stable
+// synthetic identity. WebSocket / SSE URL forms are stripped to their path
+// component (host removed) so a server `/ws/x` and a browser
+// `wss://host/ws/x` collapse. socket.io event names and Phoenix channel
+// topics (which are not URL paths, e.g. `chat` or `room:*`) pass through
+// trimmed. Empty / placeholder-only inputs return "".
+func canonicalizeRealtimePath(transport, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	switch transport {
+	case "websocket", "sse", "signalr":
+		// URL/path-shaped. Strip scheme+host if present.
+		if strings.Contains(raw, "://") {
+			raw = stripWSHost(raw)
+		}
+		// Drop query/fragment.
+		if q := strings.IndexAny(raw, "?#"); q >= 0 {
+			raw = raw[:q]
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return ""
+		}
+		// Run through the shared canonicaliser so `:id`/`{id}` placeholders
+		// match the HTTP route convention. Express canonicaliser is path-safe.
+		if strings.HasPrefix(raw, "/") {
+			if c := httproutes.Canonicalize(httproutes.FrameworkExpress, raw); c != "" {
+				return c
+			}
+		}
+		return raw
+	default:
+		// Event/topic name (socket.io event, Phoenix topic). Keep as-is but
+		// reject pure interpolation.
+		if raw == "*" || strings.HasPrefix(raw, "${") || strings.HasPrefix(raw, "+") {
+			return ""
+		}
+		return raw
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NestJS — @WebSocketGateway() + @SubscribeMessage('event')
+// ---------------------------------------------------------------------------
+
+// nestSubscribeMessageRe captures `@SubscribeMessage('event')` immediately
+// preceding a (possibly async) method declaration, capturing the event name
+// and the handler method name. Stacked decorators between the
+// @SubscribeMessage and the method (e.g. @UsePipes) are tolerated.
+var nestSubscribeMessageRe = regexp.MustCompile(
+	`@SubscribeMessage\s*\(\s*['"]([^'"\r\n]+)['"]\s*\)\s*(?:[\r\n]\s*@[^\r\n]*)*\s*(?:public\s+|private\s+|protected\s+)?(?:async\s+)?(\w+)\s*\(`,
+)
+
+func synthNestWebSocketGateway(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	// Gate on the gateway decorator so this is a no-op on non-Nest files
+	// that happen to contain a `@SubscribeMessage` string in a comment.
+	if !strings.Contains(src, "@WebSocketGateway") && !strings.Contains(src, "@SubscribeMessage") {
+		return
+	}
+	for _, m := range nestSubscribeMessageRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		event := m[1]
+		method := m[2]
+		emit(
+			realtimeVerbWS,
+			"/"+strings.TrimPrefix(event, "/"),
+			"nestjs",
+			"websocket",
+			"Function:"+method,
+			map[string]string{"event": event},
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NestJS — @Sse('path')
+// ---------------------------------------------------------------------------
+
+var nestSseRe = regexp.MustCompile(
+	`@Sse\s*\(\s*['"]([^'"\r\n]+)['"]\s*\)\s*(?:[\r\n]\s*@[^\r\n]*)*\s*(?:public\s+|private\s+|protected\s+)?(?:async\s+)?(\w+)\s*\(`,
+)
+
+func synthNestSse(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !strings.Contains(src, "@Sse(") {
+		return
+	}
+	for _, m := range nestSseRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		path := m[1]
+		method := m[2]
+		emit(
+			realtimeVerbSSE,
+			"/"+strings.TrimPrefix(path, "/"),
+			"nestjs",
+			"sse",
+			"Function:"+method,
+			nil,
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// socket.io server — socket.on('event', handler)
+// ---------------------------------------------------------------------------
+
+// socketIORealtimeOnRe mirrors socketIOEventOnRe in websocket_edges.go but is
+// scoped to this pass's endpoint emission. We reuse the same anchor logic.
+var socketIORealtimeOnRe = regexp.MustCompile(
+	`\b(?:socket|sock|client|s)\s*\.\s*on\s*\(\s*['"]([^'"\r\n]+)['"]\s*,\s*(?:async\s*)?(?:function\s*\(|\(?[\w$,\s]*\)?\s*=>)`,
+)
+
+func synthSocketIORealtimeEndpoints(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !socketIOServerCreateRe.MatchString(src) && !strings.Contains(src, "socket.on(") {
+		return
+	}
+	for _, m := range socketIORealtimeOnRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		event := m[1]
+		switch event {
+		case "connection", "disconnect", "connect", "error", "disconnecting":
+			continue
+		}
+		emit(
+			realtimeVerbWS,
+			"/"+event,
+			"socket.io",
+			"websocket",
+			"Function:socketio_on_"+sanitiseID(event),
+			map[string]string{"event": event},
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// bare ws server — new WebSocketServer(...)
+// ---------------------------------------------------------------------------
+
+func synthBareWSRealtimeEndpoint(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !bareWSServerCreateRe.MatchString(src) {
+		return
+	}
+	channel := "/ws"
+	if mm := regexp.MustCompile(`path\s*:\s*['"]([^'"\r\n]+)['"]`).FindStringSubmatch(src); len(mm) >= 2 {
+		channel = mm[1]
+	}
+	emit(realtimeVerbWS, channel, "ws", "websocket", "Function:ws_on_message", nil)
+}
+
+// ---------------------------------------------------------------------------
+// FastAPI — @app.websocket("/path")
+// ---------------------------------------------------------------------------
+
+// Reuses fastapiWebSocketRe from websocket_edges.go (capture 1 = path,
+// capture 2 = handler name, capture 3 = param sig).
+func synthFastAPIRealtimeWS(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !strings.Contains(src, ".websocket(") {
+		return
+	}
+	for _, m := range fastapiWebSocketRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		path := m[1]
+		handler := m[2]
+		emit(realtimeVerbWS, path, "fastapi", "websocket", "Function:"+handler, nil)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python SSE — sse-starlette EventSourceResponse / StreamingResponse
+// ---------------------------------------------------------------------------
+
+// pySSEHandlerRe captures a route decorator (`@app.get("/path")` /
+// `@router.get(...)`) on a handler whose body returns an SSE response. We do
+// a two-stage match: find the decorator + def, then confirm the body within a
+// reasonable window mentions an SSE response constructor / media type.
+var pySSERouteRe = regexp.MustCompile(
+	`@(?:app|router|api|\w+_router)\.(?:get|post)\s*\(\s*['"]([^'"\r\n]+)['"][^)]*\)\s*[\r\n]+(?:\s*@[^\r\n]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)\s*\([^)]*\)\s*(?:->[^\r\n:]+)?:([\s\S]{0,800})`,
+)
+
+func synthPythonSSEEndpoint(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !strings.Contains(src, "EventSourceResponse") &&
+		!strings.Contains(src, "text/event-stream") {
+		return
+	}
+	for _, m := range pySSERouteRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		path := m[1]
+		handler := m[2]
+		body := m[3]
+		if !strings.Contains(body, "EventSourceResponse") &&
+			!strings.Contains(body, "text/event-stream") {
+			continue
+		}
+		emit(realtimeVerbSSE, path, "fastapi", "sse", "Function:"+handler, nil)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SignalR — class XHub : Hub { ... } + app.MapHub<XHub>("/path")
+// ---------------------------------------------------------------------------
+
+// signalRHubClassRe captures `class ChatHub : Hub` (or `: Hub<T>`), capturing
+// the hub class name.
+var signalRHubClassRe = regexp.MustCompile(
+	`\bclass\s+(\w+)\s*:\s*Hub\b(?:\s*<[^>]+>)?`,
+)
+
+// signalRMapHubRe captures `app.MapHub<ChatHub>("/chat")` (or
+// `endpoints.MapHub<...>`), capturing the hub class name and the route path.
+var signalRMapHubRe = regexp.MustCompile(
+	`\.MapHub\s*<\s*(\w+)\s*>\s*\(\s*['"]([^'"\r\n]+)['"]`,
+)
+
+// signalRHubMethodRe captures public invokable methods inside a Hub class:
+// `public async Task SendMessage(string user, string message)` /
+// `public Task Send(...)` / `public void Notify(...)`. The SignalR client
+// invokes these by name, so each one is a realtime endpoint
+// `<hubBasePath>/<Method>`.
+var signalRHubMethodRe = regexp.MustCompile(
+	`(?m)^\s*public\s+(?:async\s+)?(?:override\s+)?(?:Task|ValueTask|void)(?:\s*<[^>]+>)?\s+(\w+)\s*\(`,
+)
+
+func synthSignalRRealtimeEndpoints(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !strings.Contains(src, ": Hub") && !strings.Contains(src, ".MapHub") {
+		return
+	}
+
+	// Build hubClass -> route base path from MapHub registrations anywhere in
+	// the file (Startup/Program.cs often co-locates with the hub in fixtures).
+	hubBase := map[string]string{}
+	for _, m := range signalRMapHubRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		hubBase[m[1]] = m[2]
+	}
+
+	for _, hm := range signalRHubClassRe.FindAllStringSubmatchIndex(src, -1) {
+		hubName := src[hm[2]:hm[3]]
+		// Default base path is the conventional `/<hubNameWithoutHub-suffix>`
+		// lower-cased; overridden by an explicit MapHub registration.
+		base := hubBase[hubName]
+		if base == "" {
+			base = "/" + strings.ToLower(strings.TrimSuffix(hubName, "Hub"))
+		}
+		// Scope method scanning to the class body: from the class declaration
+		// to the next top-level `class ` declaration (or EOF).
+		bodyStart := hm[1]
+		bodyEnd := len(src)
+		if next := signalRHubClassRe.FindStringIndex(src[bodyStart:]); next != nil {
+			bodyEnd = bodyStart + next[0]
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, mm := range signalRHubMethodRe.FindAllStringSubmatch(body, -1) {
+			if len(mm) < 2 {
+				continue
+			}
+			method := mm[1]
+			// Skip lifecycle overrides — not client-invokable RPC endpoints.
+			switch method {
+			case "OnConnectedAsync", "OnDisconnectedAsync", "Dispose":
+				continue
+			}
+			emit(
+				realtimeVerbWS,
+				strings.TrimRight(base, "/")+"/"+method,
+				"signalr",
+				"signalr",
+				"Class:"+hubName+"."+method,
+				map[string]string{"hub": hubName, "method": method},
+			)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phoenix Channels — channel "room:*", RoomChannel
+// ---------------------------------------------------------------------------
+
+// phoenixChannelRe captures `channel "topic:*", RoomChannel` inside a Phoenix
+// socket module, capturing the topic pattern and the channel module name.
+var phoenixChannelRe = regexp.MustCompile(
+	`(?m)^\s*channel\s+["']([^"'\r\n]+)["']\s*,\s*([A-Z][\w.]*)`,
+)
+
+func synthPhoenixChannelEndpoints(
+	src string,
+	emit func(verb, rawPath, framework, transport, handlerRef string, extra map[string]string),
+) {
+	if !strings.Contains(src, "channel ") && !strings.Contains(src, "channel\t") {
+		return
+	}
+	for _, m := range phoenixChannelRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		topic := m[1]
+		module := m[2]
+		emit(
+			realtimeVerbWS,
+			topic,
+			"phoenix_channels",
+			"channels",
+			"Class:"+module,
+			map[string]string{"topic": topic, "channel_module": module},
+		)
+	}
+}

--- a/internal/engine/realtime_endpoint_synthesis_test.go
+++ b/internal/engine/realtime_endpoint_synthesis_test.go
@@ -1,0 +1,276 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// realtimeEndpoints returns every http_endpoint_definition entity emitted by
+// the realtime synthesis pass (i.e. those carrying realtime=true).
+func realtimeEndpoints(ents []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range ents {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["realtime"] == "true" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// findRealtimeEndpoint returns the realtime endpoint with the given synthetic
+// ID, or nil.
+func findRealtimeEndpoint(ents []types.EntityRecord, id string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].ID == id {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// handlesEdgeTo reports whether a HANDLES edge with the given FromID targets
+// the endpoint ID.
+func handlesEdgeTo(rels []types.RelationshipRecord, fromID, toID string) bool {
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindHandles) && r.FromID == fromID && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRealtimeNestJSSubscribeMessage(t *testing.T) {
+	src := `
+import { WebSocketGateway, SubscribeMessage, MessageBody } from '@nestjs/websockets';
+
+@WebSocketGateway()
+export class ChatGateway {
+  @SubscribeMessage('chat')
+  handleChat(@MessageBody() data: string): string {
+    return data;
+  }
+
+  @SubscribeMessage('typing')
+  async handleTyping(client: Socket): Promise<void> {}
+}
+`
+	res := runDetectWS(t, "typescript", "chat.gateway.ts", src)
+
+	ep := findRealtimeEndpoint(res.Entities, "http:WS:/chat")
+	if ep == nil {
+		t.Fatalf("expected WS endpoint http:WS:/chat for @SubscribeMessage('chat'); realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["verb"] != "WS" {
+		t.Errorf("verb=%q, want WS", ep.Properties["verb"])
+	}
+	if ep.Properties["path"] != "/chat" {
+		t.Errorf("path=%q, want /chat", ep.Properties["path"])
+	}
+	if ep.Properties["transport"] != "websocket" {
+		t.Errorf("transport=%q, want websocket", ep.Properties["transport"])
+	}
+	if ep.Properties["event"] != "chat" {
+		t.Errorf("event=%q, want chat", ep.Properties["event"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Function:handleChat", "http:WS:/chat") {
+		t.Errorf("expected HANDLES edge Function:handleChat -> http:WS:/chat")
+	}
+	// The second event must also be emitted.
+	if findRealtimeEndpoint(res.Entities, "http:WS:/typing") == nil {
+		t.Errorf("expected WS endpoint http:WS:/typing for @SubscribeMessage('typing')")
+	}
+}
+
+func TestRealtimeNestJSSse(t *testing.T) {
+	src := `
+import { Controller, Sse } from '@nestjs/common';
+
+@Controller('events')
+export class EventsController {
+  @Sse('stream')
+  stream(): Observable<MessageEvent> {
+    return interval(1000).pipe(map(() => ({ data: 'tick' })));
+  }
+}
+`
+	res := runDetectWS(t, "typescript", "events.controller.ts", src)
+	ep := findRealtimeEndpoint(res.Entities, "http:SSE:/stream")
+	if ep == nil {
+		t.Fatalf("expected SSE endpoint http:SSE:/stream; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["verb"] != "SSE" {
+		t.Errorf("verb=%q, want SSE", ep.Properties["verb"])
+	}
+	if ep.Properties["transport"] != "sse" {
+		t.Errorf("transport=%q, want sse", ep.Properties["transport"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Function:stream", "http:SSE:/stream") {
+		t.Errorf("expected HANDLES edge Function:stream -> http:SSE:/stream")
+	}
+}
+
+func TestRealtimeFastAPIWebSocket(t *testing.T) {
+	src := `
+from fastapi import FastAPI, WebSocket
+
+app = FastAPI()
+
+@app.websocket("/ws/notifications")
+async def notifications(websocket: WebSocket):
+    await websocket.accept()
+`
+	res := runDetectWS(t, "python", "main.py", src)
+	ep := findRealtimeEndpoint(res.Entities, "http:WS:/ws/notifications")
+	if ep == nil {
+		t.Fatalf("expected WS endpoint http:WS:/ws/notifications; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["path"] != "/ws/notifications" {
+		t.Errorf("path=%q, want /ws/notifications", ep.Properties["path"])
+	}
+	if ep.Properties["framework"] != "fastapi" {
+		t.Errorf("framework=%q, want fastapi", ep.Properties["framework"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Function:notifications", "http:WS:/ws/notifications") {
+		t.Errorf("expected HANDLES edge Function:notifications -> http:WS:/ws/notifications")
+	}
+}
+
+func TestRealtimeFastAPISSE(t *testing.T) {
+	src := `
+from fastapi import FastAPI
+from sse_starlette.sse import EventSourceResponse
+
+app = FastAPI()
+
+@app.get("/events")
+async def events():
+    async def gen():
+        yield {"data": "hello"}
+    return EventSourceResponse(gen())
+`
+	res := runDetectWS(t, "python", "sse.py", src)
+	ep := findRealtimeEndpoint(res.Entities, "http:SSE:/events")
+	if ep == nil {
+		t.Fatalf("expected SSE endpoint http:SSE:/events; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["transport"] != "sse" {
+		t.Errorf("transport=%q, want sse", ep.Properties["transport"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Function:events", "http:SSE:/events") {
+		t.Errorf("expected HANDLES edge Function:events -> http:SSE:/events")
+	}
+}
+
+func TestRealtimeSignalRHub(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.SignalR;
+
+public class ChatHub : Hub
+{
+    public async Task SendMessage(string user, string message)
+    {
+        await Clients.All.SendAsync("ReceiveMessage", user, message);
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        await base.OnConnectedAsync();
+    }
+}
+
+public class Startup
+{
+    public void Configure(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHub<ChatHub>("/chat");
+    }
+}
+`
+	res := runDetectWS(t, "csharp", "ChatHub.cs", src)
+	ep := findRealtimeEndpoint(res.Entities, "http:WS:/chat/SendMessage")
+	if ep == nil {
+		t.Fatalf("expected realtime endpoint http:WS:/chat/SendMessage; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["transport"] != "signalr" {
+		t.Errorf("transport=%q, want signalr", ep.Properties["transport"])
+	}
+	if ep.Properties["hub"] != "ChatHub" || ep.Properties["method"] != "SendMessage" {
+		t.Errorf("hub/method = %q/%q, want ChatHub/SendMessage", ep.Properties["hub"], ep.Properties["method"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Class:ChatHub.SendMessage", "http:WS:/chat/SendMessage") {
+		t.Errorf("expected HANDLES edge Class:ChatHub.SendMessage -> http:WS:/chat/SendMessage")
+	}
+	// Lifecycle override must NOT be emitted as an endpoint.
+	if findRealtimeEndpoint(res.Entities, "http:WS:/chat/OnConnectedAsync") != nil {
+		t.Errorf("OnConnectedAsync must not be emitted as a realtime endpoint")
+	}
+}
+
+func TestRealtimeSignalRHubDefaultBasePath(t *testing.T) {
+	// No MapHub registration in-file: base path defaults to /<hub-without-suffix>.
+	src := `
+public class NotificationHub : Hub
+{
+    public Task Ping() => Task.CompletedTask;
+}
+`
+	res := runDetectWS(t, "csharp", "NotificationHub.cs", src)
+	if findRealtimeEndpoint(res.Entities, "http:WS:/notification/Ping") == nil {
+		t.Fatalf("expected default-base realtime endpoint http:WS:/notification/Ping; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+}
+
+func TestRealtimePhoenixChannel(t *testing.T) {
+	src := `
+defmodule MyAppWeb.UserSocket do
+  use Phoenix.Socket
+
+  channel "room:*", MyAppWeb.RoomChannel
+  channel "user:*", MyAppWeb.UserChannel
+end
+`
+	res := runDetectWS(t, "elixir", "user_socket.ex", src)
+	ep := findRealtimeEndpoint(res.Entities, "http:WS:room:*")
+	if ep == nil {
+		t.Fatalf("expected realtime endpoint http:WS:room:*; realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	if ep.Properties["transport"] != "channels" {
+		t.Errorf("transport=%q, want channels", ep.Properties["transport"])
+	}
+	if ep.Properties["channel_module"] != "MyAppWeb.RoomChannel" {
+		t.Errorf("channel_module=%q, want MyAppWeb.RoomChannel", ep.Properties["channel_module"])
+	}
+	if !handlesEdgeTo(res.Relationships, "Class:MyAppWeb.RoomChannel", "http:WS:room:*") {
+		t.Errorf("expected HANDLES edge Class:MyAppWeb.RoomChannel -> http:WS:room:*")
+	}
+}
+
+func TestRealtimeSocketIOEvent(t *testing.T) {
+	src := `
+const { Server } = require('socket.io');
+const io = new Server(httpServer);
+
+io.on('connection', (socket) => {
+  socket.on('message', (data) => { console.log(data); });
+});
+`
+	res := runDetectWS(t, "javascript", "server.js", src)
+	if findRealtimeEndpoint(res.Entities, "http:WS:/message") == nil {
+		t.Fatalf("expected WS endpoint http:WS:/message for socket.on('message'); realtime=%v", realtimeEndpoints(res.Entities))
+	}
+	// Lifecycle 'connection' must not be an endpoint.
+	if findRealtimeEndpoint(res.Entities, "http:WS:/connection") != nil {
+		t.Errorf("'connection' must not be emitted as a realtime endpoint")
+	}
+}
+
+// TestRealtimeNoOpOnInertFile guards against false positives: a file with no
+// realtime anchors must emit zero realtime endpoints.
+func TestRealtimeNoOpOnInertFile(t *testing.T) {
+	src := `export function add(a: number, b: number): number { return a + b; }`
+	res := runDetectWS(t, "typescript", "math.ts", src)
+	if got := realtimeEndpoints(res.Entities); len(got) != 0 {
+		t.Fatalf("expected 0 realtime endpoints on inert file, got %d: %v", len(got), got)
+	}
+}


### PR DESCRIPTION
Closes #3682 (epic #3628, area #7 — realtime endpoints).

## What
Realtime traffic was previously modelled only as *edge annotations* onto bespoke `ChannelEvent` / `Stream` / `Subscription` entities (websocket_edges.go / sse_edges.go / graphql_subscriptions.go). Those are **not** endpoint-shaped — no `verb`+`route_path` identity, not classified by the `endpoints`/`find` MCP tools, and not cross-linkable like HTTP routes.

This PR adds a new engine pass `applyRealtimeEndpointSynthesis` (registered after the existing realtime passes in detector.go) that emits the **endpoint-shaped, queryable, cross-linkable** view on top. It is purely additive — the channel/stream passes are untouched.

For every statically-identifiable realtime handler it emits an `http_endpoint_definition` entity (so `endpoints`/`find` surface it with **zero MCP-layer changes**) with:
- `verb` = `WS` or `SSE`, `path` = the channel/route/event path (canonicalised),
- `realtime=true`, `transport=websocket|sse|signalr|channels`, `framework`,
- synthetic ID `http:WS:<path>` / `http:SSE:<path>` built with the same `httproutes.SyntheticID` HTTP routes use (so server + browser client collapse onto one identity for the cross-repo linker),
- a `HANDLES` edge from the handler symbol → the realtime endpoint.

## Realtime frameworks now emitting endpoints (producer side)
- **JS/TS**: NestJS `@WebSocketGateway()` + `@SubscribeMessage('evt')` → `WS /<evt>`; NestJS `@Sse('path')` → `SSE /path`; socket.io `socket.on('evt')` → `WS /<evt>`; bare `ws` `WebSocketServer` → `WS /ws`.
- **Python**: FastAPI `@app.websocket("/ws/...")` → `WS /ws/...`; FastAPI / sse-starlette `EventSourceResponse` / `StreamingResponse(text/event-stream)` → `SSE /path`.
- **C#**: SignalR `class XHub : Hub` invokable methods → `WS /<base>/<Method>`; `app.MapHub<XHub>("/path")` rebinds the base path (default `/<hub-without-suffix>` otherwise). Lifecycle overrides excluded.
- **Elixir**: Phoenix `channel "topic:*", XChannel` → `WS topic:*` + `HANDLES` to the channel module.

Honest-partial: dynamic paths/channels are skipped, not guessed; lifecycle hooks (`connection`/`OnConnectedAsync`/etc.) are excluded.

## Realtime endpoints asserted (value-asserting tests)
- NestJS `@SubscribeMessage('chat')` → `http:WS:/chat` (verb=WS, transport=websocket, event=chat) + `HANDLES Function:handleChat → http:WS:/chat`.
- NestJS `@Sse('stream')` → `http:SSE:/stream` + HANDLES.
- FastAPI `@app.websocket("/ws/notifications")` → `http:WS:/ws/notifications` + HANDLES.
- FastAPI `EventSourceResponse` on `@app.get("/events")` → `http:SSE:/events` + HANDLES.
- SignalR `ChatHub.SendMessage` mapped at `/chat` → `http:WS:/chat/SendMessage` (transport=signalr) + `HANDLES Class:ChatHub.SendMessage → endpoint`; `OnConnectedAsync` excluded; default-base path tested (`NotificationHub.Ping` → `http:WS:/notification/Ping`).
- Phoenix `channel "room:*", MyAppWeb.RoomChannel` → `http:WS:room:*` (transport=channels) + `HANDLES Class:MyAppWeb.RoomChannel → endpoint`.
- socket.io `socket.on('message')` → `http:WS:/message`; lifecycle `connection` excluded.
- Inert file → 0 realtime endpoints (false-positive guard).

## Coverage
- Updated `msg.websocket` + `msg.sse` producer cells to cite `realtime_endpoint_synthesis.go`.
- Added `msg.signalr` + `msg.phoenix-channels` records (producer full; consumer/client honestly `missing`, tracked by #3682).
- `coverage validate` 0 errors; registry canonical (`fmt --check` ok); docs regenerated.

## Quality gates
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green.
- `gofmt -l` empty; `go vet` clean.

## DEPLOY-DEFERRED
Daemon rebuild + reindex are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)