### PR TITLE
Redis key/channel/stream topology for C#, PHP, Ruby, Rust

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -7005,9 +7005,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/custom/csharp/redis.go"],
+            "issue": "3643",
+            "notes": "Key/channel/stream topology extracted from StackExchange.Redis: concrete keys, prefix globs (user:*) from string-concat and $\"…{}\" interpolation heads; READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Mirrors the Python template (#3668). Value-asserting tests in internal/custom/csharp/redis_test.go (literal key, concat prefix, interpolated prefix, publish/subscribe channel, stream add/read, dynamic-key negative).",
             "verified_at": "2026-06-02"
           }
         },
@@ -39638,9 +39639,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/custom/php/redis.go"],
+            "issue": "3643",
+            "notes": "Key/channel/stream topology extracted from predis/phpredis: concrete keys, prefix globs (user:*) from dot-concat and double-quoted interpolation heads (user:$id / user:{$id}); READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Mirrors the Python template (#3668). Value-asserting tests in internal/custom/php/redis_test.go (literal key, prefix glob, publish/subscribe channel, stream add/read, dynamic-key negative).",
             "verified_at": "2026-06-02"
           }
         },
@@ -50048,9 +50050,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/custom/ruby/redis.go"],
+            "issue": "3643",
+            "notes": "Key/channel/stream topology extracted from redis-rb: concrete keys, prefix globs (user:*) from plus-concat and double-quoted interpolation heads (user:#{id}); single-quoted literals are not interpolated (treated as concrete keys). READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Mirrors the Python template (#3668). Value-asserting tests in internal/custom/ruby/redis_test.go (literal key, concat/interpolated prefix glob, single-quote no-interp, publish/subscribe channel, stream add, dynamic-key negative).",
             "verified_at": "2026-06-02"
           }
         },
@@ -52719,9 +52722,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3643",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/custom/rust/redis.go"],
+            "issue": "3643",
+            "notes": "Key/channel/stream topology extracted from redis-rs (typed Commands trait con.get/set/publish/xadd + low-level cmd(\"VERB\").arg(\"key\") builder): concrete literal keys/channels/streams; READS_FROM/WRITES_TO/PUBLISHES_TO/SUBSCRIBES_TO edges to SCOPE.Datastore keyspace targets. Rust has no in-literal interpolation, so format!()/bare-var keys stay dynamic (honest-partial, no fabricated key). Mirrors the Python template (#3668). Value-asserting tests in internal/custom/rust/redis_test.go (literal key, turbofish, publish channel, stream add, cmd-builder GET/SET/PUBLISH, dynamic-key negative).",
             "verified_at": "2026-06-02"
           }
         },

