### PR TITLE
feat(engine): wire lib-boundary pass — first_party/third_party on DEPENDS_ON (#3638)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -62,13 +62,14 @@ const (
 	PassCoupling      = "coupling"       // Pass 8.6: structural Ca/Ce/instability per Module (#3634)
 	PassDepHygiene    = "dep-hygiene"    // Pass 8.7: persist deplinker used/unused status onto deps (#3640)
 	PassSharedDB      = "shared-db"      // Pass 8.8: shared-database cross-service coupling (#3628 area #13)
+	PassLibBoundary   = "lib-boundary"   // Pass 8.9: first_party/third_party boundary on DEPENDS_ON edges (#3638)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassLibBoundary, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1596,6 +1597,28 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				"archigraph: shared-db tables=%d shared=%d data_access_annotated=%d coupling_edges=%d\n",
 				sdStats.TablesConsidered, sdStats.SharedTables,
 				sdStats.DataAccessAnnotated, sdStats.CouplingEdges)
+		}
+	}
+
+	// Pass 8.9 — dependency-boundary annotation (#3638, epic #3625). Restores
+	// the previously-orphaned lib_boundary enricher as a live pass. Runs AFTER
+	// the document is assembled (manifest external_dependency entities + import
+	// DEPENDS_ON edges + code-to-code DEPENDS_ON edges are all present) so the
+	// classifier sees the same graph the dashboard would. Annotates each
+	// DEPENDS_ON edge with boundary=first_party (internal/local import or
+	// repo-internal code dependency) vs third_party (manifest dep or resolved
+	// external import) — a rewrite-scope signal. Reuses the locality/kind
+	// properties the extractors already attached; does NOT re-parse source.
+	// Honest-partial: edges with ambiguous origin are left unannotated.
+	// Skippable via --skip-pass=lib-boundary.
+	if !i.skipPasses[PassLibBoundary] {
+		lbStats := engine.ApplyLibBoundary(doc)
+		if verbose() || lbStats.FirstParty > 0 || lbStats.ThirdParty > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: lib-boundary edges=%d first_party=%d third_party=%d "+
+					"ambiguous=%d entities_annotated=%d\n",
+				lbStats.EdgesConsidered, lbStats.FirstParty, lbStats.ThirdParty,
+				lbStats.Ambiguous, lbStats.EntitiesAnnotated)
 		}
 	}
 

