### PR TITLE
[plugins] plugin/extension-system registration extraction (#3628 area #25)

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -577,6 +577,16 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// the surrounding pipeline's bug-rate on files without flag checks.
 	applyPass(applyFeatureFlagEdges)
 
+	// Plugin / extension-system registration topology (#3628 area #25). For
+	// every recognised build/config file (webpack/vite/rollup config, Babel,
+	// ESLint, pytest_plugins, setuptools entry_points, pom.xml, build.gradle),
+	// emits a synthetic SCOPE.Plugin entity (`plugin:<ecosystem>:<name>`) and
+	// a REGISTERS_PLUGIN edge from the declaring file so the graph can answer
+	// "which plugins does this build/app register". Only literal plugin names
+	// are emitted; dynamic names are skipped. No-op on non-config files.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	applyPass(applyPluginSystemEdges)
+
 	// Kafka producer/consumer cross-repo edges (wave 1 of #726). Emits
 	// synthetic MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges
 	// using the same cross-repo matching strategy as #534: identical

--- a/internal/engine/plugin_system_edges.go
+++ b/internal/engine/plugin_system_edges.go
@@ -1,0 +1,493 @@
+// Plugin / extension-system registration topology (issue #3628 area #25).
+//
+// Build tools, linters, transpilers, test runners, and JVM build systems are
+// composed from plugins/extensions. Where feature flags (#3628 area #17,
+// GATED_BY) answer "what code is gated by flag X", plugin registration answers
+// "which plugins does this build/app register" — the composition of a
+// project's build/runtime behavior.
+//
+// This pass keys off the FILE (config / build manifest) rather than call
+// sites: a plugin is declared in a config, not invoked at a code offset. It
+// scans recognised config files and emits:
+//
+//   - one synthetic SCOPE.Plugin entity per distinct (ecosystem, plugin name)
+//     pair (synthetic ID `plugin:<ecosystem>:<name>`, Subtype = the system),
+//     and
+//   - one REGISTERS_PLUGIN edge from the declaring config file
+//     (`File:<path>`) to the plugin entity.
+//
+// The plugin entity ID embeds the ecosystem so two configs in the same repo
+// that register the same plugin name converge on one node (same cross-file
+// identity strategy used by MessageTopic / FeatureFlag), while a webpack
+// "html" and a babel "html" stay distinct.
+//
+// Supported systems (the dominant, clear idioms):
+//
+//   - Webpack / Vite / Rollup (JS bundler configs): a `plugins: [ ... ]`
+//     array whose elements are `new HtmlWebpackPlugin()` (constructor) or
+//     `terser()` / `vue()` (factory call). The constructed/called identifier
+//     is the plugin name.
+//   - Babel / ESLint (.babelrc / .eslintrc / package.json blocks): a
+//     `plugins: ["@babel/plugin-x", "react"]` / `extends: [...]` string array.
+//   - pytest: `pytest_plugins = ["a", "b"]` in conftest.py / a test module.
+//   - setuptools: `entry_points={"<group>": ["name = module:obj"]}` —
+//     each entry is a registered plugin under its group.
+//   - Maven: `<plugin>...<artifactId>X</artifactId>...</plugin>` in pom.xml.
+//   - Gradle: `plugins { id 'java'; id "org.x" version "1" }` in build.gradle.
+//
+// Honest-partial: only LITERAL plugin names are emitted. A dynamically
+// computed plugin (spread `...basePlugins`, a bare variable element, a
+// non-literal artifactId) yields NO entity and NO edge — the same disposition
+// the feature-flag and config-read passes use for dynamic values.
+//
+// Append-only — never modifies existing entities or edges, so this pass cannot
+// regress the surrounding pipeline on files that register no plugins.
+package engine
+
+import (
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pluginEntityKind / pluginEdgeKind are aliased through the typed enum so
+// kinds.go stays canonical (producer_kinds_test.go guardrail).
+var (
+	pluginEntityKind = string(types.EntityKindPlugin)
+	pluginEdgeKind   = string(types.RelationshipKindRegistersPlugin)
+)
+
+// pluginPatternType tags every emitted entity/edge so downstream consumers can
+// filter the pass output, matching the pattern_type convention used by the
+// feature-flag and config passes.
+const pluginPatternType = "plugin_registration"
+
+// pluginHit is one detected plugin registration.
+type pluginHit struct {
+	name   string // literal plugin name
+	system string // webpack | vite | rollup | babel | eslint | pytest | setuptools | maven | gradle
+	group  string // setuptools entry-point group ("" otherwise)
+	line   int    // 1-indexed source line
+}
+
+// applyPluginSystemEdges scans a config/build file for plugin registrations
+// and appends a SCOPE.Plugin entity (deduped per ecosystem:name) plus a
+// REGISTERS_PLUGIN edge from the declaring file. No-op for files that are not
+// a recognised config or that register no plugins. Runs append-only.
+func applyPluginSystemEdges(args DetectorPassArgs) DetectorPassResult {
+	filePath := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
+
+	if len(content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	src := string(content)
+	hits := scanPlugins(filePath, src)
+	if len(hits) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	fromID := "File:" + filePath
+
+	// Dedup the plugin entities by ecosystem:name. The first hit wins the
+	// metadata (system / group).
+	emittedPlugin := map[string]bool{}
+	// Dedup edges by plugin ID so a plugin declared twice yields one edge.
+	emittedEdge := map[string]bool{}
+
+	for _, h := range hits {
+		pluginID := buildPluginID(h.system, h.name)
+
+		if !emittedPlugin[pluginID] {
+			emittedPlugin[pluginID] = true
+			props := map[string]string{
+				"plugin":       h.name,
+				"system":       h.system,
+				"pattern_type": pluginPatternType,
+			}
+			if h.group != "" {
+				props["group"] = h.group
+			}
+			entities = append(entities, types.EntityRecord{
+				ID:                 pluginID,
+				Name:               h.name,
+				Kind:               pluginEntityKind,
+				Subtype:            h.system,
+				SourceFile:         filePath,
+				StartLine:          h.line,
+				EndLine:            h.line,
+				Language:           args.Lang,
+				Properties:         props,
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.8,
+			})
+		}
+
+		if emittedEdge[pluginID] {
+			continue
+		}
+		emittedEdge[pluginID] = true
+
+		edgeProps := map[string]string{
+			"plugin":       h.name,
+			"system":       h.system,
+			"line":         strconv.Itoa(h.line),
+			"pattern_type": pluginPatternType,
+		}
+		if h.group != "" {
+			edgeProps["group"] = h.group
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       pluginID,
+			Kind:       pluginEdgeKind,
+			Properties: edgeProps,
+		})
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// scanPlugins dispatches on the file's basename to the right system scanner.
+// Returns nil for files that are not a recognised plugin-declaring config.
+func scanPlugins(filePath, src string) []pluginHit {
+	base := strings.ToLower(path.Base(filePath))
+
+	switch {
+	case base == "pom.xml":
+		return scanMavenPlugins(src)
+	case base == "build.gradle" || base == "build.gradle.kts":
+		return scanGradlePlugins(src)
+	case base == ".babelrc" || base == ".babelrc.json" || base == "babel.config.js" || base == "babel.config.json":
+		return scanStringArrayPlugins(src, "babel", "plugins")
+	case isESLintConfig(base):
+		// ESLint registers via both `plugins` and `extends`.
+		hits := scanStringArrayPlugins(src, "eslint", "plugins")
+		hits = append(hits, scanStringArrayPlugins(src, "eslint", "extends")...)
+		return hits
+	case isBundlerConfig(base):
+		return scanBundlerPlugins(filePath, src)
+	case isPythonFile(base):
+		hits := scanPytestPlugins(src)
+		hits = append(hits, scanSetuptoolsEntryPoints(src)...)
+		return hits
+	case base == "setup.cfg":
+		return scanSetuptoolsEntryPoints(src)
+	}
+	return nil
+}
+
+func isESLintConfig(base string) bool {
+	return strings.HasPrefix(base, ".eslintrc") ||
+		base == "eslint.config.js" || base == "eslint.config.mjs" ||
+		base == "eslint.config.cjs"
+}
+
+// isBundlerConfig matches the webpack / vite / rollup bundler config files
+// whose dominant idiom is a `plugins: [ ... ]` array of constructors/factories.
+var bundlerConfigRe = regexp.MustCompile(
+	`^(webpack|vite|rollup|vitest)\.config\.(js|ts|mjs|cjs)$`)
+
+func isBundlerConfig(base string) bool {
+	return bundlerConfigRe.MatchString(base)
+}
+
+func isPythonFile(base string) bool {
+	return strings.HasSuffix(base, ".py")
+}
+
+// bundlerSystemFor returns the bundler system tag from the config basename.
+func bundlerSystemFor(base string) string {
+	if i := strings.IndexByte(base, '.'); i > 0 {
+		switch base[:i] {
+		case "webpack":
+			return "webpack"
+		case "vite", "vitest":
+			return "vite"
+		case "rollup":
+			return "rollup"
+		}
+	}
+	return "webpack"
+}
+
+// --- JS bundler (webpack / vite / rollup) ----------------------------------
+
+// pluginsArrayRe captures the bracketed body of a `plugins: [ ... ]` literal.
+// Non-greedy to the first closing bracket; nested arrays inside plugin args
+// are uncommon in the dominant idiom and are honest-partial out of scope.
+var pluginsArrayRe = regexp.MustCompile(`(?s)plugins\s*:\s*\[(.*?)\]`)
+
+// bundlerElementRe captures a plugin element as either `new Name(` (constructor)
+// or `name(` (factory call). Group 1 = constructor name, group 2 = factory name.
+var bundlerElementRe = regexp.MustCompile(
+	`\bnew\s+([A-Za-z_$][\w$]*)\s*\(|(?:^|[\[,{]\s*)([A-Za-z_$][\w$]*)\s*\(`)
+
+// scanBundlerPlugins extracts plugin entities from a `plugins: [ ... ]` array
+// in a webpack/vite/rollup config. Only constructor (`new X()`) and
+// factory-call (`x()`) elements with a literal identifier are emitted; spreads
+// and bare variable references are skipped (honest-partial).
+func scanBundlerPlugins(filePath, src string) []pluginHit {
+	system := bundlerSystemFor(strings.ToLower(path.Base(filePath)))
+
+	var hits []pluginHit
+	for _, arr := range pluginsArrayRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := arr[2], arr[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, m := range bundlerElementRe.FindAllStringSubmatch(body, -1) {
+			name := m[1]
+			if name == "" {
+				name = m[2]
+			}
+			if name == "" || isJSKeyword(name) {
+				continue
+			}
+			hits = append(hits, pluginHit{
+				name:   name,
+				system: system,
+				line:   lineAtOffset(src, bodyStart),
+			})
+		}
+	}
+	return hits
+}
+
+// isJSKeyword filters out JS keywords that bundlerElementRe's factory branch
+// could otherwise capture (e.g. `require(...)`, `if(...)`), so they don't
+// become fabricated plugin entities.
+func isJSKeyword(s string) bool {
+	switch s {
+	case "require", "if", "for", "while", "switch", "return", "function",
+		"import", "export", "await", "typeof", "new", "module", "process":
+		return true
+	}
+	return false
+}
+
+// --- Babel / ESLint (string-array plugins) ---------------------------------
+
+// stringArrayKeyRe is built per key to capture the `<key>: [ ... ]` body in a
+// JSON/JS config object.
+func stringArrayKeyRe(key string) *regexp.Regexp {
+	return regexp.MustCompile(`(?s)["']?` + regexp.QuoteMeta(key) + `["']?\s*:\s*\[(.*?)\]`)
+}
+
+// pluginStringLiteralRe captures a single/double-quoted string literal.
+var pluginStringLiteralRe = regexp.MustCompile(`"([^"\\]+)"|'([^'\\]+)'`)
+
+// scanStringArrayPlugins extracts plugin names from a `<key>: ["a", "b"]`
+// string array (Babel `plugins`, ESLint `plugins` / `extends`). Each string
+// literal is a plugin name; non-literal elements are skipped.
+func scanStringArrayPlugins(src, system, key string) []pluginHit {
+	re := stringArrayKeyRe(key)
+	var hits []pluginHit
+	for _, arr := range re.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := arr[2], arr[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, m := range pluginStringLiteralRe.FindAllStringSubmatch(body, -1) {
+			name := m[1]
+			if name == "" {
+				name = m[2]
+			}
+			if name == "" {
+				continue
+			}
+			hits = append(hits, pluginHit{
+				name:   name,
+				system: system,
+				line:   lineAtOffset(src, bodyStart),
+			})
+		}
+	}
+	return hits
+}
+
+// --- pytest -----------------------------------------------------------------
+
+// pytestPluginsRe captures the `pytest_plugins = [ ... ]` (or tuple) body.
+var pytestPluginsRe = regexp.MustCompile(`(?s)pytest_plugins\s*=\s*[\[\(](.*?)[\]\)]`)
+
+// scanPytestPlugins extracts plugin module names from a `pytest_plugins`
+// list/tuple of string literals (conftest.py or a test module).
+func scanPytestPlugins(src string) []pluginHit {
+	var hits []pluginHit
+	for _, arr := range pytestPluginsRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := arr[2], arr[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, m := range pluginStringLiteralRe.FindAllStringSubmatch(body, -1) {
+			name := m[1]
+			if name == "" {
+				name = m[2]
+			}
+			if name == "" {
+				continue
+			}
+			hits = append(hits, pluginHit{
+				name:   name,
+				system: "pytest",
+				line:   lineAtOffset(src, bodyStart),
+			})
+		}
+	}
+	return hits
+}
+
+// --- setuptools entry points ------------------------------------------------
+
+// entryPointsBlockRe captures the `entry_points={ ... }` dict body (setup.py)
+// or the `[options.entry_points]` ... block is handled by setup.cfg scanning
+// below via the same per-group regex; here we cover the dict form.
+var entryPointsDictRe = regexp.MustCompile(`(?s)entry_points\s*=\s*\{(.*?)\}`)
+
+// entryPointsGroupRe captures one `"group": [ "name = mod:obj", ... ]` pair
+// inside the entry_points dict. Group 1 = group, group 2 = the list body.
+var entryPointsGroupRe = regexp.MustCompile(`(?s)["']([^"'\\]+)["']\s*:\s*\[(.*?)\]`)
+
+// entryPointSpecRe captures the `name` of a `name = module:object` entry-point
+// string literal (the left-hand side before `=`).
+var entryPointSpecRe = regexp.MustCompile(`^\s*([\w\.\-]+)\s*=`)
+
+// scanSetuptoolsEntryPoints extracts entry-point plugins from a setuptools
+// `entry_points={"<group>": ["name = mod:obj"]}` dict (setup.py). Each entry's
+// left-hand name is a registered plugin under its group.
+func scanSetuptoolsEntryPoints(src string) []pluginHit {
+	var hits []pluginHit
+	for _, blk := range entryPointsDictRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := blk[2], blk[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, g := range entryPointsGroupRe.FindAllStringSubmatchIndex(body, -1) {
+			groupStart, groupEnd := g[2], g[3]
+			listStart, listEnd := g[4], g[5]
+			if groupStart < 0 || listStart < 0 {
+				continue
+			}
+			group := body[groupStart:groupEnd]
+			list := body[listStart:listEnd]
+			lineBase := lineAtOffset(src, bodyStart+listStart)
+			for _, m := range pluginStringLiteralRe.FindAllStringSubmatch(list, -1) {
+				entry := m[1]
+				if entry == "" {
+					entry = m[2]
+				}
+				name := entryPointName(entry)
+				if name == "" {
+					continue
+				}
+				hits = append(hits, pluginHit{
+					name:   name,
+					system: "setuptools",
+					group:  group,
+					line:   lineBase,
+				})
+			}
+		}
+	}
+	return hits
+}
+
+// entryPointName returns the registered name (left of `=`) from a
+// `name = module:object` entry-point string. Returns "" if the form is not
+// recognised.
+func entryPointName(entry string) string {
+	m := entryPointSpecRe.FindStringSubmatch(entry)
+	if m == nil {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// --- Maven ------------------------------------------------------------------
+
+// mavenPluginBlockRe captures each `<plugin> ... </plugin>` body in pom.xml.
+var mavenPluginBlockRe = regexp.MustCompile(`(?s)<plugin>(.*?)</plugin>`)
+
+// mavenArtifactRe captures the `<artifactId>X</artifactId>` value.
+var mavenArtifactRe = regexp.MustCompile(`<artifactId>\s*([^<\s][^<]*?)\s*</artifactId>`)
+
+// scanMavenPlugins extracts the artifactId of each `<plugin>` element in
+// pom.xml. Plugins under `<dependencies>` are NOT matched (those are
+// `<dependency>` elements), so only true build plugins are emitted.
+func scanMavenPlugins(src string) []pluginHit {
+	var hits []pluginHit
+	for _, blk := range mavenPluginBlockRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := blk[2], blk[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		am := mavenArtifactRe.FindStringSubmatch(body)
+		if am == nil {
+			continue
+		}
+		name := strings.TrimSpace(am[1])
+		if name == "" {
+			continue
+		}
+		hits = append(hits, pluginHit{
+			name:   name,
+			system: "maven",
+			line:   lineAtOffset(src, bodyStart),
+		})
+	}
+	return hits
+}
+
+// --- Gradle -----------------------------------------------------------------
+
+// gradlePluginsBlockRe captures the body of a `plugins { ... }` block in
+// build.gradle / build.gradle.kts.
+var gradlePluginsBlockRe = regexp.MustCompile(`(?s)plugins\s*\{(.*?)\}`)
+
+// gradleIdRe captures the plugin id from `id 'x'`, `id "x"`, or
+// `id("x")` (Kotlin DSL).
+var gradleIdRe = regexp.MustCompile(`\bid\s*[\(\s]\s*["']([^"'\\]+)["']`)
+
+// scanGradlePlugins extracts plugin ids declared in a `plugins { ... }` block.
+// Covers both the Groovy (`id 'java'`) and Kotlin (`id("java")`) DSLs.
+func scanGradlePlugins(src string) []pluginHit {
+	var hits []pluginHit
+	for _, blk := range gradlePluginsBlockRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart, bodyEnd := blk[2], blk[3]
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, m := range gradleIdRe.FindAllStringSubmatch(body, -1) {
+			name := strings.TrimSpace(m[1])
+			if name == "" {
+				continue
+			}
+			hits = append(hits, pluginHit{
+				name:   name,
+				system: "gradle",
+				line:   lineAtOffset(src, bodyStart),
+			})
+		}
+	}
+	return hits
+}
+
+// buildPluginID returns the synthetic entity ID for a plugin:
+// `plugin:<ecosystem>:<name>`. Same ecosystem+name converge on one node.
+func buildPluginID(system, name string) string {
+	return "plugin:" + system + ":" + name
+}

--- a/internal/engine/plugin_system_edges_test.go
+++ b/internal/engine/plugin_system_edges_test.go
@@ -1,0 +1,419 @@
+// Tests for the applyPluginSystemEdges pass (#3628 area #25).
+//
+// Strategy: drive the pass directly via DetectorPassArgs (the pass is a pure
+// function of Path+Content), then assert on the emitted SCOPE.Plugin entities
+// and REGISTERS_PLUGIN edges. Assertions are VALUE-ASSERTING — they check the
+// exact plugin name, the system, and the synthetic `plugin:<system>:<name>`
+// ToID with a `File:<path>` FromID — not just len>0.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pluginEdge is the minimal projection of a REGISTERS_PLUGIN edge.
+type pluginEdge struct {
+	From   string
+	To     string
+	Plugin string
+	System string
+	Group  string
+}
+
+// runPluginPass runs applyPluginSystemEdges on a single in-memory file and
+// returns the Plugin entities + REGISTERS_PLUGIN edges it appended.
+func runPluginPass(lang, path, src string) ([]types.EntityRecord, []pluginEdge) {
+	res := applyPluginSystemEdges(DetectorPassArgs{
+		Lang:    lang,
+		Path:    path,
+		Content: []byte(src),
+	})
+	var plugins []types.EntityRecord
+	for _, e := range res.Entities {
+		if e.Kind == pluginEntityKind {
+			plugins = append(plugins, e)
+		}
+	}
+	var edges []pluginEdge
+	for _, r := range res.Relationships {
+		if r.Kind != pluginEdgeKind {
+			continue
+		}
+		edges = append(edges, pluginEdge{
+			From:   r.FromID,
+			To:     r.ToID,
+			Plugin: r.Properties["plugin"],
+			System: r.Properties["system"],
+			Group:  r.Properties["group"],
+		})
+	}
+	return plugins, edges
+}
+
+// findPluginEdge returns the REGISTERS_PLUGIN edge whose plugin name == name.
+func findPluginEdge(edges []pluginEdge, name string) (pluginEdge, bool) {
+	for _, e := range edges {
+		if e.Plugin == name {
+			return e, true
+		}
+	}
+	return pluginEdge{}, false
+}
+
+// findPluginEntity returns the SCOPE.Plugin entity whose Name == name.
+func findPluginEntity(ents []types.EntityRecord, name string) (types.EntityRecord, bool) {
+	for _, e := range ents {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return types.EntityRecord{}, false
+}
+
+// --- Webpack / Vite / Rollup ------------------------------------------------
+
+func TestPluginPass_WebpackConstructorAndFactory(t *testing.T) {
+	src := `
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { terser } = require('rollup-plugin-terser');
+module.exports = {
+  plugins: [
+    new HtmlWebpackPlugin(),
+    terser(),
+  ],
+};
+`
+	ents, edges := runPluginPass("javascript", "webpack.config.js", src)
+
+	e, ok := findPluginEdge(edges, "HtmlWebpackPlugin")
+	if !ok {
+		t.Fatalf("expected plugin HtmlWebpackPlugin registered, got edges=%+v", edges)
+	}
+	if e.System != "webpack" {
+		t.Errorf("HtmlWebpackPlugin system = %q, want webpack", e.System)
+	}
+	if e.To != "plugin:webpack:HtmlWebpackPlugin" {
+		t.Errorf("HtmlWebpackPlugin ToID = %q, want plugin:webpack:HtmlWebpackPlugin", e.To)
+	}
+	if e.From != "File:webpack.config.js" {
+		t.Errorf("FromID = %q, want File:webpack.config.js", e.From)
+	}
+
+	if _, ok := findPluginEdge(edges, "terser"); !ok {
+		t.Errorf("expected factory plugin terser registered, got edges=%+v", edges)
+	}
+
+	// Entity assertion.
+	if pe, ok := findPluginEntity(ents, "HtmlWebpackPlugin"); !ok {
+		t.Errorf("expected SCOPE.Plugin entity HtmlWebpackPlugin")
+	} else if pe.Subtype != "webpack" {
+		t.Errorf("entity Subtype = %q, want webpack", pe.Subtype)
+	}
+}
+
+func TestPluginPass_ViteSystemTag(t *testing.T) {
+	src := `
+import vue from '@vitejs/plugin-vue';
+export default {
+  plugins: [vue()],
+};
+`
+	_, edges := runPluginPass("typescript", "vite.config.ts", src)
+	e, ok := findPluginEdge(edges, "vue")
+	if !ok {
+		t.Fatalf("expected vite plugin vue, got %+v", edges)
+	}
+	if e.System != "vite" {
+		t.Errorf("vue system = %q, want vite", e.System)
+	}
+	if e.To != "plugin:vite:vue" {
+		t.Errorf("ToID = %q, want plugin:vite:vue", e.To)
+	}
+}
+
+func TestPluginPass_BundlerSkipsSpreadAndVariable(t *testing.T) {
+	// Honest-partial: a spread or bare variable element must NOT become a
+	// fabricated plugin entity.
+	src := `
+module.exports = {
+  plugins: [
+    ...basePlugins,
+    myPluginVar,
+    new RealPlugin(),
+  ],
+};
+`
+	_, edges := runPluginPass("javascript", "webpack.config.js", src)
+	if _, ok := findPluginEdge(edges, "basePlugins"); ok {
+		t.Errorf("spread element must not yield a plugin, got %+v", edges)
+	}
+	if _, ok := findPluginEdge(edges, "myPluginVar"); ok {
+		t.Errorf("bare variable element must not yield a plugin, got %+v", edges)
+	}
+	if _, ok := findPluginEdge(edges, "RealPlugin"); !ok {
+		t.Errorf("expected RealPlugin constructor registered, got %+v", edges)
+	}
+}
+
+// --- Babel / ESLint ---------------------------------------------------------
+
+func TestPluginPass_BabelStringPlugins(t *testing.T) {
+	src := `{
+  "plugins": ["@babel/plugin-transform-runtime", "macros"]
+}`
+	_, edges := runPluginPass("json", ".babelrc", src)
+	e, ok := findPluginEdge(edges, "@babel/plugin-transform-runtime")
+	if !ok {
+		t.Fatalf("expected babel plugin, got %+v", edges)
+	}
+	if e.System != "babel" {
+		t.Errorf("system = %q, want babel", e.System)
+	}
+	if e.To != "plugin:babel:@babel/plugin-transform-runtime" {
+		t.Errorf("ToID = %q", e.To)
+	}
+	if _, ok := findPluginEdge(edges, "macros"); !ok {
+		t.Errorf("expected babel plugin macros, got %+v", edges)
+	}
+}
+
+func TestPluginPass_ESLintPluginsAndExtends(t *testing.T) {
+	src := `{
+  "plugins": ["react", "@typescript-eslint"],
+  "extends": ["airbnb", "prettier"]
+}`
+	_, edges := runPluginPass("json", ".eslintrc.json", src)
+	for _, want := range []string{"react", "@typescript-eslint", "airbnb", "prettier"} {
+		e, ok := findPluginEdge(edges, want)
+		if !ok {
+			t.Errorf("expected eslint plugin %q, got %+v", want, edges)
+			continue
+		}
+		if e.System != "eslint" {
+			t.Errorf("%q system = %q, want eslint", want, e.System)
+		}
+	}
+}
+
+// --- pytest -----------------------------------------------------------------
+
+func TestPluginPass_PytestPlugins(t *testing.T) {
+	src := `
+pytest_plugins = ["myproj.fixtures", "pytester"]
+
+def test_x():
+    pass
+`
+	_, edges := runPluginPass("python", "conftest.py", src)
+	e, ok := findPluginEdge(edges, "myproj.fixtures")
+	if !ok {
+		t.Fatalf("expected pytest plugin myproj.fixtures, got %+v", edges)
+	}
+	if e.System != "pytest" {
+		t.Errorf("system = %q, want pytest", e.System)
+	}
+	if e.To != "plugin:pytest:myproj.fixtures" {
+		t.Errorf("ToID = %q", e.To)
+	}
+}
+
+// --- setuptools entry points ------------------------------------------------
+
+func TestPluginPass_SetuptoolsEntryPoints(t *testing.T) {
+	src := `
+from setuptools import setup
+
+setup(
+    name="myproj",
+    entry_points={
+        "flake8.extension": [
+            "X = mod:Cls",
+            "Y = mod.other:Other",
+        ],
+        "console_scripts": [
+            "myprog = myproj.cli:main",
+        ],
+    },
+)
+`
+	_, edges := runPluginPass("python", "setup.py", src)
+	e, ok := findPluginEdge(edges, "X")
+	if !ok {
+		t.Fatalf("expected entry-point plugin X, got %+v", edges)
+	}
+	if e.System != "setuptools" {
+		t.Errorf("system = %q, want setuptools", e.System)
+	}
+	if e.Group != "flake8.extension" {
+		t.Errorf("group = %q, want flake8.extension", e.Group)
+	}
+	if e.To != "plugin:setuptools:X" {
+		t.Errorf("ToID = %q, want plugin:setuptools:X", e.To)
+	}
+
+	myprog, ok := findPluginEdge(edges, "myprog")
+	if !ok {
+		t.Fatalf("expected console_scripts entry myprog, got %+v", edges)
+	}
+	if myprog.Group != "console_scripts" {
+		t.Errorf("myprog group = %q, want console_scripts", myprog.Group)
+	}
+}
+
+// --- Maven ------------------------------------------------------------------
+
+func TestPluginPass_MavenPlugins(t *testing.T) {
+	src := `<project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <artifactId>guava</artifactId>
+    </dependency>
+  </dependencies>
+</project>`
+	_, edges := runPluginPass("xml", "pom.xml", src)
+	e, ok := findPluginEdge(edges, "maven-compiler-plugin")
+	if !ok {
+		t.Fatalf("expected maven-compiler-plugin, got %+v", edges)
+	}
+	if e.System != "maven" {
+		t.Errorf("system = %q, want maven", e.System)
+	}
+	if e.To != "plugin:maven:maven-compiler-plugin" {
+		t.Errorf("ToID = %q", e.To)
+	}
+	if _, ok := findPluginEdge(edges, "maven-surefire-plugin"); !ok {
+		t.Errorf("expected maven-surefire-plugin, got %+v", edges)
+	}
+	// Negative: a <dependency>'s artifactId must NOT be a plugin.
+	if _, ok := findPluginEdge(edges, "guava"); ok {
+		t.Errorf("dependency guava must not be a plugin, got %+v", edges)
+	}
+}
+
+// --- Gradle -----------------------------------------------------------------
+
+func TestPluginPass_GradleGroovyDSL(t *testing.T) {
+	src := `
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.0'
+}
+`
+	_, edges := runPluginPass("groovy", "build.gradle", src)
+	e, ok := findPluginEdge(edges, "java")
+	if !ok {
+		t.Fatalf("expected gradle plugin java, got %+v", edges)
+	}
+	if e.System != "gradle" {
+		t.Errorf("system = %q, want gradle", e.System)
+	}
+	if e.To != "plugin:gradle:java" {
+		t.Errorf("ToID = %q, want plugin:gradle:java", e.To)
+	}
+	if _, ok := findPluginEdge(edges, "org.springframework.boot"); !ok {
+		t.Errorf("expected spring boot gradle plugin, got %+v", edges)
+	}
+}
+
+func TestPluginPass_GradleKotlinDSL(t *testing.T) {
+	src := `
+plugins {
+    id("java")
+    kotlin("jvm") version "1.9.0"
+    id("org.jetbrains.kotlin.plugin.spring")
+}
+`
+	_, edges := runPluginPass("kotlin", "build.gradle.kts", src)
+	if e, ok := findPluginEdge(edges, "java"); !ok {
+		t.Fatalf("expected gradle kotlin-DSL plugin java, got %+v", edges)
+	} else if e.System != "gradle" {
+		t.Errorf("system = %q, want gradle", e.System)
+	}
+	if _, ok := findPluginEdge(edges, "org.jetbrains.kotlin.plugin.spring"); !ok {
+		t.Errorf("expected kotlin spring plugin, got %+v", edges)
+	}
+}
+
+// --- Negative / no-op cases -------------------------------------------------
+
+func TestPluginPass_NonConfigFileNoPlugins(t *testing.T) {
+	// A regular source file that happens to contain the word "plugins"
+	// must NOT yield any plugin entity/edge.
+	src := `
+function loadPlugins() {
+  const plugins = [new Foo(), bar()];
+  return plugins;
+}
+`
+	ents, edges := runPluginPass("javascript", "src/loader.js", src)
+	if len(ents) != 0 || len(edges) != 0 {
+		t.Errorf("non-config file must yield no plugins, got ents=%d edges=%d", len(ents), len(edges))
+	}
+}
+
+func TestPluginPass_EmptyContentNoOp(t *testing.T) {
+	ents, edges := runPluginPass("javascript", "webpack.config.js", "")
+	if len(ents) != 0 || len(edges) != 0 {
+		t.Errorf("empty content must be a no-op, got ents=%d edges=%d", len(ents), len(edges))
+	}
+}
+
+func TestPluginPass_Dedup(t *testing.T) {
+	// The same plugin declared twice yields a single entity + single edge.
+	src := `{
+  "plugins": ["react", "react"]
+}`
+	ents, edges := runPluginPass("json", ".eslintrc", src)
+	count := 0
+	for _, e := range edges {
+		if e.Plugin == "react" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 react edge after dedup, got %d", count)
+	}
+	entCount := 0
+	for _, e := range ents {
+		if e.Name == "react" {
+			entCount++
+		}
+	}
+	if entCount != 1 {
+		t.Errorf("expected exactly 1 react entity after dedup, got %d", entCount)
+	}
+}
+
+func TestPluginPass_PassThroughPreservesPriorSlices(t *testing.T) {
+	// The pass must thread through pre-existing entities/relationships
+	// unmodified (append-only contract).
+	priorEnt := types.EntityRecord{ID: "X", Kind: "SCOPE.Function"}
+	priorRel := types.RelationshipRecord{FromID: "A", ToID: "B", Kind: "CALLS"}
+	res := applyPluginSystemEdges(DetectorPassArgs{
+		Lang:          "javascript",
+		Path:          "webpack.config.js",
+		Content:       []byte(`module.exports = { plugins: [new P()] };`),
+		Entities:      []types.EntityRecord{priorEnt},
+		Relationships: []types.RelationshipRecord{priorRel},
+	})
+	if len(res.Entities) < 2 || res.Entities[0].ID != "X" {
+		t.Errorf("prior entity not preserved: %+v", res.Entities)
+	}
+	if len(res.Relationships) < 2 || res.Relationships[0].Kind != "CALLS" {
+		t.Errorf("prior relationship not preserved: %+v", res.Relationships)
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -215,6 +215,7 @@ func AllEntityKinds() []EntityKind {
 		EntityKindCustomValidator,
 		// #3628 area #17:
 		EntityKindFeatureFlag,
+		EntityKindPlugin,
 		// #3624 GraphQL DataLoader:
 		EntityKindDataLoader,
 	}
@@ -628,6 +629,19 @@ const (
 	// ("launchdarkly", "unleash", "openfeature", "flipper", "flagsmith").
 	EntityKindFeatureFlag EntityKind = "SCOPE.FeatureFlag"
 
+	// #3628 area #25: Plugin / extension-system entities. Plugin represents a
+	// single plugin / extension that a build tool, application, or framework
+	// registers — e.g. a Webpack/Vite/Rollup plugin in a bundler config, a
+	// Babel/ESLint plugin, a pytest plugin or setuptools entry-point plugin, or
+	// a Maven/Gradle build plugin. Cross-file identity = the plugin's name
+	// string within its ecosystem, encoded in the synthetic ID
+	// `plugin:<ecosystem>:<name>`. The config / build file that declares the
+	// plugin links to it via REGISTERS_PLUGIN so the graph can answer "which
+	// plugins does this build/app register". Subtype = the registering system
+	// ("webpack", "vite", "rollup", "babel", "eslint", "pytest",
+	// "setuptools", "maven", "gradle").
+	EntityKindPlugin EntityKind = "SCOPE.Plugin"
+
 	// #2904: Request-validation / DTO-extraction linkage edges. Emitted by
 	// the JS/TS extractor when a route handler / controller method is wired
 	// to a schema validator or a typed DTO, turning validators that were
@@ -787,6 +801,25 @@ const (
 	// Dynamic flag keys (non-literal first argument) are NOT emitted — no
 	// fabricated flag entity. Append-only; never modifies existing edges.
 	RelationshipKindGatedBy RelationshipKind = "GATED_BY"
+	// #3628 area #25: plugin / extension-system registration edge.
+	//   REGISTERS_PLUGIN : config / build file (or app entry) → SCOPE.Plugin
+	//                      entity (synthetic ID `plugin:<ecosystem>:<name>`).
+	//                      Reads "this build/app registers plugin X", enabling
+	//                      "which plugins does this build register" queries.
+	// Emitted by the plugin-system pass (plugin_system_edges.go) for Webpack /
+	// Vite / Rollup bundler configs, Babel / ESLint configs, pytest +
+	// setuptools entry-point plugins, and Maven / Gradle build plugins.
+	// Properties:
+	//   "plugin"    : the plugin name string
+	//   "system"    : the registering system ("webpack", "vite", "rollup",
+	//                 "babel", "eslint", "pytest", "setuptools", "maven",
+	//                 "gradle")
+	//   "group"     : (setuptools only) the entry-point group the plugin
+	//                 registers under (e.g. "flake8.extension")
+	//   "line"      : 1-indexed source line of the plugin declaration
+	// Dynamically-computed plugin names (non-literal) are NOT emitted — no
+	// fabricated plugin entity. Append-only; never modifies existing edges.
+	RelationshipKindRegistersPlugin RelationshipKind = "REGISTERS_PLUGIN"
 	// #3704 (epic #3628, area #20): finite-state-machine transition edge.
 	// Emitted by the FSM-topology pass (state_machine_edges.go) for XState
 	// (JS/TS), Ruby AASM, Spring StateMachine (Java), and the Python
@@ -952,6 +985,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindInvalidates,
 		// #3628 area #17 feature-flag gating edge:
 		RelationshipKindGatedBy,
+		// #3628 area #25 plugin / extension-system registration:
+		RelationshipKindRegistersPlugin,
 		// #3704 FSM state-transition edge:
 		RelationshipKindTransitionsTo,
 		// #3628 area #13 shared-database cross-service coupling edge:


### PR DESCRIPTION
Closes #3728 (child of epic #3628, area #25: plugin / extension / dynamic-dispatch system extraction).

## What
A new engine pass (`internal/engine/plugin_system_edges.go`) that answers **"which plugins does this build/app register"**. It keys off the config/build *file* (a plugin is declared in a config, not invoked at a code offset) and emits:

- one `SCOPE.Plugin` entity per distinct `(ecosystem, name)` — synthetic ID `plugin:<ecosystem>:<name>`, Subtype = the system, and
- one `REGISTERS_PLUGIN` edge `File:<path>` → plugin.

The ecosystem is embedded in the ID so a webpack `html` and a babel `html` stay distinct while two configs registering the same plugin converge on one node (same identity strategy as MessageTopic / FeatureFlag).

## Systems that now emit plugins
| System | Idiom |
|---|---|
| Webpack / Vite / Rollup | `plugins: [new HtmlWebpackPlugin(), terser()]` (constructor + factory) |
| Babel | `.babelrc` / `babel.config.*` `plugins: [...]` string array |
| ESLint | `.eslintrc*` / `eslint.config.*` `plugins: [...]` **and** `extends: [...]` |
| pytest | `pytest_plugins = [...]` (conftest.py / test module) |
| setuptools | `entry_points={"<group>": ["name = mod:obj"]}` — name registered, group recorded |
| Maven | `<plugin><artifactId>X</artifactId>` in pom.xml (skips `<dependency>` artifacts) |
| Gradle | `plugins { id 'x' }` Groovy + `id("x")` Kotlin DSL |

## Honest-partial
Only **literal** plugin names emit. Spreads (`...basePlugins`), bare-variable elements (`myPluginVar`), and non-literal names yield **no** entity and **no** edge. Append-only; no-op on non-config files.

## New kinds
`SCOPE.Plugin` + `REGISTERS_PLUGIN`, registered in `AllEntityKinds` / `AllRelationshipKinds` (kinds.go canonical; producer-kinds guardrail green).

## Plugin edges asserted (value-asserting tests)
- webpack `new HtmlWebpackPlugin()` → `File:webpack.config.js` --REGISTERS_PLUGIN--> `plugin:webpack:HtmlWebpackPlugin` (system=webpack); factory `terser()` → `plugin:webpack:terser`
- vite `vue()` → `plugin:vite:vue`
- babel `"@babel/plugin-transform-runtime"` → `plugin:babel:@babel/plugin-transform-runtime`
- eslint `plugins`+`extends`: react / @typescript-eslint / airbnb / prettier
- pytest `"myproj.fixtures"` → `plugin:pytest:myproj.fixtures`
- setuptools `"X = mod:Cls"` under `flake8.extension` → `plugin:setuptools:X` (group=flake8.extension)
- maven `maven-compiler-plugin` / `maven-surefire-plugin`; **negative:** `<dependency>` guava → no plugin
- gradle `id 'java'` → `plugin:gradle:java`; Kotlin `id("java")`
- negatives: non-config `loader.js` → 0 plugins; empty content → no-op; dedup → one entity/edge; prior slices preserved (append-only)

## Verification
`go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

DEPLOY-DEFERRED: no live-daemon rebuild / reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)