### PR TITLE
feat(neo4j): extend GRAPH_RELATES topology to PHP, Rust, Elixir drivers

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10737,8 +10737,10 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "notes": "Raw Elixir DB driver; no schema/model definition. Schema belongs to Ecto ORM layer, not the driver."
+            "status": "partial",
+            "cites": ["internal/custom/elixir/neo4j.go","internal/custom/elixir/neo4j_test.go"],
+            "notes": "Node labels in Cypher patterns inside Bolt.Sips.query!/Boltx.query strings surfaced as SCOPE.Schema nodes. Soft schema recovered by regex over the query string, hence partial.",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
@@ -10755,15 +10757,18 @@
             "notes": "Raw driver; no lazy loading concept."
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "notes": "Raw driver protocol; relationship modelling is Ecto's responsibility."
+            "status": "full",
+            "cites": ["internal/custom/elixir/neo4j.go","internal/custom/elixir/neo4j_test.go"],
+            "notes": "Cypher relationship patterns in Bolt.Sips.query!/Boltx.query strings promoted to traversable GRAPH_RELATES edges between node-label entities (reNeo4jExCypherTriple); statically-resolvable topology full, dynamic/interpolated relations honest-partial. Completes Neo4j GRAPH_RELATES set (epic #3606, #3618). Value-asserting test TestExNeo4jGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; left-arrow flips source; single-node MATCH yields no edge.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/custom/elixir/neo4j.go","internal/custom/elixir/neo4j_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "notes": "Bolt.Sips.query!(conn,'CYPHER') call sites captured as SCOPE.Operation/query with a coarse verb sniffed from the leading Cypher clause. Dynamically-built query strings not fully recoverable, so partial.",
             "verified_at": "2026-06-02"
           }
         },
@@ -39514,8 +39519,10 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
+            "status": "partial",
+            "cites": ["internal/custom/php/neo4j.go","internal/custom/php/neo4j_test.go"],
+            "notes": "Node labels in Cypher patterns ((n:Person),(:Movie)) inside -\u003erun/Statement::create strings surfaced as SCOPE.Schema nodes. Soft schema recovered by regex over the query string, hence partial.",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
@@ -39532,15 +39539,18 @@
             "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
+            "status": "full",
+            "cites": ["internal/custom/php/neo4j.go","internal/custom/php/neo4j_test.go"],
+            "notes": "Cypher relationship patterns in laudis -\u003erun('...') strings promoted to traversable GRAPH_RELATES edges between node-label entities (reNeo4jPHPCypherTriple); statically-resolvable topology full, dynamic/untyped/interpolated relations honest-partial. Completes Neo4j GRAPH_RELATES set (epic #3606, #3618) alongside go/java/py/jsts/csharp/ruby. Value-asserting test TestPHPNeo4jGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; left-arrow flips source; single-node MATCH yields no edge.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/custom/php/neo4j.go","internal/custom/php/neo4j_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "notes": "-\u003erun('CYPHER') / Statement::create('CYPHER') call sites captured as SCOPE.Operation/query with a coarse verb sniffed from the leading Cypher clause. Dynamically-built query strings not fully recoverable, so partial.",
             "verified_at": "2026-06-02"
           }
         },
@@ -52597,8 +52607,10 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "not_applicable",
-            "notes": "raw client driver; no schema/model definitions in user code"
+            "status": "partial",
+            "cites": ["internal/custom/rust/neo4j.go","internal/custom/rust/neo4j_test.go"],
+            "notes": "Node labels in Cypher patterns inside neo4rs query()/Query::new() strings surfaced as SCOPE.Schema nodes. Soft schema recovered by regex over the query string, hence partial.",
+            "verified_at": "2026-06-02"
           }
         },
         "Relationships": {
@@ -52615,15 +52627,18 @@
             "notes": "raw/NoSQL driver — no ORM relationship/association/FK/lazy-load layer"
           },
           "relationship_extraction": {
-            "status": "not_applicable",
-            "notes": "raw/NoSQL driver — no ORM relationship/association/FK/lazy-load layer"
+            "status": "full",
+            "cites": ["internal/custom/rust/neo4j.go","internal/custom/rust/neo4j_test.go"],
+            "notes": "Cypher relationship patterns in neo4rs query('...')/Query::new('...') strings (plain + raw literals) promoted to traversable GRAPH_RELATES edges between node-label entities (reNeo4jRustCypherTriple); statically-resolvable topology full, dynamic/untyped relations honest-partial. Completes Neo4j GRAPH_RELATES set (epic #3606, #3618). Value-asserting test TestRustNeo4jGraphRelatesEdge: Person -GRAPH_RELATES(ACTED_IN,OUTGOING)-\u003e Movie; left-arrow flips source; single-node MATCH yields no edge.",
+            "verified_at": "2026-06-02"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/custom/rust/neo4j.go","internal/custom/rust/neo4j_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "notes": "query('CYPHER') / Query::new('CYPHER') call sites captured as SCOPE.Operation/query with a coarse verb sniffed from the leading Cypher clause. Dynamically-built (format!) query strings not fully recoverable, so partial.",
             "verified_at": "2026-06-02"
           }
         },

