### PR TITLE
feat(graphql): Pothos + TypeGraphQL JS/TS code-first GraphQL server extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 216 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 18 · **java**: 21 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
+**Total**: 218 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 18 · **java**: 21 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 15 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 14 · **swift**: 4
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -70,8 +70,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
+| [JS/TS](../by-language/jsts.md) | [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟢 2/2 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [lua](../by-language/lua.md) | [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🟡 3/7 | |
 | [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🟡 3/7 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/19 | 🟢 6/6 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 30 · **Tools**: 21 · **ORMs**: 18 · **Other**: 2
+**Frameworks**: 32 · **Tools**: 21 · **ORMs**: 18 · **Other**: 2
 
 Back to [summary](../summary.md).
 
@@ -36,8 +36,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 10/10 | |
 | [Polka](../detail/lang.jsts.framework.polka.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
+| [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟢 2/2 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 | [Restify](../detail/lang.jsts.framework.restify.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 7/7 | |
 | [Sails](../detail/lang.jsts.framework.sails.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/21 | 🔴 0/7 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.jsts.framework.pothos.md
+++ b/docs/coverage/detail/lang.jsts.framework.pothos.md
@@ -1,0 +1,104 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.framework.pothos` — Pothos (GraphQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | — |
+| Handler attribution | — `not_applicable` | — | — | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | Pothos root fields are inline-arrow resolvers (builder.queryField('users', t => ...)) with no addressable handler symbol; the operation endpoint is emitted with NO source_handler (NoHandlerProp keep-path), matching the Apollo resolver-map convention. There is no method symbol to bind a HANDLES edge to. |
+| Route extraction | 🟢 `partial` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | builder.queryField/mutationField/subscriptionField + the builder.queryType/mutationType/subscriptionType fields:(t)=>({...}) maps -> http:GRAPHQL:/graphql/<Root>/<field> (EXACT canonical shape as gqlgen/Apollo/Strawberry so client links #3667 join). Honest-partial: a non-literal (variable/computed) field name is not recovered. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3619 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3619 | — | — |
+| Request validation | 🔴 `missing` | — | 3619 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3619 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3619 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3619 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3619 | — | — |
+| Type extraction | 🔴 `missing` | — | 3619 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3619 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3619 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3619 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3619 | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | 3619 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3619 | — | — |
+| Config consumption | 🔴 `missing` | — | 3619 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3619 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3619 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3619 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3619 | — | — |
+| Fs effect | 🔴 `missing` | — | 3619 | — | — |
+| HTTP effect | 🔴 `missing` | — | 3619 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 3619 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3619 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3619 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3619 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3619 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3619 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3619 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3619 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3619 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3619 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3619 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3619 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3619 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.framework.pothos ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.jsts.framework.type-graphql.md
+++ b/docs/coverage/detail/lang.jsts.framework.type-graphql.md
@@ -1,0 +1,104 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.framework.type-graphql` — TypeGraphQL (GraphQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-06-02` | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | — |
+| Handler attribution | ✅ `full` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | @Query/@Mutation/@Subscription method in an @Resolver class -> http:GRAPHQL:/graphql/<Root>/<field>; source_handler=SCOPE.Operation:<method> rebinds to a HANDLES (IMPLEMENTS) edge against the extracted method symbol (proven end-to-end in TestResolve_TypeGraphQL_HandlesEdge). |
+| Route extraction | 🟢 `partial` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | Root @Query/@Mutation/@Subscription methods only; @FieldResolver (non-root) methods are skipped, matching gqlgen/spring-graphql. Field name = method name or the { name: '...' } decorator option. Honest-partial: a dynamic/computed name option is not recovered. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3619 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3619 | — | — |
+| Request validation | 🔴 `missing` | — | 3619 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3619 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3619 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3619 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3619 | — | — |
+| Type extraction | 🔴 `missing` | — | 3619 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3619 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3619 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3619 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3619 | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | 3619 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3619 | — | — |
+| Config consumption | 🔴 `missing` | — | 3619 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3619 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3619 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3619 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3619 | — | — |
+| Fs effect | 🔴 `missing` | — | 3619 | — | — |
+| HTTP effect | 🔴 `missing` | — | 3619 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 3619 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3619 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3619 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3619 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3619 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3619 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3619 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3619 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3619 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3619 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3619 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3619 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3619 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.framework.type-graphql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -30080,6 +30080,186 @@
       }
     },
     {
+      "id": "lang.jsts.framework.pothos",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "jsts",
+      "label": "Pothos (GraphQL)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/pothos_jsts.yaml"],
+            "issue": "3619",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "not_applicable",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/pothos_jsts.yaml"],
+            "notes": "Pothos root fields are inline-arrow resolvers (builder.queryField('users', t =\u003e ...)) with no addressable handler symbol; the operation endpoint is emitted with NO source_handler (NoHandlerProp keep-path), matching the Apollo resolver-map convention. There is no method symbol to bind a HANDLES edge to."
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/pothos_jsts.yaml"],
+            "issue": "3619",
+            "notes": "builder.queryField/mutationField/subscriptionField + the builder.queryType/mutationType/subscriptionType fields:(t)=\u003e({...}) maps -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e (EXACT canonical shape as gqlgen/Apollo/Strawberry so client links #3667 join). Honest-partial: a non-literal (variable/computed) field name is not recovered."
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.jsts.framework.react",
       "category": "http_framework",
       "subcategory": "ui_frontend",
@@ -32100,6 +32280,187 @@
             "issue": "3057",
             "notes": "ctx.req.body/params shapes are detected by jstsSourceReqRe; the typed input parameter (primary user-input channel in tRPC, post-zod validation) is a known gap — not matched by current sniffer",
             "verified_at": "2026-05-29"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.jsts.framework.type-graphql",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "jsts",
+      "label": "TypeGraphQL (GraphQL)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_resolve.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml"],
+            "issue": "3619",
+            "verified_at": "2026-06-02"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_resolve.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml"],
+            "issue": "3619",
+            "notes": "@Query/@Mutation/@Subscription method in an @Resolver class -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e; source_handler=SCOPE.Operation:\u003cmethod\u003e rebinds to a HANDLES (IMPLEMENTS) edge against the extracted method symbol (proven end-to-end in TestResolve_TypeGraphQL_HandlesEdge)."
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_resolve.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml"],
+            "issue": "3619",
+            "notes": "Root @Query/@Mutation/@Subscription methods only; @FieldResolver (non-root) methods are skipped, matching gqlgen/spring-graphql. Field name = method name or the { name: '...' } decorator option. Honest-partial: a dynamic/computed name option is not recovered."
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "3619"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3619"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3619"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 40 (19 active · 21 placeholder) · **Frameworks**: 216 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 218 · **ORMs**: 152 · **Tools**: 111 · **Other**: 134
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
+| [JS/TS](by-language/jsts.md) | 32 | 21 | 18 | 2 |
 | [java](by-language/java.md) | 21 | 10 | 14 | 3 |
 | [python](by-language/python.md) | 21 | 15 | 17 | 6 |
 | [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 4 |
@@ -47,7 +47,6 @@
 
 | Language |
 |---|
-| [Avro](by-language/avro.md) |
 | [Bicep](by-language/bicep.md) |
 | [Clojure](by-language/clojure.md) |
 | [Crystal](by-language/crystal.md) |
@@ -56,7 +55,6 @@
 | [F#](by-language/fsharp.md) |
 | [Haskell](by-language/haskell.md) |
 | [Idris](by-language/idris.md) |
-| [Jsonschema](by-language/jsonschema.md) |
 | [Lisp](by-language/lisp.md) |
 | [Nim](by-language/nim.md) |
 | [OCaml](by-language/ocaml.md) |
@@ -69,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 216 frameworks · 111 tools · 152 ORMs · 134 other
+Total: 218 frameworks · 111 tools · 152 ORMs · 134 other

--- a/internal/engine/http_endpoint_graphql_jsts_codefirst.go
+++ b/internal/engine/http_endpoint_graphql_jsts_codefirst.go
@@ -1,0 +1,296 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Pothos + TypeGraphQL (JS/TS code-first GraphQL servers) — #3619 (epic #3607)
+// ---------------------------------------------------------------------------
+//
+// This file completes the JS/TS GraphQL-server family beyond Apollo / graphql-
+// tools resolver maps (synthesizeGraphQLResolvers, #1422) and NestJS GraphQL.
+// Both Pothos and TypeGraphQL are *code-first*: the schema is built from
+// TypeScript code rather than an SDL string, so the resolver-map regexes in
+// synthesizeGraphQLResolvers never fire on them.
+//
+// Both synthesizers emit the SAME canonical operation-endpoint shape used by
+// gqlgen (Go), Apollo (JS), Strawberry (Python), HotChocolate (C#), and the
+// Java spring-graphql / DGS servers:
+//
+//	http:GRAPHQL:/graphql/<RootType>/<field>
+//
+// where RootType is Query / Mutation / Subscription. Emitting the identical id
+// shape is what lets the GraphQL client-link synthesizer (#3667) and the
+// cross-repo linker join these servers to their consumers.
+
+// ---------------------------------------------------------------------------
+// Pothos — builder.queryField / mutationField / subscriptionField and the
+// queryType / mutationType / subscriptionType field-map forms.
+// ---------------------------------------------------------------------------
+//
+// Pothos (https://pothos-graphql.dev) builds a schema from a `builder` object:
+//
+//	const builder = new SchemaBuilder<...>({})
+//
+//	builder.queryField('users', (t) => t.field({ ... resolve: () => ... }))
+//	builder.mutationField('createUser', (t) => ...)
+//	builder.subscriptionField('userAdded', (t) => ...)
+//
+//	builder.queryType({
+//	  fields: (t) => ({
+//	    me: t.field({ ... }),
+//	    users: t.field({ ... }),
+//	  }),
+//	})
+//
+// The resolver in every form is an inline arrow with no addressable handler
+// symbol, so — exactly like the Apollo resolver-map synthesizer — we emit the
+// operation endpoints with NO source_handler. That lands them on the resolver's
+// NoHandlerProp keep-path so they survive Phase-2 resolution instead of being
+// dropped as handler_dropped.
+
+// pothosRootFieldRe matches the single-field registration form
+// `builder.queryField('users', ...)` / `builder.mutationField("createUser", ...)`
+// / `builder.subscriptionField('userAdded', ...)`.
+//
+// Capture groups:
+//
+//	1 = root verb (query | mutation | subscription)
+//	2 = field name (string-literal first argument)
+var pothosRootFieldRe = regexp.MustCompile(
+	`\bbuilder\s*\.\s*(query|mutation|subscription)Field\s*\(\s*['"` + "`" + `]([A-Za-z_$][\w$]*)['"` + "`" + `]`,
+)
+
+// pothosRootTypeRe matches the field-map registration form
+// `builder.queryType({` / `builder.mutationType({` / `builder.subscriptionType({`,
+// capturing the root verb. The field names are recovered by scanning the
+// `fields: (t) => ({ ... })` object that follows (see pothosFieldEntryRe).
+//
+// Capture groups:
+//
+//	1 = root verb (query | mutation | subscription)
+var pothosRootTypeRe = regexp.MustCompile(
+	`\bbuilder\s*\.\s*(query|mutation|subscription)Type\s*\(\s*\{`,
+)
+
+// pothosFieldEntryRe matches each `<field>: t.field(` / `<field>: t.<helper>(`
+// entry inside a Pothos `fields: (t) => ({ ... })` object. Pothos field helpers
+// are all `t.<something>(` (t.field, t.string, t.int, t.boolean, t.id,
+// t.stringList, t.expose*, t.prismaField, t.relation, etc.), so requiring the
+// value to start with `t.` and an open paren both scopes the match to real
+// field entries and excludes non-field config keys (e.g. `description:` /
+// `nullable:`).
+//
+// Capture group 1 = field name.
+var pothosFieldEntryRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_$][\w$]*)\s*:\s*t\s*\.\s*[A-Za-z_$][\w$]*\s*\(`,
+)
+
+// pothosVerbToRoot maps the Pothos builder verb to its GraphQL root type.
+var pothosVerbToRoot = map[string]string{
+	"query":        "Query",
+	"mutation":     "Mutation",
+	"subscription": "Subscription",
+}
+
+func synthesizePothos(content string, emit emitDefFn) {
+	// File-signal gate: require a Pothos marker so this no-ops on every other
+	// JS/TS file. `@pothos/core` is the canonical import; the `builder.<verb>`
+	// registration surface is the structural signal.
+	if !strings.Contains(content, "@pothos/") &&
+		!strings.Contains(content, "SchemaBuilder") &&
+		!strings.Contains(content, "builder.queryField") &&
+		!strings.Contains(content, "builder.mutationField") &&
+		!strings.Contains(content, "builder.subscriptionField") &&
+		!strings.Contains(content, "builder.queryType") &&
+		!strings.Contains(content, "builder.mutationType") &&
+		!strings.Contains(content, "builder.subscriptionType") {
+		return
+	}
+
+	// Dedup across BOTH registration forms (a field could in principle be
+	// declared in queryType and re-added via queryField) keyed on Root.field.
+	seen := map[string]bool{}
+	emitField := func(root, field string, defLine int) {
+		if field == "" {
+			return
+		}
+		key := root + "." + field
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		path := "/graphql/" + root + "/" + field
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPothos, path)
+		// Inline arrow resolver — no addressable handler symbol. Emit with no
+		// handler so the synthetic lands on the NoHandlerProp keep-path
+		// (mirrors synthesizeGraphQLResolvers / Apollo).
+		emit("GRAPHQL", canonical, "pothos", "", "", defLine)
+	}
+
+	// (1) Single-field registrations: builder.queryField('users', ...).
+	for _, m := range pothosRootFieldRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		root, ok := pothosVerbToRoot[content[m[2]:m[3]]]
+		if !ok {
+			continue
+		}
+		field := content[m[4]:m[5]]
+		defLine := lineOfOffset(content, m[0])
+		emitField(root, field, defLine)
+	}
+
+	// (2) Field-map registrations: builder.queryType({ fields: (t) => ({ ... }) }).
+	for _, m := range pothosRootTypeRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		root, ok := pothosVerbToRoot[content[m[2]:m[3]]]
+		if !ok {
+			continue
+		}
+		// The `{` of the builder.<verb>Type({ ... }) argument object is the
+		// last byte consumed by the regex. Scan to its matching close brace
+		// so we only read field entries inside THIS registration.
+		blockOpen := m[1] - 1
+		blockClose := findMatchingBrace(content, blockOpen)
+		if blockClose < 0 {
+			continue
+		}
+		body := content[blockOpen+1 : blockClose]
+		for _, fm := range pothosFieldEntryRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(fm) < 4 {
+				continue
+			}
+			field := body[fm[2]:fm[3]]
+			defLine := lineOfOffset(content, blockOpen+1+fm[2])
+			emitField(root, field, defLine)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TypeGraphQL — @Resolver classes with @Query / @Mutation / @Subscription
+// decorated methods.
+// ---------------------------------------------------------------------------
+//
+// TypeGraphQL (https://typegraphql.com) is class-and-decorator based:
+//
+//	@Resolver(() => User)
+//	class UserResolver {
+//	  @Query(() => [User])
+//	  users() { ... }
+//
+//	  @Query(() => User, { name: 'currentUser' })
+//	  me() { ... }
+//
+//	@Mutation(() => User)
+//	  createUser(@Arg('data') data: NewUserInput) { ... }
+//
+//	  @FieldResolver(() => [Post])   // NON-root — skipped
+//	  posts(@Root() user: User) { ... }
+//	}
+//
+// The GraphQL field name defaults to the method name, but a `{ name: '...' }`
+// option in the decorator overrides it (TypeGraphQL's `name` option). Only the
+// three ROOT operation decorators (@Query / @Mutation / @Subscription) become
+// operation endpoints; @FieldResolver methods resolve a field on a non-root
+// object type and are intentionally skipped (matching the gqlgen / spring-
+// graphql convention of root-only synthesis).
+//
+// Handler attribution: the decorated method IS an addressable symbol — the
+// JS/TS extractor lands it as a SCOPE.Operation entity named by the method.
+// We emit source_handler = `SCOPE.Operation:<method>` so the Phase-2 resolver
+// rebinds it into a HANDLES edge against the extracted method symbol (the
+// resolver's same-file / cross-kind bare-name match, #3426).
+
+// typeGraphQLOpRe matches a @Query / @Mutation / @Subscription decorator and
+// the method declaration that follows it (possibly across intervening lines
+// carrying other decorators such as @Authorized() or @UseMiddleware()).
+//
+// Capture groups:
+//
+//	1 = operation decorator (Query | Mutation | Subscription)
+//	2 = the decorator's argument list (between the outer parens), used to
+//	    recover an explicit `{ name: '...' }` field-name override; may be empty
+//	3 = the method name
+//
+// The method-name capture allows optional `async` and an optional access
+// modifier (public/private/protected) before the identifier, and requires the
+// identifier to be immediately followed by `(` so a property is not mistaken
+// for a method.
+var typeGraphQLOpRe = regexp.MustCompile(
+	`@(Query|Mutation|Subscription)\s*\(([^)]*(?:\([^)]*\)[^)]*)*)\)` +
+		`(?:\s*@[A-Za-z_$][\w$]*\s*(?:\([^)]*(?:\([^)]*\)[^)]*)*\))?)*` +
+		`\s*(?:public\s+|private\s+|protected\s+)?(?:async\s+)?([A-Za-z_$][\w$]*)\s*\(`,
+)
+
+// typeGraphQLNameOptRe extracts an explicit `name: '<field>'` from a decorator
+// argument list, e.g. `@Query(() => User, { name: 'currentUser' })`.
+//
+// Capture group 1 = the overridden field name.
+var typeGraphQLNameOptRe = regexp.MustCompile(
+	`\bname\s*:\s*['"` + "`" + `]([A-Za-z_$][\w$]*)['"` + "`" + `]`,
+)
+
+// typeGraphQLDecoToRoot maps the TypeGraphQL operation decorator to its
+// GraphQL root type.
+var typeGraphQLDecoToRoot = map[string]string{
+	"Query":        "Query",
+	"Mutation":     "Mutation",
+	"Subscription": "Subscription",
+}
+
+func synthesizeTypeGraphQL(content string, emit emitDefFn) {
+	// File-signal gate: require a TypeGraphQL marker. `type-graphql` is the
+	// canonical import; `@Resolver` is the structural class marker. The bare
+	// @Query/@Mutation gate below is intentionally NOT used as the sole signal
+	// because those identifiers also appear in NestJS GraphQL (handled
+	// elsewhere) — requiring type-graphql / @Resolver scopes this synthesizer.
+	if !strings.Contains(content, "type-graphql") &&
+		!strings.Contains(content, "@Resolver") {
+		return
+	}
+
+	seen := map[string]bool{}
+	for _, m := range typeGraphQLOpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		root, ok := typeGraphQLDecoToRoot[content[m[2]:m[3]]]
+		if !ok {
+			continue
+		}
+		method := content[m[6]:m[7]]
+		if method == "" {
+			continue
+		}
+		// Field name: explicit `{ name: '...' }` option overrides the method
+		// name (TypeGraphQL's name option).
+		field := method
+		args := content[m[4]:m[5]]
+		if nm := typeGraphQLNameOptRe.FindStringSubmatch(args); nm != nil {
+			field = nm[1]
+		}
+
+		key := root + "." + field
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		defLine := lineOfOffset(content, m[6])
+		path := "/graphql/" + root + "/" + field
+		canonical := httproutes.Canonicalize(httproutes.FrameworkTypeGraphQL, path)
+		// The decorated method is a real symbol (SCOPE.Operation, named by the
+		// method). source_handler rebinds to a HANDLES edge via the resolver's
+		// same-file / cross-kind bare-name match.
+		emit("GRAPHQL", canonical, "type-graphql", "SCOPE.Operation", method, defLine)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -642,6 +642,18 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// file just emitted when an adapter signal is present in the module.
 		applyRPCTransportBinding(string(content), entities, gqlTransportBefore,
 			"graphql", gqlHTTPAdapterSignals, gqlWSAdapterSignals)
+		// Producer side (#3619): Pothos + TypeGraphQL code-first GraphQL
+		// servers. These build the schema from TS code (a `builder` object /
+		// @Resolver classes) rather than the SDL-string resolver maps that
+		// synthesizeGraphQLResolvers (Apollo, #1422) recognises, so they need
+		// dedicated synthesizers. Both emit the SAME canonical operation-
+		// endpoint shape (http:GRAPHQL:/graphql/<Root>/<field>) as gqlgen /
+		// Apollo / Strawberry so GraphQL client links (#3667) join. emitDef so
+		// source_line points at the resolver method / field registration; each
+		// is import-/marker-gated so it no-ops on non-Pothos / non-TypeGraphQL
+		// files.
+		synthesizePothos(string(content), emitDef)
+		synthesizeTypeGraphQL(string(content), emitDef)
 		// Producer side: tRPC procedure resolvers (#2693). Each leaf
 		// procedure inside a `router({ ... })` literal becomes an
 		// addressable endpoint identified by its dotted path

--- a/internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go
+++ b/internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go
@@ -1,0 +1,287 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// The code-first GraphQL tests assert the EXACT operation-endpoint id shape
+// shared with gqlgen / Apollo / Strawberry (via findSynthDef), then probe per-
+// endpoint properties (framework, source_handler, start line).
+
+// ---------------------------------------------------------------------------
+// Pothos — #3619
+// ---------------------------------------------------------------------------
+
+// TestSynth_Pothos_RootFields covers builder.queryField / mutationField /
+// subscriptionField single-field registrations. Asserts the EXACT operation-
+// endpoint shape shared with gqlgen / Apollo / Strawberry, the framework label,
+// and that the inline-arrow resolver yields NO source_handler (NoHandlerProp
+// keep-path) so the synthetic survives Phase-2 resolution. #3619.
+func TestSynth_Pothos_RootFields(t *testing.T) {
+	src := `import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+builder.queryField('users', (t) =>
+  t.field({ type: [User], resolve: () => getUsers() }),
+);
+
+builder.mutationField('createUser', (t) =>
+  t.field({ type: User, resolve: (_, args) => create(args) }),
+);
+
+builder.subscriptionField('userAdded', (t) =>
+  t.field({ type: User, subscribe: () => pubsub.asyncIterator('USER_ADDED') }),
+);
+`
+	got, res := runDetect(t, "typescript", "schema/queries.ts", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+		"http:GRAPHQL:/graphql/Subscription/userAdded",
+	}
+	requireContains(t, got, want, "Pothos root fields")
+
+	// EXACT shape + framework + no-handler keep-path.
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/users")
+	if e == nil {
+		t.Fatalf("Pothos: missing http:GRAPHQL:/graphql/Query/users")
+	}
+	if e.Properties["framework"] != "pothos" {
+		t.Errorf("Pothos: framework = %q, want pothos", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "" {
+		t.Errorf("Pothos: source_handler = %q, want empty (inline-arrow resolver)", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Pothos: StartLine not stamped on builder.queryField('users')")
+	}
+}
+
+// TestSynth_Pothos_FieldMap covers the builder.queryType({ fields: (t) => ({...}) })
+// field-map registration form. Asserts each `<field>: t.field(` entry under the
+// root becomes an operation endpoint with the EXACT canonical shape. #3619.
+func TestSynth_Pothos_FieldMap(t *testing.T) {
+	src := `import SchemaBuilder from '@pothos/core';
+const builder = new SchemaBuilder({});
+
+builder.queryType({
+  description: 'root query',
+  fields: (t) => ({
+    me: t.field({ type: User, resolve: () => currentUser() }),
+    users: t.field({ type: [User], resolve: () => getUsers() }),
+  }),
+});
+
+builder.mutationType({
+  fields: (t) => ({
+    login: t.field({ type: Session, resolve: (_, a) => doLogin(a) }),
+  }),
+});
+`
+	got, res := runDetect(t, "typescript", "schema/root.ts", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/me",
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Mutation/login",
+	}
+	requireContains(t, got, want, "Pothos field map")
+
+	// The non-field config key `description:` must NOT produce an endpoint.
+	if e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/description"); e != nil {
+		t.Errorf("Pothos field map: emitted a bogus endpoint for the `description` config key")
+	}
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/me")
+	if e == nil {
+		t.Fatalf("Pothos field map: missing http:GRAPHQL:/graphql/Query/me")
+	}
+	if e.Properties["framework"] != "pothos" {
+		t.Errorf("Pothos field map: framework = %q, want pothos", e.Properties["framework"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TypeGraphQL — #3619
+// ---------------------------------------------------------------------------
+
+// TestSynth_TypeGraphQL_Resolver covers @Query / @Mutation decorated methods in
+// a @Resolver class. Asserts the EXACT operation-endpoint shape, the framework
+// label, and the SCOPE.Operation handler attribution that the Phase-2 resolver
+// rebinds into a HANDLES edge to the method symbol. #3619.
+func TestSynth_TypeGraphQL_Resolver(t *testing.T) {
+	src := `import { Resolver, Query, Mutation, Arg } from 'type-graphql';
+
+@Resolver(() => User)
+export class UserResolver {
+  @Query(() => [User])
+  users() {
+    return this.service.all();
+  }
+
+  @Query(() => User)
+  me() {
+    return this.service.current();
+  }
+
+  @Mutation(() => User)
+  createUser(@Arg('data') data: NewUserInput) {
+    return this.service.create(data);
+  }
+}
+`
+	got, res := runDetect(t, "typescript", "resolvers/user.resolver.ts", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Query/me",
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+	}
+	requireContains(t, got, want, "TypeGraphQL resolver")
+
+	// EXACT shape + framework + handler attribution → HANDLES edge.
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/me")
+	if e == nil {
+		t.Fatalf("TypeGraphQL: missing http:GRAPHQL:/graphql/Query/me")
+	}
+	if e.Properties["framework"] != "type-graphql" {
+		t.Errorf("TypeGraphQL: framework = %q, want type-graphql", e.Properties["framework"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("TypeGraphQL: StartLine not stamped on me() resolver")
+	}
+	// The me() method is an extracted SCOPE.Operation symbol. The synthesizer
+	// stamps source_handler = SCOPE.Operation:me; the Phase-2 resolver
+	// (ResolveHTTPEndpointHandlers, run over merged entities) rebinds this into
+	// a HANDLES edge against the method symbol. Phase-1 Detect preserves the
+	// ref, so assert the exact attribution shape here (mirrors the gqlgen test).
+	if e.Properties["source_handler"] != "SCOPE.Operation:me" {
+		t.Errorf("TypeGraphQL: source_handler = %q, want SCOPE.Operation:me", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_TypeGraphQL_NameOverride asserts the `{ name: '...' }` decorator
+// option overrides the method name for the GraphQL field. #3619.
+func TestSynth_TypeGraphQL_NameOverride(t *testing.T) {
+	src := `import { Resolver, Query } from 'type-graphql';
+
+@Resolver()
+class MeResolver {
+  @Query(() => User, { name: 'currentUser' })
+  me() {
+    return current();
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "resolvers/me.resolver.ts", src)
+	want := []string{"http:GRAPHQL:/graphql/Query/currentUser"}
+	requireContains(t, got, want, "TypeGraphQL name override")
+
+	// The method name `me` must NOT also be emitted — the option wins.
+	for _, id := range got {
+		if id == "http:GRAPHQL:/graphql/Query/me" {
+			t.Errorf("TypeGraphQL name override: emitted both Query/me and Query/currentUser; the { name } option must win")
+		}
+	}
+}
+
+// TestSynth_TypeGraphQL_SkipsFieldResolver asserts that @FieldResolver methods
+// (which resolve a field on a NON-root object type) are intentionally skipped —
+// only the three ROOT operation decorators become operation endpoints, matching
+// the gqlgen / spring-graphql root-only synthesis convention. #3619.
+func TestSynth_TypeGraphQL_SkipsFieldResolver(t *testing.T) {
+	src := `import { Resolver, Query, FieldResolver, Root } from 'type-graphql';
+
+@Resolver(() => User)
+class UserResolver {
+  @Query(() => [User])
+  users() {
+    return all();
+  }
+
+  @FieldResolver(() => [Post])
+  posts(@Root() user: User) {
+    return user.posts;
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "resolvers/user.resolver.ts", src)
+	requireContains(t, got, []string{"http:GRAPHQL:/graphql/Query/users"}, "TypeGraphQL root query")
+
+	for _, id := range got {
+		if id == "http:GRAPHQL:/graphql/Query/posts" ||
+			id == "http:GRAPHQL:/graphql/Mutation/posts" ||
+			id == "http:GRAPHQL:/graphql/Subscription/posts" {
+			t.Errorf("TypeGraphQL: @FieldResolver method posts() must not become a root operation endpoint (got %q)", id)
+		}
+	}
+}
+
+// TestSynth_GraphQL_CodeFirst_ShapeParity locks the EXACT operation-endpoint id
+// shape parity between Pothos, TypeGraphQL, and the gqlgen reference. A Pothos
+// queryField('users') and a TypeGraphQL @Query users() must both produce the
+// IDENTICAL id `http:GRAPHQL:/graphql/Query/users` — the join key for the
+// GraphQL client-link synthesizer (#3667). #3619.
+func TestSynth_GraphQL_CodeFirst_ShapeParity(t *testing.T) {
+	pothosSrc := `import SchemaBuilder from '@pothos/core';
+const builder = new SchemaBuilder({});
+builder.queryField('users', (t) => t.field({ resolve: () => all() }));
+`
+	tgSrc := `import { Resolver, Query } from 'type-graphql';
+@Resolver()
+class R { @Query(() => [User]) users() { return all(); } }
+`
+	const want = "http:GRAPHQL:/graphql/Query/users"
+
+	pGot, _ := runDetect(t, "typescript", "p.ts", pothosSrc)
+	requireContains(t, pGot, []string{want}, "Pothos parity")
+
+	tGot, _ := runDetect(t, "typescript", "t.ts", tgSrc)
+	requireContains(t, tGot, []string{want}, "TypeGraphQL parity")
+}
+
+// TestResolve_TypeGraphQL_HandlesEdge drives the Phase-2 resolver over a merged
+// set containing a TypeGraphQL operation synthetic (source_handler =
+// SCOPE.Operation:me) and the extracted SCOPE.Operation:me method symbol. It
+// proves the handler ref rebinds into an IMPLEMENTS (HANDLES) edge on the
+// method and clears the source_handler property — the same rebind gqlgen relies
+// on. #3619.
+func TestResolve_TypeGraphQL_HandlesEdge(t *testing.T) {
+	method := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "me",
+		SourceFile: "resolvers/me.resolver.ts",
+		Language:   "typescript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GRAPHQL:/graphql/Query/me",
+		SourceFile: "resolvers/me.resolver.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"source_handler": "SCOPE.Operation:me",
+			"framework":      "type-graphql",
+		},
+	}
+	merged := []types.EntityRecord{method, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.HandlerResolved != 1 || stats.HandlerDropped != 0 {
+		t.Errorf("TypeGraphQL resolve: stats unexpected: %+v", stats)
+	}
+	if len(out[0].Relationships) != 1 {
+		t.Fatalf("TypeGraphQL resolve: expected 1 edge on the me() method, got %d", len(out[0].Relationships))
+	}
+	rel := out[0].Relationships[0]
+	if rel.Kind != implementsEdgeKind {
+		t.Errorf("TypeGraphQL resolve: edge kind = %s, want %s", rel.Kind, implementsEdgeKind)
+	}
+	if rel.FromID != "SCOPE.Operation:me" ||
+		rel.ToID != "http_endpoint_definition:http:GRAPHQL:/graphql/Query/me" {
+		t.Errorf("TypeGraphQL resolve: edge ids wrong: from=%s to=%s", rel.FromID, rel.ToID)
+	}
+	if _, ok := out[1].Properties["source_handler"]; ok {
+		t.Errorf("TypeGraphQL resolve: source_handler should be cleared after rebind")
+	}
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -161,6 +161,21 @@ const (
 	// carries no framework-specific parameter syntax, so canonicalisation is
 	// identity + slash normalisation (default case).
 	FrameworkGqlgen = "gqlgen"
+	// FrameworkPothos (#3619) — Pothos is a code-first GraphQL schema builder
+	// for JS/TS. Root fields registered via builder.queryField / mutationField /
+	// subscriptionField (and queryType/mutationType/subscriptionType field maps)
+	// are synthesised as the canonical `/graphql/<RootType>/<field>` path shared
+	// with gqlgen (Go), Apollo (JS), and Strawberry (Python). The path carries
+	// no framework-specific parameter syntax, so canonicalisation is identity +
+	// slash normalisation (default case).
+	FrameworkPothos = "pothos"
+	// FrameworkTypeGraphQL (#3619) — TypeGraphQL is a code-first GraphQL library
+	// for TS that defines root operations via @Query / @Mutation / @Subscription
+	// decorated methods inside @Resolver classes. Root fields are synthesised as
+	// the canonical `/graphql/<RootType>/<field>` path shared with the other
+	// GraphQL servers. The path carries no framework-specific parameter syntax,
+	// so canonicalisation is identity + slash normalisation (default case).
+	FrameworkTypeGraphQL = "type-graphql"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical

--- a/internal/engine/rules/graphql/frameworks/pothos_jsts.yaml
+++ b/internal/engine/rules/graphql/frameworks/pothos_jsts.yaml
@@ -1,0 +1,33 @@
+server_frameworks:
+  name: Pothos (JS/TS)
+  language: TypeScript
+  category: graphql_server
+  github_stars_2025: 2900+
+  detection:
+    package_json_dependencies:
+    - "@pothos/core"
+    - "@pothos/plugin-prisma"
+    - "@pothos/plugin-relay"
+    structural_markers:
+    - new SchemaBuilder
+    - builder.queryField
+    - builder.mutationField
+    - builder.subscriptionField
+    - builder.queryType
+    - builder.mutationType
+    - builder.subscriptionType
+  extraction_targets:
+  - Root operation fields registered via builder.queryField / mutationField / subscriptionField
+  - Root operation fields in the builder.queryType / mutationType / subscriptionType `fields: (t) => ({...})` map
+  - Each root field -> http:GRAPHQL:/graphql/<RootType>/<field> (canonical operation-endpoint shape)
+  notes: 'Pothos is a code-first GraphQL schema builder for TypeScript. The schema
+    is built from a `builder` (new SchemaBuilder<...>({})) — there is no SDL string,
+    so the Apollo/graphql-tools resolver-map synthesizer never fires on it. Root
+    fields are inline-arrow resolvers with no addressable handler symbol, so the
+    operation endpoints are emitted with no source_handler (NoHandlerProp keep-path,
+    matching the Apollo resolver-map convention). Endpoint ids are byte-for-byte
+    identical to gqlgen (Go) / Apollo (JS) / Strawberry (Python) so GraphQL client
+    links (#3667) and the cross-repo linker join. Honest-partial: field names given
+    by a non-literal first argument (a variable / computed name) are not recovered.
+
+    '

--- a/internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml
+++ b/internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml
@@ -1,0 +1,32 @@
+server_frameworks:
+  name: TypeGraphQL (JS/TS)
+  language: TypeScript
+  category: graphql_server
+  github_stars_2025: 10000+
+  detection:
+    package_json_dependencies:
+    - type-graphql
+    structural_markers:
+    - "@Resolver"
+    - "@Query"
+    - "@Mutation"
+    - "@Subscription"
+    - "@FieldResolver"
+  extraction_targets:
+  - "@Query / @Mutation / @Subscription decorated methods inside @Resolver classes"
+  - GraphQL field name defaults to the method name; a `{ name: '...' }` decorator option overrides it
+  - "@FieldResolver methods (non-root object-type field resolvers) are intentionally skipped"
+  - Each root operation -> http:GRAPHQL:/graphql/<RootType>/<field> (canonical operation-endpoint shape)
+  notes: 'TypeGraphQL is a class-and-decorator code-first GraphQL library for
+    TypeScript. @Query / @Mutation / @Subscription decorate methods in @Resolver
+    classes; the decorated method is an extracted SCOPE.Operation symbol, so the
+    operation endpoint carries source_handler=SCOPE.Operation:<method> and the
+    Phase-2 resolver rebinds it into a HANDLES (IMPLEMENTS) edge against the method.
+    Only the three ROOT operation decorators become operation endpoints — @FieldResolver
+    methods (resolving a field on a non-root object type) are skipped, matching the
+    gqlgen / spring-graphql root-only convention. Endpoint ids are byte-for-byte
+    identical to gqlgen (Go) / Apollo (JS) / Strawberry (Python) so GraphQL client
+    links (#3667) join. The `{ name }` option overrides the field name. Honest-partial:
+    a dynamic / computed name option is not recovered.
+
+    '


### PR DESCRIPTION
Closes #3619 (epic #3607).

Completes the JS/TS GraphQL-server family beyond Apollo / graphql-tools resolver maps and NestJS GraphQL. **Pothos** and **TypeGraphQL** are *code-first* (schema built from TS code rather than an SDL string), so the existing `synthesizeGraphQLResolvers` resolver-map regexes never fire on them — each needs a dedicated synthesizer.

## Endpoint-shape parity (confirmed)
Both synthesizers emit the **EXACT** canonical operation-endpoint shape shared with gqlgen (Go), Apollo (JS), and Strawberry (Python):

```
http:GRAPHQL:/graphql/<RootType>/<field>
```

so the GraphQL client-link synthesizer (#3667) and the cross-repo linker join. Locked by `TestSynth_GraphQL_CodeFirst_ShapeParity`: a Pothos `queryField('users')` and a TypeGraphQL `@Query users()` both produce the byte-identical id `http:GRAPHQL:/graphql/Query/users`.

## Pothos
- `builder.queryField('users', t => ...)` / `mutationField` / `subscriptionField` → `Query/users`, `Mutation/...`, `Subscription/...`
- `builder.queryType({ fields: t => ({ me: t.field(...), users: t.field(...) }) })` field-map form (and mutation/subscription variants)
- Inline-arrow resolvers carry no addressable handler symbol → emitted with **no** `source_handler` (NoHandlerProp keep-path, matching the Apollo resolver-map convention)
- Non-field config keys (`description:` etc.) excluded

## TypeGraphQL
- `@Query` / `@Mutation` / `@Subscription` methods in `@Resolver` classes
- Field name = method name, or the `{ name: '...' }` decorator option (option wins)
- `@FieldResolver` (non-root object-type field resolvers) **skipped** — root-only synthesis, matching gqlgen / spring-graphql
- `source_handler=SCOPE.Operation:<method>` rebinds to a HANDLES (IMPLEMENTS) edge against the extracted method symbol — proven end-to-end in `TestResolve_TypeGraphQL_HandlesEdge`

## Endpoints asserted (value-asserting tests)
- `http:GRAPHQL:/graphql/Query/users`, `/Mutation/createUser`, `/Subscription/userAdded` (Pothos single-field)
- `http:GRAPHQL:/graphql/Query/me`, `/Query/users`, `/Mutation/login` (Pothos field-map)
- `http:GRAPHQL:/graphql/Query/users`, `/Query/me`, `/Mutation/createUser` (TypeGraphQL)
- `http:GRAPHQL:/graphql/Query/currentUser` (TypeGraphQL `{ name }` override; `Query/me` absent)
- `@FieldResolver posts()` produces NO `Query/posts` endpoint

## Records / discipline
- `FrameworkPothos` / `FrameworkTypeGraphQL` canonicalize constants (default identity + slash normalisation, like gqlgen)
- graphql rules YAML: `pothos_jsts.yaml`, `type_graphql_jsts.yaml`
- coverage registry records `lang.jsts.framework.{pothos,type-graphql}` (Routing endpoint_synthesis full; TypeGraphQL handler_attribution full, Pothos not_applicable per inline-arrow; route_extraction honest-partial)
- `coverage validate` 0 errors + `fmt --check` canonical (surgical +361/-0, no recompaction); `gofmt -l` empty; `go vet` clean
- Targeted suites green: `internal/extractors/javascript/...`, `internal/engine/`, `internal/engine/httproutes/...`, `internal/types/`, `tools/coverage/`

**DEPLOY-DEFERRED** — no daemon rebuild / reindex in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)