### PR TITLE
feat(graphql): Apollo Federation extraction (@key/@external/@requires/@provides + FEDERATES edges)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -260,7 +260,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/23 | 🟢 4/4 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟡 21/23 | 🟢 4/4 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/23 | 🟡 3/4 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 22/23 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 22/23 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 22/23 | ✅ 4/4 | |
 | [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🟡 2/23 | 🟢 4/4 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -85,7 +85,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 22/23 | ✅ 3/3 | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 22/23 | 🟢 4/4 | |
 | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 22/23 | ✅ 4/4 | |
 
 

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | each overridden Status RPC method -> SCOPE.Operation endpoint |
 | Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | req/resp messages emitted as SCOPE.Schema DTO refs (names only) |
 

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | each .proto rpc -> SCOPE.Operation endpoint /<Service>/<Method> |
 | Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | .proto messages+fields fully parsed (name/type/number/label); generated .pb.h message classes recovered by name |
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | — | — | `internal/custom/csharp/grpc_net.go`<br>`internal/custom/csharp/grpc_net_test.go` | [ProtoContract] annotated C# classes, [ProtoMember] field annotations, and proto file service/rpc declarations emitted as SCOPE.Schema/procedure_extraction. |
 | Schema extraction | 🟢 `partial` | — | — | `internal/custom/csharp/grpc_net.go`<br>`internal/custom/csharp/grpc_net_test.go` | Proto message declarations, [DataContract] C# classes, and XxxService:XxxServiceBase generated implementation classes emitted as SCOPE.Schema/schema_extraction. |
 

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc :Method, Req, Resp declarations in use GRPC.Service modules emitted as SCOPE.GrpcMethod (grpc:<service>/<method>) with method + request/response message names. |
 | Schema extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | Request/response protobuf message names captured per rpc; stream() wrappers stripped and classified into streaming mode. |
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | 🟢 `partial` | `2026-06-02` | 3623 | `internal/extractors/graphql/federation_test.go`<br>`internal/extractors/graphql/graphql.go`<br>`internal/types/kinds.go` | Apollo Federation SDL: type Foo @key(fields:"id") -> entity Properties {federated:true, federation:apollo, key_fields:id} (+shareable:true on @shareable); extend type Foo @key(...) { f @external/@requires/@provides } -> FEDERATES edge to owning entity Foo carrying key_fields + external_fields/requires_fields/provides_fields buckets (legacy IMPORTS edge preserved). Value-asserting tests assert exact key_fields and FEDERATES ToID=owning type. PARTIAL: regex SDL only — no @link/@composeDirective import resolution, no interfaceObject, no cross-file/cross-repo subgraph entity merge (gateway-level concern for the downstream linker). |
 | Procedure extraction | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
 | Schema extraction | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` | — |
 | Schema extraction | ✅ `full` | `2026-05-28` | 2865 | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/http_endpoint_trpc_schema.go`<br>`internal/engine/http_endpoint_trpc_schema_test.go`<br>`testdata/fixtures/typescript/trpc_input_schema.ts` | — |
 

--- a/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
+++ b/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 27
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -15,6 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | ✅ `full` | `2026-05-31` | — | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | custom_scala_grpc: each def <rpc>(request: ReqT): Eff[RespT] of a ScalaPB AbstractService / zio-grpc ZGeneratedService / fs2-grpc *Fs2Grpc service trait -> SCOPE.Operation endpoint at /<Service>/<rpc>, verb=RPC, rpc_protocol=grpc, grpc_service+grpc_method+handler_name stamped. Value-asserting tests pin sayHello/listUsers + service Greeter (Z/Fs2Grpc decorations stripped). File-local. |
 | Schema extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | custom_scala_grpc: request/response message types recovered from the method signature (Request<T> param + last effect type-arg of ZIO/Future/F[_]) and emitted as SCOPE.Schema DTO refs with grpc_message_role request/response. PARTIAL: message FIELD shapes live in ScalaPB-generated case-class companions; names only. Value-asserted (HelloRequest/HelloReply/UserList). |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3609,6 +3609,11 @@
       "label": "gRPC C++ (grpc++)",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "partial",
             "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
@@ -5189,6 +5194,11 @@
       "label": "Protocol Buffers (C++)",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "partial",
             "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
@@ -8582,6 +8592,11 @@
       "label": "grpc-dotnet",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "partial",
             "cites": ["internal/custom/csharp/grpc_net.go","internal/custom/csharp/grpc_net_test.go"],
@@ -12058,6 +12073,11 @@
       "label": "elixir-grpc",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "partial",
             "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
@@ -28196,6 +28216,13 @@
       "label": "GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "partial",
+            "cites": ["internal/extractors/graphql/federation_test.go","internal/extractors/graphql/graphql.go","internal/types/kinds.go"],
+            "issue": "3623",
+            "notes": "Apollo Federation SDL: type Foo @key(fields:\"id\") -\u003e entity Properties {federated:true, federation:apollo, key_fields:id} (+shareable:true on @shareable); extend type Foo @key(...) { f @external/@requires/@provides } -\u003e FEDERATES edge to owning entity Foo carrying key_fields + external_fields/requires_fields/provides_fields buckets (legacy IMPORTS edge preserved). Value-asserting tests assert exact key_fields and FEDERATES ToID=owning type. PARTIAL: regex SDL only — no @link/@composeDirective import resolution, no interfaceObject, no cross-file/cross-repo subgraph entity merge (gateway-level concern for the downstream linker).",
+            "verified_at": "2026-06-02"
+          },
           "procedure_extraction": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml","internal/extractors/graphql/graphql.go"],
