### PR TITLE
[jobs] Sidekiq background-job topology — ENQUEUES edge + sidekiq-cron

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -37,6 +37,6 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🔴 | 🔴 | — | 🔴 | |
+| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | 🟢 | |
 | [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -73,4 +73,4 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Category | Status | Notes |
 |---|---|---|---|
-| [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | [message_broker](../by-category/message_broker.md) | 🔴 | |
+| [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |

--- a/docs/coverage/detail/msg.sidekiq.md
+++ b/docs/coverage/detail/msg.sidekiq.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Consumer extraction | 🔴 `missing` | — | — | — | — |
-| Producer extraction | 🔴 `missing` | — | — | — | — |
+| Consumer extraction | 🟢 `partial` | — | 3700 | `internal/engine/scheduled_jobs_edges.go`<br>`internal/engine/scheduled_jobs_edges_test.go` | #3700 (epic #3628 area #14): a class including Sidekiq::Worker/Job with def perform becomes a SCOPE.ScheduledJob (sidekiq:<Worker>) with a TRIGGERS edge to perform (the job consumer). sidekiq-cron Sidekiq::Cron::Job.create(cron:,class:) attaches the cron schedule to the same worker job. Honest-partial: requires include + def perform in one file; YAML-loaded cron schedules and dynamic class refs not yet parsed. |
+| Producer extraction | 🟢 `partial` | — | 3700 | `internal/engine/scheduled_jobs_edges.go`<br>`internal/engine/scheduled_jobs_edges_test.go` | #3700 (epic #3628 area #14): Worker.perform_async/perform_in/perform_at/perform_bulk dispatch sites emit an ENQUEUES edge (new kind) from the enclosing Ruby method to the worker job entity (SCOPE.ScheduledJob sidekiq:<Worker>). Honest-partial: enqueue target resolves only when the worker class def is in the indexed group; dynamic class names not resolved. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -59174,10 +59174,16 @@
       "label": "Sidekiq (Ruby task queue)",
       "capabilities": {
         "consumer_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3700",
+          "notes": "#3700 (epic #3628 area #14): a class including Sidekiq::Worker/Job with def perform becomes a SCOPE.ScheduledJob (sidekiq:\u003cWorker\u003e) with a TRIGGERS edge to perform (the job consumer). sidekiq-cron Sidekiq::Cron::Job.create(cron:,class:) attaches the cron schedule to the same worker job. Honest-partial: requires include + def perform in one file; YAML-loaded cron schedules and dynamic class refs not yet parsed."
         },
         "producer_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3700",
+          "notes": "#3700 (epic #3628 area #14): Worker.perform_async/perform_in/perform_at/perform_bulk dispatch sites emit an ENQUEUES edge (new kind) from the enclosing Ruby method to the worker job entity (SCOPE.ScheduledJob sidekiq:\u003cWorker\u003e). Honest-partial: enqueue target resolves only when the worker class def is in the indexed group; dynamic class names not resolved."
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 40 (19 active · 21 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
 
 ## Coverage by language
 
@@ -47,7 +47,6 @@
 
 | Language |
 |---|
-| [Avro](by-language/avro.md) |
 | [Bicep](by-language/bicep.md) |
 | [Clojure](by-language/clojure.md) |
 | [Crystal](by-language/crystal.md) |
@@ -56,7 +55,6 @@
 | [F#](by-language/fsharp.md) |
 | [Haskell](by-language/haskell.md) |
 | [Idris](by-language/idris.md) |
-| [Jsonschema](by-language/jsonschema.md) |
 | [Lisp](by-language/lisp.md) |
 | [Nim](by-language/nim.md) |
 | [OCaml](by-language/ocaml.md) |

--- a/internal/engine/scheduled_jobs_edges.go
+++ b/internal/engine/scheduled_jobs_edges.go
@@ -123,6 +123,14 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeQuarkusScheduled(src, path, lang, emitJob)
 	case "go":
 		synthesizeGoCron(src, path, emitJob)
+	case "ruby":
+		// #3700: Sidekiq worker jobs + sidekiq-cron scheduled jobs, plus
+		// ENQUEUES edges from `Worker.perform_async/in/at` dispatch sites to
+		// the worker job entity. synthesizeRubySidekiq registers job IDs into
+		// seenJob; synthesizeSidekiqEnqueueEdges resolves dispatch call sites
+		// to those IDs and appends the caller→job ENQUEUES edges.
+		synthesizeRubySidekiq(src, path, emitJob)
+		relationships = synthesizeSidekiqEnqueueEdges(src, seenJob, relationships)
 	}
 
 	// YAML-based detectors run regardless of `lang` because the language
@@ -590,6 +598,185 @@ func synthesizeGoCron(
 		jobID := "go_cron:" + path + ":" + expr
 		emitJob(jobID, handler, expr, "go_cron", nil)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Ruby — Sidekiq workers + sidekiq-cron (#3700)
+// ---------------------------------------------------------------------------
+//
+// A Sidekiq worker is a class that `include Sidekiq::Worker` (or the newer
+// `Sidekiq::Job`) and defines `def perform`. The async execution of that
+// `perform` method IS the background job, so we model the worker as a
+// SCOPE.ScheduledJob entity and emit a TRIGGERS edge to the `perform`
+// handler (the runtime invokes perform when the job is popped off the queue).
+//
+// Dispatch happens at `Worker.perform_async/perform_in/perform_at(...)` call
+// sites; each such call ENQUEUES work onto the queue. We emit an ENQUEUES
+// edge from the enclosing Ruby method to the worker's job entity.
+//
+// sidekiq-cron declares recurring jobs via `Sidekiq::Cron::Job.create(
+// name: '...', cron: 'EXPR', class: 'SomeWorker')` (or a YAML schedule loaded
+// through `Sidekiq::Cron::Job.load_from_hash`). The `cron:` expression is the
+// schedule; the `class:` value is the worker that runs.
+
+// rubySidekiqWorkerJobID is the canonical job-entity ID for a Sidekiq worker
+// class. Stable across files (no path) so a `perform_async` dispatch in one
+// file resolves to the worker job defined in another. Cron jobs reuse the
+// same ID when their `class:` names the worker, so the scheduled job and the
+// dispatch target collapse onto one node.
+func rubySidekiqWorkerJobID(workerClass string) string {
+	return "sidekiq:" + workerClass
+}
+
+// reRubySidekiqClass captures a `class Foo` (or `class Foo::Bar`) declaration.
+// Group 1 = class name.
+var reRubySidekiqClass = regexp.MustCompile(`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*)`)
+
+// reRubySidekiqInclude matches `include Sidekiq::Worker` / `include Sidekiq::Job`.
+var reRubySidekiqInclude = regexp.MustCompile(`(?m)^\s*include\s+Sidekiq::(?:Worker|Job)\b`)
+
+// reRubySidekiqPerform matches the `def perform` method of a worker.
+var reRubySidekiqPerform = regexp.MustCompile(`(?m)^\s*def\s+perform\b`)
+
+// reRubySidekiqDispatch captures `Worker.perform_async(...)` /
+// `Worker.perform_in(...)` / `Worker.perform_at(...)` dispatch sites.
+// Group 1 = worker class, group 2 = dispatch method.
+var reRubySidekiqDispatch = regexp.MustCompile(`([A-Z][A-Za-z0-9_:]*)\.(perform_async|perform_in|perform_at|perform_bulk)\b`)
+
+// reRubySidekiqCron captures sidekiq-cron job declarations. We match the
+// `cron:` and `class:` kwargs of a `Sidekiq::Cron::Job.create`/`load_from_hash`
+// block within a single literal hash. Two narrowly-scoped regexes pull the
+// cron expression and the worker class respectively from the same statement.
+var reRubySidekiqCronCreate = regexp.MustCompile(`Sidekiq::Cron::Job\.(?:create|load_from_hash!?)`)
+var reRubySidekiqCronExpr = regexp.MustCompile(`(?m)['"]?cron['"]?\s*(?:=>|:)\s*['"]([^'"]+)['"]`)
+var reRubySidekiqCronClass = regexp.MustCompile(`(?m)['"]?class['"]?\s*(?:=>|:)\s*['"]?([A-Z][A-Za-z0-9_:]*)`)
+
+// reRubyEnclosingMethod captures Ruby `def name` declarations (with or without
+// parentheses). Used to attribute a dispatch call site to its enclosing method.
+var reRubyEnclosingMethod = regexp.MustCompile(`(?m)^\s*def\s+([A-Za-z_][\w?!]*)`)
+
+// rubyEnclosingMethod returns the name of the Ruby method enclosing pos, or
+// "" when the call site is at class/module body level (no enclosing def).
+func rubyEnclosingMethod(src string, pos int) string {
+	if pos > len(src) {
+		pos = len(src)
+	}
+	matches := reRubyEnclosingMethod.FindAllStringSubmatch(src[:pos], -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1][1]
+}
+
+// synthesizeRubySidekiq emits SCOPE.ScheduledJob entities for Sidekiq worker
+// classes (with a TRIGGERS edge to `perform`) and for sidekiq-cron recurring
+// jobs (carrying the cron expression). emitJob registers every job ID into the
+// caller's seenJob map so the ENQUEUES pass can resolve dispatch targets.
+func synthesizeRubySidekiq(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "Sidekiq") && !strings.Contains(src, "perform_async") {
+		return
+	}
+
+	// 1. sidekiq-cron recurring jobs FIRST, so the schedule-carrying variant
+	//    wins the seenJob dedup over the plain worker-class entity below (both
+	//    share the `sidekiq:<Worker>` ID). emitJob already emits the
+	//    TRIGGERS → perform edge for the scheduled variant.
+	if reRubySidekiqCronCreate.MatchString(src) {
+		for _, eloc := range reRubySidekiqCronExpr.FindAllStringSubmatchIndex(src, -1) {
+			expr := src[eloc[2]:eloc[3]]
+			// Find the worker class within the same `create(...)` literal hash.
+			workerClass := ""
+			win := src[eloc[0]:min(eloc[0]+400, len(src))]
+			if cm := reRubySidekiqCronClass.FindStringSubmatch(win); len(cm) >= 2 {
+				workerClass = cm[1]
+			} else {
+				back := src[max(eloc[0]-400, 0):eloc[0]]
+				if cm := reRubySidekiqCronClass.FindStringSubmatch(back); len(cm) >= 2 {
+					workerClass = cm[1]
+				}
+			}
+			var jobID string
+			if workerClass != "" {
+				jobID = rubySidekiqWorkerJobID(workerClass)
+			} else {
+				jobID = "sidekiq_cron:" + path + ":" + expr
+			}
+			emitJob(jobID, "perform", expr, "sidekiq_cron", map[string]string{
+				"worker_class": workerClass,
+				"job_type":     "scheduled",
+			})
+		}
+	}
+
+	// 2. Worker classes: a class that includes Sidekiq::Worker/Job AND defines
+	//    `def perform`. We require both to avoid flagging arbitrary classes.
+	//    Deduped against any cron entity emitted above (same job ID).
+	if reRubySidekiqInclude.MatchString(src) && reRubySidekiqPerform.MatchString(src) {
+		// Attribute each `include Sidekiq::Worker` to the class declared above
+		// it, mirroring internal/custom/ruby/sidekiq.go's class resolution.
+		for _, inc := range reRubySidekiqInclude.FindAllStringIndex(src, -1) {
+			classMatches := reRubySidekiqClass.FindAllStringSubmatch(src[:inc[0]], -1)
+			if len(classMatches) == 0 {
+				continue
+			}
+			workerClass := classMatches[len(classMatches)-1][1]
+			jobID := rubySidekiqWorkerJobID(workerClass)
+			// handler == "perform": the job triggers the worker's perform method.
+			emitJob(jobID, "perform", "", "sidekiq", map[string]string{
+				"worker_class": workerClass,
+				"job_type":     "queue",
+			})
+		}
+	}
+}
+
+// synthesizeSidekiqEnqueueEdges emits ENQUEUES edges from the enclosing Ruby
+// method of each `Worker.perform_async/in/at` dispatch site to the worker's
+// job entity. Only emits when the worker job ID is present in knownJobs (the
+// seenJob map) — this prevents phantom-node creation when the worker class is
+// defined in another, un-indexed file. Dedupes on (caller, jobID).
+func synthesizeSidekiqEnqueueEdges(
+	src string,
+	knownJobs map[string]bool,
+	relationships []types.RelationshipRecord,
+) []types.RelationshipRecord {
+	if !strings.Contains(src, "perform_async") && !strings.Contains(src, "perform_in") &&
+		!strings.Contains(src, "perform_at") && !strings.Contains(src, "perform_bulk") {
+		return relationships
+	}
+
+	seenEdge := map[string]bool{}
+	for _, idx := range reRubySidekiqDispatch.FindAllStringSubmatchIndex(src, -1) {
+		workerClass := src[idx[2]:idx[3]]
+		jobID := rubySidekiqWorkerJobID(workerClass)
+		if !knownJobs[jobID] {
+			continue
+		}
+		caller := rubyEnclosingMethod(src, idx[0])
+		if caller == "" {
+			caller = "module"
+		}
+		key := caller + "|" + jobID
+		if seenEdge[key] {
+			continue
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: "SCOPE.Operation:" + caller,
+			ToID:   scheduledJobKind + ":" + jobID,
+			Kind:   string(types.RelationshipKindEnqueues),
+			Properties: map[string]string{
+				"framework":       "sidekiq",
+				"pattern_type":    "sidekiq_enqueue_synthesis",
+				"worker_class":    workerClass,
+				"dispatch_method": src[idx[4]:idx[5]],
+			},
+		})
+	}
+	return relationships
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/scheduled_jobs_edges_test.go
+++ b/internal/engine/scheduled_jobs_edges_test.go
@@ -395,3 +395,136 @@ func main() {
 		t.Errorf("expected no entities/rels for unrelated file, got %d/%d", len(ents), len(rels))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Ruby — Sidekiq workers + sidekiq-cron + ENQUEUES edges (#3700)
+// ---------------------------------------------------------------------------
+
+func enqueuesEdges(rels []types.RelationshipRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindEnqueues) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// A Sidekiq worker class becomes a ScheduledJob with a TRIGGERS edge to its
+// perform method, and a `Worker.perform_async` dispatch site emits an ENQUEUES
+// edge from the enclosing method to the worker job.
+func TestScheduledJobs_RubySidekiq_EnqueuesEdge(t *testing.T) {
+	src := `class EmailWorker
+  include Sidekiq::Worker
+
+  def perform(user_id)
+    # send the email
+  end
+end
+
+class SignupService
+  def register(user)
+    EmailWorker.perform_async(user.id)
+  end
+end
+`
+	ents, rels := runScheduledDetect(t, "ruby", "app/workers/email_worker.rb", src)
+
+	jobs := scheduledJobsByFramework(ents, "sidekiq")
+	if len(jobs) != 1 {
+		t.Fatalf("expected exactly 1 sidekiq ScheduledJob, got %d (%v)", len(jobs), ents)
+	}
+	job := jobs[0]
+	if job.Name != "sidekiq:EmailWorker" {
+		t.Errorf("expected job ID sidekiq:EmailWorker, got %q", job.Name)
+	}
+	if job.Properties["handler"] != "perform" {
+		t.Errorf("expected handler=perform, got %q", job.Properties["handler"])
+	}
+
+	// TRIGGERS: job -> perform handler.
+	var gotTrigger bool
+	for _, e := range triggersEdges(rels) {
+		if e.FromID == scheduledJobKind+":sidekiq:EmailWorker" && e.ToID == "Function:perform" {
+			gotTrigger = true
+		}
+	}
+	if !gotTrigger {
+		t.Errorf("expected TRIGGERS edge sidekiq:EmailWorker -> Function:perform, got %v", triggersEdges(rels))
+	}
+
+	// ENQUEUES: caller `register` -> worker job.
+	enq := enqueuesEdges(rels)
+	if len(enq) != 1 {
+		t.Fatalf("expected exactly 1 ENQUEUES edge, got %d (%v)", len(enq), enq)
+	}
+	e := enq[0]
+	if e.FromID != "SCOPE.Operation:register" {
+		t.Errorf("expected ENQUEUES from SCOPE.Operation:register, got %q", e.FromID)
+	}
+	if e.ToID != scheduledJobKind+":sidekiq:EmailWorker" {
+		t.Errorf("expected ENQUEUES to %s:sidekiq:EmailWorker, got %q", scheduledJobKind, e.ToID)
+	}
+	if e.Properties["dispatch_method"] != "perform_async" {
+		t.Errorf("expected dispatch_method=perform_async, got %q", e.Properties["dispatch_method"])
+	}
+	if e.Properties["worker_class"] != "EmailWorker" {
+		t.Errorf("expected worker_class=EmailWorker, got %q", e.Properties["worker_class"])
+	}
+}
+
+// sidekiq-cron declares a recurring job carrying a cron expression; it reuses
+// the worker job ID so the scheduled job and the dispatch target are one node.
+func TestScheduledJobs_RubySidekiqCron_Schedule(t *testing.T) {
+	src := `class CleanupWorker
+  include Sidekiq::Job
+
+  def perform
+    Account.stale.delete_all
+  end
+end
+
+Sidekiq::Cron::Job.create(
+  name: 'nightly-cleanup',
+  cron: '0 0 * * *',
+  class: 'CleanupWorker'
+)
+`
+	ents, _ := runScheduledDetect(t, "ruby", "config/schedule.rb", src)
+
+	var cronJob *types.EntityRecord
+	for i := range ents {
+		if ents[i].Properties["framework"] == "sidekiq_cron" {
+			cronJob = &ents[i]
+		}
+	}
+	if cronJob == nil {
+		t.Fatalf("expected a sidekiq_cron ScheduledJob, got %v", ents)
+	}
+	if cronJob.Properties["schedule"] != "0 0 * * *" {
+		t.Errorf("expected cron schedule '0 0 * * *', got %q", cronJob.Properties["schedule"])
+	}
+	if cronJob.Name != "sidekiq:CleanupWorker" {
+		t.Errorf("expected cron job to reuse worker ID sidekiq:CleanupWorker, got %q", cronJob.Name)
+	}
+}
+
+// Negative: a plain Ruby class with no Sidekiq include must not produce any
+// job entity or enqueue edge.
+func TestScheduledJobs_RubyPlainClass_NoJob(t *testing.T) {
+	src := `class Calculator
+  def add(a, b)
+    a + b
+  end
+end
+`
+	ents, rels := runScheduledDetect(t, "ruby", "lib/calculator.rb", src)
+	for _, e := range ents {
+		if e.Kind == scheduledJobKind {
+			t.Errorf("expected no ScheduledJob entity for plain class, got %v", e)
+		}
+	}
+	if len(enqueuesEdges(rels)) != 0 {
+		t.Errorf("expected no ENQUEUES edges for plain class, got %v", enqueuesEdges(rels))
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -358,6 +358,18 @@ const (
 	//              (scheduler fires the handler on the declared schedule)
 	RelationshipKindTriggers RelationshipKind = "TRIGGERS"
 
+	// #3700 (child of #3628 area #14): background-job enqueue topology.
+	//   ENQUEUES : enclosing function (the caller) → SCOPE.ScheduledJob job
+	//              entity. Emitted at a dispatch call site that pushes work
+	//              onto a background-job queue for asynchronous execution —
+	//              e.g. Sidekiq `Worker.perform_async/perform_in/perform_at`,
+	//              Resque/Que enqueue calls. This is the queue-system
+	//              counterpart of TRIGGERS (scheduler→handler): TRIGGERS says
+	//              "fired on a schedule", ENQUEUES says "a caller pushed this
+	//              job onto the queue". Distinct from PUBLISHES_TO, which
+	//              carries broker pub/sub fan-out semantics.
+	RelationshipKindEnqueues RelationshipKind = "ENQUEUES"
+
 	// #725: gRPC service definitions + client/server cross-repo edges.
 	//   GRPC_IMPLEMENTS : handler method → GrpcMethod (server declares it implements this RPC).
 	//   GRPC_HANDLES    : client call site → GrpcMethod (client invokes this RPC).


### PR DESCRIPTION
Closes #3700 (child of epic #3628, area #14 — background-job / scheduler extraction).

## What
Adds a first-class background-job **enqueue** edge and wires **Ruby Sidekiq** (workers, dispatch, and sidekiq-cron) into the existing scheduled-job pass.

### Study-first findings
The scheduled-job pass (`internal/engine/scheduled_jobs_edges.go`, #728/#1404) already emits `SCOPE.ScheduledJob` + `TRIGGERS` for **Celery, APScheduler, schedule, node-cron, bull/bullmq, Spring `@Scheduled`, Quartz, Quarkus, Go robfig/cron, EventBridge, K8s CronJob, GitHub Actions**, and Celery dispatch emits `PUBLISHES_TO`. The real gaps:
1. No dedicated **enqueue** edge — caller→job dispatch was either absent (Sidekiq) or overloaded onto pub/sub `PUBLISHES_TO`.
2. **Ruby Sidekiq** was entirely absent from the scheduled-job pass; the custom extractor (`internal/custom/ruby/sidekiq.go`) emitted disconnected orphan entities with no edge linking dispatch to the worker job, and no sidekiq-cron.

### Changes
- **New `ENQUEUES` relationship kind** (`internal/types/kinds.go`): caller enclosing fn → job entity. Queue-system counterpart of `TRIGGERS` (scheduler→handler); distinct from `PUBLISHES_TO` (broker pub/sub fan-out).
- **Sidekiq worker** (`include Sidekiq::Worker`/`Job` + `def perform`) → `SCOPE.ScheduledJob` (`sidekiq:<Worker>`) + `TRIGGERS` → `perform`.
- **Dispatch** `Worker.perform_async/perform_in/perform_at/perform_bulk(...)` → `ENQUEUES` edge from the enclosing Ruby method to the worker job. Resolved only against in-group worker defs (phantom-node-safe), deduped on (caller, job).
- **sidekiq-cron** `Sidekiq::Cron::Job.create(cron:, class:)` → scheduled job carrying the cron expr, collapsed onto the same worker job node.
- Coverage: `msg.sidekiq` consumer + producer cells `missing` → `partial` (cited, honest-partial notes).

## Systems now emitting jobs/schedules/edges
| System | Job entity | Schedule | Enqueue/trigger edge |
|---|---|---|---|
| Sidekiq worker | `SCOPE.ScheduledJob sidekiq:<Worker>` | — | `TRIGGERS` → perform; `ENQUEUES` caller → job |
| sidekiq-cron | same node | cron expr | `TRIGGERS` → perform |

## Edges asserted (value-asserting tests)
- `ENQUEUES SCOPE.Operation:register → SCOPE.ScheduledJob:sidekiq:EmailWorker` (dispatch_method=perform_async, worker_class=EmailWorker).
- sidekiq-cron job with `schedule='0 0 * * *'` reusing worker ID `sidekiq:CleanupWorker`.
- Negative: a plain Ruby class produces no job entity and no ENQUEUES edge.

## Verification
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green.
- `gofmt -l` clean on changed files; `go vet ./internal/engine/ ./internal/types/` clean.
- `coverage validate` 0 errors; `coverage fmt --check` canonical; docs regenerated via `coverage gen`.

**DEPLOY-DEFERRED** — no live reindex performed in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)