### PR TITLE
[authz] endpoint protection extraction (FastAPI / Flask / DRF actions)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -43479,9 +43479,10 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/extractors/python/config_module.go","internal/extractors/python/django_drf_permissions.go","internal/mcp/auth_coverage.go"],
+            "cites": ["internal/extractors/python/config_module.go","internal/extractors/python/django_drf_actions.go","internal/extractors/python/django_drf_actions_test.go","internal/extractors/python/django_drf_permissions.go","internal/mcp/auth_coverage.go"],
             "issue": "2816",
-            "verified_at": "2026-05-28"
+            "notes": "#3628 area #6 (endpoint protection): class-level permission_classes / get_permissions() stamped on the ViewSet CLASS by django_drf_permissions.go (#2816); per-action protection now ALSO normalised onto the action Operation entity — django_drf_actions.go calls stampDRFActionAuth (django_drf_permissions.go) to turn the @action(permission_classes=[IsAdmin]) kwarg into auth_required/auth_method=permission_classes/auth_confidence/auth_guard, with [AllowAny] -\u003e auth_required=false (explicit public). Value-asserting tests: TestDRFAction_BasicKwargs (auth_required=true, auth_guard=IsAdmin), TestDRFAction_AllowAnyIsPublic (auth_required=false), TestDRFAction_NoPermissionInherits (no stamp -\u003e inherits class posture).",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -44200,10 +44201,10 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/custom/python/fastapi.go","internal/mcp/auth_coverage.go","internal/patterns/auth_endpoint_linker.go"],
+            "cites": ["internal/custom/python/auth_endpoint.go","internal/custom/python/auth_endpoint_test.go","internal/custom/python/fastapi.go","internal/mcp/auth_coverage.go"],
             "issue": "3052",
-            "notes": "Depends(get_current_user/get_current_active_user/oauth2_scheme/verify_token/authenticate/require_auth) detected by auth_endpoint_linker authFastAPIDependsRE; additional injection via fastapi.go decorator pass; comprehensive OAuth2/JWT coverage",
-            "verified_at": "2026-05-29"
+            "notes": "#3628 area #6 (endpoint protection): fastapi.go now scans each route handler's def signature for Depends(get_current_user) / Security(get_user, scopes=[...]) auth dependencies and the route-decorator dependencies=[Depends(verify_token)] kwarg, stamping auth_required/auth_method=dependency/auth_confidence/auth_guard/auth_scopes ON THE ENDPOINT entity (resolveFastAPIRouteAuth in auth_endpoint.go). Auth dependencies are distinguished from plain DI (get_db) by name idiom; Security(...) is always auth and carries scopes. Value-asserting tests: TestFastAPIAuth_DependsCurrentUser (/me -\u003e auth_required=true, auth_guard=get_current_user), TestFastAPIAuth_SecurityScopes (auth_scopes=items:list,items:read), TestFastAPIAuth_DependenciesKwarg, plus negatives TestFastAPIAuth_PlainDependencyNotProtected / NoDependencyUnprotected. Honest-partial: dynamic/cross-file dependency resolution out of scope. Prior auth_endpoint_linker file-proximity heuristic superseded by per-endpoint signature extraction.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -44447,10 +44448,10 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/custom/python/flask.go","internal/mcp/auth_coverage.go"],
+            "cites": ["internal/custom/python/auth_endpoint.go","internal/custom/python/auth_endpoint_test.go","internal/custom/python/flask.go","internal/mcp/auth_coverage.go"],
             "issue": "3052",