@@ -32964,6 +32991,11 @@
       "label": "tRPC",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
@@ -58591,6 +58623,11 @@
       "label": "ScalaPB / zio-grpc / fs2-grpc",
       "capabilities": {
         "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "issue": "3623",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
           "procedure_extraction": {
             "status": "full",
             "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],

--- a/internal/extractors/graphql/federation_test.go
+++ b/internal/extractors/graphql/federation_test.go
@@ -1,0 +1,170 @@
+package graphql_test
+
+// Issue #3623 (epic #3607) — Apollo Federation extraction tests.
+//
+// These assert the EXACT federation signal, not len>0:
+//   - `type User @key(fields:"id")`  -> User entity federated=true key_fields=id
+//   - `extend type Product @key(fields:"id") { reviews }` -> FEDERATES edge to
+//     Product carrying key_fields and the @external/@requires/@provides buckets.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findSchemaEntity returns the SCOPE.Schema entity named name, or nil.
+func findSchemaEntity(entities []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Schema" && entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+func TestFederation_KeyType_MarkedAsEntity(t *testing.T) {
+	src := `type User @key(fields: "id") {
+  id: ID!
+  name: String!
+}
+`
+	entities := extractGQL(t, "users.graphql", src)
+	user := findSchemaEntity(entities, "User")
+	if user == nil {
+		t.Fatal("User schema entity not emitted")
+	}
+	if user.Properties["federated"] != "true" {
+		t.Errorf("User federated = %q, want \"true\"", user.Properties["federated"])
+	}
+	if user.Properties["federation"] != "apollo" {
+		t.Errorf("User federation = %q, want \"apollo\"", user.Properties["federation"])
+	}
+	if user.Properties["key_fields"] != "id" {
+		t.Errorf("User key_fields = %q, want \"id\"", user.Properties["key_fields"])
+	}
+}
+
+func TestFederation_CompositeKey(t *testing.T) {
+	src := `type Product @key(fields: "id sku") {
+  id: ID!
+  sku: String!
+}
+`
+	entities := extractGQL(t, "products.graphql", src)
+	p := findSchemaEntity(entities, "Product")
+	if p == nil {
+		t.Fatal("Product schema entity not emitted")
+	}
+	if p.Properties["key_fields"] != "id sku" {
+		t.Errorf("Product key_fields = %q, want \"id sku\"", p.Properties["key_fields"])
+	}
+}
+
+func TestFederation_NonKeyType_NotFederated(t *testing.T) {
+	src := `type Plain {
+  id: ID!
+}
+`
+	entities := extractGQL(t, "plain.graphql", src)
+	pl := findSchemaEntity(entities, "Plain")
+	if pl == nil {
+		t.Fatal("Plain schema entity not emitted")
+	}
+	if pl.Properties["federated"] == "true" {
+		t.Errorf("Plain must NOT be marked federated; properties=%v", pl.Properties)
+	}
+}
+
+func TestFederation_Shareable(t *testing.T) {
+	src := `type Money @shareable {
+  amount: Int!
+  currency: String!
+}
+`
+	entities := extractGQL(t, "money.graphql", src)
+	m := findSchemaEntity(entities, "Money")
+	if m == nil {
+		t.Fatal("Money schema entity not emitted")
+	}
+	if m.Properties["shareable"] != "true" {
+		t.Errorf("Money shareable = %q, want \"true\"", m.Properties["shareable"])
+	}
+}
+
+func TestFederation_ExtendType_EmitsFederatesEdge(t *testing.T) {
+	src := `extend type Product @key(fields: "id") {
+  id: ID! @external
+  reviews: [Review!]!
+}
+`
+	entities := extractGQL(t, "reviews_subgraph.graphql", src)
+
+	feds := gqlRelsByKind(entities, "FEDERATES")
+	if len(feds) != 1 {
+		t.Fatalf("want exactly 1 FEDERATES edge, got %d: %+v", len(feds), feds)
+	}
+	rel := feds[0]
+	if rel.ToID != "Product" {
+		t.Errorf("FEDERATES ToID = %q, want \"Product\" (the owning entity)", rel.ToID)
+	}
+	if rel.Properties["federation"] != "apollo" {
+		t.Errorf("federation = %q, want \"apollo\"", rel.Properties["federation"])
+	}
+	if rel.Properties["import_kind"] != "federation_extend" {
+		t.Errorf("import_kind = %q, want \"federation_extend\"", rel.Properties["import_kind"])
+	}
+	if rel.Properties["key_fields"] != "id" {
+		t.Errorf("key_fields = %q, want \"id\"", rel.Properties["key_fields"])
+	}
+	if rel.Properties["external_fields"] != "id" {
+		t.Errorf("external_fields = %q, want \"id\"", rel.Properties["external_fields"])
+	}
+
+	// The legacy IMPORTS edge must still be emitted for back-compat.
+	if !hasGQLRel(entities, "IMPORTS", "Product") {
+		t.Error("legacy IMPORTS edge to Product must still be emitted")
+	}
+}
+
+func TestFederation_ExtendType_RequiresAndProvides(t *testing.T) {
+	src := `extend type User @key(fields: "id") {
+  id: ID! @external
+  email: String! @external
+  shippingEstimate: Int! @requires(fields: "weight")
+  account: Account! @provides(fields: "plan")
+}
+`
+	entities := extractGQL(t, "shipping_subgraph.graphql", src)
+
+	feds := gqlRelsByKind(entities, "FEDERATES")
+	if len(feds) != 1 {
+		t.Fatalf("want 1 FEDERATES edge, got %d", len(feds))
+	}
+	p := feds[0].Properties
+	if p["external_fields"] != "id,email" {
+		t.Errorf("external_fields = %q, want \"id,email\"", p["external_fields"])
+	}
+	if p["requires_fields"] != "shippingEstimate" {
+		t.Errorf("requires_fields = %q, want \"shippingEstimate\"", p["requires_fields"])
+	}
+	if p["provides_fields"] != "account" {
+		t.Errorf("provides_fields = %q, want \"account\"", p["provides_fields"])
+	}
+}
+
+func TestFederation_PlainExtend_NoFederatesEdge(t *testing.T) {
+	// A non-federation `extend type` (no @key, no field directives) keeps the
+	// historical IMPORTS-only behaviour and emits no FEDERATES edge.
+	src := `extend type Query {
+  extraField: String
+}
+`
+	entities := extractGQL(t, "ext.graphql", src)
+	if feds := gqlRelsByKind(entities, "FEDERATES"); len(feds) != 0 {
+		t.Errorf("plain extend must emit no FEDERATES edge, got %d: %+v", len(feds), feds)
+	}
+	if !hasGQLRel(entities, "IMPORTS", "Query") {
+		t.Error("plain extend must still emit IMPORTS edge to Query")
+	}
+}

--- a/internal/extractors/graphql/graphql.go
+++ b/internal/extractors/graphql/graphql.go
@@ -32,6 +32,22 @@
 //     {source_module, import_kind} matching the contract used by the other
 //     ported extractors.
 //
+// Issue #3623 (epic #3607) — Apollo Federation signal:
+//
+//   - A `type Foo @key(fields: "id")` definition is marked as a federated
+//     entity via Properties {federated:"true", federation:"apollo",
+//     key_fields:"id"} (plus shareable:"true" when @shareable is present). This
+//     records the subgraph that OWNS the entity.
+//
+//   - FEDERATES: an `extend type Foo @key(fields:"id") { … }` block emits a
+//     FEDERATES edge (in addition to the legacy IMPORTS edge) from the
+//     extending subgraph stub → the owning entity name `Foo`. The edge carries
+//     {federation:"apollo", import_kind:"federation_extend", key_fields,
+//     external_fields, requires_fields, provides_fields} bucketing the
+//     @external / @requires / @provides fields contributed by this subgraph.
+//     This is the cross-subgraph entity-ownership signal Federation gateways
+//     use to plan query fan-out.
+//
 // No tree-sitter grammar for GraphQL is bundled in smacker/go-tree-sitter.
 // Registers itself via init() and is imported by registry_gen.go.
 package graphql
@@ -85,6 +101,22 @@ var (
 	// closing brace.
 	fieldRE = regexp.MustCompile(
 		`(?m)^[ \t]+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:\s*[^\n]+`,
+	)
+	// Apollo Federation `@key(fields: "id")` / `@key(fields: "id sku")` on a
+	// type (or extend type) declaration line. Captures the selection set.
+	keyDirectiveRE = regexp.MustCompile(
+		`@key\s*\(\s*fields\s*:\s*"([^"]*)"`,
+	)
+	// `@shareable` directive on a type/field — value-type contributed by
+	// multiple subgraphs.
+	shareableDirectiveRE = regexp.MustCompile(`@shareable\b`)
+	// A field line carrying one of the field-level federation directives. The
+	// directive name is captured so the caller can bucket the field name.
+	//   <fieldName>: <Type> @external
+	//   <fieldName>: <Type> @requires(fields: "...")
+	//   <fieldName>: <Type> @provides(fields: "...")
+	fedFieldRE = regexp.MustCompile(
+		`(?m)^[ \t]+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:\s*[^\n@]*@(external|requires|provides)\b`,
 	)
 )
 
@@ -145,6 +177,26 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 			EndLine:            endLine,
 			Signature:          subtype + " " + name,
 			EnrichmentRequired: false,
+		}
+
+		// Apollo Federation: a `type Foo @key(fields: "id")` is a federated
+		// entity owned by this subgraph. Mark it so cross-subgraph FEDERATES
+		// edges from extending subgraphs can resolve to the owning entity.
+		headerLine := lineAt(src, m[0])
+		if fed := scanFederation(headerLine, src, bodyStart, bodyEnd); fed.isEntity || fed.shareable {
+			if ent.Properties == nil {
+				ent.Properties = map[string]string{}
+			}
+			ent.Properties["federation"] = "apollo"
+			if fed.isEntity {
+				ent.Properties["federated"] = "true"
+			}
+			if fed.keyFields != "" {
+				ent.Properties["key_fields"] = fed.keyFields
+			}
+			if fed.shareable {
+				ent.Properties["shareable"] = "true"
+			}
 		}
 
 		// Fields are only meaningful for type/interface/input. enum members
@@ -261,30 +313,127 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 		}
 		seenExtend[name] = true
 		startLine := strings.Count(src[:m[0]], "\n") + 1