--- a/internal/custom/csharp/redis.go
+++ b/internal/custom/csharp/redis.go
@@ -1,0 +1,297 @@
+package csharp
+
+// redis.go — StackExchange.Redis key/channel topology extractor
+// (#3625 epic, child of the Python template #3668).
+//
+// StackExchange.Redis is the dominant C# Redis client. A connected database
+// (IDatabase) exposes typed verbs whose FIRST argument is the RedisKey:
+//
+//	db.StringGet("session:abc")          -> READS_FROM key  "session:abc"
+//	db.StringSet("user:" + id, v)        -> WRITES_TO  key-prefix "user:*"
+//	db.HashGet("cfg:flags", f)           -> READS_FROM key  "cfg:flags"
+//	db.KeyDelete(k)                      -> op only (dynamic, honest-partial)
+//
+// Pub/Sub goes through the multiplexer's ISubscriber, keyed by a
+// RedisChannel first argument:
+//
+//	sub.Publish("events", payload)       -> PUBLISHES_TO channel "events"
+//	sub.Subscribe("events", handler)     -> SUBSCRIBES_TO channel "events"
+//
+// Streams use the Stream* verb family, keyed by a RedisKey stream name:
+//
+//	db.StreamAdd("orders", ...)          -> WRITES_TO stream "orders"
+//	db.StreamRead("orders", ...)         -> READS_FROM stream "orders"
+//
+// For each keyed op we emit a SCOPE.Datastore keyspace target node
+// (Name == "Datastore:redis:<label>", deduplicated per file) and an access
+// edge (READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO) from the
+// operation site to that target — mirroring the Python template (#3668) so the
+// data-access graph is cross-language consistent and traversable.
+//
+// Key topology (honest-partial for dynamic keys — no fabricated key):
+//
+//	"session:abc"            -> key  "session:abc"
+//	"user:" + id             -> key-prefix "user:*"   (string-concat head)
+//	$"session:{sid}"         -> key-prefix "session:*" (interpolated head)
+//	$"{tenant}:cfg" / k      -> dynamic (no static head, no key emitted)
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_redis", &redisExtractor{})
+}
+
+type redisExtractor struct{}
+
+func (e *redisExtractor) Language() string { return "custom_csharp_redis" }
+
+// csRedisKeyArg matches the first key/channel/stream argument literal. It
+// accepts a plain string literal "x" or an interpolated string $"x{...}".
+// Group offsets relative to the whole match: group 1 = verb, group 2 = the
+// `$` interpolation marker (or empty), group 3 = literal body.
+const csRedisKeyArg = `(\$?)"([^"]*)"`
+
+var (
+	// csRedisCacheRe — string/hash/list/set/sorted-set ops keyed by a RedisKey.
+	csRedisCacheRe = regexp.MustCompile(
+		`\.(StringGet|StringSet|StringGetSet|StringIncrement|StringDecrement|StringAppend|HashGet|HashGetAll|HashSet|HashDelete|HashIncrement|HashExists|KeyDelete|KeyExists|KeyExpire|KeyTimeToLive|KeyPersist|ListLeftPush|ListRightPush|ListLeftPop|ListRightPop|ListRange|ListLength|SetAdd|SetRemove|SetMembers|SetContains|SortedSetAdd|SortedSetRemove|SortedSetRangeByRank|SortedSetRangeByScore|SortedSetScore)\s*\(\s*` + csRedisKeyArg)
+	csRedisCacheAllRe = regexp.MustCompile(
+		`\.(StringGet|StringSet|StringGetSet|StringIncrement|StringDecrement|StringAppend|HashGet|HashGetAll|HashSet|HashDelete|HashIncrement|HashExists|KeyDelete|KeyExists|KeyExpire|KeyTimeToLive|KeyPersist|ListLeftPush|ListRightPush|ListLeftPop|ListRightPop|ListRange|ListLength|SetAdd|SetRemove|SetMembers|SetContains|SortedSetAdd|SortedSetRemove|SortedSetRangeByRank|SortedSetRangeByScore|SortedSetScore)\s*\(`)
+
+	csRedisPubSubRe = regexp.MustCompile(
+		`\.(Publish|Subscribe)\s*\(\s*` + csRedisKeyArg)
+	csRedisPubSubAllRe = regexp.MustCompile(
+		`\.(Publish|Subscribe)\s*\(`)
+
+	csRedisStreamRe = regexp.MustCompile(
+		`\.(StreamAdd|StreamRead|StreamReadGroup|StreamRange|StreamLength|StreamTrim|StreamDelete|StreamAcknowledge)\s*\(\s*` + csRedisKeyArg)
+	csRedisStreamAllRe = regexp.MustCompile(
+		`\.(StreamAdd|StreamRead|StreamReadGroup|StreamRange|StreamLength|StreamTrim|StreamDelete|StreamAcknowledge)\s*\(`)
+)
+
+// csRedisReadVerbs is the set of cache verbs that only read.
+var csRedisReadVerbs = map[string]bool{
+	"StringGet": true, "HashGet": true, "HashGetAll": true, "HashExists": true,
+	"KeyExists": true, "KeyTimeToLive": true, "ListRange": true, "ListLength": true,
+	"ListLeftPop": true, "ListRightPop": true, "SetMembers": true, "SetContains": true,
+	"SortedSetRangeByRank": true, "SortedSetRangeByScore": true, "SortedSetScore": true,
+}
+
+func csRedisCacheEdge(verb string) string {
+	if csRedisReadVerbs[verb] {
+		return string(types.RelationshipKindReadsFrom)
+	}
+	return string(types.RelationshipKindWritesTo)
+}
+
+func csRedisPubSubEdge(verb string) string {
+	if verb == "Subscribe" {
+		return string(types.RelationshipKindSubscribesTo)
+	}
+	return string(types.RelationshipKindPublishesTo)
+}
+
+func csRedisStreamEdge(verb string) string {
+	switch verb {
+	case "StreamAdd", "StreamTrim", "StreamDelete", "StreamAcknowledge":
+		return string(types.RelationshipKindWritesTo)
+	default:
+		return string(types.RelationshipKindReadsFrom)
+	}
+}
+
+func csRedisKeyspaceRef(label string) string {
+	return fmt.Sprintf("Datastore:redis:%s", label)
+}
+
+// csRedisAccess is the resolved key topology for one keyed op.
+type csRedisAccess struct {
+	key       string
+	keyPrefix string
+	dynamic   bool
+}
+
+// csNormaliseRedisKey resolves a captured (interp-marker, literal, after) into
+// a csRedisAccess. `after` is the source window immediately following the
+// literal, used to detect a `+`-concatenation prefix.
+func csNormaliseRedisKey(interp, literal, after string) csRedisAccess {
+	if interp == "$" {
+		if i := strings.IndexByte(literal, '{'); i >= 0 {
+			head := literal[:i]
+			if head == "" {
+				return csRedisAccess{dynamic: true}
+			}
+			return csRedisAccess{keyPrefix: head + "*"}
+		}
+		if literal == "" {
+			return csRedisAccess{dynamic: true}
+		}
+		return csRedisAccess{key: literal}
+	}
+	if literal == "" {
+		return csRedisAccess{dynamic: true}
+	}
+	if strings.HasPrefix(strings.TrimLeft(after, " \t"), "+") {
+		return csRedisAccess{keyPrefix: literal + "*"}
+	}
+	return csRedisAccess{key: literal}
+}
+
+// csKeyedRedisOp pairs a verb with its resolved key, keyed by line.
+type csKeyedRedisOp struct {
+	verb   string
+	access csRedisAccess
+}
+
+func csKeyedRedisOps(src string, re *regexp.Regexp) map[int]csKeyedRedisOp {
+	res := make(map[int]csKeyedRedisOp)
+	for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+		// groups: 0-1 full, 2-3 verb, 4-5 interp, 6-7 literal
+		if len(m) < 8 {
+			continue
+		}
+		line := lineOf(src, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb := src[m[2]:m[3]]
+		interp := ""
+		if m[4] >= 0 {
+			interp = src[m[4]:m[5]]
+		}
+		literal := ""
+		if m[6] >= 0 {
+			literal = src[m[6]:m[7]]
+		}
+		after := ""
+		if m[1] < len(src) {
+			end := m[1] + 8
+			if end > len(src) {
+				end = len(src)
+			}
+			after = src[m[1]:end]
+		}
+		res[line] = csKeyedRedisOp{verb: verb, access: csNormaliseRedisKey(interp, literal, after)}
+	}
+	return res
+}
+
+// csRedisLabel writes the key/channel/stream prop and returns the keyspace
+// label, or "" when fully dynamic (honest-partial — no fabricated key).
+func csRedisLabel(e *types.EntityRecord, a csRedisAccess, keyProp, prefixProp string) string {
+	switch {
+	case a.key != "":
+		setProps(e, keyProp, a.key)
+		return a.key
+	case a.keyPrefix != "":
+		setProps(e, prefixProp, a.keyPrefix)
+		return a.keyPrefix
+	default:
+		setProps(e, keyProp, "<dynamic>", "dynamic", "true")
+		return ""
+	}
+}
+
+func (e *redisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.csharp_redis")
+	_, span := tracer.Start(ctx, "custom.csharp_redis")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Cheap pre-filter: only run the regexes on files that look Redis-ish.
+	// StackExchange.Redis verbs are PascalCase and namespaced (String*/Hash*/
+	// Stream*/Publish/Subscribe), distinctive enough to gate on.
+	if !strings.Contains(src, "Redis") && !strings.Contains(src, ".String") &&
+		!strings.Contains(src, ".Hash") && !strings.Contains(src, ".Stream") &&
+		!strings.Contains(src, ".Publish") && !strings.Contains(src, ".Subscribe") &&
+		!strings.Contains(src, ".Key") && !strings.Contains(src, ".List") &&
+		!strings.Contains(src, ".Set") && !strings.Contains(src, ".Sorted") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenKeyspace := make(map[string]bool)
+	seenLine := map[string]map[int]bool{}
+	getSeen := func(cat string) map[int]bool {
+		if seenLine[cat] == nil {
+			seenLine[cat] = map[int]bool{}
+		}
+		return seenLine[cat]
+	}
+
+	emitKeyspace := func(label, keyType string, line int) string {
+		ref := csRedisKeyspaceRef(label)
+		if !seenKeyspace[ref] {
+			seenKeyspace[ref] = true
+			ent := makeEntity(ref, "SCOPE.Datastore", keyType, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", "keyspace",
+				"keyspace", label, "key_type", keyType)
+			out = append(out, ent)
+		}
+		return ref
+	}
+
+	scan := func(allRe, keyRe *regexp.Regexp, cat, subtype, idPrefix string,
+		edgeFor func(string) string, keyProp, prefixProp, edgeLabel string) {
+		keyed := csKeyedRedisOps(src, keyRe)
+		for _, m := range allRe.FindAllStringSubmatchIndex(src, -1) {
+			line := lineOf(src, m[0])
+			seen := getSeen(cat)
+			if seen[line] {
+				continue
+			}
+			seen[line] = true
+			ent := makeEntity(fmt.Sprintf("%s:%s:%d", idPrefix, file.Path, line),
+				"SCOPE.Operation", subtype, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", subtype)
+			if op, ok := keyed[line]; ok {
+				label := csRedisLabel(&ent, op.access, keyProp, prefixProp)
+				if label != "" {
+					keyType := keyProp
+					if op.access.keyPrefix != "" {
+						keyType = prefixProp
+					}
+					ref := emitKeyspace(label, keyType, line)
+					ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+						ToID: ref,
+						Kind: edgeFor(op.verb),
+						Properties: map[string]string{
+							"framework": "redis", "op": op.verb, edgeLabel: label,
+						},
+					})
+				}
+			} else {
+				// Op matched the keyed-verb form but no static key literal could
+				// be resolved (fully-dynamic key) — honest-partial: emit the op
+				// site flagged dynamic, with NO fabricated keyspace/edge.
+				setProps(&ent, keyProp, "<dynamic>", "dynamic", "true")
+			}
+			out = append(out, ent)
+		}
+	}
+
+	scan(csRedisCacheAllRe, csRedisCacheRe, "cache", "cache_op", "redis_cache",
+		csRedisCacheEdge, "key", "key_prefix", "keyspace")
+	scan(csRedisPubSubAllRe, csRedisPubSubRe, "pubsub", "pubsub", "redis_pubsub",
+		csRedisPubSubEdge, "channel", "channel_prefix", "channel")
+	scan(csRedisStreamAllRe, csRedisStreamRe, "stream", "stream_op", "redis_stream",
+		csRedisStreamEdge, "stream", "stream_prefix", "stream")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/csharp/redis_test.go
+++ b/internal/custom/csharp/redis_test.go
@@ -1,0 +1,152 @@
+package csharp_test
+
+// redis_test.go — value-asserting tests for the custom_csharp_redis extractor
+// (StackExchange.Redis key/channel/stream topology; #3625 epic).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runCSharpRedis(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_csharp_redis")
+	if !ok {
+		t.Fatal("custom_csharp_redis not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "Cache.cs", Language: "csharp", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findRedisEdge(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func findKeyspaceEntity(ents []types.EntityRecord, ref string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == ref && ents[i].Kind == "SCOPE.Datastore" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestCSharpRedis_StringGet_ReadsFromLiteralKey(t *testing.T) {
+	ents := runCSharpRedis(t, `var v = db.StringGet("session:abc");`)
+	ref := "Datastore:redis:session:abc"
+	if findKeyspaceEntity(ents, ref) == nil {
+		t.Fatalf("expected keyspace entity %q", ref)
+	}
+	rel := findRedisEdge(ents, "READS_FROM", ref)
+	if rel == nil {
+		t.Fatalf("expected READS_FROM edge to %q", ref)
+	}
+	if rel.Properties["keyspace"] != "session:abc" {
+		t.Errorf("keyspace prop = %q, want session:abc", rel.Properties["keyspace"])
+	}
+}
+
+func TestCSharpRedis_StringSet_WritesToLiteralKey(t *testing.T) {
+	ents := runCSharpRedis(t, `db.StringSet("user:42", payload);`)
+	ref := "Datastore:redis:user:42"
+	if findRedisEdge(ents, "WRITES_TO", ref) == nil {
+		t.Fatalf("expected WRITES_TO edge to %q", ref)
+	}
+}
+
+func TestCSharpRedis_StringSet_ConcatPrefixGlob(t *testing.T) {
+	ents := runCSharpRedis(t, `db.StringSet("user:" + id, payload);`)
+	ref := "Datastore:redis:user:*"
+	if findRedisEdge(ents, "WRITES_TO", ref) == nil {
+		t.Fatalf("expected WRITES_TO edge to prefix glob %q", ref)
+	}
+	ks := findKeyspaceEntity(ents, ref)
+	if ks == nil || ks.Subtype != "key_prefix" {
+		t.Fatalf("expected key_prefix keyspace %q, got %+v", ref, ks)
+	}
+}
+
+func TestCSharpRedis_InterpolatedPrefixGlob(t *testing.T) {
+	ents := runCSharpRedis(t, `var v = db.StringGet($"session:{sid}");`)
+	ref := "Datastore:redis:session:*"
+	if findRedisEdge(ents, "READS_FROM", ref) == nil {
+		t.Fatalf("expected READS_FROM edge to prefix glob %q", ref)
+	}
+}
+
+func TestCSharpRedis_Publish_PublishesToChannel(t *testing.T) {
+	ents := runCSharpRedis(t, `sub.Publish("events", payload);`)
+	ref := "Datastore:redis:events"
+	rel := findRedisEdge(ents, "PUBLISHES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected PUBLISHES_TO edge to channel %q", ref)
+	}
+	if rel.Properties["channel"] != "events" {
+		t.Errorf("channel prop = %q, want events", rel.Properties["channel"])
+	}
+}
+
+func TestCSharpRedis_Subscribe_SubscribesToChannel(t *testing.T) {
+	ents := runCSharpRedis(t, `sub.Subscribe("events", handler);`)
+	if findRedisEdge(ents, "SUBSCRIBES_TO", "Datastore:redis:events") == nil {
+		t.Fatal("expected SUBSCRIBES_TO edge to channel events")
+	}
+}
+
+func TestCSharpRedis_StreamAdd_WritesToStream(t *testing.T) {
+	ents := runCSharpRedis(t, `db.StreamAdd("orders", values);`)
+	ref := "Datastore:redis:orders"
+	rel := findRedisEdge(ents, "WRITES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected WRITES_TO edge to stream %q", ref)
+	}
+	if rel.Properties["stream"] != "orders" {
+		t.Errorf("stream prop = %q, want orders", rel.Properties["stream"])
+	}
+}
+
+func TestCSharpRedis_StreamRead_ReadsFromStream(t *testing.T) {
+	ents := runCSharpRedis(t, `var r = db.StreamRead("orders", "0");`)
+	if findRedisEdge(ents, "READS_FROM", "Datastore:redis:orders") == nil {
+		t.Fatal("expected READS_FROM edge to stream orders")
+	}
+}
+
+func TestCSharpRedis_DynamicKey_NoFabricatedKey(t *testing.T) {
+	ents := runCSharpRedis(t, `var v = db.StringGet(dynamicKey);`)
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected NO keyspace entity for dynamic key, got %q", ents[i].Name)
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "READS_FROM" || r.Kind == "WRITES_TO" {
+				t.Fatalf("expected NO access edge for dynamic key, got %s -> %s", r.Kind, r.ToID)
+			}
+		}
+	}
+	// The op site itself is still emitted (honest-partial), flagged dynamic.
+	var found bool
+	for i := range ents {
+		if ents[i].Subtype == "cache_op" && ents[i].Properties["dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a dynamic-flagged cache_op site")
+	}
+}