-            "notes": "@login_required (Flask-Login) explicitly extracted by flask.go flLoginRequiredRe; jwt_required/fresh_jwt_required/roles_required/roles_accepted in authAnnotationNames; comprehensive Flask auth decorator coverage",
-            "verified_at": "2026-05-29"
+            "notes": "#3628 area #6 (endpoint protection): flask.go now scans the stacked-decorator block of each @app.route / @app.get route for a Flask-Login / Flask-Security / Flask-Principal auth decorator (login_required/roles_required/permission_required/jwt_required/...), stamping auth_required=true/auth_method=decorator/auth_confidence/auth_guard ON THE ENDPOINT entity, with roles captured from @roles_required('admin','superuser') (resolveFlaskDecoratorAuth in auth_endpoint.go). Value-asserting tests: TestFlaskAuth_LoginRequired (/dashboard -\u003e auth_required=true, auth_guard=login_required, auth_method=decorator), TestFlaskAuth_RolesRequired (auth_roles=admin,superuser), negative TestFlaskAuth_NoDecoratorUnprotected (/public -\u003e no auth_required).",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {

--- a/internal/custom/python/auth_endpoint.go
+++ b/internal/custom/python/auth_endpoint.go
@@ -1,0 +1,366 @@
+// auth_endpoint.go — endpoint-protection extraction for Python web frameworks
+// (#3628 area #6 child: authz endpoint protection).
+//
+// The meta-audit (#3628) found the per-framework `auth_coverage` rows were
+// unverified placeholders: the FastAPI / Flask / DRF custom extractors emitted
+// route endpoints but never recorded WHICH endpoints are protected and BY WHAT.
+// The parity oracle (Django → NestJS rewrite) needs the auth requirement on the
+// endpoint itself to compare guard-for-guard.
+//
+// This file resolves a per-endpoint auth posture from static route-level signals
+// and stamps it onto the route endpoint entity using the same flat property
+// contract the Java (java_auth_policy.go) and JS/TS (http_endpoint_jsts_auth.go)
+// resolvers already write, so archigraph_auth_coverage and the security
+// dashboard light up uniformly:
+//
+//	auth_required   — "true" | "false"
+//	auth_method     — "dependency" | "decorator" | "permission_classes"
+//	auth_confidence — "high" | "medium" | "low"
+//	auth_guard      — the recognised guard symbol (dependency fn / decorator /
+//	                  permission class) — the MCP signal-2 key
+//	auth_scopes     — comma-joined OAuth2 scopes (FastAPI Security(scopes=[...]))
+//	auth_roles      — comma-joined roles (where a role-bearing guard is named)
+//
+// Supported surfaces:
+//
+//	FastAPI — a route handler whose signature carries `= Depends(get_current_user)`
+//	          or `= Security(get_user, scopes=["items:read"])`, or a router/route
+//	          `dependencies=[Depends(verify_token)]` kwarg. The dependency
+//	          function is the guard; Security scopes are captured.
+//	Flask   — a `@login_required` / `@roles_required('admin')` /
+//	          `@permission_required('x')` decorator on the route (Flask-Login /
+//	          Flask-Security / Flask-Principal).
+//	DRF     — per-method `@permission_classes([IsAdminUser])` /
+//	          `@action(..., permission_classes=[IsAuthenticated])` decorators.
+//	          (Class-level permission_classes are stamped on the CLASS entity by
+//	          django_drf_permissions.go; this covers the per-route decorator.)
+//
+// Honest-partial: a dynamic guard (a dependency resolved at runtime, a
+// permission class assembled in get_permissions()) is out of scope here and is
+// handled — for DRF class-level — by django_drf_permissions.go.
+package python
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// pyEndpointAuth is the resolved auth posture for one route endpoint.
+type pyEndpointAuth struct {
+	Required   bool
+	Method     string // "dependency" | "decorator" | "permission_classes"
+	Guard      string // primary guard symbol (evidence)
+	Scopes     []string
+	Roles      []string
+	Confidence string // "high" | "medium" | "low"
+	found      bool   // an explicit auth signal was recognised
+	publicSet  bool   // an explicit public marker was recognised (AllowAny)
+}
+
+// stamp writes the resolved posture onto an endpoint Properties map, mirroring
+// the Java/JS-TS flat contract. It is a no-op when no auth signal was found AND
+// no explicit-public marker was set, leaving the endpoint's posture "unknown"
+// (the caller/detector decides default-deny vs default-allow per repo).
+func (a pyEndpointAuth) stamp(props map[string]string) {
+	if props == nil {
+		return
+	}
+	if !a.found && !a.publicSet {
+		return
+	}
+	if a.found {
+		props["auth_required"] = "true"
+		props["auth_method"] = a.Method
+		props["auth_confidence"] = a.Confidence
+		if a.Guard != "" {
+			props["auth_guard"] = a.Guard
+		}
+		if len(a.Scopes) > 0 {
+			s := append([]string(nil), a.Scopes...)
+			sort.Strings(s)
+			props["auth_scopes"] = strings.Join(s, ",")
+		}
+		if len(a.Roles) > 0 {
+			r := append([]string(nil), a.Roles...)
+			sort.Strings(r)
+			props["auth_roles"] = strings.Join(r, ",")
+		}
+		return
+	}
+	// Explicit public (AllowAny / @permission_classes([AllowAny])).
+	props["auth_required"] = "false"
+	props["auth_method"] = a.Method
+	props["auth_confidence"] = a.Confidence
+}
+
+// ---------------------------------------------------------------------------
+// FastAPI: Depends / Security in the route signature + dependencies= kwarg
+// ---------------------------------------------------------------------------
+
+// faSecurityCallRe captures a `Security(dep, scopes=[...])` call so we can pull
+// both the dependency function and its OAuth2 scopes. Group 1 = dependency
+// symbol, group 2 = the raw scopes list (may be empty).
+var faSecurityCallRe = regexp.MustCompile(
+	`Security\s*\(\s*([A-Za-z_][\w.]*)\s*(?:,[^)]*scopes\s*=\s*\[([^\]]*)\])?[^)]*\)`)
+
+// faDependsCallRe captures a `Depends(dep)` call. Group 1 = dependency symbol.
+// A bare `Depends()` (no arg, FastAPI infers from the type annotation) yields
+// no guard symbol but still counts as a dependency-injection site.
+var faDependsCallRe = regexp.MustCompile(`Depends\s*\(\s*([A-Za-z_][\w.]*)?\s*\)`)
+
+// faQuotedRe pulls quoted tokens out of a scopes / roles list.
+var faQuotedRe = regexp.MustCompile(`['"]([^'"]+)['"]`)
+
+// faAuthDependencyNames recognises whether a FastAPI dependency function is an
+// AUTH dependency (vs. a plain DI dependency like `get_db`). FastAPI has no
+// syntactic auth marker — auth is a convention — so we recognise the dominant
+// auth-dependency naming idioms. A Security(...) call is *always* auth
+// (OAuth2/scopes), regardless of name.
+var faAuthDependencyRe = regexp.MustCompile(
+	`(?i)(?:current[_]?user|active[_]?user|authenticated|auth|oauth|jwt|token|login|` +
+		`verify[_]?token|get[_]?user|require[_]?|principal|identity|api[_]?key|bearer|session[_]?user|scopes?)`)
+
+// resolveFastAPIRouteAuth scans a FastAPI route block (the decorator line
+// through the handler signature) for Depends()/Security() auth dependencies and
+// the route-level `dependencies=[...]` kwarg. `signature` is the handler def's
+// parameter region; `decoratorArgs` is the route decorator's argument list
+// (where `dependencies=[Depends(...)]` may appear).
+func resolveFastAPIRouteAuth(signature, decoratorArgs string) pyEndpointAuth {
+	var a pyEndpointAuth
+
+	// 1. Security(dep, scopes=[...]) anywhere in the signature → always auth.
+	if m := faSecurityCallRe.FindStringSubmatch(signature); m != nil {
+		a.found = true
+		a.Method = "dependency"
+		a.Confidence = "high"
+		a.Guard = leafSymbol(m[1])
+		if len(m) > 2 && m[2] != "" {
+			for _, q := range faQuotedRe.FindAllStringSubmatch(m[2], -1) {
+				if tok := strings.TrimSpace(q[1]); tok != "" {
+					a.Scopes = append(a.Scopes, tok)
+				}
+			}
+		}
+		return a
+	}
+
+	// 2. dependencies=[Depends(verify_token)] route/router kwarg → auth when the
+	//    dependency name reads as an auth guard.
+	if g, ok := faDependenciesKwargAuth(decoratorArgs); ok {
+		a.found = true
+		a.Method = "dependency"
+		a.Confidence = "high"
+		a.Guard = g
+		return a
+	}
+
+	// 3. Depends(get_current_user) in the signature → auth when the dependency
+	//    name reads as an auth guard. A plain `Depends(get_db)` is NOT auth.
+	for _, m := range faDependsCallRe.FindAllStringSubmatch(signature, -1) {
+		dep := m[1]
+		if dep == "" {
+			continue
+		}
+		if faAuthDependencyRe.MatchString(leafSymbol(dep)) {
+			a.found = true
+			a.Method = "dependency"
+			a.Confidence = "high"
+			a.Guard = leafSymbol(dep)
+			return a
+		}
+	}
+
+	return a
+}
+
+// faDependenciesKwargAuth inspects a route/router-decorator argument list for a
+// `dependencies=[Depends(x), Security(y, scopes=[...])]` kwarg and reports the
+// first recognised auth guard. Returns (guard, true) on a match.
+func faDependenciesKwargAuth(decoratorArgs string) (string, bool) {
+	idx := strings.Index(decoratorArgs, "dependencies")
+	if idx < 0 {
+		return "", false
+	}
+	region := decoratorArgs[idx:]
+	if sm := faSecurityCallRe.FindStringSubmatch(region); sm != nil {
+		return leafSymbol(sm[1]), true
+	}
+	for _, m := range faDependsCallRe.FindAllStringSubmatch(region, -1) {
+		if m[1] != "" && faAuthDependencyRe.MatchString(leafSymbol(m[1])) {
+			return leafSymbol(m[1]), true
+		}
+	}
+	return "", false
+}
+
+// ---------------------------------------------------------------------------
+// Flask: @login_required / @roles_required('x') / @permission_required('x')
+// ---------------------------------------------------------------------------
+
+// flAuthDecoratorRe captures a Flask-Login / Flask-Security / Flask-Principal
+// auth decorator on a route. Group 1 = decorator name, group 2 = the raw
+// argument list (roles/permissions, may be empty for @login_required).
+var flAuthDecoratorRe = regexp.MustCompile(
+	`@(login_required|fresh_login_required|roles_required|roles_accepted|` +
+		`permission_required|auth_required|auth\.login_required|token_required|jwt_required|` +
+		`admin_required|requires_auth)\b\s*(?:\(([^)]*)\))?`)
+
+// resolveFlaskDecoratorAuth scans the decorator block preceding a Flask route
+// handler for a recognised auth decorator. `decoratorBlock` is the text between
+// the route decorator and the `def` (the stacked decorators).
+func resolveFlaskDecoratorAuth(decoratorBlock string) pyEndpointAuth {
+	var a pyEndpointAuth
+	m := flAuthDecoratorRe.FindStringSubmatch(decoratorBlock)
+	if m == nil {
+		return a
+	}
+	a.found = true
+	a.Method = "decorator"
+	a.Confidence = "high"
+	a.Guard = m[1]
+	if len(m) > 2 && m[2] != "" {
+		for _, q := range faQuotedRe.FindAllStringSubmatch(m[2], -1) {
+			if tok := strings.TrimSpace(q[1]); tok != "" {
+				a.Roles = append(a.Roles, tok)
+			}
+		}
+	}
+	return a
+}
+
+// ---------------------------------------------------------------------------
+// DRF: per-method @permission_classes([...]) / @action(permission_classes=[...])
+// ---------------------------------------------------------------------------
+
+// drfPermissionClassesRe captures a `@permission_classes([IsAdminUser])`
+// decorator. Group 1 = the raw class list.
+var drfPermissionClassesRe = regexp.MustCompile(`@permission_classes\s*\(\s*\[([^\]]*)\]`)
+
+// drfActionPermsRe captures the `permission_classes=[...]` kwarg inside an
+// `@action(...)` (or `@api_view`-adjacent) decorator. Group 1 = the raw list.
+var drfActionPermsRe = regexp.MustCompile(`permission_classes\s*=\s*\[([^\]]*)\]`)
+
+// drfPublicPermissions are permission classes that grant anonymous access; an
+// endpoint whose ONLY permission classes are public markers is explicitly open.
+var drfPublicPermissions = map[string]bool{
+	"AllowAny": true,
+}
+
+// resolveDRFDecoratorAuth scans a decorator block for a per-method DRF
+// permission declaration. Returns a posture that is `found` (protected) when a
+// non-public permission class is present, or `publicSet` when the only
+// permission class is AllowAny.
+func resolveDRFDecoratorAuth(decoratorBlock string) pyEndpointAuth {
+	var a pyEndpointAuth
+	var raw string
+	if m := drfPermissionClassesRe.FindStringSubmatch(decoratorBlock); m != nil {
+		raw = m[1]
+	} else if m := drfActionPermsRe.FindStringSubmatch(decoratorBlock); m != nil {
+		raw = m[1]
+	} else {
+		return a
+	}
+
+	classes := drfPermClassList(raw)
+	if len(classes) == 0 {
+		return a
+	}
+	nonPublic := make([]string, 0, len(classes))
+	for _, c := range classes {
+		if !drfPublicPermissions[c] {
+			nonPublic = append(nonPublic, c)
+		}
+	}
+	if len(nonPublic) == 0 {
+		// Only AllowAny → explicitly public.
+		a.publicSet = true
+		a.Method = "permission_classes"
+		a.Confidence = "high"
+		return a
+	}
+	a.found = true
+	a.Method = "permission_classes"
+	a.Confidence = "high"
+	a.Guard = nonPublic[0]
+	// Role-bearing permission classes (IsAdminUser → ADMIN) are surfaced as a
+	// guard only; DRF permission classes are opaque policies, not named roles,
+	// so we do not synthesise speculative role strings.
+	return a
+}
+
+// drfPermClassList parses a permission-class list literal into leaf class
+// names, dropping module qualifiers and call args
+// (`permissions.IsAdminUser` → `IsAdminUser`, `HasScope("x")` → `HasScope`).
+func drfPermClassList(raw string) []string {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if leaf := leafSymbol(strings.TrimSpace(part)); leaf != "" {
+			out = append(out, leaf)
+		}
+	}
+	return out
+}
+
+// pyCallArgRegion returns the source span from `open` (the index just after an
+// open paren) to its matching close paren, tracking nested parens / brackets /
+// braces and skipping string literals. Used to isolate a handler def's
+// parameter region so multi-line signatures (the FastAPI norm) are scanned in
+// full. Bounded so a missing close paren can't run away.
+func pyCallArgRegion(source string, open int) string {
+	depth := 1
+	i := open
+	for i < len(source) && i-open < 8192 {
+		c := source[i]
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return source[open:i]
+			}
+		case '"', '\'':
+			i = pySkipString(source, i, c)
+			continue
+		}
+		i++
+	}
+	end := open + 8192
+	if end > len(source) {
+		end = len(source)
+	}
+	return source[open:end]
+}
+
+// pySkipString advances past a quoted string literal starting at `i` (whose
+// quote char is q), honouring backslash escapes. Returns the index of the char
+// after the closing quote (or len(source) if unterminated).
+func pySkipString(source string, i int, q byte) int {
+	i++
+	for i < len(source) {
+		c := source[i]
+		if c == '\\' {
+			i += 2
+			continue
+		}
+		if c == q {
+			return i + 1
+		}
+		i++
+	}
+	return len(source)
+}
+
+// leafSymbol reduces a dotted / called reference to its bare leaf identifier:
+// `permissions.IsAdminUser` → `IsAdminUser`, `deps.get_user()` → `get_user`.
+func leafSymbol(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if paren := strings.IndexByte(ref, '('); paren >= 0 {
+		ref = ref[:paren]
+	}
+	if dot := strings.LastIndexByte(ref, '.'); dot >= 0 {
+		ref = ref[dot+1:]
+	}
+	return strings.TrimSpace(ref)
+}

