### PR TITLE
[serialization] Protobuf/Avro/JSON-Schema message extraction

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -59381,6 +59381,39 @@
       }
     },
     {
+      "id": "protocol.avro",
+      "category": "protocol",
+      "language": "multi",
+      "label": "Apache Avro (.avsc / .avpr)",
+      "capabilities": {
+        "cross_repo_linkage": {
+          "status": "missing",
+          "issue": "3690"
+        },
+        "field_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/avro/avro.go","internal/extractors/avro/avro_test.go"],
+          "notes": "#3690 — each field -\u003e SCOPE.Schema/field (Name=\u003cRecord\u003e.\u003cfield\u003e, Properties.type incl. array\u003cT\u003e/map\u003cT\u003e/union a|b) + record-\u003enamed-type REFERENCES edge (array items followed); primitives carry no edge",
+          "verified_at": "2026-06-02"
+        },
+        "method_attribution": {
+          "status": "missing",
+          "issue": "3690"
+        },
+        "schema_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/avro/avro.go","internal/extractors/avro/avro_test.go"],
+          "notes": "#3690 — record/enum/fixed -\u003e SCOPE.Schema; .avpr protocol envelope 'types' walked; namespaces stripped to local name",
+          "verified_at": "2026-06-02"
+        },
+        "service_extraction": {
+          "status": "missing",
+          "issue": "3690",
+          "notes": "Avro protocol (.avpr) messages not yet emitted as services; #3690 covers data-contract types only"
+        }
+      }
+    },
+    {
       "id": "protocol.c-asm",
       "category": "protocol",
       "language": "multi",
@@ -59479,6 +59512,39 @@
       }
     },
     {
+      "id": "protocol.json-schema",
+      "category": "protocol",
+      "language": "multi",
+      "label": "JSON Schema (*.schema.json)",
+      "capabilities": {
+        "cross_repo_linkage": {
+          "status": "missing",
+          "issue": "3690"
+        },
+        "field_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/jsonschema/jsonschema.go","internal/extractors/jsonschema/jsonschema_test.go"],
+          "notes": "#3690 — each property -\u003e SCOPE.Schema/field (Name=\u003cSchema\u003e.\u003cprop\u003e, Properties.type incl. array\u003cT\u003e) + $ref -\u003e REFERENCES edge (direct, array items, allOf/anyOf/oneOf branches)",
+          "verified_at": "2026-06-02"
+        },
+        "method_attribution": {
+          "status": "missing",
+          "issue": "3690"
+        },
+        "schema_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/jsonschema/jsonschema.go","internal/extractors/jsonschema/jsonschema_test.go"],
+          "notes": "#3690 — root object schema (named via title, basename fallback) + each $defs/definitions subschema -\u003e SCOPE.Schema/object; content-sniffed for $schema/properties/$defs/$ref so misrouted JSON is a no-op",
+          "verified_at": "2026-06-02"
+        },
+        "service_extraction": {
+          "status": "missing",
+          "issue": "3690",
+          "notes": "JSON Schema is a data-contract format with no service/RPC concept"
+        }
+      }
+    },
+    {
       "id": "protocol.jsonrpc",
       "category": "protocol",
       "language": "multi",
@@ -59529,10 +59595,22 @@
           "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
+        "field_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/proto/fields_test.go","internal/extractors/proto/proto.go"],
+          "notes": "#3690 — each message field -\u003e SCOPE.Schema/field entity (Name=\u003cMsg\u003e.\u003cfield\u003e, Properties.type/label) + message-\u003etype REFERENCES edge for named (non-scalar) types incl. map\u003cK,V\u003e value; scalars carry no edge",
+          "verified_at": "2026-06-02"
+        },
         "method_attribution": {
           "status": "full",
           "cites": ["internal/extractors/proto"],
           "verified_at": "2026-05-28"
+        },
+        "schema_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/proto/proto.go","internal/extractors/proto/proto_test.go"],
+          "notes": "#3690 — message/enum -\u003e SCOPE.Schema with file CONTAINS edges; messages_and_enums covered by buildMessage/buildEnum",
+          "verified_at": "2026-06-02"
         },
         "service_extraction": {
           "status": "full",

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -484,6 +484,13 @@ var extensionLanguageMap = map[string]string{
 	".bicep": "bicep",
 	// Protobuf
 	".proto": "protobuf",
+	// Avro schema (#3690) — Avro schemas are JSON documents with a `.avsc`
+	// extension declaring record/enum/fixed data-contract types. Routed to the
+	// content-based "avro" extractor (no tree-sitter grammar; it json-decodes
+	// the file body). The companion `.avpr` protocol file carries the same
+	// record-type schemas inside a `types` array and is handled identically.
+	".avsc": "avro",
+	".avpr": "avro",
 	// CSS / SCSS / LESS
 	".css":  "css",
 	".scss": "css",
@@ -655,6 +662,17 @@ func detectLanguage(norm string) string {
 	// the generic .json branch so OpenTofu JSON config always wins.
 	if strings.HasSuffix(lower, ".tofu.json") {
 		return "terraform"
+	}
+
+	// JSON Schema (#3690) — files following the `*.schema.json` convention are
+	// JSON Schema data-contract documents. Routed to the content-based
+	// "jsonschema" extractor, which json-decodes the body and content-sniffs for
+	// a `$schema`/`properties`/`$ref` shape before emitting (a false positive is
+	// a harmless no-op). Checked before the generic `.json` branch so schema
+	// files always win over the Debezium routing below. `.tofu.json` already
+	// returned above, so there is no conflict with the OpenTofu compound suffix.
+	if strings.HasSuffix(lower, ".schema.json") {
+		return "jsonschema"
 	}
 
 	// Issue #1708 — narrow JSON routing for Debezium / Kafka-Connect

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -193,6 +193,32 @@ func TestClassify_JavaFile(t *testing.T) {
 // Classify — vendor / dependency directory skips
 // ---------------------------------------------------------------------------
 
+func TestClassify_SerializationSchemas(t *testing.T) {
+	c := newTestClassifier(t)
+	cases := []struct {
+		path string
+		lang string
+	}{
+		{"schemas/user.avsc", "avro"},
+		{"protocols/order.avpr", "avro"},
+		{"schemas/user.schema.json", "jsonschema"},
+		{"api/order.proto", "protobuf"},
+	}
+	for _, tc := range cases {
+		r := c.Classify(context.Background(), tc.path)
+		if r.Skip {
+			t.Errorf("%s should not be skipped: reason=%q", tc.path, r.SkipReason)
+		}
+		if r.Language != tc.lang {
+			t.Errorf("%s: Language = %q, want %q", tc.path, r.Language, tc.lang)
+		}
+	}
+	// A plain config .json must NOT be routed to jsonschema.
+	if r := c.Classify(context.Background(), "package.json"); r.Language == "jsonschema" {
+		t.Errorf("package.json wrongly routed to jsonschema")
+	}
+}
+
 func TestClassify_NodeModules_Skipped(t *testing.T) {
 	c := newTestClassifier(t)
 	r := c.Classify(context.Background(), "node_modules/lodash/lodash.js")

--- a/internal/extractors/avro/avro.go
+++ b/internal/extractors/avro/avro.go
@@ -1,0 +1,343 @@
+// Package avro implements a content-based extractor for Apache Avro schema
+// files (.avsc) and Avro protocol files (.avpr). Avro schemas are JSON
+// documents, so this extractor json-decodes the file body rather than using a
+// tree-sitter grammar (the dispatcher passes a nil Tree for the "avro" language;
+// classifier routes .avsc/.avpr here).
+//
+// Extracted entities (issue #3690):
+//
+//   - record  → Kind="SCOPE.Schema", Subtype="record" — a named Avro record
+//     data-contract. Each declared field becomes a SCOPE.Schema/field child
+//     entity named "<Record>.<field>" carrying Properties["type"] (the resolved
+//     Avro type token, e.g. "long", "string", "Address", "array<Order>").
+//   - enum    → Kind="SCOPE.Schema", Subtype="enum" — a named Avro enum; its
+//     symbols become field children.
+//   - fixed   → Kind="SCOPE.Schema", Subtype="fixed" — a named fixed-size type.
+//
+// Relationships:
+//
+//   - CONTAINS  record → each field (Format-B member ref so the resolver binds
+//     it via byMember[file][Record][field]); enum → each symbol.
+//   - REFERENCES record → each named (non-primitive) field type, so a field
+//     `{"name":"orders","type":{"type":"array","items":"Order"}}` yields an
+//     edge Record → Order. The edge ToID is the Format-A operation ref for the
+//     same file so the resolver binds it to the sibling record entity.
+//
+// Nested inline record definitions inside a field's "type" are recursively
+// extracted as their own SCOPE.Schema/record entities. Avro namespaces are
+// stripped to the trailing type name so references bind to the local record.
+package avro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("avro", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Avro schemas.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "avro" }
+
+// avroPrimitives is the set of Avro primitive type names. A field whose
+// resolved type is one of these carries no REFERENCES edge.
+var avroPrimitives = map[string]bool{
+	"null": true, "boolean": true, "int": true, "long": true,
+	"float": true, "double": true, "bytes": true, "string": true,
+}
+
+// Extract json-decodes the Avro schema and walks named types.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	var root interface{}
+	if err := json.Unmarshal(file.Content, &root); err != nil {
+		// Not valid JSON — a harmless no-op (an .avsc that doesn't parse).
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	// .avpr protocol files wrap schemas in a top-level "types" array; .avsc
+	// files are a single schema (object) or a union (array). walkSchema handles
+	// both, plus the protocol "types"/"messages" envelope.
+	if obj, ok := root.(map[string]interface{}); ok {
+		if rawTypes, ok := obj["types"].([]interface{}); ok {
+			// Avro protocol envelope.
+			for _, t := range rawTypes {
+				walkSchema(t, file, &entities)
+			}
+			return entities, nil
+		}
+	}
+	walkSchema(root, file, &entities)
+	return entities, nil
+}
+
+// walkSchema dispatches on the shape of an Avro schema node, emitting entities
+// for named record/enum/fixed types and recursing into nested definitions.
+func walkSchema(node interface{}, file extractor.FileInput, out *[]types.EntityRecord) {
+	switch v := node.(type) {
+	case []interface{}:
+		// A union — walk each branch.
+		for _, b := range v {
+			walkSchema(b, file, out)
+		}
+	case map[string]interface{}:
+		typeName, _ := v["type"].(string)
+		switch typeName {
+		case "record", "error":
+			buildRecord(v, file, out)
+		case "enum":
+			buildEnum(v, file, out)
+		case "fixed":
+			buildFixed(v, file, out)
+		case "array":
+			walkSchema(v["items"], file, out)
+		case "map":
+			walkSchema(v["values"], file, out)
+		}
+	}
+}
+
+// buildRecord emits a SCOPE.Schema/record entity plus a field child per
+// declared field, with CONTAINS + REFERENCES edges.
+func buildRecord(v map[string]interface{}, file extractor.FileInput, out *[]types.EntityRecord) {
+	name, _ := v["name"].(string)
+	name = localName(name)
+	if name == "" {
+		return
+	}
+
+	var rels []types.RelationshipRecord
+	var fieldEnts []types.EntityRecord
+	refSeen := map[string]bool{}
+
+	rawFields, _ := v["fields"].([]interface{})
+	for _, rf := range rawFields {
+		fm, ok := rf.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fname, _ := fm["name"].(string)
+		if fname == "" {
+			continue
+		}
+		ftypeNode := fm["type"]
+		typeStr := renderType(ftypeNode)
+
+		// CONTAINS record → field.
+		rels = append(rels, types.RelationshipRecord{
+			ToID: fieldMemberRef(file.Path, name, fname),
+			Kind: "CONTAINS",
+		})
+		fieldEnts = append(fieldEnts, buildField(file, name, fname, typeStr))
+
+		// REFERENCES to each named (non-primitive) type the field points at.
+		for _, ref := range namedTypeRefs(ftypeNode) {
+			if refSeen[ref] {
+				continue
+			}
+			refSeen[ref] = true
+			rels = append(rels, types.RelationshipRecord{
+				ToID:       extractor.BuildOperationStructuralRef("avro", file.Path, ref),
+				Kind:       "REFERENCES",
+				Properties: map[string]string{"via_field": fname, "type": ref},
+			})
+		}
+
+		// Recurse into any inline nested record/enum/fixed definition so it is
+		// emitted as its own named entity.
+		walkSchema(ftypeNode, file, &fieldEnts)
+	}
+
+	rec := types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "record",
+		SourceFile:         file.Path,
+		Language:           "avro",
+		Signature:          "record " + name,
+		EnrichmentRequired: false,
+		Relationships:      rels,
+	}
+	*out = append(*out, rec)
+	*out = append(*out, fieldEnts...)
+}
+
+// buildEnum emits a SCOPE.Schema/enum entity with a field child per symbol.
+func buildEnum(v map[string]interface{}, file extractor.FileInput, out *[]types.EntityRecord) {
+	name := localName(asString(v["name"]))
+	if name == "" {
+		return
+	}
+	var rels []types.RelationshipRecord
+	var symEnts []types.EntityRecord
+	symbols, _ := v["symbols"].([]interface{})
+	for _, s := range symbols {
+		sym, _ := s.(string)
+		if sym == "" {
+			continue
+		}
+		rels = append(rels, types.RelationshipRecord{
+			ToID: fieldMemberRef(file.Path, name, sym),
+			Kind: "CONTAINS",
+		})
+		symEnts = append(symEnts, buildField(file, name, sym, "enum_symbol"))
+	}
+	*out = append(*out, types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "enum",
+		SourceFile:         file.Path,
+		Language:           "avro",
+		Signature:          "enum " + name,
+		EnrichmentRequired: false,
+		Relationships:      rels,
+	})
+	*out = append(*out, symEnts...)
+}
+
+// buildFixed emits a SCOPE.Schema/fixed entity.
+func buildFixed(v map[string]interface{}, file extractor.FileInput, out *[]types.EntityRecord) {
+	name := localName(asString(v["name"]))
+	if name == "" {
+		return
+	}
+	props := map[string]string{}
+	if size, ok := v["size"].(float64); ok {
+		props["size"] = fmt.Sprintf("%d", int(size))
+	}
+	*out = append(*out, types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "fixed",
+		SourceFile:         file.Path,
+		Language:           "avro",
+		Signature:          "fixed " + name,
+		Properties:         props,
+		EnrichmentRequired: false,
+	})
+}
+
+// buildField emits a SCOPE.Schema/field child named "<parent>.<field>" so the
+// Format-B member resolver binds the CONTAINS edge.
+func buildField(file extractor.FileInput, parent, fname, ftype string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:               parent + "." + fname,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "field",
+		SourceFile:         file.Path,
+		Language:           "avro",
+		Signature:          ftype + " " + fname,
+		QualifiedName:      parent + "." + fname,
+		Properties:         map[string]string{"type": ftype},
+		EnrichmentRequired: false,
+	}
+}
+
+// fieldMemberRef returns the Format-B member structural-ref for a parent#member
+// edge inside an Avro file.
+func fieldMemberRef(filePath, parent, member string) string {
+	return "scope:schema:column:avro:" + filePath + ":" + parent + "#" + member
+}
+
+// renderType produces a stable human-readable token for an Avro field type
+// node: a primitive/named string, a union "a|b", an "array<T>", a "map<T>", or
+// the name of an inline record/enum/fixed definition.
+func renderType(node interface{}) string {
+	switch v := node.(type) {
+	case string:
+		return localName(v)
+	case []interface{}:
+		parts := make([]string, 0, len(v))
+		for _, b := range v {
+			parts = append(parts, renderType(b))
+		}
+		return strings.Join(parts, "|")
+	case map[string]interface{}:
+		t, _ := v["type"].(string)
+		switch t {
+		case "array":
+			return "array<" + renderType(v["items"]) + ">"
+		case "map":
+			return "map<" + renderType(v["values"]) + ">"
+		case "record", "error", "enum", "fixed":
+			return localName(asString(v["name"]))
+		default:
+			// Logical type or primitive wrapped in an object.
+			return localName(t)
+		}
+	}
+	return ""
+}
+
+// namedTypeRefs returns the named (non-primitive) type names referenced by a
+// field-type node, deduped and sorted for deterministic output.
+func namedTypeRefs(node interface{}) []string {
+	set := map[string]bool{}
+	collectRefs(node, set)
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectRefs(node interface{}, set map[string]bool) {
+	switch v := node.(type) {
+	case string:
+		n := localName(v)
+		if n != "" && !avroPrimitives[n] {
+			set[n] = true
+		}
+	case []interface{}:
+		for _, b := range v {
+			collectRefs(b, set)
+		}
+	case map[string]interface{}:
+		t, _ := v["type"].(string)
+		switch t {
+		case "array":
+			collectRefs(v["items"], set)
+		case "map":
+			collectRefs(v["values"], set)
+		case "record", "error", "enum", "fixed":
+			if n := localName(asString(v["name"])); n != "" {
+				set[n] = true
+			}
+		default:
+			n := localName(t)
+			if n != "" && !avroPrimitives[n] {
+				set[n] = true
+			}
+		}
+	}
+}
+
+// localName strips an Avro namespace, returning the trailing type name so a
+// fully-qualified reference ("com.example.Order") binds to the local record
+// ("Order").
+func localName(name string) string {
+	name = strings.TrimSpace(name)
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+func asString(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/extractors/avro/avro_test.go
+++ b/internal/extractors/avro/avro_test.go
@@ -1,0 +1,144 @@
+package avro_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/avro"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("avro")
+	if !ok {
+		t.Fatal("avro extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "avro",
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func find(ents []types.EntityRecord, subtype, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestAvro_RecordFieldType asserts an Avro record User with field id:long.
+func TestAvro_RecordFieldType(t *testing.T) {
+	src := `{
+  "type": "record",
+  "name": "User",
+  "namespace": "com.example",
+  "fields": [
+    {"name": "id", "type": "long"},
+    {"name": "name", "type": "string"}
+  ]
+}`
+	ents := extract(t, "user.avsc", src)
+
+	rec := find(ents, "record", "User")
+	if rec == nil {
+		t.Fatal("expected record entity User")
+	}
+	if rec.Kind != "SCOPE.Schema" {
+		t.Errorf("User kind = %q, want SCOPE.Schema", rec.Kind)
+	}
+
+	idField := find(ents, "field", "User.id")
+	if idField == nil {
+		t.Fatal("expected field entity User.id")
+	}
+	if got := idField.Properties["type"]; got != "long" {
+		t.Errorf("User.id type = %q, want long", got)
+	}
+
+	// CONTAINS edge record → id field.
+	wantRef := "scope:schema:column:avro:user.avsc:User#id"
+	found := false
+	for _, r := range rec.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == wantRef {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CONTAINS edge User → id (%q)", wantRef)
+	}
+}
+
+// TestAvro_NamedTypeReference asserts a record field referencing another named
+// record yields a REFERENCES edge.
+func TestAvro_NamedTypeReference(t *testing.T) {
+	src := `{
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {"name": "id", "type": "long"},
+    {"name": "address", "type": "Address"},
+    {"name": "orders", "type": {"type": "array", "items": "Order"}}
+  ]
+}`
+	ents := extract(t, "user.avsc", src)
+	rec := find(ents, "record", "User")
+	if rec == nil {
+		t.Fatal("expected record User")
+	}
+	wantAddress := extractor.BuildOperationStructuralRef("avro", "user.avsc", "Address")
+	wantOrder := extractor.BuildOperationStructuralRef("avro", "user.avsc", "Order")
+	gotAddress, gotOrder := false, false
+	for _, r := range rec.Relationships {
+		if r.Kind != "REFERENCES" {
+			continue
+		}
+		if r.ToID == wantAddress {
+			gotAddress = true
+		}
+		if r.ToID == wantOrder {
+			gotOrder = true
+		}
+	}
+	if !gotAddress {
+		t.Error("expected REFERENCES edge User → Address")
+	}
+	if !gotOrder {
+		t.Error("expected REFERENCES edge User → Order (array items)")
+	}
+
+	// array<Order> field type rendered.
+	orders := find(ents, "field", "User.orders")
+	if orders == nil || orders.Properties["type"] != "array<Order>" {
+		t.Errorf("User.orders type = %v, want array<Order>", orders)
+	}
+}
+
+// TestAvro_Enum asserts an Avro enum becomes a schema with symbol children.
+func TestAvro_Enum(t *testing.T) {
+	src := `{"type":"enum","name":"Suit","symbols":["SPADES","HEARTS"]}`
+	ents := extract(t, "suit.avsc", src)
+	e := find(ents, "enum", "Suit")
+	if e == nil {
+		t.Fatal("expected enum entity Suit")
+	}
+	if find(ents, "field", "Suit.SPADES") == nil {
+		t.Error("expected symbol field Suit.SPADES")
+	}
+}
+
+// TestAvro_NonJSON is a no-op.
+func TestAvro_NonJSON(t *testing.T) {
+	ents := extract(t, "x.avsc", "not json {{{")
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-JSON, got %d", len(ents))
+	}
+}

--- a/internal/extractors/jsonschema/jsonschema.go
+++ b/internal/extractors/jsonschema/jsonschema.go
@@ -1,0 +1,282 @@
+// Package jsonschema implements a content-based extractor for JSON Schema
+// data-contract documents (files following the *.schema.json convention, routed
+// here by the classifier). JSON Schema documents are JSON, so this extractor
+// json-decodes the file body rather than using a tree-sitter grammar (the
+// dispatcher passes a nil Tree for the "jsonschema" language).
+//
+// Extracted entities (issue #3690):
+//
+//   - The root object schema → Kind="SCOPE.Schema", Subtype="object". Named from
+//     "title" when present, else the file basename (sans .schema.json). Each
+//     declared property becomes a SCOPE.Schema/field child entity named
+//     "<Schema>.<prop>" carrying Properties["type"] (the JSON Schema type token,
+//     e.g. "integer", "string", "array<#/$defs/Order>" reduced to "array<Order>").
+//   - Each named subschema under "$defs" / "definitions" → its own
+//     SCOPE.Schema/object entity with its own property field children.
+//
+// Relationships:
+//
+//   - CONTAINS    schema → each property (Format-B member ref so the resolver
+//     binds it via byMember[file][Schema][prop]).
+//   - REFERENCES  schema → each referenced schema named by a "$ref"
+//     ("#/$defs/Address" → Address). The edge ToID is the Format-A operation ref
+//     for the same file so the resolver binds it to the sibling $defs entity.
+//
+// content-sniff: a document is only treated as a JSON Schema when it carries a
+// "$schema", "properties", "$defs", "definitions", or "$ref" key, so a
+// misrouted JSON file is a harmless no-op.
+package jsonschema
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("jsonschema", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for JSON Schema.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "jsonschema" }
+
+// Extract json-decodes the schema document and emits schema + field entities.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	var root map[string]interface{}
+	if err := json.Unmarshal(file.Content, &root); err != nil {
+		return nil, nil
+	}
+	if !looksLikeSchema(root) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	rootName := schemaName(root, file.Path)
+	buildObjectSchema(root, rootName, file, &entities)
+
+	// Named subschemas under $defs / definitions become their own entities.
+	for _, key := range []string{"$defs", "definitions"} {
+		defs, ok := root[key].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		names := make([]string, 0, len(defs))
+		for n := range defs {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			sub, ok := defs[n].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			buildObjectSchema(sub, n, file, &entities)
+		}
+	}
+	return entities, nil
+}
+
+// looksLikeSchema content-sniffs a decoded JSON document for the JSON Schema
+// shape so misrouted JSON files emit nothing.
+func looksLikeSchema(root map[string]interface{}) bool {
+	for _, k := range []string{"$schema", "properties", "$defs", "definitions", "$ref"} {
+		if _, ok := root[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// buildObjectSchema emits a SCOPE.Schema/object entity for a (sub)schema plus a
+// field child per declared property, with CONTAINS + REFERENCES edges.
+func buildObjectSchema(schema map[string]interface{}, name string, file extractor.FileInput, out *[]types.EntityRecord) {
+	if name == "" {
+		return
+	}
+	var rels []types.RelationshipRecord
+	var fieldEnts []types.EntityRecord
+	refSeen := map[string]bool{}
+
+	// A schema may $ref another schema directly (composition).
+	for _, ref := range refsOf(schema) {
+		if refSeen[ref] {
+			continue
+		}
+		refSeen[ref] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID:       extractor.BuildOperationStructuralRef("jsonschema", file.Path, ref),
+			Kind:       "REFERENCES",
+			Properties: map[string]string{"type": ref},
+		})
+	}
+
+	props, _ := schema["properties"].(map[string]interface{})
+	pnames := make([]string, 0, len(props))
+	for p := range props {
+		pnames = append(pnames, p)
+	}
+	sort.Strings(pnames)
+	for _, pname := range pnames {
+		pschema, _ := props[pname].(map[string]interface{})
+		typeStr := renderType(pschema)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: fieldMemberRef(file.Path, name, pname),
+			Kind: "CONTAINS",
+		})
+		fieldEnts = append(fieldEnts, buildField(file, name, pname, typeStr))
+
+		for _, ref := range refsOf(pschema) {
+			if refSeen[ref] {
+				continue
+			}
+			refSeen[ref] = true
+			rels = append(rels, types.RelationshipRecord{
+				ToID:       extractor.BuildOperationStructuralRef("jsonschema", file.Path, ref),
+				Kind:       "REFERENCES",
+				Properties: map[string]string{"via_field": pname, "type": ref},
+			})
+		}
+	}
+
+	*out = append(*out, types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "object",
+		SourceFile:         file.Path,
+		Language:           "jsonschema",
+		Signature:          "schema " + name,
+		EnrichmentRequired: false,
+		Relationships:      rels,
+	})
+	*out = append(*out, fieldEnts...)
+}
+
+// buildField emits a SCOPE.Schema/field child named "<parent>.<prop>".
+func buildField(file extractor.FileInput, parent, fname, ftype string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:               parent + "." + fname,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "field",
+		SourceFile:         file.Path,
+		Language:           "jsonschema",
+		Signature:          ftype + " " + fname,
+		QualifiedName:      parent + "." + fname,
+		Properties:         map[string]string{"type": ftype},
+		EnrichmentRequired: false,
+	}
+}
+
+func fieldMemberRef(filePath, parent, member string) string {
+	return "scope:schema:column:jsonschema:" + filePath + ":" + parent + "#" + member
+}
+
+// renderType produces a stable token for a property schema: its "type" keyword,
+// an "array<items>" wrapper, or the trailing name of a "$ref" target.
+func renderType(prop map[string]interface{}) string {
+	if prop == nil {
+		return ""
+	}
+	if ref, ok := prop["$ref"].(string); ok {
+		return refLocalName(ref)
+	}
+	switch t := prop["type"].(type) {
+	case string:
+		if t == "array" {
+			if items, ok := prop["items"].(map[string]interface{}); ok {
+				return "array<" + renderType(items) + ">"
+			}
+			return "array"
+		}
+		return t
+	case []interface{}:
+		parts := make([]string, 0, len(t))
+		for _, x := range t {
+			if s, ok := x.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, "|")
+	}
+	// composition keywords
+	for _, k := range []string{"allOf", "anyOf", "oneOf"} {
+		if _, ok := prop[k]; ok {
+			return k
+		}
+	}
+	return ""
+}
+
+// refsOf returns every $ref target name reachable one level inside a schema
+// node: a direct "$ref", an array "items.$ref", and composition
+// allOf/anyOf/oneOf branch "$ref"s.
+func refsOf(schema map[string]interface{}) []string {
+	if schema == nil {
+		return nil
+	}
+	set := map[string]bool{}
+	add := func(s map[string]interface{}) {
+		if ref, ok := s["$ref"].(string); ok {
+			if n := refLocalName(ref); n != "" {
+				set[n] = true
+			}
+		}
+	}
+	add(schema)
+	if items, ok := schema["items"].(map[string]interface{}); ok {
+		add(items)
+	}
+	for _, k := range []string{"allOf", "anyOf", "oneOf"} {
+		branches, ok := schema[k].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, b := range branches {
+			if bm, ok := b.(map[string]interface{}); ok {
+				add(bm)
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// refLocalName reduces a JSON-Pointer $ref ("#/$defs/Address",
+// "#/definitions/Order", "other.schema.json#/$defs/Foo") to its trailing
+// schema name ("Address", "Order", "Foo").
+func refLocalName(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		ref = ref[i+1:]
+	}
+	return ref
+}
+
+// schemaName derives the root schema's name from its "title", falling back to
+// the file basename with the .schema.json / .json suffix stripped.
+func schemaName(root map[string]interface{}, filePath string) string {
+	if title, ok := root["title"].(string); ok && strings.TrimSpace(title) != "" {
+		return strings.TrimSpace(title)
+	}
+	base := path.Base(filePath)
+	base = strings.TrimSuffix(base, ".json")
+	base = strings.TrimSuffix(base, ".schema")
+	return base
+}

--- a/internal/extractors/jsonschema/jsonschema_test.go
+++ b/internal/extractors/jsonschema/jsonschema_test.go
@@ -1,0 +1,171 @@
+package jsonschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/jsonschema"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("jsonschema")
+	if !ok {
+		t.Fatal("jsonschema extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "jsonschema",
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func find(ents []types.EntityRecord, subtype, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestJSONSchema_PropertyType asserts a schema's property becomes a typed field.
+func TestJSONSchema_PropertyType(t *testing.T) {
+	src := `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "id": {"type": "integer"},
+    "name": {"type": "string"}
+  }
+}`
+	ents := extract(t, "user.schema.json", src)
+
+	sc := find(ents, "object", "User")
+	if sc == nil {
+		t.Fatal("expected object schema User")
+	}
+	if sc.Kind != "SCOPE.Schema" {
+		t.Errorf("User kind = %q, want SCOPE.Schema", sc.Kind)
+	}
+	idField := find(ents, "field", "User.id")
+	if idField == nil {
+		t.Fatal("expected field User.id")
+	}
+	if got := idField.Properties["type"]; got != "integer" {
+		t.Errorf("User.id type = %q, want integer", got)
+	}
+
+	wantRef := "scope:schema:column:jsonschema:user.schema.json:User#id"
+	found := false
+	for _, r := range sc.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == wantRef {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CONTAINS edge User → id (%q)", wantRef)
+	}
+}
+
+// TestJSONSchema_RefEdge asserts a $ref to another schema yields a REFERENCES
+// edge, and the $defs subschema is emitted as its own entity.
+func TestJSONSchema_RefEdge(t *testing.T) {
+	src := `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "address": {"$ref": "#/$defs/Address"}
+  },
+  "$defs": {
+    "Address": {
+      "type": "object",
+      "properties": {"city": {"type": "string"}}
+    }
+  }
+}`
+	ents := extract(t, "user.schema.json", src)
+
+	user := find(ents, "object", "User")
+	if user == nil {
+		t.Fatal("expected schema User")
+	}
+	wantRef := extractor.BuildOperationStructuralRef("jsonschema", "user.schema.json", "Address")
+	found := false
+	for _, r := range user.Relationships {
+		if r.Kind == "REFERENCES" && r.ToID == wantRef {
+			found = true
+			if r.Properties["via_field"] != "address" {
+				t.Errorf("REFERENCES via_field = %q, want address", r.Properties["via_field"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected REFERENCES edge User → Address (%q)", wantRef)
+	}
+
+	// $defs.Address emitted as its own schema with a city field.
+	addr := find(ents, "object", "Address")
+	if addr == nil {
+		t.Fatal("expected $defs schema Address")
+	}
+	if find(ents, "field", "Address.city") == nil {
+		t.Error("expected field Address.city")
+	}
+}
+
+// TestJSONSchema_ArrayRef asserts array-of-$ref yields a REFERENCES edge and an
+// array<T> field type.
+func TestJSONSchema_ArrayRef(t *testing.T) {
+	src := `{
+  "title": "Cart",
+  "properties": {
+    "orders": {"type": "array", "items": {"$ref": "#/$defs/Order"}}
+  }
+}`
+	ents := extract(t, "cart.schema.json", src)
+	cart := find(ents, "object", "Cart")
+	if cart == nil {
+		t.Fatal("expected schema Cart")
+	}
+	wantRef := extractor.BuildOperationStructuralRef("jsonschema", "cart.schema.json", "Order")
+	found := false
+	for _, r := range cart.Relationships {
+		if r.Kind == "REFERENCES" && r.ToID == wantRef {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected REFERENCES edge Cart → Order (array items $ref)")
+	}
+	orders := find(ents, "field", "Cart.orders")
+	if orders == nil || orders.Properties["type"] != "array<Order>" {
+		t.Errorf("Cart.orders type = %v, want array<Order>", orders)
+	}
+}
+
+// TestJSONSchema_NonSchemaNoOp asserts a JSON file without schema markers emits
+// nothing.
+func TestJSONSchema_NonSchemaNoOp(t *testing.T) {
+	ents := extract(t, "data.schema.json", `{"foo": 1, "bar": [2,3]}`)
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-schema JSON, got %d", len(ents))
+	}
+}
+
+// TestJSONSchema_TitleFallback asserts the file basename is used when no title.
+func TestJSONSchema_TitleFallback(t *testing.T) {
+	src := `{"$schema":"x","properties":{"a":{"type":"string"}}}`
+	ents := extract(t, "path/to/order.schema.json", src)
+	if find(ents, "object", "order") == nil {
+		t.Error("expected schema named 'order' from basename fallback")
+	}
+}

--- a/internal/extractors/proto/fields_test.go
+++ b/internal/extractors/proto/fields_test.go
@@ -1,0 +1,131 @@
+package proto_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/proto"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestFields_TypedFieldEntities asserts each message field becomes a
+// SCOPE.Schema/field entity carrying its resolved type, and that a field whose
+// type is another message produces a REFERENCES edge to that message.
+func TestFields_TypedFieldEntities(t *testing.T) {
+	src := `syntax = "proto3";
+
+message Order { string id = 1; }
+
+message User {
+  string name = 1;
+  int32 id = 2;
+  repeated Order orders = 3;
+}
+`
+	entities := extract(t, "u.proto", src)
+
+	// Field entity name:string must exist with type=string.
+	var nameField *types.EntityRecord
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == "User.name" {
+			nameField = e
+		}
+	}
+	if nameField == nil {
+		t.Fatal("expected SCOPE.Schema/field entity User.name")
+	}
+	if got := nameField.Properties["type"]; got != "string" {
+		t.Errorf("User.name type = %q, want string", got)
+	}
+
+	// repeated Order orders → field with type containing Order + label repeated.
+	var ordersField *types.EntityRecord
+	for i := range entities {
+		e := &entities[i]
+		if e.Subtype == "field" && e.Name == "User.orders" {
+			ordersField = e
+		}
+	}
+	if ordersField == nil {
+		t.Fatal("expected field entity User.orders")
+	}
+	if ordersField.Properties["type"] != "Order" {
+		t.Errorf("User.orders type = %q, want Order", ordersField.Properties["type"])
+	}
+	if ordersField.Properties["label"] != "repeated" {
+		t.Errorf("User.orders label = %q, want repeated", ordersField.Properties["label"])
+	}
+
+	// REFERENCES edge User → Order via the orders field.
+	var userMsg *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "message" && entities[i].Name == "User" {
+			userMsg = &entities[i]
+		}
+	}
+	if userMsg == nil {
+		t.Fatal("User message entity not found")
+	}
+	wantRef := extractor.BuildOperationStructuralRef("proto", "u.proto", "Order")
+	found := false
+	for _, r := range userMsg.Relationships {
+		if r.Kind == "REFERENCES" && r.ToID == wantRef {
+			found = true
+			if r.Properties["via_field"] != "orders" {
+				t.Errorf("REFERENCES via_field = %q, want orders", r.Properties["via_field"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected REFERENCES edge User → Order (%q)", wantRef)
+	}
+}
+
+// TestFields_ScalarsNoReference asserts scalar-typed fields emit NO REFERENCES
+// edge — only named message/enum types do.
+func TestFields_ScalarsNoReference(t *testing.T) {
+	src := `syntax = "proto3";
+message Plain {
+  string a = 1;
+  int64 b = 2;
+  bool c = 3;
+}
+`
+	entities := extract(t, "p.proto", src)
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" {
+				t.Errorf("unexpected REFERENCES edge on scalar-only message: %+v", r)
+			}
+		}
+	}
+}
+
+// TestFields_MapValueReference asserts map<string, Order> references Order.
+func TestFields_MapValueReference(t *testing.T) {
+	src := `syntax = "proto3";
+message Order { string id = 1; }
+message Cart {
+  map<string, Order> items = 1;
+}
+`
+	entities := extract(t, "c.proto", src)
+	wantRef := extractor.BuildOperationStructuralRef("proto", "c.proto", "Order")
+	found := false
+	for _, e := range entities {
+		if e.Subtype != "message" || e.Name != "Cart" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" && r.ToID == wantRef {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected REFERENCES edge Cart → Order for map value type")
+	}
+	_ = context.Background
+}

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -122,8 +122,8 @@ func walkProto(node *sitter.Node, file extractor.FileInput, out *[]types.EntityR
 		}
 		return // Don't recurse further into service — already handled.
 	case "message":
-		if rec, ok := buildMessage(node, file); ok {
-			*out = append(*out, rec)
+		if recs, ok := buildMessage(node, file); ok {
+			*out = append(*out, recs...)
 		}
 	case "enum":
 		if rec, ok := buildEnum(node, file); ok {
@@ -243,27 +243,35 @@ func buildRPC(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, 
 	}, true
 }
 
-func buildMessage(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildMessage(node *sitter.Node, file extractor.FileInput) ([]types.EntityRecord, bool) {
 	nameNode := childByType(node, "message_name")
 	if nameNode == nil {
-		return types.EntityRecord{}, false
+		return nil, false
 	}
 	name := strings.TrimSpace(nodeText(nameNode, file.Content))
 	if ident := childByType(nameNode, "identifier"); ident != nil {
 		name = nodeText(ident, file.Content)
 	}
 	if name == "" {
-		return types.EntityRecord{}, false
+		return nil, false
 	}
 
 	// CONTAINS edges: file → message + message → each field.
+	// REFERENCES edges: message → each named (non-scalar) field type, so a
+	// field `repeated Order orders = 3;` yields message User → message Order.
 	var rels []types.RelationshipRecord
 	rels = append(rels, fileContainsRel(file.Path, name))
+	var fieldEnts []types.EntityRecord
 	if body := childByType(node, "message_body"); body != nil {
 		seen := make(map[string]bool)
+		refSeen := make(map[string]bool)
 		for i := range body.ChildCount() {
 			ch := body.Child(int(i))
-			if ch == nil || ch.Type() != "field" {
+			if ch == nil {
+				continue
+			}
+			isMap := ch.Type() == "map_field"
+			if ch.Type() != "field" && !isMap {
 				continue
 			}
 			fname := fieldName(ch, file.Content)
@@ -271,14 +279,39 @@ func buildMessage(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 				continue
 			}
 			seen[fname] = true
+			var ftype, label string
+			if isMap {
+				ftype, label = mapFieldTypeAndLabel(ch, file.Content)
+			} else {
+				ftype, label = fieldTypeAndLabel(ch, file.Content)
+			}
 			rels = append(rels, types.RelationshipRecord{
 				ToID: fieldMemberRef(file.Path, name, fname),
 				Kind: "CONTAINS",
 			})
+			// Emit a per-field SCOPE.Field entity carrying the resolved scalar
+			// or message type + repeated/optional/required label. The entity ID
+			// reuses the Format-B member ref so it lines up with the CONTAINS
+			// edge target above.
+			fieldEnts = append(fieldEnts, buildField(file, name, fname, ftype, label, ch))
+			// REFERENCES edge to a named (non-scalar) message/enum type. Scalars
+			// (string, int32, …) carry no edge. The map type's value component is
+			// also followed (map<string, Order> → Order).
+			for _, ref := range namedTypeRefs(ftype) {
+				if refSeen[ref] {
+					continue
+				}
+				refSeen[ref] = true
+				rels = append(rels, types.RelationshipRecord{
+					ToID:       extractor.BuildOperationStructuralRef("proto", file.Path, ref),
+					Kind:       "REFERENCES",
+					Properties: map[string]string{"via_field": fname, "type": ref},
+				})
+			}
 		}
 	}
 
-	return types.EntityRecord{
+	msg := types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Schema",
 		Subtype:            "message",
@@ -289,7 +322,45 @@ func buildMessage(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 		Signature:          "message " + name,
 		EnrichmentRequired: false,
 		Relationships:      rels,
-	}, true
+	}
+	out := make([]types.EntityRecord, 0, 1+len(fieldEnts))
+	out = append(out, msg)
+	out = append(out, fieldEnts...)
+	return out, true
+}
+
+// buildField emits a per-message-field SCOPE.Field entity. The entity ID reuses
+// the Format-B member ref (scope:schema:column:proto:<file>:<parent>#<field>) so
+// it coincides with the message→field CONTAINS edge target. Properties carry the
+// resolved field type and the proto label (repeated/optional/required) when one
+// is present.
+func buildField(file extractor.FileInput, parent, fname, ftype, label string, node *sitter.Node) types.EntityRecord {
+	props := map[string]string{"type": ftype}
+	if label != "" {
+		props["label"] = label
+	}
+	sig := ftype + " " + fname
+	if label != "" {
+		sig = label + " " + sig
+	}
+	return types.EntityRecord{
+		// Name is "<parent>.<field>" so the Format-B member resolver
+		// (Index.byMember[file][parent][field], internal/resolve/refs.go) binds
+		// the message→field CONTAINS edge — the dotted name splits into
+		// scope=<parent>, member=<field>. Mirrors the SQL table.column and ORM
+		// Model.field conventions.
+		Name:               parent + "." + fname,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "field",
+		SourceFile:         file.Path,
+		Language:           "protobuf",
+		StartLine:          int(node.StartPoint().Row) + 1,
+		EndLine:            int(node.EndPoint().Row) + 1,
+		Signature:          sig,
+		QualifiedName:      parent + "." + fname,
+		Properties:         props,
+		EnrichmentRequired: false,
+	}
 }
 
 func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
@@ -362,6 +433,100 @@ func fieldName(node *sitter.Node, src []byte) string {
 		}
 	}
 	return ""
+}
+
+// protoScalars is the set of protobuf built-in scalar types. A field whose
+// resolved type is one of these carries no REFERENCES edge.
+var protoScalars = map[string]bool{
+	"double": true, "float": true, "int32": true, "int64": true,
+	"uint32": true, "uint64": true, "sint32": true, "sint64": true,
+	"fixed32": true, "fixed64": true, "sfixed32": true, "sfixed64": true,
+	"bool": true, "string": true, "bytes": true,
+}
+
+// fieldTypeAndLabel returns the resolved field type and the proto label
+// (repeated / optional / required) for a `field` node. The grammar lays the
+// field out as an optional label keyword, a `type` node, the field-name
+// identifier, `=`, and the field number. The `type` node wraps either a scalar
+// keyword, a `message_or_enum_type`, or a `map_type` (`map<K, V>`); we return
+// the textual type (e.g. "string", "Order", "map<string, Order>").
+func fieldTypeAndLabel(node *sitter.Node, src []byte) (ftype, label string) {
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "repeated", "optional", "required":
+			label = ch.Type()
+		case "type", "map_type":
+			ftype = strings.TrimSpace(nodeText(ch, src))
+		}
+	}
+	// Some grammars surface a map field as a `map_field` node whose `type`
+	// child already includes the `map<...>` text — covered by the `type` case
+	// above. As a fallback, if no `type` child was found, scan for a
+	// message_or_enum_type directly.
+	if ftype == "" {
+		if t := childByType(node, "message_or_enum_type"); t != nil {
+			ftype = strings.TrimSpace(nodeText(t, src))
+		}
+	}
+	return ftype, label
+}
+
+// mapFieldTypeAndLabel renders a `map_field` node's type as "map<K, V>" so
+// namedTypeRefs follows the value (and key) component to any named message type.
+// Map fields carry no repeated/optional label in proto3, so the label is empty.
+// Grammar shape:
+//
+//	map_field
+//	  map  <  key_type  ,  type  >  identifier  =  field_number  ;
+func mapFieldTypeAndLabel(node *sitter.Node, src []byte) (ftype, label string) {
+	var key, val string
+	if k := childByType(node, "key_type"); k != nil {
+		key = strings.TrimSpace(nodeText(k, src))
+	}
+	if v := childByType(node, "type"); v != nil {
+		val = strings.TrimSpace(nodeText(v, src))
+	}
+	return "map<" + key + ", " + val + ">", ""
+}
+
+// namedTypeRefs extracts the named (non-scalar) type names referenced by a field
+// type and returns one structural-ref per referenced type. Scalars yield none.
+// A `map<K, V>` yields a ref for each of K and V that is itself a named type
+// (the key is constrained to scalars in proto, so in practice only V matters,
+// but both are checked for robustness). Leading dots and package qualifiers are
+// stripped to the trailing type segment so the ref binds to the local message
+// name (e.g. `.foo.bar.Order` → `Order`).
+func namedTypeRefs(ftype string) []string {
+	ftype = strings.TrimSpace(ftype)
+	if ftype == "" {
+		return nil
+	}
+	var raws []string
+	if strings.HasPrefix(ftype, "map<") && strings.HasSuffix(ftype, ">") {
+		inner := ftype[len("map<") : len(ftype)-1]
+		for _, part := range strings.Split(inner, ",") {
+			raws = append(raws, strings.TrimSpace(part))
+		}
+	} else {
+		raws = append(raws, ftype)
+	}
+	var out []string
+	for _, r := range raws {
+		// Strip leading dot and package qualifier to the trailing segment.
+		r = strings.TrimPrefix(r, ".")
+		if idx := strings.LastIndex(r, "."); idx >= 0 {
+			r = r[idx+1:]
+		}
+		if r == "" || protoScalars[r] {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // enumValueName returns the first identifier child of an `enum_field` node.

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -11,6 +11,7 @@ package extractors
 import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/assembly"
 	_ "github.com/cajasmota/archigraph/internal/extractors/astro"
+	_ "github.com/cajasmota/archigraph/internal/extractors/avro"
 	_ "github.com/cajasmota/archigraph/internal/extractors/bicep"
 	_ "github.com/cajasmota/archigraph/internal/extractors/clojure"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cobol"
@@ -35,6 +36,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/java"
 	_ "github.com/cajasmota/archigraph/internal/extractors/javascript"
 	_ "github.com/cajasmota/archigraph/internal/extractors/jcl"
+	_ "github.com/cajasmota/archigraph/internal/extractors/jsonschema"
 	_ "github.com/cajasmota/archigraph/internal/extractors/just"
 	_ "github.com/cajasmota/archigraph/internal/extractors/kotlin"
 	_ "github.com/cajasmota/archigraph/internal/extractors/lisp"

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -69,7 +69,7 @@ categories:
   security:
     capabilities: [auth_policy, secret_detection, sql_injection]
   protocol:
-    capabilities: [service_extraction, method_attribution, cross_repo_linkage]
+    capabilities: [service_extraction, method_attribution, cross_repo_linkage, schema_extraction, field_extraction]
   ci_cd:
     capabilities: [file_parsing, env_resolution]
   validation:

--- a/tools/coverage/languages.go
+++ b/tools/coverage/languages.go
@@ -30,6 +30,7 @@ var extractorUtilityDirs = map[string]bool{
 // represented in the coverage matrix's "multi" bucket rather than as
 // standalone language rows.
 var extractorNonLanguageFormats = map[string]bool{
+	"avro":       true,
 	"bazel":      true,
 	"css":        true,
 	"dockerfile": true,
@@ -37,6 +38,7 @@ var extractorNonLanguageFormats = map[string]bool{
 	"graphql":    true,
 	"hcl":        true,
 	"html":       true,
+	"jsonschema": true,
 	"just":       true,
 	"mage":       true,
 	"markdown":   true,


### PR DESCRIPTION
Closes #3690 (child of epic #3628, area #15 — serialization / data-contract extraction).

## What
Extract serialization data-contracts as schema/DTO entities with **typed fields** and **cross-type reference edges**.

### Formats that now emit schemas
| Format | Files | Entities | Edges |
|---|---|---|---|
| **Protobuf** | `.proto` | message/enum → `SCOPE.Schema`; each field → `SCOPE.Schema/field` (type + repeated/optional/required label) | message→field `CONTAINS`; message→named-type `REFERENCES` (incl. `map<K,V>` value; scalars none) |
| **Avro** *(new extractor)* | `.avsc` / `.avpr` | record/enum/fixed → `SCOPE.Schema`; each field → `SCOPE.Schema/field` (`array<T>`/`map<T>`/union `a\|b`) | record→field `CONTAINS`; record→named-type `REFERENCES` (array items followed) |
| **JSON Schema** *(new extractor)* | `*.schema.json` | root + each `$defs`/`definitions` subschema → `SCOPE.Schema/object`; each property → `SCOPE.Schema/field` | schema→property `CONTAINS`; `$ref` → `REFERENCES` (direct, array items, allOf/anyOf/oneOf) |

gRPC still owns `service`/`rpc`; this PR only enriches the message/data-contract side. Field entities are named `<Schema>.<field>` so the message→field `CONTAINS` edge binds via the Format-B `byMember` resolver. JSON Schema is content-sniffed (`$schema`/`properties`/`$defs`/`$ref`) so a misrouted JSON file is a no-op.

## Plumbing
- Classifier: `.avsc`/`.avpr` → `avro`, `*.schema.json` → `jsonschema`.
- Avro/JSON-Schema are JSON, so the extractors json-decode `FileInput.Content` (nil tree, like bicep). Registered in `registry_gen.go`; added to coverage `extractorNonLanguageFormats`.
- Coverage: `protocol` category gains `schema_extraction` + `field_extraction`; records `protocol.protobuf` (enriched), `protocol.avro`, `protocol.json-schema`. `coverage validate` 0 errors, `fmt --check` canonical.

## Asserted (value-asserting tests)
- proto `message User { string name = 1; repeated Order orders = 3; }` → Schema `User` with field `name:string` + `REFERENCES` edge User→Order (and `map<string,Order>`→Order); scalars emit no edge.
- Avro record `User` with field `id:long`; `array` items → `REFERENCES`.
- JSON Schema `User` property `$ref:#/$defs/Address` → `REFERENCES` edge User→Address; `$defs.Address` emitted as its own schema.

## Testing
`go test` green for `internal/extractors/{avro,jsonschema,proto}`, `internal/extractors`, `internal/classifier`, `internal/types`, `tools/coverage`. `gofmt -l` clean on touched files, `go vet` clean, full `go build ./...` OK.

**DEPLOY-DEFERRED**: new extractors require a daemon rebuild + reindex to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)