### PR TITLE
[caching] cache read-through/invalidation topology (Spring/Flask/NestJS/Rails)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1055,6 +1055,26 @@
       }
     },
     {
+      "id": "db.cache",
+      "category": "databases",
+      "language": "multi",
+      "label": "Caching (regions/keys)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
+          "issue": "3692",
+          "notes": "CACHES (read-through/write) + INVALIDATES (evict) edges from function/method to cache region/key. Cross-language consistent target ref cache:\u003cfw\u003e:\u003cregion\u003e."
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
+          "issue": "3692",
+          "notes": "Cache-region/key SCOPE.Datastore nodes from Spring @Cacheable/@CacheEvict/@CachePut, Python lru_cache/Flask-Caching/cachetools, Rails.cache.fetch/delete, NestJS @CacheKey + cache-manager. Dynamic keys honest-partial."
+        }
+      }
+    },
+    {
       "id": "db.cassandra",
       "category": "databases",
       "language": "multi",

--- a/internal/custom/java/caching.go
+++ b/internal/custom/java/caching.go
@@ -1,0 +1,260 @@
+// caching.go — Spring caching-abstraction topology extraction (#3692,
+// epic #3628, area #18).
+//
+// Captures Spring's declarative caching annotations and turns them into a
+// traversable cache-topology subgraph that sits ON TOP of the raw redis/
+// memcached key work (internal/custom/python/redis.go): rather than recording
+// the low-level GET/SET, this records the higher-level read-through / write /
+// invalidation INTENT a method declares.
+//
+// Annotations handled (Spring Cache Abstraction — spring-context):
+//
+//	@Cacheable(value="users", key="#id")  → method CACHES region "users"
+//	                                        (read-through: result stored+served)
+//	@CachePut(value="users")              → method CACHES region "users"
+//	                                        (write: always executes, refreshes)
+//	@CacheEvict(value="users")            → method INVALIDATES region "users"
+//	@CacheEvict(value="users", allEntries=true)
+//	                                        → INVALIDATES whole region (flush)
+//	@Caching(cacheable=..., evict=...)     → handled per inner annotation
+//
+// `value=` and its alias `cacheNames=` may name one OR several regions
+// ({"a","b"}); each region becomes its own target node + edge. A method with no
+// static region (annotation present but value omitted — Spring then derives the
+// region from config) is honest-partial: the edge is emitted against a
+// "<default>" region with dynamic="true" so the intent is still traversable.
+//
+// Entity/edge shape (cross-language consistent with the python redis keyspace
+// node):
+//
+//	target  : SCOPE.Datastore  subtype "cache_region"
+//	          Ref  "cache:spring:<region>"   (converges all sites on one node)
+//	carrier : SCOPE.Operation  the annotated method  (owner of the edge)
+//	edge    : CACHES | INVALIDATES   owner → region
+//
+// Dynamic SpEL keys (key="#id") are recorded as a `key_spel` property on the
+// edge — they are intentionally NOT promoted to distinct target nodes, because
+// the region is the cache-topology unit (a single region holds many keys); the
+// SpEL key is metadata about which entries a call touches.
+package java
+
+import (
+	"regexp"
+	"strings"
+)
+
+// cachingFrameworks gates the extractor to Spring identifiers. The dispatch
+// layer feeds spring_boot/spring_mvc/etc. candidates; we accept the whole
+// Spring family because @Cacheable lives in spring-context and can appear in
+// any Spring stereotype (service, repository, component).
+var cachingFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_mvc": true, "spring": true,
+	"spring_webflux": true, "spring_data_jpa": true,
+}
+
+// cacheAnnotationRE matches a Spring cache annotation and the method it
+// decorates. Group 1 = annotation name (Cacheable|CachePut|CacheEvict);
+// Group 2 = the annotation argument body (may be empty for `@Cacheable` with no
+// parens — but Spring requires at least a region somewhere, so the no-paren form
+// is honest-partial dynamic); Group 3 = the decorated method name.
+//
+// Intervening annotations between the cache annotation and the method signature
+// are skipped (`@Transactional`, `@Override`, …).
+var cacheAnnotationRE = regexp.MustCompile(
+	`(?s)@(Cacheable|CachePut|CacheEvict)\b\s*(?:\(([^)]*)\))?\s*` +
+		`(?:@\w+(?:\([^)]*\))?\s*)*` +
+		`(?:public|protected|private|)\s+(?:static\s+)?` +
+		`(?:<[^>]*>\s*)?(?:[\w.<>\[\],?\s]+?\s+)(\w+)\s*\(`)
+
+// cacheRegionArgRE pulls region names out of a cache annotation argument body.
+// It matches `value=` or its alias `cacheNames=` followed by either a single
+// "x" literal or a {"a","b"} brace list. Group 1 = the literal-or-brace body.
+var cacheRegionArgRE = regexp.MustCompile(
+	`(?:value|cacheNames)\s*=\s*(\{[^}]*\}|"[^"]*")`)
+
+// cacheBareRegionRE matches the single-value shorthand `@Cacheable("users")`
+// where the region is the first positional argument (no `value=`). Group 1 =
+// the literal-or-brace body. Only meaningful when no `value=`/`cacheNames=` key
+// is present in the body.
+var cacheBareRegionRE = regexp.MustCompile(
+	`^\s*(\{[^}]*\}|"[^"]*")`)
+
+// cacheKeySpelRE captures the SpEL key expression (`key="#id"`) so it can be
+// recorded as edge metadata. Group 1 = the SpEL body (without quotes).
+var cacheKeySpelRE = regexp.MustCompile(`key\s*=\s*"([^"]*)"`)
+
+// cacheAllEntriesRE detects `allEntries=true` on a @CacheEvict (region flush).
+var cacheAllEntriesRE = regexp.MustCompile(`allEntries\s*=\s*true`)
+
+// regionLiteralRE pulls each "name" out of a single literal or {"a","b"} body.
+var regionLiteralRE = regexp.MustCompile(`"([^"]*)"`)
+
+// cacheRegionRef builds the stable, framework-prefixed target ref so every
+// call-site that caches/invalidates the same region converges on one node
+// (mirrors redisKeyspaceRef in the python redis extractor).
+func cacheRegionRef(region string) string {
+	return "cache:spring:" + region
+}
+
+// parseCacheRegions returns the list of static region names declared in a cache
+// annotation argument body, plus whether the region set is dynamic (annotation
+// present but no static region resolvable). The bare positional shorthand
+// (`@Cacheable("users")`) is honoured only when no `value=`/`cacheNames=` key is
+// present.
+func parseCacheRegions(body string) (regions []string, dynamic bool) {
+	body = strings.TrimSpace(body)
+
+	var literalBody string
+	if m := cacheRegionArgRE.FindStringSubmatch(body); m != nil {
+		literalBody = m[1]
+	} else if m := cacheBareRegionRE.FindStringSubmatch(body); m != nil &&
+		!strings.Contains(body, "value") && !strings.Contains(body, "cacheNames") {
+		literalBody = m[1]
+	}
+
+	if literalBody == "" {
+		// Annotation present, region not statically resolvable (omitted, or a
+		// constant reference like CacheConfig.USERS). Honest-partial: one
+		// dynamic edge so the caching intent is still traversable.
+		return nil, true
+	}
+
+	for _, lm := range regionLiteralRE.FindAllStringSubmatch(literalBody, -1) {
+		if r := strings.TrimSpace(lm[1]); r != "" {
+			regions = append(regions, r)
+		}
+	}
+	if len(regions) == 0 {
+		return nil, true
+	}
+	return regions, false
+}
+
+// ExtractJavaCaching runs the Spring caching-abstraction extractor. It emits a
+// SCOPE.Datastore cache-region node per distinct region and a CACHES /
+// INVALIDATES edge from each annotated method to the region(s) it touches.
+func ExtractJavaCaching(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" && ctx.Language != "kotlin" {
+		return result
+	}
+	if !cachingFrameworks[ctx.Framework] {
+		return result
+	}
+	source := ctx.Source
+	// Quick-exit: no Spring cache annotation present.
+	if !strings.Contains(source, "@Cacheable") &&
+		!strings.Contains(source, "@CachePut") &&
+		!strings.Contains(source, "@CacheEvict") {
+		return result
+	}
+
+	fp := ctx.FilePath
+	fw := ctx.Framework
+	seenEnt := make(map[string]bool)
+	seenRel := make(map[relKey]bool)
+
+	for _, m := range cacheAnnotationRE.FindAllStringSubmatchIndex(source, -1) {
+		annotation := source[m[2]:m[3]]
+		body := ""
+		if m[4] >= 0 {
+			body = source[m[4]:m[5]]
+		}
+		method := source[m[6]:m[7]]
+		ownerCls := findEnclosingClass(source, m[0])
+		line := lineOf(source, m[0])
+
+		ownerName := method
+		if ownerCls != "" {
+			ownerName = ownerCls + "." + method
+		}
+		ownerRef := "scope:operation:caching:" + fp + ":" + ownerName
+
+		// Edge direction: @CacheEvict invalidates; @Cacheable/@CachePut populate.
+		isEvict := annotation == "CacheEvict"
+		relType := "CACHES"
+		mode := "read_through"
+		if annotation == "CachePut" {
+			mode = "write"
+		}
+		if isEvict {
+			relType = "INVALIDATES"
+			mode = "evict"
+			if cacheAllEntriesRE.MatchString(body) {
+				mode = "evict_all"
+			}
+		}
+
+		// Carrier: the annotated method (owner of the edge).
+		addEntity(&result, seenEnt, SecondaryEntity{
+			Name: ownerName, Kind: "SCOPE.Operation", Subtype: "cache_method",
+			SourceFile: fp, LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_" + strings.ToUpper(annotation),
+			Ref:        ownerRef,
+			Properties: map[string]any{
+				"framework":        "spring",
+				"cache_annotation": annotation,
+				"cache_mode":       mode,
+			},
+		})
+
+		regions, dynamic := parseCacheRegions(body)
+		keySpel := ""
+		if km := cacheKeySpelRE.FindStringSubmatch(body); km != nil {
+			keySpel = km[1]
+		}
+
+		emit := func(region string, isDynamic bool) {
+			ref := cacheRegionRef(region)
+			label := region
+			subtype := "cache_region"
+			props := map[string]any{
+				"framework":  "spring",
+				"region":     region,
+				"cache_kind": "region",
+				"language":   "java",
+			}
+			if isDynamic {
+				props["dynamic"] = "true"
+			}
+			addEntity(&result, seenEnt, SecondaryEntity{
+				Name: label, Kind: "SCOPE.Datastore", Subtype: subtype,
+				SourceFile: fp, LineStart: line, LineEnd: line,
+				Provenance: "INFERRED_FROM_SPRING_CACHE",
+				Ref:        ref,
+				Properties: props,
+			})
+			edgeProps := map[string]string{
+				"framework": "spring",
+				"region":    region,
+				"mode":      mode,
+				"language":  "java",
+			}
+			if keySpel != "" {
+				edgeProps["key_spel"] = keySpel
+			}
+			if isDynamic {
+				edgeProps["dynamic"] = "true"
+			}
+			addRel(&result, seenRel, Relationship{
+				SourceRef:        ownerRef,
+				TargetRef:        ref,
+				RelationshipType: relType,
+				Properties:       edgeProps,
+			})
+		}
+
+		if dynamic {
+			// Honest-partial: region not statically resolvable.
+			emit("<default>", true)
+		} else {
+			for _, r := range regions {
+				emit(r, false)
+			}
+		}
+		_ = fw
+	}
+
+	return result
+}