--- a/internal/custom/python/auth_endpoint_test.go
+++ b/internal/custom/python/auth_endpoint_test.go
@@ -1,0 +1,186 @@
+package python_test
+
+import "testing"
+
+// findEndpoint returns the route-endpoint extractResult whose path property
+// matches, or fails the test.
+func findEndpoint(t *testing.T, ents []extractResult, path string) extractResult {
+	t.Helper()
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "endpoint" && e.Props["path"] == path {
+			return e
+		}
+	}
+	t.Fatalf("no endpoint with path %q (got %d entities)", path, len(ents))
+	return extractResult{}
+}
+
+// ---------------------------------------------------------------------------
+// FastAPI endpoint protection (#3628 area #6)
+// ---------------------------------------------------------------------------
+
+func TestFastAPIAuth_DependsCurrentUser(t *testing.T) {
+	src := `
+from fastapi import FastAPI, Depends
+app = FastAPI()
+
+@app.get("/me")
+def read_me(user = Depends(get_current_user)):
+    return user
+`
+	ents := extract(t, "python_fastapi", src)
+	e := findEndpoint(t, ents, "/me")
+	if e.Props["auth_required"] != "true" {
+		t.Fatalf("/me auth_required = %q, want true", e.Props["auth_required"])
+	}
+	if e.Props["auth_guard"] != "get_current_user" {
+		t.Fatalf("/me auth_guard = %q, want get_current_user", e.Props["auth_guard"])
+	}
+	if e.Props["auth_method"] != "dependency" {
+		t.Fatalf("/me auth_method = %q, want dependency", e.Props["auth_method"])
+	}
+}
+
+func TestFastAPIAuth_SecurityScopes(t *testing.T) {
+	src := `
+from fastapi import FastAPI, Security
+app = FastAPI()
+
+@app.get("/items")
+def list_items(user = Security(get_user, scopes=["items:read", "items:list"])):
+    return []
+`
+	ents := extract(t, "python_fastapi", src)
+	e := findEndpoint(t, ents, "/items")
+	if e.Props["auth_required"] != "true" {
+		t.Fatalf("/items auth_required = %q, want true", e.Props["auth_required"])
+	}
+	if e.Props["auth_guard"] != "get_user" {
+		t.Fatalf("/items auth_guard = %q, want get_user", e.Props["auth_guard"])
+	}
+	if e.Props["auth_scopes"] != "items:list,items:read" {
+		t.Fatalf("/items auth_scopes = %q, want items:list,items:read", e.Props["auth_scopes"])
+	}
+}
+
+func TestFastAPIAuth_DependenciesKwarg(t *testing.T) {
+	src := `
+from fastapi import FastAPI, Depends
+app = FastAPI()
+
+@app.post("/admin", dependencies=[Depends(verify_token)])
+def do_admin():
+    return {}
+`
+	ents := extract(t, "python_fastapi", src)
+	e := findEndpoint(t, ents, "/admin")
+	if e.Props["auth_required"] != "true" {
+		t.Fatalf("/admin auth_required = %q, want true", e.Props["auth_required"])
+	}
+	if e.Props["auth_guard"] != "verify_token" {
+		t.Fatalf("/admin auth_guard = %q, want verify_token", e.Props["auth_guard"])
+	}
+}
+
+// Negative: a plain (non-auth) dependency must NOT mark the endpoint protected.
+func TestFastAPIAuth_PlainDependencyNotProtected(t *testing.T) {
+	src := `
+from fastapi import FastAPI, Depends
+app = FastAPI()
+
+@app.get("/widgets")
+def list_widgets(db = Depends(get_db)):
+    return []
+`
+	ents := extract(t, "python_fastapi", src)
+	e := findEndpoint(t, ents, "/widgets")
+	if v, ok := e.Props["auth_required"]; ok {
+		t.Fatalf("/widgets should have no auth_required, got %q", v)
+	}
+	if v, ok := e.Props["auth_guard"]; ok {
+		t.Fatalf("/widgets should have no auth_guard, got %q", v)
+	}
+}
+
+// Negative: an endpoint with no dependency at all is unprotected.
+func TestFastAPIAuth_NoDependencyUnprotected(t *testing.T) {
+	src := `
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+`
+	ents := extract(t, "python_fastapi", src)
+	e := findEndpoint(t, ents, "/health")
+	if _, ok := e.Props["auth_required"]; ok {
+		t.Fatalf("/health should be unprotected, got auth_required=%q", e.Props["auth_required"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flask endpoint protection (#3628 area #6)
+// ---------------------------------------------------------------------------
+
+func TestFlaskAuth_LoginRequired(t *testing.T) {
+	src := `
+from flask import Flask
+from flask_login import login_required
+app = Flask(__name__)
+
+@app.route("/dashboard")
+@login_required
+def dashboard():
+    return "ok"
+`
+	ents := extract(t, "python_flask", src)
+	e := findEndpoint(t, ents, "/dashboard")
+	if e.Props["auth_required"] != "true" {
+		t.Fatalf("/dashboard auth_required = %q, want true", e.Props["auth_required"])
+	}
+	if e.Props["auth_guard"] != "login_required" {
+		t.Fatalf("/dashboard auth_guard = %q, want login_required", e.Props["auth_guard"])
+	}
+	if e.Props["auth_method"] != "decorator" {
+		t.Fatalf("/dashboard auth_method = %q, want decorator", e.Props["auth_method"])
+	}
+}
+
+func TestFlaskAuth_RolesRequired(t *testing.T) {
+	src := `
+from flask import Flask
+from flask_security import roles_required
+app = Flask(__name__)
+
+@app.get("/admin")
+@roles_required('admin', 'superuser')
+def admin_panel():
+    return "ok"
+`
+	ents := extract(t, "python_flask", src)
+	e := findEndpoint(t, ents, "/admin")
+	if e.Props["auth_required"] != "true" {
+		t.Fatalf("/admin auth_required = %q, want true", e.Props["auth_required"])
+	}
+	if e.Props["auth_roles"] != "admin,superuser" {
+		t.Fatalf("/admin auth_roles = %q, want admin,superuser", e.Props["auth_roles"])
+	}
+}
+
+// Negative: an unguarded Flask route is unprotected.
+func TestFlaskAuth_NoDecoratorUnprotected(t *testing.T) {
+	src := `
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/public")
+def public():
+    return "hi"
+`
+	ents := extract(t, "python_flask", src)
+	e := findEndpoint(t, ents, "/public")
+	if _, ok := e.Props["auth_required"]; ok {
+		t.Fatalf("/public should be unprotected, got auth_required=%q", e.Props["auth_required"])
+	}
+}

--- a/internal/custom/python/fastapi.go
+++ b/internal/custom/python/fastapi.go
@@ -37,7 +37,7 @@ func (e *FastAPIExtractor) Language() string { return "python_fastapi" }
 var (
 	faRouteDecoratorRe = regexp.MustCompile(
 		`(?m)@(\w+)\.(get|post|put|delete|patch|head|options|trace)\s*` +
-			`\(\s*(?:r)?["']([^"']*)["'][^)]*\)\s*\n` +
+			`\(\s*(?:r)?["']([^"']*)["']((?:[^()]|\([^()]*\))*)\)\s*\n` +
 			`(?:\s*(?:#[^\n]*)?\n)*` +
 			`\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	faDependsParamRe = regexp.MustCompile(`=\s*Depends\s*\(\s*(\w+)\s*\)`)
@@ -80,10 +80,17 @@ func (e *FastAPIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		appName := source[idx[2]:idx[3]]
 		httpMethod := strings.ToUpper(source[idx[4]:idx[5]])
 		path := source[idx[6]:idx[7]]
-		handlerName := source[idx[8]:idx[9]]
+		decoratorArgs := source[idx[8]:idx[9]]
+		handlerName := source[idx[10]:idx[11]]
 		line := lineOf(source, idx[0])
-		out = append(out, entity(handlerName, "SCOPE.Operation", "endpoint", file.Path, line,
-			map[string]string{"framework": "fastapi", "pattern_type": "route", "http_method": httpMethod, "path": path, "app_name": appName}))
+		props := map[string]string{"framework": "fastapi", "pattern_type": "route", "http_method": httpMethod, "path": path, "app_name": appName}
+		// #3628 area #6 — endpoint protection. The handler's def signature is the
+		// open-paren the route regex anchored on (idx[1] is just past `def name(`);
+		// scan from there to the matching close-paren for Depends()/Security() auth
+		// dependencies, and the decorator args for a `dependencies=[...]` kwarg.
+		sig := pyCallArgRegion(source, idx[1])
+		resolveFastAPIRouteAuth(sig, decoratorArgs).stamp(props)
+		out = append(out, entity(handlerName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
 	// 2. Depends() injection

--- a/internal/custom/python/flask.go
+++ b/internal/custom/python/flask.go
@@ -74,8 +74,13 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			methods = parseHTTPMethods(mm[1])
 		}
 		line := lineOf(source, idx[0])
-		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line,
-			map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": methods, "blueprint": appVar}))
+		props := map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": methods, "blueprint": appVar}
+		// #3628 area #6 — endpoint protection. The full match spans the route
+		// decorator through the stacked decorators to `def`; scan it for a
+		// Flask-Login / Flask-Security auth decorator (the route decorator itself
+		// is never an auth decorator, so it can't false-positive).
+		resolveFlaskDecoratorAuth(source[idx[0]:idx[1]]).stamp(props)
+		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
 	// 2. HTTP method shorthand (@app.get, @app.post, etc.)
@@ -85,8 +90,9 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		path := source[idx[6]:idx[7]]
 		funcName := source[idx[10]:idx[11]]
 		line := lineOf(source, idx[0])
-		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line,
-			map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": httpMethod, "blueprint": appVar}))
+		props := map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": httpMethod, "blueprint": appVar}
+		resolveFlaskDecoratorAuth(source[idx[0]:idx[1]]).stamp(props)
+		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
 	// 3. Blueprints

--- a/internal/extractors/python/django_drf_actions.go
+++ b/internal/extractors/python/django_drf_actions.go
@@ -148,6 +148,11 @@ func scanClassBodyForActions(body *sitter.Node, parentClass string, file extract
 			for k, v := range props {
 				op.Properties[k] = v
 			}
+			// #3628 area #6 — endpoint protection. Normalise the @action's
+			// permission_classes into the cross-framework auth contract so the
+			// parity oracle / archigraph_auth_coverage reads DRF action guards the
+			// same way as Spring/FastAPI/Express.
+			stampDRFActionAuth(op.Properties)
 		}
 
 		// Also stamp on the parent class as a `decorator_<method>` property so

--- a/internal/extractors/python/django_drf_actions_test.go
+++ b/internal/extractors/python/django_drf_actions_test.go
@@ -58,11 +58,61 @@ class ContractViewSet:
 		"serializer_class":   "AssignContactsSerializer",
 		"url_path":           "assign",
 		"permission_classes": "IsAdmin",
+		// #3628 area #6 — endpoint protection normalised onto the action.
+		"auth_required":   "true",
+		"auth_guard":      "IsAdmin",
+		"auth_method":     "permission_classes",
+		"auth_confidence": "high",
 	}
 	for k, want := range checks {
 		if got := op.Properties[k]; got != want {
 			t.Errorf("Properties[%q] = %q, want %q", k, got, want)
 		}
+	}
+}
+
+// TestDRFAction_AllowAnyIsPublic verifies a per-action permission_classes of
+// only [AllowAny] marks the endpoint explicitly public (auth_required=false),
+// not protected. #3628 area #6.
+func TestDRFAction_AllowAnyIsPublic(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+class PublicViewSet:
+    @action(detail=False, methods=["get"], permission_classes=[AllowAny])
+    def ping(self, request):
+        return None
+`
+	out := extractPy(t, src, "api/views.py")
+	op := findDRFOp(out, "api/views.py", "PublicViewSet.ping")
+	if op == nil {
+		t.Fatalf("expected PublicViewSet.ping operation entity")
+	}
+	if got := op.Properties["auth_required"]; got != "false" {
+		t.Errorf("auth_required = %q, want \"false\"", got)
+	}
+	if got := op.Properties["auth_guard"]; got != "" {
+		t.Errorf("auth_guard = %q, want empty (public)", got)
+	}
+}
+
+// TestDRFAction_NoPermissionInherits verifies an action WITHOUT a per-action
+// permission_classes does not get an auth_required stamp here — it inherits the
+// class-level posture (django_drf_permissions.go). #3628 area #6.
+func TestDRFAction_NoPermissionInherits(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+class InheritViewSet:
+    @action(detail=True, methods=["post"])
+    def archive(self, request):
+        return None
+`
+	out := extractPy(t, src, "api/views.py")
+	op := findDRFOp(out, "api/views.py", "InheritViewSet.archive")
+	if op == nil {
+		t.Fatalf("expected InheritViewSet.archive operation entity")
+	}
+	if _, ok := op.Properties["auth_required"]; ok {
+		t.Errorf("auth_required should be unset (inherits class posture), got %q", op.Properties["auth_required"])
 	}
 }
 

--- a/internal/extractors/python/django_drf_permissions.go
+++ b/internal/extractors/python/django_drf_permissions.go
@@ -121,6 +121,48 @@ func applyDRFPermissionProperties(parent *types.EntityRecord, classBody *sitter.
 	}
 }
 
+// drfPublicPermissionClasses are DRF permission classes that grant anonymous
+// access; an endpoint whose only permission class is one of these is open.
+var drfPublicPermissionClasses = map[string]bool{
+	"AllowAny": true,
+}
+
+// stampDRFActionAuth normalises a per-action `permission_classes` property
+// (set by the @action kwarg parser) into the cross-framework auth contract
+// (auth_required / auth_method / auth_confidence / auth_guard), mirroring the
+// Spring (java_auth_policy.go), FastAPI and Express resolvers. It is a no-op
+// when no permission_classes property is present (the action inherits the
+// class-level posture stamped by applyDRFPermissionProperties). An explicit
+// `[AllowAny]` marks the endpoint public.
+func stampDRFActionAuth(props map[string]string) {
+	if props == nil {
+		return
+	}
+	raw, ok := props["permission_classes"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return
+	}
+	var nonPublic []string
+	for _, p := range strings.Split(raw, ",") {
+		leaf := permissionLeafName(p)
+		if leaf == "" {
+			continue
+		}
+		if !drfPublicPermissionClasses[leaf] {
+			nonPublic = append(nonPublic, leaf)
+		}
+	}
+	props["auth_method"] = "permission_classes"
+	props["auth_confidence"] = "high"
+	if len(nonPublic) == 0 {
+		// Only AllowAny → explicitly public.
+		props["auth_required"] = "false"
+		return
+	}
+	props["auth_required"] = "true"
+	props["auth_guard"] = nonPublic[0]
+}
+
 // isGetPermissionsDef reports whether fnDef is `def get_permissions(self):`.
 func isGetPermissionsDef(fnDef *sitter.Node, src []byte) bool {
 	if fnDef == nil {


### PR DESCRIPTION
Closes #3694 (child of #3628 area #6 — "Auth row unverified for 155 frameworks").

## What
Attaches endpoint-protection metadata directly onto the route-endpoint `SCOPE.Operation` entity for the dominant non-NestJS Python frameworks, so the rewrite-parity oracle (and `archigraph_auth_coverage`) knows *which* endpoints are protected and *by what*. Uses the same flat contract as the Java (`java_auth_policy.go`) and JS/TS (`http_endpoint_jsts_auth.go`) resolvers, and the MCP signal-2 `auth_guard` key:

`auth_required` / `auth_method` / `auth_confidence` / `auth_guard` / `auth_scopes` / `auth_roles`

## Frameworks now marking endpoint protection
| Framework | Surface | Method |
|---|---|---|
| **FastAPI** | `Depends(get_current_user)`, `Security(get_user, scopes=[...])`, route `dependencies=[Depends(verify_token)]` | `dependency` |
| **Flask** | `@login_required` / `@roles_required('admin')` / `@permission_required` / `@jwt_required` | `decorator` |
| **DRF** | per-action `@action(permission_classes=[IsAdmin])` (`[AllowAny]` → public) | `permission_classes` |

NestJS (#3649), Spring Security (`java_auth_policy.go`) and Express (`http_endpoint_jsts_auth.go`) already stamped the endpoint — this closes the remaining dominant Python gap. Auth `Depends` are distinguished from plain DI (`get_db`) by name idiom; `Security(...)` is always auth and carries scopes. Honest-partial: dynamic / cross-file dependency or `get_permissions()` resolution out of scope (class-level DRF stays in `django_drf_permissions.go` #2816).

## Protected endpoints asserted (value-asserting, not len>0)
- FastAPI `/me` `Depends(get_current_user)` → `auth_required=true`, `auth_guard=get_current_user`, `auth_method=dependency`
- FastAPI `/items` `Security(get_user, scopes=["items:read","items:list"])` → `auth_scopes=items:list,items:read`
- FastAPI `/admin` `dependencies=[Depends(verify_token)]` → `auth_guard=verify_token`
- Flask `/dashboard` `@login_required` → `auth_required=true`, `auth_guard=login_required`, `auth_method=decorator`
- Flask `/admin` `@roles_required('admin','superuser')` → `auth_roles=admin,superuser`
- DRF `@action(permission_classes=[IsAdmin])` → `auth_required=true`, `auth_guard=IsAdmin`, `auth_method=permission_classes`

Negatives: FastAPI `Depends(get_db)` and unguarded routes → no `auth_required`; DRF `[AllowAny]` → `auth_required=false`; DRF action w/o per-action perms → no stamp (inherits class posture).

## Quality gates
- `go test` targeted green: `internal/custom/python/`, `internal/extractors/python/`, `internal/engine/`, `internal/types/`, `tools/coverage/`
- `coverage validate`: 0 errors; `coverage fmt --check`: canonical (surgical 9/8-line diff)
- `gofmt -l` empty on all touched files; `go vet` clean
- Registry: FastAPI / Flask / django-drf Auth cells re-cited to the real per-endpoint extractor + tests

## DEPLOY-DEFERRED
Extractor change — requires a coordinated live-daemon rebuild + reindex before the new endpoint auth properties appear in served graphs. No daemon/index/MCP operations performed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)