-		entities = append(entities, types.EntityRecord{
-			Name:       name,
-			Kind:       "SCOPE.Component",
-			Subtype:    "import",
-			SourceFile: filePath,
-			Language:   "graphql",
-			StartLine:  startLine,
-			EndLine:    startLine,
-			Relationships: []types.RelationshipRecord{
-				{
-					FromID: filePath,
-					ToID:   name,
-					Kind:   "IMPORTS",
-					Properties: map[string]string{
-						"source_module": name,
-						"imported_name": name,
-						"import_kind":   "extend",
-					},
+		_, bodyStart, bodyEnd := findBlockBounds(src, m[0])
+
+		// Always preserve the historical IMPORTS edge (extend → extended type).
+		rels := []types.RelationshipRecord{
+			{
+				FromID: filePath,
+				ToID:   name,
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"source_module": name,
+					"imported_name": name,
+					"import_kind":   "extend",
 				},
 			},
+		}
+
+		// Apollo Federation: `extend type Foo @key(fields:"id") { … }` means
+		// this subgraph contributes fields to entity Foo whose canonical
+		// definition lives in another subgraph. Emit a FEDERATES edge from the
+		// extending stub to the owning entity, carrying the @key selection set
+		// and the @external / @requires / @provides field buckets.
+		headerLine := lineAt(src, m[0])
+		fed := scanFederation(headerLine, src, bodyStart, bodyEnd)
+		if fed.isEntity || len(fed.externalFields) > 0 ||
+			len(fed.requiresFields) > 0 || len(fed.providesFields) > 0 {
+			props := map[string]string{
+				"federation":   "apollo",
+				"import_kind":  "federation_extend",
+				"owning_type":  name,
+				"subgraph_ref": filePath,
+			}
+			if fed.keyFields != "" {
+				props["key_fields"] = fed.keyFields
+			}
+			if len(fed.externalFields) > 0 {
+				props["external_fields"] = strings.Join(fed.externalFields, ",")
+			}
+			if len(fed.requiresFields) > 0 {
+				props["requires_fields"] = strings.Join(fed.requiresFields, ",")
+			}
+			if len(fed.providesFields) > 0 {
+				props["provides_fields"] = strings.Join(fed.providesFields, ",")
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     filePath,
+				ToID:       name,
+				Kind:       "FEDERATES",
+				Properties: props,
+			})
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:          name,
+			Kind:          "SCOPE.Component",
+			Subtype:       "import",
+			SourceFile:    filePath,
+			Language:      "graphql",
+			StartLine:     startLine,
+			EndLine:       startLine,
+			Relationships: rels,
 		})
 	}
 
 	return entities
