### PR TITLE
feat(csharp): Neo4j GRAPH_RELATES graph-schema topology

### DIFF
--- a/internal/custom/csharp/neo4j.go
+++ b/internal/custom/csharp/neo4j.go
@@ -1,0 +1,302 @@
+// neo4j.go — Cypher-DSL extractor for the C# Neo4j drivers
+// (Neo4j.Driver — the official driver — and Neo4jClient — the fluent
+// community client). #3616, epic #3606.
+//
+// C# is driver-based: like the Go driver, relationships are first-class but
+// live inline in the Cypher *query text* rather than in OGM decorators. The
+// official driver runs Cypher strings:
+//
+//	session.RunAsync("MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m")
+//	await session.ExecuteWriteAsync(tx =>
+//	    tx.RunAsync("CREATE (a:Person)-[:KNOWS]->(b:Person)"))
+//
+// Neo4jClient exposes a fluent builder whose .Match(...) / .Create(...) /
+// .Merge(...) arguments are likewise Cypher pattern strings:
+//
+//	client.Cypher.Match("(p:Person)-[:ACTED_IN]->(m:Movie)").Return(...)
+//
+// Honest coverage shape (mirrors the Go extractor exactly):
+//
+//   - Models / Schema — partial. Node labels in Cypher patterns ((n:Person),
+//     (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a soft schema
+//     recovered from a query string by regex, hence partial.
+//   - Relationships — full (topology). Relationship types in Cypher patterns
+//     (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as SCOPE.Schema entities with
+//     subtype "relationship". When BOTH endpoints of the pattern carry a
+//     static node label and the relation a static type —
+//     (a:Person)-[:ACTED_IN]->(m:Movie) — the graph-schema topology is
+//     additionally promoted to a traversable GRAPH_RELATES edge between the
+//     node-label entities (Person ─GRAPH_RELATES(ACTED_IN)→ Movie), the
+//     graph-DB analogue of Mongo's JOINS_COLLECTION and the Java SDN
+//     @Relationship edge. Parameterised / dynamic relations (no static type,
+//     or built by string concatenation / interpolation) stay type-only —
+//     honest-partial.
+//   - Queries — partial. RunAsync("CYPHER") / .Match("CYPHER") call sites are
+//     captured with a coarse verb sniffed from the leading Cypher clause.
+//     Dynamically-built query strings are not fully recoverable, so partial.
+//   - Migrations — not_applicable. Neo4j is schema-flexible / graph-native;
+//     the driver has no migration runner (constraints/indexes are applied via
+//     ad-hoc Cypher).
+//
+// The extractor gates on a Neo4j.Driver / Neo4jClient using actually being
+// present.
+//
+// Registration key: "custom_csharp_neo4j"
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_neo4j", &neo4jExtractor{})
+}
+
+type neo4jExtractor struct{}
+
+func (e *neo4jExtractor) Language() string { return "custom_csharp_neo4j" }
+
+var (
+	// Gate: a using of the official driver (Neo4j.Driver) or the fluent
+	// community client (Neo4jClient).
+	reCSNeo4jImport = regexp.MustCompile(`using\s+Neo4j(?:\.Driver|Client)\b`)
+
+	// Cypher strings passed to the driver / fluent client. We capture the
+	// contents of any C# string literal argument to a Cypher-running method:
+	//
+	//   RunAsync("...") / Run("...")            — official driver, sync + async
+	//   .Match("...") / .Create("...") /        — Neo4jClient fluent builder
+	//   .Merge("...") / .OptionalMatch("...")
+	//
+	// Verbatim (@"...") and interpolated ($"...") prefixes are tolerated by the
+	// optional [@$]* before the quote. Interpolated strings still surface their
+	// static label/type tokens; the dynamic ({var}) holes simply do not match
+	// the node/rel regexes — honest-partial.
+	reCSNeo4jRun = regexp.MustCompile(
+		`(?:RunAsync|Run|Match|OptionalMatch|Create|Merge)\s*\(\s*[@$]*"((?:[^"\\]|\\.)*)"`,
+	)
+
+	// A node label inside a Cypher pattern: (var:Label) or (:Label). Captures
+	// the first (primary) label; chained labels (:A:B) capture A.
+	reCSCypherLabel = regexp.MustCompile(`\([A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|\(\s*:\s*([A-Za-z_]\w*)`)
+
+	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
+	reCSCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+
+	// A full directed relationship triple inside a Cypher pattern:
+	//
+	//   (a:LeftLabel) -[ rvar :REL_TYPE ]-> (b:RightLabel)
+	//   (a:LeftLabel) <-[ rvar :REL_TYPE ]-  (b:RightLabel)
+	//
+	// Both endpoints must carry a statically-resolvable node label and the
+	// relationship a statically-resolvable type for an edge to be emitted. The
+	// arrow head (-> vs <-) decides GRAPH_RELATES direction.
+	//
+	// Captures:
+	//   1 = left node label
+	//   2 = optional left-arrow head ("<")
+	//   3 = relationship type
+	//   4 = optional right-arrow head (">")
+	//   5 = right node label
+	//
+	// A bare relationship with no type (-[r]-> / -[]->) or a dynamic type does
+	// NOT match the type group, so no edge is emitted — honest-partial.
+	reCSCypherTriple = regexp.MustCompile(
+		`\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^()]*\)\s*` +
+			`(<)?-\[\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^\]]*\]-(>)?` +
+			`\s*\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)`,
+	)
+)
+
+func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_neo4j_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neo4j"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "csharp" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reCSNeo4jImport.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// nodeIdx maps "node:<label>" to the index, in `entities`, of its
+	// SCOPE.Schema node entity. The GRAPH_RELATES pass hangs the topology edge
+	// off the *source* node-label entity (the graph "table"), mirroring the Go
+	// extractor and the Mongo JOINS_COLLECTION source collection.
+	nodeIdx := make(map[string]int)
+
+	for _, rm := range reCSNeo4jRun.FindAllStringSubmatchIndex(src, -1) {
+		cypher := src[rm[2]:rm[3]]
+		line := lineOf(src, rm[0])
+
+		// Query operation, verb sniffed from the leading Cypher clause.
+		verb := neo4jCSVerbKind(cypher)
+		q := makeEntity("cypher:"+verb+":"+itoa(line), "SCOPE.Operation", "query", file.Path, "csharp", line)
+		setProps(&q, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+			"query_type", verb)
+		add(q)
+
+		// Schema: node labels in the Cypher pattern.
+		for _, lm := range reCSCypherLabel.FindAllStringSubmatch(cypher, -1) {
+			label := lm[1]
+			if label == "" {
+				label = lm[2]
+			}
+			if label == "" {
+				continue
+			}
+			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "csharp", line)
+			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"node_label", label)
+			before := len(entities)
+			add(n)
+			// add() dedupes; only register the index when actually appended.
+			if len(entities) == before+1 {
+				nodeIdx["node:"+label] = before
+			}
+		}
+
+		// Relationships: relationship types in the Cypher pattern (first-class).
+		for _, relm := range reCSCypherRelType.FindAllStringSubmatch(cypher, -1) {
+			relType := relm[1]
+			if relType == "" {
+				relType = relm[2]
+			}
+			if relType == "" {
+				continue
+			}
+			r := makeEntity("rel:"+relType, "SCOPE.Schema", "relationship", file.Path, "csharp", line)
+			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"rel_type", relType)
+			add(r)
+		}
+
+		// --- GRAPH_RELATES edges (#3616, epic #3606) ---
+		// Promote the graph-schema topology encoded in a Cypher relationship
+		// pattern — (a:Person)-[:ACTED_IN]->(m:Movie) — into a traversable edge
+		// between the node-label entities (the graph "tables"), the graph-DB
+		// analogue of the Mongo JOINS_COLLECTION and the Java SDN @Relationship
+		// GRAPH_RELATES. The edge hangs off the OUTGOING source node entity; the
+		// arrow head decides which endpoint that is:
+		//
+		//   (a:A)-[:R]->(b:B)   →  A ─GRAPH_RELATES(R, OUTGOING)→ node:B
+		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
+		//
+		// The resolver fills FromID from the owning node entity and resolves
+		// ToID ("node:<label>") to the target node entity by name. Only emitted
+		// when BOTH endpoints carry a static label AND the relation a static
+		// type; dynamic / parameterised relations stay label/type-only —
+		// honest-partial.
+		for _, tm := range reCSCypherTriple.FindAllStringSubmatch(cypher, -1) {
+			leftLabel, relType, rightLabel := tm[1], tm[3], tm[5]
+			pointsRight := tm[4] == ">"
+			pointsLeft := tm[2] == "<"
+			if relType == "" || leftLabel == "" || rightLabel == "" {
+				continue
+			}
+			// Determine OUTGOING source / target from the arrow head. A pattern
+			// with no head on either side is undirected; Neo4j stores every
+			// relationship with a concrete direction, so we treat the written
+			// left→right order as the source and record direction=UNDIRECTED.
+			srcLabel, dstLabel, direction := leftLabel, rightLabel, "OUTGOING"
+			switch {
+			case pointsRight && !pointsLeft:
+				srcLabel, dstLabel = leftLabel, rightLabel
+			case pointsLeft && !pointsRight:
+				srcLabel, dstLabel = rightLabel, leftLabel
+			default:
+				direction = "UNDIRECTED"
+			}
+
+			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			if !ok {
+				continue
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "node:" + dstLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neo4j",
+						"rel_type":   relType,
+						"direction":  direction,
+						"provenance": "INFERRED_FROM_NEO4J_CYPHER",
+					},
+				},
+			)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// neo4jCSVerbKind sniffs a coarse verb from the leading Cypher clause so
+// query_type is comparable across the C# data-access extractors.
+func neo4jCSVerbKind(cypher string) string {
+	i := 0
+	for i < len(cypher) && (cypher[i] == ' ' || cypher[i] == '\t' || cypher[i] == '\n' || cypher[i] == '\r') {
+		i++
+	}
+	j := i
+	for j < len(cypher) {
+		c := cypher[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			j++
+			continue
+		}
+		break
+	}
+	switch upperCypherCS(cypher[i:j]) {
+	case "MATCH", "RETURN", "WITH", "UNWIND", "CALL", "OPTIONAL":
+		return "read"
+	case "CREATE", "MERGE":
+		return "create"
+	case "SET":
+		return "update"
+	case "DELETE", "REMOVE", "DETACH":
+		return "delete"
+	default:
+		return "query"
+	}
+}
+
+// upperCypherCS upper-cases an ASCII keyword without allocating via strings.
+func upperCypherCS(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/custom/csharp/neo4j_test.go
+++ b/internal/custom/csharp/neo4j_test.go
@@ -1,0 +1,276 @@
+package csharp_test
+
+// neo4j_test.go — tests for the custom_csharp_neo4j extractor's GRAPH_RELATES
+// graph-schema topology (#3616, epic #3606). Completes the Neo4j topology set
+// alongside Java (#3663), Python+JS (#3670) and Go (#3612).
+//
+// C#'s Neo4j access is driver-based (Neo4j.Driver, Neo4jClient) with no OGM
+// decorators, so the graph schema lives in the Cypher query text. The
+// extractor parses relationship patterns —
+//   (a:Person)-[:ACTED_IN]->(m:Movie)
+// — and promotes them to traversable GRAPH_RELATES edges between the
+// node-label entities, the graph-DB analogue of Mongo's JOINS_COLLECTION.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractCSNeo4j runs the custom_csharp_neo4j extractor and returns the raw
+// EntityRecords (with their Relationships intact).
+func extractCSNeo4j(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_csharp_neo4j")
+	if !ok {
+		t.Fatal("custom_csharp_neo4j not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "Store.cs",
+		Language: "csharp",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findCSGraphRelates returns the GRAPH_RELATES edge from the node entity named
+// "node:<fromLabel>" to ToID "node:<toLabel>", or nil if absent.
+func findCSGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// anyCSGraphRelates reports whether ANY GRAPH_RELATES edge exists in the set.
+func anyCSGraphRelates(ents []types.EntityRecord) bool {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const csNeo4jUsing = "using Neo4j.Driver;\n"
+
+func wrapCS(body string) string {
+	return csNeo4jUsing + "namespace App {\n  class Store {\n" + body + "\n  }\n}\n"
+}
+
+// ---------------------------------------------------------------------------
+// Headline: MATCH (p:Person)-[:ACTED_IN]->(m:Movie) in a C# string →
+//           Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ node:Movie
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jGraphRelatesEdge(t *testing.T) {
+	src := wrapCS(`    async Task Q(IAsyncSession session) {
+      await session.RunAsync("MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	edge := findCSGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie edge; got entities %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "ACTED_IN" {
+		t.Errorf("rel_type = %q, want ACTED_IN", got)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if got := edge.Properties["framework"]; got != "neo4j" {
+		t.Errorf("framework = %q, want neo4j", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Direction: a left-pointing arrow flips the OUTGOING source endpoint.
+//   (m:Movie)<-[:ACTED_IN]-(p:Person) → Person ─ACTED_IN→ node:Movie
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jGraphRelatesLeftArrow(t *testing.T) {
+	src := wrapCS(`    async Task Q(IAsyncSession session) {
+      await session.RunAsync("MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN p");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	// Source is Person (the arrow points away from Person).
+	edge := findCSGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie (arrow flipped); got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	// And there must be NO edge in the written left→right order.
+	if rev := findCSGraphRelates(ents, "Movie", "Person"); rev != nil {
+		t.Errorf("unexpected reverse edge Movie->Person: %+v", rev)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Undirected pattern records direction=UNDIRECTED, written order as source.
+//   (a:Person)-[:KNOWS]-(b:Person)
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jGraphRelatesUndirected(t *testing.T) {
+	src := wrapCS(`    async Task Q(IAsyncSession session) {
+      await session.RunAsync("MATCH (a:Person)-[:KNOWS]-(b:Person) RETURN a, b");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	edge := findCSGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Person; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "KNOWS" {
+		t.Errorf("rel_type = %q, want KNOWS", got)
+	}
+	if got := edge.Properties["direction"]; got != "UNDIRECTED" {
+		t.Errorf("direction = %q, want UNDIRECTED", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Neo4jClient fluent .Match("...") is also a Cypher carrier.
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jClientFluentMatch(t *testing.T) {
+	src := "using Neo4jClient;\nnamespace App {\n  class Store {\n" +
+		`    void Q(IGraphClient client) {
+      client.Cypher.Match("(u:User)-[:FOLLOWS]->(o:Org)").Return(x => x).Results.ToList();
+    }` + "\n  }\n}\n"
+
+	ents := extractCSNeo4j(t, src)
+
+	edge := findCSGraphRelates(ents, "User", "Org")
+	if edge == nil {
+		t.Fatalf("expected User -GRAPH_RELATES-> node:Org via .Match; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "FOLLOWS" {
+		t.Errorf("rel_type = %q, want FOLLOWS", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE / MERGE write patterns also yield topology.
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jCreateWritePattern(t *testing.T) {
+	src := wrapCS(`    async Task W(IAsyncTransaction tx) {
+      await tx.RunAsync("CREATE (a:Author)-[:WROTE]->(b:Book)");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	edge := findCSGraphRelates(ents, "Author", "Book")
+	if edge == nil {
+		t.Fatalf("expected Author -GRAPH_RELATES-> node:Book; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "WROTE" {
+		t.Errorf("rel_type = %q, want WROTE", got)
+	}
+	// The query op verb should be sniffed as "create".
+	var sawCreate bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Properties["query_type"] == "create" {
+			sawCreate = true
+		}
+	}
+	if !sawCreate {
+		t.Errorf("expected a query op with query_type=create; got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a single-node MATCH yields NO GRAPH_RELATES edge.
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jSingleNodeNoEdge(t *testing.T) {
+	src := wrapCS(`    async Task Q(IAsyncSession session) {
+      await session.RunAsync("MATCH (p:Person) RETURN p");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	if anyCSGraphRelates(ents) {
+		t.Fatalf("single-node MATCH must not emit a GRAPH_RELATES edge; got %+v", ents)
+	}
+	// But the node label must still be surfaced as schema.
+	var sawNode bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Name == "node:Person" {
+			sawNode = true
+		}
+	}
+	if !sawNode {
+		t.Errorf("expected node:Person schema entity; got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a dynamic / parameterised relationship type is honest-partial —
+// no edge, but endpoints still surface as node schema.
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jDynamicRelHonestPartial(t *testing.T) {
+	// Untyped relationship -[r]-> : no static type, so no topology edge.
+	src := wrapCS(`    async Task Q(IAsyncSession session, string rel) {
+      await session.RunAsync($"MATCH (p:Person)-[r]->(m:Movie) RETURN r");
+    }`)
+
+	ents := extractCSNeo4j(t, src)
+
+	if anyCSGraphRelates(ents) {
+		t.Fatalf("untyped relationship must not emit a GRAPH_RELATES edge; got %+v", ents)
+	}
+	// Both endpoint labels still surface (honest-partial).
+	if findNodeSchema(ents, "Person") == nil || findNodeSchema(ents, "Movie") == nil {
+		t.Errorf("expected both Person and Movie node schema entities; got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: no Neo4j using → extractor is a no-op (gate).
+// ---------------------------------------------------------------------------
+
+func TestCSNeo4jGateNoImport(t *testing.T) {
+	src := "namespace App {\n  class Store {\n" +
+		`    void Q() {
+      var s = "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p";
+    }` + "\n  }\n}\n"
+
+	ents := extractCSNeo4j(t, src)
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without a Neo4j using; got %+v", ents)
+	}
+}
+
+func findNodeSchema(ents []types.EntityRecord, label string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+label {
+			return &ents[i]
+		}
+	}
+	return nil
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -10486,17 +10486,64 @@ records:
 
   lang.csharp.driver.neo4j:
     capabilities:
+      Models:
+        schema_extraction:
+          # Node labels in Cypher patterns ((n:Person), (:Movie)) carried in C#
+          # driver string literals (RunAsync("..."), Neo4jClient .Match("..."))
+          # => SCOPE.Schema nodes (reCSCypherLabel). Labels are a soft schema
+          # recovered from query strings by regex, hence partial.
+          status: partial
+          symbols:
+            - file: internal/custom/csharp/neo4j.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/neo4j_test.go
+          issues_implemented: ["3616"]
+          verified_at: "2026-06-02"
+      Relationships:
+        relationship_extraction:
+          # Relationship types in Cypher patterns (-[:ACTED_IN]->, -[r:KNOWS]-)
+          # carried in C# Neo4j.Driver / Neo4jClient string literals
+          # => SCOPE.Schema subtype=relationship (reCSCypherRelType). When BOTH
+          # endpoints carry a static node label and the relation a static type
+          # ((a:Person)-[:ACTED_IN]->(m:Movie)), the graph-schema topology is
+          # additionally promoted to a traversable GRAPH_RELATES edge between the
+          # node-label entities (reCSCypherTriple), the graph-DB analogue of
+          # Mongo's JOINS_COLLECTION and the Java SDN @Relationship edge. The
+          # arrow head decides the OUTGOING source endpoint; undirected patterns
+          # record direction=UNDIRECTED. Dynamic / parameterised relations
+          # (untyped -[r]->, string interpolation) stay type-only —
+          # honest-partial — but the statically-resolvable topology is full.
+          # Completes the Neo4j GRAPH_RELATES set: java (#3663) + python/jsts
+          # (#3670) + go (#3612) + csharp (#3616). Reverses the #3635 downgrade.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/neo4j.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/neo4j_test.go
+          issues_implemented: ["3616"]
+          verified_at: "2026-06-02"
       Queries:
         query_attribution:
           # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
           # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
-          # issue #3262.
+          # issue #3262. Additionally, RunAsync("CYPHER") / .Match("CYPHER")
+          # call sites are captured as SCOPE.Operation query entities with a
+          # coarse verb sniffed from the leading Cypher clause (neo4jCSVerbKind).
           status: partial
           symbols:
             - file: internal/substrate/effect_sinks_csharp.go
               functions: [sniffEffectsCSharp]
-          issues_implemented: ["3262"]
-          verified_at: "2026-05-30"
+            - file: internal/custom/csharp/neo4j.go
+              functions: [Extract, neo4jCSVerbKind]
+          issues_implemented: ["3262", "3616"]
+          verified_at: "2026-06-02"
+      Migrations:
+        migration_parsing:
+          status: not_applicable
+          notes: "Neo4j is schema-flexible / graph-native; the driver has no migration runner (constraints/indexes are applied via ad-hoc Cypher)."
+          issues_implemented: ["3616"]
 
   lang.csharp.driver.npgsql:
     capabilities:


### PR DESCRIPTION
Extend the Neo4j `GRAPH_RELATES` graph-schema topology to C# (Neo4j.Driver / Neo4jClient), completing the set: Neo4j topology now spans **java / py / jsts / go / csharp**.

## What
C# is driver-based — the graph schema lives inline in the Cypher query text rather than in OGM decorators (the Go-extractor shape, not the Java SDN-decorator shape). New `custom_csharp_neo4j` extractor parses Cypher relationship patterns carried in C# string literals:

- official driver: `session.RunAsync("MATCH (p:Person)-[:ACTED_IN]->(m:Movie)")`, `tx.RunAsync("CREATE (a:Author)-[:WROTE]->(b:Book)")`
- Neo4jClient fluent: `client.Cypher.Match("(u:User)-[:FOLLOWS]->(o:Org)")`

Statically-resolvable triples are promoted to traversable `GRAPH_RELATES` edges between the node-label entities, e.g.

```
Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ node:Movie
```

Mirrors the Go extractor exactly: same `rel_type`/`direction` props, `node:<label>` ToID shape, arrow-direction handling, `UNDIRECTED` fallback for headless patterns. Handles MATCH/CREATE/MERGE. Verbatim (`@"..."`) and interpolated (`$"..."`) string prefixes tolerated.

**Honest-partial:** node labels / relationship types stay schema-only when an endpoint label or the relation type is dynamic / parameterised (untyped `-[r]->`, string interpolation). Migrations not_applicable (graph-native).

## Records
Reverses the #3635 downgrade for `lang.csharp.driver.neo4j`:
- `Relationships/relationship_extraction` → **full** (topology)
- `Models/schema_extraction` → partial
- `Queries/query_attribution` augmented (Cypher call sites + verb sniff)
- `Migrations/migration_parsing` → not_applicable

## Tests (value-asserting)
`MATCH (p:Person)-[:ACTED_IN]->(m:Movie)` in a C# string ⇒ Person GRAPH_RELATES Movie (`rel_type=ACTED_IN`, `direction=OUTGOING`). Plus: left-arrow direction flip, undirected, Neo4jClient `.Match`, CREATE write-verb sniff, single-node MATCH ⇒ no edge, dynamic/untyped rel ⇒ honest-partial, import gate.

`go test ./internal/custom/csharp/... ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

DEPLOY-DEFERRED.

Closes #3616 (epic #3606)

🤖 Generated with [Claude Code](https://claude.com/claude-code)