### PR TITLE
Extend Neo4j GRAPH_RELATES topology to Ruby (activegraph OGM)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -48087,33 +48087,41 @@
       "category": "orm",
       "subcategory": "orm_mapper",
       "language": "ruby",
-      "label": "neo4j-ruby-driver",
+      "label": "neo4j-ruby-driver / activegraph OGM",
       "capabilities": {
         "Models": {
           "model_extraction": {
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "notes": "raw client driver; no ORM model/schema in user code"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/neo4j_activegraph.go","internal/custom/ruby/neo4j_activegraph_test.go"],
+            "issue": "3614",
+            "notes": "activegraph / neo4j.rb OGM (not just the raw driver): each class that includes ActiveGraph::Node (or legacy Neo4j::ActiveNode) is extracted as a SCOPE.Schema/node (the graph node label) and each `property :name` declaration as a SCOPE.Schema/property. Regex over class bodies; partial (no inheritance/mixin node resolution).",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "not_applicable",
-            "notes": "raw client driver; no association DSL"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/neo4j_activegraph.go"],
+            "issue": "3614",
+            "notes": "activegraph has_many / has_one :out|:in associations are extracted as SCOPE.Component/relationship entities carrying relation_type, direction, and target_node (model_class)."
           },
           "foreign_key_extraction": {
             "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship/lazy-load layer"
+            "notes": "graph DB — no foreign-key concept"
           },
           "lazy_loading_recognition": {
             "status": "not_applicable",
-            "notes": "raw driver — no ORM relationship/lazy-load layer"
+            "notes": "graph DB — no lazy-loading concept"
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "notes": "raw client driver; no relationship DSL"
+            "status": "full",
+            "cites": ["internal/custom/ruby/neo4j_activegraph.go","internal/custom/ruby/neo4j_activegraph_test.go"],
+            "issue": "3614",
+            "notes": "activegraph has_many/has_one(:out|:in, type:, model_class:) associations are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-node -\u003e target-node (mirrors the Python neomodel template #3670 / Java SDN #3663 / JOINS_COLLECTION for graph DBs); the domain graph topology is a navigable subgraph rather than opaque string props. Full for same-file ActiveGraph::Node targets (value-asserting test TestActiveGraphGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; has_one :in -\u003e INCOMING). Cross-file / dynamic model_class targets are honest-partial (kept as target_node props only). Reverses the #3635 datastore-pass downgrade for this OGM.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {

--- a/internal/custom/ruby/neo4j_activegraph.go
+++ b/internal/custom/ruby/neo4j_activegraph.go
@@ -1,0 +1,314 @@
+// neo4j_activegraph.go — custom extractor for activegraph / neo4j.rb
+// (the Neo4j Ruby OGM) graph-schema mappings. #3614, epic #3606.
+//
+// activegraph (formerly neo4j.rb / Neo4j::ActiveNode) maps Ruby classes to
+// Neo4j graph nodes and relationships through a decorator-style DSL, NOT through
+// Cypher query strings — so it is the Ruby analogue of the Python neomodel
+// OGM (#3670) and the Java Spring-Data-Neo4j template (#3663), and the closest
+// model to mirror:
+//
+//	class Person
+//	  include ActiveGraph::Node           # (or legacy: Neo4j::ActiveNode)
+//	  property :name
+//	  has_many :out, :movies, type: :ACTED_IN, model_class: 'Movie'
+//	  has_one  :in,  :studio, type: :OWNS,     model_class: 'Studio'
+//	end
+//
+// A class that includes ActiveGraph::Node (or Neo4j::ActiveNode) is the graph
+// "node" (the analogue of a SQL table / a neomodel StructuredNode); the node
+// label is the class name. Each has_many / has_one declares a typed, directed
+// edge to another node label:
+//
+//	has_many :out, ...  → direction OUTGOING
+//	has_many :in,  ...  → direction INCOMING
+//	type:    :ACTED_IN  → the Neo4j relationship type
+//	model_class: 'Movie'→ the target node label
+//
+// Extracted entities
+// ------------------
+//
+//	SCOPE.Schema / node          — one per ActiveGraph::Node class
+//	SCOPE.Schema / property      — one per `property :name` declaration
+//	SCOPE.Component / relationship — one per has_many / has_one association
+//
+// GRAPH_RELATES topology (#3614, epic #3606)
+// ------------------------------------------
+// Mirroring the neomodel template (#3670) and the Java SDN template (#3663),
+// every association whose model_class resolves to a same-file ActiveGraph::Node
+// class also emits a traversable GRAPH_RELATES edge that hangs off the owner
+// node entity:
+//
+//	Person ──GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)──▶ Class:Movie
+//
+// `:out` → direction OUTGOING; `:in` → direction INCOMING. The rel_type is the
+// `type:` symbol/string; the target label is `model_class:`. The ToID uses the
+// "Class:<Label>" convention so the intra-repo resolver's byName index links it
+// to the target node entity (same convention as neomodel and the Java SDN
+// template). Cross-file / dynamic model_class targets are honest-partial: no
+// edge is emitted, the topology stays only as a `target_node` prop on the
+// relationship Component.
+//
+// Registration key: "custom_ruby_neo4j_activegraph"
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_ruby_neo4j_activegraph", &neo4jActiveGraphExtractor{})
+}
+
+// neo4jActiveGraphExtractor emits graph-schema entities and GRAPH_RELATES
+// topology for activegraph / neo4j.rb ActiveGraph::Node classes.
+type neo4jActiveGraphExtractor struct{}
+
+func (e *neo4jActiveGraphExtractor) Language() string {
+	return "custom_ruby_neo4j_activegraph"
+}
+
+var (
+	// Gate: the file must include the OGM node mixin (current activegraph or the
+	// legacy neo4j.rb name).
+	reAGNodeMixin = regexp.MustCompile(
+		`(?m)^\s*include\s+(?:ActiveGraph::Node|Neo4j::ActiveNode)\b`)
+
+	// class Person / class Person < Foo — captures group 1 = class name.
+	reAGClass = regexp.MustCompile(
+		`(?m)^[ \t]*class\s+([A-Z][A-Za-z0-9_]*)`)
+
+	// end of a class body (de-dent `end` at column-ish). Used only to scope
+	// node-membership: a class is a node iff a node-mixin include appears between
+	// its `class` line and the next `class` line.
+
+	// property :name  /  property :name, type: Integer
+	reAGProperty = regexp.MustCompile(
+		`(?m)^[ \t]+property\s+:([a-z_][A-Za-z0-9_]*)`)
+
+	// has_many / has_one association. activegraph requires the direction symbol
+	// (:out / :in) as the first argument and the association name as the second:
+	//
+	//   has_many :out, :movies, type: :ACTED_IN, model_class: 'Movie'
+	//   has_one  :in,  :studio, type: 'OWNS',     model_class: 'Studio'
+	//
+	// Captures: 1 macro (has_many|has_one), 2 direction (out|in), 3 assoc name.
+	// type: and model_class: are pulled out of the trailing options separately so
+	// their order does not matter.
+	reAGAssociation = regexp.MustCompile(
+		`(?m)^[ \t]+(has_many|has_one)\s+:(out|in)\s*,\s*:([a-z_][A-Za-z0-9_]*)([^\n]*)`)
+
+	// type: :ACTED_IN  /  type: 'ACTED_IN'  /  type: "ACTED_IN"
+	reAGRelType = regexp.MustCompile(`type:\s*['":]?([A-Za-z_][A-Za-z0-9_]*)['"]?`)
+
+	// model_class: 'Movie'  /  model_class: "Movie"  /  model_class: Movie
+	reAGModelClass = regexp.MustCompile(`model_class:\s*['"]?([A-Za-z_][A-Za-z0-9_:]*)['"]?`)
+)
+
+// agLabel returns the short node label for a possibly-namespaced model_class
+// reference such as 'Graph::Movie' → 'Movie'.
+func agLabel(ref string) string {
+	if i := strings.LastIndex(ref, "::"); i >= 0 {
+		return ref[i+2:]
+	}
+	return ref
+}
+
+func (e *neo4jActiveGraphExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/ruby")
+	_, span := tracer.Start(ctx, "indexer.ruby_neo4j_activegraph_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "activegraph"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "ruby" || len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !reAGNodeMixin.MatchString(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) int {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return -1
+		}
+		seen[key] = true
+		out = append(out, ent)
+		return len(out) - 1
+	}
+
+	// --- ActiveGraph::Node classes (the graph "nodes") ---
+	// A class is a node iff a node-mixin include falls in its class body, i.e.
+	// between its `class` offset and the offset of the next `class`.
+	type nodeInfo struct {
+		name   string
+		offset int
+		idx    int // index into out of the node entity
+	}
+	var nodes []nodeInfo
+	knownNodes := make(map[string]bool)
+
+	classMatches := reAGClass.FindAllStringSubmatchIndex(src, -1)
+	mixinMatches := reAGNodeMixin.FindAllStringIndex(src, -1)
+	classHasMixin := func(start, end int) bool {
+		for _, mm := range mixinMatches {
+			if mm[0] > start && (end < 0 || mm[0] < end) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for ci, cm := range classMatches {
+		className := src[cm[2]:cm[3]]
+		classStart := cm[0]
+		classEnd := -1
+		if ci+1 < len(classMatches) {
+			classEnd = classMatches[ci+1][0]
+		}
+		if !classHasMixin(classStart, classEnd) {
+			continue
+		}
+		ent := makeEntity(className, "SCOPE.Schema", "node", file.Path, file.Language, lineOf(src, classStart))
+		setProps(&ent,
+			"framework", "activegraph",
+			"node_label", className,
+			"provenance", "INFERRED_FROM_NEO4J_ACTIVEGRAPH_NODE",
+		)
+		idx := add(ent)
+		if idx >= 0 {
+			nodes = append(nodes, nodeInfo{name: className, offset: classStart, idx: idx})
+			knownNodes[className] = true
+		}
+	}
+
+	if len(nodes) == 0 {
+		span.SetAttributes(attribute.Int("entity_count", len(out)))
+		return out, nil
+	}
+
+	// owningNode / owningNodeIdx resolve the ActiveGraph::Node class whose
+	// declaration most closely precedes a class-body offset.
+	owningNode := func(offset int) string {
+		best := ""
+		for _, n := range nodes {
+			if n.offset <= offset {
+				best = n.name
+			}
+		}
+		return best
+	}
+	owningNodeIdx := func(offset int) int {
+		best := -1
+		for _, n := range nodes {
+			if n.offset <= offset {
+				best = n.idx
+			}
+		}
+		return best
+	}
+
+	// --- property declarations (schema_extraction — properties) ---
+	for _, m := range reAGProperty.FindAllStringSubmatchIndex(src, -1) {
+		propName := src[m[2]:m[3]]
+		owner := owningNode(m[0])
+		if owner == "" {
+			continue
+		}
+		ent := makeEntity(owner+"."+propName, "SCOPE.Schema", "property", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "activegraph",
+			"property_name", propName,
+			"owner_node", owner,
+			"provenance", "INFERRED_FROM_NEO4J_ACTIVEGRAPH_PROPERTY",
+		)
+		add(ent)
+	}
+
+	// --- has_many / has_one associations (relationship_extraction + topology) ---
+	for _, m := range reAGAssociation.FindAllStringSubmatchIndex(src, -1) {
+		macro := src[m[2]:m[3]]     // has_many | has_one
+		dirSym := src[m[4]:m[5]]    // out | in
+		assocName := src[m[6]:m[7]] // movies
+		opts := src[m[8]:m[9]]      // ", type: :ACTED_IN, model_class: 'Movie'"
+
+		relType := ""
+		if rm := reAGRelType.FindStringSubmatch(opts); rm != nil {
+			relType = rm[1]
+		}
+		targetRef := ""
+		if mc := reAGModelClass.FindStringSubmatch(opts); mc != nil {
+			targetRef = mc[1]
+		}
+		targetLabel := agLabel(targetRef)
+
+		direction := "OUTGOING"
+		if dirSym == "in" {
+			direction = "INCOMING"
+		}
+
+		owner := owningNode(m[0])
+		if owner == "" {
+			continue
+		}
+		name := relType
+		if name == "" {
+			name = assocName
+		}
+		name = owner + "." + name
+
+		relEnt := makeEntity(name, "SCOPE.Component", "relationship", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&relEnt,
+			"framework", "activegraph",
+			"relation_type", relType,
+			"direction", direction,
+			"macro", macro,
+			"field_name", assocName,
+			"owner_node", owner,
+			"target_node", targetLabel,
+			"provenance", "INFERRED_FROM_NEO4J_ACTIVEGRAPH_RELATIONSHIP",
+		)
+		add(relEnt)
+
+		// --- GRAPH_RELATES edge (#3614, epic #3606) ---
+		// Emit the domain graph schema as a traversable edge owner-node
+		// ──GRAPH_RELATES──▶ target-node carrying rel_type + direction, instead
+		// of leaving the topology encoded only as the `target_node` string prop.
+		// Only when model_class resolves to a same-file ActiveGraph::Node class —
+		// cross-file / dynamic targets stay honest-partial (props only).
+		ownerIdx := owningNodeIdx(m[0])
+		if ownerIdx >= 0 && knownNodes[targetLabel] {
+			out[ownerIdx].Relationships = append(out[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "Class:" + targetLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "activegraph",
+						"rel_type":   relType,
+						"direction":  direction,
+						"field_name": assocName,
+						"provenance": "INFERRED_FROM_NEO4J_ACTIVEGRAPH_RELATIONSHIP",
+					},
+				})
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/ruby/neo4j_activegraph_test.go
+++ b/internal/custom/ruby/neo4j_activegraph_test.go
@@ -1,0 +1,198 @@
+package ruby_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+// extractFull (defined in observability_test.go) returns the raw EntityRecords
+// with Relationships intact, unlike the shared `extract` helper.
+
+func findNode(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "node" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestActiveGraphGraphRelatesEdge is the value-asserting topology test:
+//
+//	has_many :out, :movies, type: :ACTED_IN, model_class: 'Movie'
+//	  in a Person ActiveGraph::Node
+//	→ Person GRAPH_RELATES Movie (rel_type=ACTED_IN, direction=OUTGOING)
+//
+//	has_one :in, :studio, type: :OWNS, model_class: 'Studio'
+//	→ Studio direction=INCOMING
+func TestActiveGraphGraphRelatesEdge(t *testing.T) {
+	src := `
+class Person
+  include ActiveGraph::Node
+  property :name
+  has_many :out, :movies, type: :ACTED_IN, model_class: 'Movie'
+  has_one  :in,  :studio, type: :OWNS, model_class: 'Studio'
+end
+
+class Movie
+  include ActiveGraph::Node
+  property :title
+end
+
+class Studio
+  include ActiveGraph::Node
+end
+`
+	ents := extractFull(t, "custom_ruby_neo4j_activegraph", fi("person.rb", "ruby", src))
+
+	person := findNode(ents, "Person")
+	if person == nil {
+		t.Fatal("Person node entity not extracted")
+	}
+	if findNode(ents, "Movie") == nil {
+		t.Fatal("Movie node entity not extracted")
+	}
+
+	// Exactly the two GRAPH_RELATES edges off Person, with asserted values.
+	var actedIn, owns *types.RelationshipRecord
+	for i := range person.Relationships {
+		r := &person.Relationships[i]
+		if r.Kind != string(types.RelationshipKindGraphRelates) {
+			t.Fatalf("unexpected relationship kind %q", r.Kind)
+		}
+		switch r.ToID {
+		case "Class:Movie":
+			actedIn = r
+		case "Class:Studio":
+			owns = r
+		default:
+			t.Fatalf("unexpected GRAPH_RELATES ToID %q", r.ToID)
+		}
+	}
+
+	if actedIn == nil {
+		t.Fatal("missing Person -GRAPH_RELATES-> Class:Movie edge")
+	}
+	if got := actedIn.Properties["rel_type"]; got != "ACTED_IN" {
+		t.Errorf("Movie edge rel_type = %q, want ACTED_IN", got)
+	}
+	if got := actedIn.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("Movie edge (has_many :out) direction = %q, want OUTGOING", got)
+	}
+
+	if owns == nil {
+		t.Fatal("missing Person -GRAPH_RELATES-> Class:Studio edge")
+	}
+	if got := owns.Properties["rel_type"]; got != "OWNS" {
+		t.Errorf("Studio edge rel_type = %q, want OWNS", got)
+	}
+	if got := owns.Properties["direction"]; got != "INCOMING" {
+		t.Errorf("Studio edge (has_one :in) direction = %q, want INCOMING", got)
+	}
+}
+
+// TestActiveGraphNoEdgeForPlainProperty is the negative test: a class with only
+// a `property :name` declaration (no association) yields a node with zero
+// GRAPH_RELATES edges.
+func TestActiveGraphNoEdgeForPlainProperty(t *testing.T) {
+	src := `
+class Tag
+  include ActiveGraph::Node
+  property :name
+end
+`
+	ents := extractFull(t, "custom_ruby_neo4j_activegraph", fi("tag.rb", "ruby", src))
+	tag := findNode(ents, "Tag")
+	if tag == nil {
+		t.Fatal("Tag node entity not extracted")
+	}
+	if len(tag.Relationships) != 0 {
+		t.Errorf("plain property class should have no GRAPH_RELATES edges, got %d", len(tag.Relationships))
+	}
+	// The property itself is still extracted as a schema property.
+	var foundProp bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "property" && e.Name == "Tag.name" {
+			foundProp = true
+		}
+	}
+	if !foundProp {
+		t.Error("expected Tag.name property entity")
+	}
+}
+
+// TestActiveGraphCrossFileTargetHonestPartial: a model_class whose target is NOT
+// a same-file ActiveGraph::Node is honest-partial — the relationship Component
+// is emitted (with a target_node prop) but no GRAPH_RELATES edge hangs off the
+// owner node.
+func TestActiveGraphCrossFileTargetHonestPartial(t *testing.T) {
+	src := `
+class Person
+  include ActiveGraph::Node
+  has_many :out, :friends, type: :KNOWS, model_class: 'ExternalPerson'
+end
+`
+	ents := extractFull(t, "custom_ruby_neo4j_activegraph", fi("person.rb", "ruby", src))
+	person := findNode(ents, "Person")
+	if person == nil {
+		t.Fatal("Person node entity not extracted")
+	}
+	if len(person.Relationships) != 0 {
+		t.Errorf("cross-file target should not emit a GRAPH_RELATES edge, got %d", len(person.Relationships))
+	}
+	// But the relationship Component is still present (honest-partial topology).
+	var rel *types.EntityRecord
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Component" && ents[i].Subtype == "relationship" {
+			rel = &ents[i]
+		}
+	}
+	if rel == nil {
+		t.Fatal("expected a SCOPE.Component relationship entity")
+	}
+	if got := rel.Properties["target_node"]; got != "ExternalPerson" {
+		t.Errorf("relationship target_node = %q, want ExternalPerson", got)
+	}
+}
+
+// TestActiveGraphLegacyMixin verifies the legacy neo4j.rb mixin name
+// (Neo4j::ActiveNode) also gates the extractor.
+func TestActiveGraphLegacyMixin(t *testing.T) {
+	src := `
+class Account
+  include Neo4j::ActiveNode
+  has_one :out, :owner, type: :OWNED_BY, model_class: 'Owner'
+end
+
+class Owner
+  include Neo4j::ActiveNode
+end
+`
+	ents := extractFull(t, "custom_ruby_neo4j_activegraph", fi("account.rb", "ruby", src))
+	account := findNode(ents, "Account")
+	if account == nil {
+		t.Fatal("Account node entity not extracted (legacy Neo4j::ActiveNode mixin)")
+	}
+	if len(account.Relationships) != 1 || account.Relationships[0].ToID != "Class:Owner" {
+		t.Fatalf("expected one GRAPH_RELATES edge to Class:Owner, got %+v", account.Relationships)
+	}
+}
+
+// TestActiveGraphNoMixinNoExtraction: a plain Ruby class without the node mixin
+// produces nothing (gate negative).
+func TestActiveGraphNoMixinNoExtraction(t *testing.T) {
+	src := `
+class PlainOldRuby
+  def initialize
+    @x = 1
+  end
+end
+`
+	ents := extractFull(t, "custom_ruby_neo4j_activegraph", fi("plain.rb", "ruby", src))
+	if len(ents) != 0 {
+		t.Errorf("non-activegraph file should yield no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3614 (epic #3606).

Adds `custom_ruby_neo4j_activegraph` — a custom extractor for the activegraph / neo4j.rb Ruby OGM. activegraph is decorator-based (not Cypher strings), so it mirrors the Python neomodel template (#3670) and the Java SDN template (#3663) rather than the C#/Go driver Cypher-string extractors.

## What it does
```ruby
class Person
  include ActiveGraph::Node      # or legacy Neo4j::ActiveNode
  property :name
  has_many :out, :movies, type: :ACTED_IN, model_class: 'Movie'
  has_one  :in,  :studio, type: :OWNS,     model_class: 'Studio'
end
```
emits:
- `Person` — `SCOPE.Schema/node` (node label = class including ActiveGraph::Node / Neo4j::ActiveNode)
- `Person.name` — `SCOPE.Schema/property`
- `Person.ACTED_IN` — `SCOPE.Component/relationship` (relation_type, direction, target_node)
- **`Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ Class:Movie`** — the traversable graph-schema edge

`:out` → OUTGOING, `:in` → INCOMING. ToID uses the `Class:<Target>` convention (from `model_class:`) so the intra-repo resolver's byName index links it to the target node. The edge is emitted only when `model_class` resolves to a same-file ActiveGraph::Node class; cross-file / dynamic `model_class` stays honest-partial (kept as `target_node` prop only).

## Coverage
`lang.ruby.driver.neo4j` (relabeled `neo4j-ruby-driver / activegraph OGM`):
- `relationship_extraction` → **full** (reverses the #3635 datastore-pass downgrade for this OGM)
- `schema_extraction`, `association_extraction` → **partial**

Neo4j GRAPH_RELATES topology now spans **java / python / jsts / go / csharp / ruby** — completing the set.

## Tests (value-asserting, not len>0)
- `TestActiveGraphGraphRelatesEdge`: `Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ Class:Movie`; `has_one :in` → `INCOMING`
- Negative: plain `property :name` class → zero GRAPH_RELATES edges
- `TestActiveGraphCrossFileTargetHonestPartial`: unknown target → no edge, but relationship Component retains `target_node`
- `TestActiveGraphLegacyMixin` (Neo4j::ActiveNode), `TestActiveGraphNoMixinNoExtraction` (gate negative)

Targeted `go test ./internal/custom/ruby/... ./internal/types/ ./tools/coverage/...` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

**DEPLOY-DEFERRED**: extractor + registry only; no daemon rebuild / reindex performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)