### PR TITLE
feat(engine): wire orphaned migration_sequence as live Pass 8.9 (#3639)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -62,13 +62,14 @@ const (
 	PassCoupling      = "coupling"       // Pass 8.6: structural Ca/Ce/instability per Module (#3634)
 	PassDepHygiene    = "dep-hygiene"    // Pass 8.7: persist deplinker used/unused status onto deps (#3640)
 	PassSharedDB      = "shared-db"      // Pass 8.8: shared-database cross-service coupling (#3628 area #13)
+	PassMigrationSeq  = "migration-seq"  // Pass 8.9: DB-migration ordering metadata + Alembic PRECEDES (#3639)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassMigrationSeq, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1596,6 +1597,26 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				"archigraph: shared-db tables=%d shared=%d data_access_annotated=%d coupling_edges=%d\n",
 				sdStats.TablesConsidered, sdStats.SharedTables,
 				sdStats.DataAccessAnnotated, sdStats.CouplingEdges)
+		}
+	}
+
+	// Pass 8.9 — DB-migration ordering metadata (#3639, epic #3625). Restores
+	// the previously-orphaned migration_sequence enricher as a live pass. Runs
+	// AFTER the document is assembled so every migration-anchored entity the
+	// language extractors emitted (Rails db/migrate/*.rb, Django/Alembic *.py,
+	// Flyway/golang-migrate *.sql) is present. Parses each migration FILENAME to
+	// stamp sequence_number + migration_name + migration_pattern, and — for
+	// Alembic, whose apply-order DAG lives in the file body — emits a PRECEDES
+	// edge along each down_revision → revision link so the migration chain is a
+	// traversable subgraph. No new entities; annotation-only. Honest: only
+	// recognised filename conventions are touched. Skippable via
+	// --skip-pass=migration-seq.
+	if !i.skipPasses[PassMigrationSeq] {
+		msStats := engine.ApplyMigrationSequence(doc, engine.DiskMigrationSourceReader(absRepo))
+		if verbose() || msStats.EntitiesAnnotated > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: migration-seq files=%d entities_annotated=%d precedes_edges=%d\n",
+				msStats.FilesMatched, msStats.EntitiesAnnotated, msStats.PrecedesEdges)
 		}
 	}
 

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | ✅ `full` | `2026-05-29` | 3060 | `internal/engine/rules/python/orms/alembic.yaml`<br>`internal/enrichers/migration_sequence_enricher.go` | YAML rule detects alembic.ini and versions/*.py files; migration_sequence_enricher.go parses Alembic filename convention ([A-Za-z0-9]{12}_<name>.py). upgrade()/downgrade() operation content is not yet parsed (full would require a dedicated alembic migration extractor analogous to django_migration.go). |
+| Migration parsing | 🟢 `partial` | `2026-06-02` | 3639 | `internal/custom/python/alembic_schema.go`<br>`internal/engine/migration_sequence.go`<br>`internal/engine/rules/python/orms/alembic.yaml`<br>`internal/enrichers/migration_sequence_enricher.go` | Previously FALSE-full (#3630): the cited migration_sequence_enricher.go was orphaned (imported by zero production code) so no sequence/ordering metadata was ever emitted. #3639 wires it as live Pass 8.9 (engine.ApplyMigrationSequence, cmd/archigraph/index.go): each Alembic versions/*.py entity is stamped sequence_number/migration_name/migration_pattern from the filename, and the pass reads the file body (enrichers.ParseAlembicRevisions) to emit a PRECEDES edge along the down_revision to revision DAG, making the migration chain traversable. Separately alembic_schema.go parses upgrade() op content. Partial: op.alter_column type changes, dropped columns, and server_default/constraint metadata are still not modeled. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/python/django_migration.go` | — |
+| Migration parsing | ✅ `full` | `2026-06-02` | 3639 | `internal/engine/migration_sequence.go`<br>`internal/extractors/python/django_migration.go` | django_migration.go parses NNNN_name.py into op_count/operations/dependencies. #3639 additionally stamps sequence_number (the NNNN ordinal) + migration_name + migration_pattern=django on each migration entity via live Pass 8.9 (engine.ApplyMigrationSequence). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. |
+| Migration parsing | ✅ `full` | — | 3639 | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go`<br>`internal/engine/migration_sequence.go` | db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. #3639 additionally stamps sequence_number (the YYYYMMDDHHMMSS timestamp) + migration_name + migration_pattern=rails on each db/migrate entity via live Pass 8.9 (engine.ApplyMigrationSequence). |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -49048,11 +49048,11 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "full",
-            "cites": ["internal/engine/rules/python/orms/alembic.yaml","internal/enrichers/migration_sequence_enricher.go"],
-            "issue": "3060",
-            "notes": "YAML rule detects alembic.ini and versions/*.py files; migration_sequence_enricher.go parses Alembic filename convention ([A-Za-z0-9]{12}_\u003cname\u003e.py). upgrade()/downgrade() operation content is not yet parsed (full would require a dedicated alembic migration extractor analogous to django_migration.go).",
-            "verified_at": "2026-05-29"
+            "status": "partial",
+            "cites": ["internal/custom/python/alembic_schema.go","internal/engine/migration_sequence.go","internal/engine/rules/python/orms/alembic.yaml","internal/enrichers/migration_sequence_enricher.go"],
+            "issue": "3639",
+            "notes": "Previously FALSE-full (#3630): the cited migration_sequence_enricher.go was orphaned (imported by zero production code) so no sequence/ordering metadata was ever emitted. #3639 wires it as live Pass 8.9 (engine.ApplyMigrationSequence, cmd/archigraph/index.go): each Alembic versions/*.py entity is stamped sequence_number/migration_name/migration_pattern from the filename, and the pass reads the file body (enrichers.ParseAlembicRevisions) to emit a PRECEDES edge along the down_revision to revision DAG, making the migration chain traversable. Separately alembic_schema.go parses upgrade() op content. Partial: op.alter_column type changes, dropped columns, and server_default/constraint metadata are still not modeled.",
+            "verified_at": "2026-06-02"
           }
         }
       }
@@ -49172,8 +49172,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "full",
-            "cites": ["internal/extractors/python/django_migration.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/migration_sequence.go","internal/extractors/python/django_migration.go"],
+            "issue": "3639",
+            "notes": "django_migration.go parses NNNN_name.py into op_count/operations/dependencies. #3639 additionally stamps sequence_number (the NNNN ordinal) + migration_name + migration_pattern=django on each migration entity via live Pass 8.9 (engine.ApplyMigrationSequence).",
+            "verified_at": "2026-06-02"
           }
         }
       }
@@ -52098,8 +52100,9 @@
         "Migrations": {
           "migration_parsing": {
             "status": "full",
-            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
-            "notes": "db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs."
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go","internal/engine/migration_sequence.go"],
+            "issue": "3639",
+            "notes": "db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. #3639 additionally stamps sequence_number (the YYYYMMDDHHMMSS timestamp) + migration_name + migration_pattern=rails on each db/migrate entity via live Pass 8.9 (engine.ApplyMigrationSequence)."
           }
         }
       }

--- a/internal/engine/migration_sequence.go
+++ b/internal/engine/migration_sequence.go
@@ -1,0 +1,254 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/enrichers"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// MigrationSequence is the engine pass that restores the previously-orphaned
+// migration_sequence enricher (issue #3639, epic #3625): a parser existed at
+// internal/enrichers/migration_sequence_enricher.go but was imported by zero
+// production code, so no migration entity ever carried a sequence_number /
+// migration_name property and no migration-ordering edge was ever emitted.
+//
+// WHAT IT DOES. For every graph entity anchored to a recognised migration file
+// — Rails (db/migrate/YYYYMMDDHHMMSS_name.rb), Django (NNNN_name.py),
+// Flyway (V{n}__desc.sql), golang-migrate (NNNNNN_name.up|down.sql), and
+// Alembic (versions/{rev}_name.py) — the pass parses the FILENAME and stamps:
+//
+//	sequence_number   the migration's ordinal (int for Rails/Django/golang-migrate
+//	                  & Alembic-fallback; dotted string for Flyway "1.2"; for
+//	                  Alembic the 12+-char revision hash from the filename).
+//	migration_name    the human-readable description (underscores → spaces).
+//	migration_pattern which convention matched (rails|django|flyway|
+//	                  golang_migrate|alembic).
+//
+// This is the DB-migration ordering signal: it lets find/neighbors/agents read
+// "which migration is this, and where does it sit in the sequence" directly off
+// the entity instead of re-deriving it from the path.
+//
+// ALEMBIC ORDERING EDGE. Alembic stores its apply-order DAG inside the file
+// body (`revision = "..."`, `down_revision = "..."`), not in the filename. When
+// a source reader is supplied, the pass parses those assignments and emits a
+// PRECEDES edge down_revision → revision for every migration whose parent is
+// present in the graph. PRECEDES means "the source migration must be applied
+// BEFORE the target". This makes the Alembic migration chain a traversable
+// subgraph rather than opaque filename ordering.
+//
+// HONEST / IDEMPOTENT. Only files whose basename matches a known migration
+// convention are touched (unknown-prefix schema files are left untouched). No
+// new migration entities are created — the pass annotates entities the
+// language extractors already emitted. A second call recomputes identical
+// values and (because edges are keyed on a stable RelationshipID) does not
+// duplicate the PRECEDES edges.
+
+// migrationPrecedesKind is the directed apply-order edge between migration
+// entities: FromID (the earlier migration) PRECEDES ToID (the later one).
+var migrationPrecedesKind = string(types.RelationshipKindPrecedes)
+
+// pendingAlembic refers to an Alembic migration entity by its index in
+// doc.Entities, deferred so the file body can be read once and parsed for the
+// revision DAG.
+type pendingAlembic struct {
+	idx int
+}
+
+// MigrationSequenceStats summarises a MigrationSequence run.
+type MigrationSequenceStats struct {
+	// EntitiesAnnotated is the number of entities that received
+	// sequence_number / migration_name / migration_pattern properties.
+	EntitiesAnnotated int
+	// FilesMatched is the number of distinct migration files whose basename
+	// matched a known convention.
+	FilesMatched int
+	// PrecedesEdges is the number of Alembic down_revision → revision PRECEDES
+	// edges emitted.
+	PrecedesEdges int
+	// Skipped is true when there were no entities to scan.
+	Skipped bool
+}
+
+// MigrationSourceReader returns the full source text of a migration file given
+// its (repo-relative) SourceFile path. The second return is false when the file
+// could not be read; callers that have no disk access (e.g. unit tests) may
+// pass nil, which disables Alembic PRECEDES-edge emission while leaving
+// filename-derived annotation fully functional.
+type MigrationSourceReader func(sourceFile string) (string, bool)
+
+// DiskMigrationSourceReader builds a MigrationSourceReader that resolves each
+// SourceFile against absRepo and reads it from disk. Used by the indexer.
+func DiskMigrationSourceReader(absRepo string) MigrationSourceReader {
+	return func(sourceFile string) (string, bool) {
+		if sourceFile == "" {
+			return "", false
+		}
+		path := sourceFile
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(absRepo, sourceFile)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", false
+		}
+		return string(data), true
+	}
+}
+
+// ApplyMigrationSequence annotates migration entities in doc with ordering
+// metadata and (for Alembic, when reader != nil) emits PRECEDES edges along the
+// down_revision chain. It returns stats describing the run.
+func ApplyMigrationSequence(doc *graph.Document, reader MigrationSourceReader) MigrationSequenceStats {
+	if doc == nil || len(doc.Entities) == 0 {
+		return MigrationSequenceStats{Skipped: true}
+	}
+
+	// Build the enricher input from every entity that carries a SourceFile.
+	// AnnotateMigrationSequences discriminates by basename, so non-migration
+	// files fall through to the unknown bucket and are never annotated.
+	input := make([]enrichers.MigrationEntity, 0, len(doc.Entities))
+	idByEntityID := make(map[string]int, len(doc.Entities))
+	for i := range doc.Entities {
+		idByEntityID[doc.Entities[i].ID] = i
+		if doc.Entities[i].SourceFile == "" {
+			continue
+		}
+		input = append(input, enrichers.MigrationEntity{
+			EntityID:   doc.Entities[i].ID,
+			SourceFile: doc.Entities[i].SourceFile,
+		})
+	}
+
+	annotations, _ := enrichers.AnnotateMigrationSequences(input)
+	if len(annotations) == 0 {
+		return MigrationSequenceStats{Skipped: false}
+	}
+
+	matchedFiles := make(map[string]bool)
+	annotated := 0
+	// alembicEntities collects the entity that anchors each Alembic migration
+	// file, so we read each file once and key the revision DAG by file.
+	alembicEntities := make([]pendingAlembic, 0)
+
+	for _, a := range annotations {
+		idx, ok := idByEntityID[a.EntityID]
+		if !ok {
+			continue
+		}
+		e := &doc.Entities[idx]
+		if e.Properties == nil {
+			e.Properties = make(map[string]string)
+		}
+		e.Properties["sequence_number"] = fmt.Sprintf("%v", a.SequenceNumber)
+		e.Properties["migration_name"] = a.MigrationName
+		e.Properties["migration_pattern"] = string(a.PatternMatched)
+		annotated++
+		matchedFiles[e.SourceFile] = true
+
+		if a.PatternMatched == enrichers.MigrationPatternAlembic {
+			alembicEntities = append(alembicEntities, pendingAlembic{idx: idx})
+		}
+	}
+
+	stats := MigrationSequenceStats{
+		EntitiesAnnotated: annotated,
+		FilesMatched:      len(matchedFiles),
+		Skipped:           false,
+	}
+
+	if reader != nil && len(alembicEntities) > 0 {
+		stats.PrecedesEdges = emitAlembicPrecedes(doc, alembicEntities, reader)
+	}
+
+	return stats
+}
+
+// emitAlembicPrecedes reads each Alembic migration file once, extracts its
+// (revision, down_revision) pair, and emits a PRECEDES edge from the parent
+// migration entity (down_revision) to the child (revision) when BOTH endpoints
+// are present in the graph. Returns the number of edges added.
+func emitAlembicPrecedes(doc *graph.Document, alembic []pendingAlembic, reader MigrationSourceReader) int {
+	// Map revision-id → entity ID. One entity per distinct file is enough; if
+	// several entities share a file (rare for Alembic .py) we key on the file
+	// to read it once and attribute the revision to the first entity seen.
+	type revInfo struct {
+		entityID     string
+		downRevision string
+	}
+	revToEntity := make(map[string]string)    // revision id → entity ID
+	infos := make([]revInfo, 0, len(alembic)) // preserve order for determinism
+	seenFile := make(map[string]bool)
+
+	for _, pe := range alembic {
+		e := &doc.Entities[pe.idx]
+		if seenFile[e.SourceFile] {
+			continue
+		}
+		seenFile[e.SourceFile] = true
+		src, ok := reader(e.SourceFile)
+		if !ok {
+			continue
+		}
+		rev, down := enrichers.ParseAlembicRevisions(src)
+		if rev == "" {
+			continue
+		}
+		// Record the parsed revision id on the entity too — it is the canonical
+		// Alembic identity (filename hash can be truncated/aliased).
+		if e.Properties == nil {
+			e.Properties = make(map[string]string)
+		}
+		e.Properties["revision"] = rev
+		if down != "" {
+			e.Properties["down_revision"] = down
+		}
+		revToEntity[rev] = e.ID
+		infos = append(infos, revInfo{entityID: e.ID, downRevision: down})
+	}
+
+	// Emit one PRECEDES edge per child whose parent revision resolves to a
+	// known entity: parent (down_revision) PRECEDES child (revision).
+	existing := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		existing[doc.Relationships[k].ID] = true
+	}
+
+	// Deterministic order.
+	sort.Slice(infos, func(i, j int) bool { return infos[i].entityID < infos[j].entityID })
+
+	added := 0
+	for _, info := range infos {
+		if info.downRevision == "" {
+			continue // base migration: nothing precedes it
+		}
+		parentID, ok := revToEntity[info.downRevision]
+		if !ok {
+			continue // parent not in graph: don't fabricate an edge
+		}
+		if parentID == info.entityID {
+			continue // defensive self-edge guard
+		}
+		relID := graph.RelationshipID(parentID, info.entityID, migrationPrecedesKind)
+		if existing[relID] {
+			continue
+		}
+		existing[relID] = true
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     relID,
+			FromID: parentID,
+			ToID:   info.entityID,
+			Kind:   migrationPrecedesKind,
+			Properties: map[string]string{
+				"ordering": "alembic_down_revision",
+				"pattern":  string(enrichers.MigrationPatternAlembic),
+			},
+		})
+		added++
+	}
+	return added
+}

--- a/internal/engine/migration_sequence_test.go
+++ b/internal/engine/migration_sequence_test.go
@@ -1,0 +1,147 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeMigEntity is a tiny helper for building a migration-anchored entity.
+func makeMigEntity(id, sourceFile string) graph.Entity {
+	return graph.Entity{ID: id, Name: id, Kind: "Migration", SourceFile: sourceFile}
+}
+
+// TestApplyMigrationSequence_DjangoSequenceAndName asserts the Django value
+// signal: 0002_add_email.py → sequence_number=2, migration_name="add email".
+func TestApplyMigrationSequence_DjangoSequenceAndName(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		makeMigEntity("d1", "app/migrations/0002_add_email.py"),
+	}}
+	stats := ApplyMigrationSequence(doc, nil)
+	if stats.EntitiesAnnotated != 1 || stats.FilesMatched != 1 {
+		t.Fatalf("expected 1 annotated/1 file, got %+v", stats)
+	}
+	p := doc.Entities[0].Properties
+	if p["sequence_number"] != "2" {
+		t.Fatalf("expected sequence_number=2, got %q", p["sequence_number"])
+	}
+	if p["migration_name"] != "add email" {
+		t.Fatalf("expected migration_name='add email', got %q", p["migration_name"])
+	}
+	if p["migration_pattern"] != "django" {
+		t.Fatalf("expected migration_pattern=django, got %q", p["migration_pattern"])
+	}
+}
+
+// TestApplyMigrationSequence_FlywaySequence asserts Flyway V3__add_index.sql →
+// sequence 3. Flyway sequence is a (possibly dotted) string.
+func TestApplyMigrationSequence_FlywaySequence(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		{ID: "f1", Name: "products", Kind: "SCOPE.Datastore", SourceFile: "db/migrations/V3__add_index.sql"},
+	}}
+	stats := ApplyMigrationSequence(doc, nil)
+	if stats.EntitiesAnnotated != 1 {
+		t.Fatalf("expected 1 annotated, got %+v", stats)
+	}
+	p := doc.Entities[0].Properties
+	if p["sequence_number"] != "3" {
+		t.Fatalf("expected sequence_number=3, got %q", p["sequence_number"])
+	}
+	if p["migration_name"] != "add index" {
+		t.Fatalf("expected migration_name='add index', got %q", p["migration_name"])
+	}
+	if p["migration_pattern"] != "flyway" {
+		t.Fatalf("expected migration_pattern=flyway, got %q", p["migration_pattern"])
+	}
+}
+
+// TestApplyMigrationSequence_RailsAndGolangMigrate asserts the Rails timestamp
+// sequence and the golang-migrate numeric sequence in one document.
+func TestApplyMigrationSequence_RailsAndGolangMigrate(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		makeMigEntity("r1", "db/migrate/20231101120000_create_users.rb"),
+		{ID: "g1", Name: "users", Kind: "SCOPE.Datastore", SourceFile: "migrations/000005_add_orders.up.sql"},
+	}}
+	ApplyMigrationSequence(doc, nil)
+
+	rails := doc.Entities[0].Properties
+	if rails["sequence_number"] != "20231101120000" || rails["migration_pattern"] != "rails" {
+		t.Fatalf("rails: got seq=%q pattern=%q", rails["sequence_number"], rails["migration_pattern"])
+	}
+	if rails["migration_name"] != "create users" {
+		t.Fatalf("rails: expected 'create users', got %q", rails["migration_name"])
+	}
+
+	gm := doc.Entities[1].Properties
+	if gm["sequence_number"] != "5" || gm["migration_pattern"] != "golang_migrate" {
+		t.Fatalf("golang-migrate: got seq=%q pattern=%q", gm["sequence_number"], gm["migration_pattern"])
+	}
+	if gm["migration_name"] != "add orders" {
+		t.Fatalf("golang-migrate: expected 'add orders', got %q", gm["migration_name"])
+	}
+}
+
+// TestApplyMigrationSequence_AlembicPrecedesEdge asserts the Alembic ordering
+// signal: when the child migration declares down_revision = parent, the pass
+// emits exactly one PRECEDES edge parent → child, and leaves the base migration
+// (down_revision = None) with no incoming edge.
+func TestApplyMigrationSequence_AlembicPrecedesEdge(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		makeMigEntity("base", "alembic/versions/aaaaaaaaaaaa_initial.py"),
+		makeMigEntity("child", "alembic/versions/bbbbbbbbbbbb_add_col.py"),
+	}}
+
+	// In-memory reader: base has down_revision=None; child points back to base.
+	src := map[string]string{
+		"alembic/versions/aaaaaaaaaaaa_initial.py": "revision = 'aaaaaaaaaaaa'\ndown_revision = None\n",
+		"alembic/versions/bbbbbbbbbbbb_add_col.py": "revision = \"bbbbbbbbbbbb\"\ndown_revision = \"aaaaaaaaaaaa\"\n",
+	}
+	reader := func(f string) (string, bool) { s, ok := src[f]; return s, ok }
+
+	stats := ApplyMigrationSequence(doc, reader)
+	if stats.PrecedesEdges != 1 {
+		t.Fatalf("expected exactly 1 PRECEDES edge, got %d (stats=%+v)", stats.PrecedesEdges, stats)
+	}
+
+	// Find the PRECEDES edge and assert its direction: base PRECEDES child.
+	var found *graph.Relationship
+	for i := range doc.Relationships {
+		if doc.Relationships[i].Kind == "PRECEDES" {
+			found = &doc.Relationships[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("no PRECEDES edge emitted")
+	}
+	if found.FromID != "base" || found.ToID != "child" {
+		t.Fatalf("expected base→child, got %s→%s", found.FromID, found.ToID)
+	}
+
+	// Revision props were stamped from the file body.
+	if doc.Entities[1].Properties["down_revision"] != "aaaaaaaaaaaa" {
+		t.Fatalf("expected child down_revision=aaaaaaaaaaaa, got %q",
+			doc.Entities[1].Properties["down_revision"])
+	}
+
+	// Idempotency: a second run adds no new edge.
+	before := len(doc.Relationships)
+	ApplyMigrationSequence(doc, reader)
+	if len(doc.Relationships) != before {
+		t.Fatalf("second run added edges: before=%d after=%d", before, len(doc.Relationships))
+	}
+}
+
+// TestApplyMigrationSequence_NoMigrationsSkips asserts honest behaviour: a graph
+// with no migration files annotates nothing and emits no edges.
+func TestApplyMigrationSequence_NoMigrationsSkips(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		{ID: "x", Name: "handler", Kind: "Operation", SourceFile: "internal/api/handler.go"},
+	}}
+	stats := ApplyMigrationSequence(doc, nil)
+	if stats.EntitiesAnnotated != 0 || stats.PrecedesEdges != 0 {
+		t.Fatalf("expected no annotation, got %+v", stats)
+	}
+	if _, ok := doc.Entities[0].Properties["sequence_number"]; ok {
+		t.Fatal("non-migration entity should not be stamped")
+	}
+}

--- a/internal/enrichers/enrichers_test.go
+++ b/internal/enrichers/enrichers_test.go
@@ -557,6 +557,34 @@ func TestAnnotateMigrationSequences_EmptySourceFile(t *testing.T) {
 	}
 }
 
+func TestParseAlembicRevisions_WithParent(t *testing.T) {
+	src := "revision = 'abc123def456'\ndown_revision = 'parent000000'\n"
+	rev, down := ParseAlembicRevisions(src)
+	if rev != "abc123def456" || down != "parent000000" {
+		t.Fatalf("got rev=%q down=%q", rev, down)
+	}
+}
+
+func TestParseAlembicRevisions_BaseNone(t *testing.T) {
+	src := "revision = \"root00000000\"\ndown_revision = None\n"
+	rev, down := ParseAlembicRevisions(src)
+	if rev != "root00000000" {
+		t.Fatalf("expected rev=root00000000, got %q", rev)
+	}
+	if down != "" {
+		t.Fatalf("expected empty down_revision for base, got %q", down)
+	}
+}
+
+func TestParseAlembicRevisions_TypedAnnotation(t *testing.T) {
+	// Newer Alembic templates annotate the module vars: `revision: str = "..."`.
+	src := "revision: str = 'x12345678901'\ndown_revision: Union[str, None] = 'y98765432109'\n"
+	rev, down := ParseAlembicRevisions(src)
+	if rev != "x12345678901" || down != "y98765432109" {
+		t.Fatalf("got rev=%q down=%q", rev, down)
+	}
+}
+
 // pagination
 
 func TestEnrichPagination_ParametersList(t *testing.T) {

--- a/internal/enrichers/migration_sequence_enricher.go
+++ b/internal/enrichers/migration_sequence_enricher.go
@@ -39,10 +39,39 @@ type MigrationEntity struct {
 var (
 	railsMigrationRe   = regexp.MustCompile(`^(\d{14})_([^.]+)\.rb$`)
 	djangoMigrationRe  = regexp.MustCompile(`^(\d{4})_([^.]+)\.py$`)
-	flywayMigrationRe  = regexp.MustCompile(`^V(\d+\.\d+)__([^.]+)\.sql$`)
-	golangMigrateRe    = regexp.MustCompile(`^(\d{1,13})_([^.]+)\.(up|down)\.sql$`)
-	alembicMigrationRe = regexp.MustCompile(`^([A-Za-z0-9]{12})_([^.]+)\.py$`)
+	flywayMigrationRe  = regexp.MustCompile(`^V(\d+(?:\.\d+)*)__([^.]+)\.sql$`)
+	golangMigrateRe    = regexp.MustCompile(`^(\d{1,14})_([^.]+)\.(up|down)\.sql$`)
+	alembicMigrationRe = regexp.MustCompile(`^([A-Za-z0-9]{12,})_([^.]+)\.py$`)
 )
+
+// alembicRevisionRe and alembicDownRevisionRe extract the module-level
+// `revision` and `down_revision` string assignments from an Alembic migration
+// file body. Alembic stores the DAG ordering in these variables (not in the
+// filename): `down_revision = None` for the root migration, otherwise the id of
+// the parent revision. We match both single- and double-quoted string literals
+// and the `None` sentinel. Anchored with (?m) so they match a top-level
+// assignment on its own line, tolerating leading whitespace.
+var (
+	alembicRevisionRe     = regexp.MustCompile(`(?m)^\s*revision\s*(?::[^=]*)?=\s*['"]([A-Za-z0-9_]+)['"]`)
+	alembicDownRevisionRe = regexp.MustCompile(`(?m)^\s*down_revision\s*(?::[^=]*)?=\s*(?:['"]([A-Za-z0-9_]+)['"]|None)`)
+)
+
+// ParseAlembicRevisions extracts the (revision, downRevision) pair from an
+// Alembic migration file's source. revision is the id this migration defines;
+// downRevision is the parent it must run AFTER (empty string when the source
+// declares `down_revision = None`, i.e. this is the base migration). Either
+// return value is empty when the corresponding assignment is absent or
+// unparseable. Pure: no I/O, deterministic.
+func ParseAlembicRevisions(source string) (revision, downRevision string) {
+	if m := alembicRevisionRe.FindStringSubmatch(source); m != nil {
+		revision = m[1]
+	}
+	if m := alembicDownRevisionRe.FindStringSubmatch(source); m != nil {
+		// m[1] is empty when the literal was `None`.
+		downRevision = m[1]
+	}
+	return revision, downRevision
+}
 
 func parseMigrationFilename(basename string) (seq interface{}, name string, pattern MigrationPattern, ok bool) {
 	if m := railsMigrationRe.FindStringSubmatch(basename); m != nil {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -282,6 +282,14 @@ const (
 	// tag entities.
 	RelationshipKindTaggedAs RelationshipKind = "TAGGED_AS"
 
+	// #3639 (epic #3625): DB-migration apply-order edge. Emitted by the
+	// migration-sequence engine pass (Pass 8.9) from a parent migration entity
+	// to the child that must run AFTER it. Currently derived from Alembic's
+	// down_revision → revision DAG (read from the migration file body); the
+	// FromID migration PRECEDES the ToID migration. Lets expand/traces walk the
+	// migration chain in apply order rather than re-deriving it from filenames.
+	RelationshipKindPrecedes RelationshipKind = "PRECEDES"
+
 	// ADR-0018: Agent-learned pattern edge kinds (append-only additions).
 	// Outgoing from Pattern entities:
 	RelationshipKindExemplar      RelationshipKind = "EXEMPLAR"        // Pattern -> Entity: real code example of this pattern in use
@@ -907,6 +915,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindTransitionsTo,
 		// #3628 area #13 shared-database cross-service coupling edge:
 		RelationshipKindSharesData,
+		// #3639 (epic #3625) DB-migration apply-order edge (Alembic chain):
+		RelationshipKindPrecedes,
 	}
 }
 


### PR DESCRIPTION
## Summary

Restores the previously **orphaned** `migration_sequence` enricher — imported by zero production code, so no migration entity ever carried ordering metadata — as a **live indexer pass (Pass 8.9)**, emitting the DB-migration ordering signal across Rails / Django / Flyway / golang-migrate / Alembic.

## What it does

- **`engine.ApplyMigrationSequence`** (`internal/engine/migration_sequence.go`), wired into `cmd/archigraph/index.go` as **Pass 8.9** (skippable via `--skip-pass=migration-seq`). For every entity anchored to a recognised migration file it stamps `sequence_number` + `migration_name` + `migration_pattern` parsed from the filename:
  - Rails `db/migrate/YYYYMMDDHHMMSS_name.rb`
  - Django `migrations/NNNN_name.py`
  - Flyway `V{n}__desc.sql`
  - golang-migrate `NNNNNN_name.up|down.sql`
  - Alembic `versions/{rev}_name.py`
- **Alembic ordering DAG**: the pass reads each Alembic migration body (`enrichers.ParseAlembicRevisions` parses `revision` / `down_revision`, including typed `revision: str = ...` templates and `down_revision = None` base) and emits a **`PRECEDES`** edge `down_revision → revision` when both endpoints are present. New `RelationshipKindPrecedes` registered + added to `AllRelationshipKinds()`.
- **Honest + idempotent**: only known filename conventions are touched; no new entities created; stable `RelationshipID` keys prevent duplicate edges on re-run.

## Fixes the FALSE alembic cell

`lang.python.orm.alembic → Migrations.migration_parsing` was `full` citing the **orphaned** enricher (#3630). Re-stamped **`partial`** citing the now-live pass + the `down_revision` PRECEDES DAG (`internal/engine/migration_sequence.go`, `internal/custom/python/alembic_schema.go`). Also augmented the `django` and `activerecord` `migration_parsing` cells to cite the live sequence stamping. `coverage fmt` canonical, `coverage validate` 0 errors, detail markdown regenerated.

## Reachable from a live path

`cmd/archigraph/index.go` → indexer `Run` → Pass 8.9 `engine.ApplyMigrationSequence(doc, engine.DiskMigrationSourceReader(absRepo))`.

## Tests (value-asserting, not len>0)

- Django `0002_add_email.py` → `sequence_number=2`, `migration_name="add email"`, `migration_pattern=django`
- Flyway `V3__add_index.sql` → `sequence_number=3`
- Rails timestamp sequence + golang-migrate numeric sequence
- Alembic with `down_revision` → exactly **one** `base → child` `PRECEDES` edge (correct direction) + idempotency (no dup on second run)
- `ParseAlembicRevisions`: parent / `None`-base / typed-annotation forms

`go test` (engine, enrichers, types, coverage) green; `go vet` clean; `gofmt -l` empty.

## DEPLOY-DEFERRED

Requires a coordinated live-daemon rebuild + restart before the signal appears in the served graph.

Closes #3639 (epic #3625)

🤖 Generated with [Claude Code](https://claude.com/claude-code)