### PR TITLE
[grpc] client→server cross-repo linking: modern TS clients (nice-grpc, Connect)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -59437,13 +59437,15 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_edges_test.go","internal/links/grpc_pass.go"],
+          "issue": "3686",
+          "notes": "Client stub calls emit SCOPE.GrpcMethod entities keyed grpc:\u003cService\u003e/\u003cMethod\u003e + GRPC_HANDLES edges matching the server identity; P6 (links/grpc_pass.go) joins client↔server across repos. Node/TS client coverage now includes the modern factory-function stubs nice-grpc (createClient(\u003cService\u003eDefinition, ch)) and Connect/connectrpc (createPromiseClient(\u003cService\u003eService, transport)) alongside classic @grpc/grpc-js constructor stubs.",
+          "verified_at": "2026-06-02"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_edges_test.go"],
+          "verified_at": "2026-06-02"
         },
         "service_extraction": {
           "status": "full",

--- a/internal/engine/grpc_edges.go
+++ b/internal/engine/grpc_edges.go
@@ -900,6 +900,45 @@ var nodeAddServiceRe = regexp.MustCompile(
 var nodeGrpcClientCtorRe = regexp.MustCompile(
 	`(?:const|let|var)\s+(\w+)\s*=\s*new\s+(?:[\w.]+\.)?(\w+)\s*\(`)
 
+// nodeGrpcFactoryClientRe captures the modern TS-first factory-function stub
+// forms used by nice-grpc and Connect (connectrpc), which do NOT use `new`:
+//
+//	const client = createClient(GreeterDefinition, channel);          // nice-grpc
+//	const client = createPromiseClient(ElizaService, transport);      // Connect
+//	const client = createCallbackClient(ElizaService, transport);     // Connect
+//
+// Group 1: variable name. Group 2: descriptor identifier (the service
+// definition/descriptor passed as the first argument, e.g. GreeterDefinition,
+// ElizaService). The canonical protobuf service name is derived from this
+// descriptor by stripping a trailing "Definition" or "Service" suffix.
+var nodeGrpcFactoryClientRe = regexp.MustCompile(
+	`(?:const|let|var)\s+(\w+)\s*=\s*` +
+		`(?:await\s+)?` +
+		`(?:create(?:Promise|Callback)?Client)\s*\(\s*` +
+		`(?:[\w.]+\.)?(\w+)\s*,`)
+
+// grpcServiceNameFromNodeDescriptor derives the canonical protobuf service
+// name from a nice-grpc / Connect descriptor identifier. The protoc-gen-* TS
+// generators name these `<Service>Definition` (nice-grpc / ts-proto) or
+// `<Service>Service` (Connect / protobuf-es). The bare service name (already
+// without a suffix) is returned unchanged so it still matches a server emitting
+// `grpc:<Service>/<Method>`.
+//
+//	"GreeterDefinition" → "Greeter"   (nice-grpc / ts-proto)
+//	"ElizaService"      → "Eliza"     (Connect / protobuf-es)
+//	"Greeter"           → "Greeter"   (already canonical)
+func grpcServiceNameFromNodeDescriptor(descriptor string) string {
+	if descriptor == "" {
+		return ""
+	}
+	for _, suffix := range []string{"Definition", "Service"} {
+		if strings.HasSuffix(descriptor, suffix) && len(descriptor) > len(suffix) {
+			return strings.TrimSuffix(descriptor, suffix)
+		}
+	}
+	return descriptor
+}
+
 // nodeGrpcCallRe captures `client.method(req, cb)`.
 // Group 1: client variable. Group 2: method name.
 var nodeGrpcCallRe = regexp.MustCompile(
@@ -911,8 +950,11 @@ var nodeGrpcCallRe = regexp.MustCompile(
 var nodeImplMethodRe = regexp.MustCompile(
 	`\b(\w+)\s*:\s*(?:async\s+)?function\s*\(|(\w+)\s*:\s*\(`)
 
-// nodeGrpcHasMarkerRe checks for any grpc-shaped token.
-var nodeGrpcHasMarkerRe = regexp.MustCompile(`grpc|@grpc/grpc-js|proto\.`)
+// nodeGrpcHasMarkerRe checks for any grpc-shaped token. Includes the modern
+// TS-first client factories (nice-grpc, Connect/connectrpc) whose import paths
+// (e.g. "@connectrpc/connect") do not contain the substring "grpc".
+var nodeGrpcHasMarkerRe = regexp.MustCompile(
+	`grpc|@grpc/grpc-js|proto\.|createPromiseClient|createCallbackClient|@connectrpc/|connectrpc`)
 
 func synthesizeNodeGRPC(
 	src, path string,
@@ -969,6 +1011,22 @@ func synthesizeNodeGRPC(
 		// Filter out non-gRPC constructors by requiring the context contains
 		// grpc, Grpc, or proto hint within a few hundred bytes.
 		if !strings.Contains(src, "grpc") && !strings.Contains(src, "proto") {
+			continue
+		}
+		stubRegistry[varName] = serviceName
+		emitService(serviceName, "grpc_node_client", map[string]string{"role": "client"})
+	}
+
+	// Modern TS-first factory-function stubs (nice-grpc, Connect). These derive
+	// the canonical service name from the descriptor argument so the emitted
+	// `grpc:<Service>/<Method>` id matches a server side exactly.
+	for _, m := range nodeGrpcFactoryClientRe.FindAllStringSubmatch(src, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		varName := m[1]
+		serviceName := grpcServiceNameFromNodeDescriptor(m[2])
+		if serviceName == "" {
 			continue
 		}
 		stubRegistry[varName] = serviceName

--- a/internal/engine/grpc_edges_test.go
+++ b/internal/engine/grpc_edges_test.go
@@ -462,6 +462,116 @@ function fetchUser(id) {
 	requireGRPCHandles(t, rels, "UserService", "getUser", "node-client")
 }
 
+// TestGRPC_Node_Client_NiceGrpc verifies the modern nice-grpc factory-function
+// client form (#3686). `createClient(GreeterDefinition, channel)` followed by
+// `client.sayHello(req)` must emit a GrpcMethod entity + GRPC_HANDLES edge with
+// the EXACT shared id `grpc:Greeter/sayHello`, so the P6 cross-repo linker can
+// join it to a server emitting the same id.
+func TestGRPC_Node_Client_NiceGrpc(t *testing.T) {
+	src := `import { createChannel, createClient } from 'nice-grpc';
+import { GreeterDefinition } from './greeter.js';
+
+export async function greet(name) {
+    const channel = createChannel('localhost:50051');
+    const client = createClient(GreeterDefinition, channel);
+    const response = await client.sayHello({ name: name });
+    return response.message;
+}
+`
+	ents, rels := runGRPCDetect(t, "typescript", "greeter_client.ts", src)
+
+	// EXACT server shape: service derived from the *Definition descriptor.
+	requireGRPCMethod(t, ents, "Greeter", "sayHello", "nice-grpc-client")
+	requireGRPCHandles(t, rels, "Greeter", "sayHello", "nice-grpc-client")
+
+	// The GRPC_HANDLES edge must originate from the enclosing function, not a
+	// synthetic placeholder.
+	edges := grpcEdgesOfKind(rels, grpcHandlesEdgeKind)
+	if len(edges) == 0 {
+		t.Fatalf("nice-grpc: no GRPC_HANDLES edge emitted")
+	}
+	if !strings.Contains(edges[0].FromID, "greet") {
+		t.Errorf("nice-grpc: GRPC_HANDLES should originate from enclosing fn 'greet'; got FromID=%q", edges[0].FromID)
+	}
+}
+
+// TestGRPC_Node_Client_Connect verifies the Connect (connectrpc) factory-client
+// form (#3686). `createPromiseClient(ElizaService, transport)` + `client.say(req)`
+// must emit `grpc:Eliza/say` (service derived from the *Service descriptor),
+// matching the exact server gRPC shape. Note: the Connect import path
+// `@connectrpc/connect` does not contain the substring "grpc", so this also
+// exercises the extended marker pre-filter.
+func TestGRPC_Node_Client_Connect(t *testing.T) {
+	src := `import { createPromiseClient } from '@connectrpc/connect';
+import { ElizaService } from './gen/eliza_connect.js';
+
+async function chat(sentence) {
+    const client = createPromiseClient(ElizaService, transport);
+    const res = await client.say({ sentence: sentence });
+    return res.sentence;
+}
+`
+	ents, rels := runGRPCDetect(t, "typescript", "eliza_client.ts", src)
+
+	requireGRPCMethod(t, ents, "Eliza", "say", "connect-client")
+	requireGRPCHandles(t, rels, "Eliza", "say", "connect-client")
+}
+
+// TestGRPC_Node_Client_FactoryParity verifies that the modern factory-client
+// id matches a server side emitting the same `grpc:Greeter/sayHello` id, so a
+// cross-repo link would form. This is the load-bearing property for #3686.
+func TestGRPC_Node_Client_FactoryParity(t *testing.T) {
+	// Go server side declaring the Greeter.sayHello RPC.
+	serverSrc := `package main
+
+import (
+    "context"
+    "google.golang.org/grpc"
+    pb "example.com/proto/greeter"
+)
+
+type greeterServer struct{}
+
+func (s *greeterServer) sayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
+    return &pb.HelloReply{}, nil
+}
+
+func main() {
+    gs := grpc.NewServer()
+    pb.RegisterGreeterServer(gs, &greeterServer{})
+}
+`
+	clientSrc := `import { createClient } from 'nice-grpc';
+import { GreeterDefinition } from './greeter.js';
+async function run() {
+    const client = createClient(GreeterDefinition, channel);
+    await client.sayHello({ name: 'world' });
+}
+`
+	serverEnts, _ := runGRPCDetect(t, "go", "greeter_server.go", serverSrc)
+	clientEnts, _ := runGRPCDetect(t, "typescript", "greeter_client.ts", clientSrc)
+
+	want := "grpc:Greeter/sayHello"
+	hasServer := false
+	for _, e := range serverEnts {
+		if e.Kind == grpcMethodKind && e.Name == want {
+			hasServer = true
+		}
+	}
+	hasClient := false
+	for _, e := range clientEnts {
+		if e.Kind == grpcMethodKind && e.Name == want {
+			hasClient = true
+		}
+	}
+	if !hasServer {
+		t.Errorf("Go server did not emit %q; server GrpcMethods=%v", want, grpcEntitiesOfKind(serverEnts, grpcMethodKind))
+	}
+	if !hasClient {
+		t.Errorf("nice-grpc client did not emit matching %q; client GrpcMethods=%v", want, grpcEntitiesOfKind(clientEnts, grpcMethodKind))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Cross-language entity ID parity
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3686 (child of #3628, area #8 — RPC / service-mesh cross-repo linking).

## What already existed
gRPC client→server cross-repo linking is built end-to-end:
- `internal/engine/grpc_edges.go` (#725) emits `SCOPE.GrpcMethod` entities keyed `grpc:<Service>/<Method>` plus `GRPC_HANDLES` (client) / `GRPC_IMPLEMENTS` (server) edges, for Go, Java/Kotlin, Python and classic Node `@grpc/grpc-js` constructor stubs.
- `internal/links/grpc_pass.go` (#1447, P6) joins the two sides across repos by the shared `grpc:<Service>/<Method>` identity, mirroring the HTTP and GraphQL client linkers.

## The gap this PR closes
The Node/TS client path only recognized `new proto.Service(addr, creds)`. The two dominant **modern TS-first** gRPC client libraries produced **zero** `GRPC_HANDLES` edges → no cross-repo link formed for TS service meshes:

| Library | Client form |
|---|---|
| nice-grpc | `const client = createClient(GreeterDefinition, channel); client.sayHello(req)` |
| Connect (connectrpc) | `const client = createPromiseClient(ElizaService, transport); client.say(req)` |

(Verified: both emitted 0 `GRPC_HANDLES` edges before this change.)

## Change
- New `nodeGrpcFactoryClientRe` recognizes `create(Promise|Callback)?Client(<Descriptor>, ...)` factory stubs.
- `grpcServiceNameFromNodeDescriptor` derives the canonical service name from the descriptor (`<Service>Definition` → `<Service>` for nice-grpc/ts-proto; `<Service>Service` → `<Service>` for Connect/protobuf-es), so the emitted client-call id is the **exact** server shape `grpc:<Service>/<Method>` and the P6 linker forms the edge.
- Marker pre-filter extended (`createPromiseClient`/`createCallbackClient`/`@connectrpc/`) because the Connect import path does not contain the substring `grpc`.

## gRPC link asserted
nice-grpc / Connect client call `client.sayHello(req)` → client-call entity `grpc:Greeter/sayHello` **matching** a Go server's `grpc:Greeter/sayHello` (parity test) + `GRPC_HANDLES` edge from the enclosing function.

## Langs
JS/TS (Node) client surface extended. Go / Java / Python / classic grpc-js unchanged (already covered).

## Verification
- `go test ./internal/engine/ ./internal/links/... ./internal/types/ ./tools/coverage/` — green.
- `gofmt -l` empty; `go vet ./internal/engine/` clean.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.

DEPLOY-DEFERRED (no daemon rebuild / reindex in this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)