### PR TITLE
Python Graphene + Ariadne GraphQL server extraction (#3620)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 216 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 18 · **java**: 21 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
+**Total**: 218 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 18 · **java**: 21 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 23 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -91,6 +91,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🟡 1/7 | |
+| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
@@ -98,6 +99,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # python
 
-**Frameworks**: 21 · **Tools**: 15 · **ORMs**: 17 · **Other**: 6
+**Frameworks**: 23 · **Tools**: 15 · **ORMs**: 17 · **Other**: 6
 
 Back to [summary](../summary.md).
 
@@ -26,6 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
+| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
@@ -33,6 +34,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Falcon](../detail/lang.python.framework.falcon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [Hug](../detail/lang.python.framework.hug.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 7/7 | |

--- a/docs/coverage/detail/lang.python.framework.ariadne.md
+++ b/docs/coverage/detail/lang.python.framework.ariadne.md
@@ -1,0 +1,104 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.ariadne` — Ariadne GraphQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | schema-first Ariadne: QueryType()/MutationType()/SubscriptionType()/ObjectType("Query") binders + @<binder>.field("<name>") decorator resolvers -> http:GRAPHQL:/graphql/<Root>/<field>, identical shape to Strawberry. synthesizeAriadne. |
+| Handler attribution | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | decorated resolver function is the handler; source_handler=SCOPE.Operation:<funcName> rebinds to a HANDLES edge. |
+| Route extraction | 🟢 `partial` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | Binder var -> root type resolved from QueryType/MutationType/SubscriptionType ctor or ObjectType("<Type>") arg; field name is the literal decorator string. Dynamically-named fields and set_field()/schema-directive bindings not resolved (honest-partial). |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3620 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3620 | — | — |
+| Request validation | 🔴 `missing` | — | 3620 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3620 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3620 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3620 | — | — |
+| Type extraction | 🔴 `missing` | — | 3620 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3620 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3620 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3620 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3620 | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | 3620 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3620 | — | — |
+| Config consumption | 🔴 `missing` | — | 3620 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3620 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3620 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3620 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3620 | — | — |
+| Fs effect | 🔴 `missing` | — | 3620 | — | — |
+| HTTP effect | 🔴 `missing` | — | 3620 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 3620 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3620 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3620 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3620 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3620 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3620 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3620 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3620 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3620 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3620 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3620 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.ariadne ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.graphene.md
+++ b/docs/coverage/detail/lang.python.framework.graphene.md
@@ -1,0 +1,104 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.graphene` — Graphene GraphQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | graphene.ObjectType Query/Mutation/Subscription root classes; resolve_<field> methods and graphene.<X>(...) class-attribute fields -> http:GRAPHQL:/graphql/<Root>/<field>, identical shape to Strawberry/gqlgen. synthesizeGraphene. |
+| Handler attribution | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | resolve_<field> method is the handler; source_handler=SCOPE.Operation:<Root>.resolve_<field> rebinds to a HANDLES edge. Default-resolver fields (no method) emitted honest-partial with the conventional resolver name. |
+| Route extraction | 🟢 `partial` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | Operation endpoints synthesised from root-class fields; field name is the snake_case attribute (no name mangling). Dynamic/programmatically-named fields not resolved (honest-partial). |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3620 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3620 | — | — |
+| Request validation | 🔴 `missing` | — | 3620 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3620 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3620 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3620 | — | — |
+| Type extraction | 🔴 `missing` | — | 3620 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3620 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3620 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3620 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3620 | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | 3620 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3620 | — | — |
+| Config consumption | 🔴 `missing` | — | 3620 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3620 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3620 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3620 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3620 | — | — |
+| Fs effect | 🔴 `missing` | — | 3620 | — | — |
+| HTTP effect | 🔴 `missing` | — | 3620 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 3620 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3620 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3620 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3620 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3620 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3620 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3620 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3620 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3620 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3620 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3620 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.graphene ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -42581,6 +42581,190 @@
       }
     },
     {
+      "id": "lang.python.framework.ariadne",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "python",
+      "label": "Ariadne GraphQL",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "schema-first Ariadne: QueryType()/MutationType()/SubscriptionType()/ObjectType(\"Query\") binders + @\u003cbinder\u003e.field(\"\u003cname\u003e\") decorator resolvers -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e, identical shape to Strawberry. synthesizeAriadne.",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "decorated resolver function is the handler; source_handler=SCOPE.Operation:\u003cfuncName\u003e rebinds to a HANDLES edge.",
+            "verified_at": "2026-06-02"
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "Binder var -\u003e root type resolved from QueryType/MutationType/SubscriptionType ctor or ObjectType(\"\u003cType\u003e\") arg; field name is the literal decorator string. Dynamically-named fields and set_field()/schema-directive bindings not resolved (honest-partial).",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.python.framework.bottle",
       "category": "http_framework",
       "subcategory": "http_backend",
@@ -44750,6 +44934,190 @@
             "status": "full",
             "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/flask.go"],
             "verified_at": "2026-05-30"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.graphene",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "python",