+}
+
+// fedInfo holds the Apollo Federation signal scanned from a type/extend-type
+// definition (its header line plus body field directives).
+type fedInfo struct {
+	isEntity       bool     // header carries @key — a federated entity
+	keyFields      string   // the @key(fields: "...") selection set
+	shareable      bool     // header carries @shareable
+	externalFields []string // fields carrying @external
+	requiresFields []string // fields carrying @requires
+	providesFields []string // fields carrying @provides
+}
+
+// lineAt returns the full source line containing byte offset pos. Used to scan
+// header-line directives (`type Foo @key(...)`) without crossing into the body.
+func lineAt(src string, pos int) string {
+	start := strings.LastIndexByte(src[:pos], '\n') + 1
+	end := strings.IndexByte(src[pos:], '\n')
+	if end < 0 {
+		return src[start:]
+	}
+	return src[start : pos+end]
+}
+
+// scanFederation extracts Apollo Federation directives from a definition's
+// header line and (when present) its `{ … }` body. The header is checked for
+// `@key(fields:"…")` and `@shareable`; the body is scanned for field-level
+// `@external` / `@requires` / `@provides` directives, bucketing the field
+// names. When bodyStart < 0 the body scan is skipped.
+func scanFederation(headerLine, src string, bodyStart, bodyEnd int) fedInfo {
+	var fed fedInfo
+	if mm := keyDirectiveRE.FindStringSubmatch(headerLine); mm != nil {
+		fed.isEntity = true
+		fed.keyFields = strings.TrimSpace(mm[1])
+	}
+	if shareableDirectiveRE.MatchString(headerLine) {
+		fed.shareable = true
+	}
+	if bodyStart < 0 || bodyEnd <= bodyStart {
+		return fed
+	}
+	body := src[bodyStart:bodyEnd]
+	for _, m := range fedFieldRE.FindAllStringSubmatch(body, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		field, directive := m[1], m[2]
+		switch directive {
+		case "external":
+			fed.externalFields = append(fed.externalFields, field)
+		case "requires":
+			fed.requiresFields = append(fed.requiresFields, field)
+		case "provides":
+			fed.providesFields = append(fed.providesFields, field)
+		}
+	}
+	return fed
 }
 
 // fieldHit is one captured field declaration inside a type/interface/input body.

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -782,6 +782,21 @@ const (
 	// lexicographically smaller module ID is FromID) so it is deterministic and
 	// not double-counted.
 	RelationshipKindSharesData RelationshipKind = "SHARES_DATA"
+
+	// #3623 (epic #3607): Apollo Federation cross-subgraph entity edge.
+	//   FEDERATES : the extending subgraph's `extend type Foo @key(fields:"id")`
+	//               SCOPE.Component stub → the owning entity type `Foo`. The edge
+	//               records that this subgraph contributes fields to an entity
+	//               whose canonical definition (the @key-bearing `type Foo`) lives
+	//               in another subgraph. Properties on the edge:
+	//                 federation=apollo, key_fields (the @key selection set),
+	//                 external_fields / requires_fields / provides_fields
+	//                 (comma-joined field names carrying @external / @requires /
+	//                 @provides), and import_kind=federation_extend. Emitted by
+	//                 internal/extractors/graphql/graphql.go. It is the
+	//                 cross-subgraph entity-ownership signal Federation gateways
+	//                 use to plan query fan-out.
+	RelationshipKindFederates RelationshipKind = "FEDERATES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -907,6 +922,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindTransitionsTo,
 		// #3628 area #13 shared-database cross-service coupling edge:
 		RelationshipKindSharesData,
+		// #3623 (epic #3607) Apollo Federation cross-subgraph entity edge:
+		RelationshipKindFederates,
 	}
 }
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -441,6 +441,7 @@ subcategories:
     capabilities:
       - procedure_extraction
       - schema_extraction