--- a/internal/engine/lib_boundary.go
+++ b/internal/engine/lib_boundary.go
@@ -1,0 +1,192 @@
+// Package engine — dependency-boundary annotation pass (#3638, epic #3625).
+//
+// This pass promotes the previously-orphaned lib_boundary enricher
+// (internal/enrichers/lib_boundary_enricher.go — a Go port of the Python
+// lib_boundary_enricher.py that was imported by zero production code) into a
+// live, registered project-scope pass. It annotates every dependency /import
+// DEPENDS_ON edge with a boundary signal:
+//
+//   - boundary=first_party  — the target is internal to this org/module: a
+//     local/relative import, or a code-to-code dependency between two entities
+//     that both live in this repo (neither end is an external manifest dep).
+//   - boundary=third_party  — the target is an external library: a manifest
+//     dependency (DEPENDS_ON kind=external_dependency) or a non-local import
+//     resolved to an external package.
+//
+// WHY. The first_party / third_party split is a rewrite-scope signal: code
+// inside a rewrite boundary is first_party (you own it, you can change it),
+// whereas third_party edges cross an org boundary into a vendored library (you
+// can swap it but not rewrite it). Persisting it onto the graph lets
+// find/neighbors/agents reason about rewrite scope without re-deriving it.
+//
+// REUSE, DO NOT RE-PARSE. The classification is read entirely off properties the
+// extractors already attached to each edge:
+//
+//   - cross/manifest emits DEPENDS_ON{kind=external_dependency} for declared
+//     manifest deps                                            → third_party.
+//   - cross/imports emits DEPENDS_ON{kind=import, is_local, external_dependency}
+//     where is_local distinguishes a relative/internal import (first_party)
+//     from a resolved external package (third_party).
+//   - language extractors emit DEPENDS_ON code-to-code edges (struct field,
+//     receiver, …). When NEITHER endpoint is an external_dependency entity the
+//     dependency is internal → first_party.
+//
+// No source is re-read and no manifest is re-parsed; this pass runs after the
+// document is assembled and mutates existing edges (and external_dependency
+// entities, for parity) in place — no new entities, no double emit.
+//
+// HONEST-PARTIAL. When an edge's origin is genuinely ambiguous (a DEPENDS_ON
+// whose kind/locality cannot be determined and whose endpoints are not both
+// resolvable in this document), the pass leaves it UNANNOTATED rather than
+// guessing. The boundary property is therefore present only where the signal is
+// real; its absence reads as "unknown", not "first_party".
+package engine
+
+import "github.com/cajasmota/archigraph/internal/graph"
+
+// boundaryProp is the edge/entity property key carrying the dependency-boundary
+// classification. Kept in one place so queries and tests agree on the name.
+const boundaryProp = "boundary"
+
+// Boundary classification values.
+const (
+	boundaryFirstParty = "first_party"
+	boundaryThirdParty = "third_party"
+)
+
+// LibBoundaryStats summarises one ApplyLibBoundary run.
+type LibBoundaryStats struct {
+	// EdgesConsidered is the number of DEPENDS_ON edges inspected.
+	EdgesConsidered int
+	// FirstParty is the count of edges annotated boundary=first_party.
+	FirstParty int
+	// ThirdParty is the count of edges annotated boundary=third_party.
+	ThirdParty int
+	// Ambiguous is the count of DEPENDS_ON edges left unannotated because their
+	// origin could not be determined (honest-partial — see package doc).
+	Ambiguous int
+	// EntitiesAnnotated is the number of external_dependency entities stamped
+	// boundary=third_party for parity with their edges.
+	EntitiesAnnotated int
+}
+
+// ApplyLibBoundary classifies every DEPENDS_ON edge in doc as first_party or
+// third_party from the locality/kind properties the extractors already attached,
+// writing boundary onto the edges (and onto external_dependency entities) in
+// place. It returns stats describing the run. Deterministic and idempotent: a
+// second call recomputes identical values. Safe to call on a nil/empty doc.
+func ApplyLibBoundary(doc *graph.Document) LibBoundaryStats {
+	stats := LibBoundaryStats{}
+	if doc == nil {
+		return stats
+	}
+
+	// Index entity IDs that are external_dependency carriers so a code-to-code
+	// DEPENDS_ON edge whose target is one of them can be classed third_party,
+	// and so we know which endpoints are "owned" (present, non-external) when
+	// resolving the internal-vs-unknown case.
+	externalDepIDs := make(map[string]bool)
+	ownedIDs := make(map[string]bool)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		ownedIDs[e.ID] = true
+		if e.Kind == "SCOPE.Component" && e.Subtype == "external_dependency" {
+			externalDepIDs[e.ID] = true
+		}
+	}
+
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "DEPENDS_ON" {
+			continue
+		}
+		stats.EdgesConsidered++
+
+		boundary := classifyBoundary(r, externalDepIDs, ownedIDs)
+		switch boundary {
+		case boundaryFirstParty:
+			if r.Properties == nil {
+				r.Properties = make(map[string]string)
+			}
+			r.Properties[boundaryProp] = boundaryFirstParty
+			stats.FirstParty++
+		case boundaryThirdParty:
+			if r.Properties == nil {
+				r.Properties = make(map[string]string)
+			}
+			r.Properties[boundaryProp] = boundaryThirdParty
+			stats.ThirdParty++
+		default:
+			// Ambiguous — leave unannotated (honest-partial).
+			stats.Ambiguous++
+		}
+	}
+
+	// Parity: stamp the external_dependency entities themselves third_party so
+	// entity-oriented queries surface the boundary without an edge lookup. By
+	// definition a manifest external dependency is third_party.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "external_dependency" {
+			continue
+		}
+		if e.Properties == nil {
+			e.Properties = make(map[string]string)
+		}
+		e.Properties[boundaryProp] = boundaryThirdParty
+		stats.EntitiesAnnotated++
+	}
+
+	return stats
+}
+
+// classifyBoundary returns boundaryFirstParty, boundaryThirdParty, or "" (the
+// ambiguous sentinel) for a single DEPENDS_ON edge, reading only properties the
+// extractors already attached plus the resolved-endpoint sets.
+func classifyBoundary(r *graph.Relationship, externalDepIDs, ownedIDs map[string]bool) string {
+	props := r.Properties
+
+	// 1. Manifest dependency edge — DEPENDS_ON{kind=external_dependency}. A
+	//    declared third-party library by construction.
+	if props != nil && props["kind"] == "external_dependency" {
+		return boundaryThirdParty
+	}
+	// A code-to-code edge whose target is a manifest external_dependency entity
+	// is likewise crossing into a third-party library.
+	if externalDepIDs[r.ToID] {
+		return boundaryThirdParty
+	}
+
+	// 2. Import edge — DEPENDS_ON{kind=import}. The cross/imports extractor
+	//    already decided locality; reuse it verbatim.
+	if props != nil && props["kind"] == "import" {
+		// is_local=true → relative/internal import → first_party.
+		if props["is_local"] == "true" {
+			return boundaryFirstParty
+		}
+		// external_dependency mirrors !is_local on the import edge's carrier.
+		if v, ok := props["external_dependency"]; ok {
+			if v == "false" {
+				return boundaryFirstParty
+			}
+			return boundaryThirdParty
+		}
+		if props["is_local"] == "false" {
+			return boundaryThirdParty
+		}
+		// kind=import but no locality signal at all — ambiguous.
+		return ""
+	}
+
+	// 3. Code-to-code DEPENDS_ON (struct field, receiver, injected bean, …).
+	//    When BOTH endpoints resolve to entities owned by this document — and
+	//    neither is an external dependency (handled above) — the dependency is
+	//    internal to the repo → first_party.
+	if ownedIDs[r.FromID] && ownedIDs[r.ToID] {
+		return boundaryFirstParty
+	}
+
+	// 4. Otherwise the origin is ambiguous (unresolved target, no kind/locality
+	//    signal). Honest-partial: do not guess.
+	return ""
+}