--- a/internal/custom/elixir/neo4j.go
+++ b/internal/custom/elixir/neo4j.go
@@ -1,0 +1,293 @@
+// neo4j.go — Cypher-DSL extractor for the Elixir Neo4j drivers
+// (Bolt.Sips and boltx). #3618, epic #3606.
+//
+// Elixir is driver-based: like the Go and C# drivers, Neo4j relationships are
+// first-class but live inline in the Cypher *query text* rather than in OGM
+// decorators. Both Bolt.Sips and boltx run Cypher strings through query/query!:
+//
+//	Bolt.Sips.query!(conn, "MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m")
+//	Bolt.Sips.query(conn, "CREATE (a:Person)-[:KNOWS]->(b:Person)")
+//	Boltx.query!(conn, "MATCH (u:User)-[:OWNS]->(o:Order) RETURN o")
+//
+// Honest coverage shape (mirrors the Go / C# extractors exactly):
+//
+//   - Models / Schema — partial. Node labels in Cypher patterns ((n:Person),
+//     (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a soft schema
+//     recovered from a query string by regex, hence partial.
+//   - Relationships — full (topology). Relationship types in Cypher patterns
+//     (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as SCOPE.Schema entities with
+//     subtype "relationship". When BOTH endpoints of the pattern carry a
+//     static node label and the relation a static type —
+//     (a:Person)-[:ACTED_IN]->(m:Movie) — the graph-schema topology is
+//     additionally promoted to a traversable GRAPH_RELATES edge between the
+//     node-label entities (Person ─GRAPH_RELATES(ACTED_IN)→ Movie), the
+//     graph-DB analogue of Mongo's JOINS_COLLECTION and the Java SDN
+//     @Relationship edge. Parameterised / dynamic relations (no static type,
+//     or built by string interpolation) stay type-only — honest-partial.
+//   - Queries — partial. Bolt.Sips.query!(conn, "CYPHER") call sites are
+//     captured with a coarse verb sniffed from the leading Cypher clause.
+//     Dynamically-built query strings are not fully recoverable, so partial.
+//   - Migrations — not_applicable. Neo4j is schema-flexible / graph-native;
+//     the driver has no migration runner.
+//
+// The extractor gates on a Bolt.Sips / Boltx reference actually being present.
+//
+// Registration key: "custom_elixir_neo4j"
+package elixir
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_neo4j", &neo4jElixirExtractor{})
+}
+
+type neo4jElixirExtractor struct{}
+
+func (e *neo4jElixirExtractor) Language() string { return "custom_elixir_neo4j" }
+
+var (
+	// Gate: a Bolt.Sips or Boltx reference (alias/use/module call).
+	reNeo4jExImport = regexp.MustCompile(`\bBolt\.Sips\b|\bBoltx\b`)
+
+	// Cypher strings passed to the driver: Bolt.Sips.query!(conn, "…") /
+	// Bolt.Sips.query(conn, "…") / Boltx.query!(conn, "…"). The conn argument is
+	// skipped (a non-greedy run of non-quote characters) and the Cypher string
+	// literal is captured.
+	//
+	// Interpolated strings still surface their static label/type tokens; the
+	// dynamic (#{var}) holes simply do not match the node/rel regexes —
+	// honest-partial.
+	reNeo4jExRun = regexp.MustCompile(
+		`(?:Bolt\.Sips|Boltx)\.query!?\s*\(\s*[^"]*?"((?:[^"\\]|\\.)*)"`,
+	)
+
+	// A node label inside a Cypher pattern: (var:Label) or (:Label). Captures
+	// the first (primary) label; chained labels (:A:B) capture A.
+	reNeo4jExCypherLabel = regexp.MustCompile(`\([A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|\(\s*:\s*([A-Za-z_]\w*)`)
+
+	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
+	reNeo4jExCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+
+	// A full directed relationship triple inside a Cypher pattern:
+	//
+	//   (a:LeftLabel) -[ rvar :REL_TYPE ]-> (b:RightLabel)
+	//   (a:LeftLabel) <-[ rvar :REL_TYPE ]-  (b:RightLabel)
+	//
+	// Both endpoints must carry a statically-resolvable node label and the
+	// relationship a statically-resolvable type for an edge to be emitted. The
+	// arrow head (-> vs <-) decides GRAPH_RELATES direction.
+	//
+	// Captures:
+	//   1 = left node label
+	//   2 = optional left-arrow head ("<")
+	//   3 = relationship type
+	//   4 = optional right-arrow head (">")
+	//   5 = right node label
+	//
+	// A bare relationship with no type (-[r]-> / -[]->) or a dynamic type does
+	// NOT match the type group, so no edge is emitted — honest-partial.
+	reNeo4jExCypherTriple = regexp.MustCompile(
+		`\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^()]*\)\s*` +
+			`(<)?-\[\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^\]]*\]-(>)?` +
+			`\s*\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)`,
+	)
+)
+
+func (e *neo4jElixirExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.elixir_neo4j_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neo4j"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "elixir" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reNeo4jExImport.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// nodeIdx maps "node:<label>" to the index, in `entities`, of its
+	// SCOPE.Schema node entity. The GRAPH_RELATES pass hangs the topology edge
+	// off the *source* node-label entity (the graph "table"), mirroring the Go
+	// / C# extractors and the Mongo JOINS_COLLECTION source collection.
+	nodeIdx := make(map[string]int)
+
+	for _, rm := range reNeo4jExRun.FindAllStringSubmatchIndex(src, -1) {
+		if rm[2] < 0 {
+			continue
+		}
+		cypher := src[rm[2]:rm[3]]
+		if cypher == "" {
+			continue
+		}
+		line := lineOf(src, rm[0])
+
+		// Query operation, verb sniffed from the leading Cypher clause.
+		verb := neo4jExVerbKind(cypher)
+		q := makeEntity("cypher:"+verb+":"+itoa(line), "SCOPE.Operation", "query", file.Path, "elixir", line)
+		setProps(&q, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+			"query_type", verb)
+		add(q)
+
+		// Schema: node labels in the Cypher pattern.
+		for _, lm := range reNeo4jExCypherLabel.FindAllStringSubmatch(cypher, -1) {
+			label := lm[1]
+			if label == "" {
+				label = lm[2]
+			}
+			if label == "" {
+				continue
+			}
+			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "elixir", line)
+			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"node_label", label)
+			before := len(entities)
+			add(n)
+			// add() dedupes; only register the index when actually appended.
+			if len(entities) == before+1 {
+				nodeIdx["node:"+label] = before
+			}
+		}
+
+		// Relationships: relationship types in the Cypher pattern (first-class).
+		for _, relm := range reNeo4jExCypherRelType.FindAllStringSubmatch(cypher, -1) {
+			relType := relm[1]
+			if relType == "" {
+				relType = relm[2]
+			}
+			if relType == "" {
+				continue
+			}
+			r := makeEntity("rel:"+relType, "SCOPE.Schema", "relationship", file.Path, "elixir", line)
+			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"rel_type", relType)
+			add(r)
+		}
+
+		// --- GRAPH_RELATES edges (#3618, epic #3606) ---
+		// Promote the graph-schema topology encoded in a Cypher relationship
+		// pattern — (a:Person)-[:ACTED_IN]->(m:Movie) — into a traversable edge
+		// between the node-label entities (the graph "tables"), the graph-DB
+		// analogue of the Mongo JOINS_COLLECTION and the Java SDN @Relationship
+		// GRAPH_RELATES. The edge hangs off the OUTGOING source node entity; the
+		// arrow head decides which endpoint that is:
+		//
+		//   (a:A)-[:R]->(b:B)   →  A ─GRAPH_RELATES(R, OUTGOING)→ node:B
+		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
+		//
+		// Only emitted when BOTH endpoints carry a static label AND the relation
+		// a static type; dynamic / parameterised relations stay label/type-only
+		// — honest-partial.
+		for _, tm := range reNeo4jExCypherTriple.FindAllStringSubmatch(cypher, -1) {
+			leftLabel, relType, rightLabel := tm[1], tm[3], tm[5]
+			pointsRight := tm[4] == ">"
+			pointsLeft := tm[2] == "<"
+			if relType == "" || leftLabel == "" || rightLabel == "" {
+				continue
+			}
+			// Determine OUTGOING source / target from the arrow head. A pattern
+			// with no head on either side is undirected; Neo4j stores every
+			// relationship with a concrete direction, so we treat the written
+			// left→right order as the source and record direction=UNDIRECTED.
+			srcLabel, dstLabel, direction := leftLabel, rightLabel, "OUTGOING"
+			switch {
+			case pointsRight && !pointsLeft:
+				srcLabel, dstLabel = leftLabel, rightLabel
+			case pointsLeft && !pointsRight:
+				srcLabel, dstLabel = rightLabel, leftLabel
+			default:
+				direction = "UNDIRECTED"
+			}
+
+			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			if !ok {
+				continue
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "node:" + dstLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neo4j",
+						"rel_type":   relType,
+						"direction":  direction,
+						"provenance": "INFERRED_FROM_NEO4J_CYPHER",
+					},
+				},
+			)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// neo4jExVerbKind sniffs a coarse verb from the leading Cypher clause so
+// query_type is comparable across the Elixir data-access extractors.
+func neo4jExVerbKind(cypher string) string {
+	i := 0
+	for i < len(cypher) && (cypher[i] == ' ' || cypher[i] == '\t' || cypher[i] == '\n' || cypher[i] == '\r') {
+		i++
+	}
+	j := i
+	for j < len(cypher) {
+		c := cypher[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			j++
+			continue
+		}
+		break
+	}
+	switch upperCypherEx(cypher[i:j]) {
+	case "MATCH", "RETURN", "WITH", "UNWIND", "CALL", "OPTIONAL":
+		return "read"
+	case "CREATE", "MERGE":
+		return "create"
+	case "SET":
+		return "update"
+	case "DELETE", "REMOVE", "DETACH":
+		return "delete"
+	default:
+		return "query"
+	}
+}
+
+// upperCypherEx upper-cases an ASCII keyword without allocating via strings.
+func upperCypherEx(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/custom/elixir/neo4j_test.go
+++ b/internal/custom/elixir/neo4j_test.go
@@ -1,0 +1,171 @@
+package elixir_test
+
+// neo4j_test.go — tests for the custom_elixir_neo4j extractor's GRAPH_RELATES
+// graph-schema topology (#3618, epic #3606). Completes the Neo4j topology set
+// alongside Java (#3663), Python+JS (#3670), Go (#3612), C# (#3616) and
+// Ruby (#3614).
+//
+// Elixir's Neo4j access is driver-based (Bolt.Sips / boltx) with no OGM
+// decorators, so the graph schema lives in the Cypher query text passed to
+// query!/2. The extractor parses relationship patterns —
+//   (a:Person)-[:ACTED_IN]->(m:Movie)
+// — and promotes them to traversable GRAPH_RELATES edges between the
+// node-label entities, the graph-DB analogue of Mongo's JOINS_COLLECTION.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractExNeo4j(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_elixir_neo4j")
+	if !ok {
+		t.Fatal("custom_elixir_neo4j not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "store.ex",
+		Language: "elixir",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findExGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func anyExGraphRelates(ents []types.EntityRecord) bool {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const exNeo4jUse = "defmodule App.Store do\n  alias Bolt.Sips\n"
+
+// Headline: MATCH (p:Person)-[:ACTED_IN]->(m:Movie) in query!/2 →
+//
+//	Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ node:Movie
+func TestExNeo4jGraphRelatesEdge(t *testing.T) {
+	src := exNeo4jUse +
+		"  def q(conn) do\n" +
+		"    Bolt.Sips.query!(conn, \"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\")\n" +
+		"  end\nend\n"
+
+	ents := extractExNeo4j(t, src)
+	edge := findExGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie edge; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "ACTED_IN" {
+		t.Errorf("rel_type = %q, want ACTED_IN", got)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if got := edge.Properties["framework"]; got != "neo4j" {
+		t.Errorf("framework = %q, want neo4j", got)
+	}
+}
+
+// Boltx.query/2 is also a Cypher carrier.
+func TestExNeo4jBoltx(t *testing.T) {
+	src := "defmodule App.Store do\n  alias Boltx\n" +
+		"  def q(conn) do\n" +
+		"    Boltx.query(conn, \"MATCH (u:User)-[:OWNS]->(o:Order) RETURN o\")\n" +
+		"  end\nend\n"
+
+	ents := extractExNeo4j(t, src)
+	edge := findExGraphRelates(ents, "User", "Order")
+	if edge == nil {
+		t.Fatalf("expected User -GRAPH_RELATES-> node:Order; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "OWNS" {
+		t.Errorf("rel_type = %q, want OWNS", got)
+	}
+}
+
+// Direction: a left-pointing arrow flips the OUTGOING source endpoint.
+func TestExNeo4jLeftArrow(t *testing.T) {
+	src := exNeo4jUse +
+		"  def q(conn) do\n" +
+		"    Bolt.Sips.query!(conn, \"MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN p\")\n" +
+		"  end\nend\n"
+
+	ents := extractExNeo4j(t, src)
+	edge := findExGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie (arrow flipped); got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if rev := findExGraphRelates(ents, "Movie", "Person"); rev != nil {
+		t.Errorf("unexpected reverse edge Movie->Person: %+v", rev)
+	}
+}
+
+// Undirected pattern records direction=UNDIRECTED.
+func TestExNeo4jUndirected(t *testing.T) {
+	src := exNeo4jUse +
+		"  def q(conn) do\n" +
+		"    Bolt.Sips.query!(conn, \"MATCH (a:Person)-[:KNOWS]-(b:Person) RETURN a, b\")\n" +
+		"  end\nend\n"
+
+	ents := extractExNeo4j(t, src)
+	edge := findExGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Person; got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "UNDIRECTED" {
+		t.Errorf("direction = %q, want UNDIRECTED", got)
+	}
+}
+
+// Negative: a single-node MATCH yields NO GRAPH_RELATES edge.
+func TestExNeo4jSingleNodeNoEdge(t *testing.T) {
+	src := exNeo4jUse +
+		"  def q(conn) do\n" +
+		"    Bolt.Sips.query!(conn, \"MATCH (p:Person) RETURN p\")\n" +
+		"  end\nend\n"
+
+	ents := extractExNeo4j(t, src)
+	if anyExGraphRelates(ents) {
+		t.Fatalf("expected NO GRAPH_RELATES edge for single-node MATCH; got %+v", ents)
+	}
+}
+
+// Negative: without the Bolt.Sips / Boltx gate, nothing is extracted.
+func TestExNeo4jNoImportNoExtraction(t *testing.T) {
+	src := "defmodule App.Store do\n" +
+		"  def q(conn) do\n" +
+		"    SomethingElse.query!(conn, \"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p\")\n" +
+		"  end\nend\n"
+	ents := extractExNeo4j(t, src)
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without Bolt.Sips/Boltx; got %+v", ents)
+	}
+}

--- a/internal/custom/php/neo4j.go
+++ b/internal/custom/php/neo4j.go
@@ -1,0 +1,302 @@
+// neo4j.go — Cypher-DSL extractor for the PHP Neo4j driver
+// (laudis/neo4j-php-client). #3618, epic #3606.
+//
+// PHP is driver-based: like the Go and C# drivers, Neo4j relationships are
+// first-class but live inline in the Cypher *query text* rather than in OGM
+// decorators. The laudis client runs Cypher strings through ->run(...):
+//
+//	$client->run("MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m");
+//	$session->run('CREATE (a:Person)-[:KNOWS]->(b:Person)');
+//	$tsx->run("MATCH (u:User)-[:OWNS]->(o:Order) RETURN o");
+//	Statement::create("MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p");
+//
+// Honest coverage shape (mirrors the Go / C# extractors exactly):
+//
+//   - Models / Schema — partial. Node labels in Cypher patterns ((n:Person),
+//     (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a soft schema
+//     recovered from a query string by regex, hence partial.
+//   - Relationships — full (topology). Relationship types in Cypher patterns
+//     (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as SCOPE.Schema entities with
+//     subtype "relationship". When BOTH endpoints of the pattern carry a
+//     static node label and the relation a static type —
+//     (a:Person)-[:ACTED_IN]->(m:Movie) — the graph-schema topology is
+//     additionally promoted to a traversable GRAPH_RELATES edge between the
+//     node-label entities (Person ─GRAPH_RELATES(ACTED_IN)→ Movie), the
+//     graph-DB analogue of Mongo's JOINS_COLLECTION and the Java SDN
+//     @Relationship edge. Parameterised / dynamic relations (no static type,
+//     or built by string concatenation / interpolation) stay type-only —
+//     honest-partial.
+//   - Queries — partial. ->run("CYPHER") / Statement::create("CYPHER") call
+//     sites are captured with a coarse verb sniffed from the leading Cypher
+//     clause. Dynamically-built query strings are not fully recoverable, so
+//     partial.
+//   - Migrations — not_applicable. Neo4j is schema-flexible / graph-native;
+//     the driver has no migration runner (constraints/indexes are applied via
+//     ad-hoc Cypher).
+//
+// The extractor gates on a laudis/neo4j-php-client `use Laudis\Neo4j…`
+// statement actually being present.
+//
+// Registration key: "custom_php_neo4j"
+package php
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_php_neo4j", &neo4jExtractor{})
+}
+
+type neo4jExtractor struct{}
+
+func (e *neo4jExtractor) Language() string { return "custom_php_neo4j" }
+
+var (
+	// Gate: a `use Laudis\Neo4j…` import of the laudis/neo4j-php-client driver.
+	reNeo4jPHPImport = regexp.MustCompile(`use\s+Laudis\\Neo4j\b`)
+
+	// Cypher strings passed to the driver: $client->run("…") /
+	// $session->run('…') / $tsx->run("…") / Statement::create("…"). Both
+	// double-quoted and single-quoted PHP string literals are captured.
+	//
+	// Interpolated double-quoted strings still surface their static
+	// label/type tokens; the dynamic ({$var}) holes simply do not match the
+	// node/rel regexes — honest-partial.
+	reNeo4jPHPRun = regexp.MustCompile(
+		`(?:->run|::create|::run)\s*\(\s*"((?:[^"\\]|\\.)*)"|` +
+			`(?:->run|::create|::run)\s*\(\s*'((?:[^'\\]|\\.)*)'`,
+	)
+
+	// A node label inside a Cypher pattern: (var:Label) or (:Label). Captures
+	// the first (primary) label; chained labels (:A:B) capture A.
+	reNeo4jPHPCypherLabel = regexp.MustCompile(`\([A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|\(\s*:\s*([A-Za-z_]\w*)`)
+
+	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
+	reNeo4jPHPCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+
+	// A full directed relationship triple inside a Cypher pattern:
+	//
+	//   (a:LeftLabel) -[ rvar :REL_TYPE ]-> (b:RightLabel)
+	//   (a:LeftLabel) <-[ rvar :REL_TYPE ]-  (b:RightLabel)
+	//
+	// Both endpoints must carry a statically-resolvable node label and the
+	// relationship a statically-resolvable type for an edge to be emitted. The
+	// arrow head (-> vs <-) decides GRAPH_RELATES direction.
+	//
+	// Captures:
+	//   1 = left node label
+	//   2 = optional left-arrow head ("<")
+	//   3 = relationship type
+	//   4 = optional right-arrow head (">")
+	//   5 = right node label
+	//
+	// A bare relationship with no type (-[r]-> / -[]->) or a dynamic type does
+	// NOT match the type group, so no edge is emitted — honest-partial.
+	reNeo4jPHPCypherTriple = regexp.MustCompile(
+		`\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^()]*\)\s*` +
+			`(<)?-\[\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^\]]*\]-(>)?` +
+			`\s*\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)`,
+	)
+)
+
+func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.php_neo4j_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neo4j"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "php" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reNeo4jPHPImport.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// nodeIdx maps "node:<label>" to the index, in `entities`, of its
+	// SCOPE.Schema node entity. The GRAPH_RELATES pass hangs the topology edge
+	// off the *source* node-label entity (the graph "table"), mirroring the Go
+	// / C# extractors and the Mongo JOINS_COLLECTION source collection.
+	nodeIdx := make(map[string]int)
+
+	for _, rm := range reNeo4jPHPRun.FindAllStringSubmatchIndex(src, -1) {
+		// Group 1 = double-quoted literal, group 2 = single-quoted literal.
+		var cypher string
+		if rm[2] >= 0 {
+			cypher = src[rm[2]:rm[3]]
+		} else if rm[4] >= 0 {
+			cypher = src[rm[4]:rm[5]]
+		}
+		if cypher == "" {
+			continue
+		}
+		line := lineOf(src, rm[0])
+
+		// Query operation, verb sniffed from the leading Cypher clause.
+		verb := neo4jPHPVerbKind(cypher)
+		q := makeEntity("cypher:"+verb+":"+strconv.Itoa(line), "SCOPE.Operation", "query", file.Path, "php", line)
+		setProps(&q, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+			"query_type", verb)
+		add(q)
+
+		// Schema: node labels in the Cypher pattern.
+		for _, lm := range reNeo4jPHPCypherLabel.FindAllStringSubmatch(cypher, -1) {
+			label := lm[1]
+			if label == "" {
+				label = lm[2]
+			}
+			if label == "" {
+				continue
+			}
+			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "php", line)
+			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"node_label", label)
+			before := len(entities)
+			add(n)
+			// add() dedupes; only register the index when actually appended.
+			if len(entities) == before+1 {
+				nodeIdx["node:"+label] = before
+			}
+		}
+
+		// Relationships: relationship types in the Cypher pattern (first-class).
+		for _, relm := range reNeo4jPHPCypherRelType.FindAllStringSubmatch(cypher, -1) {
+			relType := relm[1]
+			if relType == "" {
+				relType = relm[2]
+			}
+			if relType == "" {
+				continue
+			}
+			r := makeEntity("rel:"+relType, "SCOPE.Schema", "relationship", file.Path, "php", line)
+			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"rel_type", relType)
+			add(r)
+		}
+
+		// --- GRAPH_RELATES edges (#3618, epic #3606) ---
+		// Promote the graph-schema topology encoded in a Cypher relationship
+		// pattern — (a:Person)-[:ACTED_IN]->(m:Movie) — into a traversable edge
+		// between the node-label entities (the graph "tables"), the graph-DB
+		// analogue of the Mongo JOINS_COLLECTION and the Java SDN @Relationship
+		// GRAPH_RELATES. The edge hangs off the OUTGOING source node entity; the
+		// arrow head decides which endpoint that is:
+		//
+		//   (a:A)-[:R]->(b:B)   →  A ─GRAPH_RELATES(R, OUTGOING)→ node:B
+		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
+		//
+		// Only emitted when BOTH endpoints carry a static label AND the relation
+		// a static type; dynamic / parameterised relations stay label/type-only
+		// — honest-partial.
+		for _, tm := range reNeo4jPHPCypherTriple.FindAllStringSubmatch(cypher, -1) {
+			leftLabel, relType, rightLabel := tm[1], tm[3], tm[5]
+			pointsRight := tm[4] == ">"
+			pointsLeft := tm[2] == "<"
+			if relType == "" || leftLabel == "" || rightLabel == "" {
+				continue
+			}
+			// Determine OUTGOING source / target from the arrow head. A pattern
+			// with no head on either side is undirected; Neo4j stores every
+			// relationship with a concrete direction, so we treat the written
+			// left→right order as the source and record direction=UNDIRECTED.
+			srcLabel, dstLabel, direction := leftLabel, rightLabel, "OUTGOING"
+			switch {
+			case pointsRight && !pointsLeft:
+				srcLabel, dstLabel = leftLabel, rightLabel
+			case pointsLeft && !pointsRight:
+				srcLabel, dstLabel = rightLabel, leftLabel
+			default:
+				direction = "UNDIRECTED"
+			}
+
+			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			if !ok {
+				continue
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "node:" + dstLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neo4j",
+						"rel_type":   relType,
+						"direction":  direction,
+						"provenance": "INFERRED_FROM_NEO4J_CYPHER",
+					},
+				},
+			)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// neo4jPHPVerbKind sniffs a coarse verb from the leading Cypher clause so
+// query_type is comparable across the PHP data-access extractors.
+func neo4jPHPVerbKind(cypher string) string {
+	i := 0
+	for i < len(cypher) && (cypher[i] == ' ' || cypher[i] == '\t' || cypher[i] == '\n' || cypher[i] == '\r') {
+		i++
+	}
+	j := i
+	for j < len(cypher) {
+		c := cypher[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			j++
+			continue
+		}
+		break
+	}
+	switch upperCypherPHP(cypher[i:j]) {
+	case "MATCH", "RETURN", "WITH", "UNWIND", "CALL", "OPTIONAL":
+		return "read"
+	case "CREATE", "MERGE":
+		return "create"
+	case "SET":
+		return "update"
+	case "DELETE", "REMOVE", "DETACH":
+		return "delete"
+	default:
+		return "query"
+	}
+}
+
+// upperCypherPHP upper-cases an ASCII keyword without allocating via strings.
+func upperCypherPHP(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/custom/php/neo4j_test.go
+++ b/internal/custom/php/neo4j_test.go
@@ -1,0 +1,161 @@
+package php_test
+
+// neo4j_test.go — tests for the custom_php_neo4j extractor's GRAPH_RELATES
+// graph-schema topology (#3618, epic #3606). Completes the Neo4j topology set
+// alongside Java (#3663), Python+JS (#3670), Go (#3612), C# (#3616) and
+// Ruby (#3614).
+//
+// PHP's Neo4j access is driver-based (laudis/neo4j-php-client) with no OGM
+// decorators, so the graph schema lives in the Cypher query text passed to
+// ->run(...). The extractor parses relationship patterns —
+//   (a:Person)-[:ACTED_IN]->(m:Movie)
+// — and promotes them to traversable GRAPH_RELATES edges between the
+// node-label entities, the graph-DB analogue of Mongo's JOINS_COLLECTION.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/php"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractPHPNeo4j(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_php_neo4j")
+	if !ok {
+		t.Fatal("custom_php_neo4j not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "Store.php",
+		Language: "php",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findPHPGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func anyPHPGraphRelates(ents []types.EntityRecord) bool {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const phpNeo4jUse = "<?php\nuse Laudis\\Neo4j\\ClientBuilder;\n"
+
+// Headline: MATCH (p:Person)-[:ACTED_IN]->(m:Movie) in a ->run() string →
+//
+//	Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ node:Movie
+func TestPHPNeo4jGraphRelatesEdge(t *testing.T) {
+	src := phpNeo4jUse +
+		"$client->run(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\");\n"
+
+	ents := extractPHPNeo4j(t, src)
+
+	edge := findPHPGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie edge; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "ACTED_IN" {
+		t.Errorf("rel_type = %q, want ACTED_IN", got)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if got := edge.Properties["framework"]; got != "neo4j" {
+		t.Errorf("framework = %q, want neo4j", got)
+	}
+}
+
+// Single-quoted string is also a Cypher carrier.
+func TestPHPNeo4jSingleQuoted(t *testing.T) {
+	src := phpNeo4jUse +
+		"$session->run('MATCH (u:User)-[:OWNS]->(o:Order) RETURN o');\n"
+
+	ents := extractPHPNeo4j(t, src)
+	edge := findPHPGraphRelates(ents, "User", "Order")
+	if edge == nil {
+		t.Fatalf("expected User -GRAPH_RELATES-> node:Order; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "OWNS" {
+		t.Errorf("rel_type = %q, want OWNS", got)
+	}
+}
+
+// Direction: a left-pointing arrow flips the OUTGOING source endpoint.
+//
+//	(m:Movie)<-[:ACTED_IN]-(p:Person) → Person ─ACTED_IN→ node:Movie
+func TestPHPNeo4jLeftArrow(t *testing.T) {
+	src := phpNeo4jUse +
+		"$client->run(\"MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN p\");\n"
+
+	ents := extractPHPNeo4j(t, src)
+	edge := findPHPGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie (arrow flipped); got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if rev := findPHPGraphRelates(ents, "Movie", "Person"); rev != nil {
+		t.Errorf("unexpected reverse edge Movie->Person: %+v", rev)
+	}
+}
+
+// Undirected pattern records direction=UNDIRECTED, written order as source.
+func TestPHPNeo4jUndirected(t *testing.T) {
+	src := phpNeo4jUse +
+		"$client->run(\"MATCH (a:Person)-[:KNOWS]-(b:Person) RETURN a, b\");\n"
+
+	ents := extractPHPNeo4j(t, src)
+	edge := findPHPGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Person; got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "UNDIRECTED" {
+		t.Errorf("direction = %q, want UNDIRECTED", got)
+	}
+}
+
+// Negative: a single-node MATCH yields NO GRAPH_RELATES edge (honest-partial).
+func TestPHPNeo4jSingleNodeNoEdge(t *testing.T) {
+	src := phpNeo4jUse +
+		"$client->run(\"MATCH (p:Person) RETURN p\");\n"
+
+	ents := extractPHPNeo4j(t, src)
+	if anyPHPGraphRelates(ents) {
+		t.Fatalf("expected NO GRAPH_RELATES edge for single-node MATCH; got %+v", ents)
+	}
+}
+
+// Negative: without the laudis import gate, nothing is extracted.
+func TestPHPNeo4jNoImportNoExtraction(t *testing.T) {
+	src := "<?php\n$client->run(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p\");\n"
+	ents := extractPHPNeo4j(t, src)
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without laudis import; got %+v", ents)
+	}
+}

--- a/internal/custom/rust/neo4j.go
+++ b/internal/custom/rust/neo4j.go
@@ -1,0 +1,297 @@
+// neo4j.go — Cypher-DSL extractor for the Rust Neo4j driver (neo4rs).
+// #3618, epic #3606.
+//
+// Rust is driver-based: like the Go and C# drivers, Neo4j relationships are
+// first-class but live inline in the Cypher *query text* rather than in OGM
+// decorators. neo4rs wraps Cypher in a query(...) builder run through
+// graph.execute / graph.run:
+//
+//	graph.execute(query("MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m")).await?;
+//	graph.run(query("CREATE (a:Person)-[:KNOWS]->(b:Person)")).await?;
+//	let q = Query::new("MATCH (u:User)-[:OWNS]->(o:Order) RETURN o".to_string());
+//
+// Honest coverage shape (mirrors the Go / C# extractors exactly):
+//
+//   - Models / Schema — partial. Node labels in Cypher patterns ((n:Person),
+//     (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a soft schema
+//     recovered from a query string by regex, hence partial.
+//   - Relationships — full (topology). Relationship types in Cypher patterns
+//     (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as SCOPE.Schema entities with
+//     subtype "relationship". When BOTH endpoints of the pattern carry a
+//     static node label and the relation a static type —
+//     (a:Person)-[:ACTED_IN]->(m:Movie) — the graph-schema topology is
+//     additionally promoted to a traversable GRAPH_RELATES edge between the
+//     node-label entities (Person ─GRAPH_RELATES(ACTED_IN)→ Movie), the
+//     graph-DB analogue of Mongo's JOINS_COLLECTION and the Java SDN
+//     @Relationship edge. Parameterised / dynamic relations (no static type,
+//     or built by format!()/string concatenation) stay type-only —
+//     honest-partial.
+//   - Queries — partial. query("CYPHER") / Query::new("CYPHER") call sites are
+//     captured with a coarse verb sniffed from the leading Cypher clause.
+//     Dynamically-built query strings are not fully recoverable, so partial.
+//   - Migrations — not_applicable. Neo4j is schema-flexible / graph-native;
+//     the driver has no migration runner.
+//
+// The extractor gates on a `use neo4rs` import actually being present.
+//
+// Registration key: "custom_rust_neo4j"
+package rust
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_neo4j", &neo4jRustExtractor{})
+}
+
+type neo4jRustExtractor struct{}
+
+func (e *neo4jRustExtractor) Language() string { return "custom_rust_neo4j" }
+
+var (
+	// Gate: a `use neo4rs…` import of the neo4rs driver.
+	reNeo4jRustImport = regexp.MustCompile(`use\s+neo4rs\b`)
+
+	// Cypher strings wrapped by neo4rs: query("…") / Query::new("…"). Both the
+	// plain Rust string literal ("…") and the raw string literal (r#"…"#) forms
+	// are captured.
+	//
+	//   group 1 = plain-string body
+	//   group 2 = raw-string (r"…" / r#"…"#) body
+	reNeo4jRustRun = regexp.MustCompile(
+		`(?:query|Query::new)\s*\(\s*r#*"((?:[^"]|"[^#])*)"#*|` +
+			`(?:query|Query::new)\s*\(\s*"((?:[^"\\]|\\.)*)"`,
+	)
+
+	// A node label inside a Cypher pattern: (var:Label) or (:Label). Captures
+	// the first (primary) label; chained labels (:A:B) capture A.
+	reNeo4jRustCypherLabel = regexp.MustCompile(`\([A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|\(\s*:\s*([A-Za-z_]\w*)`)
+
+	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
+	reNeo4jRustCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+
+	// A full directed relationship triple inside a Cypher pattern:
+	//
+	//   (a:LeftLabel) -[ rvar :REL_TYPE ]-> (b:RightLabel)
+	//   (a:LeftLabel) <-[ rvar :REL_TYPE ]-  (b:RightLabel)
+	//
+	// Both endpoints must carry a statically-resolvable node label and the
+	// relationship a statically-resolvable type for an edge to be emitted. The
+	// arrow head (-> vs <-) decides GRAPH_RELATES direction.
+	//
+	// Captures:
+	//   1 = left node label
+	//   2 = optional left-arrow head ("<")
+	//   3 = relationship type
+	//   4 = optional right-arrow head (">")
+	//   5 = right node label
+	//
+	// A bare relationship with no type (-[r]-> / -[]->) or a dynamic type does
+	// NOT match the type group, so no edge is emitted — honest-partial.
+	reNeo4jRustCypherTriple = regexp.MustCompile(
+		`\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^()]*\)\s*` +
+			`(<)?-\[\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)[^\]]*\]-(>)?` +
+			`\s*\(\s*(?:[A-Za-z_]\w*)?\s*:\s*([A-Za-z_]\w*)`,
+	)
+)
+
+func (e *neo4jRustExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_neo4j_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neo4j"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "rust" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reNeo4jRustImport.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// nodeIdx maps "node:<label>" to the index, in `entities`, of its
+	// SCOPE.Schema node entity. The GRAPH_RELATES pass hangs the topology edge
+	// off the *source* node-label entity (the graph "table"), mirroring the Go
+	// / C# extractors and the Mongo JOINS_COLLECTION source collection.
+	nodeIdx := make(map[string]int)
+
+	for _, rm := range reNeo4jRustRun.FindAllStringSubmatchIndex(src, -1) {
+		// Group 1 = raw-string body, group 2 = plain-string body.
+		var cypher string
+		if rm[2] >= 0 {
+			cypher = src[rm[2]:rm[3]]
+		} else if rm[4] >= 0 {
+			cypher = src[rm[4]:rm[5]]
+		}
+		if cypher == "" {
+			continue
+		}
+		line := lineOf(src, rm[0])
+
+		// Query operation, verb sniffed from the leading Cypher clause.
+		verb := neo4jRustVerbKind(cypher)
+		q := makeEntity("cypher:"+verb+":"+itoa(line), "SCOPE.Operation", "query", file.Path, "rust", line)
+		setProps(&q, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+			"query_type", verb)
+		add(q)
+
+		// Schema: node labels in the Cypher pattern.
+		for _, lm := range reNeo4jRustCypherLabel.FindAllStringSubmatch(cypher, -1) {
+			label := lm[1]
+			if label == "" {
+				label = lm[2]
+			}
+			if label == "" {
+				continue
+			}
+			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "rust", line)
+			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"node_label", label)
+			before := len(entities)
+			add(n)
+			// add() dedupes; only register the index when actually appended.
+			if len(entities) == before+1 {
+				nodeIdx["node:"+label] = before
+			}
+		}
+
+		// Relationships: relationship types in the Cypher pattern (first-class).
+		for _, relm := range reNeo4jRustCypherRelType.FindAllStringSubmatch(cypher, -1) {
+			relType := relm[1]
+			if relType == "" {
+				relType = relm[2]
+			}
+			if relType == "" {
+				continue
+			}
+			r := makeEntity("rel:"+relType, "SCOPE.Schema", "relationship", file.Path, "rust", line)
+			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"rel_type", relType)
+			add(r)
+		}
+
+		// --- GRAPH_RELATES edges (#3618, epic #3606) ---
+		// Promote the graph-schema topology encoded in a Cypher relationship
+		// pattern — (a:Person)-[:ACTED_IN]->(m:Movie) — into a traversable edge
+		// between the node-label entities (the graph "tables"), the graph-DB
+		// analogue of the Mongo JOINS_COLLECTION and the Java SDN @Relationship
+		// GRAPH_RELATES. The edge hangs off the OUTGOING source node entity; the
+		// arrow head decides which endpoint that is:
+		//
+		//   (a:A)-[:R]->(b:B)   →  A ─GRAPH_RELATES(R, OUTGOING)→ node:B
+		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
+		//
+		// Only emitted when BOTH endpoints carry a static label AND the relation
+		// a static type; dynamic / parameterised relations stay label/type-only
+		// — honest-partial.
+		for _, tm := range reNeo4jRustCypherTriple.FindAllStringSubmatch(cypher, -1) {
+			leftLabel, relType, rightLabel := tm[1], tm[3], tm[5]
+			pointsRight := tm[4] == ">"
+			pointsLeft := tm[2] == "<"
+			if relType == "" || leftLabel == "" || rightLabel == "" {
+				continue
+			}
+			// Determine OUTGOING source / target from the arrow head. A pattern
+			// with no head on either side is undirected; Neo4j stores every
+			// relationship with a concrete direction, so we treat the written
+			// left→right order as the source and record direction=UNDIRECTED.
+			srcLabel, dstLabel, direction := leftLabel, rightLabel, "OUTGOING"
+			switch {
+			case pointsRight && !pointsLeft:
+				srcLabel, dstLabel = leftLabel, rightLabel
+			case pointsLeft && !pointsRight:
+				srcLabel, dstLabel = rightLabel, leftLabel
+			default:
+				direction = "UNDIRECTED"
+			}
+
+			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			if !ok {
+				continue
+			}
+			entities[ownerIdx].Relationships = append(
+				entities[ownerIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: "node:" + dstLabel,
+					Kind: string(types.RelationshipKindGraphRelates),
+					Properties: map[string]string{
+						"framework":  "neo4j",
+						"rel_type":   relType,
+						"direction":  direction,
+						"provenance": "INFERRED_FROM_NEO4J_CYPHER",
+					},
+				},
+			)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// neo4jRustVerbKind sniffs a coarse verb from the leading Cypher clause so
+// query_type is comparable across the Rust data-access extractors.
+func neo4jRustVerbKind(cypher string) string {
+	i := 0
+	for i < len(cypher) && (cypher[i] == ' ' || cypher[i] == '\t' || cypher[i] == '\n' || cypher[i] == '\r') {
+		i++
+	}
+	j := i
+	for j < len(cypher) {
+		c := cypher[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			j++
+			continue
+		}
+		break
+	}
+	switch upperCypherRust(cypher[i:j]) {
+	case "MATCH", "RETURN", "WITH", "UNWIND", "CALL", "OPTIONAL":
+		return "read"
+	case "CREATE", "MERGE":
+		return "create"
+	case "SET":
+		return "update"
+	case "DELETE", "REMOVE", "DETACH":
+		return "delete"
+	default:
+		return "query"
+	}
+}
+
+// upperCypherRust upper-cases an ASCII keyword without allocating via strings.
+func upperCypherRust(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/custom/rust/neo4j_test.go
+++ b/internal/custom/rust/neo4j_test.go
@@ -1,0 +1,170 @@
+package rust_test
+
+// neo4j_test.go — tests for the custom_rust_neo4j extractor's GRAPH_RELATES
+// graph-schema topology (#3618, epic #3606). Completes the Neo4j topology set
+// alongside Java (#3663), Python+JS (#3670), Go (#3612), C# (#3616) and
+// Ruby (#3614).
+//
+// Rust's Neo4j access is driver-based (neo4rs) with no OGM decorators, so the
+// graph schema lives in the Cypher query text wrapped by query(...) /
+// Query::new(...). The extractor parses relationship patterns —
+//   (a:Person)-[:ACTED_IN]->(m:Movie)
+// — and promotes them to traversable GRAPH_RELATES edges between the
+// node-label entities, the graph-DB analogue of Mongo's JOINS_COLLECTION.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/rust"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractRustNeo4j(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_rust_neo4j")
+	if !ok {
+		t.Fatal("custom_rust_neo4j not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "store.rs",
+		Language: "rust",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findRustGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func anyRustGraphRelates(ents []types.EntityRecord) bool {
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const rustNeo4jUse = "use neo4rs::*;\n"
+
+// Headline: MATCH (p:Person)-[:ACTED_IN]->(m:Movie) in query("…") →
+//
+//	Person ─GRAPH_RELATES(ACTED_IN, OUTGOING)→ node:Movie
+func TestRustNeo4jGraphRelatesEdge(t *testing.T) {
+	src := rustNeo4jUse +
+		"async fn q(graph: &Graph) {\n" +
+		"  graph.execute(query(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\")).await.unwrap();\n" +
+		"}\n"
+
+	ents := extractRustNeo4j(t, src)
+	edge := findRustGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie edge; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "ACTED_IN" {
+		t.Errorf("rel_type = %q, want ACTED_IN", got)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if got := edge.Properties["framework"]; got != "neo4j" {
+		t.Errorf("framework = %q, want neo4j", got)
+	}
+}
+
+// Raw string literal r#"…"# is also a Cypher carrier (Query::new form).
+func TestRustNeo4jRawString(t *testing.T) {
+	src := rustNeo4jUse +
+		"fn q() {\n" +
+		"  let _ = Query::new(r#\"MATCH (u:User)-[:OWNS]->(o:Order) RETURN o\"#.to_string());\n" +
+		"}\n"
+
+	ents := extractRustNeo4j(t, src)
+	edge := findRustGraphRelates(ents, "User", "Order")
+	if edge == nil {
+		t.Fatalf("expected User -GRAPH_RELATES-> node:Order; got %+v", ents)
+	}
+	if got := edge.Properties["rel_type"]; got != "OWNS" {
+		t.Errorf("rel_type = %q, want OWNS", got)
+	}
+}
+
+// Direction: a left-pointing arrow flips the OUTGOING source endpoint.
+func TestRustNeo4jLeftArrow(t *testing.T) {
+	src := rustNeo4jUse +
+		"async fn q(graph: &Graph) {\n" +
+		"  graph.run(query(\"MATCH (m:Movie)<-[:ACTED_IN]-(p:Person) RETURN p\")).await.unwrap();\n" +
+		"}\n"
+
+	ents := extractRustNeo4j(t, src)
+	edge := findRustGraphRelates(ents, "Person", "Movie")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Movie (arrow flipped); got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "OUTGOING" {
+		t.Errorf("direction = %q, want OUTGOING", got)
+	}
+	if rev := findRustGraphRelates(ents, "Movie", "Person"); rev != nil {
+		t.Errorf("unexpected reverse edge Movie->Person: %+v", rev)
+	}
+}
+
+// Undirected pattern records direction=UNDIRECTED.
+func TestRustNeo4jUndirected(t *testing.T) {
+	src := rustNeo4jUse +
+		"async fn q(graph: &Graph) {\n" +
+		"  graph.execute(query(\"MATCH (a:Person)-[:KNOWS]-(b:Person) RETURN a, b\")).await.unwrap();\n" +
+		"}\n"
+
+	ents := extractRustNeo4j(t, src)
+	edge := findRustGraphRelates(ents, "Person", "Person")
+	if edge == nil {
+		t.Fatalf("expected Person -GRAPH_RELATES-> node:Person; got %+v", ents)
+	}
+	if got := edge.Properties["direction"]; got != "UNDIRECTED" {
+		t.Errorf("direction = %q, want UNDIRECTED", got)
+	}
+}
+
+// Negative: a single-node MATCH yields NO GRAPH_RELATES edge.
+func TestRustNeo4jSingleNodeNoEdge(t *testing.T) {
+	src := rustNeo4jUse +
+		"async fn q(graph: &Graph) {\n" +
+		"  graph.execute(query(\"MATCH (p:Person) RETURN p\")).await.unwrap();\n" +
+		"}\n"
+
+	ents := extractRustNeo4j(t, src)
+	if anyRustGraphRelates(ents) {
+		t.Fatalf("expected NO GRAPH_RELATES edge for single-node MATCH; got %+v", ents)
+	}
+}
+
+// Negative: without the neo4rs import gate, nothing is extracted.
+func TestRustNeo4jNoImportNoExtraction(t *testing.T) {
+	src := "fn q(graph: &Graph) {\n" +
+		"  graph.execute(query(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p\"));\n" +
+		"}\n"
+	ents := extractRustNeo4j(t, src)
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without neo4rs import; got %+v", ents)
+	}
+}


### PR DESCRIPTION
Closes #3618 (epic #3606).

Neo4j `GRAPH_RELATES` graph-schema topology now spans **9 langs** — the existing java / python / jsts / go / csharp / ruby plus the three driver-based langs added here: **PHP, Rust, Elixir**.

## What
All three remaining langs are driver-based (Cypher lives in string literals run through the driver), so each mirrors the Go (#3612) / C# (#3616) template: parse the Cypher relationship pattern `(a:Person)-[:ACTED_IN]->(m:Movie)` and promote it to a traversable `GRAPH_RELATES` edge between the node-label entities (the graph-DB analogue of Mongo's `JOINS_COLLECTION` / the Java SDN `@Relationship` edge).

| Lang | Extractor key | Driver | Gate | Cypher carrier |
|---|---|---|---|---|
| PHP | `custom_php_neo4j` | laudis/neo4j-php-client | `use Laudis\Neo4j` | `->run(...)`, `Statement::create(...)` (single + double quoted) |
| Rust | `custom_rust_neo4j` | neo4rs | `use neo4rs` | `query(...)`, `Query::new(...)` (plain + raw `r#"..."#`) |
| Elixir | `custom_elixir_neo4j` | Bolt.Sips / boltx | `Bolt.Sips` / `Boltx` | `query!/2`, `query/2` |

Node labels → `SCOPE.Schema` nodes (partial); rel types → `SCOPE.Schema` relationship entities; statically-typed both-endpoint triples → `GRAPH_RELATES` (`rel_type`, `direction` OUTGOING/UNDIRECTED). Dynamic / parameterised / interpolated relations stay label/type-only — **honest-partial**.

## Edges asserted (value-asserting, not len>0)
Per lang: `MATCH (p:Person)-[:ACTED_IN]->(m:Movie)` ⇒ `Person ─GRAPH_RELATES(rel_type=ACTED_IN, direction=OUTGOING)→ node:Movie`. Plus: left-arrow flips the OUTGOING source (`(m:Movie)<-[:ACTED_IN]-(p:Person)` ⇒ Person→Movie, no reverse edge); undirected `-[:KNOWS]-` records `direction=UNDIRECTED`; single-node `MATCH (p:Person)` ⇒ **no** edge; import-gate negative ⇒ no extraction.

## Coverage covered vs honest-skipped
All three target langs **covered** — each has a clear driver idiom (Cypher-in-strings). None skipped. `lang.{php,rust,elixir}.driver.neo4j`: `relationship_extraction` not_applicable → **full**; `schema_extraction` / `query_attribution` → **partial**, cited to the new extractors.

## Validation
- `go test ./internal/custom/{php,rust,elixir}/... ./internal/types/ ./tools/coverage/` — green
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical
- `gofmt -l` empty; `go vet` clean

**DEPLOY-DEFERRED** — extractors land in code + registry; live daemon rebuild/reindex is deferred to the coordinated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)