### PR TITLE
[coupling] shared-database cross-service coupling analysis

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -61,6 +61,7 @@ const (
 	PassCommitCouple  = "commit-couple"  // Pass 8.5: VCS-derived COMMIT_COUPLED soft edges (#21)
 	PassCoupling      = "coupling"       // Pass 8.6: structural Ca/Ce/instability per Module (#3634)
 	PassDepHygiene    = "dep-hygiene"    // Pass 8.7: persist deplinker used/unused status onto deps (#3640)
+	PassSharedDB      = "shared-db"      // Pass 8.8: shared-database cross-service coupling (#3628 area #13)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
@@ -1571,6 +1572,30 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 					"entities_annotated=%d edges_annotated=%d\n",
 				dhStats.Declared, dhStats.Used, dhStats.Unused, dhStats.Phantom,
 				dhStats.EntitiesAnnotated, dhStats.EdgesAnnotated)
+		}
+	}
+
+	// Pass 8.8 — shared-database cross-service coupling (#3628 area #13). Runs
+	// AFTER module-agg (Pass 8) so synthetic Module nodes exist and every
+	// entity carries Properties["module"]. Detects when ≥2 DISTINCT modules
+	// access the SAME table/collection (via ACCESSES_TABLE / JOINS_COLLECTION /
+	// SCOPE.DataAccess attribution): annotates the shared SCOPE.DataAccess
+	// entities with shared/accessor_count/accessor_modules and emits a
+	// SHARES_DATA edge between each co-accessing Module pair — the cross-service
+	// DATA coupling axis, orthogonal to structural (Pass 8.6) and temporal
+	// (Pass 8.5) coupling. Honest: only when the shared table + ≥2 distinct
+	// real-module accessors genuinely exist. Skippable via --skip-pass=shared-db.
+	if !i.skipPasses[PassSharedDB] {
+		sdStats := engine.ApplySharedDataCoupling(doc)
+		if sdStats.Skipped {
+			if verbose() {
+				fmt.Fprintf(os.Stderr, "archigraph: shared-db skipped (no module graph or data access)\n")
+			}
+		} else if verbose() || sdStats.SharedTables > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: shared-db tables=%d shared=%d data_access_annotated=%d coupling_edges=%d\n",
+				sdStats.TablesConsidered, sdStats.SharedTables,
+				sdStats.DataAccessAnnotated, sdStats.CouplingEdges)
 		}
 	}
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2,6 +2,20 @@
   "$schema_version": 1,
   "records": [
     {
+      "id": "analysis.architecture.shared-db-coupling",
+      "category": "platform",
+      "language": "multi",
+      "label": "Shared-database cross-service coupling (SHARES_DATA)",
+      "capabilities": {
+        "shared_data_coupling": {
+          "status": "full",
+          "cites": ["cmd/archigraph/index.go","internal/engine/shared_db_coupling.go","internal/engine/shared_db_coupling_test.go"],
+          "notes": "#3628 area #13: detects when ≥2 DISTINCT modules access the SAME logical table/collection — the cross-service data-ownership / boundary-violation signal. LIVE project-scope engine pass engine.ApplySharedDataCoupling, registered in cmd/archigraph/index.go as Pass 8.8 (PassSharedDB, --skip-pass=shared-db) AFTER module-agg (Pass 8) so synthetic Module nodes exist and every entity carries Properties[module]. Over the assembled graph it converges table/collection accesses by NAME (per repo) from three signals: ACCESSES_TABLE edges (function→SCOPE.DataAccess, table from the DataAccess `table` prop, accessor module from the source/function entity), JOINS_COLLECTION edges (Mongo $lookup, `from` collection), and SCOPE.DataAccess entities directly (module+table props). For each (repo,table) touched by ≥2 distinct REAL-module accessors it stamps shared=true/accessor_count=N/accessor_modules=\u003csorted csv\u003e on the SCOPE.DataAccess entities and emits a SHARES_DATA edge between every co-accessing Module pair (smaller Module ID = FromID; props coupling=shared_data, shared_tables csv, shared_count, provenance=SHARED_DB_COUPLING). Distinct axis from structural coupling (Pass 8.6 import fan-in/out) and commit-couple (Pass 8.5 temporal). Honest: the `_external`/empty module is never a distinct accessor (unattributed access cannot fabricate coupling); a table touched by ONE module is stamped shared=false with no edge; self-pairs suppressed; skips entirely with no Module graph or no data access. Value-asserting tests: OrderSvc+BillingSvc both ACCESSES_TABLE orders → orders.shared=true/accessor_count=2/accessor_modules=BillingSvc,OrderSvc + exactly one SHARES_DATA edge (OrderSvc,BillingSvc, shared_tables=orders); a single-module table → shared=false/0 edges; JOINS_COLLECTION co-join → coupling edge; idempotent re-run adds no duplicate edge.",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "analysis.architecture.structural-coupling",
       "category": "platform",
       "language": "multi",

--- a/internal/engine/shared_db_coupling.go
+++ b/internal/engine/shared_db_coupling.go
@@ -1,0 +1,429 @@
+// Package engine — shared-database cross-service coupling analysis
+// (#3628 area #13).
+//
+// SharedDataCoupling is a PROJECT-SCOPE pass (sibling to structural_coupling.go
+// and dependency_hygiene.go) that detects when two or more distinct modules
+// access the SAME logical table or collection. Shared mutable data is the
+// classic service-boundary smell: two services that read/write the same table
+// are coupled through the datastore even when there is no direct call or import
+// edge between them, so a clean split / extraction has to reconcile that shared
+// ownership first. This pass surfaces that otherwise-invisible coupling.
+//
+// AXIS — DATA, NOT CONTROL. structural_coupling.go measures import/dependency
+// fan-in/fan-out (Ca/Ce/instability on Module nodes). commit_coupling_edges.go
+// measures temporal git co-change. This pass measures DATA coupling: the shared
+// persistence substrate. The three are orthogonal and answer different
+// questions for rewrite-boundary planning.
+//
+// INPUT. The pass consumes the already-assembled graph after document assembly
+// AND module aggregation (so synthetic Module nodes exist and every entity
+// carries Properties["module"]). It looks at three converged data-access
+// signals, all of which encode the table/collection by NAME:
+//
+//   - ACCESSES_TABLE edges (function → SCOPE.DataAccess). The accessed table is
+//     the `table` property on the target SCOPE.DataAccess entity; the accessing
+//     module is the module of the SOURCE (enclosing-function) entity, falling
+//     back to the DataAccess entity's own module when the source is unresolved.
+//   - JOINS_COLLECTION edges (collection → collection, Mongo $lookup). Both the
+//     joining and joined collections are shared data; the accessing module is
+//     the module of the edge's SOURCE entity (the aggregating collection's
+//     call-site file).
+//   - SCOPE.DataAccess entities directly (covers accesses whose ACCESSES_TABLE
+//     source did not resolve to a real function entity — the DataAccess node
+//     itself carries `table` + `module`).
+//
+// OUTPUT. For every distinct (repo, table) key touched by ≥2 distinct modules:
+//
+//  1. The SCOPE.DataAccess entities for that table are annotated with
+//     shared=true, accessor_count=N, accessor_modules=<sorted csv>. A table
+//     touched by exactly one module is annotated shared=false (explicit, not
+//     unknown) with accessor_count=1.
+//  2. A SHARES_DATA edge is emitted between every unordered pair of co-accessing
+//     Module nodes (FromID = lexicographically smaller Module ID), carrying the
+//     comma-joined sorted list of co-accessed tables and a shared_count. This
+//     is the cross-service data-coupling edge.
+//
+// HONEST. A SHARES_DATA edge / shared=true annotation is emitted ONLY when the
+// shared table entity genuinely exists AND ≥2 DISTINCT modules access it. The
+// "_external" catch-all module and the empty module are ignored as accessors so
+// unattributed access never fabricates coupling. Self-pairs are suppressed. The
+// pass is deterministic and idempotent.
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Kind / property constants for the shared-db-coupling pass.
+const (
+	sharedKindDataAccess  = "SCOPE.DataAccess"
+	sharedKindModule      = "Module"
+	sharedRelAccessTable  = "ACCESSES_TABLE"
+	sharedRelJoinsColl    = "JOINS_COLLECTION"
+	sharedRelSharesData   = "SHARES_DATA"
+	sharedModuleExternal  = "_external"
+	sharedProvenance      = "SHARED_DB_COUPLING"
+	sharedCouplingKindTag = "shared_data"
+)
+
+// SharedDataStats summarises a SharedDataCoupling run.
+type SharedDataStats struct {
+	// TablesConsidered is the number of distinct (repo, table) keys that had at
+	// least one resolved module accessor.
+	TablesConsidered int
+	// SharedTables is the number of those tables touched by ≥2 distinct modules.
+	SharedTables int
+	// DataAccessAnnotated is the number of SCOPE.DataAccess entities stamped
+	// with shared / accessor_count / accessor_modules.
+	DataAccessAnnotated int
+	// CouplingEdges is the number of SHARES_DATA Module→Module edges emitted.
+	CouplingEdges int
+	// Skipped is true when there is nothing to analyse (no Module nodes or no
+	// data-access signal). Honest: no edge / annotation is produced.
+	Skipped bool
+}
+
+// modulePair is an unordered pair of Module entity IDs with the smaller ID
+// first, used as a deterministic key when accumulating co-accessed tables.
+type modulePair struct {
+	a, b string // a < b lexicographically
+}
+
+// makePair normalises two module IDs into a modulePair (smaller first).
+func makePair(x, y string) modulePair {
+	if x < y {
+		return modulePair{a: x, b: y}
+	}
+	return modulePair{a: y, b: x}
+}
+
+// ApplySharedDataCoupling runs the shared-database coupling analysis over the
+// assembled doc. It MUST run after module.Aggregate (so Module nodes exist and
+// every entity carries Properties["module"]). It returns stats describing the
+// run. Deterministic and idempotent.
+func ApplySharedDataCoupling(doc *graph.Document) SharedDataStats {
+	if doc == nil {
+		return SharedDataStats{Skipped: true}
+	}
+
+	// Index Module entities by their synthetic (repo, name) → Module ID so we
+	// can resolve a module name to the real graph node, and confirm the node
+	// exists before emitting an edge to it.
+	moduleNodeID := make(map[moduleKeyLite]string)
+	haveModuleNode := false
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != sharedKindModule {
+			continue
+		}
+		repo := entityRepo(doc, e)
+		name := e.Properties["module"]
+		if name == "" {
+			name = e.Name
+		}
+		moduleNodeID[moduleKeyLite{repo: repo, name: name}] = e.ID
+		haveModuleNode = true
+	}
+	if !haveModuleNode {
+		// Module aggregation did not run / produced nothing — no module
+		// attribution is possible, so we cannot honestly assert coupling.
+		return SharedDataStats{Skipped: true}
+	}
+
+	// entityModule resolves any entity ID to its (repo, moduleName). Used to
+	// attribute the source end of ACCESSES_TABLE / JOINS_COLLECTION edges.
+	entityModule := make(map[string]moduleKeyLite, len(doc.Entities))
+	// dataAccessByTable groups SCOPE.DataAccess entity indices by (repo, table).
+	dataAccessByTable := make(map[tableKey][]int)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == sharedKindModule {
+			continue
+		}
+		repo := entityRepo(doc, e)
+		mk := moduleKeyLite{repo: repo, name: moduleNameOf(e)}
+		entityModule[e.ID] = mk
+		if e.Kind == sharedKindDataAccess {
+			tbl := normTable(e.Properties["table"])
+			if tbl != "" {
+				dataAccessByTable[tableKey{repo: repo, table: tbl}] = append(
+					dataAccessByTable[tableKey{repo: repo, table: tbl}], i)
+			}
+		}
+	}
+	if len(dataAccessByTable) == 0 {
+		return SharedDataStats{Skipped: true}
+	}
+
+	// tableAccessors collects the DISTINCT accessor module names per table.
+	tableAccessors := make(map[tableKey]map[string]struct{})
+	addAccessor := func(tk tableKey, mk moduleKeyLite) {
+		if mk.name == "" || mk.name == sharedModuleExternal {
+			return // unattributed — never fabricate coupling
+		}
+		// Only count an accessor whose module resolves to a real Module node in
+		// the same repo, so the SHARES_DATA endpoints are guaranteed to exist.
+		if _, ok := moduleNodeID[mk]; !ok {
+			return
+		}
+		set := tableAccessors[tk]
+		if set == nil {
+			set = make(map[string]struct{})
+			tableAccessors[tk] = set
+		}
+		set[mk.name] = struct{}{}
+	}
+
+	// (1) Direct SCOPE.DataAccess attribution: each DataAccess node carries its
+	// own module + table.
+	for tk, idxs := range dataAccessByTable {
+		for _, i := range idxs {
+			addAccessor(tk, entityModule[doc.Entities[i].ID])
+		}
+	}
+
+	// daTableOf resolves a SCOPE.DataAccess entity ID → its (repo, table) key,
+	// so edge endpoints landing on a DataAccess node map back to a table.
+	daTableOf := make(map[string]tableKey)
+	for tk, idxs := range dataAccessByTable {
+		for _, i := range idxs {
+			daTableOf[doc.Entities[i].ID] = tk
+		}
+	}
+
+	// (2) ACCESSES_TABLE edges: function(source) → SCOPE.DataAccess(target).
+	// Attribute the table to the SOURCE entity's module (the caller), which is
+	// the most precise accessor. The target's table key is taken from the
+	// DataAccess node, or, when the edge carries a `table` property and the
+	// target did not index as a DataAccess node, from the edge property.
+	// (3) JOINS_COLLECTION edges: attribute both endpoints' shared collection to
+	// the source module.
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		switch r.Kind {
+		case sharedRelAccessTable:
+			tk, ok := tableKeyForEdge(doc, r, daTableOf, entityModule)
+			if !ok {
+				continue
+			}
+			if mk, ok := entityModule[r.FromID]; ok {
+				addAccessor(tk, mk)
+			}
+		case sharedRelJoinsColl:
+			// The joined collection is shared data; attribute it to the source
+			// module (the file performing the $lookup). Resolve the table key
+			// from either endpoint that is a known DataAccess/collection.
+			tk, ok := tableKeyForEdge(doc, r, daTableOf, entityModule)
+			if !ok {
+				continue
+			}
+			if mk, ok := entityModule[r.FromID]; ok {
+				addAccessor(tk, mk)
+			}
+		}
+	}
+
+	stats := SharedDataStats{}
+
+	// pairTables accumulates the sorted set of co-accessed tables per module
+	// pair, so a single SHARES_DATA edge can carry every shared table.
+	pairTables := make(map[modulePair]map[string]struct{})
+
+	// Annotate SCOPE.DataAccess entities and build module pairs.
+	for tk, set := range tableAccessors {
+		stats.TablesConsidered++
+		count := len(set)
+
+		names := make([]string, 0, count)
+		for n := range set {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		csv := strings.Join(names, ",")
+
+		shared := count >= 2
+		if shared {
+			stats.SharedTables++
+		}
+
+		// Annotate every DataAccess entity for this table.
+		for _, i := range dataAccessByTable[tk] {
+			e := &doc.Entities[i]
+			if e.Properties == nil {
+				e.Properties = make(map[string]string)
+			}
+			if shared {
+				e.Properties["shared"] = "true"
+			} else {
+				e.Properties["shared"] = "false"
+			}
+			e.Properties["accessor_count"] = fmt.Sprintf("%d", count)
+			e.Properties["accessor_modules"] = csv
+			stats.DataAccessAnnotated++
+		}
+
+		if !shared {
+			continue
+		}
+		// Record every unordered module pair co-accessing this table.
+		repo := tk.repo
+		for x := 0; x < len(names); x++ {
+			for y := x + 1; y < len(names); y++ {
+				idA := moduleNodeID[moduleKeyLite{repo: repo, name: names[x]}]
+				idB := moduleNodeID[moduleKeyLite{repo: repo, name: names[y]}]
+				if idA == "" || idB == "" || idA == idB {
+					continue
+				}
+				p := makePair(idA, idB)
+				ts := pairTables[p]
+				if ts == nil {
+					ts = make(map[string]struct{})
+					pairTables[p] = ts
+				}
+				ts[tk.table] = struct{}{}
+			}
+		}
+	}
+
+	// Pre-index existing SHARES_DATA edge IDs so a re-run is idempotent (the
+	// pass appends edges; without this guard a second invocation would
+	// double-emit). Deterministic IDs make the guard exact.
+	existingShares := make(map[string]struct{})
+	for k := range doc.Relationships {
+		if doc.Relationships[k].Kind == sharedRelSharesData {
+			existingShares[doc.Relationships[k].ID] = struct{}{}
+		}
+	}
+
+	// Emit one SHARES_DATA edge per module pair, deterministically ordered.
+	pairs := make([]modulePair, 0, len(pairTables))
+	for p := range pairTables {
+		pairs = append(pairs, p)
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].a != pairs[j].a {
+			return pairs[i].a < pairs[j].a
+		}
+		return pairs[i].b < pairs[j].b
+	})
+	for _, p := range pairs {
+		tbls := pairTables[p]
+		names := make([]string, 0, len(tbls))
+		for t := range tbls {
+			names = append(names, t)
+		}
+		sort.Strings(names)
+		relID := graph.RelationshipID(p.a, p.b, sharedRelSharesData)
+		if _, ok := existingShares[relID]; ok {
+			continue // already emitted on a prior run — stay idempotent
+		}
+		rel := graph.Relationship{
+			ID:     relID,
+			FromID: p.a,
+			ToID:   p.b,
+			Kind:   sharedRelSharesData,
+			Properties: map[string]string{
+				"coupling":      sharedCouplingKindTag,
+				"shared_tables": strings.Join(names, ","),
+				"shared_count":  fmt.Sprintf("%d", len(names)),
+				"provenance":    sharedProvenance,
+			},
+		}
+		doc.Relationships = append(doc.Relationships, rel)
+		stats.CouplingEdges++
+	}
+
+	doc.Stats.Relationships = len(doc.Relationships)
+	return stats
+}
+
+// moduleKeyLite is a (repo, module-name) key local to this pass.
+type moduleKeyLite struct {
+	repo string
+	name string
+}
+
+// tableKey identifies a logical table/collection within a repo.
+type tableKey struct {
+	repo  string
+	table string
+}
+
+// entityRepo returns the per-entity repo tag, falling back to the document repo
+// (mirrors module.Aggregate's resolution for multi-repo group documents).
+func entityRepo(doc *graph.Document, e *graph.Entity) string {
+	if e.Properties != nil {
+		if v, ok := e.Properties["repo"]; ok && v != "" {
+			return v
+		}
+	}
+	return doc.Repo
+}
+
+// moduleNameOf returns the entity's module label, or "_external" when absent
+// (mirrors module.Aggregate).
+func moduleNameOf(e *graph.Entity) string {
+	if e.Properties != nil {
+		if v, ok := e.Properties["module"]; ok && v != "" {
+			return v
+		}
+	}
+	return sharedModuleExternal
+}
+
+// normTable canonicalises a table/collection name for converge-by-name grouping:
+// trim, lowercase, and strip a schema/db qualifier prefix (e.g. "public.orders"
+// → "orders", "mydb.orders" → "orders"). UNKNOWN dynamic tables are dropped.
+func normTable(t string) string {
+	s := strings.ToLower(strings.TrimSpace(t))
+	if s == "" || s == "unknown" {
+		return ""
+	}
+	if i := strings.LastIndex(s, "."); i >= 0 && i+1 < len(s) {
+		s = s[i+1:]
+	}
+	// Strip surrounding quotes/backticks an ORM might leave on.
+	s = strings.Trim(s, "`\"'[]")
+	return s
+}
+
+// tableKeyForEdge resolves the (repo, table) key an ACCESSES_TABLE /
+// JOINS_COLLECTION edge points at. Resolution order: (1) the target entity is a
+// known SCOPE.DataAccess node → use its table key; (2) the edge carries a
+// `table` property → use it with the source entity's repo. Returns false when
+// neither yields a non-empty table.
+func tableKeyForEdge(
+	doc *graph.Document,
+	r *graph.Relationship,
+	daTableOf map[string]tableKey,
+	entityModule map[string]moduleKeyLite,
+) (tableKey, bool) {
+	if tk, ok := daTableOf[r.ToID]; ok {
+		return tk, true
+	}
+	if tk, ok := daTableOf[r.FromID]; ok {
+		return tk, true
+	}
+	if r.Properties != nil {
+		tbl := normTable(r.Properties["table"])
+		if tbl == "" {
+			tbl = normTable(r.Properties["from"]) // JOINS_COLLECTION `from`
+		}
+		if tbl != "" {
+			repo := doc.Repo
+			if mk, ok := entityModule[r.FromID]; ok && mk.repo != "" {
+				repo = mk.repo
+			}
+			return tableKey{repo: repo, table: tbl}, true
+		}
+	}
+	return tableKey{}, false
+}
+
+// compile-time assertion that the SHARES_DATA kind is registered.
+var _ = types.RelationshipKindSharesData