--- a/internal/engine/lib_boundary_test.go
+++ b/internal/engine/lib_boundary_test.go
@@ -1,0 +1,172 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestApplyLibBoundary_FirstVsThirdParty is the core value-asserting test for
+// #3638. Fixture: module A imports internal pkg B (a local/relative import →
+// first_party) and external lib C (a manifest external dependency → third_party).
+// We assert the A→B edge gets boundary=first_party and the A→C edge gets
+// boundary=third_party — not merely that some annotation happened.
+func TestApplyLibBoundary_FirstVsThirdParty(t *testing.T) {
+	const (
+		fileA = "scope:component:file:src/a.go"
+		pkgB  = "scope:component:import:local:./b"
+		libC  = "scope:component:external_dep:gomod:github.com/external/c"
+	)
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// External library C — the manifest external_dependency carrier.
+			{
+				ID:      libC,
+				Name:    "github.com/external/c",
+				Kind:    "SCOPE.Component",
+				Subtype: "external_dependency",
+				Properties: map[string]string{
+					"package_manager":     "gomod",
+					"external_dependency": "true",
+				},
+			},
+		},
+		Relationships: []graph.Relationship{
+			// A → B: local/internal import → first_party.
+			{
+				ID:     "a->b",
+				FromID: fileA,
+				ToID:   pkgB,
+				Kind:   "DEPENDS_ON",
+				Properties: map[string]string{
+					"kind":                "import",
+					"is_local":            "true",
+					"external_dependency": "false",
+				},
+			},
+			// A → C: manifest external dependency edge → third_party.
+			{
+				ID:     "a->c",
+				FromID: "scope:component:project:go.mod",
+				ToID:   libC,
+				Kind:   "DEPENDS_ON",
+				Properties: map[string]string{
+					"kind":            "external_dependency",
+					"package_manager": "gomod",
+				},
+			},
+		},
+	}
+
+	stats := ApplyLibBoundary(doc)
+
+	// Edge A→B must be first_party.
+	abEdge := findRel(t, doc, "a->b")
+	if got := abEdge.Properties[boundaryProp]; got != boundaryFirstParty {
+		t.Errorf("A->B (internal import) boundary=%q, want %q", got, boundaryFirstParty)
+	}
+
+	// Edge A→C must be third_party.
+	acEdge := findRel(t, doc, "a->c")
+	if got := acEdge.Properties[boundaryProp]; got != boundaryThirdParty {
+		t.Errorf("A->C (external dep) boundary=%q, want %q", got, boundaryThirdParty)
+	}
+
+	// The external_dependency entity C must also be stamped third_party.
+	cEnt := findEnt(t, doc, libC)
+	if got := cEnt.Properties[boundaryProp]; got != boundaryThirdParty {
+		t.Errorf("entity C boundary=%q, want %q", got, boundaryThirdParty)
+	}
+
+	if stats.FirstParty != 1 {
+		t.Errorf("FirstParty=%d, want 1", stats.FirstParty)
+	}
+	if stats.ThirdParty != 1 {
+		t.Errorf("ThirdParty=%d, want 1", stats.ThirdParty)
+	}
+	if stats.EntitiesAnnotated != 1 {
+		t.Errorf("EntitiesAnnotated=%d, want 1", stats.EntitiesAnnotated)
+	}
+}
+
+// TestApplyLibBoundary_CodeToCodeAndAmbiguous covers the remaining branches:
+// a repo-internal code-to-code DEPENDS_ON (both endpoints owned, neither
+// external) is first_party, an import edge resolved external is third_party, and
+// an edge with no locality/kind signal and an unresolved target is left
+// UNANNOTATED (honest-partial).
+func TestApplyLibBoundary_CodeToCodeAndAmbiguous(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "ent:order", Kind: "SCOPE.Component", Subtype: "class"},
+			{ID: "ent:store", Kind: "SCOPE.Component", Subtype: "class"},
+		},
+		Relationships: []graph.Relationship{
+			// Code-to-code: both endpoints owned, neither external → first_party.
+			{ID: "code", FromID: "ent:order", ToID: "ent:store", Kind: "DEPENDS_ON"},
+			// External import → third_party.
+			{
+				ID:     "ext-import",
+				FromID: "scope:component:file:src/a.go",
+				ToID:   "scope:component:import:external:lodash",
+				Kind:   "DEPENDS_ON",
+				Properties: map[string]string{
+					"kind":     "import",
+					"is_local": "false",
+				},
+			},
+			// Ambiguous: no kind/locality, target not in this document.
+			{ID: "ambig", FromID: "ent:order", ToID: "unresolved:target", Kind: "DEPENDS_ON"},
+		},
+	}
+
+	stats := ApplyLibBoundary(doc)
+
+	if got := findRel(t, doc, "code").Properties[boundaryProp]; got != boundaryFirstParty {
+		t.Errorf("code-to-code boundary=%q, want %q", got, boundaryFirstParty)
+	}
+	if got := findRel(t, doc, "ext-import").Properties[boundaryProp]; got != boundaryThirdParty {
+		t.Errorf("external import boundary=%q, want %q", got, boundaryThirdParty)
+	}
+	// The ambiguous edge must NOT be annotated.
+	if ambig := findRel(t, doc, "ambig"); ambig.Properties != nil {
+		if _, ok := ambig.Properties[boundaryProp]; ok {
+			t.Errorf("ambiguous edge was annotated, want unannotated (honest-partial)")
+		}
+	}
+	if stats.Ambiguous != 1 {
+		t.Errorf("Ambiguous=%d, want 1", stats.Ambiguous)
+	}
+	if stats.FirstParty != 1 || stats.ThirdParty != 1 {
+		t.Errorf("FirstParty=%d ThirdParty=%d, want 1/1", stats.FirstParty, stats.ThirdParty)
+	}
+}
+
+// TestApplyLibBoundary_NilSafe asserts the pass is safe on an empty document.
+func TestApplyLibBoundary_NilSafe(t *testing.T) {
+	if got := ApplyLibBoundary(nil); got.EdgesConsidered != 0 {
+		t.Errorf("nil doc EdgesConsidered=%d, want 0", got.EdgesConsidered)
+	}
+}
+
+func findRel(t *testing.T, doc *graph.Document, id string) *graph.Relationship {
+	t.Helper()
+	for i := range doc.Relationships {
+		if doc.Relationships[i].ID == id {
+			return &doc.Relationships[i]
+		}
+	}
+	t.Fatalf("relationship %q not found", id)
+	return nil
+}
+
+func findEnt(t *testing.T, doc *graph.Document, id string) *graph.Entity {
+	t.Helper()
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == id {
+			return &doc.Entities[i]
+		}
+	}
+	t.Fatalf("entity %q not found", id)
+	return nil
+}


