### PR TITLE
[gateway] API-gateway route topology (Spring Cloud Gateway/Ocelot/Express-Gateway)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1389,6 +1389,27 @@
       }
     },
     {
+      "id": "infra.gateway.api-routing",
+      "category": "platform",
+      "language": "multi",
+      "label": "API-gateway route topology (application frameworks)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/classifier/classifier.go","internal/engine/api_gateway_routing_edges.go","internal/engine/api_gateway_routing_edges_test.go"],
+          "notes": "#3723 (epic #3628 area #21): application-framework API-gateway route→upstream-service topology, complementing the #3633 deployment_topology cell which owns the reverse-proxy / infra gateways (nginx/Caddy/Kong/Traefik). New LIVE engine pass applyAPIGatewayRoutingEdges (registered in detector.go after applyDeploymentTopologyEdges). Mints a SCOPE.Route node per gateway route and a ROUTES_TO edge to the upstream `service:\u003cname\u003e` SCOPE.Service node — the SAME canonical key the deployment-topology pass uses, so a gateway route to `lb://user-service` and a docker-compose service `user-service` collapse onto one node. Gateways: Spring Cloud Gateway YAML (`spring.cloud.gateway.routes[].uri` lb://USER-SERVICE / http(s):// with Path predicate carried as edge prop) + Java RouteLocatorBuilder DSL (`.route(r -\u003e r.path(\"/users/**\").uri(\"lb://user-service\"))`); Ocelot .NET (`ocelot.json`/`ocelot.\u003cenv\u003e.json` Routes[]/ReRoutes[] — ServiceName or DownstreamHostAndPorts[0].Host, UpstreamPathTemplate carried); Express Gateway (`gateway.config.yml` pipelines→proxy policy serviceEndpoint→url host, per bound apiEndpoint); http-proxy-middleware (`createProxyMiddleware({target})` host). ocelot.json basename routed to language=json by the classifier so it reaches the Pass 2.5 detector. Value-asserting tests assert each specific route→service edge (Path=/users/** uri lb://USER-SERVICE → ROUTES_TO service:USER-SERVICE; Ocelot UpstreamPathTemplate /api/orders → service:order-service). Honest-partial: dynamic/templated upstreams (${...}) are omitted, not guessed.",
+          "verified_at": "2026-06-02"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/api_gateway_routing_edges.go","internal/engine/api_gateway_routing_edges_test.go"],
+          "issue": "3723",
+          "notes": "#3723: mints SCOPE.Route nodes for each gateway route (props: gateway_tool, path/predicate, uri/target/upstream_path_template, variant) and SCOPE.Service nodes (role=backend) for each upstream. Partial because only the request-flow-relevant route fields are extracted (route identity, path predicate, upstream identity), not the full gateway config (filters/policies/rate-limits/CORS/auth-per-route remain unmodelled).",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "infra.iac.ansible",
       "category": "platform",
       "language": "multi",

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -625,6 +626,10 @@ var exactBasenameLanguageMap = map[string]string{
 	"Package.swift": "swift_package",
 }
 
+// apiGwOcelotJSONRe matches Ocelot config files with the conventional
+// ocelot.<env>.json naming (ocelot.json is matched explicitly). #3723.
+var apiGwOcelotJSONRe = regexp.MustCompile(`(?i)^ocelot\.[a-z0-9_-]+\.json$`)
+
 // basenameLanguageMap maps exact file basenames (case-sensitive) to language
 // tokens. Checked only when the file has no extension or its extension is not
 // in extensionLanguageMap.