+      "label": "Graphene GraphQL",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "graphene.ObjectType Query/Mutation/Subscription root classes; resolve_\u003cfield\u003e methods and graphene.\u003cX\u003e(...) class-attribute fields -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e, identical shape to Strawberry/gqlgen. synthesizeGraphene.",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "resolve_\u003cfield\u003e method is the handler; source_handler=SCOPE.Operation:\u003cRoot\u003e.resolve_\u003cfield\u003e rebinds to a HANDLES edge. Default-resolver fields (no method) emitted honest-partial with the conventional resolver name.",
+            "verified_at": "2026-06-02"
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go","internal/engine/httproutes/canonicalize.go"],
+            "issue": "3620",
+            "notes": "Operation endpoints synthesised from root-class fields; field name is the snake_case attribute (no name mangling). Dynamic/programmatically-named fields not resolved (honest-partial).",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "3620"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3620"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3620"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,15 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 40 (19 active · 21 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 218 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
+| [python](by-language/python.md) | 23 | 15 | 17 | 6 |
 | [java](by-language/java.md) | 21 | 10 | 14 | 3 |
-| [python](by-language/python.md) | 21 | 15 | 17 | 6 |
 | [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 4 |
 | [go](by-language/go.md) | 18 | 8 | 17 | 0 |
 | [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
@@ -47,7 +47,6 @@
 
 | Language |
 |---|
-| [Avro](by-language/avro.md) |
 | [Bicep](by-language/bicep.md) |
 | [Clojure](by-language/clojure.md) |
 | [Crystal](by-language/crystal.md) |
@@ -56,7 +55,6 @@
 | [F#](by-language/fsharp.md) |
 | [Haskell](by-language/haskell.md) |
 | [Idris](by-language/idris.md) |
-| [Jsonschema](by-language/jsonschema.md) |
 | [Lisp](by-language/lisp.md) |
 | [Nim](by-language/nim.md) |
 | [OCaml](by-language/ocaml.md) |
@@ -69,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 216 frameworks · 111 tools · 152 ORMs · 134 other
+Total: 218 frameworks · 111 tools · 152 ORMs · 134 other

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -556,6 +556,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// http:GRAPHQL:/graphql/<Root>/<field> synthetics. Gated on "strawberry"
 		// in the file so it is a no-op on all other Python framework files.
 		synthesizeStrawberry(string(content), emitDef)
+		// #3620 — Graphene + Ariadne GraphQL operation synthesis. Maps Python
+		// Graphene root classes (graphene.ObjectType Query/Mutation/Subscription)
+		// and Ariadne binder field decorators to the same
+		// http:GRAPHQL:/graphql/<Root>/<field> shape as Strawberry. Each is gated
+		// on a framework-specific file marker so it no-ops on all other files.
+		synthesizeGraphene(string(content), emitDef)
+		synthesizeAriadne(string(content), emitDef)
 		// Producer side: Flask + FastAPI run FIRST so their synthetics —
 		// which carry a real handler function name as source_handler —
 		// claim each ID before the Django composed-route pass walks the
@@ -3238,6 +3245,307 @@ func synthesizeStrawberry(content string, emit emitDefFn) {
 			handlerRef := rootType + "." + methodName
 			emit("GRAPHQL", canonical, "strawberry-graphql", "SCOPE.Operation", handlerRef, defLine)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Graphene (Python) — #3620 (epic #3607)
+// ---------------------------------------------------------------------------
+//
+// Graphene is a code-first GraphQL library for Python. Root types subclass
+// graphene.ObjectType and declare fields as class attributes; the resolver for
+// a field `users` is the method `resolve_users`:
+//
+//	class Query(graphene.ObjectType):
+//	    users = graphene.List(User)
+//	    me = graphene.Field(User)
+//	    def resolve_users(self, info):
+//	        ...
+//	    def resolve_me(self, info):
+//	        ...
+//
+//	class Mutation(graphene.ObjectType):
+//	    create_user = CreateUser.Field()
+//	    def resolve_create_user(self, info, name):
+//	        ...
+//
+// The schema is wired with `graphene.Schema(query=Query, mutation=Mutation,
+// subscription=Subscription)`. We map each root-type field to the SAME
+// operation-endpoint shape emitted by Strawberry / gqlgen / the JS/TS GraphQL
+// server:
+//
+//	http:GRAPHQL:/graphql/<RootType>/<field>
+//
+// where RootType is Query / Mutation / Subscription and <field> is the snake_case
+// field name (Graphene/Python convention — no name mangling, the attribute name
+// IS the GraphQL field name). Emitting the identical id shape is what lets the
+// GraphQL client-link synthesizer and the cross-repo linker join Python Graphene
+// servers to their consumers.
+//
+// Field discovery: we enumerate `resolve_<field>` methods inside the root-type
+// class body. The resolver method is the authoritative field signal (it carries
+// the def line for handler attribution); a `<field> = graphene.<X>(...)` class
+// attribute without a matching resolver uses Graphene's default resolver and is
+// also emitted (honest-partial — no explicit handler, so source_handler points
+// at the would-be resolver name). The resolver method, when present, is the
+// handler, referenced as `SCOPE.Operation:<ClassName>.resolve_<field>`.
+//
+// Detection is gated on the presence of "graphene" in the file so the
+// synthesizer is a no-op on every other Python file.
+
+// grapheneRootTypeRe matches a class declaration whose base class list contains
+// a graphene.ObjectType (or bare ObjectType) base, for one of the three root
+// type names. The class name must be Query, Mutation, or Subscription.
+//
+// Capture groups:
+//
+//	1 = root type name (Query | Mutation | Subscription)
+var grapheneRootTypeRe = regexp.MustCompile(
+	`(?m)^[ \t]*class\s+(Query|Mutation|Subscription)\s*\(([^)]*)\)\s*:`,
+)
+
+// grapheneResolverRe matches a `def resolve_<field>(self` (optionally async)
+// method inside a root-type class body, capturing the field name (the suffix
+// after `resolve_`).
+//
+// Capture groups:
+//
+//	1 = field name (snake_case GraphQL field)
+var grapheneResolverRe = regexp.MustCompile(
+	`(?m)^[ \t]+(?:async\s+)?def\s+resolve_([A-Za-z_]\w*)\s*\(\s*self`,
+)
+
+// grapheneFieldAttrRe matches a `<field> = graphene.<Type>(...)` class-attribute
+// field declaration inside a root-type class body, capturing the field name.
+// This covers fields that rely on Graphene's default resolver (no explicit
+// resolve_<field> method).
+//
+// Capture groups:
+//
+//	1 = field name
+var grapheneFieldAttrRe = regexp.MustCompile(
+	`(?m)^[ \t]+([A-Za-z_]\w*)\s*=\s*graphene\.`,
+)
+
+func synthesizeGraphene(content string, emit emitDefFn) {
+	// File-signal gate: require a graphene marker so this no-ops on every other
+	// Python file (including Strawberry / Ariadne GraphQL servers).
+	if !strings.Contains(content, "graphene") {
+		return
+	}
+
+	for _, rm := range grapheneRootTypeRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(rm) < 6 {
+			continue
+		}
+		rootType := content[rm[2]:rm[3]] // "Query" | "Mutation" | "Subscription"
+		bases := content[rm[4]:rm[5]]
+		// Require an ObjectType base so we don't fire on unrelated classes that
+		// happen to be named Query/Mutation/Subscription.
+		if !strings.Contains(bases, "ObjectType") {
+			continue
+		}
+
+		classStart := rm[1] // byte offset right after the class header match
+		bodyEnd := grapheneClassBodyEnd(content[classStart:])
+		classBody := content[classStart : classStart+bodyEnd]
+
+		seen := map[string]bool{}
+
+		// Resolver methods are the authoritative, handler-bearing signal. Emit
+		// them first so the attribute pass below can dedup against them.
+		for _, mm := range grapheneResolverRe.FindAllStringSubmatchIndex(classBody, -1) {
+			if len(mm) < 4 {
+				continue
+			}
+			field := classBody[mm[2]:mm[3]]
+			if field == "" || seen[field] {
+				continue
+			}
+			seen[field] = true
+
+			methodOffsetInFile := classStart + mm[2]
+			defLine := lineOfOffset(content, methodOffsetInFile)
+
+			path := "/graphql/" + rootType + "/" + field
+			canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+			handlerRef := rootType + ".resolve_" + field
+			emit("GRAPHQL", canonical, "graphene", "SCOPE.Operation", handlerRef, defLine)
+		}
+
+		// Class-attribute fields without an explicit resolver use Graphene's
+		// default resolver. Emit them too (honest-partial: source_handler points
+		// at the conventional resolver name even though no def exists).
+		for _, mm := range grapheneFieldAttrRe.FindAllStringSubmatchIndex(classBody, -1) {
+			if len(mm) < 4 {
+				continue
+			}
+			field := classBody[mm[2]:mm[3]]
+			if field == "" || seen[field] {
+				continue
+			}
+			seen[field] = true
+
+			attrOffsetInFile := classStart + mm[2]
+			defLine := lineOfOffset(content, attrOffsetInFile)
+
+			path := "/graphql/" + rootType + "/" + field
+			canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+			handlerRef := rootType + ".resolve_" + field
+			emit("GRAPHQL", canonical, "graphene", "SCOPE.Operation", handlerRef, defLine)
+		}
+	}
+}
+
+// grapheneClassBodyEnd returns the byte length of the class body that begins at
+// the start of searchIn (the text immediately after a class header match),
+// walking line by line until the first top-level (column-0, non-blank) line.
+func grapheneClassBodyEnd(searchIn string) int {
+	lines := strings.Split(searchIn, "\n")
+	bodyEnd := len(searchIn)
+	for i, line := range lines {
+		if i == 0 {
+			// Tail of the class header line — skip.
+			continue
+		}
+		if len(line) == 0 {
+			continue // blank line — still inside the class
+		}
+		if line[0] != ' ' && line[0] != '\t' {
+			bodyEnd = 0
+			for j := 0; j < i; j++ {
+				bodyEnd += len(lines[j]) + 1 // +1 for '\n'
+			}
+			break
+		}
+	}
+	return bodyEnd
+}
+
+// ---------------------------------------------------------------------------
+// Ariadne (Python) — #3620 (epic #3607)
+// ---------------------------------------------------------------------------
+//
+// Ariadne is a schema-first GraphQL library for Python. The SDL is defined as a
+// string and resolvers are bound to fields imperatively via a `QueryType()` /
+// `MutationType()` / `ObjectType("Query")` binder object whose `.field("<name>")`
+// decorator registers the resolver function:
+//
+//	query = QueryType()
+//
+//	@query.field("me")
+//	def resolve_me(_, info):
+//	    ...
+//
+//	@query.field("users")
+//	def resolve_users(_, info):
+//	    ...
+//
+//	mutation = MutationType()
+//
+//	@mutation.field("create_user")
+//	def resolve_create_user(_, info, name):
+//	    ...
+//
+// ObjectType binders can also target an arbitrary type by name
+// (`ObjectType("Query")`); we resolve the binder variable → root type by
+// inspecting its constructor. We map each bound field to the SAME
+// operation-endpoint shape as Strawberry / Graphene / gqlgen:
+//
+//	http:GRAPHQL:/graphql/<RootType>/<field>
+//
+// Handler attribution: the decorated function immediately below the
+// `@<binder>.field("<name>")` decorator is the resolver, referenced as
+// `SCOPE.Operation:<funcName>`.
+//
+// Detection is gated on the presence of "ariadne" OR a QueryType/MutationType/
+// SubscriptionType/ObjectType binder construction so the synthesizer is a no-op
+// on every other Python file.
+
+// ariadneBinderCtorRe matches a binder construction, capturing the variable name
+// and the binder kind so we can resolve `@<var>.field(...)` decorators to a root
+// type. Handles `query = QueryType()` and `query = ObjectType("Query")`.
+//
+// Capture groups:
+//
+//	1 = binder variable name
+//	2 = binder constructor (QueryType | MutationType | SubscriptionType | ObjectType)
+//	3 = ObjectType type-name argument (only set for ObjectType("Query"))
+var ariadneBinderCtorRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_]\w*)\s*=\s*(QueryType|MutationType|SubscriptionType|ObjectType)\s*\(\s*(?:["']([A-Za-z_]\w*)["'])?\s*\)`,
+)
+
+// ariadneFieldDecoratorRe matches a `@<binder>.field("<name>")` decorator
+// immediately followed by a (optionally async) `def <func>(`. It captures the
+// binder variable, the field name, and the resolver function name.
+//
+// Capture groups:
+//
+//	1 = binder variable name
+//	2 = field name
+//	3 = resolver function name
+var ariadneFieldDecoratorRe = regexp.MustCompile(
+	`(?m)^[ \t]*@([A-Za-z_]\w*)\.field\(\s*["']([A-Za-z_]\w*)["']\s*\)\s*\n[ \t]*(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// ariadneCtorToRoot maps an Ariadne binder constructor to its GraphQL root type.
+var ariadneCtorToRoot = map[string]string{
+	"QueryType":        "Query",
+	"MutationType":     "Mutation",
+	"SubscriptionType": "Subscription",
+}
+
+func synthesizeAriadne(content string, emit emitDefFn) {
+	// File-signal gate: require an ariadne marker or a binder construction so
+	// this no-ops on every other Python file.
+	if !strings.Contains(content, "ariadne") &&
+		!strings.Contains(content, "QueryType") &&
+		!strings.Contains(content, "MutationType") &&
+		!strings.Contains(content, "SubscriptionType") {
+		return
+	}
+
+	// Resolve each binder variable → root type.
+	binderRoot := map[string]string{}
+	for _, m := range ariadneBinderCtorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		varName := content[m[2]:m[3]]
+		ctor := content[m[4]:m[5]]
+		if root, ok := ariadneCtorToRoot[ctor]; ok {
+			binderRoot[varName] = root
+			continue
+		}
+		// ObjectType("Query") — root type is the string argument.
+		if m[6] >= 0 && m[7] > m[6] {
+			binderRoot[varName] = content[m[6]:m[7]]
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, m := range ariadneFieldDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		binder := content[m[2]:m[3]]
+		field := content[m[4]:m[5]]
+		funcName := content[m[6]:m[7]]
+		root, ok := binderRoot[binder]
+		if !ok || root == "" || field == "" {
+			continue
+		}
+		dedupKey := root + "." + field
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+
+		defLine := lineOfOffset(content, m[0])
+		path := "/graphql/" + root + "/" + field
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+		// Handler ref points at the decorated resolver function symbol.
+		emit("GRAPHQL", canonical, "ariadne", "SCOPE.Operation", funcName, defLine)
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go
+++ b/internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go
@@ -1,0 +1,307 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestSynth_Graphene_Query covers a graphene.ObjectType Query with class-attribute
+// fields backed by resolve_<field> methods. Asserts exact endpoint-shape parity
+// with Strawberry (http:GRAPHQL:/graphql/<Root>/<field>) and handler attribution
+// to the resolve_<field> method. #3620.
+func TestSynth_Graphene_Query(t *testing.T) {
+	src := `import graphene
+
+class User(graphene.ObjectType):
+    name = graphene.String()
+
+class Query(graphene.ObjectType):
+    users = graphene.List(User)
+    me = graphene.Field(User)
+
+    def resolve_users(self, info):
+        return []
+
+    def resolve_me(self, info):
+        return None
+
+schema = graphene.Schema(query=Query)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Query/me",
+	}
+	requireContains(t, got, want, "Graphene Query")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/users")
+	if e == nil {
+		t.Fatalf("Graphene Query: missing http:GRAPHQL:/graphql/Query/users")
+	}
+	if e.Properties["framework"] != "graphene" {
+		t.Errorf("Graphene Query: framework = %q, want graphene", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Query.resolve_users" {
+		t.Errorf("Graphene Query: source_handler = %q, want SCOPE.Operation:Query.resolve_users", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Graphene Query: StartLine not stamped on resolve_users")
+	}
+}
+
+// TestSynth_Graphene_Mutation covers a graphene.ObjectType Mutation with
+// resolve_<field> methods. #3620.
+func TestSynth_Graphene_Mutation(t *testing.T) {
+	src := `import graphene
+
+class Mutation(graphene.ObjectType):
+    create_user = graphene.Field(graphene.String, name=graphene.String())
+
+    def resolve_create_user(self, info, name):
+        return name
+
+    def resolve_delete_user(self, info, id):
+        return True
+
+schema = graphene.Schema(mutation=Mutation)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Mutation/create_user",
+		"http:GRAPHQL:/graphql/Mutation/delete_user",
+	}
+	requireContains(t, got, want, "Graphene Mutation")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Mutation/create_user")
+	if e == nil {
+		t.Fatalf("Graphene Mutation: missing http:GRAPHQL:/graphql/Mutation/create_user")
+	}
+	if e.Properties["framework"] != "graphene" {
+		t.Errorf("Graphene Mutation: framework = %q, want graphene", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Mutation.resolve_create_user" {
+		t.Errorf("Graphene Mutation: source_handler = %q, want SCOPE.Operation:Mutation.resolve_create_user", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Graphene_Subscription covers a graphene.ObjectType Subscription. #3620.
+func TestSynth_Graphene_Subscription(t *testing.T) {
+	src := `import graphene
+
+class Subscription(graphene.ObjectType):
+    count = graphene.Int()
+
+    async def resolve_count(self, info):
+        yield 1
+
+schema = graphene.Schema(query=Query, subscription=Subscription)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Subscription/count",
+	}
+	requireContains(t, got, want, "Graphene Subscription")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Subscription/count")
+	if e == nil {
+		t.Fatalf("Graphene Subscription: missing http:GRAPHQL:/graphql/Subscription/count")
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Subscription.resolve_count" {
+		t.Errorf("Graphene Subscription: source_handler = %q, want SCOPE.Operation:Subscription.resolve_count", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Graphene_DefaultResolverField asserts that a class-attribute field
+// WITHOUT an explicit resolve_<field> method (relying on Graphene's default
+// resolver) is still emitted (honest-partial). #3620.
+func TestSynth_Graphene_DefaultResolverField(t *testing.T) {
+	src := `import graphene
+
+class Query(graphene.ObjectType):
+    hello = graphene.String()
+    explicit = graphene.String()
+
+    def resolve_explicit(self, info):
+        return "x"
+`
+	got, _ := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/hello",
+		"http:GRAPHQL:/graphql/Query/explicit",
+	}
+	requireContains(t, got, want, "Graphene default-resolver field")
+}
+
+// TestSynth_Graphene_NoOpOnFlask asserts the Graphene synthesizer does not fire
+// on a plain Flask file. #3620.
+func TestSynth_Graphene_NoOpOnFlask(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/ping")
+def ping():
+    return "pong"
+`
+	_, res := runDetect(t, "python", "flask_app.py", src)
+	for _, ent := range res.Entities {
+		if ent.Kind == httpEndpointDefinitionKind && ent.Properties["framework"] == "graphene" {
+			t.Errorf("Graphene synthesizer fired on Flask file, emitted: %s", ent.ID)
+		}
+	}
+}
+
+// TestSynth_Ariadne_Query covers schema-first Ariadne with a QueryType() binder
+// and @query.field("<name>") decorator resolvers. Asserts exact endpoint-shape
+// parity with Strawberry and handler attribution to the decorated resolver. #3620.
+func TestSynth_Ariadne_Query(t *testing.T) {
+	src := `from ariadne import QueryType, make_executable_schema, gql
+
+type_defs = gql("""
+    type Query {
+        me: User
+        users: [User]
+    }
+""")
+
+query = QueryType()
+
+@query.field("me")
+def resolve_me(_, info):
+    return {"name": "ada"}
+
+@query.field("users")
+def resolve_users(_, info):
+    return []
+
+schema = make_executable_schema(type_defs, query)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/me",
+		"http:GRAPHQL:/graphql/Query/users",
+	}
+	requireContains(t, got, want, "Ariadne Query")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/me")
+	if e == nil {
+		t.Fatalf("Ariadne Query: missing http:GRAPHQL:/graphql/Query/me")
+	}
+	if e.Properties["framework"] != "ariadne" {
+		t.Errorf("Ariadne Query: framework = %q, want ariadne", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:resolve_me" {
+		t.Errorf("Ariadne Query: source_handler = %q, want SCOPE.Operation:resolve_me", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Ariadne Query: StartLine not stamped on resolve_me decorator")
+	}
+}
+
+// TestSynth_Ariadne_Mutation covers a MutationType() binder. #3620.
+func TestSynth_Ariadne_Mutation(t *testing.T) {
+	src := `from ariadne import MutationType
+
+mutation = MutationType()
+
+@mutation.field("create_user")
+def resolve_create_user(_, info, name):
+    return {"name": name}
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Mutation/create_user",
+	}
+	requireContains(t, got, want, "Ariadne Mutation")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Mutation/create_user")
+	if e == nil {
+		t.Fatalf("Ariadne Mutation: missing http:GRAPHQL:/graphql/Mutation/create_user")
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:resolve_create_user" {
+		t.Errorf("Ariadne Mutation: source_handler = %q, want SCOPE.Operation:resolve_create_user", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Ariadne_ObjectTypeNamedBinder covers ObjectType("Query") style
+// binders that name the root type as a constructor argument. #3620.
+func TestSynth_Ariadne_ObjectTypeNamedBinder(t *testing.T) {
+	src := `from ariadne import ObjectType
+
+query = ObjectType("Query")
+
+@query.field("health")
+def resolve_health(_, info):
+    return "ok"
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/health",
+	}
+	requireContains(t, got, want, "Ariadne ObjectType named binder")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/health")
+	if e == nil {
+		t.Fatalf("Ariadne ObjectType: missing http:GRAPHQL:/graphql/Query/health")
+	}
+	if e.Properties["framework"] != "ariadne" {
+		t.Errorf("Ariadne ObjectType: framework = %q, want ariadne", e.Properties["framework"])
+	}
+}
+
+// TestSynth_Ariadne_NoOpOnFlask asserts the Ariadne synthesizer does not fire on
+// a plain Flask file. #3620.
+func TestSynth_Ariadne_NoOpOnFlask(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/ping")
+def ping():
+    return "pong"
+`
+	_, res := runDetect(t, "python", "flask_app.py", src)
+	for _, ent := range res.Entities {
+		if ent.Kind == httpEndpointDefinitionKind && ent.Properties["framework"] == "ariadne" {
+			t.Errorf("Ariadne synthesizer fired on Flask file, emitted: %s", ent.ID)
+		}
+	}
+}
+
+// TestSynth_GrapheneAriadne_ShapeParityWithStrawberry asserts that the operation
+// endpoint ids emitted for Graphene and Ariadne are byte-for-byte identical in
+// shape to the canonical Strawberry shape — same /graphql/<Root>/<field> path,
+// same http:GRAPHQL: prefix. #3620.
+func TestSynth_GrapheneAriadne_ShapeParityWithStrawberry(t *testing.T) {
+	strawberrySrc := `import strawberry
+
+@strawberry.type
+class Query:
+    def me(self) -> str:
+        return ""
+`
+	grapheneSrc := `import graphene
+
+class Query(graphene.ObjectType):
+    me = graphene.String()
+
+    def resolve_me(self, info):
+        return ""
+`
+	ariadneSrc := `from ariadne import QueryType
+
+query = QueryType()
+
+@query.field("me")
+def resolve_me(_, info):
+    return ""
+`
+	const wantID = "http:GRAPHQL:/graphql/Query/me"
+
+	sb, _ := runDetect(t, "python", "sb.py", strawberrySrc)
+	gr, _ := runDetect(t, "python", "gr.py", grapheneSrc)
+	ar, _ := runDetect(t, "python", "ar.py", ariadneSrc)
+
+	requireContains(t, sb, []string{wantID}, "Strawberry baseline")
+	requireContains(t, gr, []string{wantID}, "Graphene parity")
+	requireContains(t, ar, []string{wantID}, "Ariadne parity")
+}


### PR DESCRIPTION
## Summary

Adds operation-endpoint synthesis for the two remaining mainstream Python GraphQL servers — **Graphene** (code-first) and **Ariadne** (schema-first) — completing Python GraphQL server coverage beyond Strawberry under epic #3607.

Both synthesizers emit the **canonical operation-endpoint shape** shared by Strawberry, gqlgen, and the JS/TS GraphQL server, so GraphQL client links join across stacks:

```
http:GRAPHQL:/graphql/<RootType>/<field>
```

## Endpoint-shape parity confirmation

`TestSynth_GrapheneAriadne_ShapeParityWithStrawberry` asserts all three frameworks emit the **byte-identical** id `http:GRAPHQL:/graphql/Query/me` from equivalent sources. RootType ∈ {Query, Mutation, Subscription}; field names are snake_case (Python/Graphene convention, no name mangling). Canonicalized via the same `httproutes` path used by Strawberry.

## Graphene (`synthesizeGraphene`)

- `class Query(graphene.ObjectType): users = graphene.List(User); def resolve_users(self, info)` → `http:GRAPHQL:/graphql/Query/users`
- HANDLES via `source_handler=SCOPE.Operation:Query.resolve_users`
- Query / Mutation / Subscription root classes (requires an `ObjectType` base)
- Class-attribute fields without an explicit `resolve_<field>` (Graphene default resolver) emitted honest-partial
- Gated on the `graphene` file marker — no-op on every other Python file

## Ariadne (`synthesizeAriadne`)

- `query = QueryType(); @query.field("me") def resolve_me(...)` → `http:GRAPHQL:/graphql/Query/me`
- `QueryType`/`MutationType`/`SubscriptionType` and `ObjectType("Query")` binders resolved to root types
- HANDLES via `source_handler=SCOPE.Operation:resolve_me` (decorated resolver function)
- Gated on ariadne / binder markers — no-op on every other Python file

## Endpoints asserted (value-asserting tests)

- Graphene Query: `/graphql/Query/users`, `/graphql/Query/me` (+ default-resolver `/graphql/Query/hello`)
- Graphene Mutation: `/graphql/Mutation/create_user`, `/graphql/Mutation/delete_user`
- Graphene Subscription: `/graphql/Subscription/count`
- Ariadne Query: `/graphql/Query/me`, `/graphql/Query/users`
- Ariadne Mutation: `/graphql/Mutation/create_user`
- Ariadne ObjectType("Query"): `/graphql/Query/health`
- Flask no-op guards for both; framework label + source_handler + StartLine asserted

## Coverage records

New `lang.python.framework.graphene` and `lang.python.framework.ariadne` (http_framework / http_backend). Routing `endpoint_synthesis` + `handler_attribution` **full**, `route_extraction` **partial**, all citing the synthesizer + test. Remaining lanes backfilled `missing` (#3620). `coverage validate` 0 errors, `fmt --check` canonical, docs regenerated.

## Verification

- `go test ./internal/custom/python/... ./internal/engine/ ./internal/extractors/graphql/... ./internal/types/ ./tools/coverage/` — green
- `gofmt -l` clean on touched files; `go vet ./internal/engine/ ./tools/coverage/` clean

**DEPLOY-DEFERRED** — no daemon rebuild / reindex performed in this change.

Closes #3620

🤖 Generated with [Claude Code](https://claude.com/claude-code)