### PR TITLE
[observability] OpenTelemetry tracing span extraction (Python/Go/JS-TS/Java)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1605,9 +1605,11 @@
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/golang/tracing.go","internal/extractors/java/tracing.go","internal/extractors/javascript/tracing.go","internal/extractors/python/tracing.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3689",
+          "notes": "OpenTelemetry span-creation sites: emits INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub) for the dominant span-start idioms in Python (start_as_current_span/start_span + decorator), Go (tracer.Start), JS/TS (startSpan/startActiveSpan), Java (@WithSpan + spanBuilder().startSpan()). Honest-partial: dynamic/variable span names emit traced=true without a fabricated name; non-OTel vendors and other langs not yet covered.",
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -1053,6 +1053,12 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string, structFiel
 			})
 		}
 
+		// Issue #3689 — OpenTelemetry span-creation sites: emit INSTRUMENTS
+		// edges from this operation → synthetic span stubs. nameText is the
+		// bare function/method name used to key dynamic-name stubs.
+		relationships = append(relationships,
+			goTracingSpanEdges(bodyNode, nameText, fromID, src)...)
+
 		rec := types.EntityRecord{
 			Name:               name,
 			QualifiedName:      "",

--- a/internal/extractors/golang/issue3689_tracing_test.go
+++ b/internal/extractors/golang/issue3689_tracing_test.go
@@ -1,0 +1,166 @@
+// issue3689_tracing_test.go — epic #3628, area #11: verifies OpenTelemetry
+// span-creation extraction emits INSTRUMENTS edges from the enclosing Go
+// function/method → a synthetic span stub carrying the span name.
+package golang_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findGoEnt returns the EntityRecord with the given Name from a []interface{}
+// of records, or a zero value + false.
+func findGoEnt(recs []interface{}, name string) (types.EntityRecord, bool) {
+	for _, r := range recs {
+		e, ok := r.(types.EntityRecord)
+		if ok && e.Name == name {
+			return e, true
+		}
+	}
+	return types.EntityRecord{}, false
+}
+
+// goSpanEdge returns the first INSTRUMENTS edge on the named entity matching
+// wantToID, or nil.
+func goSpanEdge(recs []interface{}, entName, wantToID string) *types.RelationshipRecord {
+	e, ok := findGoEnt(recs, entName)
+	if !ok {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestTracing_Go_TracerStart_InstrumentsEnclosingFn verifies that
+// `ctx, span := tracer.Start(ctx, "db.query")` inside a function produces a
+// span "db.query" instrumenting that function.
+func TestTracing_Go_TracerStart_InstrumentsEnclosingFn(t *testing.T) {
+	src := `package svc
+
+func query(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "db.query")
+	defer span.End()
+	_ = ctx
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	r := goSpanEdge(recs, "query", "span:db.query")
+	if r == nil {
+		if e, ok := findGoEnt(recs, "query"); ok {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge query → span:db.query not found")
+	}
+	if r.Properties["span_name"] != "db.query" {
+		t.Errorf("span_name=%q, want db.query", r.Properties["span_name"])
+	}
+	if r.Properties["library"] != "opentelemetry" {
+		t.Errorf("library=%q, want opentelemetry", r.Properties["library"])
+	}
+	if r.Properties["api"] != "tracer.Start" {
+		t.Errorf("api=%q, want tracer.Start", r.Properties["api"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if r.Properties["line"] == "" {
+		t.Error("line property is empty")
+	}
+	if r.Properties["dynamic"] != "" {
+		t.Errorf("dynamic=%q, want empty for static span name", r.Properties["dynamic"])
+	}
+}
+
+// TestTracing_Go_Method verifies a method receiver gets the edge keyed on the
+// dotted method name and the stub on the span name.
+func TestTracing_Go_Method(t *testing.T) {
+	src := `package svc
+
+func (s *Server) Handle(ctx context.Context) {
+	ctx, span := s.tracer.Start(ctx, "server.handle")
+	_ = span
+	_ = ctx
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	r := goSpanEdge(recs, "Server.Handle", "span:server.handle")
+	if r == nil {
+		t.Fatal("INSTRUMENTS edge Server.Handle → span:server.handle not found")
+	}
+	if r.Properties["span_name"] != "server.handle" {
+		t.Errorf("span_name=%q, want server.handle", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Go_DynamicName_NoFabrication is the honest-partial negative: a
+// variable span name emits traced+dynamic with NO fabricated span_name, keyed
+// on the enclosing fn ("span:<fn>").
+func TestTracing_Go_DynamicName_NoFabrication(t *testing.T) {
+	src := `package svc
+
+func run(ctx context.Context, opName string) {
+	ctx, span := tracer.Start(ctx, opName)
+	_ = span
+	_ = ctx
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	r := goSpanEdge(recs, "run", "span:run")
+	if r == nil {
+		if e, ok := findGoEnt(recs, "run"); ok {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge run → span:run not found for dynamic span name")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if _, ok := r.Properties["span_name"]; ok {
+		t.Errorf("span_name must be absent for dynamic name; got %q", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Go_NoSpan_NoEdge verifies no false positives on a plain fn and on
+// an unrelated single-result `.Start` call (e.g. server.Start()).
+func TestTracing_Go_NoSpan_NoEdge(t *testing.T) {
+	src := `package svc
+
+func boot() {
+	server.Start()
+	x := compute()
+	_ = x
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	e, ok := findGoEnt(recs, "boot")
+	if !ok {
+		t.Fatal("entity boot not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on boot: → %s", r.ToID)
+		}
+	}
+}

--- a/internal/extractors/golang/tracing.go
+++ b/internal/extractors/golang/tracing.go
@@ -1,0 +1,175 @@
+// tracing.go — Issue #3689 (epic #3628, area #11).
+//
+// Extracts OpenTelemetry distributed-tracing span-creation sites from Go
+// function/method bodies and emits an INSTRUMENTS edge from the enclosing
+// operation entity → a synthetic span stub ("span:<name>").
+//
+// Dominant OpenTelemetry Go idiom in scope:
+//
+//	ctx, span := tracer.Start(ctx, "db.query")
+//
+// The OTel Go API surface is `Tracer.Start(ctx context.Context, spanName string,
+// opts ...SpanStartOption) (context.Context, Span)`. We match a call_expression
+// whose function is a selector `<recv>.Start` and whose SECOND argument is a
+// string literal (the span name). The first argument is always the context.
+//
+// We match on the `.Start` method name with a string-literal second argument
+// rather than resolving the receiver type (which would need cross-file flow
+// analysis). To keep this precise — `.Start` is a common method name — we
+// additionally require the call to be in the two-result short-var form
+// `ctx, span := <recv>.Start(...)` (the canonical OTel idiom returns
+// (Context, Span)); a bare `x.Start("foo")` with one result is NOT matched.
+//
+// Honest-partial rule (#3689): when the second argument is not a string literal
+// the span name is dynamic — we emit traced=true + dynamic=true and key the
+// stub on the enclosing function name ("span:<fn>") rather than fabricating one.
+//
+// The walk is tolerant: a panic inside the traversal is recovered so the
+// primary extraction pipeline is unaffected.
+package golang
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// goSpanHit captures one OpenTelemetry span-creation site in a Go function body.
+type goSpanHit struct {
+	spanName string // static span name; "" when dynamic
+	line     int    // 1-indexed source line of the call
+	dynamic  bool   // true when the span name is not a string literal
+}
+
+// extractGoSpanHits walks a function/method body and returns one goSpanHit per
+// `<recv>.Start(ctx, "name")` OpenTelemetry span-creation call found in the
+// canonical two-result short-var form.
+func extractGoSpanHits(body *sitter.Node, src []byte) []goSpanHit {
+	if body == nil {
+		return nil
+	}
+	var hits []goSpanHit
+	seen := make(map[string]bool)
+
+	defer func() { _ = recover() }()
+
+	// Walk short var declarations of the form `ctx, span := tracer.Start(...)`.
+	// In tree-sitter Go these are short_var_declaration nodes whose right side
+	// is an expression_list containing the call_expression.
+	for _, decl := range findAll(body, "short_var_declaration") {
+		left := decl.ChildByFieldName("left")
+		right := decl.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		// Canonical OTel form returns (Context, Span) — exactly two LHS targets.
+		if left.NamedChildCount() != 2 {
+			continue
+		}
+		call := firstCallExpr(right)
+		if call == nil {
+			continue
+		}
+		h, ok := goSpanFromStartCall(call, src)
+		if !ok {
+			continue
+		}
+		key := h.spanName + "|" + strconv.FormatBool(h.dynamic)
+		if h.dynamic {
+			key += "|" + strconv.Itoa(h.line)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		hits = append(hits, h)
+	}
+	return hits
+}
+
+// firstCallExpr returns the first call_expression directly inside node's
+// expression list (or node itself when it is a call_expression). Returns nil
+// when no direct call_expression is present.
+func firstCallExpr(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type() == "call_expression" {
+		return node
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		ch := node.NamedChild(i)
+		if ch != nil && ch.Type() == "call_expression" {
+			return ch
+		}
+	}
+	return nil
+}
+
+// goSpanFromStartCall inspects a call_expression and returns a goSpanHit when it
+// is an OpenTelemetry `<recv>.Start(ctx, <name>)` span-creation call.
+func goSpanFromStartCall(call *sitter.Node, src []byte) (goSpanHit, bool) {
+	if call == nil || call.Type() != "call_expression" {
+		return goSpanHit{}, false
+	}
+	fn := call.ChildByFieldName("function")
+	args := call.ChildByFieldName("arguments")
+	if fn == nil || args == nil || fn.Type() != "selector_expression" {
+		return goSpanHit{}, false
+	}
+	field := fn.ChildByFieldName("field")
+	if field == nil || nodeText(field, src) != "Start" {
+		return goSpanHit{}, false
+	}
+	// OTel Tracer.Start takes (ctx, name, ...opts): the span name is the second
+	// argument. Require at least two args.
+	if args.NamedChildCount() < 2 {
+		return goSpanHit{}, false
+	}
+	nameArg := args.NamedChild(1)
+	line := int(call.StartPoint().Row) + 1
+	if nameArg != nil && nameArg.Type() == "interpreted_string_literal" {
+		name := goStripStringLiteral(nodeText(nameArg, src))
+		if name != "" {
+			return goSpanHit{spanName: name, line: line}, true
+		}
+	}
+	// Dynamic / non-literal span name → honest-partial flag, no fabricated name.
+	return goSpanHit{dynamic: true, line: line}, true
+}
+
+// goTracingSpanEdges returns the INSTRUMENTS edges for every OpenTelemetry
+// span-creation site found in body. enclosingName is the bare function/method
+// name used to key the synthetic stub for dynamic span names ("span:<fn>").
+func goTracingSpanEdges(body *sitter.Node, enclosingName, fromID string, src []byte) []types.RelationshipRecord {
+	hits := extractGoSpanHits(body, src)
+	if len(hits) == 0 {
+		return nil
+	}
+	out := make([]types.RelationshipRecord, 0, len(hits))
+	for _, h := range hits {
+		props := map[string]string{
+			"library": "opentelemetry",
+			"api":     "tracer.Start",
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		var toID string
+		if h.dynamic {
+			props["dynamic"] = "true"
+			toID = "span:" + enclosingName
+		} else {
+			props["span_name"] = h.spanName
+			toID = "span:" + h.spanName
+		}
+		out = append(out, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+	return out
+}

--- a/internal/extractors/java/issue3689_tracing_test.go
+++ b/internal/extractors/java/issue3689_tracing_test.go
@@ -1,0 +1,162 @@
+// Package java_test — issue #3689 (epic #3628, area #11): verifies the
+// OpenTelemetry tracing-span pass emits INSTRUMENTS edges from the enclosing
+// Java method → a synthetic span stub carrying the span name.
+package java_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// javaSpanEdge returns the first INSTRUMENTS edge on the named method entity
+// matching wantToID, or nil.
+func javaSpanEdge(ents []types.EntityRecord, methodName, wantToID string) *types.RelationshipRecord {
+	e := javaFind(ents, methodName, "SCOPE.Operation")
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestTracing_Java_WithSpan_DefaultName verifies that a bare `@WithSpan` on
+// `void handle()` produces a span named after the method instrumenting handle.
+func TestTracing_Java_WithSpan_DefaultName(t *testing.T) {
+	src := `package svc;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+class Service {
+    @WithSpan
+    void handle() {
+        doWork();
+    }
+}
+`
+	ents := runJava(t, src)
+	r := javaSpanEdge(ents, "Service.handle", "span:handle")
+	if r == nil {
+		if e := javaFind(ents, "Service.handle", "SCOPE.Operation"); e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge Service.handle → span:handle not found")
+	}
+	if r.Properties["span_name"] != "handle" {
+		t.Errorf("span_name=%q, want handle", r.Properties["span_name"])
+	}
+	if r.Properties["api"] != "WithSpan" {
+		t.Errorf("api=%q, want WithSpan", r.Properties["api"])
+	}
+	if r.Properties["library"] != "opentelemetry" {
+		t.Errorf("library=%q, want opentelemetry", r.Properties["library"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if r.Properties["dynamic"] != "" {
+		t.Errorf("dynamic=%q, want empty for @WithSpan default name", r.Properties["dynamic"])
+	}
+}
+
+// TestTracing_Java_WithSpan_AnnotationValue verifies @WithSpan("custom") uses
+// the annotation value as the span name.
+func TestTracing_Java_WithSpan_AnnotationValue(t *testing.T) {
+	src := `package svc;
+class Service {
+    @WithSpan("custom-op")
+    void run() { }
+}
+`
+	ents := runJava(t, src)
+	r := javaSpanEdge(ents, "Service.run", "span:custom-op")
+	if r == nil {
+		t.Fatal("INSTRUMENTS edge Service.run → span:custom-op not found")
+	}
+	if r.Properties["span_name"] != "custom-op" {
+		t.Errorf("span_name=%q, want custom-op", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Java_SpanBuilder verifies the
+// `tracer.spanBuilder("db.query").startSpan()` builder form.
+func TestTracing_Java_SpanBuilder(t *testing.T) {
+	src := `package svc;
+class Repo {
+    void query() {
+        Span span = tracer.spanBuilder("db.query").startSpan();
+        span.end();
+    }
+}
+`
+	ents := runJava(t, src)
+	r := javaSpanEdge(ents, "Repo.query", "span:db.query")
+	if r == nil {
+		if e := javaFind(ents, "Repo.query", "SCOPE.Operation"); e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge Repo.query → span:db.query not found")
+	}
+	if r.Properties["span_name"] != "db.query" {
+		t.Errorf("span_name=%q, want db.query", r.Properties["span_name"])
+	}
+	if r.Properties["api"] != "spanBuilder" {
+		t.Errorf("api=%q, want spanBuilder", r.Properties["api"])
+	}
+}
+
+// TestTracing_Java_SpanBuilder_DynamicName_NoFabrication is the honest-partial
+// negative: a non-literal spanBuilder argument emits traced+dynamic with NO
+// fabricated span_name, keyed on the enclosing method ("span:<method>").
+func TestTracing_Java_SpanBuilder_DynamicName_NoFabrication(t *testing.T) {
+	src := `package svc;
+class Repo {
+    void run(String opName) {
+        Span span = tracer.spanBuilder(opName).startSpan();
+        span.end();
+    }
+}
+`
+	ents := runJava(t, src)
+	r := javaSpanEdge(ents, "Repo.run", "span:run")
+	if r == nil {
+		if e := javaFind(ents, "Repo.run", "SCOPE.Operation"); e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge Repo.run → span:run not found for dynamic name")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if _, ok := r.Properties["span_name"]; ok {
+		t.Errorf("span_name must be absent for dynamic name; got %q", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Java_NoSpan_NoEdge verifies no false positives on a plain method.
+func TestTracing_Java_NoSpan_NoEdge(t *testing.T) {
+	src := `package svc;
+class Plain {
+    int add(int x) { return x + 1; }
+}
+`
+	ents := runJava(t, src)
+	e := javaFind(ents, "Plain.add", "SCOPE.Operation")
+	if e == nil {
+		t.Fatal("entity Plain.add not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on Plain.add: → %s", r.ToID)
+		}
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -528,6 +528,10 @@ func walk(
 					node.ChildByFieldName("body"),
 					file.Content, selfName, cc, paramTypes, imports,
 				)...)
+			// Issue #3689 — OpenTelemetry span instrumentation: @WithSpan
+			// annotations and spanBuilder(...).startSpan() chains.
+			rec.Relationships = append(rec.Relationships,
+				javaTracingSpanEdges(node, selfName, file.Content)...)
 			*out = append(*out, rec)
 		}
 		return

--- a/internal/extractors/java/tracing.go
+++ b/internal/extractors/java/tracing.go
@@ -1,0 +1,226 @@
+// tracing.go — Issue #3689 (epic #3628, area #11).
+//
+// Extracts OpenTelemetry distributed-tracing span-creation sites from Java
+// method declarations and emits an INSTRUMENTS edge from the enclosing
+// operation entity → a synthetic span stub ("span:<name>").
+//
+// Dominant OpenTelemetry Java idioms in scope:
+//
+//	@WithSpan                              // span name = method name
+//	void handle() { ... }
+//
+//	@WithSpan("custom-op")                 // span name = annotation value
+//	void handle() { ... }
+//
+//	Span span = tracer.spanBuilder("db.query").startSpan();   // builder form
+//
+// The @WithSpan annotation (io.opentelemetry.instrumentation.annotations.WithSpan)
+// auto-instruments the method; per the OTel spec the span name defaults to
+// "<SimpleClassName>.<method>" but the extractor records the developer-facing
+// name — the annotation's value when present, otherwise the bare method name.
+//
+// The builder form is matched as a method_invocation named `startSpan` whose
+// receiver chain includes a `spanBuilder("name")` call carrying the span name.
+//
+// Honest-partial rule (#3689): a non-literal span name (a variable/expression
+// passed to spanBuilder) emits traced=true + dynamic=true keyed on the method
+// name ("span:<method>") rather than a fabricated name.
+//
+// The walk is tolerant: a panic inside the traversal is recovered so the
+// primary extraction pipeline is unaffected.
+package java
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// javaSpanHit captures one OpenTelemetry span-creation site for a Java method.
+type javaSpanHit struct {
+	spanName string // static span name; "" when dynamic
+	api      string // "WithSpan" | "spanBuilder"
+	line     int    // 1-indexed source line of the annotation / call
+	dynamic  bool   // true when the span name is a non-literal expression
+}
+
+// javaTracingSpanEdges scans a method_declaration node for OpenTelemetry
+// span-creation sites — the @WithSpan annotation in its modifiers and
+// `spanBuilder(...).startSpan()` calls in its body — and returns the
+// corresponding INSTRUMENTS edges. methodName is the bare method name used as
+// the @WithSpan default span name and to key dynamic-name stubs.
+func javaTracingSpanEdges(methodNode *sitter.Node, methodName string, src []byte) []types.RelationshipRecord {
+	if methodNode == nil {
+		return nil
+	}
+	var hits []javaSpanHit
+
+	func() {
+		defer func() { _ = recover() }()
+		hits = append(hits, javaWithSpanHits(methodNode, methodName, src)...)
+		hits = append(hits, javaSpanBuilderHits(methodNode.ChildByFieldName("body"), src)...)
+	}()
+
+	if len(hits) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	out := make([]types.RelationshipRecord, 0, len(hits))
+	for _, h := range hits {
+		key := h.api + "|" + h.spanName + "|" + strconv.FormatBool(h.dynamic) + "|" + strconv.Itoa(h.line)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		props := map[string]string{
+			"library": "opentelemetry",
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		var toID string
+		if h.dynamic {
+			props["dynamic"] = "true"
+			toID = "span:" + methodName
+		} else {
+			props["span_name"] = h.spanName
+			toID = "span:" + h.spanName
+		}
+		out = append(out, types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+	return out
+}
+
+// javaWithSpanHits returns a single hit when the method carries a @WithSpan
+// annotation. The span name is the annotation's first string-literal argument
+// when present, otherwise the bare method name.
+func javaWithSpanHits(methodNode *sitter.Node, methodName string, src []byte) []javaSpanHit {
+	var hits []javaSpanHit
+	// The modifiers child carries the annotations preceding the method.
+	for i := 0; i < int(methodNode.ChildCount()); i++ {
+		child := methodNode.Child(i)
+		if child == nil || child.Type() != "modifiers" {
+			continue
+		}
+		for j := 0; j < int(child.ChildCount()); j++ {
+			a := child.Child(j)
+			if a == nil {
+				continue
+			}
+			if a.Type() != "annotation" && a.Type() != "marker_annotation" {
+				continue
+			}
+			nameNode := a.ChildByFieldName("name")
+			if nameNode == nil || lastIdent(nodeText(nameNode, src)) != "WithSpan" {
+				continue
+			}
+			line := int(a.StartPoint().Row) + 1
+			// @WithSpan("name") or @WithSpan(value="name"): pull a string literal.
+			name := javaAnnotationStringValue(a.ChildByFieldName("arguments"), src)
+			if name != "" {
+				hits = append(hits, javaSpanHit{spanName: name, api: "WithSpan", line: line})
+			} else {
+				// Bare @WithSpan → span name defaults to the method name. This is
+				// a known static name, NOT dynamic.
+				hits = append(hits, javaSpanHit{spanName: methodName, api: "WithSpan", line: line})
+			}
+		}
+	}
+	return hits
+}
+
+// javaAnnotationStringValue returns the first string-literal value found in an
+// annotation_argument_list — handling both @X("v") and @X(value="v") — or ""
+// when none is present.
+func javaAnnotationStringValue(args *sitter.Node, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	for _, lit := range findAllNodes(args, "string_literal") {
+		v := javaStripString(nodeText(lit, src))
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// javaSpanBuilderHits scans a method body for fluent
+// `<recv>.spanBuilder("name").…​.startSpan()` chains, returning one hit per
+// chain. It anchors on the terminal `startSpan()` invocation and walks down its
+// receiver chain to find the `spanBuilder(...)` call that carries the span name.
+// Anchoring on startSpan (the OTel call that actually creates the span) avoids
+// matching a bare `spanBuilder(...)` whose span is never started.
+func javaSpanBuilderHits(body *sitter.Node, src []byte) []javaSpanHit {
+	if body == nil {
+		return nil
+	}
+	var hits []javaSpanHit
+	for _, call := range findAllNodes(body, "method_invocation") {
+		if javaInvocationName(call, src) != "startSpan" {
+			continue
+		}
+		builder := javaFindSpanBuilderInChain(call, src)
+		if builder == nil {
+			continue
+		}
+		line := int(builder.StartPoint().Row) + 1
+		name := javaFirstStringArg(builder.ChildByFieldName("arguments"), src)
+		if name != "" {
+			hits = append(hits, javaSpanHit{spanName: name, api: "spanBuilder", line: line})
+		} else {
+			hits = append(hits, javaSpanHit{api: "spanBuilder", line: line, dynamic: true})
+		}
+	}
+	return hits
+}
+
+// javaFindSpanBuilderInChain walks the receiver (`object`) chain of a startSpan
+// invocation looking for the `spanBuilder(...)` call. Returns the spanBuilder
+// method_invocation node, or nil when the chain does not contain one.
+func javaFindSpanBuilderInChain(startSpanCall *sitter.Node, src []byte) *sitter.Node {
+	obj := startSpanCall.ChildByFieldName("object")
+	for obj != nil && obj.Type() == "method_invocation" {
+		if javaInvocationName(obj, src) == "spanBuilder" {
+			return obj
+		}
+		obj = obj.ChildByFieldName("object")
+	}
+	return nil
+}
+
+// javaFirstStringArg returns the first string-literal argument value in an
+// argument_list, or "" when the first argument is non-literal / absent.
+func javaFirstStringArg(args *sitter.Node, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		arg := args.NamedChild(i)
+		if arg == nil {
+			continue
+		}
+		if arg.Type() == "string_literal" {
+			return javaStripString(nodeText(arg, src))
+		}
+		// First positional arg is non-literal → dynamic.
+		break
+	}
+	return ""
+}
+
+// javaInvocationName returns the bare name of a method_invocation node.
+func javaInvocationName(call *sitter.Node, src []byte) string {
+	name := call.ChildByFieldName("name")
+	if name == nil {
+		return ""
+	}
+	return strings.TrimSpace(nodeText(name, src))
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -797,6 +797,8 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	// Issue #2885 — stamp general branch conditions (member comparisons,
 	// relational operators, ternary/switch) the discriminator pass misses.
 	x.stampBranchConditions(body)
+	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
+	x.stampTracingSpans(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so handleVariableDeclarator suppresses non-addressable
@@ -917,6 +919,8 @@ func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBi
 	// Issue #2885 — stamp general branch conditions (member comparisons,
 	// relational operators, ternary/switch) the discriminator pass misses.
 	x.stampBranchConditions(body)
+	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
+	x.stampTracingSpans(body)
 }
 
 // isNativeScriptStateSetter recognises the NativeScript Observable
@@ -1081,6 +1085,8 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 	// Issue #2885 — stamp general branch conditions (member comparisons,
 	// relational operators, ternary/switch) the discriminator pass misses.
 	x.stampBranchConditions(body)
+	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
+	x.stampTracingSpans(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so nested const declarations inside this arrow
@@ -1431,6 +1437,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// Issue #2885 — stamp general branch conditions the discriminator
 		// pass misses (member comparisons, relational ops, ternary/switch).
 		x.stampBranchConditions(body)
+		// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS).
+		x.stampTracingSpans(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// arrow body are not emitted as addressable entities (#1748).
@@ -1470,6 +1478,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// Issue #2885 — stamp general branch conditions the discriminator
 		// pass misses (member comparisons, relational ops, ternary/switch).
 		x.stampBranchConditions(body)
+		// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS).
+		x.stampTracingSpans(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// function-expression body are not emitted as addressable entities (#1748).

--- a/internal/extractors/javascript/issue3689_tracing_test.go
+++ b/internal/extractors/javascript/issue3689_tracing_test.go
@@ -1,0 +1,139 @@
+// Package javascript_test — issue #3689 (epic #3628, area #11): verifies the
+// OpenTelemetry tracing-span pass emits INSTRUMENTS edges from the enclosing
+// JS/TS function/method → a synthetic span stub carrying the span name.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsSpanEdge returns the first INSTRUMENTS edge on the named entity matching
+// wantToID, or nil.
+func jsSpanEdge(ents []types.EntityRecord, entName, wantToID string) *types.RelationshipRecord {
+	e := findByNameRel(ents, entName)
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestTracing_JS_StartSpan_InstrumentsEnclosingFn verifies that
+// `tracer.startSpan('checkout')` inside a function produces a span "checkout"
+// instrumenting that function.
+func TestTracing_JS_StartSpan_InstrumentsEnclosingFn(t *testing.T) {
+	src := `
+function process() {
+  const span = tracer.startSpan('checkout');
+  span.end();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsSpanEdge(ents, "process", "span:checkout")
+	if r == nil {
+		if e := findByNameRel(ents, "process"); e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge process → span:checkout not found")
+	}
+	if r.Properties["span_name"] != "checkout" {
+		t.Errorf("span_name=%q, want checkout", r.Properties["span_name"])
+	}
+	if r.Properties["library"] != "opentelemetry" {
+		t.Errorf("library=%q, want opentelemetry", r.Properties["library"])
+	}
+	if r.Properties["api"] != "startSpan" {
+		t.Errorf("api=%q, want startSpan", r.Properties["api"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if r.Properties["line"] == "" {
+		t.Error("line property is empty")
+	}
+	if r.Properties["dynamic"] != "" {
+		t.Errorf("dynamic=%q, want empty for static span name", r.Properties["dynamic"])
+	}
+}
+
+// TestTracing_JS_StartActiveSpan verifies the startActiveSpan form.
+func TestTracing_JS_StartActiveSpan(t *testing.T) {
+	src := `
+function query() {
+  tracer.startActiveSpan('db.query', (span) => {
+    span.end();
+  });
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsSpanEdge(ents, "query", "span:db.query")
+	if r == nil {
+		t.Fatal("INSTRUMENTS edge query → span:db.query not found")
+	}
+	if r.Properties["span_name"] != "db.query" {
+		t.Errorf("span_name=%q, want db.query", r.Properties["span_name"])
+	}
+	if r.Properties["api"] != "startActiveSpan" {
+		t.Errorf("api=%q, want startActiveSpan", r.Properties["api"])
+	}
+}
+
+// TestTracing_JS_DynamicName_NoFabrication is the honest-partial negative: a
+// variable span name emits traced+dynamic with NO fabricated span_name, keyed
+// on the enclosing fn ("span:<fn>").
+func TestTracing_JS_DynamicName_NoFabrication(t *testing.T) {
+	src := `
+function run(opName) {
+  const span = tracer.startSpan(opName);
+  span.end();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsSpanEdge(ents, "run", "span:run")
+	if r == nil {
+		if e := findByNameRel(ents, "run"); e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge run → span:run not found for dynamic span name")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if _, ok := r.Properties["span_name"]; ok {
+		t.Errorf("span_name must be absent for dynamic name; got %q", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_JS_NoSpan_NoEdge verifies no false positives on a plain function.
+func TestTracing_JS_NoSpan_NoEdge(t *testing.T) {
+	src := `
+function plain(x) {
+  return x + 1;
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	e := findByNameRel(ents, "plain")
+	if e == nil {
+		t.Fatal("entity plain not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on plain fn: → %s", r.ToID)
+		}
+	}
+}

--- a/internal/extractors/javascript/tracing.go
+++ b/internal/extractors/javascript/tracing.go
@@ -1,0 +1,141 @@
+// tracing.go — Issue #3689 (epic #3628, area #11).
+//
+// Extracts OpenTelemetry distributed-tracing span-creation sites from JS/TS
+// function/method/arrow bodies and stamps an INSTRUMENTS edge from the
+// enclosing operation entity → a synthetic span stub ("span:<name>").
+//
+// Dominant OpenTelemetry JS/TS idioms in scope:
+//
+//	const span = tracer.startSpan('checkout');
+//	tracer.startActiveSpan('db.query', (span) => { ... });
+//
+// We match a call_expression whose function is a member_expression
+// `<recv>.startSpan` / `<recv>.startActiveSpan` and whose first argument is a
+// string literal (the span name). startSpan/startActiveSpan are OTel-reserved
+// Tracer API surface, so matching on the property name is precise; we do not
+// resolve the receiver type (which would need cross-file flow analysis).
+//
+// Honest-partial rule (#3689): when the first argument is not a string literal
+// the span name is dynamic — we emit traced=true + dynamic=true and key the
+// stub on the enclosing function name ("span:<fn>") rather than fabricating one.
+//
+// The walk is tolerant: a panic inside the traversal is recovered so the
+// primary extraction pipeline is unaffected.
+package javascript
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsSpanHit captures one OpenTelemetry span-creation site in a JS/TS body.
+type jsSpanHit struct {
+	spanName string // static span name; "" when dynamic
+	api      string // "startSpan" | "startActiveSpan"
+	line     int    // 1-indexed source line of the call
+	dynamic  bool   // true when the span name is not a string literal
+}
+
+// jsTracingSpanMethods is the set of OpenTelemetry Tracer method names that
+// create a span. These are OTel-reserved API names.
+var jsTracingSpanMethods = map[string]bool{
+	"startSpan":       true,
+	"startActiveSpan": true,
+}
+
+// extractTracingSpanHits walks a function/method/arrow body and returns one
+// jsSpanHit per OpenTelemetry span-creation call found.
+func (x *extractor) extractTracingSpanHits(body *sitter.Node) []jsSpanHit {
+	if body == nil {
+		return nil
+	}
+	var hits []jsSpanHit
+	seen := make(map[string]bool)
+
+	defer func() { _ = recover() }()
+
+	for _, call := range findAllNodes(body, "call_expression") {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_expression" {
+			continue
+		}
+		propNode := fn.ChildByFieldName("property")
+		if propNode == nil {
+			continue
+		}
+		method := x.nodeText(propNode)
+		if !jsTracingSpanMethods[method] {
+			continue
+		}
+
+		line := int(call.StartPoint().Row) + 1
+		hit := jsSpanHit{api: method, line: line}
+
+		args := call.ChildByFieldName("arguments")
+		var nameNode *sitter.Node
+		if args != nil {
+			nameNode = firstMeaningfulArg(args)
+		}
+		if nameNode != nil && nameNode.Type() == "string" {
+			name := stringLiteralValue(x.nodeText(nameNode))
+			if name != "" {
+				hit.spanName = name
+			} else {
+				hit.dynamic = true
+			}
+		} else {
+			hit.dynamic = true
+		}
+
+		key := hit.api + "|" + hit.spanName + "|" + strconv.FormatBool(hit.dynamic)
+		if hit.dynamic {
+			key += "|" + strconv.Itoa(hit.line)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		hits = append(hits, hit)
+	}
+	return hits
+}
+
+// stampTracingSpans emits INSTRUMENTS edges on the last entity appended to
+// x.entities for every OpenTelemetry span-creation site found in body. Called
+// immediately after a function/method/arrow entity is emitted (alongside
+// stampDiscriminators / stampBranchConditions).
+func (x *extractor) stampTracingSpans(body *sitter.Node) {
+	if body == nil || len(x.entities) == 0 {
+		return
+	}
+	hits := x.extractTracingSpanHits(body)
+	if len(hits) == 0 {
+		return
+	}
+	last := &x.entities[len(x.entities)-1]
+	enclosing := last.Name
+	for _, h := range hits {
+		props := map[string]string{
+			"library": "opentelemetry",
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		var toID string
+		if h.dynamic {
+			props["dynamic"] = "true"
+			toID = "span:" + enclosing
+		} else {
+			props["span_name"] = h.spanName
+			toID = "span:" + h.spanName
+		}
+		last.Relationships = append(last.Relationships, types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -718,6 +718,9 @@ func walkNode(
 			*funcCount++
 			// Issue #2654 — stamp discriminator comparisons found in the body.
 			stampPythonDiscriminators(node.ChildByFieldName("body"), file.Content, out, funcIdx)
+			// Issue #3689 — stamp OpenTelemetry span-creation sites (no decorator
+			// parent for a bare function_definition).
+			stampPythonTracingSpans(node, nil, selfName, file.Content, out, funcIdx)
 		}
 		return // do not recurse into function body for nested definitions
 
@@ -744,6 +747,10 @@ func walkNode(
 				*funcCount++
 				// Issue #2654 — stamp discriminator comparisons found in the body.
 				stampPythonDiscriminators(inner.ChildByFieldName("body"), file.Content, out, decoratedFuncIdx)
+				// Issue #3689 — stamp OpenTelemetry span-creation sites, scanning
+				// both the body and the decorator list (node is the
+				// decorated_definition wrapping inner).
+				stampPythonTracingSpans(inner, node, selfName, file.Content, out, decoratedFuncIdx)
 			}
 		case "class_definition":
 			rec := buildClass(inner, file)

--- a/internal/extractors/python/issue3689_tracing_test.go
+++ b/internal/extractors/python/issue3689_tracing_test.go
@@ -1,0 +1,164 @@
+// Package python_test — issue #3689 (epic #3628, area #11): verifies that the
+// OpenTelemetry tracing-span pass emits INSTRUMENTS edges from the enclosing
+// function/method to a synthetic span stub, carrying the span name + the
+// operation it instruments.
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// spanEdge returns the first INSTRUMENTS edge on the named entity whose ToID
+// matches wantToID, or nil.
+func spanEdge(ents []types.EntityRecord, entName, wantToID string) *types.RelationshipRecord {
+	e := findEntPy(ents, entName)
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestTracing_Python_ContextManager_InstrumentsEnclosingFn verifies that
+// `with tracer.start_as_current_span("checkout"):` inside `def process()`
+// produces a span "checkout" instrumenting process.
+func TestTracing_Python_ContextManager_InstrumentsEnclosingFn(t *testing.T) {
+	src := `
+def process(order):
+    with tracer.start_as_current_span("checkout"):
+        do_work(order)
+`
+	ents := extractPy(t, src, "shop/service.py")
+	r := spanEdge(ents, "process", "span:checkout")
+	if r == nil {
+		e := findEntPy(ents, "process")
+		if e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge process → span:checkout not found")
+	}
+	if r.Properties["span_name"] != "checkout" {
+		t.Errorf("span_name=%q, want %q", r.Properties["span_name"], "checkout")
+	}
+	if r.Properties["library"] != "opentelemetry" {
+		t.Errorf("library=%q, want opentelemetry", r.Properties["library"])
+	}
+	if r.Properties["api"] != "start_as_current_span" {
+		t.Errorf("api=%q, want start_as_current_span", r.Properties["api"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if r.Properties["line"] == "" {
+		t.Error("line property is empty")
+	}
+	if r.Properties["dynamic"] != "" {
+		t.Errorf("dynamic=%q, want empty for static span name", r.Properties["dynamic"])
+	}
+}
+
+// TestTracing_Python_ManualStartSpan verifies the manual `tracer.start_span`
+// form binds the span to the enclosing method.
+func TestTracing_Python_ManualStartSpan(t *testing.T) {
+	src := `
+class Repo:
+    def fetch(self):
+        span = self.tracer.start_span("db.query")
+        return span
+`
+	ents := extractPy(t, src, "repo.py")
+	r := spanEdge(ents, "Repo.fetch", "span:db.query")
+	if r == nil {
+		t.Fatal("INSTRUMENTS edge Repo.fetch → span:db.query not found")
+	}
+	if r.Properties["span_name"] != "db.query" {
+		t.Errorf("span_name=%q, want db.query", r.Properties["span_name"])
+	}
+	if r.Properties["api"] != "start_span" {
+		t.Errorf("api=%q, want start_span", r.Properties["api"])
+	}
+}
+
+// TestTracing_Python_DecoratorForm verifies the decorator
+// `@tracer.start_as_current_span("handle")` instruments the decorated function.
+func TestTracing_Python_DecoratorForm(t *testing.T) {
+	src := `
+@tracer.start_as_current_span("handle")
+def handle(req):
+    return 1
+`
+	ents := extractPy(t, src, "h.py")
+	r := spanEdge(ents, "handle", "span:handle")
+	if r == nil {
+		e := findEntPy(ents, "handle")
+		if e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge handle → span:handle not found")
+	}
+	if r.Properties["span_name"] != "handle" {
+		t.Errorf("span_name=%q, want handle", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Python_DynamicName_NoFabrication is the honest-partial negative:
+// a variable span name emits traced+dynamic but NO fabricated span_name, and
+// keys the stub on the enclosing function ("span:<fn>").
+func TestTracing_Python_DynamicName_NoFabrication(t *testing.T) {
+	src := `
+def run(op_name):
+    with tracer.start_as_current_span(op_name):
+        work()
+`
+	ents := extractPy(t, src, "d.py")
+	// Dynamic span keys on the enclosing fn name.
+	r := spanEdge(ents, "run", "span:run")
+	if r == nil {
+		e := findEntPy(ents, "run")
+		if e != nil {
+			for _, rel := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", rel.Kind, rel.ToID, rel.Properties)
+			}
+		}
+		t.Fatal("INSTRUMENTS edge run → span:run not found for dynamic span name")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if _, ok := r.Properties["span_name"]; ok {
+		t.Errorf("span_name must be absent for dynamic name; got %q", r.Properties["span_name"])
+	}
+}
+
+// TestTracing_Python_NoSpan_NoEdge verifies a plain function with no OTel call
+// produces no INSTRUMENTS edge (no false positives).
+func TestTracing_Python_NoSpan_NoEdge(t *testing.T) {
+	src := `
+def plain(x):
+    return x + 1
+`
+	ents := extractPy(t, src, "p.py")
+	e := findEntPy(ents, "plain")
+	if e == nil {
+		t.Fatal("entity plain not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on plain fn: → %s", r.ToID)
+		}
+	}
+}

--- a/internal/extractors/python/tracing.go
+++ b/internal/extractors/python/tracing.go
@@ -1,0 +1,236 @@
+// tracing.go — Issue #3689 (epic #3628, area #11).
+//
+// Extracts OpenTelemetry distributed-tracing span-creation sites from Python
+// function/method bodies and decorators, and stamps an INSTRUMENTS edge from
+// the enclosing operation entity → a synthetic span stub ("span:<name>").
+//
+// Dominant OpenTelemetry Python idioms in scope:
+//
+//	with tracer.start_as_current_span("checkout"):   # context-manager form
+//	    ...
+//	span = tracer.start_span("db.query")             # manual form
+//
+//	@tracer.start_as_current_span("handle")          # decorator form
+//	def handle(): ...
+//
+// The method name must be start_as_current_span or start_span on a
+// tracer-like receiver. We do NOT require the receiver to literally be named
+// "tracer" — any `<recv>.start_as_current_span(...)` / `<recv>.start_span(...)`
+// call qualifies, because OTel tracers are routinely bound to other names
+// (self.tracer, _TRACER, get_tracer(__name__), etc.). The method name is the
+// discriminating signal; OTel reserves these exact method names.
+//
+// Honest-partial rule (#3689): when the first positional argument is NOT a
+// string literal (a variable, attribute, f-string, or call) the span name is
+// dynamic. We emit the edge with traced=true + dynamic=true and key the stub
+// on the enclosing function name ("span:<fn>") rather than fabricating a name.
+//
+// The walk is tolerant: a panic inside the traversal is recovered so the
+// primary extraction pipeline is unaffected.
+package python
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pySpanHit captures one OpenTelemetry span-creation site found in a Python
+// function/method body or decorator list.
+type pySpanHit struct {
+	spanName string // static span name; "" when dynamic
+	api      string // "start_as_current_span" | "start_span"
+	line     int    // 1-indexed source line of the call
+	dynamic  bool   // true when the span name is not a string literal
+}
+
+// pyTracingSpanMethods is the set of OpenTelemetry tracer method names that
+// create a span. These names are OTel-reserved API surface, so matching on the
+// method name (rather than the receiver identifier) is both precise and robust
+// to the many ways a tracer object is bound.
+var pyTracingSpanMethods = map[string]bool{
+	"start_as_current_span": true,
+	"start_span":            true,
+}
+
+// extractPythonSpanHits walks a function/method node and returns one pySpanHit
+// per OpenTelemetry span-creation site found in its body OR in its decorators.
+// The decoratorParent node, when non-nil, is the decorated_definition wrapping
+// funcNode; its decorator children are scanned for the decorator form.
+func extractPythonSpanHits(funcNode, decoratorParent *sitter.Node, src []byte) []pySpanHit {
+	if funcNode == nil {
+		return nil
+	}
+	var hits []pySpanHit
+	seen := make(map[string]bool)
+
+	defer func() { _ = recover() }()
+
+	add := func(h pySpanHit) {
+		// Dedup on (api, name, dynamic) — a function instrumented with the same
+		// span twice (rare) collapses to one edge, matching discriminator
+		// semantics. Dynamic hits dedup per line so two distinct dynamic spans
+		// in the same function both survive.
+		key := h.api + "|" + h.spanName + "|" + strconv.FormatBool(h.dynamic)
+		if h.dynamic {
+			key += "|" + strconv.Itoa(h.line)
+		}
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		hits = append(hits, h)
+	}
+
+	// Decorator form: scan decorator nodes attached to the decorated_definition.
+	if decoratorParent != nil {
+		for i := 0; i < int(decoratorParent.ChildCount()); i++ {
+			ch := decoratorParent.Child(i)
+			if ch == nil || ch.Type() != "decorator" {
+				continue
+			}
+			// A decorator child wraps either an `attribute` (bare @x.y) or a
+			// `call` (@x.y(...)). Only the call form carries a span-name arg.
+			callNode := findFirstChildOfType(ch, "call")
+			if callNode == nil {
+				continue
+			}
+			if h, ok := pySpanFromCall(callNode, src); ok {
+				add(h)
+			}
+		}
+	}
+
+	// Body forms: context-manager `with tracer.start_as_current_span(...)` and
+	// manual `tracer.start_span(...)`. Both reduce to a `call` node anywhere in
+	// the body whose function is `<recv>.<spanMethod>`.
+	body := funcNode.ChildByFieldName("body")
+	if body != nil {
+		for _, callNode := range findAll(body, "call") {
+			if h, ok := pySpanFromCall(callNode, src); ok {
+				add(h)
+			}
+		}
+	}
+
+	return hits
+}
+
+// pySpanFromCall inspects a `call` node and returns a pySpanHit when it is an
+// OpenTelemetry span-creation call (`<recv>.start_as_current_span(...)` or
+// `<recv>.start_span(...)`).
+func pySpanFromCall(call *sitter.Node, src []byte) (pySpanHit, bool) {
+	if call == nil || call.Type() != "call" {
+		return pySpanHit{}, false
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "attribute" {
+		return pySpanHit{}, false
+	}
+	attr := fn.ChildByFieldName("attribute")
+	if attr == nil {
+		return pySpanHit{}, false
+	}
+	method := nodeText(attr, src)
+	if !pyTracingSpanMethods[method] {
+		return pySpanHit{}, false
+	}
+
+	line := int(call.StartPoint().Row) + 1
+	hit := pySpanHit{api: method, line: line}
+
+	// First positional argument is the span name. A string literal yields a
+	// static name; anything else is dynamic (honest-partial).
+	args := call.ChildByFieldName("arguments")
+	nameNode := firstPositionalArg(args)
+	if nameNode != nil && nameNode.Type() == "string" {
+		name := pythonLiteralValue(nameNode, src)
+		if name != "" {
+			hit.spanName = name
+			return hit, true
+		}
+	}
+	// Dynamic / missing literal name → traced flag without a fabricated name.
+	hit.dynamic = true
+	return hit, true
+}
+
+// firstPositionalArg returns the first positional argument node inside an
+// argument_list, skipping the structural "(" "," ")" tokens and keyword
+// arguments. Returns nil when there is no positional argument.
+func firstPositionalArg(args *sitter.Node) *sitter.Node {
+	if args == nil {
+		return nil
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "(", ")", ",":
+			continue
+		case "keyword_argument":
+			// e.g. name="..." — OTel's first positional is the name; a
+			// keyword-only call (name=expr) is treated as dynamic by falling
+			// through (we do not parse the keyword value here).
+			continue
+		default:
+			return ch
+		}
+	}
+	return nil
+}
+
+// findFirstChildOfType returns the first descendant of root whose Type() equals
+// kind (depth-first), or nil. Used to locate the `call` inside a `decorator`.
+func findFirstChildOfType(root *sitter.Node, kind string) *sitter.Node {
+	if root == nil {
+		return nil
+	}
+	all := findAll(root, kind)
+	if len(all) == 0 {
+		return nil
+	}
+	return all[0]
+}
+
+// stampPythonTracingSpans emits INSTRUMENTS edges on the entity at index idx in
+// out for every OpenTelemetry span-creation site found in funcNode's body or
+// decorators. Called immediately after the function/method entity is appended.
+//
+// enclosingName is the bare function/method name, used to key the synthetic
+// stub for dynamic span names ("span:<fn>").
+func stampPythonTracingSpans(funcNode, decoratorParent *sitter.Node, enclosingName string, src []byte, out *[]types.EntityRecord, idx int) {
+	if funcNode == nil || out == nil || idx < 0 || idx >= len(*out) {
+		return
+	}
+	hits := extractPythonSpanHits(funcNode, decoratorParent, src)
+	if len(hits) == 0 {
+		return
+	}
+	e := &(*out)[idx]
+	for _, h := range hits {
+		props := map[string]string{
+			"library": "opentelemetry",
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		var toID string
+		if h.dynamic {
+			props["dynamic"] = "true"
+			toID = "span:" + enclosingName
+		} else {
+			props["span_name"] = h.spanName
+			toID = "span:" + h.spanName
+		}
+		e.Relationships = append(e.Relationships, types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -651,6 +651,27 @@ const (
 	// layer; this extractor never crosses a file boundary, so its org guard is
 	// trivially satisfied. Append-only — never modifies existing entities/edges.
 	RelationshipKindConsumesAPI RelationshipKind = "CONSUMES_API"
+
+	// #3689 (epic #3628, area #11): OpenTelemetry tracing-span instrumentation
+	// edge. Emitted by the per-language tracing-span passes (Python, Go, JS/TS,
+	// Java) from the enclosing function/method operation entity → a synthetic
+	// span stub ("span:<name>" for a string-literal span name, "span:<fn>" for
+	// a dynamic/variable span name). The edge records WHERE a distributed-tracing
+	// span is created and WHICH operation it instruments. Mirrors the
+	// DISCRIMINATES_ON / BRANCHES_ON / NAVIGATES_TO precedent (enclosing op →
+	// synthetic stub) so no new entity Kind is introduced. Properties:
+	//   "span_name" : the static span name (omitted when dynamic)
+	//   "library"   : "opentelemetry"
+	//   "api"       : the idiom observed (e.g. "start_as_current_span",
+	//                 "tracer.Start", "startActiveSpan", "spanBuilder",
+	//                 "WithSpan")
+	//   "line"      : 1-indexed source line of the span-creation site
+	//   "traced"    : "true" (always; lets honest-partial dynamic-name spans
+	//                 carry the flag without a fabricated name)
+	//   "dynamic"   : "true" when the span name is a variable/expression rather
+	//                 than a string literal (omitted otherwise)
+	// Append-only — never modifies existing entities or edges.
+	RelationshipKindInstruments RelationshipKind = "INSTRUMENTS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -765,6 +786,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindOverrides,
 		// #3632 API-consumption edge (same-file client→endpoint):
 		RelationshipKindConsumesAPI,
+		// #3689 OpenTelemetry tracing-span instrumentation edge:
+		RelationshipKindInstruments,
 	}
 }
 


### PR DESCRIPTION
Closes #3689 (epic #3628, area #11 — observability/tracing).

## What
Captures **where** code creates OpenTelemetry distributed-tracing spans and **which operation** each span instruments — a domain the graph had no notion of. The `infra.observability.opentelemetry` coverage row claimed `trace_extraction: full`, but its cites (`internal/engine/event_flow.go`, `process_flow.go`) contain zero span/tracer references — an unverified placeholder. The only real prior signal was `internal/patterns/observability_jsts_extractor.go`, which is file-level library-presence detection ("this file imports @opentelemetry"), not span-site extraction.

## How
Adds one relationship kind **`INSTRUMENTS`** (enclosing operation → synthetic `span:<name>` stub), mirroring the `DISCRIMINATES_ON` / `BRANCHES_ON` / `NAVIGATES_TO` precedent — so **no new entity Kind** is introduced. Reuses existing `SCOPE.Operation` entities.

## Languages now emitting spans (dominant idioms)
| Lang | Idioms captured |
|------|-----------------|
| **Python** | `with tracer.start_as_current_span("op")`, `tracer.start_span("op")`, `@tracer.start_as_current_span("op")` decorator |
| **Go** | `ctx, span := tracer.Start(ctx, "op")` (canonical two-result OTel form) |
| **JS/TS** | `tracer.startSpan('op')`, `tracer.startActiveSpan('op', cb)` |
| **Java** | `@WithSpan` (annotation value or method name), `tracer.spanBuilder("op").startSpan()` |

Edge properties: `span_name`, `library=opentelemetry`, `api`, `line`, `traced=true`, and `dynamic=true` for honest-partial cases.

## Honest-partial discipline
Dynamic/variable span names (`start_span(name)`) emit `traced=true` + `dynamic=true`, keyed on the enclosing function (`span:<fn>`), with **no fabricated name**. Non-OTel vendors and other languages are not yet covered → the coverage cell is set to **partial** (not full), citing the four real extractors.

## Spans asserted (value-asserting tests, not len>0)
- Python `with tracer.start_as_current_span("checkout")` in `def process()` → INSTRUMENTS `process` → `span:checkout`
- Go `tracer.Start(ctx, "db.query")` → INSTRUMENTS `query` → `span:db.query`
- JS/TS `tracer.startSpan('checkout')` → INSTRUMENTS `process` → `span:checkout`; `startActiveSpan('db.query', …)` → `span:db.query`
- Java `@WithSpan void handle()` → INSTRUMENTS `Service.handle` → `span:handle`; `@WithSpan("custom-op")` → `span:custom-op`; `spanBuilder("db.query").startSpan()` → `span:db.query`
- Negative (each lang): dynamic span name → `dynamic=true`, no `span_name` property, stub keyed on the enclosing fn
- No-false-positive (each lang): plain functions emit no INSTRUMENTS edge

## Records
`infra.observability.opentelemetry` `trace_extraction`: placeholder `full` → honest **partial**, cites the four new `tracing.go` extractors, `verified_at` today, linked to #3689.

## Verification
- `go test` (targeted): python, golang, javascript, java, internal/types, internal/engine, tools/coverage — all green
- `internal/types` producer-kind validator accepts the new `INSTRUMENTS` kind
- `coverage validate` 0 errors; `coverage fmt --check` canonical
- `gofmt -l` empty; `go vet` clean

**DEPLOY-DEFERRED**: no daemon rebuild / reindex performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)