--- a/internal/custom/php/redis.go
+++ b/internal/custom/php/redis.go
@@ -1,0 +1,285 @@
+package php
+
+// redis.go — predis / phpredis key/channel/stream topology extractor
+// (#3625 epic, child of the Python template #3668).
+//
+// Both predis and the phpredis C-extension expose lowercase command verbs on a
+// client object whose FIRST argument is the key / channel / stream:
+//
+//	$redis->get("session:abc")        -> READS_FROM key  "session:abc"
+//	$redis->set("user:".$id, $v)      -> WRITES_TO  key-prefix "user:*"
+//	$redis->hget("cfg:flags", $f)     -> READS_FROM key  "cfg:flags"
+//	$redis->del($k)                   -> op only (dynamic, honest-partial)
+//	$redis->publish("events", $p)     -> PUBLISHES_TO channel "events"
+//	$redis->subscribe(["events"], $h) -> SUBSCRIBES_TO channel "events"
+//	$redis->xadd("orders", ...)       -> WRITES_TO  stream "orders"
+//	$redis->xread(...)                -> READS_FROM stream "orders"
+//
+// For each keyed op we emit a SCOPE.Datastore keyspace target node
+// (Name == "Datastore:redis:<label>", deduplicated per file) and an access
+// edge (READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO) from the op site
+// to that target — mirroring the Python template (#3668).
+//
+// Key topology (honest-partial for dynamic keys — no fabricated key):
+//
+//	"session:abc" / 'session:abc'  -> key  "session:abc"
+//	"user:".$id                    -> key-prefix "user:*"  (`.`-concat head)
+//	"user:$id" / "user:{$id}"      -> key-prefix "user:*"  (interp head)
+//	"$tenant:cfg" / $k             -> dynamic (no static head, no key emitted)
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_php_redis", &phpRedisExtractor{})
+}
+
+type phpRedisExtractor struct{}
+
+func (e *phpRedisExtractor) Language() string { return "custom_php_redis" }
+
+// phpRedisKeyArg matches the first key argument literal: a single- or
+// double-quoted string (optionally inside a `[` for subscribe array arg).
+// Group 1 = verb, group 2 = quote char, group 3 = literal body.
+const phpRedisKeyArg = `\[?\s*(["'])([^"']*)["']`
+
+var (
+	phpRedisCacheRe = regexp.MustCompile(
+		`->(get|set|setex|setnx|getset|mget|mset|hget|hgetall|hset|hmget|hmset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|incrby|decrby|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*\(\s*` + phpRedisKeyArg)
+	phpRedisCacheAllRe = regexp.MustCompile(
+		`->(get|set|setex|setnx|getset|mget|mset|hget|hgetall|hset|hmget|hmset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|incrby|decrby|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*\(`)
+
+	phpRedisPubSubRe = regexp.MustCompile(
+		`->(publish|subscribe|psubscribe)\s*\(\s*` + phpRedisKeyArg)
+	phpRedisPubSubAllRe = regexp.MustCompile(
+		`->(publish|subscribe|psubscribe)\s*\(`)
+
+	phpRedisStreamRe = regexp.MustCompile(
+		`(?i)->(xadd|xread|xreadgroup|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*\(\s*` + phpRedisKeyArg)
+	phpRedisStreamAllRe = regexp.MustCompile(
+		`(?i)->(xadd|xread|xreadgroup|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*\(`)
+)
+
+var phpRedisReadVerbs = map[string]bool{
+	"get": true, "hget": true, "hgetall": true, "hmget": true, "hexists": true,
+	"getset": true, "mget": true, "ttl": true, "pttl": true, "exists": true,
+	"lrange": true, "llen": true, "smembers": true, "sismember": true,
+	"zrange": true, "zrangebyscore": true, "zscore": true, "lpop": true, "rpop": true,
+}
+
+func phpRedisCacheEdge(verb string) string {
+	if phpRedisReadVerbs[strings.ToLower(verb)] {
+		return string(types.RelationshipKindReadsFrom)
+	}
+	return string(types.RelationshipKindWritesTo)
+}
+
+func phpRedisPubSubEdge(verb string) string {
+	v := strings.ToLower(verb)
+	if strings.HasPrefix(v, "sub") || strings.HasPrefix(v, "psub") {
+		return string(types.RelationshipKindSubscribesTo)
+	}
+	return string(types.RelationshipKindPublishesTo)
+}
+
+func phpRedisStreamEdge(verb string) string {
+	switch strings.ToLower(verb) {
+	case "xadd", "xtrim", "xdel", "xack":
+		return string(types.RelationshipKindWritesTo)
+	default:
+		return string(types.RelationshipKindReadsFrom)
+	}
+}
+
+func phpRedisKeyspaceRef(label string) string {
+	return fmt.Sprintf("Datastore:redis:%s", label)
+}
+
+type phpRedisAccess struct {
+	key       string
+	keyPrefix string
+	dynamic   bool
+}
+
+// phpNormaliseRedisKey resolves a captured (quote, literal, after) into a
+// phpRedisAccess. Single-quoted strings do NOT interpolate in PHP, so only
+// double-quoted literals are checked for `$` interpolation; `after` detects a
+// `.`-concatenation prefix.
+func phpNormaliseRedisKey(quote, literal, after string) phpRedisAccess {
+	if quote == `"` {
+		// Double-quoted: `$var` or `{$var}` interpolates. Take static head.
+		if i := phpInterpIndex(literal); i >= 0 {
+			head := literal[:i]
+			if head == "" {
+				return phpRedisAccess{dynamic: true}
+			}
+			return phpRedisAccess{keyPrefix: head + "*"}
+		}
+	}
+	if literal == "" {
+		return phpRedisAccess{dynamic: true}
+	}
+	if strings.HasPrefix(strings.TrimLeft(after, " \t"), ".") {
+		return phpRedisAccess{keyPrefix: literal + "*"}
+	}
+	return phpRedisAccess{key: literal}
+}
+
+// phpInterpIndex returns the index of the first interpolation marker (`$` or
+// `{$`) in a double-quoted literal body, or -1 if none.
+func phpInterpIndex(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '$' {
+			return i
+		}
+		if s[i] == '{' && i+1 < len(s) && s[i+1] == '$' {
+			return i
+		}
+	}
+	return -1
+}
+
+type phpKeyedRedisOp struct {
+	verb   string
+	access phpRedisAccess
+}
+
+func phpKeyedRedisOps(src string, re *regexp.Regexp) map[int]phpKeyedRedisOp {
+	res := make(map[int]phpKeyedRedisOp)
+	for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+		// groups: 0-1 full, 2-3 verb, 4-5 quote, 6-7 literal
+		if len(m) < 8 {
+			continue
+		}
+		line := lineOf(src, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb := src[m[2]:m[3]]
+		quote := src[m[4]:m[5]]
+		literal := ""
+		if m[6] >= 0 {
+			literal = src[m[6]:m[7]]
+		}
+		after := ""
+		if m[1] < len(src) {
+			end := m[1] + 8
+			if end > len(src) {
+				end = len(src)
+			}
+			after = src[m[1]:end]
+		}
+		res[line] = phpKeyedRedisOp{verb: verb, access: phpNormaliseRedisKey(quote, literal, after)}
+	}
+	return res
+}
+
+func phpRedisLabel(e *types.EntityRecord, a phpRedisAccess, keyProp, prefixProp string) string {
+	switch {
+	case a.key != "":
+		setProps(e, keyProp, a.key)
+		return a.key
+	case a.keyPrefix != "":
+		setProps(e, prefixProp, a.keyPrefix)
+		return a.keyPrefix
+	default:
+		setProps(e, keyProp, "<dynamic>", "dynamic", "true")
+		return ""
+	}
+}
+
+func (e *phpRedisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.php_redis")
+	_, span := tracer.Start(ctx, "custom.php_redis")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "Redis") && !strings.Contains(src, "redis") &&
+		!strings.Contains(src, "predis") && !strings.Contains(src, "Predis") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenKeyspace := make(map[string]bool)
+	seenLine := map[string]map[int]bool{}
+	getSeen := func(cat string) map[int]bool {
+		if seenLine[cat] == nil {
+			seenLine[cat] = map[int]bool{}
+		}
+		return seenLine[cat]
+	}
+
+	emitKeyspace := func(label, keyType string, line int) string {
+		ref := phpRedisKeyspaceRef(label)
+		if !seenKeyspace[ref] {
+			seenKeyspace[ref] = true
+			ent := makeEntity(ref, "SCOPE.Datastore", keyType, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", "keyspace",
+				"keyspace", label, "key_type", keyType)
+			out = append(out, ent)
+		}
+		return ref
+	}
+
+	scan := func(allRe, keyRe *regexp.Regexp, cat, subtype, idPrefix string,
+		edgeFor func(string) string, keyProp, prefixProp, edgeLabel string) {
+		keyed := phpKeyedRedisOps(src, keyRe)
+		for _, m := range allRe.FindAllStringSubmatchIndex(src, -1) {
+			line := lineOf(src, m[0])
+			seen := getSeen(cat)
+			if seen[line] {
+				continue
+			}
+			seen[line] = true
+			ent := makeEntity(fmt.Sprintf("%s:%s:%d", idPrefix, file.Path, line),
+				"SCOPE.Operation", subtype, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", subtype)
+			if op, ok := keyed[line]; ok {
+				label := phpRedisLabel(&ent, op.access, keyProp, prefixProp)
+				if label != "" {
+					keyType := keyProp
+					if op.access.keyPrefix != "" {
+						keyType = prefixProp
+					}
+					ref := emitKeyspace(label, keyType, line)
+					ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+						ToID: ref,
+						Kind: edgeFor(op.verb),
+						Properties: map[string]string{
+							"framework": "redis", "op": strings.ToLower(op.verb), edgeLabel: label,
+						},
+					})
+				}
+			} else {
+				// Fully-dynamic key — honest-partial: op site flagged dynamic,
+				// no fabricated keyspace/edge.
+				setProps(&ent, keyProp, "<dynamic>", "dynamic", "true")
+			}
+			out = append(out, ent)
+		}
+	}
+
+	scan(phpRedisCacheAllRe, phpRedisCacheRe, "cache", "cache_op", "redis_cache",
+		phpRedisCacheEdge, "key", "key_prefix", "keyspace")
+	scan(phpRedisPubSubAllRe, phpRedisPubSubRe, "pubsub", "pubsub", "redis_pubsub",
+		phpRedisPubSubEdge, "channel", "channel_prefix", "channel")
+	scan(phpRedisStreamAllRe, phpRedisStreamRe, "stream", "stream_op", "redis_stream",
+		phpRedisStreamEdge, "stream", "stream_prefix", "stream")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/php/redis_test.go
+++ b/internal/custom/php/redis_test.go
@@ -1,0 +1,149 @@
+package php_test
+
+// redis_test.go — value-asserting tests for the custom_php_redis extractor
+// (predis / phpredis key/channel/stream topology; #3625 epic).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runPHPRedis(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_php_redis")
+	if !ok {
+		t.Fatal("custom_php_redis not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "Cache.php", Language: "php", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findPHPRedisEdge(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func findPHPKeyspace(ents []types.EntityRecord, ref string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == ref && ents[i].Kind == "SCOPE.Datastore" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestPHPRedis_Get_ReadsFromLiteralKey(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $v = $redis->get("session:abc");`)
+	ref := "Datastore:redis:session:abc"
+	if findPHPKeyspace(ents, ref) == nil {
+		t.Fatalf("expected keyspace entity %q", ref)
+	}
+	rel := findPHPRedisEdge(ents, "READS_FROM", ref)
+	if rel == nil {
+		t.Fatalf("expected READS_FROM edge to %q", ref)
+	}
+	if rel.Properties["keyspace"] != "session:abc" {
+		t.Errorf("keyspace prop = %q, want session:abc", rel.Properties["keyspace"])
+	}
+}
+
+func TestPHPRedis_Get_SingleQuoteKey(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $v = $redis->get('cfg:flags');`)
+	if findPHPRedisEdge(ents, "READS_FROM", "Datastore:redis:cfg:flags") == nil {
+		t.Fatal("expected READS_FROM edge to cfg:flags")
+	}
+}
+
+func TestPHPRedis_Set_WritesToLiteralKey(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->set("user:42", $payload);`)
+	if findPHPRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:42") == nil {
+		t.Fatal("expected WRITES_TO edge to user:42")
+	}
+}
+
+func TestPHPRedis_Set_ConcatPrefixGlob(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->set("user:" . $id, $payload);`)
+	ref := "Datastore:redis:user:*"
+	if findPHPRedisEdge(ents, "WRITES_TO", ref) == nil {
+		t.Fatalf("expected WRITES_TO edge to prefix glob %q", ref)
+	}
+	ks := findPHPKeyspace(ents, ref)
+	if ks == nil || ks.Subtype != "key_prefix" {
+		t.Fatalf("expected key_prefix keyspace %q, got %+v", ref, ks)
+	}
+}
+
+func TestPHPRedis_Set_InterpolatedPrefixGlob(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->set("user:$id", $payload);`)
+	if findPHPRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:*") == nil {
+		t.Fatal("expected WRITES_TO edge to user:* (interpolated)")
+	}
+}
+
+func TestPHPRedis_Publish_PublishesToChannel(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->publish("events", $payload);`)
+	ref := "Datastore:redis:events"
+	rel := findPHPRedisEdge(ents, "PUBLISHES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected PUBLISHES_TO edge to channel %q", ref)
+	}
+	if rel.Properties["channel"] != "events" {
+		t.Errorf("channel prop = %q, want events", rel.Properties["channel"])
+	}
+}
+
+func TestPHPRedis_Subscribe_SubscribesToChannel(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->subscribe(["events"], $cb);`)
+	if findPHPRedisEdge(ents, "SUBSCRIBES_TO", "Datastore:redis:events") == nil {
+		t.Fatal("expected SUBSCRIBES_TO edge to channel events")
+	}
+}
+
+func TestPHPRedis_Xadd_WritesToStream(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $redis->xadd("orders", "*", $fields);`)
+	ref := "Datastore:redis:orders"
+	rel := findPHPRedisEdge(ents, "WRITES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected WRITES_TO edge to stream %q", ref)
+	}
+	if rel.Properties["stream"] != "orders" {
+		t.Errorf("stream prop = %q, want orders", rel.Properties["stream"])
+	}
+}
+
+func TestPHPRedis_DynamicKey_NoFabricatedKey(t *testing.T) {
+	ents := runPHPRedis(t, `<?php $v = $redis->get($key);`)
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected NO keyspace entity for dynamic key, got %q", ents[i].Name)
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "READS_FROM" || r.Kind == "WRITES_TO" {
+				t.Fatalf("expected NO access edge for dynamic key, got %s -> %s", r.Kind, r.ToID)
+			}
+		}
+	}
+	var found bool
+	for i := range ents {
+		if ents[i].Subtype == "cache_op" && ents[i].Properties["dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a dynamic-flagged cache_op site")
+	}
+}

--- a/internal/custom/ruby/redis.go
+++ b/internal/custom/ruby/redis.go
@@ -1,0 +1,268 @@
+package ruby
+
+// redis.go — redis-rb key/channel/stream topology extractor
+// (#3625 epic, child of the Python template #3668).
+//
+// redis-rb exposes lowercase command verbs on a Redis client whose FIRST
+// argument is the key / channel / stream:
+//
+//	redis.get("session:abc")        -> READS_FROM key  "session:abc"
+//	redis.set("user:" + id, v)      -> WRITES_TO  key-prefix "user:*"
+//	redis.hget("cfg:flags", f)      -> READS_FROM key  "cfg:flags"
+//	redis.del(k)                    -> op only (dynamic, honest-partial)
+//	redis.publish("events", p)      -> PUBLISHES_TO channel "events"
+//	redis.subscribe("events")       -> SUBSCRIBES_TO channel "events"
+//	redis.xadd("orders", ...)       -> WRITES_TO  stream "orders"
+//	redis.xread("orders", ...)      -> READS_FROM stream "orders"
+//
+// For each keyed op we emit a SCOPE.Datastore keyspace target node
+// (Name == "Datastore:redis:<label>", deduplicated per file) and an access
+// edge (READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO) from the op site
+// to that target — mirroring the Python template (#3668).
+//
+// Key topology (honest-partial for dynamic keys — no fabricated key):
+//
+//	"session:abc" / 'session:abc'  -> key  "session:abc"
+//	"user:" + id                   -> key-prefix "user:*"  (`+`-concat head)
+//	"user:#{id}"                   -> key-prefix "user:*"  (interp head)
+//	"#{tenant}:cfg" / k            -> dynamic (no static head, no key emitted)
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_ruby_redis", &rubyRedisExtractor{})
+}
+
+type rubyRedisExtractor struct{}
+
+func (e *rubyRedisExtractor) Language() string { return "custom_ruby_redis" }
+
+// rubyRedisKeyArg matches the first key argument literal. Group 1 = verb,
+// group 2 = quote char, group 3 = literal body (a `#{` interpolation marker may
+// appear inside a double-quoted body and is captured up to the closing quote).
+const rubyRedisKeyArg = `(["'])((?:[^"'\\]|\\.)*?)["']`
+
+var (
+	rubyRedisCacheRe = regexp.MustCompile(
+		`\.(get|set|setex|setnx|getset|mget|mset|hget|hgetall|hset|hmget|hmset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|incrby|decrby|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*\(\s*` + rubyRedisKeyArg)
+	rubyRedisCacheAllRe = regexp.MustCompile(
+		`\.(get|set|setex|setnx|getset|mget|mset|hget|hgetall|hset|hmget|hmset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|incrby|decrby|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*\(`)
+
+	rubyRedisPubSubRe = regexp.MustCompile(
+		`\.(publish|subscribe|psubscribe)\s*\(\s*` + rubyRedisKeyArg)
+	rubyRedisPubSubAllRe = regexp.MustCompile(
+		`\.(publish|subscribe|psubscribe)\s*\(`)
+
+	rubyRedisStreamRe = regexp.MustCompile(
+		`\.(xadd|xread|xreadgroup|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*\(\s*` + rubyRedisKeyArg)
+	rubyRedisStreamAllRe = regexp.MustCompile(
+		`\.(xadd|xread|xreadgroup|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*\(`)
+)
+
+var rubyRedisReadVerbs = map[string]bool{
+	"get": true, "hget": true, "hgetall": true, "hmget": true, "hexists": true,
+	"getset": true, "mget": true, "ttl": true, "pttl": true, "exists": true,
+	"lrange": true, "llen": true, "smembers": true, "sismember": true,
+	"zrange": true, "zrangebyscore": true, "zscore": true, "lpop": true, "rpop": true,
+}
+
+func rubyRedisCacheEdge(verb string) string {
+	if rubyRedisReadVerbs[verb] {
+		return string(types.RelationshipKindReadsFrom)
+	}
+	return string(types.RelationshipKindWritesTo)
+}
+
+func rubyRedisPubSubEdge(verb string) string {
+	if strings.HasPrefix(verb, "sub") || strings.HasPrefix(verb, "psub") {
+		return string(types.RelationshipKindSubscribesTo)
+	}
+	return string(types.RelationshipKindPublishesTo)
+}
+
+func rubyRedisStreamEdge(verb string) string {
+	switch verb {
+	case "xadd", "xtrim", "xdel", "xack":
+		return string(types.RelationshipKindWritesTo)
+	default:
+		return string(types.RelationshipKindReadsFrom)
+	}
+}
+
+func rubyRedisKeyspaceRef(label string) string {
+	return fmt.Sprintf("Datastore:redis:%s", label)
+}
+
+type rubyRedisAccess struct {
+	key       string
+	keyPrefix string
+	dynamic   bool
+}
+
+// rubyNormaliseRedisKey resolves a captured (quote, literal, after) into a
+// rubyRedisAccess. Single-quoted strings do NOT interpolate in Ruby, so only
+// double-quoted literals are scanned for a `#{` marker; `after` detects a
+// `+`-concatenation prefix.
+func rubyNormaliseRedisKey(quote, literal, after string) rubyRedisAccess {
+	if quote == `"` {
+		if i := strings.Index(literal, "#{"); i >= 0 {
+			head := literal[:i]
+			if head == "" {
+				return rubyRedisAccess{dynamic: true}
+			}
+			return rubyRedisAccess{keyPrefix: head + "*"}
+		}
+	}
+	if literal == "" {
+		return rubyRedisAccess{dynamic: true}
+	}
+	if strings.HasPrefix(strings.TrimLeft(after, " \t"), "+") {
+		return rubyRedisAccess{keyPrefix: literal + "*"}
+	}
+	return rubyRedisAccess{key: literal}
+}
+
+type rubyKeyedRedisOp struct {
+	verb   string
+	access rubyRedisAccess
+}
+
+func rubyKeyedRedisOps(src string, re *regexp.Regexp) map[int]rubyKeyedRedisOp {
+	res := make(map[int]rubyKeyedRedisOp)
+	for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+		// groups: 0-1 full, 2-3 verb, 4-5 quote, 6-7 literal
+		if len(m) < 8 {
+			continue
+		}
+		line := lineOf(src, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb := src[m[2]:m[3]]
+		quote := src[m[4]:m[5]]
+		literal := ""
+		if m[6] >= 0 {
+			literal = src[m[6]:m[7]]
+		}
+		after := ""
+		if m[1] < len(src) {
+			end := m[1] + 8
+			if end > len(src) {
+				end = len(src)
+			}
+			after = src[m[1]:end]
+		}
+		res[line] = rubyKeyedRedisOp{verb: verb, access: rubyNormaliseRedisKey(quote, literal, after)}
+	}
+	return res
+}
+
+func rubyRedisLabel(e *types.EntityRecord, a rubyRedisAccess, keyProp, prefixProp string) string {
+	switch {
+	case a.key != "":
+		setProps(e, keyProp, a.key)
+		return a.key
+	case a.keyPrefix != "":
+		setProps(e, prefixProp, a.keyPrefix)
+		return a.keyPrefix
+	default:
+		setProps(e, keyProp, "<dynamic>", "dynamic", "true")
+		return ""
+	}
+}
+
+func (e *rubyRedisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.ruby_redis")
+	_, span := tracer.Start(ctx, "custom.ruby_redis")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "redis") && !strings.Contains(src, "Redis") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenKeyspace := make(map[string]bool)
+	seenLine := map[string]map[int]bool{}
+	getSeen := func(cat string) map[int]bool {
+		if seenLine[cat] == nil {
+			seenLine[cat] = map[int]bool{}
+		}
+		return seenLine[cat]
+	}
+
+	emitKeyspace := func(label, keyType string, line int) string {
+		ref := rubyRedisKeyspaceRef(label)
+		if !seenKeyspace[ref] {
+			seenKeyspace[ref] = true
+			ent := makeEntity(ref, "SCOPE.Datastore", keyType, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", "keyspace",
+				"keyspace", label, "key_type", keyType)
+			out = append(out, ent)
+		}
+		return ref
+	}
+
+	scan := func(allRe, keyRe *regexp.Regexp, cat, subtype, idPrefix string,
+		edgeFor func(string) string, keyProp, prefixProp, edgeLabel string) {
+		keyed := rubyKeyedRedisOps(src, keyRe)
+		for _, m := range allRe.FindAllStringSubmatchIndex(src, -1) {
+			line := lineOf(src, m[0])
+			seen := getSeen(cat)
+			if seen[line] {
+				continue
+			}
+			seen[line] = true
+			ent := makeEntity(fmt.Sprintf("%s:%s:%d", idPrefix, file.Path, line),
+				"SCOPE.Operation", subtype, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", subtype)
+			if op, ok := keyed[line]; ok {
+				label := rubyRedisLabel(&ent, op.access, keyProp, prefixProp)
+				if label != "" {
+					keyType := keyProp
+					if op.access.keyPrefix != "" {
+						keyType = prefixProp
+					}
+					ref := emitKeyspace(label, keyType, line)
+					ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+						ToID: ref,
+						Kind: edgeFor(op.verb),
+						Properties: map[string]string{
+							"framework": "redis", "op": op.verb, edgeLabel: label,
+						},
+					})
+				}
+			} else {
+				// Fully-dynamic key — honest-partial: op site flagged dynamic,
+				// no fabricated keyspace/edge.
+				setProps(&ent, keyProp, "<dynamic>", "dynamic", "true")
+			}
+			out = append(out, ent)
+		}
+	}
+
+	scan(rubyRedisCacheAllRe, rubyRedisCacheRe, "cache", "cache_op", "redis_cache",
+		rubyRedisCacheEdge, "key", "key_prefix", "keyspace")
+	scan(rubyRedisPubSubAllRe, rubyRedisPubSubRe, "pubsub", "pubsub", "redis_pubsub",
+		rubyRedisPubSubEdge, "channel", "channel_prefix", "channel")
+	scan(rubyRedisStreamAllRe, rubyRedisStreamRe, "stream", "stream_op", "redis_stream",
+		rubyRedisStreamEdge, "stream", "stream_prefix", "stream")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/ruby/redis_test.go
+++ b/internal/custom/ruby/redis_test.go
@@ -1,0 +1,150 @@
+package ruby_test
+
+// redis_test.go — value-asserting tests for the custom_ruby_redis extractor
+// (redis-rb key/channel/stream topology; #3625 epic).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runRubyRedis(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_ruby_redis")
+	if !ok {
+		t.Fatal("custom_ruby_redis not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "cache.rb", Language: "ruby", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findRubyRedisEdge(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func findRubyKeyspace(ents []types.EntityRecord, ref string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == ref && ents[i].Kind == "SCOPE.Datastore" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestRubyRedis_Get_ReadsFromLiteralKey(t *testing.T) {
+	ents := runRubyRedis(t, `v = redis.get("session:abc")`)
+	ref := "Datastore:redis:session:abc"
+	if findRubyKeyspace(ents, ref) == nil {
+		t.Fatalf("expected keyspace entity %q", ref)
+	}
+	rel := findRubyRedisEdge(ents, "READS_FROM", ref)
+	if rel == nil {
+		t.Fatalf("expected READS_FROM edge to %q", ref)
+	}
+	if rel.Properties["keyspace"] != "session:abc" {
+		t.Errorf("keyspace prop = %q, want session:abc", rel.Properties["keyspace"])
+	}
+}
+
+func TestRubyRedis_Set_WritesToLiteralKey(t *testing.T) {
+	ents := runRubyRedis(t, `redis.set("user:42", payload)`)
+	if findRubyRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:42") == nil {
+		t.Fatal("expected WRITES_TO edge to user:42")
+	}
+}
+
+func TestRubyRedis_Set_ConcatPrefixGlob(t *testing.T) {
+	ents := runRubyRedis(t, `redis.set("user:" + id, payload)`)
+	ref := "Datastore:redis:user:*"
+	if findRubyRedisEdge(ents, "WRITES_TO", ref) == nil {
+		t.Fatalf("expected WRITES_TO edge to prefix glob %q", ref)
+	}
+	ks := findRubyKeyspace(ents, ref)
+	if ks == nil || ks.Subtype != "key_prefix" {
+		t.Fatalf("expected key_prefix keyspace %q, got %+v", ref, ks)
+	}
+}
+
+func TestRubyRedis_Set_InterpolatedPrefixGlob(t *testing.T) {
+	ents := runRubyRedis(t, `redis.set("user:#{id}", payload)`)
+	if findRubyRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:*") == nil {
+		t.Fatal("expected WRITES_TO edge to user:* (interpolated)")
+	}
+}
+
+func TestRubyRedis_SingleQuoteNoInterp(t *testing.T) {
+	// Single-quoted strings do not interpolate in Ruby; '#{id}' is a literal key.
+	ents := runRubyRedis(t, `redis.get('user:#{id}')`)
+	if findRubyRedisEdge(ents, "READS_FROM", "Datastore:redis:user:#{id}") == nil {
+		t.Fatal("expected single-quoted literal key user:#{id}")
+	}
+}
+
+func TestRubyRedis_Publish_PublishesToChannel(t *testing.T) {
+	ents := runRubyRedis(t, `redis.publish("events", payload)`)
+	ref := "Datastore:redis:events"
+	rel := findRubyRedisEdge(ents, "PUBLISHES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected PUBLISHES_TO edge to channel %q", ref)
+	}
+	if rel.Properties["channel"] != "events" {
+		t.Errorf("channel prop = %q, want events", rel.Properties["channel"])
+	}
+}
+
+func TestRubyRedis_Subscribe_SubscribesToChannel(t *testing.T) {
+	ents := runRubyRedis(t, `redis.subscribe("events") do |on| end`)
+	if findRubyRedisEdge(ents, "SUBSCRIBES_TO", "Datastore:redis:events") == nil {
+		t.Fatal("expected SUBSCRIBES_TO edge to channel events")
+	}
+}
+
+func TestRubyRedis_Xadd_WritesToStream(t *testing.T) {
+	ents := runRubyRedis(t, `redis.xadd("orders", { f: 1 })`)
+	ref := "Datastore:redis:orders"
+	rel := findRubyRedisEdge(ents, "WRITES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected WRITES_TO edge to stream %q", ref)
+	}
+	if rel.Properties["stream"] != "orders" {
+		t.Errorf("stream prop = %q, want orders", rel.Properties["stream"])
+	}
+}
+
+func TestRubyRedis_DynamicKey_NoFabricatedKey(t *testing.T) {
+	ents := runRubyRedis(t, `v = redis.get(key)`)
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected NO keyspace entity for dynamic key, got %q", ents[i].Name)
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "READS_FROM" || r.Kind == "WRITES_TO" {
+				t.Fatalf("expected NO access edge for dynamic key, got %s -> %s", r.Kind, r.ToID)
+			}
+		}
+	}
+	var found bool
+	for i := range ents {
+		if ents[i].Subtype == "cache_op" && ents[i].Properties["dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a dynamic-flagged cache_op site")
+	}
+}

