### PR TITLE
feat(graphql): extract DataLoader N+1 batch-loader wiring (#3624)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -28364,6 +28364,17 @@
             "verified_at": "2026-05-29"
           }
         }
+      },
+      "framework_specific": {
+        "DataLoader (N+1 batching)": {
+          "dataloader_extraction": {
+            "status": "partial",
+            "cites": ["internal/extractors/javascript/graphql_dataloader.go","internal/extractors/javascript/issue3624_dataloader_test.go","internal/types/kinds.go"],
+            "issue": "3624",
+            "notes": "new DataLoader(batchFn) (the 'dataloader' npm pkg) -\u003e SCOPE.DataLoader entity named by the assigned const/field + BATCHES edge to the wrapped batch fn (bare ident or single-call delegating arrow); loader.load(id)/loadMany(ids) in a resolver body -\u003e USES edge resolver-\u003eloader, via=graphql_dataloader. Value-asserted: userLoader BATCHES batchUsers + resolveAuthor USES userLoader. PARTIAL (honest): only statically-named loaders; dynamic/factory-built loaders and lambda batch fns get no BATCHES edge.",
+            "verified_at": "2026-06-02"
+          }
+        }
       }
     },
     {
@@ -44133,6 +44144,17 @@
           "vulnerability_finding": {
             "status": "missing",
             "issue": "3620"
+          }
+        }
+      },
+      "framework_specific": {
+        "DataLoader (N+1 batching)": {
+          "dataloader_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/python/graphql_dataloader.go","internal/custom/python/graphql_dataloader_test.go","internal/types/kinds.go"],
+            "issue": "3624",
+            "notes": "aiodataloader DataLoader(load_fn=batch_users) / DataLoader(batch_users) -\u003e SCOPE.DataLoader entity named by the assigned var + BATCHES edge to the named batch fn; \u003cloader\u003e.load(id)/.load_many(ids) in a resolver body -\u003e USES edge resolver-\u003eloader (resolver = nearest enclosing def), via=graphql_dataloader. Value-asserted: user_loader BATCHES batch_users + author resolver USES user_loader. PARTIAL (honest): regex+enclosing-def heuristic; lambda batch fns get no BATCHES edge; top-level .load() with no enclosing def skipped.",
+            "verified_at": "2026-06-02"
           }
         }
       }