+      - federation_extraction
       - client_codegen
       - transport_binding
       - constant_propagation
@@ -468,7 +469,7 @@ subcategories:
       - template_pattern_catalog
     groups:
       - name: Schema
-        keys: [schema_extraction, procedure_extraction]
+        keys: [schema_extraction, procedure_extraction, federation_extraction]
       - name: Codegen
         keys: [client_codegen]
       - name: Transport


### PR DESCRIPTION
Closes #3623 (epic #3607).

## What this adds

Teaches the shared GraphQL SDL extractor (`internal/extractors/graphql/graphql.go`) the Apollo Federation signal — cross-subgraph entity ownership, the highest cross-repo-value federation construct.

### Federation signal emitted

**Owning subgraph (`@key` type):**
`type User @key(fields: "id") { ... }` -> the `User` schema entity gains `Properties`:
- `federated="true"`, `federation="apollo"`, `key_fields="id"` (composite keys preserved verbatim, e.g. `"id sku"`)
- `shareable="true"` when the type carries `@shareable`

**Extending subgraph (`extend type @key`):**
`extend type Product @key(fields:"id") { id @external; reviews: [Review!]! }` emits a new **FEDERATES** edge (in addition to the preserved legacy IMPORTS edge) from the extending subgraph stub -> the owning entity `Product`. Edge `Properties`:
- `federation="apollo"`, `import_kind="federation_extend"`, `key_fields`
- `external_fields` / `requires_fields` / `provides_fields` — comma-joined field-name buckets from `@external` / `@requires` / `@provides`

