### PR TITLE
coverage: add datastore mongodb driver records for python/java/ruby

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18898,6 +18898,57 @@
       }
     },
     {
+      "id": "lang.java.driver.mongodb",
+      "category": "orm",
+      "subcategory": "orm_mapper",
+      "language": "java",
+      "label": "MongoDB Java Driver",
+      "capabilities": {
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          },
+          "schema_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          }
+        },
+        "Relationships": {
+          "association_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "foreign_key_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "lazy_loading_recognition": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "relationship_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          }
+        },
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_drivers_other.go","internal/engine/orm_queries_drivers_other_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "Driver topology: database.getCollection('x') literal captured via scanJavaDrivers (javaGetCollectionRe); QUERIES edge to Class:\u003cCollection\u003e; dynamic names honest-skipped.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.java.framework.akka-http",
       "category": "http_framework",
       "subcategory": "jvm_backend",
@@ -43525,6 +43576,57 @@
       }
     },
     {
+      "id": "lang.python.driver.mongodb",
+      "category": "orm",
+      "subcategory": "orm_mapper",
+      "language": "python",
+      "label": "pymongo / motor",
+      "capabilities": {
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          },
+          "schema_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          }
+        },
+        "Relationships": {
+          "association_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "foreign_key_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "lazy_loading_recognition": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "relationship_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          }
+        },
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_drivers_other.go","internal/engine/orm_queries_drivers_other_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "Driver topology: db.get_collection('x') / db['x'] subscript captured via scanPythonDrivers (pyMongoCollGetRe/pyMongoSubscriptRe); QUERIES edge to Class:\u003cCollection\u003e; dynamic names honest-skipped.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.python.driver.mysql",
       "category": "orm",
       "subcategory": "orm_mapper",
@@ -49947,6 +50049,57 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
             "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.mongodb",
+      "category": "orm",
+      "subcategory": "orm_mapper",
+      "language": "ruby",
+      "label": "mongo Ruby Driver",
+      "capabilities": {
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          },
+          "schema_extraction": {
+            "status": "not_applicable",
+            "notes": "NoSQL driver — no relational schema/ORM model in user code"
+          }
+        },
+        "Relationships": {
+          "association_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "foreign_key_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "lazy_loading_recognition": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          },
+          "relationship_extraction": {
+            "status": "not_applicable",
+            "notes": "raw driver — no ORM relationship/lazy-load layer"
+          }
+        },
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_drivers_other.go","internal/engine/orm_queries_drivers_other_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "Driver topology: client[:x] symbol / client['x'] string collection accessor captured via scanRubyDrivers (rubyMongoCollRe/rubyMongoCollStrRe); QUERIES edge to Class:\u003cCollection\u003e; dynamic names honest-skipped.",
             "verified_at": "2026-06-02"
           }
         },


### PR DESCRIPTION
## What

Adds the missing `lang.<lang>.driver.mongodb` registry RECORDS that #3726 flagged but couldn't stamp.

#3726 extended the native query-topology extractor `internal/engine/orm_queries_drivers_other.go` to emit Mongo **collection topology** for Python, Java and Ruby (with tests in `orm_queries_drivers_other_test.go`). But the real extraction had no registry home:

- Python had `lang.python.driver.*` records but **no** `lang.python.driver.mongodb`
- Ruby had `lang.ruby.driver.*` records but **no** `lang.ruby.driver.mongodb`
- **Java had no `lang.java.driver.*` records at all**

## Records added

| ID | Label | query_attribution |
|---|---|---|
| `lang.python.driver.mongodb` | pymongo / motor | **full** |
| `lang.java.driver.mongodb` | MongoDB Java Driver | **full** |
| `lang.ruby.driver.mongodb` | mongo Ruby Driver | **full** |

Each mirrors the canonical peer driver record shape exactly (e.g. `lang.ruby.driver.cassandra`, `lang.python.driver.dynamodb` — full via the same `orm_queries_drivers_other.go` extractor):

- **query_attribution = full** — proven by the #3726 extractor. Cites the live `internal/engine/orm_queries.go`, `internal/engine/orm_queries_drivers_other.go`, and its test `internal/engine/orm_queries_drivers_other_test.go`. Per-lang emit paths:
  - Python: `db.get_collection('x')` / `db['x']` → `scanPythonDrivers` (`pyMongoCollGetRe`/`pyMongoSubscriptRe`)
  - Java: `database.getCollection('x')` → `scanJavaDrivers` (`javaGetCollectionRe`)
  - Ruby: `client[:x]` / `client['x']` → `scanRubyDrivers` (`rubyMongoCollRe`/`rubyMongoCollStrRe`)
- **Models / Relationships / Migrations = not_applicable** — raw NoSQL driver: no relational schema, no ORM relationship/lazy-load layer, no migrations. Taxonomy seeded via `coverage backfill`.

Quality-first: `full` only where the #3726 extractor genuinely emits QUERIES edges; everything else honestly `not_applicable`.

## Gates

- `coverage validate`: **0 errors** (the 3 new `capability-map ... no mapping entry` warnings match the established peer pattern — `ruby.driver.cassandra`, `python.driver.dynamodb`, `ruby.driver.dynamodb` emit the identical non-blocking warning)
- `coverage fmt --check`: **canonical**
- `go test ./tools/coverage/`: **green**, incl. `TestDatastoreCiteValidityGuard` (confirms cites point at a real query-emitting extractor, not detection-only YAML)

Refs #3726, #3645 (epic #3625) — adds the records #3726 couldn't stamp.

**DEPLOY-DEFERRED**: registry-only change; live daemon untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)