--- a/internal/custom/rust/redis.go
+++ b/internal/custom/rust/redis.go
@@ -1,0 +1,330 @@
+package rust
+
+// redis.go — redis-rs key/channel/stream topology extractor
+// (#3625 epic, child of the Python template #3668).
+//
+// redis-rs offers two call idioms. The typed Commands trait exposes lowercase
+// verbs on a connection whose FIRST argument is the key / channel / stream:
+//
+//	con.get("session:abc")          -> READS_FROM key  "session:abc"
+//	con.set("user:xyz", v)          -> WRITES_TO  key  "user:xyz"
+//	con.hget("cfg:flags", f)        -> READS_FROM key  "cfg:flags"
+//	con.del(k)                      -> op only (dynamic, honest-partial)
+//	con.publish("events", p)        -> PUBLISHES_TO channel "events"
+//	con.subscribe("events")         -> SUBSCRIBES_TO channel "events"
+//	con.xadd("orders", ...)         -> WRITES_TO  stream "orders"
+//
+// The low-level command builder names the verb in cmd("VERB") and the key in
+// the first .arg("key"):
+//
+//	cmd("GET").arg("session:abc").query(...)   -> READS_FROM key "session:abc"
+//	cmd("SET").arg("user:xyz").arg(v)...        -> WRITES_TO  key "user:xyz"
+//	cmd("PUBLISH").arg("events").arg(p)...      -> PUBLISHES_TO channel "events"
+//
+// For each keyed op we emit a SCOPE.Datastore keyspace target node
+// (Name == "Datastore:redis:<label>", deduplicated per file) and an access
+// edge (READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO) from the op site
+// to that target — mirroring the Python template (#3668).
+//
+// Key topology (honest-partial for dynamic keys — no fabricated key). Rust has
+// no in-literal interpolation; dynamic keys are built with format!(...) or a
+// bare variable, both of which yield no static key (op-only):
+//
+//	"session:abc"   -> key  "session:abc"
+//	format!(...)/k  -> dynamic (no static head, no key emitted)
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_redis", &rustRedisExtractor{})
+}
+
+type rustRedisExtractor struct{}
+
+func (e *rustRedisExtractor) Language() string { return "custom_rust_redis" }
+
+// rustRedisKeyArg matches a double-quoted string literal first argument.
+// Group 1 = verb, group 2 = literal body.
+const rustRedisKeyArg = `"([^"]*)"`
+
+var (
+	// Typed Commands-trait methods (con.get("k"), con.set("k", v), …).
+	rustRedisCacheRe = regexp.MustCompile(
+		`\.(get|set|set_ex|set_nx|getset|mget|mset|hget|hget_all|hset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*::<[^>]*>\s*\(\s*` + rustRedisKeyArg + `|\.(get|set|set_ex|set_nx|getset|mget|mset|hget|hget_all|hset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*\(\s*` + rustRedisKeyArg)
+	rustRedisCacheAllRe = regexp.MustCompile(
+		`\.(get|set|set_ex|set_nx|getset|mget|mset|hget|hget_all|hset|hdel|hexists|del|exists|expire|ttl|pttl|persist|incr|decr|append|lpush|rpush|lpop|rpop|lrange|llen|sadd|srem|smembers|sismember|zadd|zrem|zrange|zrangebyscore|zscore)\s*(?:::<[^>]*>)?\s*\(`)
+
+	rustRedisPubSubRe = regexp.MustCompile(
+		`\.(publish|subscribe|psubscribe)\s*(?:::<[^>]*>)?\s*\(\s*` + rustRedisKeyArg)
+	rustRedisPubSubAllRe = regexp.MustCompile(
+		`\.(publish|subscribe|psubscribe)\s*(?:::<[^>]*>)?\s*\(`)
+
+	rustRedisStreamRe = regexp.MustCompile(
+		`\.(xadd|xread|xread_options|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*(?:::<[^>]*>)?\s*\(\s*` + rustRedisKeyArg)
+	rustRedisStreamAllRe = regexp.MustCompile(
+		`\.(xadd|xread|xread_options|xack|xlen|xrange|xrevrange|xtrim|xdel)\s*(?:::<[^>]*>)?\s*\(`)
+
+	// Low-level builder: cmd("VERB").arg("key").
+	rustRedisCmdRe = regexp.MustCompile(
+		`(?:cmd|Cmd::new)\s*\(\s*"([A-Za-z]+)"\s*\)\s*\.arg\s*\(\s*` + rustRedisKeyArg)
+	rustRedisCmdAllRe = regexp.MustCompile(`(?:cmd|Cmd::new)\s*\(\s*"([A-Za-z]+)"\s*\)`)
+)
+
+var rustRedisReadVerbs = map[string]bool{
+	"get": true, "hget": true, "hget_all": true, "hexists": true, "getset": true,
+	"mget": true, "ttl": true, "pttl": true, "exists": true, "lrange": true,
+	"llen": true, "smembers": true, "sismember": true, "zrange": true,
+	"zrangebyscore": true, "zscore": true, "lpop": true, "rpop": true,
+}
+
+func rustRedisCacheEdge(verb string) string {
+	if rustRedisReadVerbs[verb] {
+		return string(types.RelationshipKindReadsFrom)
+	}
+	return string(types.RelationshipKindWritesTo)
+}
+
+func rustRedisPubSubEdge(verb string) string {
+	if strings.HasPrefix(verb, "sub") || strings.HasPrefix(verb, "psub") {
+		return string(types.RelationshipKindSubscribesTo)
+	}
+	return string(types.RelationshipKindPublishesTo)
+}
+
+func rustRedisStreamEdge(verb string) string {
+	switch verb {
+	case "xadd", "xtrim", "xdel", "xack":
+		return string(types.RelationshipKindWritesTo)
+	default:
+		return string(types.RelationshipKindReadsFrom)
+	}
+}
+
+// rustRedisCmdEdge classifies an UPPERCASE raw-command verb (GET/SET/PUBLISH/…)
+// into READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO.
+func rustRedisCmdEdge(rawVerb string) (string, string, string) {
+	v := strings.ToUpper(rawVerb)
+	switch v {
+	case "GET", "MGET", "HGET", "HGETALL", "HEXISTS", "EXISTS", "TTL", "PTTL",
+		"LRANGE", "LLEN", "SMEMBERS", "SISMEMBER", "ZRANGE", "ZSCORE",
+		"XRANGE", "XREVRANGE", "XLEN", "XREAD":
+		return string(types.RelationshipKindReadsFrom), "key", "keyspace"
+	case "PUBLISH":
+		return string(types.RelationshipKindPublishesTo), "channel", "channel"
+	case "SUBSCRIBE", "PSUBSCRIBE":
+		return string(types.RelationshipKindSubscribesTo), "channel", "channel"
+	default:
+		return string(types.RelationshipKindWritesTo), "key", "keyspace"
+	}
+}
+
+func rustRedisKeyspaceRef(label string) string {
+	return fmt.Sprintf("Datastore:redis:%s", label)
+}
+
+type rustRedisAccess struct {
+	key     string
+	dynamic bool
+}
+
+func rustNormaliseRedisKey(literal string) rustRedisAccess {
+	if literal == "" {
+		return rustRedisAccess{dynamic: true}
+	}
+	return rustRedisAccess{key: literal}
+}
+
+type rustKeyedRedisOp struct {
+	verb   string
+	access rustRedisAccess
+}
+
+// rustKeyedRedisOps handles the typed-method regex whose two alternations each
+// capture (verb, literal): turbofish form groups 2-3/4-5, plain form 6-7/8-9.
+func rustKeyedRedisOps(src string, re *regexp.Regexp) map[int]rustKeyedRedisOp {
+	res := make(map[int]rustKeyedRedisOp)
+	for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb, literal := rustPickVerbLiteral(src, m)
+		if verb == "" {
+			continue
+		}
+		res[line] = rustKeyedRedisOp{verb: verb, access: rustNormaliseRedisKey(literal)}
+	}
+	return res
+}
+
+// rustPickVerbLiteral walks the submatch pairs and returns the first matched
+// (verb, literal) couple. The cache regex has two alternations; pub/sub and
+// stream regexes have one. We scan every (start,end) pair: the first non-(-1)
+// captured group is the verb, the next is the literal.
+func rustPickVerbLiteral(src string, m []int) (string, string) {
+	var got []string
+	for i := 2; i+1 < len(m); i += 2 {
+		if m[i] >= 0 {
+			got = append(got, src[m[i]:m[i+1]])
+		}
+	}
+	switch len(got) {
+	case 0:
+		return "", ""
+	case 1:
+		return got[0], ""
+	default:
+		return got[0], got[1]
+	}
+}
+
+// rustKeyedRedisCmds handles the cmd("VERB").arg("key") builder form.
+func rustKeyedRedisCmds(src string) map[int]rustKeyedRedisOp {
+	res := make(map[int]rustKeyedRedisOp)
+	for _, m := range rustRedisCmdRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOf(src, m[0])
+		if _, ok := res[line]; ok {
+			continue
+		}
+		verb := src[m[2]:m[3]]
+		literal := ""
+		if m[4] >= 0 {
+			literal = src[m[4]:m[5]]
+		}
+		res[line] = rustKeyedRedisOp{verb: verb, access: rustNormaliseRedisKey(literal)}
+	}
+	return res
+}
+
+func rustRedisLabel(e *types.EntityRecord, a rustRedisAccess, keyProp string) string {
+	if a.key != "" {
+		setProps(e, keyProp, a.key)
+		return a.key
+	}
+	setProps(e, keyProp, "<dynamic>", "dynamic", "true")
+	return ""
+}
+
+func (e *rustRedisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.rust_redis")
+	_, span := tracer.Start(ctx, "custom.rust_redis")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "redis") && !strings.Contains(src, "Redis") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenKeyspace := make(map[string]bool)
+	seenLine := map[string]map[int]bool{}
+	getSeen := func(cat string) map[int]bool {
+		if seenLine[cat] == nil {
+			seenLine[cat] = map[int]bool{}
+		}
+		return seenLine[cat]
+	}
+
+	emitKeyspace := func(label, keyType string, line int) string {
+		ref := rustRedisKeyspaceRef(label)
+		if !seenKeyspace[ref] {
+			seenKeyspace[ref] = true
+			ent := makeEntity(ref, "SCOPE.Datastore", keyType, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", "keyspace",
+				"keyspace", label, "key_type", keyType)
+			out = append(out, ent)
+		}
+		return ref
+	}
+
+	scan := func(allRe *regexp.Regexp, keyed map[int]rustKeyedRedisOp, cat, subtype, idPrefix string,
+		edgeFor func(string) string, keyProp, edgeLabel string) {
+		for _, m := range allRe.FindAllStringSubmatchIndex(src, -1) {
+			line := lineOf(src, m[0])
+			seen := getSeen(cat)
+			if seen[line] {
+				continue
+			}
+			seen[line] = true
+			ent := makeEntity(fmt.Sprintf("%s:%s:%d", idPrefix, file.Path, line),
+				"SCOPE.Operation", subtype, file.Path, file.Language, line)
+			setProps(&ent, "framework", "redis", "pattern_type", subtype)
+			if op, ok := keyed[line]; ok {
+				label := rustRedisLabel(&ent, op.access, keyProp)
+				if label != "" {
+					ref := emitKeyspace(label, keyProp, line)
+					ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+						ToID: ref,
+						Kind: edgeFor(op.verb),
+						Properties: map[string]string{
+							"framework": "redis", "op": op.verb, edgeLabel: label,
+						},
+					})
+				}
+			} else {
+				// Fully-dynamic key (format!(...) / bare var) — honest-partial:
+				// op site flagged dynamic, no fabricated keyspace/edge.
+				setProps(&ent, keyProp, "<dynamic>", "dynamic", "true")
+			}
+			out = append(out, ent)
+		}
+	}
+
+	scan(rustRedisCacheAllRe, rustKeyedRedisOps(src, rustRedisCacheRe),
+		"cache", "cache_op", "redis_cache", rustRedisCacheEdge, "key", "keyspace")
+	scan(rustRedisPubSubAllRe, rustKeyedRedisOps(src, rustRedisPubSubRe),
+		"pubsub", "pubsub", "redis_pubsub", rustRedisPubSubEdge, "channel", "channel")
+	scan(rustRedisStreamAllRe, rustKeyedRedisOps(src, rustRedisStreamRe),
+		"stream", "stream_op", "redis_stream", rustRedisStreamEdge, "stream", "stream")
+
+	// Low-level cmd("VERB").arg("key") builder form.
+	cmdKeyed := rustKeyedRedisCmds(src)
+	for _, m := range rustRedisCmdAllRe.FindAllStringSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		seen := getSeen("cmd")
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		rawVerb := src[m[2]:m[3]]
+		ent := makeEntity(fmt.Sprintf("redis_cmd:%s:%d", file.Path, line),
+			"SCOPE.Operation", "cache_op", file.Path, file.Language, line)
+		setProps(&ent, "framework", "redis", "pattern_type", "cache_op", "raw_verb", strings.ToUpper(rawVerb))
+		if op, ok := cmdKeyed[line]; ok {
+			edge, keyProp, edgeLabel := rustRedisCmdEdge(op.verb)
+			label := rustRedisLabel(&ent, op.access, keyProp)
+			if label != "" {
+				ref := emitKeyspace(label, keyProp, line)
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID: ref,
+					Kind: edge,
+					Properties: map[string]string{
+						"framework": "redis", "op": strings.ToUpper(op.verb), edgeLabel: label,
+					},
+				})
+			}
+		}
+		out = append(out, ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/rust/redis_test.go
+++ b/internal/custom/rust/redis_test.go
@@ -1,0 +1,158 @@
+package rust_test
+
+// redis_test.go — value-asserting tests for the custom_rust_redis extractor
+// (redis-rs key/channel/stream topology; #3625 epic).
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runRustRedis(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_rust_redis")
+	if !ok {
+		t.Fatal("custom_rust_redis not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "cache.rs", Language: "rust", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findRustRedisEdge(ents []types.EntityRecord, kind, targetRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == targetRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func findRustKeyspace(ents []types.EntityRecord, ref string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == ref && ents[i].Kind == "SCOPE.Datastore" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestRustRedis_Get_ReadsFromLiteralKey(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+let v: String = con.get("session:abc")?;`)
+	ref := "Datastore:redis:session:abc"
+	if findRustKeyspace(ents, ref) == nil {
+		t.Fatalf("expected keyspace entity %q", ref)
+	}
+	rel := findRustRedisEdge(ents, "READS_FROM", ref)
+	if rel == nil {
+		t.Fatalf("expected READS_FROM edge to %q", ref)
+	}
+	if rel.Properties["keyspace"] != "session:abc" {
+		t.Errorf("keyspace prop = %q, want session:abc", rel.Properties["keyspace"])
+	}
+}
+
+func TestRustRedis_Get_Turbofish(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+let v = con.get::<_, String>("cfg:flags")?;`)
+	if findRustRedisEdge(ents, "READS_FROM", "Datastore:redis:cfg:flags") == nil {
+		t.Fatal("expected READS_FROM edge to cfg:flags (turbofish)")
+	}
+}
+
+func TestRustRedis_Set_WritesToLiteralKey(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+con.set("user:42", payload)?;`)
+	if findRustRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:42") == nil {
+		t.Fatal("expected WRITES_TO edge to user:42")
+	}
+}
+
+func TestRustRedis_Publish_PublishesToChannel(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+con.publish("events", payload)?;`)
+	ref := "Datastore:redis:events"
+	rel := findRustRedisEdge(ents, "PUBLISHES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected PUBLISHES_TO edge to channel %q", ref)
+	}
+	if rel.Properties["channel"] != "events" {
+		t.Errorf("channel prop = %q, want events", rel.Properties["channel"])
+	}
+}
+
+func TestRustRedis_Xadd_WritesToStream(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+con.xadd("orders", "*", &items)?;`)
+	ref := "Datastore:redis:orders"
+	rel := findRustRedisEdge(ents, "WRITES_TO", ref)
+	if rel == nil {
+		t.Fatalf("expected WRITES_TO edge to stream %q", ref)
+	}
+	if rel.Properties["stream"] != "orders" {
+		t.Errorf("stream prop = %q, want orders", rel.Properties["stream"])
+	}
+}
+
+func TestRustRedis_CmdBuilder_Get_ReadsFromKey(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+let v: String = cmd("GET").arg("session:abc").query(&mut con)?;`)
+	ref := "Datastore:redis:session:abc"
+	rel := findRustRedisEdge(ents, "READS_FROM", ref)
+	if rel == nil {
+		t.Fatalf("expected READS_FROM edge to %q via cmd builder", ref)
+	}
+	if rel.Properties["op"] != "GET" {
+		t.Errorf("op prop = %q, want GET", rel.Properties["op"])
+	}
+}
+
+func TestRustRedis_CmdBuilder_Set_WritesToKey(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+cmd("SET").arg("user:42").arg(v).execute(&mut con);`)
+	if findRustRedisEdge(ents, "WRITES_TO", "Datastore:redis:user:42") == nil {
+		t.Fatal("expected WRITES_TO edge to user:42 via cmd builder")
+	}
+}
+
+func TestRustRedis_CmdBuilder_Publish_PublishesToChannel(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+cmd("PUBLISH").arg("events").arg(p).execute(&mut con);`)
+	if findRustRedisEdge(ents, "PUBLISHES_TO", "Datastore:redis:events") == nil {
+		t.Fatal("expected PUBLISHES_TO edge to events via cmd builder")
+	}
+}
+
+func TestRustRedis_DynamicKey_NoFabricatedKey(t *testing.T) {
+	ents := runRustRedis(t, `use redis::Commands;
+let v: String = con.get(format!("user:{}", id))?;`)
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Datastore" {
+			t.Fatalf("expected NO keyspace entity for dynamic key, got %q", ents[i].Name)
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "READS_FROM" || r.Kind == "WRITES_TO" {
+				t.Fatalf("expected NO access edge for dynamic key, got %s -> %s", r.Kind, r.ToID)
+			}
+		}
+	}
+	var found bool
+	for i := range ents {
+		if ents[i].Subtype == "cache_op" && ents[i].Properties["dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a dynamic-flagged cache_op site")
+	}
+}


### PR DESCRIPTION
Closes #3724 (child of epic #3625).

Extends the Redis key/channel/stream topology template established for Python (#3668) to **C#, PHP, Ruby, and Rust**. Each new `custom_<lang>_redis` extractor pulls the literal key/channel/stream a Redis op touches and emits a `SCOPE.Datastore` keyspace target node (`Datastore:redis:<label>`, deduped per file) plus an access edge — mirroring `internal/custom/python/redis.go` so the data-access graph is cross-language consistent and traversable.

## Langs now emitting Redis key-topology
| Lang | Client | Edges | Keys asserted in tests |
|---|---|---|---|
| **C#** | StackExchange.Redis | READS_FROM / WRITES_TO / PUBLISHES_TO / SUBSCRIBES_TO | `session:abc`, `user:42`, `user:*` (concat), `session:*` (interp), channel `events`, stream `orders` |
| **PHP** | predis / phpredis | same | `session:abc`, `cfg:flags`, `user:42`, `user:*` (`.`-concat + `"$id"` interp), channel `events`, stream `orders` |
| **Ruby** | redis-rb | same | `session:abc`, `user:42`, `user:*` (`+`-concat + `"#{id}"` interp), `user:#{id}` (single-quote literal), channel `events`, stream `orders` |
| **Rust** | redis-rs | same | `session:abc`, `cfg:flags` (turbofish), `user:42`, channel `events`, stream `orders`, plus `cmd("GET"/"SET"/"PUBLISH").arg(...)` builder |

## Edge direction
- read verbs (get/hget/lrange/xread/…) → `READS_FROM`
- write verbs (set/hset/xadd/del/…) → `WRITES_TO`
- `publish` → `PUBLISHES_TO`, `subscribe`/`psubscribe` → `SUBSCRIBES_TO`

## Honest-partial
Fully-dynamic keys (`db.StringGet(k)`, `$redis->get($k)`, `con.get(format!(...))`) emit the op site flagged `dynamic=true` with **no** fabricated keyspace node or access edge. Each language has a value-asserting negative test for this.

## Records
Re-stamps `lang.{csharp,php,ruby,rust}.driver.redis` `query_attribution` cells `missing → full`, citing the new extractors (reverses the #3635 downgrades). `coverage validate` exits 0 (only pre-existing unrelated warnings); `coverage fmt --check` reports canonical.

## Quality gates
- `go test ./internal/custom/{csharp,php,ruby,rust}/... ./internal/types/ ./tools/coverage/` — green
- `gofmt -l` empty, `go vet` clean on all four packages
- Wiring confirmed: `custom_{csharp,php,ruby,rust}_` prefixes are mapped in `internal/extractors/custom_dispatch.go`; registry-key registration via `init()` auto-dispatches.

**DEPLOY-DEFERRED** — requires a daemon rebuild + reindex to take effect on live graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)