--- a/internal/custom/java/caching_test.go
+++ b/internal/custom/java/caching_test.go
@@ -1,0 +1,169 @@
+package java
+
+import "testing"
+
+// caching_test.go — value-asserting tests for ExtractJavaCaching (#3692, epic
+// #3628, area #18). Asserts the actual region + CACHES/INVALIDATES edge, not
+// len>0.
+
+func runCaching(src string) PatternResult {
+	return ExtractJavaCaching(PatternContext{
+		Source: src, Language: "java", Framework: "spring_boot", FilePath: "UserService.java",
+	})
+}
+
+// findCacheRel returns the relationship of kind relType targeting the given
+// region ref, or nil.
+func findCacheRel(res PatternResult, relType, targetRef string) *Relationship {
+	for i := range res.Relationships {
+		r := &res.Relationships[i]
+		if r.RelationshipType == relType && r.TargetRef == targetRef {
+			return r
+		}
+	}
+	return nil
+}
+
+func hasRegionEntity(res PatternResult, ref string) bool {
+	for _, e := range res.Entities {
+		if e.Ref == ref && e.Kind == "SCOPE.Datastore" && e.Subtype == "cache_region" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestJavaCaching_Cacheable_ReadThrough(t *testing.T) {
+	src := `
+@Service
+class UserService {
+    @Cacheable(value="users", key="#id")
+    public User getUser(Long id) { return repo.find(id); }
+}
+`
+	res := runCaching(src)
+	ref := "cache:spring:users"
+	if !hasRegionEntity(res, ref) {
+		t.Fatalf("expected cache_region entity %q", ref)
+	}
+	r := findCacheRel(res, "CACHES", ref)
+	if r == nil {
+		t.Fatalf("expected getUser CACHES region users")
+	}
+	if r.Properties["mode"] != "read_through" {
+		t.Errorf("mode = %q, want read_through", r.Properties["mode"])
+	}
+	if r.Properties["key_spel"] != "#id" {
+		t.Errorf("key_spel = %q, want #id", r.Properties["key_spel"])
+	}
+	// Carrier owner must be the method.
+	if findCacheRel(res, "CACHES", ref).SourceRef == "" {
+		t.Errorf("CACHES edge missing source carrier")
+	}
+}
+
+func TestJavaCaching_CacheEvict_Invalidates(t *testing.T) {
+	src := `
+@Service
+class UserService {
+    @CacheEvict(value="users")
+    public void updateUser(User u) { repo.save(u); }
+}
+`
+	res := runCaching(src)
+	ref := "cache:spring:users"
+	r := findCacheRel(res, "INVALIDATES", ref)
+	if r == nil {
+		t.Fatalf("expected updateUser INVALIDATES region users")
+	}
+	if r.Properties["mode"] != "evict" {
+		t.Errorf("mode = %q, want evict", r.Properties["mode"])
+	}
+}
+
+func TestJavaCaching_CacheEvict_AllEntries(t *testing.T) {
+	src := `
+class UserService {
+    @CacheEvict(value="users", allEntries=true)
+    public void clear() {}
+}
+`
+	res := runCaching(src)
+	r := findCacheRel(res, "INVALIDATES", "cache:spring:users")
+	if r == nil || r.Properties["mode"] != "evict_all" {
+		t.Fatalf("expected evict_all mode, got %+v", r)
+	}
+}
+
+func TestJavaCaching_BareRegion_Shorthand(t *testing.T) {
+	src := `
+class UserService {
+    @Cacheable("profiles")
+    public Profile get(Long id) { return null; }
+}
+`
+	res := runCaching(src)
+	if findCacheRel(res, "CACHES", "cache:spring:profiles") == nil {
+		t.Fatalf("expected bare @Cacheable(\"profiles\") to CACHES region profiles")
+	}
+}
+
+func TestJavaCaching_MultiRegion(t *testing.T) {
+	src := `
+class UserService {
+    @Cacheable(cacheNames={"users","admins"})
+    public User get(Long id) { return null; }
+}
+`
+	res := runCaching(src)
+	if findCacheRel(res, "CACHES", "cache:spring:users") == nil {
+		t.Errorf("expected CACHES region users")
+	}
+	if findCacheRel(res, "CACHES", "cache:spring:admins") == nil {
+		t.Errorf("expected CACHES region admins")
+	}
+}
+
+func TestJavaCaching_DynamicRegion_HonestPartial(t *testing.T) {
+	src := `
+class UserService {
+    @Cacheable(key="#id")
+    public User get(Long id) { return null; }
+}
+`
+	res := runCaching(src)
+	r := findCacheRel(res, "CACHES", "cache:spring:<default>")
+	if r == nil {
+		t.Fatalf("expected honest-partial dynamic CACHES edge")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("region-less annotation should be dynamic")
+	}
+}
+
+// Negative: a plain method with no cache annotation emits no cache edge.
+func TestJavaCaching_PlainMethod_NoEdge(t *testing.T) {
+	src := `
+@Service
+class UserService {
+    public User getUser(Long id) { return repo.find(id); }
+}
+`
+	res := runCaching(src)
+	for _, r := range res.Relationships {
+		if r.RelationshipType == "CACHES" || r.RelationshipType == "INVALIDATES" {
+			t.Fatalf("plain method should emit no cache edge, got %+v", r)
+		}
+	}
+}
+
+// Negative: the extractor must reject non-Spring frameworks.
+func TestJavaCaching_NonSpring_NoOp(t *testing.T) {
+	src := `@Cacheable("users") public User getUser(Long id) { return null; }`
+	res := ExtractJavaCaching(PatternContext{
+		Source: src, Language: "java", Framework: "quarkus", FilePath: "X.java",
+	})
+	if len(res.Entities) != 0 || len(res.Relationships) != 0 {
+		t.Fatalf("non-Spring framework must be a no-op, got %+v", res)
+	}
+}

--- a/internal/custom/java/patterns_dispatch.go
+++ b/internal/custom/java/patterns_dispatch.go
@@ -74,6 +74,7 @@ var allPatternExtractors = []patternFn{
 	ExtractJakartaEE,
 	ExtractJakartaEEAdvanced,
 	ExtractJakartaJaxrsDTO,
+	ExtractJavaCaching,
 	ExtractJavaDIScopeDeepen,
 	ExtractJavaMethodSecurity,
 	ExtractJavalin,

--- a/internal/custom/javascript/caching.go
+++ b/internal/custom/javascript/caching.go
@@ -1,0 +1,197 @@
+package javascript
+
+// caching.go — JS/TS caching-topology extraction (#3692, epic #3628, area #18).
+//
+// Cross-language consistent with the Spring cache-region node
+// (internal/custom/java/caching.go), the Python cache-region node, and the
+// Rails cache-region node. Two dominant JS/TS cache abstractions:
+//
+//	NestJS (@nestjs/cache-manager):
+//	  @CacheKey('users')   on a handler  → method CACHES key "users"
+//	                                       (read-through via CacheInterceptor)
+//
+//	cache-manager (the library NestJS wraps, also used standalone):
+//	  cache.wrap('user:1', fn)   → call-site CACHES key "user:1" (read-through)
+//	  cache.set('user:1', v)     → CACHES key "user:1"          (write)
+//	  cache.del('user:1')        → INVALIDATES key "user:1"     (evict)
+//	  cacheManager.del(...)      → INVALIDATES                  (evict)
+//
+// Entity/edge shape:
+//
+//	target  : SCOPE.Datastore  subtype "cache_region"
+//	          Ref  "cache:<framework>:<key>"  (sites converge on one node)
+//	carrier : SCOPE.Operation  the decorated method / cache call-site
+//	edge    : CACHES | INVALIDATES   carrier → key
+//
+// Dynamic keys (`cache.wrap(key, fn)` / template literal `` `user:${id}` ``) are
+// honest-partial: the edge is emitted with dynamic="true" against a key-prefix
+// (template head) or "<dynamic>" target.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_caching", &jsCachingExtractor{})
+}
+
+type jsCachingExtractor struct{}
+
+func (e *jsCachingExtractor) Language() string { return "custom_js_caching" }
+
+var (
+	// reNestCacheKey matches @CacheKey('users') on a method. Group 1 = key
+	// literal body; Group 2 = decorated method name. Intervening decorators
+	// (@CacheTTL, @UseInterceptors) are skipped.
+	reNestCacheKey = regexp.MustCompile(
+		`@CacheKey\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]*)['"` + "`" + `]\s*\)\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+			`(?:public\s+|private\s+|protected\s+)?(?:async\s+)?(\w+)\s*\(`)
+
+	// reCacheManagerOp matches a cache-manager op. Group 1 = receiver
+	// (cache|cacheManager|cacheStore); Group 2 = verb; Group 3 = the first-arg
+	// key — either a quoted/backtick literal body, or empty when dynamic.
+	reCacheManagerOp = regexp.MustCompile(
+		`\b(cache|cacheManager|cacheStore)\.(wrap|set|get|del|delete|reset|mget|mset)\s*\(\s*(['"` + "`" + `][^'"` + "`" + `$]*)?`)
+)
+
+func jsCacheRef(framework, key string) string {
+	return fmt.Sprintf("cache:%s:%s", framework, key)
+}
+
+// cacheManagerEdge classifies a cache-manager verb into (relType, mode).
+func cacheManagerEdge(verb string) (string, string) {
+	switch verb {
+	case "del", "delete", "reset":
+		return "INVALIDATES", "evict"
+	case "set", "mset":
+		return "CACHES", "write"
+	default: // wrap, get, mget
+		return "CACHES", "read_through"
+	}
+}
+
+func (e *jsCachingExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.js_caching")
+	_, span := tracer.Start(ctx, "custom.js_caching")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "@CacheKey") && !strings.Contains(src, "cache") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenRegion := make(map[string]bool)
+	add := func(e types.EntityRecord) { out = append(out, e) }
+
+	emitRegion := func(framework, key string, dynamic bool, line int) string {
+		ref := jsCacheRef(framework, key)
+		if !seenRegion[ref] {
+			seenRegion[ref] = true
+			ent := makeEntity(key, "SCOPE.Datastore", "cache_region", file.Path, file.Language, line)
+			setProps(&ent, "framework", framework, "region", key,
+				"cache_kind", "region", "provenance", "INFERRED_FROM_JS_CACHE")
+			if dynamic {
+				setProps(&ent, "dynamic", "true")
+			}
+			add(ent)
+		}
+		return ref
+	}
+
+	// 1. NestJS @CacheKey decorators (always read-through via CacheInterceptor).
+	for _, m := range reNestCacheKey.FindAllStringSubmatchIndex(src, -1) {
+		key := src[m[2]:m[3]]
+		method := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		ent := makeEntity(method, "SCOPE.Operation", "cache_method", file.Path, file.Language, line)
+		setProps(&ent, "framework", "nestjs", "cache_mode", "read_through",
+			"cache_decorator", "CacheKey", "provenance", "INFERRED_FROM_CACHE_KEY")
+		ref := emitRegion("nestjs", key, false, line)
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: ref, Kind: "CACHES",
+			Properties: map[string]string{
+				"framework": "nestjs", "region": key, "mode": "read_through", "language": file.Language,
+			},
+		})
+		add(ent)
+	}
+
+	// 2. cache-manager call-sites.
+	for _, m := range reCacheManagerOp.FindAllStringSubmatchIndex(src, -1) {
+		receiver := src[m[2]:m[3]]
+		verb := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+
+		rawKey := ""
+		if m[6] >= 0 {
+			rawKey = src[m[6]:m[7]]
+		}
+		key, dynamic := normaliseJSCacheKey(rawKey)
+
+		relType, mode := cacheManagerEdge(verb)
+		ent := makeEntity(receiver+"."+verb, "SCOPE.Operation", "cache_method", file.Path, file.Language, line)
+		setProps(&ent, "framework", "cache_manager", "cache_verb", verb, "cache_mode", mode,
+			"provenance", "INFERRED_FROM_CACHE_MANAGER")
+		if dynamic {
+			setProps(&ent, "dynamic", "true")
+		}
+		ref := emitRegion("cache_manager", key, dynamic, line)
+		edgeProps := map[string]string{
+			"framework": "cache_manager", "region": key, "mode": mode, "language": file.Language,
+		}
+		if dynamic {
+			edgeProps["dynamic"] = "true"
+		}
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: ref, Kind: relType, Properties: edgeProps,
+		})
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// normaliseJSCacheKey resolves the captured first-argument literal:
+//
+//	'home'        -> ("home", false)
+//	"user:1"      -> ("user:1", false)
+//	`user:${...}  -> the regex stops the literal at `$`, so a backtick literal
+//	                 with interpolation yields its static head -> key-prefix.
+//	""            -> ("<dynamic>", true)   (variable key)
+func normaliseJSCacheKey(raw string) (string, bool) {
+	if raw == "" {
+		return "<dynamic>", true
+	}
+	// Strip the leading quote/backtick.
+	body := strings.TrimLeft(raw, "'\"`")
+	if body == "" {
+		// Was a bare opening backtick before an interpolation -> fully dynamic.
+		return "<dynamic>", true
+	}
+	// A backtick literal whose interpolation was cut leaves a static head; mark
+	// it as a prefix (dynamic). A plain-quote literal that reached here is a
+	// concrete key. We distinguish by the original opening delimiter.
+	if strings.HasPrefix(raw, "`") {
+		return body + "*", true
+	}
+	return body, false
+}

--- a/internal/custom/javascript/caching_test.go
+++ b/internal/custom/javascript/caching_test.go
@@ -1,0 +1,127 @@
+package javascript_test
+
+// caching_test.go — value-asserting tests for the custom_js_caching extractor
+// (#3692, epic #3628, area #18).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runJSCaching(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_caching")
+	if !ok {
+		t.Fatal("custom_js_caching not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "typescript", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findJSCacheRel(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func TestJSCaching_NestCacheKey_ReadThrough(t *testing.T) {
+	src := `
+@Controller('users')
+export class UsersController {
+  @CacheKey('users')
+  @Get()
+  findAll() { return this.svc.all(); }
+}
+`
+	ents := runJSCaching(t, "users.controller.ts", src)
+	r := findJSCacheRel(ents, "CACHES", "cache:nestjs:users")
+	if r == nil {
+		t.Fatalf("expected @CacheKey('users') to CACHES key users (read-through)")
+	}
+	if r.Properties["mode"] != "read_through" {
+		t.Errorf("mode = %q, want read_through", r.Properties["mode"])
+	}
+}
+
+func TestJSCaching_CacheManagerWrap_ReadThrough(t *testing.T) {
+	src := `
+async function getUser(id) {
+  return cache.wrap('user:1', () => db.find(id));
+}
+`
+	ents := runJSCaching(t, "svc.ts", src)
+	r := findJSCacheRel(ents, "CACHES", "cache:cache_manager:user:1")
+	if r == nil {
+		t.Fatalf("expected cache.wrap('user:1', fn) to CACHES key user:1")
+	}
+	if r.Properties["mode"] != "read_through" {
+		t.Errorf("mode = %q, want read_through", r.Properties["mode"])
+	}
+}
+
+func TestJSCaching_CacheManagerDel_Invalidates(t *testing.T) {
+	src := `
+async function evict() {
+  await cacheManager.del('user:1');
+}
+`
+	ents := runJSCaching(t, "svc.ts", src)
+	r := findJSCacheRel(ents, "INVALIDATES", "cache:cache_manager:user:1")
+	if r == nil {
+		t.Fatalf("expected cacheManager.del('user:1') to INVALIDATE key user:1")
+	}
+	if r.Properties["mode"] != "evict" {
+		t.Errorf("mode = %q, want evict", r.Properties["mode"])
+	}
+}
+
+func TestJSCaching_CacheManagerSet_Write(t *testing.T) {
+	src := `await cache.set('config', value);`
+	ents := runJSCaching(t, "svc.ts", src)
+	r := findJSCacheRel(ents, "CACHES", "cache:cache_manager:config")
+	if r == nil || r.Properties["mode"] != "write" {
+		t.Fatalf("expected write mode on config, got %+v", r)
+	}
+}
+
+func TestJSCaching_TemplateLiteral_Dynamic(t *testing.T) {
+	src := "async function f(id) { return cache.wrap(`user:${id}`, fn); }"
+	ents := runJSCaching(t, "svc.ts", src)
+	r := findJSCacheRel(ents, "CACHES", "cache:cache_manager:user:*")
+	if r == nil {
+		t.Fatalf("expected template-literal key to CACHES prefix user:*")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("template-literal key should be dynamic")
+	}
+}
+
+// Negative: a plain method with no cache call/decorator emits no cache edge.
+func TestJSCaching_Plain_NoEdge(t *testing.T) {
+	src := `
+export class UsersController {
+  findAll() { return this.svc.all(); }
+}
+`
+	ents := runJSCaching(t, "users.controller.ts", src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "CACHES" || r.Kind == "INVALIDATES" {
+				t.Fatalf("plain method should emit no cache edge, got %+v", r)
+			}
+		}
+	}
+}

--- a/internal/custom/python/caching.go
+++ b/internal/custom/python/caching.go
@@ -1,0 +1,202 @@
+package python
+
+// caching.go — Python caching-decorator topology extraction (#3692, epic
+// #3628, area #18).
+//
+// Sits ON TOP of the raw redis key work (redis.go): instead of low-level
+// GET/SET it records the read-through caching INTENT a decorated function
+// declares. Three idioms are covered:
+//
+//	@lru_cache / @cache / @functools.lru_cache  (stdlib, in-process memoisation)
+//	    → function CACHES an in-process region keyed by the function's qualname.
+//	      mode=in_process. No external key — the cache key is the call args.
+//
+//	@cache.cached(timeout=60, key_prefix='view/%s')   (Flask-Caching)
+//	    → function CACHES region <key_prefix>. mode=read_through.
+//	      Missing key_prefix → Flask derives it from the request path → dynamic.
+//
+//	@cached(cache, key=...)  /  @cachetools.cached(...)   (cachetools)
+//	    → function CACHES an in-process region keyed by the function qualname.
+//	      A `key=` callable is dynamic; recorded honest-partial.
+//
+// Entity/edge shape (cross-language consistent with the redis keyspace node and
+// the Spring cache-region node):
+//
+//	target  : SCOPE.Datastore  subtype "cache_region"
+//	          Ref  "cache:<framework>:<region>"  (converges sites on one node)
+//	carrier : the decorated function operation (owner of the edge)
+//	edge    : CACHES   owner → region
+//
+// Python has no first-class declarative eviction decorator (eviction is an
+// imperative `cache.delete(...)` call already modelled as a redis WRITES_TO
+// op), so this extractor only emits CACHES; INVALIDATES is owned by the Java
+// (@CacheEvict) and Rails (Rails.cache.delete) passes.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_caching", &CachingExtractor{})
+}
+
+// CachingExtractor extracts Python caching decorators and the regions they
+// populate.
+type CachingExtractor struct{}
+
+func (e *CachingExtractor) Language() string { return "python_caching" }
+
+var (
+	// cacheLruRe matches @lru_cache / @cache / @functools.lru_cache /
+	// @functools.cache (with or without parens) immediately above a def.
+	// Group 1 = decorated function name.
+	cacheLruRe = regexp.MustCompile(
+		`(?m)@(?:functools\.)?(?:lru_cache|cache)\b\s*(?:\([^)]*\))?\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// cacheFlaskRe matches @cache.cached(...) / @<something>.cached(...)
+	// (Flask-Caching). Group 1 = the argument body; Group 2 = function name.
+	cacheFlaskRe = regexp.MustCompile(
+		`(?m)@\w+\.cached\s*\(([^)]*)\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// cacheToolsRe matches @cached(...) or @cachetools.cached(...) (cachetools).
+	// Group 1 = argument body; Group 2 = function name. The leading `\w+\.`
+	// alternation lets it match both the bare and module-qualified forms while
+	// NOT overlapping the `\w+.cached` Flask form (handled above) — we
+	// post-filter so a `.cached` match is not double-counted.
+	cacheToolsRe = regexp.MustCompile(
+		`(?m)@(?:cachetools\.)?cached\s*\(([^)]*)\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// flaskKeyPrefixRe pulls key_prefix='view/%s' out of a Flask-Caching body.
+	// Group 1 = the key-prefix literal body.
+	flaskKeyPrefixRe = regexp.MustCompile(`key_prefix\s*=\s*["']([^"']*)["']`)
+)
+
+// cacheRegionRef builds the stable target ref so multiple decorated functions
+// that share a region converge on one node (mirrors redisKeyspaceRef).
+func cacheRegionRef(framework, region string) string {
+	return fmt.Sprintf("cache:%s:%s", framework, region)
+}
+
+func (e *CachingExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_caching")
+	_, span := tracer.Start(ctx, "custom.python_caching")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "cache") && !strings.Contains(source, "cached") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenRegion := make(map[string]bool)
+	seenOwner := make(map[string]bool)
+
+	// emitRegion adds one SCOPE.Datastore cache-region node per distinct region
+	// (deduplicated across the file). Returns the target ref for the edge.
+	emitRegion := func(framework, region string, dynamic bool, line int) string {
+		ref := cacheRegionRef(framework, region)
+		if !seenRegion[ref] {
+			seenRegion[ref] = true
+			props := map[string]string{
+				"framework":  framework,
+				"region":     region,
+				"cache_kind": "region",
+				"language":   "python",
+			}
+			if dynamic {
+				props["dynamic"] = "true"
+			}
+			out = append(out, entity(ref, "SCOPE.Datastore", "cache_region", file.Path, line, props))
+		}
+		return ref
+	}
+
+	// emitCache appends the cache-region target (if new) and the decorated-
+	// function carrier with its CACHES edge already attached. Region is appended
+	// BEFORE the owner so the owner is the last element — no live pointer is held
+	// across a slice append (which would reallocate and silently drop the edge).
+	emitCache := func(framework, fn, region, mode string, dynamic bool, line int) {
+		ownerRef := fmt.Sprintf("cache_fn:%s:%s:%d", framework, file.Path, line)
+		if seenOwner[ownerRef] {
+			return
+		}
+		seenOwner[ownerRef] = true
+
+		targetRef := emitRegion(framework, region, dynamic, line)
+
+		edgeProps := map[string]string{
+			"framework": framework,
+			"region":    region,
+			"mode":      mode,
+			"language":  "python",
+		}
+		if dynamic {
+			edgeProps["dynamic"] = "true"
+		}
+		owner := entity(ownerRef, "SCOPE.Operation", "cache_method", file.Path, line,
+			map[string]string{
+				"framework":    framework,
+				"cache_mode":   mode,
+				"cached_fn":    fn,
+				"language":     "python",
+				"pattern_type": "cache_decorator",
+			})
+		owner.Relationships = append(owner.Relationships, types.RelationshipRecord{
+			ToID:       targetRef,
+			Kind:       string(types.RelationshipKindCaches),
+			Properties: edgeProps,
+		})
+		out = append(out, owner)
+	}
+
+	// 1. @lru_cache / @cache — in-process memoisation. Region = function qualname.
+	for _, m := range cacheLruRe.FindAllStringSubmatchIndex(source, -1) {
+		fn := source[m[2]:m[3]]
+		line := lineOf(source, m[0])
+		emitCache("lru_cache", fn, "fn:"+fn, "in_process", false, line)
+	}
+
+	// 2. @cache.cached(...) — Flask-Caching. Region = key_prefix or dynamic.
+	flaskLines := make(map[int]bool)
+	for _, m := range cacheFlaskRe.FindAllStringSubmatchIndex(source, -1) {
+		body := source[m[2]:m[3]]
+		fn := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		flaskLines[line] = true
+		region := ""
+		dynamic := false
+		if km := flaskKeyPrefixRe.FindStringSubmatch(body); km != nil && strings.TrimSpace(km[1]) != "" {
+			region = km[1]
+		} else {
+			region = "<request_path>"
+			dynamic = true
+		}
+		emitCache("flask_caching", fn, region, "read_through", dynamic, line)
+	}
+
+	// 3. @cached(...) / @cachetools.cached(...) — cachetools. Region = fn qualname.
+	for _, m := range cacheToolsRe.FindAllStringSubmatchIndex(source, -1) {
+		line := lineOf(source, m[0])
+		if flaskLines[line] {
+			continue // already claimed by the Flask `.cached` form.
+		}
+		fn := source[m[4]:m[5]]
+		emitCache("cachetools", fn, "fn:"+fn, "in_process", false, line)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/caching_test.go
+++ b/internal/custom/python/caching_test.go
@@ -1,0 +1,143 @@
+package python_test
+
+// caching_test.go — value-asserting tests for the python_caching extractor
+// (#3692, epic #3628, area #18). Asserts the actual cache region and CACHES
+// edge, not len>0.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runPyCaching(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("python_caching")
+	if !ok {
+		t.Fatal("python_caching not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extractor.FileInput{Path: "svc.py", Language: "python", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findCachesEdge returns the CACHES edge whose target ref == wantRef, or nil.
+func findCachesEdge(ents []types.EntityRecord, wantRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindCaches) && r.ToID == wantRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func hasCacheRegion(ents []types.EntityRecord, ref string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Subtype == "cache_region" && e.Name != "" {
+			// region entities are keyed by ref via their downstream ID; assert by
+			// matching the region label embedded in the ref.
+			if "cache:"+e.Properties["framework"]+":"+e.Properties["region"] == ref {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestPyCaching_LruCache_InProcess(t *testing.T) {
+	src := `
+import functools
+
+@functools.lru_cache(maxsize=128)
+def fib(n):
+    return n
+`
+	ents := runPyCaching(t, src)
+	ref := "cache:lru_cache:fn:fib"
+	if !hasCacheRegion(ents, ref) {
+		t.Fatalf("expected in-process cache region %q", ref)
+	}
+	e := findCachesEdge(ents, ref)
+	if e == nil {
+		t.Fatalf("expected fib CACHES region fn:fib")
+	}
+	if e.Properties["mode"] != "in_process" {
+		t.Errorf("mode = %q, want in_process", e.Properties["mode"])
+	}
+}
+
+func TestPyCaching_FlaskCaching_KeyPrefix(t *testing.T) {
+	src := `
+@app.route("/users")
+@cache.cached(timeout=60, key_prefix='view/users')
+def list_users():
+    return query()
+`
+	ents := runPyCaching(t, src)
+	ref := "cache:flask_caching:view/users"
+	e := findCachesEdge(ents, ref)
+	if e == nil {
+		t.Fatalf("expected list_users CACHES region view/users (read-through)")
+	}
+	if e.Properties["mode"] != "read_through" {
+		t.Errorf("mode = %q, want read_through", e.Properties["mode"])
+	}
+	if e.Properties["dynamic"] == "true" {
+		t.Errorf("static key_prefix should not be dynamic")
+	}
+}
+
+func TestPyCaching_FlaskCaching_NoKeyPrefix_Dynamic(t *testing.T) {
+	src := `
+@cache.cached(timeout=30)
+def home():
+    return render()
+`
+	ents := runPyCaching(t, src)
+	ref := "cache:flask_caching:<request_path>"
+	e := findCachesEdge(ents, ref)
+	if e == nil {
+		t.Fatalf("expected honest-partial dynamic CACHES edge")
+	}
+	if e.Properties["dynamic"] != "true" {
+		t.Errorf("missing key_prefix should be dynamic")
+	}
+}
+
+func TestPyCaching_Cachetools(t *testing.T) {
+	src := `
+@cached(cache, key=hashkey)
+def expensive(x):
+    return x
+`
+	ents := runPyCaching(t, src)
+	ref := "cache:cachetools:fn:expensive"
+	if findCachesEdge(ents, ref) == nil {
+		t.Fatalf("expected expensive CACHES region fn:expensive")
+	}
+}
+
+// Negative: a plain function with no cache decorator must emit no cache edge.
+func TestPyCaching_PlainFunction_NoEdge(t *testing.T) {
+	src := `
+def get_user(uid):
+    return db.query(uid)
+`
+	ents := runPyCaching(t, src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindCaches) {
+				t.Fatalf("plain function should emit no CACHES edge, got %+v", r)
+			}
+		}
+	}
+}

--- a/internal/custom/ruby/caching.go
+++ b/internal/custom/ruby/caching.go
@@ -1,0 +1,188 @@
+package ruby
+
+// caching.go — Rails caching-topology extraction (#3692, epic #3628, area #18).
+//
+// Captures the Rails low-level cache store API as read-through / invalidation
+// topology, cross-language consistent with the Spring cache-region node
+// (internal/custom/java/caching.go) and the Python cache-region node:
+//
+//	Rails.cache.fetch("home") { ... }   → cache-site CACHES key "home"
+//	                                      (read-through: block result memoised)
+//	Rails.cache.read("home")            → CACHES key "home"  (read)
+//	Rails.cache.write("home", v)        → CACHES key "home"  (write)
+//	Rails.cache.delete("home")          → INVALIDATES key "home"
+//	Rails.cache.delete_matched("home/*")→ INVALIDATES key-prefix "home/*"
+//
+// `Rails.cache` and a bare `cache.fetch`/`cache.delete` inside a controller/view
+// both resolve to the same store, so both receiver forms are accepted.
+//
+// Entity/edge shape:
+//
+//	target  : SCOPE.Datastore  subtype "cache_region"
+//	          Ref  "cache:rails:<key>"   (sites converge on one node)
+//	carrier : SCOPE.Operation  the cache call-site  (owner of the edge)
+//	edge    : CACHES | INVALIDATES   site → key
+//
+// Dynamic keys (`Rails.cache.fetch(user_key)` / interpolated "user/#{id}") are
+// honest-partial: the edge is emitted with dynamic="true" against a key-prefix
+// (interpolation head) or "<dynamic>" target so the intent stays traversable.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_ruby_caching", &railsCachingExtractor{})
+}
+
+type railsCachingExtractor struct{}
+
+func (e *railsCachingExtractor) Language() string { return "custom_ruby_caching" }
+
+// reRailsCacheOp matches a Rails cache store call. Group 1 = receiver
+// (`Rails.cache` or `cache`); Group 2 = verb; Group 3 = the first-argument key
+// literal body (with surrounding quotes captured in the literal alternation).
+// The receiver `Rails.cache` is required, OR a bare `cache.<verb>` — the bare
+// form is gated on the file containing `Rails.cache` somewhere (so we don't
+// match unrelated `cache.foo` on arbitrary objects).
+var reRailsCacheOp = regexp.MustCompile(
+	`(Rails\.cache|cache)\.(fetch|read|write|delete|delete_matched|read_multi|write_multi|exist\?)\s*\(\s*(["'][^"']*["']|"[^"]*#\{)`)
+
+// railsReadVerbs/railsWriteVerbs/railsInvalidateVerbs classify the verb into the
+// cache edge direction + mode.
+var (
+	railsReadVerbs       = map[string]bool{"fetch": true, "read": true, "read_multi": true, "exist?": true}
+	railsWriteVerbs      = map[string]bool{"write": true, "write_multi": true}
+	railsInvalidateVerbs = map[string]bool{"delete": true, "delete_matched": true}
+)
+
+func railsCacheRef(key string) string {
+	return "cache:rails:" + key
+}
+
+func (e *railsCachingExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.ruby_caching")
+	_, span := tracer.Start(ctx, "custom.ruby_caching")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "Rails.cache") && !strings.Contains(src, ".cache.") {
+		return nil, nil
+	}
+	hasRailsCache := strings.Contains(src, "Rails.cache")
+
+	var out []types.EntityRecord
+	seenRegion := make(map[string]bool)
+	add := func(e types.EntityRecord) { out = append(out, e) }
+
+	emitRegion := func(key string, dynamic bool, line int) string {
+		ref := railsCacheRef(key)
+		if !seenRegion[ref] {
+			seenRegion[ref] = true
+			ent := makeEntity(key, "SCOPE.Datastore", "cache_region", file.Path, file.Language, line)
+			setProps(&ent, "framework", "rails", "region", key,
+				"cache_kind", "region", "provenance", "INFERRED_FROM_RAILS_CACHE")
+			if dynamic {
+				setProps(&ent, "dynamic", "true")
+			}
+			add(ent)
+		}
+		return ref
+	}
+
+	for _, m := range reRailsCacheOp.FindAllStringSubmatchIndex(src, -1) {
+		receiver := src[m[2]:m[3]]
+		verb := src[m[4]:m[5]]
+		rawKey := src[m[6]:m[7]]
+		line := lineOf(src, m[0])
+
+		// Bare `cache.<verb>` only counts when the file uses Rails.cache somewhere.
+		if receiver == "cache" && !hasRailsCache {
+			continue
+		}
+
+		// Resolve the key literal. A trailing `#{` marks an interpolated key —
+		// the static head before it is a key-prefix (dynamic); a clean literal
+		// is a concrete key.
+		key, dynamic := normaliseRailsCacheKey(rawKey)
+
+		relType := "CACHES"
+		mode := "read_through"
+		switch {
+		case railsInvalidateVerbs[verb]:
+			relType = "INVALIDATES"
+			mode = "evict"
+			if verb == "delete_matched" {
+				mode = "evict_matched"
+			}
+		case railsWriteVerbs[verb]:
+			mode = "write"
+		case railsReadVerbs[verb]:
+			mode = "read_through"
+		}
+
+		siteRef := fmt.Sprintf("rails_cache_op:%s:%d", file.Path, line)
+		ent := makeEntity(receiver+"."+verb, "SCOPE.Operation", "cache_method", file.Path, file.Language, line)
+		setProps(&ent, "framework", "rails", "cache_verb", verb, "cache_mode", mode,
+			"provenance", "INFERRED_FROM_RAILS_CACHE", "ref", siteRef)
+		if dynamic {
+			setProps(&ent, "dynamic", "true")
+		}
+
+		targetRef := emitRegion(key, dynamic, line)
+		edgeProps := map[string]string{
+			"framework": "rails", "region": key, "mode": mode, "language": file.Language,
+		}
+		if dynamic {
+			edgeProps["dynamic"] = "true"
+		}
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID:       targetRef,
+			Kind:       relType,
+			Properties: edgeProps,
+		})
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// normaliseRailsCacheKey resolves the captured first-argument literal into a
+// (label, dynamic) pair:
+//
+//	"home"        -> ("home", false)
+//	'users/index' -> ("users/index", false)
+//	"user/#{      -> ("user/*", true)   (interpolation head before #{)
+//	"#{           -> ("<dynamic>", true)
+func normaliseRailsCacheKey(raw string) (string, bool) {
+	// Strip surrounding quotes (the capture may be a full literal `"user/#{id}"`
+	// or a cut interpolation head `"user/#{`).
+	body := strings.Trim(raw, `"'`)
+	// Interpolated literal: a `#{` anywhere means the key is dynamic; the static
+	// head before the first interpolation is the key-prefix.
+	if i := strings.Index(body, "#{"); i >= 0 {
+		head := strings.TrimRight(body[:i], `"'`)
+		if head == "" {
+			return "<dynamic>", true
+		}
+		return head + "*", true
+	}
+	if body == "" {
+		return "<dynamic>", true
+	}
+	return body, false
+}

--- a/internal/custom/ruby/caching_test.go
+++ b/internal/custom/ruby/caching_test.go
@@ -1,0 +1,123 @@
+package ruby_test
+
+// caching_test.go — value-asserting tests for the custom_ruby_caching extractor
+// (#3692, epic #3628, area #18).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runRubyCaching(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_ruby_caching")
+	if !ok {
+		t.Fatal("custom_ruby_caching not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "app.rb", Language: "ruby", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findRubyCacheRel(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func TestRubyCaching_Fetch_ReadThrough(t *testing.T) {
+	src := `
+class HomeController
+  def index
+    Rails.cache.fetch("home") { expensive_render }
+  end
+end
+`
+	ents := runRubyCaching(t, src)
+	r := findRubyCacheRel(ents, "CACHES", "cache:rails:home")
+	if r == nil {
+		t.Fatalf("expected Rails.cache.fetch(\"home\") to CACHES key home (read-through)")
+	}
+	if r.Properties["mode"] != "read_through" {
+		t.Errorf("mode = %q, want read_through", r.Properties["mode"])
+	}
+}
+
+func TestRubyCaching_Delete_Invalidates(t *testing.T) {
+	src := `
+class HomeController
+  def update
+    Rails.cache.delete("home")
+  end
+end
+`
+	ents := runRubyCaching(t, src)
+	r := findRubyCacheRel(ents, "INVALIDATES", "cache:rails:home")
+	if r == nil {
+		t.Fatalf("expected Rails.cache.delete(\"home\") to INVALIDATE key home")
+	}
+	if r.Properties["mode"] != "evict" {
+		t.Errorf("mode = %q, want evict", r.Properties["mode"])
+	}
+}
+
+func TestRubyCaching_DeleteMatched_Prefix(t *testing.T) {
+	src := `Rails.cache.delete_matched("home/*")`
+	ents := runRubyCaching(t, src)
+	r := findRubyCacheRel(ents, "INVALIDATES", "cache:rails:home/*")
+	if r == nil || r.Properties["mode"] != "evict_matched" {
+		t.Fatalf("expected evict_matched on home/*, got %+v", r)
+	}
+}
+
+func TestRubyCaching_Interpolated_Dynamic(t *testing.T) {
+	src := `Rails.cache.fetch("user/#{id}") { load }`
+	ents := runRubyCaching(t, src)
+	r := findRubyCacheRel(ents, "CACHES", "cache:rails:user/*")
+	if r == nil {
+		t.Fatalf("expected interpolated key to CACHES prefix user/*")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("interpolated key should be dynamic")
+	}
+}
+
+func TestRubyCaching_Write(t *testing.T) {
+	src := `Rails.cache.write("config", v)`
+	ents := runRubyCaching(t, src)
+	r := findRubyCacheRel(ents, "CACHES", "cache:rails:config")
+	if r == nil || r.Properties["mode"] != "write" {
+		t.Fatalf("expected write mode on config, got %+v", r)
+	}
+}
+
+// Negative: a non-cache method call emits no cache edge.
+func TestRubyCaching_PlainCall_NoEdge(t *testing.T) {
+	src := `
+class HomeController
+  def index
+    render :index
+  end
+end
+`
+	ents := runRubyCaching(t, src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "CACHES" || r.Kind == "INVALIDATES" {
+				t.Fatalf("plain call should emit no cache edge, got %+v", r)
+			}
+		}
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -672,6 +672,35 @@ const (
 	//                 than a string literal (omitted otherwise)
 	// Append-only — never modifies existing entities or edges.
 	RelationshipKindInstruments RelationshipKind = "INSTRUMENTS"
+
+	// #3692 (epic #3628, area #18): caching-topology edges. Emitted by the
+	// per-framework caching passes (Spring @Cacheable/@CachePut/@CacheEvict,
+	// Python @lru_cache/Flask-Caching/cachetools, NestJS @CacheKey/cache-manager,
+	// Rails Rails.cache.fetch/delete) from the enclosing function/method
+	// operation entity → a synthetic cache-region/key target entity
+	// ("cache:<framework>:<region-or-key>", Kind SCOPE.Datastore, subtype
+	// "cache_region"). Two directions:
+	//   CACHES      : read-through / write cache population
+	//                 (@Cacheable, @CachePut, lru_cache, cache.fetch{}, cache.wrap).
+	//                 The function's result is stored/served under the region/key.
+	//   INVALIDATES : cache eviction (@CacheEvict, Rails.cache.delete,
+	//                 cacheManager.del). The function clears the region/key.
+	// Multiple call-sites that touch the same region converge on one target node,
+	// so CACHES and INVALIDATES edges for the same region are traversable together
+	// (a producer ↔ invalidator subgraph). Properties on the edge:
+	//   "framework" : spring | flask_caching | cachetools | lru_cache | nestjs |
+	//                 cache_manager | rails
+	//   "region"    : the cache region/name (Spring value=, Flask key_prefix,
+	//                 NestJS CacheKey) when statically resolvable
+	//   "key"       : the static cache key when resolvable (Rails fetch literal,
+	//                 cache.wrap literal)
+	//   "mode"      : read_through | write | evict | in_process
+	//   "dynamic"   : "true" when the region/key is a runtime expression
+	//                 (honest-partial: edge + mode recorded, target labelled
+	//                 "<dynamic>")
+	// Append-only — never modifies existing entities or edges.
+	RelationshipKindCaches      RelationshipKind = "CACHES"
+	RelationshipKindInvalidates RelationshipKind = "INVALIDATES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -788,6 +817,9 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindConsumesAPI,
 		// #3689 OpenTelemetry tracing-span instrumentation edge:
 		RelationshipKindInstruments,
+		// #3692 (epic #3628, area #18) caching-topology edges:
+		RelationshipKindCaches,
+		RelationshipKindInvalidates,
 	}
 }
 


### PR DESCRIPTION
Closes #3702 (child of epic #3628, area #18: caching topology).

## What
Adds **caching-topology extraction** — the higher-level cache decorator/annotation layer that sits ON TOP of the raw redis/memcached key work (#3668). Each cache read-through / write / invalidation site now emits a cache-region/key `SCOPE.Datastore` target plus a directed edge from the function/method that touches it, so producer↔invalidator subgraphs are traversable and cross-language consistent (target ref `cache:<framework>:<region>`, mirroring the redis keyspace node).

## New typed edge kinds
`CACHES` (read-through / write population) and `INVALIDATES` (evict) — `internal/types/kinds.go`, added to `AllRelationshipKinds()`.

## Frameworks that now emit cache edges
| Framework | Read-through / write (CACHES) | Invalidate (INVALIDATES) | Extractor |
|---|---|---|---|
| Spring (Java) | `@Cacheable`, `@CachePut` | `@CacheEvict` (`allEntries` → evict_all) | `internal/custom/java/caching.go` |
| Python | `@lru_cache`/`@cache`, cachetools `@cached`, Flask-Caching `@cache.cached(key_prefix=)` | — (eviction is imperative `cache.delete`, already a redis WRITES_TO) | `internal/custom/python/caching.go` |
| Rails (Ruby) | `Rails.cache.fetch`/`read`/`write` | `delete`, `delete_matched` | `internal/custom/ruby/caching.go` |
| JS/TS | NestJS `@CacheKey`, cache-manager `wrap`/`get`/`set` | cache-manager `del`/`reset` | `internal/custom/javascript/caching.go` |

- Spring `value=`/`cacheNames=` handle single + `{multi}` regions and bare shorthand; SpEL `key=` recorded as edge `key_spel`.
- Dynamic regions/keys are **honest-partial**: edge + `mode` recorded, target labelled `<dynamic>`/prefix `*`, `dynamic=true`.

## Cache edges asserted (value-asserting tests)
- Spring `@Cacheable("users")` on `getUser` → `getUser CACHES cache:spring:users` (mode=read_through, key_spel=#id)
- Spring `@CacheEvict("users")` on `updateUser` → `updateUser INVALIDATES cache:spring:users` (mode=evict; `allEntries` → evict_all)
- Spring multi `cacheNames={"users","admins"}` → two CACHES edges; region-less `@Cacheable(key=…)` → `<default>` dynamic
- Python `@lru_cache` → `CACHES cache:lru_cache:fn:fib` (in_process); Flask `key_prefix='view/users'` → read-through; no key_prefix → `<request_path>` dynamic; cachetools `@cached` → `fn:expensive`
- Rails `Rails.cache.fetch("home")` → `CACHES cache:rails:home` (read_through); `delete("home")` → INVALIDATES; `delete_matched("home/*")` → evict_matched; `"user/#{id}"` → prefix `user/*` dynamic
- NestJS `@CacheKey('users')` → `CACHES cache:nestjs:users`; cache-manager `wrap('user:1')` → read-through, `set` → write, `del` → INVALIDATES; `` `user:${id}` `` → prefix `user:*` dynamic
- Negative: plain method/call → no cache edge; non-Spring framework → no-op

## Records
New `db.cache` coverage record (multi-language) — `resource_extraction` + `dependency_attribution` partial, citing all four extractors.

## Verification
- `go test` green: custom/{java,python,ruby,javascript}, engine, types, tools/coverage
- `coverage validate` 0 errors; `coverage fmt --check` canonical
- `gofmt -l` empty; `go vet` clean

**DEPLOY-DEFERRED**: requires a coordinated live-daemon rebuild + reindex before these edges appear in the served graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)