This is the signal Federation gateways use to plan query fan-out across subgraphs.

### New relationship kind
`RelationshipKindFederates = "FEDERATES"` added to `internal/types/kinds.go` and `AllRelationshipKinds()` so the producer-kind validator accepts it.

### Coverage
New `federation_extraction` capability under the `rpc_framework` Schema group (capability-dictionary.yaml). Status **partial** on `lang.jsts.framework.graphql-resolvers` (honest: regex SDL only — no `@link`/`@composeDirective` import resolution, no `interfaceObject`, no cross-file/cross-repo subgraph entity merge — gateway merge is a downstream linker concern); **not_applicable** on the gRPC/tRPC/protobuf rpc_framework records. Docs regenerated.

## Tests
Value-asserting (`internal/extractors/graphql/federation_test.go`) — assert exact values, not `len>0`:
- `type User @key(fields:"id")` -> `federated=true`, `key_fields=id`
- composite `@key(fields:"id sku")` -> `key_fields="id sku"`
- non-`@key` type NOT federated; `@shareable`-only type flagged
- `extend type Product @key(fields:"id") { reviews }` -> exactly one FEDERATES edge, ToID=`Product`, `external_fields=id`, legacy IMPORTS preserved
- `@requires`/`@provides` field bucketing
- plain `extend type Query` -> no FEDERATES edge (IMPORTS-only back-compat)

## Verification
- `go test ./internal/extractors/graphql/... ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical; `gofmt -l` — empty; `go vet` — clean

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)