--- a/internal/custom/python/graphql_dataloader.go
+++ b/internal/custom/python/graphql_dataloader.go
@@ -1,0 +1,273 @@
+package python
+
+// graphql_dataloader.go — Python GraphQL DataLoader N+1 batch-loader
+// extraction (#3624, epic #3607).
+//
+// GraphQL servers in Python (Strawberry, Ariadne, Graphene) avoid the classic
+// N+1 resolver problem with the `aiodataloader` package: a DataLoader batches
+// the per-key loads issued by sibling field resolvers into a single call to a
+// user-supplied async batch function.
+//
+//	from aiodataloader import DataLoader
+//
+//	async def batch_users(keys):
+//	    rows = await db.fetch_users(keys)
+//	    return [rows.get(k) for k in keys]
+//
+//	user_loader = DataLoader(batch_fn=batch_users)   # or DataLoader(batch_users)
+//
+//	@strawberry.field
+//	async def author(self, info) -> User:
+//	    return await user_loader.load(self.author_id)   # batched fetch
+//
+// This extractor records the N+1-avoidance wiring (cross-language consistent
+// with the JS/TS dataloader pass):
+//
+//	target  : SCOPE.DataLoader  subtype "dataloader"
+//	          Name = the LHS variable the loader is assigned to (e.g. "user_loader")
+//	edge 1  : BATCHES   loader → batch function   (the load_fn / first positional)
+//	edge 2  : USES      resolver → loader         (each `<loader>.load(id)` site,
+//	                                                attached to the enclosing def)
+//
+// Both edges carry Properties["via"] = "graphql_dataloader".
+//
+// Honest-partial: only loaders assigned to a simple module/class-level name are
+// captured, and the batch function is recorded only when it is a bare name
+// (`load_fn=batch_users` or `DataLoader(batch_users)`); a lambda or inline
+// callable yields a loader entity with no BATCHES edge. A `.load()` call whose
+// enclosing `def` cannot be resolved (e.g. module top-level) is skipped.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_graphql_dataloader", &GraphQLDataLoaderExtractor{})
+}
+
+// GraphQLDataLoaderExtractor extracts aiodataloader DataLoader instances and
+// the resolver→loader / loader→batch-fn wiring around them.
+type GraphQLDataLoaderExtractor struct{}
+
+func (e *GraphQLDataLoaderExtractor) Language() string { return "python_graphql_dataloader" }
+
+var (
+	// dlAssignRe matches `  user_loader = DataLoader(...)` capturing the LHS
+	// name (group 1) and the constructor argument body (group 2). Anchored to
+	// line start (with optional indentation) so `self.user_loader = ...` and
+	// bare-name forms both match via the LHS group, which tolerates a trailing
+	// attribute. Only the trailing identifier of the LHS is used as the name.
+	dlAssignRe = regexp.MustCompile(`(?m)^[ \t]*([A-Za-z_][\w.]*)\s*=\s*DataLoader\(([^\n]*)\)`)
+
+	// dlLoadFnKwRe pulls `load_fn=batch_users` or `batch_load_fn=batch_users`
+	// out of a constructor body (group 1 = the batch function name).
+	dlLoadFnKwRe = regexp.MustCompile(`(?:load_fn|batch_load_fn)\s*=\s*([A-Za-z_]\w*)`)
+
+	// dlFirstPosRe pulls a leading bare positional argument (`DataLoader(batch_users)`)
+	// — group 1 = the batch function name. Requires the arg to be a plain name
+	// not followed by `=` (which would make it a keyword) or `(` (a call).
+	dlFirstPosRe = regexp.MustCompile(`^\s*([A-Za-z_]\w*)\s*(?:,|$)`)
+
+	// dlLoadCallRe matches a `<loader>.load(` or `<loader>.load_many(` call,
+	// capturing the receiver expression (group 1) and the load method (group 2).
+	// The receiver may be dotted (`self.user_loader`, `info.context.user_loader`);
+	// only its trailing identifier is matched against known loaders.
+	dlLoadCallRe = regexp.MustCompile(`([A-Za-z_][\w.]*)\.(load|load_many)\(`)
+
+	// pyDefRe matches a python `def` / `async def` line, capturing leading
+	// indentation (group 1) and the function name (group 2).
+	pyDefRe = regexp.MustCompile(`(?m)^([ \t]*)(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(`)
+)
+
+func (e *GraphQLDataLoaderExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_graphql_dataloader")
+	_, span := tracer.Start(ctx, "custom.python_graphql_dataloader")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	// Fast-path gate: the file must mention DataLoader and import aiodataloader
+	// (or the Strawberry dataloader shim). Avoids matching unrelated classes
+	// named DataLoader.
+	if !strings.Contains(source, "DataLoader") {
+		return nil, nil
+	}
+	if !strings.Contains(source, "aiodataloader") &&
+		!strings.Contains(source, "strawberry.dataloader") &&
+		!strings.Contains(source, "from strawberry import dataloader") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	// 1. Loader entities + BATCHES edges. Record the trailing-identifier name of
+	//    each loader so that load()-site USES edges can be gated to known loaders.
+	loaderNames := make(map[string]bool)
+	loaderLines := make(map[string]int)
+	for _, m := range dlAssignRe.FindAllStringSubmatchIndex(source, -1) {
+		lhs := source[m[2]:m[3]]
+		body := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+
+		name := lhs
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		if name == "" {
+			continue
+		}
+		loaderNames[name] = true
+		loaderLines[name] = line
+
+		props := map[string]string{
+			"via":         "graphql_dataloader",
+			"loader_name": name,
+			"language":    "python",
+		}
+		var rels []types.RelationshipRecord
+		if batchFn := pyBatchFnName(body); batchFn != "" {
+			props["batch_fn"] = batchFn
+			rels = append(rels, types.RelationshipRecord{
+				ToID: batchFn,
+				Kind: string(types.RelationshipKindBatches),
+				Properties: map[string]string{
+					"via":      "graphql_dataloader",
+					"language": "python",
+				},
+			})
+		}
+		ld := entity(name, string(types.EntityKindDataLoader), "dataloader", file.Path, line, props)
+		ld.Relationships = rels
+		out = append(out, ld)
+	}
+
+	if len(loaderNames) == 0 {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 2. resolver→loader USES edges. For each `<loader>.load(id)` call, attach a
+	//    USES edge to the enclosing def. One carrier entity per (def-line) so
+	//    multiple loads in the same resolver converge on one owner.
+	defs := pyDefIndex(source)
+	type carrier struct {
+		name string
+		line int
+		uses map[string]bool
+	}
+	carriers := make(map[int]*carrier) // keyed by def start line
+	for _, m := range dlLoadCallRe.FindAllStringSubmatchIndex(source, -1) {
+		recv := source[m[2]:m[3]]
+		name := recv
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		if !loaderNames[name] {
+			continue
+		}
+		callLine := lineOf(source, m[0])
+		d := enclosingDef(defs, callLine)
+		if d == nil {
+			continue // top-level load() — no resolver to anchor the edge.
+		}
+		c := carriers[d.line]
+		if c == nil {
+			c = &carrier{name: d.name, line: d.line, uses: make(map[string]bool)}
+			carriers[d.line] = c
+		}
+		c.uses[name] = true
+	}
+
+	for _, c := range carriers {
+		ownerRef := fmt.Sprintf("dataloader_resolver:%s:%d", file.Path, c.line)
+		owner := entity(ownerRef, "SCOPE.Operation", "resolver", file.Path, c.line, map[string]string{
+			"via":           "graphql_dataloader",
+			"resolver_name": c.name,
+			"language":      "python",
+		})
+		for loaderName := range c.uses {
+			owner.Relationships = append(owner.Relationships, types.RelationshipRecord{
+				ToID: loaderName,
+				Kind: string(types.RelationshipKindUses),
+				Properties: map[string]string{
+					"via":      "graphql_dataloader",
+					"loader":   loaderName,
+					"language": "python",
+				},
+			})
+		}
+		out = append(out, owner)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// pyBatchFnName resolves the batch function name from a DataLoader constructor
+// body. Prefers a `load_fn=` / `batch_load_fn=` keyword; falls back to a bare
+// leading positional name. Returns "" for lambdas / inline callables.
+func pyBatchFnName(body string) string {
+	if km := dlLoadFnKwRe.FindStringSubmatch(body); km != nil {
+		return km[1]
+	}
+	if pm := dlFirstPosRe.FindStringSubmatch(body); pm != nil {
+		// Guard: a bare leading name that is immediately a kwarg (`foo=`) or a
+		// call (`foo(`) is not a batch-fn positional. dlFirstPosRe already
+		// requires `,` or end-of-string after the name, so `foo=` / `foo(`
+		// won't match. Also exclude obvious non-fn keywords.
+		switch pm[1] {
+		case "max_batch_size", "cache", "cache_key_fn", "load_fn", "batch_load_fn":
+			return ""
+		}
+		return pm[1]
+	}
+	return ""
+}
+
+// pyDef is a single python function definition: its name, start line (1-based),
+// and indentation width (number of leading spaces/tabs).
+type pyDef struct {
+	name   string
+	line   int
+	indent int
+}
+
+// pyDefIndex returns all `def` / `async def` definitions in source, in source
+// order, with their 1-based line numbers and indentation widths.
+func pyDefIndex(source string) []pyDef {
+	var defs []pyDef
+	for _, m := range pyDefRe.FindAllStringSubmatchIndex(source, -1) {
+		indent := m[3] - m[2]
+		name := source[m[4]:m[5]]
+		defs = append(defs, pyDef{name: name, line: lineOf(source, m[0]), indent: indent})
+	}
+	return defs
+}
+
+// enclosingDef returns the innermost def whose body contains callLine: the
+// last def at or before callLine. Honest-partial — it uses source order plus
+// line position rather than full block-scope analysis, which is sufficient for
+// the common single-resolver-per-def GraphQL shape. Returns nil when callLine
+// precedes every def (module top-level).
+func enclosingDef(defs []pyDef, callLine int) *pyDef {
+	var best *pyDef
+	for i := range defs {
+		if defs[i].line > callLine {
+			break
+		}
+		best = &defs[i]
+	}
+	return best
+}

--- a/internal/custom/python/graphql_dataloader_test.go
+++ b/internal/custom/python/graphql_dataloader_test.go
@@ -1,0 +1,143 @@
+package python_test
+
+// graphql_dataloader_test.go — value-asserting tests for the
+// python_graphql_dataloader extractor (#3624, epic #3607). Asserts the actual
+// loader entity, BATCHES edge, and resolver→loader USES edge — not len>0.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runPyDataLoader(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("python_graphql_dataloader")
+	if !ok {
+		t.Fatal("python_graphql_dataloader not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extractor.FileInput{Path: "resolvers.py", Language: "python", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findEdge(ents []types.EntityRecord, kind, toID string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == toID {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// TestPyDataLoader_LoadFnKwarg is the value-asserting case:
+//
+//	user_loader = DataLoader(load_fn=batch_users)   → loader user_loader BATCHES batch_users
+//	await user_loader.load(self.author_id)           → resolver author USES user_loader
+func TestPyDataLoader_LoadFnKwarg(t *testing.T) {
+	src := `
+from aiodataloader import DataLoader
+
+async def batch_users(keys):
+    return keys
+
+user_loader = DataLoader(load_fn=batch_users)
+
+@strawberry.field
+async def author(self, info):
+    return await user_loader.load(self.author_id)
+`
+	ents := runPyDataLoader(t, src)
+
+	// 1. Loader entity.
+	var loader *types.EntityRecord
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindDataLoader) && ents[i].Name == "user_loader" {
+			loader = &ents[i]
+			break
+		}
+	}
+	if loader == nil {
+		t.Fatal("expected SCOPE.DataLoader entity 'user_loader'")
+	}
+	if loader.Properties["via"] != "graphql_dataloader" {
+		t.Fatalf("loader via = %q; want graphql_dataloader", loader.Properties["via"])
+	}
+
+	// 2. BATCHES edge user_loader → batch_users.
+	if e := findEdge(ents, string(types.RelationshipKindBatches), "batch_users"); e == nil {
+		t.Fatal("expected BATCHES edge user_loader → batch_users")
+	} else if e.Properties["via"] != "graphql_dataloader" {
+		t.Fatalf("BATCHES via = %q; want graphql_dataloader", e.Properties["via"])
+	}
+
+	// 3. USES edge author resolver → user_loader.
+	usesEdge := findEdge(ents, string(types.RelationshipKindUses), "user_loader")
+	if usesEdge == nil {
+		t.Fatal("expected USES edge resolver → user_loader")
+	}
+	if usesEdge.Properties["via"] != "graphql_dataloader" {
+		t.Fatalf("USES via = %q; want graphql_dataloader", usesEdge.Properties["via"])
+	}
+	// The carrier must be the enclosing resolver 'author'.
+	var carrierOK bool
+	for i := range ents {
+		if ents[i].Subtype == "resolver" && ents[i].Properties["resolver_name"] == "author" {
+			carrierOK = true
+		}
+	}
+	if !carrierOK {
+		t.Fatal("expected USES carrier to be the enclosing resolver 'author'")
+	}
+}
+
+// TestPyDataLoader_PositionalBatchFn covers DataLoader(batch_users) (positional)
+// and a load_many() call site.
+func TestPyDataLoader_PositionalBatchFn(t *testing.T) {
+	src := `
+from aiodataloader import DataLoader
+
+async def batch_posts(keys):
+    return keys
+
+post_loader = DataLoader(batch_posts)
+
+async def resolve_posts(self, info):
+    return await post_loader.load_many(self.post_ids)
+`
+	ents := runPyDataLoader(t, src)
+
+	if e := findEdge(ents, string(types.RelationshipKindBatches), "batch_posts"); e == nil {
+		t.Fatal("expected BATCHES edge post_loader → batch_posts (positional)")
+	}
+	if e := findEdge(ents, string(types.RelationshipKindUses), "post_loader"); e == nil {
+		t.Fatal("expected USES edge resolve_posts → post_loader (load_many)")
+	}
+}
+
+// TestPyDataLoader_NoAioImportNoEmit verifies the fast-path: a file that
+// constructs DataLoader without importing aiodataloader (an unrelated local
+// class) must NOT emit a loader entity.
+func TestPyDataLoader_NoAioImportNoEmit(t *testing.T) {
+	src := `
+class DataLoader:
+    def __init__(self, fn): ...
+
+x = DataLoader(some_fn)
+`
+	ents := runPyDataLoader(t, src)
+	for _, e := range ents {
+		if e.Kind == string(types.EntityKindDataLoader) {
+			t.Fatalf("did not expect a SCOPE.DataLoader entity without aiodataloader import; got %q", e.Name)
+		}
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -241,6 +241,14 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// Without this, traces terminated at useAuthStore ("no_outgoing_calls").
 	x.zustand.emitStoreActionEntities(x)
 
+	// Issue #3624 (epic #3607) — build the GraphQL DataLoader tracker before
+	// walk() so that extractCallRelationships can emit USES edges for
+	// `<loader>.load(id)` call sites. buildDataLoaderTracker also emits a
+	// SCOPE.DataLoader entity (+ a BATCHES edge to the wrapped batch function)
+	// for each statically-named `new DataLoader(...)` construction. No-ops when
+	// the file does not import the "dataloader" package.
+	x.dataLoader = x.buildDataLoaderTracker(root)
+
 	// Issue #2894 PR1 — React Ecosystem framework_specific group: emit
 	// decorated Redux slice/store, RTK Query api/endpoint and createAsyncThunk
 	// entities (+ CONTAINS edges) before walk() so they're present alongside the
@@ -475,6 +483,15 @@ type extractor struct {
 	// emits a CALLS edge tagged Properties["via"]="zustand_store".
 	// Nil when no zustand import is found in the file (fast-path).
 	zustand *zustandTracker
+
+	// dataLoader — Issue #3624 (epic #3607). Built once per file in
+	// buildDataLoaderTracker (called from Extract before walk). Tracks
+	// statically-named GraphQL DataLoader instances (`new DataLoader(...)` from
+	// the "dataloader" package). When a resolver body calls `<loader>.load(id)`
+	// extractCallRelationships emits a USES edge tagged
+	// Properties["via"]="graphql_dataloader". Nil when no dataloader import is
+	// found in the file (fast-path).
+	dataLoader *dataLoaderTracker
 
 	// destructureBindings — Issue #2625. Built once per file in
 	// buildDestructureBindings (called from Extract before walk). Tracks
@@ -2245,6 +2262,21 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 				if !seen[zr.ToID] {
 					seen[zr.ToID] = true
 					rels = append(rels, zr)
+				}
+			}
+		}
+
+		// Issue #3624 — GraphQL DataLoader: `<loader>.load(id)` /
+		// `<loader>.loadMany(ids)` inside a resolver body emits a USES edge from
+		// the enclosing function (callerName) to the loader entity. We key the
+		// dedup set on a "uses:" prefix so a same-named CALLS edge isn't
+		// suppressed (and vice-versa).
+		if dlRels := x.dataLoader.dataLoaderLoadEdges(x, call); len(dlRels) > 0 {
+			for _, dr := range dlRels {
+				key := "uses:" + dr.ToID
+				if !seen[key] {
+					seen[key] = true
+					rels = append(rels, dr)
 				}
 			}
 		}

--- a/internal/extractors/javascript/graphql_dataloader.go
+++ b/internal/extractors/javascript/graphql_dataloader.go
@@ -1,0 +1,354 @@
+// graphql_dataloader.go — issue #3624 (epic #3607).
+//
+// GraphQL DataLoader N+1 batch-loader extraction
+// ───────────────────────────────────────────────
+// GraphQL field resolvers that naively fetch a related record per parent
+// object trigger the classic N+1 query problem: resolving `author` for N
+// posts issues N separate user fetches. The `dataloader` npm package solves
+// this by batching per-key loads into a single call:
+//
+//   import DataLoader from 'dataloader'
+//
+//   const userLoader = new DataLoader(batchUsers)          // wraps a batch fn
+//   const postLoader = new DataLoader((ids) => batchPosts(ids))  // inline arrow
+//
+//   const resolvers = {
+//     Post: {
+//       author: (post) => userLoader.load(post.authorId),  // batched fetch
+//     },
+//   }
+//
+// This extractor records the N+1-avoidance wiring:
+//
+//   1. Loader entity — one SCOPE.DataLoader per `new DataLoader(...)` that is
+//      assigned to a const/let/var or a class field. The entity is named by
+//      the variable/field it is assigned to (e.g. `userLoader`).
+//
+//   2. BATCHES edge — SCOPE.DataLoader → batch function. When the first
+//      argument to `new DataLoader(...)` is a bare identifier (a named batch
+//      function) or an arrow that immediately delegates to a single call
+//      (`(ids) => batchPosts(ids)`), we emit a BATCHES edge to that function.
+//
+//   3. USES edge — resolver → loader. At each `<loader>.load(id)` /
+//      `<loader>.loadMany(ids)` call site inside a resolver (any function/
+//      method body), we emit a USES edge from the enclosing function to the
+//      loader. This surfaces which resolver batches via which loader.
+//
+// Honest-partial: only statically-named loaders (assigned to an identifier or
+// a class field) are captured. Loaders built dynamically (returned from a
+// factory, stored in a map, constructed inline inside a resolver return) are
+// out of scope; the load()-site USES edge still fires for any name that
+// resolves to a known loader in the same file.
+//
+// All entities/edges carry Properties["via"] = "graphql_dataloader" so the
+// resolver and dashboards can classify them.
+
+package javascript
+
+import (
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/types"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// PropViaGraphQLDataLoader is the value stamped on Properties["via"] for every
+// entity / edge emitted by the GraphQL DataLoader pass.
+const PropViaGraphQLDataLoader = "graphql_dataloader"
+
+// dataLoaderTracker holds the per-file set of statically-named DataLoader
+// instances. Built once per file by buildDataLoaderTracker after
+// importByLocal is populated. Nil when the file does not import the
+// "dataloader" package (fast-path for the overwhelming majority of files).
+type dataLoaderTracker struct {
+	// loaders maps a loader variable/field name (e.g. "userLoader") to a true
+	// flag. Used by load()-site detection to gate USES edges to known loaders.
+	loaders map[string]bool
+}
+
+// buildDataLoaderTracker constructs a dataLoaderTracker by scanning the file
+// for `new DataLoader(...)` constructions, where the `DataLoader` identifier
+// is bound to the "dataloader" npm package.
+//
+// Returns nil when no "dataloader" import is found (fast-path) or when the
+// file contains no statically-named loader.
+func (x *extractor) buildDataLoaderTracker(root *sitter.Node) *dataLoaderTracker {
+	if x.importByLocal == nil || root == nil {
+		return nil
+	}
+	// Find local names bound to the "dataloader" package (default import is the
+	// idiomatic `import DataLoader from 'dataloader'`; also accept a named or
+	// namespace import that resolves to the same package).
+	ctorLocals := make(map[string]bool)
+	for localName, b := range x.importByLocal {
+		if b == nil || b.importPath != "dataloader" {
+			continue
+		}
+		ctorLocals[localName] = true
+	}
+	if len(ctorLocals) == 0 {
+		return nil
+	}
+
+	t := &dataLoaderTracker{loaders: make(map[string]bool)}
+	t.scanForLoaders(x, root, ctorLocals)
+	if len(t.loaders) == 0 {
+		return nil
+	}
+	return t
+}
+
+// scanForLoaders walks the AST recording, for each
+//
+//	const <loaderVar> = new DataLoader(<batch>)
+//	<loaderVar> = new DataLoader(<batch>)              (assignment_expression)
+//	class C { <field> = new DataLoader(<batch>) }      (field_definition)
+//
+// the loader entity (named by the LHS) and a BATCHES edge to the wrapped batch
+// function when it can be statically resolved.
+func (t *dataLoaderTracker) scanForLoaders(x *extractor, root *sitter.Node, ctorLocals map[string]bool) {
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		switch n.Type() {
+		case "variable_declarator":
+			t.processAssignment(x, n.ChildByFieldName("name"), n.ChildByFieldName("value"), ctorLocals)
+		case "assignment_expression":
+			t.processAssignment(x, n.ChildByFieldName("left"), n.ChildByFieldName("right"), ctorLocals)
+		case "public_field_definition", "field_definition":
+			t.processAssignment(x, n.ChildByFieldName("name"), n.ChildByFieldName("value"), ctorLocals)
+		}
+		for i := int(n.ChildCount()) - 1; i >= 0; i-- {
+			stack = append(stack, n.Child(i))
+		}
+	}
+}
+
+// processAssignment records a loader when valueNode is `new DataLoader(...)`
+// and nameNode is a simple identifier / property name.
+func (t *dataLoaderTracker) processAssignment(x *extractor, nameNode, valueNode *sitter.Node, ctorLocals map[string]bool) {
+	if nameNode == nil || valueNode == nil {
+		return
+	}
+	loaderName := loaderLHSName(x, nameNode)
+	if loaderName == "" {
+		return
+	}
+	if valueNode.Type() != "new_expression" {
+		return
+	}
+	if !isDataLoaderConstruction(x, valueNode, ctorLocals) {
+		return
+	}
+
+	t.loaders[loaderName] = true
+
+	props := map[string]string{
+		"via":         PropViaGraphQLDataLoader,
+		"loader_name": loaderName,
+	}
+	var rels []types.RelationshipRecord
+	if batchFn := dataLoaderBatchFn(x, valueNode); batchFn != "" {
+		props["batch_fn"] = batchFn
+		rels = append(rels, types.RelationshipRecord{
+			ToID: batchFn,
+			Kind: string(types.RelationshipKindBatches),
+			Properties: map[string]string{
+				"via":  PropViaGraphQLDataLoader,
+				"line": strconv.Itoa(int(valueNode.StartPoint().Row) + 1),
+			},
+		})
+	}
+	x.emitWithProps(loaderName, string(types.EntityKindDataLoader), valueNode, "dataloader", "new DataLoader("+loaderName+")", props, rels)
+}
+
+// loaderLHSName returns the loader name for the LHS of an assignment:
+//   - identifier            → its text ("userLoader")
+//   - property_identifier   → its text (class field "userLoader")
+//   - member_expression     → the trailing property ("this.userLoader" → "userLoader")
+//
+// Returns "" for destructuring / computed / unsupported shapes.
+func loaderLHSName(x *extractor, nameNode *sitter.Node) string {
+	switch nameNode.Type() {
+	case "identifier", "property_identifier", "shorthand_property_identifier":
+		return x.nodeText(nameNode)
+	case "member_expression":
+		prop := nameNode.ChildByFieldName("property")
+		if prop != nil {
+			return x.nodeText(prop)
+		}
+	}
+	return ""
+}
+
+// isDataLoaderConstruction reports whether newExpr is `new DataLoader(...)`
+// where the constructor identifier is bound to the "dataloader" package.
+func isDataLoaderConstruction(x *extractor, newExpr *sitter.Node, ctorLocals map[string]bool) bool {
+	ctor := newExpr.ChildByFieldName("constructor")
+	if ctor == nil {
+		return false
+	}
+	switch ctor.Type() {
+	case "identifier":
+		// `new DataLoader(...)` — default/named import.
+		return ctorLocals[x.nodeText(ctor)]
+	case "member_expression":
+		// `new dl.DataLoader(...)` — namespace import. Accept when the object is
+		// a dataloader-bound local; the property is the class name.
+		obj := ctor.ChildByFieldName("object")
+		if obj != nil && obj.Type() == "identifier" {
+			return ctorLocals[x.nodeText(obj)]
+		}
+	}
+	return false
+}
+
+// dataLoaderBatchFn resolves the wrapped batch function name from the first
+// argument to `new DataLoader(<batch>)`:
+//
+//   - bare identifier:            new DataLoader(batchUsers)        → "batchUsers"
+//   - delegating arrow:           new DataLoader((ids) => batchUsers(ids)) → "batchUsers"
+//   - delegating function expr:   new DataLoader(function (ids) { return batchUsers(ids) }) → "batchUsers"
+//
+// Returns "" when the batch function cannot be named statically (inline
+// multi-statement body, member-expression callee, etc.). In that honest-partial
+// case the loader entity is still emitted; only the BATCHES edge is omitted.
+func dataLoaderBatchFn(x *extractor, newExpr *sitter.Node) string {
+	args := newExpr.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	var firstArg *sitter.Node
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "(", ")", ",":
+			continue
+		}
+		firstArg = ch
+		break
+	}
+	if firstArg == nil {
+		return ""
+	}
+
+	switch firstArg.Type() {
+	case "identifier":
+		return x.nodeText(firstArg)
+	case "arrow_function", "function_expression":
+		return delegatedCallName(x, firstArg.ChildByFieldName("body"))
+	}
+	return ""
+}
+
+// delegatedCallName extracts the callee identifier from an arrow/function body
+// that immediately delegates to a single call:
+//
+//	(ids) => batchUsers(ids)                  body = call_expression
+//	(ids) => { return batchUsers(ids) }       body = statement_block → return → call
+//
+// Returns "" when the body is not a simple single-call delegation or when the
+// callee is not a bare identifier (e.g. `this.batch(ids)`).
+func delegatedCallName(x *extractor, body *sitter.Node) string {
+	if body == nil {
+		return ""
+	}
+	switch body.Type() {
+	case "call_expression":
+		fn := body.ChildByFieldName("function")
+		if fn != nil && fn.Type() == "identifier" {
+			return x.nodeText(fn)
+		}
+	case "statement_block":
+		for i := 0; i < int(body.ChildCount()); i++ {
+			stmt := body.Child(i)
+			if stmt == nil || stmt.Type() != "return_statement" {
+				continue
+			}
+			for j := 0; j < int(stmt.ChildCount()); j++ {
+				ch := stmt.Child(j)
+				if ch == nil || ch.Type() != "call_expression" {
+					continue
+				}
+				fn := ch.ChildByFieldName("function")
+				if fn != nil && fn.Type() == "identifier" {
+					return x.nodeText(fn)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// dataLoaderLoadEdges checks whether callNode is `<loader>.load(id)` or
+// `<loader>.loadMany(ids)` where <loader> is a statically-known loader in this
+// file. When it matches, it returns a USES RelationshipRecord from the
+// enclosing resolver (callerName) to the loader, tagged
+// Properties["via"]="graphql_dataloader".
+//
+// Recognised receiver shapes:
+//
+//	userLoader.load(id)            object = identifier
+//	this.userLoader.load(id)       object = member_expression (trailing prop)
+//	context.userLoader.load(id)    object = member_expression (trailing prop)
+func (t *dataLoaderTracker) dataLoaderLoadEdges(x *extractor, callNode *sitter.Node) []types.RelationshipRecord {
+	if t == nil {
+		return nil
+	}
+	fn := callNode.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return nil
+	}
+	method := fn.ChildByFieldName("property")
+	if method == nil {
+		return nil
+	}
+	switch x.nodeText(method) {
+	case "load", "loadMany":
+	default:
+		return nil
+	}
+
+	loaderName := loaderReceiverName(x, fn.ChildByFieldName("object"))
+	if loaderName == "" || !t.loaders[loaderName] {
+		return nil
+	}
+
+	return []types.RelationshipRecord{{
+		ToID: loaderName,
+		Kind: string(types.RelationshipKindUses),
+		Properties: map[string]string{
+			"via":    PropViaGraphQLDataLoader,
+			"loader": loaderName,
+			"line":   strconv.Itoa(int(callNode.StartPoint().Row) + 1),
+		},
+	}}
+}
+
+// loaderReceiverName resolves the loader name from the object of the
+// `<obj>.load(...)` member expression:
+//   - identifier            → its text ("userLoader")
+//   - member_expression     → the trailing property ("this.userLoader" /
+//     "context.loaders.userLoader" → "userLoader")
+func loaderReceiverName(x *extractor, obj *sitter.Node) string {
+	if obj == nil {
+		return ""
+	}
+	switch obj.Type() {
+	case "identifier":
+		return x.nodeText(obj)
+	case "member_expression":
+		prop := obj.ChildByFieldName("property")
+		if prop != nil {
+			return x.nodeText(prop)
+		}
+	}
+	return ""
+}

--- a/internal/extractors/javascript/issue3624_dataloader_test.go
+++ b/internal/extractors/javascript/issue3624_dataloader_test.go
@@ -1,0 +1,200 @@
+// Package javascript_test — issue #3624 (epic #3607): GraphQL DataLoader
+// N+1 batch-loader extraction.
+//
+// Verifies that the extractor:
+//   - emits a SCOPE.DataLoader entity for each statically-named
+//     `new DataLoader(...)` (from the "dataloader" package), named by the LHS;
+//   - emits a BATCHES edge from the loader to the wrapped batch function;
+//   - emits a USES edge from a resolver to the loader at each
+//     `<loader>.load(id)` call site, tagged via=graphql_dataloader.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestTSExtractor_DataLoader_BatchesAndUses is the value-asserting case from
+// the issue:
+//
+//	const userLoader = new DataLoader(batchUsers)   → loader userLoader, BATCHES batchUsers
+//	userLoader.load(id) inside resolveAuthor        → resolveAuthor USES userLoader
+func TestTSExtractor_DataLoader_BatchesAndUses(t *testing.T) {
+	src := `
+import DataLoader from 'dataloader';
+
+async function batchUsers(ids) {
+  return ids.map((id) => ({ id }));
+}
+
+const userLoader = new DataLoader(batchUsers);
+
+export function resolveAuthor(post) {
+  return userLoader.load(post.authorId);
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	// 1. SCOPE.DataLoader entity named "userLoader".
+	loader := findByNameRel(ents, "userLoader")
+	if loader == nil {
+		t.Fatal("expected SCOPE.DataLoader entity 'userLoader' to be emitted")
+	}
+	if loader.Kind != string(types.EntityKindDataLoader) {
+		t.Fatalf("userLoader kind = %q; want %q", loader.Kind, types.EntityKindDataLoader)
+	}
+	if loader.Properties["via"] != "graphql_dataloader" {
+		t.Fatalf("userLoader via = %q; want graphql_dataloader", loader.Properties["via"])
+	}
+
+	// 2. BATCHES edge userLoader → batchUsers.
+	foundBatches := false
+	for _, r := range loader.Relationships {
+		if r.Kind == string(types.RelationshipKindBatches) && r.ToID == "batchUsers" {
+			if r.Properties["via"] != "graphql_dataloader" {
+				t.Fatalf("BATCHES via = %q; want graphql_dataloader", r.Properties["via"])
+			}
+			foundBatches = true
+		}
+	}
+	if !foundBatches {
+		t.Logf("userLoader relationships:")
+		for _, r := range loader.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Fatal("expected BATCHES edge userLoader → batchUsers")
+	}
+
+	// 3. USES edge resolveAuthor → userLoader.
+	resolver := findByNameRel(ents, "resolveAuthor")
+	if resolver == nil {
+		t.Fatal("expected entity 'resolveAuthor' to be emitted")
+	}
+	foundUses := false
+	for _, r := range resolver.Relationships {
+		if r.Kind == string(types.RelationshipKindUses) && r.ToID == "userLoader" {
+			if r.Properties["via"] != "graphql_dataloader" {
+				t.Fatalf("USES via = %q; want graphql_dataloader", r.Properties["via"])
+			}
+			foundUses = true
+		}
+	}
+	if !foundUses {
+		t.Logf("resolveAuthor relationships:")
+		for _, r := range resolver.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Fatal("expected USES edge resolveAuthor → userLoader")
+	}
+}
+
+// TestTSExtractor_DataLoader_InlineArrowDelegation verifies that an inline
+// delegating arrow batch function is resolved through to the named function:
+//
+//	const postLoader = new DataLoader((ids) => batchPosts(ids))  → BATCHES batchPosts
+//
+// and that loadMany() also produces a USES edge.
+func TestTSExtractor_DataLoader_InlineArrowDelegation(t *testing.T) {
+	src := `
+import DataLoader from 'dataloader';
+
+function batchPosts(ids) { return ids; }
+
+const postLoader = new DataLoader((ids) => batchPosts(ids));
+
+export function resolvePosts(user) {
+  return postLoader.loadMany(user.postIds);
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	loader := findByNameRel(ents, "postLoader")
+	if loader == nil {
+		t.Fatal("expected SCOPE.DataLoader entity 'postLoader'")
+	}
+	foundBatches := false
+	for _, r := range loader.Relationships {
+		if r.Kind == string(types.RelationshipKindBatches) && r.ToID == "batchPosts" {
+			foundBatches = true
+		}
+	}
+	if !foundBatches {
+		t.Fatal("expected BATCHES edge postLoader → batchPosts (inline arrow delegation)")
+	}
+
+	resolver := findByNameRel(ents, "resolvePosts")
+	if resolver == nil {
+		t.Fatal("expected entity 'resolvePosts'")
+	}
+	foundUses := false
+	for _, r := range resolver.Relationships {
+		if r.Kind == string(types.RelationshipKindUses) && r.ToID == "postLoader" {
+			foundUses = true
+		}
+	}
+	if !foundUses {
+		t.Fatal("expected USES edge resolvePosts → postLoader (loadMany)")
+	}
+}
+
+// TestTSExtractor_DataLoader_ContextReceiver verifies the idiomatic GraphQL
+// resolver shape where loaders live on the context object:
+//
+//	(parent, args, context) => context.userLoader.load(parent.id)
+//
+// The trailing receiver property must still resolve to the known loader.
+func TestTSExtractor_DataLoader_ContextReceiver(t *testing.T) {
+	src := `
+import DataLoader from 'dataloader';
+
+function batchUsers(ids) { return ids; }
+
+const userLoader = new DataLoader(batchUsers);
+
+export function resolveOwner(parent, args, context) {
+  return context.userLoader.load(parent.ownerId);
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	resolver := findByNameRel(ents, "resolveOwner")
+	if resolver == nil {
+		t.Fatal("expected entity 'resolveOwner'")
+	}
+	foundUses := false
+	for _, r := range resolver.Relationships {
+		if r.Kind == string(types.RelationshipKindUses) && r.ToID == "userLoader" &&
+			r.Properties["via"] == "graphql_dataloader" {
+			foundUses = true
+		}
+	}
+	if !foundUses {
+		t.Logf("resolveOwner relationships:")
+		for _, r := range resolver.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Fatal("expected USES edge resolveOwner → userLoader (context receiver)")
+	}
+}
+
+// TestTSExtractor_DataLoader_NoImportNoEmit verifies the fast-path: a file that
+// constructs `new DataLoader(...)` WITHOUT importing the "dataloader" package
+// (some unrelated local class named DataLoader) must NOT emit a loader entity.
+func TestTSExtractor_DataLoader_NoImportNoEmit(t *testing.T) {
+	src := `
+class DataLoader { constructor(fn) {} }
+const x = new DataLoader(() => {});
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	for _, e := range ents {
+		if e.Kind == string(types.EntityKindDataLoader) {
+			t.Fatalf("did not expect a SCOPE.DataLoader entity without a dataloader import; got %q", e.Name)
+		}
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -138,6 +138,21 @@ const (
 	// on-disk graphs indexed before this release can still be read without
 	// a migration step. No extractor emits this kind after #1217.
 	HTTPEndpointKindLegacy EntityKind = "http_endpoint"
+
+	// #3624 (epic #3607): GraphQL DataLoader N+1 batch-loader topology.
+	// A DataLoader instance batches per-key fetches to avoid the N+1 query
+	// problem in GraphQL field resolvers. One entity per statically-named
+	// loader: a `new DataLoader(batchFn)` construction in JS/TS (the
+	// `dataloader` npm package) or a `DataLoader(load_fn=batch_fn)`
+	// construction in Python (the `aiodataloader` package used by
+	// Strawberry/Ariadne). The loader is named by the const/field/variable it
+	// is assigned to. Two edges connect it to the rest of the graph:
+	//   - RelationshipKindBatches : loader → batch function (the wrapped
+	//     per-key fetch function).
+	//   - RelationshipKindUses    : resolver → loader, emitted at each
+	//     `loader.load(id)` / `loader.loadMany(ids)` call site. This surfaces
+	//     which field resolver avoids N+1 via which batch loader.
+	EntityKindDataLoader EntityKind = "SCOPE.DataLoader"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -200,6 +215,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindCustomValidator,
 		// #3628 area #17:
 		EntityKindFeatureFlag,
+		// #3624 GraphQL DataLoader:
+		EntityKindDataLoader,
 	}
 }
 
@@ -366,6 +383,13 @@ const (
 	RelationshipKindStreamsTo         RelationshipKind = "STREAMS_TO"
 	RelationshipKindGraphQLSubscribes RelationshipKind = "GRAPHQL_SUBSCRIBES"
 	RelationshipKindGraphQLPublishes  RelationshipKind = "GRAPHQL_PUBLISHES"
+
+	// #3624 (epic #3607): GraphQL DataLoader N+1 batch wiring.
+	//   BATCHES : SCOPE.DataLoader → batch function (the wrapped per-key
+	//             fetch function that the loader coalesces calls into).
+	// The complementary resolver→loader edge reuses RelationshipKindUses
+	// ("USES"), emitted at each `loader.load(id)` call site.
+	RelationshipKindBatches RelationshipKind = "BATCHES"
 
 	// #728: Scheduled-job and webhook edges.
 	//   TRIGGERS : SCOPE.ScheduledJob → handler function/method
@@ -839,6 +863,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindStreamsTo,
 		RelationshipKindGraphQLSubscribes,
 		RelationshipKindGraphQLPublishes,
+		// #3624 GraphQL DataLoader:
+		RelationshipKindBatches,
 		// #728 scheduled jobs + webhooks:
 		RelationshipKindTriggers,
 		// #725 gRPC:


### PR DESCRIPTION
Closes #3624 (epic #3607).

## What

Captures the GraphQL **DataLoader N+1-avoidance wiring** in JS/TS and Python: which field resolver batches per-key loads via which loader, and which batch function each loader wraps.

## The loader/batch signal

New graph shape (cross-language consistent):

| Element | Meaning |
|---|---|
| `SCOPE.DataLoader` entity | one per **statically-named** loader, named by the const/field/var it is assigned to |
| `BATCHES` loader → batchFn | the wrapped per-key fetch function |
| `USES` resolver → loader | emitted at each `.load(id)` / `.loadMany(ids)` call site |

**JS/TS** (`internal/extractors/javascript/graphql_dataloader.go`) — `new DataLoader(batchUsers)` / `new DataLoader((ids) => batchPosts(ids))` from the `dataloader` npm package; `loader.load()/loadMany()` sites in any resolver body. Wired into the core JS extractor before `walk()`.

**Python** (`internal/custom/python/graphql_dataloader.go`) — aiodataloader `DataLoader(load_fn=batch_users)` / `DataLoader(batch_users)`; `<loader>.load(id)/.load_many(ids)` attributed to the nearest enclosing `def`. Auto-discovered via the `python_*` custom-extractor prefix.

**Kinds** (`internal/types/kinds.go`) — added `EntityKindDataLoader` (`SCOPE.DataLoader`) + `RelationshipKindBatches` (`BATCHES`); resolver→loader reuses `USES`.

## Asserted loader edge (value-asserting, not len>0)

- **JS**: `const userLoader = new DataLoader(batchUsers)` → loader `userLoader` **BATCHES** `batchUsers`; `userLoader.load(id)` in `resolveAuthor` → `resolveAuthor` **USES** `userLoader`.
- **Python**: `user_loader = DataLoader(load_fn=batch_users)` → **BATCHES** `batch_users`; `await user_loader.load(...)` in `author` → `author` resolver **USES** `user_loader`.

Plus inline-arrow delegation, context-receiver (`context.userLoader.load`), `loadMany`/`load_many`, and no-import fast-path negative cases.

## Honest-partial

Only statically-named loaders; lambda/inline batch fns get the loader entity but no BATCHES edge; dynamic/factory-built loaders are out of scope. Python uses a regex + nearest-enclosing-def heuristic.

## Records

`framework_specific` "DataLoader (N+1 batching)" cells added on `lang.jsts.framework.graphql-resolvers` and `lang.python.framework.ariadne`, citing the extractors. `coverage validate` 0 errors + canonical.

## Quality gates

- `go test ./internal/extractors/javascript/... ./internal/custom/python/... ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `gofmt -l` empty, `go vet` clean
- `coverage validate` 0 errors, `coverage fmt --check` canonical

## DEPLOY-DEFERRED

No daemon rebuild / reindex performed; this PR only adds extractor code + kinds + records. Live-daemon rebuild + reindex deferred to a coordinated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)