--- a/internal/engine/shared_db_coupling_test.go
+++ b/internal/engine/shared_db_coupling_test.go
@@ -1,0 +1,272 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const sdRepo = "acme/shop"
+
+// sdModule builds a synthetic Module node with the deterministic ID the pass
+// resolves via moduleNodeID (graph.EntityID(repo,"Module",name,"")).
+func sdModule(name string) graph.Entity {
+	return graph.Entity{
+		ID:         graph.EntityID(sdRepo, "Module", name, ""),
+		Name:       name,
+		Kind:       "Module",
+		Properties: map[string]string{"module": name, "synthetic": "true", "repo": sdRepo},
+	}
+}
+
+// sdAccess builds a SCOPE.DataAccess entity attributed to module `mod` that
+// accesses table `table`.
+func sdAccess(id, mod, table string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       "SELECT " + table,
+		Kind:       "SCOPE.DataAccess",
+		SourceFile: mod + "/repo.go",
+		Properties: map[string]string{"module": mod, "repo": sdRepo, "table": table},
+	}
+}
+
+func sdModuleID(name string) string {
+	return graph.EntityID(sdRepo, "Module", name, "")
+}
+
+// TestApplySharedDataCoupling_SharedAndPrivate is the value-asserting fixture:
+//
+//	OrderSvc   ACCESSES_TABLE orders   (shared)
+//	BillingSvc ACCESSES_TABLE orders   (shared)
+//	OrderSvc   ACCESSES_TABLE audit    (private — only OrderSvc touches it)
+//
+// Expected:
+//   - `orders` → shared=true, accessor_count=2, accessor_modules="BillingSvc,OrderSvc"
+//   - `audit`  → shared=false, accessor_count=1
+//   - exactly ONE SHARES_DATA edge, between OrderSvc and BillingSvc, listing
+//     `orders` as the shared table.
+func TestApplySharedDataCoupling_SharedAndPrivate(t *testing.T) {
+	orderMod := sdModuleID("OrderSvc")
+	billMod := sdModuleID("BillingSvc")
+
+	doc := &graph.Document{
+		Repo: sdRepo,
+		Entities: []graph.Entity{
+			sdModule("OrderSvc"),
+			sdModule("BillingSvc"),
+			sdAccess("da-order-orders", "OrderSvc", "orders"),
+			sdAccess("da-bill-orders", "BillingSvc", "orders"),
+			sdAccess("da-order-audit", "OrderSvc", "audit"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn-order", ToID: "da-order-orders", Kind: "ACCESSES_TABLE"},
+			{ID: "r2", FromID: "fn-bill", ToID: "da-bill-orders", Kind: "ACCESSES_TABLE"},
+			{ID: "r3", FromID: "fn-order2", ToID: "da-order-audit", Kind: "ACCESSES_TABLE"},
+		},
+	}
+
+	stats := ApplySharedDataCoupling(doc)
+	if stats.Skipped {
+		t.Fatalf("expected pass to run, got Skipped=true")
+	}
+	if stats.SharedTables != 1 {
+		t.Errorf("SharedTables = %d, want 1", stats.SharedTables)
+	}
+	if stats.CouplingEdges != 1 {
+		t.Errorf("CouplingEdges = %d, want 1", stats.CouplingEdges)
+	}
+
+	byID := make(map[string]graph.Entity, len(doc.Entities))
+	for _, e := range doc.Entities {
+		byID[e.ID] = e
+	}
+
+	// `orders` is shared by exactly 2 modules.
+	for _, id := range []string{"da-order-orders", "da-bill-orders"} {
+		e := byID[id]
+		if e.Properties["shared"] != "true" {
+			t.Errorf("%s: shared = %q, want \"true\"", id, e.Properties["shared"])
+		}
+		if e.Properties["accessor_count"] != "2" {
+			t.Errorf("%s: accessor_count = %q, want \"2\"", id, e.Properties["accessor_count"])
+		}
+		if got := e.Properties["accessor_modules"]; got != "BillingSvc,OrderSvc" {
+			t.Errorf("%s: accessor_modules = %q, want \"BillingSvc,OrderSvc\"", id, got)
+		}
+	}
+
+	// `audit` is private to one module.
+	audit := byID["da-order-audit"]
+	if audit.Properties["shared"] != "false" {
+		t.Errorf("audit: shared = %q, want \"false\"", audit.Properties["shared"])
+	}
+	if audit.Properties["accessor_count"] != "1" {
+		t.Errorf("audit: accessor_count = %q, want \"1\"", audit.Properties["accessor_count"])
+	}
+
+	// Exactly one SHARES_DATA edge, between OrderSvc and BillingSvc.
+	var shares []graph.Relationship
+	for _, r := range doc.Relationships {
+		if r.Kind == "SHARES_DATA" {
+			shares = append(shares, r)
+		}
+	}
+	if len(shares) != 1 {
+		t.Fatalf("want 1 SHARES_DATA edge, got %d", len(shares))
+	}
+	edge := shares[0]
+	// Endpoints must be the two module IDs (smaller first).
+	wantA, wantB := orderMod, billMod
+	if wantA > wantB {
+		wantA, wantB = wantB, wantA
+	}
+	if edge.FromID != wantA || edge.ToID != wantB {
+		t.Errorf("SHARES_DATA endpoints = (%s,%s), want (%s,%s)", edge.FromID, edge.ToID, wantA, wantB)
+	}
+	if edge.Properties["shared_tables"] != "orders" {
+		t.Errorf("shared_tables = %q, want \"orders\"", edge.Properties["shared_tables"])
+	}
+	if edge.Properties["shared_count"] != "1" {
+		t.Errorf("shared_count = %q, want \"1\"", edge.Properties["shared_count"])
+	}
+	if edge.Properties["coupling"] != "shared_data" {
+		t.Errorf("coupling = %q, want \"shared_data\"", edge.Properties["coupling"])
+	}
+	if edge.Properties["provenance"] != "SHARED_DB_COUPLING" {
+		t.Errorf("provenance = %q, want \"SHARED_DB_COUPLING\"", edge.Properties["provenance"])
+	}
+
+	// Idempotent: a second run must not add a second SHARES_DATA edge.
+	before := len(doc.Relationships)
+	ApplySharedDataCoupling(doc)
+	count := 0
+	for _, r := range doc.Relationships {
+		if r.Kind == "SHARES_DATA" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("after second run: SHARES_DATA count = %d, want 1 (idempotent)", count)
+	}
+	if len(doc.Relationships) != before {
+		t.Errorf("second run changed relationship count %d → %d (not idempotent)", before, len(doc.Relationships))
+	}
+}
+
+// TestApplySharedDataCoupling_SingleAccessorNoEdge asserts a table touched by a
+// single module produces NO coupling edge and shared=false (not len>0 logic).
+func TestApplySharedDataCoupling_SingleAccessorNoEdge(t *testing.T) {
+	doc := &graph.Document{
+		Repo: sdRepo,
+		Entities: []graph.Entity{
+			sdModule("OrderSvc"),
+			sdAccess("da1", "OrderSvc", "orders"),
+			sdAccess("da2", "OrderSvc", "orders"), // same module, second op
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn1", ToID: "da1", Kind: "ACCESSES_TABLE"},
+			{ID: "r2", FromID: "fn2", ToID: "da2", Kind: "ACCESSES_TABLE"},
+		},
+	}
+	stats := ApplySharedDataCoupling(doc)
+	if stats.SharedTables != 0 {
+		t.Errorf("SharedTables = %d, want 0", stats.SharedTables)
+	}
+	if stats.CouplingEdges != 0 {
+		t.Errorf("CouplingEdges = %d, want 0", stats.CouplingEdges)
+	}
+	for _, r := range doc.Relationships {
+		if r.Kind == "SHARES_DATA" {
+			t.Errorf("unexpected SHARES_DATA edge for single-module table")
+		}
+	}
+	for _, e := range doc.Entities {
+		if e.Kind == "SCOPE.DataAccess" && e.Properties["shared"] != "false" {
+			t.Errorf("%s: shared = %q, want \"false\"", e.ID, e.Properties["shared"])
+		}
+	}
+}
+
+// TestApplySharedDataCoupling_ExternalNotCounted asserts that the "_external"
+// catch-all module is never counted as a distinct accessor, so unattributed
+// access cannot fabricate coupling.
+func TestApplySharedDataCoupling_ExternalNotCounted(t *testing.T) {
+	doc := &graph.Document{
+		Repo: sdRepo,
+		Entities: []graph.Entity{
+			sdModule("OrderSvc"),
+			sdAccess("da1", "OrderSvc", "orders"),
+			// second accessor is unattributed (no module → _external).
+			{ID: "da2", Kind: "SCOPE.DataAccess", Name: "SELECT orders",
+				Properties: map[string]string{"repo": sdRepo, "table": "orders"}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn1", ToID: "da1", Kind: "ACCESSES_TABLE"},
+		},
+	}
+	stats := ApplySharedDataCoupling(doc)
+	if stats.SharedTables != 0 {
+		t.Errorf("SharedTables = %d, want 0 (external not a real accessor)", stats.SharedTables)
+	}
+	if stats.CouplingEdges != 0 {
+		t.Errorf("CouplingEdges = %d, want 0", stats.CouplingEdges)
+	}
+}
+
+// TestApplySharedDataCoupling_JoinsCollection asserts the Mongo
+// JOINS_COLLECTION signal contributes accessors, and two modules joining the
+// same collection are flagged shared with a coupling edge.
+func TestApplySharedDataCoupling_JoinsCollection(t *testing.T) {
+	doc := &graph.Document{
+		Repo: sdRepo,
+		Entities: []graph.Entity{
+			sdModule("CartSvc"),
+			sdModule("ReportSvc"),
+			sdAccess("da-cart", "CartSvc", "products"),
+			sdAccess("da-report", "ReportSvc", "products"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "j1", FromID: "agg-cart", ToID: "da-cart", Kind: "JOINS_COLLECTION",
+				Properties: map[string]string{"from": "products"}},
+			{ID: "j2", FromID: "agg-report", ToID: "da-report", Kind: "JOINS_COLLECTION",
+				Properties: map[string]string{"from": "products"}},
+		},
+	}
+	stats := ApplySharedDataCoupling(doc)
+	if stats.SharedTables != 1 {
+		t.Errorf("SharedTables = %d, want 1", stats.SharedTables)
+	}
+	if stats.CouplingEdges != 1 {
+		t.Errorf("CouplingEdges = %d, want 1", stats.CouplingEdges)
+	}
+	var found bool
+	for _, r := range doc.Relationships {
+		if r.Kind == "SHARES_DATA" {
+			found = true
+			if !strings.Contains(r.Properties["shared_tables"], "products") {
+				t.Errorf("shared_tables = %q, want it to contain \"products\"", r.Properties["shared_tables"])
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a SHARES_DATA edge for the co-joined collection")
+	}
+}
+
+// TestApplySharedDataCoupling_NoModulesSkips asserts an honest skip when module
+// aggregation has not run (no Module nodes → no attribution possible).
+func TestApplySharedDataCoupling_NoModulesSkips(t *testing.T) {
+	doc := &graph.Document{
+		Repo: sdRepo,
+		Entities: []graph.Entity{
+			sdAccess("da1", "OrderSvc", "orders"),
+			sdAccess("da2", "BillingSvc", "orders"),
+		},
+	}
+	stats := ApplySharedDataCoupling(doc)
+	if !stats.Skipped {
+		t.Errorf("expected Skipped=true with no Module nodes, got %+v", stats)
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -672,6 +672,21 @@ const (
 	//                 than a string literal (omitted otherwise)
 	// Append-only — never modifies existing entities or edges.
 	RelationshipKindInstruments RelationshipKind = "INSTRUMENTS"
+
+	// #3628 area #13: shared-database cross-service coupling edge. Emitted by
+	// the project-scope shared-db-coupling pass (engine.ApplySharedDataCoupling)
+	// between two synthetic Module entities that BOTH access the same table or
+	// collection entity (via ACCESSES_TABLE / JOINS_COLLECTION / SCOPE.DataAccess
+	// attribution). It is the cross-service data-ownership / boundary-violation
+	// signal: when ≥2 distinct modules touch one table, those modules are
+	// data-coupled even with no direct call/import edge between them. Properties
+	// on the edge: coupling=shared_data, shared_tables (comma-joined sorted list
+	// of the co-accessed table/collection names), shared_count (how many tables
+	// the pair co-accesses), provenance=SHARED_DB_COUPLING. The edge is
+	// undirected in meaning but emitted once per unordered module pair (the
+	// lexicographically smaller module ID is FromID) so it is deterministic and
+	// not double-counted.
+	RelationshipKindSharesData RelationshipKind = "SHARES_DATA"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -788,6 +803,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindConsumesAPI,
 		// #3689 OpenTelemetry tracing-span instrumentation edge:
 		RelationshipKindInstruments,
+		// #3628 area #13 shared-database cross-service coupling edge:
+		RelationshipKindSharesData,
 	}
 }
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -65,7 +65,7 @@ categories:
   databases:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
-    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution]
+    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection]
   protocol:


### PR DESCRIPTION
Closes #3709 (child of epic #3628, area #13).

## What this adds
A PROJECT-SCOPE engine pass — `engine.ApplySharedDataCoupling` — registered as **Pass 8.8** (`PassSharedDB`, `--skip-pass=shared-db`) in `cmd/archigraph/index.go`, running AFTER module aggregation. Sibling to structural-coupling (Pass 8.6, #3634) and dep-hygiene (Pass 8.7, #3640).

It detects when **≥2 distinct modules/services access the SAME table or collection** — the cross-service data-ownership / boundary-violation signal. Two services that share a table are coupled through the datastore even with no direct call/import edge, so a clean split must reconcile that ownership first; this pass makes the otherwise-invisible coupling explicit.

## What signal now emits
Over the assembled graph, the pass converges table/collection accesses **by name** (per repo) from three existing signals:
- `ACCESSES_TABLE` edges (#3684): function → `SCOPE.DataAccess`; table from the `table` prop, accessor module from the source/function entity.
- Mongo `JOINS_COLLECTION` ($lookup `from` collection).
- `SCOPE.DataAccess` entities directly (carry `module` + `table`).

For each (repo, table) touched by ≥2 distinct **real** modules it:
1. Annotates the `SCOPE.DataAccess` entities: `shared=true`, `accessor_count=N`, `accessor_modules=<sorted csv>` (single-accessor tables get `shared=false` — explicit, not unknown).
2. Emits a new **`SHARES_DATA`** edge between every co-accessing `Module` pair (smaller Module ID = FromID), props: `coupling=shared_data`, `shared_tables` (sorted csv), `shared_count`, `provenance=SHARED_DB_COUPLING`.

`RelationshipKindSharesData` is added and registered in `AllRelationshipKinds()` (producer-kind validator green).

## Axis
DATA coupling — orthogonal to structural coupling (import fan-in/out, Pass 8.6) and commit-couple (temporal git co-change, Pass 8.5).

## Honesty
- `_external`/empty module is never a distinct accessor → unattributed access cannot fabricate coupling.
- A table touched by ONE module → `shared=false`, **no** edge.
- Skips entirely with no Module graph or no data access (`Skipped`).
- Deterministic + idempotent (unordered pair key; re-run adds no duplicate edge).

## Tests (value-asserting, not len>0)
- `OrderSvc` + `BillingSvc` both ACCESSES_TABLE `orders` → `orders.shared=true`, `accessor_count=2`, `accessor_modules="BillingSvc,OrderSvc"`, **exactly one** `SHARES_DATA` edge `(OrderSvc,BillingSvc)` with `shared_tables=orders`; the private `audit` table → `shared=false`, `accessor_count=1`, no edge.
- Single-module table → 0 shared tables, 0 edges, `shared=false`.
- `_external` (unattributed) second accessor → not counted, 0 edges.
- Mongo `JOINS_COLLECTION` co-join → coupling edge listing the collection.
- No Module nodes → honest `Skipped`.
- Idempotent re-run → no duplicate `SHARES_DATA` edge.

## Coverage
New cell `analysis.architecture.shared-db-coupling` / `shared_data_coupling` (category `platform`), citing the pass + tests. `coverage validate` 0 errors, `fmt --check` canonical, surgical 14-line insert.

## Gates
`go test ./internal/engine/ ./internal/links/... ./internal/types/ ./tools/coverage/` green; `gofmt -l` empty; `go vet` clean; producer-kind validator green.

## DEPLOY-DEFERRED
Graph-shape change (new edge kind + entity annotations). Goes live on the next coordinated live-daemon rebuild + reindex; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)