@@ -706,6 +711,13 @@ func detectLanguage(norm string) string {
 		// spec forms already classify as "yaml" via the extension map.
 		if b := path.Base(lower); b == "openapi.json" || b == "swagger.json" ||
 			strings.HasSuffix(b, ".openapi.json") || strings.HasSuffix(b, ".swagger.json") {
+			return "json"
+		}
+		// #3723 (epic #3628 area #21) — Ocelot (.NET) API-gateway config. The
+		// conventional basename ocelot.json (and ocelot.<env>.json) has no other
+		// meaning; route it to "json" so it reaches the Pass 2.5 detector, where
+		// applyAPIGatewayRoutingEdges parses Routes[]→downstream service topology.
+		if b := path.Base(lower); b == "ocelot.json" || apiGwOcelotJSONRe.MatchString(b) {
 			return "json"
 		}
 		switch {

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -1264,6 +1264,29 @@ func TestClassify_DebeziumConnectorJSON(t *testing.T) {
 	}
 }
 
+// TestClassify_OcelotJSON: the Ocelot (.NET) gateway config basename
+// (ocelot.json / ocelot.<env>.json) routes to language="json" so it reaches the
+// Pass 2.5 detector (applyAPIGatewayRoutingEdges). #3723.
+func TestClassify_OcelotJSON(t *testing.T) {
+	c := newTestClassifier(t)
+	for _, p := range []string{
+		"src/Gateway/ocelot.json",
+		"ocelot.json",
+		"config/ocelot.Production.json",
+		"ocelot.dev.json",
+	} {
+		t.Run(p, func(t *testing.T) {
+			r := c.Classify(context.Background(), p)
+			if r.Skip {
+				t.Errorf("%s should not be skipped: %q", p, r.SkipReason)
+			}
+			if r.Language != "json" {
+				t.Errorf("expected Language=json, got %q", r.Language)
+			}
+		})
+	}
+}
+
 func TestClassify_GenericJSONNotIndexed(t *testing.T) {
 	c := newTestClassifier(t)
 	// These must NOT be picked up — they would balloon indexing scope and

--- a/internal/engine/api_gateway_routing_edges.go
+++ b/internal/engine/api_gateway_routing_edges.go
@@ -1,0 +1,517 @@
+// API-gateway route topology synthesis — #3723 (epic #3628, roadmap area #21).
+//
+// The deployment_topology pass (#3633, deployment_topology_edges.go) modelled the
+// reverse-proxy / infra-gateway layer that sits in FRONT of an application:
+// nginx, Caddy, Kong, Traefik. This pass covers the complementary, previously-
+// invisible layer — the APPLICATION-FRAMEWORK API gateways whose configuration
+// declares a route and the upstream service it forwards to:
+//
+//   - Spring Cloud Gateway (Spring Boot): `application.yml`
+//     `spring.cloud.gateway.routes` and the Java `RouteLocatorBuilder` DSL.
+//   - Ocelot (.NET): `ocelot.json` `Routes[].DownstreamHostAndPorts`.
+//   - Express Gateway / http-proxy-middleware (Node): `gateway.config.yml`
+//     apiEndpoints+serviceEndpoints, and `createProxyMiddleware({target})`.
+//
+// It mints a first-class gateway-route node and a ROUTES_TO edge to the upstream
+// backend service, mirroring the edge shape #3633 established:
+//
+//	gateway route (SCOPE.Route)  -- ROUTES_TO -->  backend SCOPE.Service
+//
+// The backend service is keyed `service:<name>` — the SAME canonical key the
+// deployment-topology pass uses — so a Spring Cloud Gateway route to
+// `lb://user-service` and a docker-compose service `user-service` collapse onto
+// one SCOPE.Service node, and the route edge lands on the service the rest of the
+// graph already knows.
+//
+// # Scope guard
+//
+// Append-only: this pass never modifies or removes existing entities or edges,
+// so it cannot regress the surrounding pipeline. It fires only for a file whose
+// basename / language / content the gate recognises as one of the gateway
+// sources above; every other file is a fast no-op. Where the upstream URI is
+// dynamic / templated (a `${...}` placeholder, a variable) the edge is honestly
+// omitted rather than emitting a garbage node (honest-partial).
+//
+// Closes #3723. Epic #3628.
+package engine
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	apiGwRouteKind   = string(types.EntityKindRoute)
+	apiGwServiceKind = string(types.EntityKindService)
+	apiGwRoutesTo    = string(types.RelationshipKindRoutesTo)
+)
+
+// apiGwServiceID returns the canonical, file-independent ID for a backend
+// service. It MUST match deployment_topology_edges.go's depTopoServiceID so the
+// gateway route and any compose/proxy node for the same logical service collapse
+// onto a single SCOPE.Service node.
+func apiGwServiceID(name string) string { return "service:" + name }
+
+// apiGwRouteID keys a gateway route node by gateway-tool + file + route
+// identity, keeping two routes in the same file (and the same route across two
+// gateways) distinct.
+func apiGwRouteID(tool, base, routeKey string) string {
+	return "route:" + tool + ":" + base + ":" + routeKey
+}
+
+// applyAPIGatewayRoutingEdges is the per-file entry point, registered in
+// detector.go after applyDeploymentTopologyEdges. Append-only.
+func applyAPIGatewayRoutingEdges(args DetectorPassArgs) DetectorPassResult {
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(args.Content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	src := string(args.Content)
+	base := strings.ToLower(filepath.Base(args.Path))
+
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitService := func(name string) string {
+		if name == "" {
+			return ""
+		}
+		id := apiGwServiceID(name)
+		if !seenEnt[id] {
+			seenEnt[id] = true
+			entities = append(entities, types.EntityRecord{
+				ID:            id,
+				Name:          name,
+				QualifiedName: id,
+				Kind:          apiGwServiceKind,
+				SourceFile:    args.Path,
+				Language:      args.Lang,
+				Properties: map[string]string{
+					"deployment_role": "backend",
+					"synthesis":       "api_gateway_routing",
+				},
+				EnrichmentStatus: types.StatusPending,
+				QualityScore:     0.8,
+			})
+		}
+		return id
+	}
+
+	emitRoute := func(tool, base, routeKey, name string, props map[string]string) string {
+		id := apiGwRouteID(tool, base, routeKey)
+		if !seenEnt[id] {
+			seenEnt[id] = true
+			p := map[string]string{
+				"gateway_tool": tool,
+				"synthesis":    "api_gateway_routing",
+			}
+			for k, v := range props {
+				if v != "" {
+					p[k] = v
+				}
+			}
+			entities = append(entities, types.EntityRecord{
+				ID:               id,
+				Name:             name,
+				QualifiedName:    id,
+				Kind:             apiGwRouteKind,
+				SourceFile:       args.Path,
+				Language:         args.Lang,
+				Properties:       p,
+				EnrichmentStatus: types.StatusPending,
+				QualityScore:     0.8,
+			})
+		}
+		return id
+	}
+
+	emitRoutesTo := func(routeID, serviceID, flow, predicate string) {
+		if routeID == "" || serviceID == "" || routeID == serviceID {
+			return
+		}
+		key := routeID + "|" + serviceID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		props := map[string]string{
+			"flow":      flow,
+			"synthesis": "api_gateway_routing",
+		}
+		if predicate != "" {
+			props["predicate"] = predicate
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     routeID,
+			ToID:       serviceID,
+			Kind:       apiGwRoutesTo,
+			Properties: props,
+		})
+	}
+
+	switch {
+	case base == "ocelot.json" || apiGwIsOcelotName(base):
+		applyOcelotRouting(src, base, emitService, emitRoute, emitRoutesTo)
+	case args.Lang == "yaml" && apiGwIsSpringGatewayYAML(src):
+		applySpringCloudGatewayYAML(src, base, emitService, emitRoute, emitRoutesTo)
+	case args.Lang == "yaml" && apiGwIsExpressGatewayYAML(src):
+		applyExpressGatewayYAML(src, base, emitService, emitRoute, emitRoutesTo)
+	case args.Lang == "java" && strings.Contains(src, "RouteLocatorBuilder"):
+		applySpringCloudGatewayJava(src, base, emitService, emitRoute, emitRoutesTo)
+	case (args.Lang == "javascript" || args.Lang == "typescript") &&
+		strings.Contains(src, "createProxyMiddleware"):
+		applyHTTPProxyMiddleware(src, base, emitService, emitRoute, emitRoutesTo)
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// apiGwIsOcelotName matches Ocelot config files following the conventional
+// `ocelot.<env>.json` naming (ocelot.json is checked explicitly).
+var apiGwOcelotNameRe = regexp.MustCompile(`(?i)^ocelot\.[a-z0-9_-]+\.json$`)
+
+func apiGwIsOcelotName(base string) bool { return apiGwOcelotNameRe.MatchString(base) }
+
+// apiGwUpstreamFromURI extracts the upstream service name from a Spring Cloud
+// Gateway `uri`. Forms handled: `lb://USER-SERVICE` (service-discovery load-
+// balanced — the authority IS the service id), and `http(s)://host[:port]`
+// (the host is the service). A `${...}` placeholder or empty value yields "".
+func apiGwUpstreamFromURI(uri string) string {
+	uri = strings.TrimSpace(uri)
+	if uri == "" || strings.Contains(uri, "${") {
+		return ""
+	}
+	i := strings.Index(uri, "://")
+	if i < 0 {
+		return ""
+	}
+	authority := uri[i+3:]
+	// Strip path / query.
+	if j := strings.IndexAny(authority, "/?"); j >= 0 {
+		authority = authority[:j]
+	}
+	// Strip :port.
+	if j := strings.LastIndex(authority, ":"); j >= 0 && isAllDigits(authority[j+1:]) {
+		authority = authority[:j]
+	}
+	authority = strings.TrimSpace(authority)
+	if authority == "" || authority == "localhost" || strings.Contains(authority, "$") {
+		return ""
+	}
+	return authority
+}
+
+// ---------------------------------------------------------------------------
+// Spring Cloud Gateway — YAML (application.yml spring.cloud.gateway.routes)
+// ---------------------------------------------------------------------------
+
+func apiGwIsSpringGatewayYAML(src string) bool {
+	return strings.Contains(src, "spring:") &&
+		strings.Contains(src, "gateway:") &&
+		strings.Contains(src, "routes:")
+}
+
+type springGatewayYAML struct {
+	Spring struct {
+		Cloud struct {
+			Gateway struct {
+				Routes []struct {
+					ID         string   `yaml:"id"`
+					URI        string   `yaml:"uri"`
+					Predicates []string `yaml:"predicates"`
+				} `yaml:"routes"`
+			} `yaml:"gateway"`
+		} `yaml:"cloud"`
+	} `yaml:"spring"`
+}
+
+// springGatewayPathPredicate returns the first `Path=...` predicate value, the
+// most common gateway match. Other predicate kinds are kept verbatim if no Path
+// is present.
+func springGatewayPathPredicate(predicates []string) string {
+	for _, p := range predicates {
+		if strings.HasPrefix(p, "Path=") {
+			return strings.TrimPrefix(p, "Path=")
+		}
+	}
+	if len(predicates) > 0 {
+		return predicates[0]
+	}
+	return ""
+}
+
+func applySpringCloudGatewayYAML(src, base string, emitService func(string) string, emitRoute func(tool, base, routeKey, name string, props map[string]string) string, emitRoutesTo func(routeID, serviceID, flow, predicate string)) {
+	var doc springGatewayYAML
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		return
+	}
+	for idx, r := range doc.Spring.Cloud.Gateway.Routes {
+		svcName := apiGwUpstreamFromURI(r.URI)
+		if svcName == "" {
+			continue
+		}
+		predicate := springGatewayPathPredicate(r.Predicates)
+		routeKey := r.ID
+		if routeKey == "" {
+			routeKey = "route" + itoa(idx)
+		}
+		routeID := emitRoute("spring-cloud-gateway", base, routeKey, routeKey, map[string]string{
+			"path":    predicate,
+			"uri":     r.URI,
+			"variant": "yaml",
+		})
+		svcID := emitService(svcName)
+		emitRoutesTo(routeID, svcID, "spring_cloud_gateway_route", predicate)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Spring Cloud Gateway — Java RouteLocatorBuilder DSL
+// ---------------------------------------------------------------------------
+
+// apiGwJavaRouteRe matches one `.route(...)` builder chain (lazily, up to the
+// closing of the lambda's `.uri(...)`), capturing the whole body so the path()
+// and uri() sub-matches can be pulled out. A `.route("id", r -> ...)` form is
+// also covered: the optional first string arg is ignored for upstream purposes.
+var (
+	apiGwJavaRouteChainRe = regexp.MustCompile(`(?s)\.route\s*\((.*?)\.uri\s*\(\s*"([^"]*)"\s*\)`)
+	apiGwJavaPathRe       = regexp.MustCompile(`\.path\s*\(\s*"([^"]*)"`)
+	apiGwJavaRouteIDRe    = regexp.MustCompile(`\.route\s*\(\s*"([^"]*)"`)
+)
+
+func applySpringCloudGatewayJava(src, base string, emitService func(string) string, emitRoute func(tool, base, routeKey, name string, props map[string]string) string, emitRoutesTo func(routeID, serviceID, flow, predicate string)) {
+	idx := 0
+	for _, m := range apiGwJavaRouteChainRe.FindAllStringSubmatch(src, -1) {
+		body, uri := m[1], m[2]
+		svcName := apiGwUpstreamFromURI(uri)
+		if svcName == "" {
+			continue
+		}
+		var path string
+		if pm := apiGwJavaPathRe.FindStringSubmatch(body); pm != nil {
+			path = pm[1]
+		}
+		routeKey := ""
+		if rid := apiGwJavaRouteIDRe.FindStringSubmatch(m[0]); rid != nil {
+			routeKey = rid[1]
+		}
+		if routeKey == "" {
+			routeKey = "route" + itoa(idx)
+		}
+		idx++
+		routeID := emitRoute("spring-cloud-gateway", base, routeKey, routeKey, map[string]string{
+			"path":    path,
+			"uri":     uri,
+			"variant": "java",
+		})
+		svcID := emitService(svcName)
+		emitRoutesTo(routeID, svcID, "spring_cloud_gateway_route", path)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ocelot (.NET) — ocelot.json Routes[]
+// ---------------------------------------------------------------------------
+
+type ocelotConfig struct {
+	Routes []ocelotRoute `json:"Routes"`
+	// Legacy Ocelot (pre-v16) used "ReRoutes".
+	ReRoutes []ocelotRoute `json:"ReRoutes"`
+}
+
+type ocelotRoute struct {
+	UpstreamPathTemplate   string `json:"UpstreamPathTemplate"`
+	DownstreamPathTemplate string `json:"DownstreamPathTemplate"`
+	ServiceName            string `json:"ServiceName"`
+	DownstreamHostAndPorts []struct {
+		Host string `json:"Host"`
+		Port int    `json:"Port"`
+	} `json:"DownstreamHostAndPorts"`
+}
+
+func applyOcelotRouting(src, base string, emitService func(string) string, emitRoute func(tool, base, routeKey, name string, props map[string]string) string, emitRoutesTo func(routeID, serviceID, flow, predicate string)) {
+	var cfg ocelotConfig
+	if err := json.Unmarshal([]byte(src), &cfg); err != nil {
+		return
+	}
+	routes := cfg.Routes
+	routes = append(routes, cfg.ReRoutes...)
+	for idx, r := range routes {
+		// Prefer the service-discovery name; fall back to the first
+		// DownstreamHostAndPorts host (a static upstream).
+		svcName := strings.TrimSpace(r.ServiceName)
+		if svcName == "" && len(r.DownstreamHostAndPorts) > 0 {
+			svcName = strings.TrimSpace(r.DownstreamHostAndPorts[0].Host)
+		}
+		if svcName == "" || strings.Contains(svcName, "{") || svcName == "localhost" {
+			continue
+		}
+		upstream := r.UpstreamPathTemplate
+		routeKey := upstream
+		if routeKey == "" {
+			routeKey = "route" + itoa(idx)
+		}
+		routeID := emitRoute("ocelot", base, routeKey, upstream, map[string]string{
+			"upstream_path_template":   upstream,
+			"downstream_path_template": r.DownstreamPathTemplate,
+		})
+		svcID := emitService(svcName)
+		emitRoutesTo(routeID, svcID, "ocelot_route", upstream)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Express Gateway — gateway.config.yml (apiEndpoints + serviceEndpoints + pipelines)
+// ---------------------------------------------------------------------------
+
+func apiGwIsExpressGatewayYAML(src string) bool {
+	return strings.Contains(src, "apiEndpoints:") &&
+		strings.Contains(src, "serviceEndpoints:")
+}
+
+type expressGatewayYAML struct {
+	APIEndpoints     map[string]yaml.Node `yaml:"apiEndpoints"`
+	ServiceEndpoints map[string]struct {
+		URL string `yaml:"url"`
+	} `yaml:"serviceEndpoints"`
+	Pipelines map[string]struct {
+		APIEndpoints []string `yaml:"apiEndpoints"`
+		// Each policy is a single-key map; for the proxy policy the value is the
+		// action struct `{action: {serviceEndpoint: <name>}}`.
+		Policies []map[string]struct {
+			Action struct {
+				ServiceEndpoint string `yaml:"serviceEndpoint"`
+			} `yaml:"action"`
+		} `yaml:"policies"`
+	} `yaml:"pipelines"`
+}
+
+// expressURLHost extracts the host (service name) from a serviceEndpoint url.
+func expressURLHost(url string) string {
+	url = strings.TrimSpace(url)
+	if url == "" || strings.Contains(url, "${") {
+		return ""
+	}
+	if i := strings.Index(url, "://"); i >= 0 {
+		url = url[i+3:]
+	}
+	if j := strings.IndexAny(url, "/?"); j >= 0 {
+		url = url[:j]
+	}
+	if j := strings.LastIndex(url, ":"); j >= 0 && isAllDigits(url[j+1:]) {
+		url = url[:j]
+	}
+	url = strings.TrimSpace(url)
+	if url == "" || url == "localhost" || strings.Contains(url, "$") {
+		return ""
+	}
+	return url
+}
+
+func applyExpressGatewayYAML(src, base string, emitService func(string) string, emitRoute func(tool, base, routeKey, name string, props map[string]string) string, emitRoutesTo func(routeID, serviceID, flow, predicate string)) {
+	var doc expressGatewayYAML
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		return
+	}
+	for pipeName, pipe := range doc.Pipelines {
+		// Resolve the proxy policy's target serviceEndpoint → its url host.
+		var svcName string
+		for _, pol := range pipe.Policies {
+			for name, body := range pol {
+				if name != "proxy" {
+					continue
+				}
+				ep := body.Action.ServiceEndpoint
+				if ep == "" {
+					continue
+				}
+				if se, ok := doc.ServiceEndpoints[ep]; ok {
+					if h := expressURLHost(se.URL); h != "" {
+						svcName = h
+					}
+				}
+			}
+		}
+		if svcName == "" {
+			continue
+		}
+		// Each apiEndpoint bound to the pipeline is a route entry point.
+		for _, apiName := range pipe.APIEndpoints {
+			routeID := emitRoute("express-gateway", base, pipeName+":"+apiName, apiName, map[string]string{
+				"pipeline":     pipeName,
+				"api_endpoint": apiName,
+			})
+			svcID := emitService(svcName)
+			emitRoutesTo(routeID, svcID, "express_gateway_route", apiName)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// http-proxy-middleware (Node) — createProxyMiddleware({ target, ... })
+// ---------------------------------------------------------------------------
+
+// apiGwProxyMiddlewareRe captures one createProxyMiddleware({...}) options
+// object so the target can be pulled out.
+var (
+	apiGwProxyMiddlewareRe  = regexp.MustCompile(`(?s)createProxyMiddleware\s*\(\s*\{(.*?)\}\s*\)`)
+	apiGwProxyTargetRe      = regexp.MustCompile(`target\s*:\s*['"` + "`" + `]([^'"` + "`" + `]*)['"` + "`" + `]`)
+	apiGwProxyPathRewriteRe = regexp.MustCompile(`pathRewrite`)
+)
+
+// apiGwHostFromTarget extracts the service host from an http-proxy-middleware
+// target. Template literals containing `${...}` are dynamic → "".
+func apiGwHostFromTarget(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" || strings.Contains(target, "${") {
+		return ""
+	}
+	if i := strings.Index(target, "://"); i >= 0 {
+		target = target[i+3:]
+	}
+	if j := strings.IndexAny(target, "/?"); j >= 0 {
+		target = target[:j]
+	}
+	if j := strings.LastIndex(target, ":"); j >= 0 && isAllDigits(target[j+1:]) {
+		target = target[:j]
+	}
+	target = strings.TrimSpace(target)
+	if target == "" || target == "localhost" || strings.Contains(target, "$") {
+		return ""
+	}
+	return target
+}
+
+func applyHTTPProxyMiddleware(src, base string, emitService func(string) string, emitRoute func(tool, base, routeKey, name string, props map[string]string) string, emitRoutesTo func(routeID, serviceID, flow, predicate string)) {
+	idx := 0
+	for _, m := range apiGwProxyMiddlewareRe.FindAllStringSubmatch(src, -1) {
+		body := m[1]
+		tm := apiGwProxyTargetRe.FindStringSubmatch(body)
+		if tm == nil {
+			continue
+		}
+		svcName := apiGwHostFromTarget(tm[1])
+		if svcName == "" {
+			continue
+		}
+		hasRewrite := ""
+		if apiGwProxyPathRewriteRe.MatchString(body) {
+			hasRewrite = "true"
+		}
+		routeKey := "proxy" + itoa(idx)
+		idx++
+		routeID := emitRoute("http-proxy-middleware", base, routeKey, svcName, map[string]string{
+			"target":       tm[1],
+			"path_rewrite": hasRewrite,
+		})
+		svcID := emitService(svcName)
+		emitRoutesTo(routeID, svcID, "http_proxy_middleware", "")
+	}
+}

--- a/internal/engine/api_gateway_routing_edges_test.go
+++ b/internal/engine/api_gateway_routing_edges_test.go
@@ -1,0 +1,304 @@
+// Tests for the API-gateway route topology pass — #3723 (epic #3628 area #21).
+//
+// Value-asserting: every test asserts a SPECIFIC ROUTES_TO edge from a concrete
+// gateway-route node to a canonically-keyed `service:<name>` SCOPE.Service node
+// — never `len > 0`.
+//
+//   - Spring Cloud Gateway YAML  Path=/users/** uri lb://USER-SERVICE
+//     → route ROUTES_TO service:USER-SERVICE
+//   - Spring Cloud Gateway Java  .path("/orders/**").uri("lb://order-service")
+//     → route ROUTES_TO service:order-service
+//   - Ocelot UpstreamPathTemplate /api/orders → ROUTES_TO service:order-service
+//   - Express Gateway pipeline serviceEndpoint url → ROUTES_TO service host
+//   - http-proxy-middleware target → ROUTES_TO service host
+//
+// plus negative / no-op guards (a non-gateway yaml emits no route).
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runAPIGwDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	res := applyAPIGatewayRoutingEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
+}
+
+// apiGwEdgeTo returns the ROUTES_TO edge landing on serviceID, or nil.
+func apiGwEdgeTo(rels []types.RelationshipRecord, serviceID string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].Kind == apiGwRoutesTo && rels[i].ToID == serviceID {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+func apiGwEntity(ents []types.EntityRecord, id string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].ID == id {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// apiGwHasRoutesTo asserts a ROUTES_TO edge from any route to serviceID and that
+// the FROM node is a SCOPE.Route. Returns the edge for further property checks.
+func apiGwHasRoutesTo(t *testing.T, ents []types.EntityRecord, rels []types.RelationshipRecord, serviceID string) *types.RelationshipRecord {
+	t.Helper()
+	e := apiGwEdgeTo(rels, serviceID)
+	if e == nil {
+		t.Fatalf("expected a ROUTES_TO edge to %q; got %+v", serviceID, rels)
+	}
+	from := apiGwEntity(ents, e.FromID)
+	if from == nil {
+		t.Fatalf("ROUTES_TO source node %q not minted", e.FromID)
+	}
+	if from.Kind != apiGwRouteKind {
+		t.Fatalf("route node %q kind = %q, want %q", e.FromID, from.Kind, apiGwRouteKind)
+	}
+	svc := apiGwEntity(ents, serviceID)
+	if svc == nil {
+		t.Fatalf("backend service node %q not minted", serviceID)
+	}
+	if svc.Kind != apiGwServiceKind {
+		t.Fatalf("service node %q kind = %q, want %q", serviceID, svc.Kind, apiGwServiceKind)
+	}
+	return e
+}
+
+// TestSpringCloudGatewayYAML_RoutesTo is the headline assertion: a
+// spring.cloud.gateway.routes entry with uri lb://USER-SERVICE and a
+// Path=/users/** predicate yields route ROUTES_TO service:USER-SERVICE, with the
+// path predicate carried on the edge.
+func TestSpringCloudGatewayYAML_RoutesTo(t *testing.T) {
+	src := `
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: users-route
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/users/**
+        - id: orders-route
+          uri: lb://ORDER-SERVICE
+          predicates:
+            - Path=/orders/**
+`
+	ents, rels := runAPIGwDetect(t, "yaml", "application.yml", src)
+
+	const userSvc = "service:USER-SERVICE"
+	e := apiGwHasRoutesTo(t, ents, rels, userSvc)
+	if e.Properties["predicate"] != "/users/**" {
+		t.Fatalf("edge predicate = %q, want /users/**", e.Properties["predicate"])
+	}
+	// The route node carries the path + uri.
+	route := apiGwEntity(ents, e.FromID)
+	if route.Properties["path"] != "/users/**" {
+		t.Fatalf("route path prop = %q, want /users/**", route.Properties["path"])
+	}
+	if route.Properties["uri"] != "lb://USER-SERVICE" {
+		t.Fatalf("route uri prop = %q", route.Properties["uri"])
+	}
+	// Second route resolves independently.
+	apiGwHasRoutesTo(t, ents, rels, "service:ORDER-SERVICE")
+}
+
+// TestSpringCloudGatewayYAML_DynamicURI_Omitted: a templated uri (${...}) is
+// honestly dropped, not guessed.
+func TestSpringCloudGatewayYAML_DynamicURI_Omitted(t *testing.T) {
+	src := `
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: dyn
+          uri: ${UPSTREAM_URI}
+          predicates:
+            - Path=/x/**
+`
+	_, rels := runAPIGwDetect(t, "yaml", "application.yml", src)
+	for _, r := range rels {
+		if r.Kind == apiGwRoutesTo {
+			t.Fatalf("dynamic ${...} uri must NOT emit a ROUTES_TO edge; got %+v", r)
+		}
+	}
+}
+
+// TestSpringCloudGatewayJava_RoutesTo: the RouteLocatorBuilder DSL form.
+func TestSpringCloudGatewayJava_RoutesTo(t *testing.T) {
+	src := `
+package com.example.gw;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+
+public class GatewayConfig {
+    public RouteLocator routes(RouteLocatorBuilder builder) {
+        return builder.routes()
+            .route("orders", r -> r.path("/orders/**").uri("lb://order-service"))
+            .route(r -> r.path("/users/**").uri("lb://user-service"))
+            .build();
+    }
+}
+`
+	ents, rels := runAPIGwDetect(t, "java", "GatewayConfig.java", src)
+	e := apiGwHasRoutesTo(t, ents, rels, "service:order-service")
+	if e.Properties["predicate"] != "/orders/**" {
+		t.Fatalf("java route predicate = %q, want /orders/**", e.Properties["predicate"])
+	}
+	apiGwHasRoutesTo(t, ents, rels, "service:user-service")
+}
+
+// TestOcelot_UpstreamPathTemplate_RoutesTo: Ocelot ocelot.json
+// UpstreamPathTemplate /api/orders → downstream order-service.
+func TestOcelot_UpstreamPathTemplate_RoutesTo(t *testing.T) {
+	src := `
+{
+  "Routes": [
+    {
+      "UpstreamPathTemplate": "/api/orders",
+      "DownstreamPathTemplate": "/orders",
+      "DownstreamHostAndPorts": [ { "Host": "order-service", "Port": 80 } ]
+    },
+    {
+      "UpstreamPathTemplate": "/api/users",
+      "DownstreamPathTemplate": "/users",
+      "ServiceName": "user-service"
+    }
+  ]
+}
+`
+	ents, rels := runAPIGwDetect(t, "json", "ocelot.json", src)
+	e := apiGwHasRoutesTo(t, ents, rels, "service:order-service")
+	route := apiGwEntity(ents, e.FromID)
+	if route.Properties["upstream_path_template"] != "/api/orders" {
+		t.Fatalf("ocelot route upstream = %q, want /api/orders", route.Properties["upstream_path_template"])
+	}
+	if route.Properties["downstream_path_template"] != "/orders" {
+		t.Fatalf("ocelot downstream = %q, want /orders", route.Properties["downstream_path_template"])
+	}
+	// ServiceName form also resolves.
+	apiGwHasRoutesTo(t, ents, rels, "service:user-service")
+}
+
+// TestOcelot_ReRoutes_LegacyKey: pre-v16 Ocelot used "ReRoutes".
+func TestOcelot_ReRoutes_LegacyKey(t *testing.T) {
+	src := `
+{
+  "ReRoutes": [
+    { "UpstreamPathTemplate": "/legacy", "ServiceName": "legacy-svc" }
+  ]
+}
+`
+	ents, rels := runAPIGwDetect(t, "json", "ocelot.json", src)
+	apiGwHasRoutesTo(t, ents, rels, "service:legacy-svc")
+}
+
+// TestExpressGateway_RoutesTo: gateway.config.yml pipeline whose proxy policy
+// targets a serviceEndpoint resolves the apiEndpoint route → service host.
+func TestExpressGateway_RoutesTo(t *testing.T) {
+	src := `
+apiEndpoints:
+  users:
+    host: '*'
+    paths: '/users/*'
+serviceEndpoints:
+  usersService:
+    url: 'http://user-service:8080'
+pipelines:
+  usersPipeline:
+    apiEndpoints:
+      - users
+    policies:
+      - proxy:
+          action:
+            serviceEndpoint: usersService
+`
+	ents, rels := runAPIGwDetect(t, "yaml", "gateway.config.yml", src)
+	e := apiGwHasRoutesTo(t, ents, rels, "service:user-service")
+	route := apiGwEntity(ents, e.FromID)
+	if route.Properties["api_endpoint"] != "users" {
+		t.Fatalf("express route api_endpoint = %q, want users", route.Properties["api_endpoint"])
+	}
+}
+
+// TestHTTPProxyMiddleware_RoutesTo: createProxyMiddleware({ target }) → service.
+func TestHTTPProxyMiddleware_RoutesTo(t *testing.T) {
+	src := `
+const { createProxyMiddleware } = require('http-proxy-middleware');
+app.use('/api', createProxyMiddleware({
+  target: 'http://catalog-service:3000',
+  changeOrigin: true,
+  pathRewrite: { '^/api': '' },
+}));
+`
+	ents, rels := runAPIGwDetect(t, "javascript", "proxy.js", src)
+	e := apiGwHasRoutesTo(t, ents, rels, "service:catalog-service")
+	route := apiGwEntity(ents, e.FromID)
+	if route.Properties["path_rewrite"] != "true" {
+		t.Fatalf("expected path_rewrite=true prop; got %q", route.Properties["path_rewrite"])
+	}
+	if route.Properties["target"] != "http://catalog-service:3000" {
+		t.Fatalf("target prop = %q", route.Properties["target"])
+	}
+}
+
+// TestHTTPProxyMiddleware_DynamicTarget_Omitted: a `${...}` template-literal
+// target is honestly dropped.
+func TestHTTPProxyMiddleware_DynamicTarget_Omitted(t *testing.T) {
+	src := "const m = createProxyMiddleware({ target: `http://${HOST}:3000` });"
+	_, rels := runAPIGwDetect(t, "javascript", "proxy.js", src)
+	for _, r := range rels {
+		if r.Kind == apiGwRoutesTo {
+			t.Fatalf("dynamic ${...} target must NOT emit a ROUTES_TO edge; got %+v", r)
+		}
+	}
+}
+
+// TestNegative_PlainYAML_NoRoute: an ordinary application.yml that is NOT a
+// gateway config emits no route entities or edges.
+func TestNegative_PlainYAML_NoRoute(t *testing.T) {
+	src := `
+server:
+  port: 8080
+spring:
+  application:
+    name: my-service
+  datasource:
+    url: jdbc:postgresql://db:5432/app
+`
+	ents, rels := runAPIGwDetect(t, "yaml", "application.yml", src)
+	for _, e := range ents {
+		if e.Kind == apiGwRouteKind {
+			t.Fatalf("non-gateway yaml must NOT mint a route node; got %+v", e)
+		}
+	}
+	for _, r := range rels {
+		if r.Kind == apiGwRoutesTo {
+			t.Fatalf("non-gateway yaml must NOT emit ROUTES_TO; got %+v", r)
+		}
+	}
+}
+
+// TestNegative_EmptyContent_NoOp: nil content is a fast no-op.
+func TestNegative_EmptyContent_NoOp(t *testing.T) {
+	res := applyAPIGatewayRoutingEdges(DetectorPassArgs{Lang: "yaml", Path: "ocelot.json", Content: nil})
+	if len(res.Entities) != 0 || len(res.Relationships) != 0 {
+		t.Fatalf("empty content should be a no-op; got %d ents %d rels", len(res.Entities), len(res.Relationships))
+	}
+}
+
+// TestServiceID_CollapsesWithDeploymentTopology proves the canonical key match:
+// a gateway route to lb://user-service and the deployment-topology service node
+// for the same name share one ID, so the edge lands on the known node.
+func TestServiceID_CollapsesWithDeploymentTopology(t *testing.T) {
+	if apiGwServiceID("user-service") != depTopoServiceID("user-service") {
+		t.Fatalf("api-gateway service key %q must equal deployment-topology key %q",
+			apiGwServiceID("user-service"), depTopoServiceID("user-service"))
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -784,6 +784,21 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// dedicated passes (applyKubernetesEdges, applyServerlessFrameworkEdges).
 	// Append-only — cannot regress surrounding passes.
 	applyPass(applyDeploymentTopologyEdges)
+	// API-gateway route topology edges (#3723, epic #3628 area #21). Complements
+	// applyDeploymentTopologyEdges (which owns the reverse-proxy / infra gateways
+	// nginx/Caddy/Kong/Traefik) by modelling the APPLICATION-FRAMEWORK API
+	// gateways whose config declares a route + the upstream service it forwards
+	// to: Spring Cloud Gateway (application.yml spring.cloud.gateway.routes +
+	// Java RouteLocatorBuilder DSL), Ocelot (ocelot.json Routes[]), Express
+	// Gateway (gateway.config.yml apiEndpoints+serviceEndpoints), and
+	// http-proxy-middleware (createProxyMiddleware({target})). Mints a
+	// SCOPE.Route node per gateway route and a ROUTES_TO edge to the upstream
+	// `service:<name>` SCOPE.Service node — the SAME canonical key the
+	// deployment-topology pass uses, so a gateway route to `lb://user-service`
+	// and a compose service `user-service` collapse onto one node. Honest-partial:
+	// dynamic/templated upstreams (${...}) are omitted, not guessed. Append-only
+	// — cannot regress surrounding passes.
+	applyPass(applyAPIGatewayRoutingEdges)
 	// Workflow orchestration edges (#934). Emits SCOPE.Workflow, SCOPE.Activity,
 	// and SCOPE.StateMachine entities plus STARTS_WORKFLOW, EXECUTES_ACTIVITY,
 	// and STEPFUNCTION_STEP_INVOKES edges for Temporal (Python, Go, Java, Node),


### PR DESCRIPTION
Closes #3723. Epic #3628 (roadmap area #21).

Adds `applyAPIGatewayRoutingEdges` — a new append-only Pass 2.5 detector pass that models the **application-framework** API-gateway route→upstream-service topology. This is distinct from #3662/#3633 `deployment_topology_edges.go`, which owns the **reverse-proxy / infra** gateways (nginx / Caddy / Kong / Traefik). This PR does NOT duplicate those; it mirrors their `ROUTES_TO` edge shape and reuses the SAME `service:<name>` canonical key so route edges land on services the graph already knows (e.g. a gateway route to `lb://user-service` collapses onto a docker-compose service `user-service`).

## Gateways that now emit route→service

| Gateway | Source | Upstream extracted | Edge |
|---|---|---|---|
| **Spring Cloud Gateway** (YAML) | `application.yml` `spring.cloud.gateway.routes[]` | `uri: lb://USER-SERVICE` / `http(s)://host` (Path predicate carried) | route `ROUTES_TO` `service:USER-SERVICE` |
| **Spring Cloud Gateway** (Java) | `RouteLocatorBuilder` `.route(r -> r.path("/users/**").uri("lb://user-service"))` | uri authority | route `ROUTES_TO` `service:user-service` |
| **Ocelot** (.NET) | `ocelot.json` / `ocelot.<env>.json` `Routes[]`/`ReRoutes[]` | `ServiceName` or `DownstreamHostAndPorts[0].Host` (UpstreamPathTemplate carried) | route `ROUTES_TO` downstream service |
| **Express Gateway** | `gateway.config.yml` pipelines→proxy-policy `serviceEndpoint`→`url` host | per bound `apiEndpoint` | route `ROUTES_TO` service host |
| **http-proxy-middleware** | `createProxyMiddleware({ target })` | target host | route `ROUTES_TO` service host |

Each route is a `SCOPE.Route` node carrying `gateway_tool`, the path/predicate, and the upstream uri/target/UpstreamPathTemplate. `ocelot.json` basenames are routed to `language=json` by the classifier so they reach the detector.

## Route edges asserted (value-asserting tests, not len>0)
- Spring Cloud Gateway YAML: `Path=/users/**` uri `lb://USER-SERVICE` → route `ROUTES_TO` `service:USER-SERVICE` (predicate carried on edge).
- Spring Cloud Gateway Java: `.path("/orders/**").uri("lb://order-service")` → route `ROUTES_TO` `service:order-service`.
- Ocelot: `UpstreamPathTemplate /api/orders` + `DownstreamHostAndPorts[0].Host order-service` → route `ROUTES_TO` `service:order-service`; `ServiceName` form too; legacy `ReRoutes` key.
- Express Gateway: pipeline proxy policy → `serviceEndpoint url http://user-service:8080` → route `ROUTES_TO` `service:user-service`.
- http-proxy-middleware: `target http://catalog-service:3000` → route `ROUTES_TO` `service:catalog-service` (path_rewrite prop).
- **Negatives**: plain non-gateway `application.yml` → no route; dynamic `${...}` uri/target → omitted; nil content → no-op. Plus a canonical-key collapse assertion (`apiGwServiceID == depTopoServiceID`).

## Honest-partial
- `dependency_attribution`: **full** — the route→service edge for every static upstream.
- `resource_extraction`: **partial** (#3723) — route identity + path + upstream only; per-route filters/policies/rate-limits/CORS/auth not modelled. Dynamic/templated upstreams are omitted, not guessed.

## Checks
- `go test ./internal/engine/ ./internal/classifier/ ./internal/types/ ./tools/coverage/` — green.
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical (new cell `infra.gateway.api-routing`).
- `gofmt -l` empty; `go vet` clean.

## DEPLOY-DEFERRED
Built and verified in an isolated sandbox; the live-daemon rebuild + reindex is deferred to a coordinated deploy (live daemon serves the rewrite agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)