### PR DESCRIPTION
Closes #3638 (epic #3625).

## What

Restores the previously-orphaned `lib_boundary` enricher (`internal/enrichers/lib_boundary_enricher.go`, imported by zero production code) as a **live, registered project-scope pass** that annotates every `DEPENDS_ON` edge with a dependency-boundary signal — the rewrite-scope axis (you own first_party code; third_party edges cross into a vendored library).

## Boundary asserted

- `boundary=first_party` — a local/relative import (`is_local=true`), or a repo-internal code-to-code dependency (both endpoints owned by this document, neither an external dependency).
- `boundary=third_party` — a manifest `DEPENDS_ON{kind=external_dependency}` edge, or a non-local import resolved to an external package; `external_dependency` entities are also stamped `third_party` for entity-query parity.

## How

- New `internal/engine/lib_boundary.go` (`ApplyLibBoundary`), registered as **Pass 8.9** in `cmd/archigraph/index.go`, mirroring coupling (8.6) / dep-hygiene (8.7) / shared-db (8.8). Reachable from the live index flow; skippable via `--skip-pass=lib-boundary`.
- **Reuse, no re-parse**: reads only the locality/kind properties the `cross/imports` and `cross/manifest` extractors already attach (`kind`, `is_local`, `external_dependency`).
- Drive-by: added `PassSharedDB` to `allPassNames` (it was omitted, making `--skip-pass=shared-db` an invalid entry).

## Honest-partial

Edges whose origin is genuinely ambiguous (no kind/locality signal and an unresolved target) are left **unannotated** rather than guessed — absence reads as "unknown", not first_party.

## Quality

- **Value-asserting test**: module A imports internal pkg B (first_party) and external lib C (third_party) → asserts `A→B boundary=first_party`, `A→C boundary=third_party` (plus code-to-code, external-import, and ambiguous-skip branches). Not `len>0`.
- `go test ./internal/enrichers/... ./internal/engine/ ./internal/types/ ./tools/coverage/` green.
- `gofmt -l` empty; `go vet` clean; `coverage validate` 0 errors; registry.json canonical.

**DEPLOY-DEFERRED** — registered behind the existing skip-pass switch; live daemon rebuild intentionally not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)