### PR TITLE
feat(engine): Azure Service Bus / Event Hubs producer/consumer extraction

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -60998,16 +60998,22 @@
       "id": "msg.broker.azure-service-bus",
       "category": "message_broker",
       "language": "multi",
-      "label": "Azure Service Bus",
+      "label": "Azure Service Bus / Event Hubs",
       "capabilities": {
         "consumer_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/azure_messaging_edges.go"],
+          "verified_at": "2026-06-02"
         },
         "producer_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/azure_messaging_edges.go"],
+          "verified_at": "2026-06-02"
         },
         "topic_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/azure_messaging_edges.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/engine/azure_messaging_edges.go
+++ b/internal/engine/azure_messaging_edges.go
@@ -1,0 +1,363 @@
+// Azure Service Bus / Event Hubs producer/consumer detection (#3674,
+// #3628 area #2 — completes azure broker topology).
+//
+// Before this pass azure had NO messaging emitter, so although the
+// broker-agnostic topic_pass join (internal/links/topic_pass.go) was ready,
+// nothing emitted the PUBLISHES_TO / SUBSCRIBES_TO edges to an azure-keyed
+// topic entity — azure producer→consumer topology could never form.
+//
+// For every Service Bus / Event Hubs send or receive call site this pass can
+// statically recognize, we emit a synthetic `SCOPE.MessageTopic` entity keyed
+// `azure:<name>` (where <name> is the queue / topic / hub name), plus a
+// PUBLISHES_TO or SUBSCRIBES_TO edge from the enclosing function/method. The
+// synthetic topic ID is identical across repos, so topic_pass joins producer
+// and consumer sides on shared entity Name without any new matching code
+// (brokerFromTopicName already maps `azure:<name>` → channel "azure").
+//
+// Libraries / frameworks covered:
+//   - C# Azure.Messaging.ServiceBus:
+//     client.CreateSender("orders").SendMessageAsync(...)      → producer
+//     client.CreateProcessor("orders") / CreateReceiver("orders") → consumer
+//   - C# Azure.Messaging.EventHubs:
+//     new EventHubProducerClient(cs, "hub") / SendAsync(...)    → producer
+//     new EventHubConsumerClient(grp, cs, "hub")               → consumer
+//   - JS/TS @azure/service-bus:
+//     client.createSender("orders").sendMessages(...)          → producer
+//     client.createReceiver("orders") / .subscribe(...)        → consumer
+//   - JS/TS @azure/event-hubs:
+//     new EventHubProducerClient(cs, "hub")                     → producer
+//     new EventHubConsumerClient(grp, cs, "hub")               → consumer
+//   - Python azure-servicebus:
+//     client.get_queue_sender(queue_name="orders") / send_messages  → producer
+//     client.get_topic_sender(topic_name="orders")             → producer
+//     client.get_queue_receiver(queue_name="orders")           → consumer
+//     client.get_subscription_receiver(topic_name="orders", ...) → consumer
+//   - Python azure-eventhub:
+//     EventHubProducerClient(..., eventhub_name="hub") / send_batch → producer
+//     EventHubConsumerClient(..., eventhub_name="hub")          → consumer
+//
+// Honest-partial: dynamic (non-literal) names are skipped — we never fabricate
+// a topic entity for a name we cannot read statically. Azure EventGrid is
+// intentionally out of scope here; it is already covered by event_bus_edges.go
+// under the `event:eventgrid:*` synthetic.
+//
+// Append-only — never modifies or removes existing entities or edges, so this
+// pass cannot regress the surrounding pipeline's bug-rate.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// azureMessagingSupportsLanguage reports whether applyAzureMessagingEdges can
+// emit synthetics for `lang`. The dominant Azure SDK languages are C#, JS/TS,
+// and Python.
+func azureMessagingSupportsLanguage(lang string) bool {
+	switch lang {
+	case "csharp", "javascript", "typescript", "python":
+		return true
+	default:
+		return false
+	}
+}
+
+// azureTopicID returns the canonical synthetic ID for an Azure Service Bus /
+// Event Hubs entity. The same `azure:<name>` form is emitted by producers and
+// consumers across repos so topic_pass joins them on Name.
+func azureTopicID(name string) string {
+	return "azure:" + name
+}
+
+// looksLikeAzureName returns true when `s` is a plausible Service Bus / Event
+// Hubs entity name. Names are alphanumeric plus `-`, `_`, `.`, `/` (the slash
+// allows topic/subscription paths), 1-260 chars. Rejects anything with
+// interpolation/template markers so dynamic names are not fabricated.
+func looksLikeAzureName(s string) bool {
+	if s == "" || len(s) > 260 {
+		return false
+	}
+	if strings.ContainsAny(s, "\n\r\t<>{}$`") {
+		return false
+	}
+	hasAlnum := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			hasAlnum = true
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		default:
+			return false
+		}
+	}
+	return hasAlnum
+}
+
+// applyAzureMessagingEdges runs after the other broker passes and APPENDS
+// SCOPE.MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges.
+func applyAzureMessagingEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	if !azureMessagingSupportsLanguage(lang) {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	src := string(content)
+
+	// Dedup-by-ID: one MessageTopic entity per topic per file, one
+	// PUBLISHES_TO / SUBSCRIBES_TO per (caller, topic, direction).
+	seenTopic := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitTopic := func(topicID, topicName string, props map[string]string) {
+		if seenTopic[topicID] {
+			return
+		}
+		seenTopic[topicID] = true
+		merged := map[string]string{
+			"broker":          "azure",
+			"topic_name":      topicName,
+			"pattern_type":    "azure_messaging_synthesis",
+			"runtime_dynamic": "false",
+		}
+		for k, v := range props {
+			if v != "" {
+				merged[k] = v
+			}
+		}
+		// SourceFile left empty so identical topic names collapse to ONE
+		// entity per repo and match across repos via topic_pass.
+		entities = append(entities, types.EntityRecord{
+			Name:               topicID,
+			Kind:               messageTopicKind,
+			SourceFile:         "",
+			Language:           lang,
+			Properties:         merged,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	emitEdge := func(callerKind, callerName, topicID, edgeKind string, props map[string]string) {
+		if callerName == "" || topicID == "" {
+			return
+		}
+		key := edgeKind + "|" + callerKind + ":" + callerName + "|" + topicID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		base := map[string]string{
+			"broker":       "azure",
+			"pattern_type": "azure_messaging_synthesis",
+		}
+		for k, v := range props {
+			if v != "" {
+				base[k] = v
+			}
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fmt.Sprintf("%s:%s", callerKind, callerName),
+			ToID:       fmt.Sprintf("%s:%s", messageTopicKind, topicID),
+			Kind:       edgeKind,
+			Properties: base,
+		})
+	}
+
+	switch lang {
+	case "csharp":
+		synthesizeCSharpAzureMessaging(src, emitTopic, emitEdge)
+	case "javascript", "typescript":
+		synthesizeNodeAzureMessaging(src, emitTopic, emitEdge)
+	case "python":
+		synthesizePyAzureMessaging(src, emitTopic, emitEdge)
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// emitAzure is a small helper shared by the per-language synthesizers: it
+// validates the name, emits the topic, and emits the directional edge from the
+// enclosing caller.
+func emitAzure(
+	name, callerKind, caller, edgeKind, layer, kind string,
+	emitTopic func(topicID, topicName string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	if !looksLikeAzureName(name) {
+		return
+	}
+	tID := azureTopicID(name)
+	emitTopic(tID, name, map[string]string{"messaging_layer": layer, "entity_kind": kind})
+	emitEdge(callerKind, caller, tID, edgeKind, map[string]string{
+		"messaging_layer": layer,
+		"entity_kind":     kind,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// C# — Azure.Messaging.ServiceBus / Azure.Messaging.EventHubs
+// ---------------------------------------------------------------------------
+
+// csServiceBusSenderRe captures client.CreateSender("orders").
+var csServiceBusSenderRe = regexp.MustCompile(`\.CreateSender\s*\(\s*"([^"\n\r]+)"`)
+
+// csServiceBusReceiverRe captures client.CreateReceiver("orders") and the
+// session/processor variants CreateProcessor / CreateSessionReceiver /
+// CreateSessionProcessor.
+var csServiceBusReceiverRe = regexp.MustCompile(`\.Create(?:Processor|Receiver|SessionReceiver|SessionProcessor)\s*\(\s*"([^"\n\r]+)"`)
+
+// csEventHubProducerRe captures new EventHubProducerClient(<cs>, "hub").
+// The hub name is the LAST string literal argument; group 1 = hub.
+var csEventHubProducerRe = regexp.MustCompile(`new\s+EventHubProducerClient\s*\([^)]*?,\s*"([^"\n\r]+)"`)
+
+// csEventHubConsumerRe captures new EventHubConsumerClient(group, <cs>, "hub").
+var csEventHubConsumerRe = regexp.MustCompile(`new\s+EventHubConsumerClient\s*\([^)]*?,\s*"([^"\n\r]+)"\s*\)`)
+
+func synthesizeCSharpAzureMessaging(
+	src string,
+	emitTopic func(topicID, topicName string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	if !strings.Contains(src, "ServiceBus") && !strings.Contains(src, "EventHub") &&
+		!strings.Contains(src, "CreateSender") && !strings.Contains(src, "CreateReceiver") &&
+		!strings.Contains(src, "CreateProcessor") {
+		return
+	}
+	enclosing := func(offset int) string {
+		return findEnclosingCSharpMethod(src, offset)
+	}
+
+	for _, m := range csServiceBusSenderRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-servicebus-dotnet", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range csServiceBusReceiverRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-servicebus-dotnet", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range csEventHubProducerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-eventhubs-dotnet", "eventhub", emitTopic, emitEdge)
+	}
+	for _, m := range csEventHubConsumerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-eventhubs-dotnet", "eventhub", emitTopic, emitEdge)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JS / TS — @azure/service-bus + @azure/event-hubs
+// ---------------------------------------------------------------------------
+
+// nodeServiceBusSenderRe captures client.createSender("orders").
+var nodeServiceBusSenderRe = regexp.MustCompile("" +
+	`\.createSender\s*\(\s*` + "[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeServiceBusReceiverRe captures client.createReceiver("orders", ...).
+// The first argument (queue/topic name) is group 1.
+var nodeServiceBusReceiverRe = regexp.MustCompile("" +
+	`\.createReceiver\s*\(\s*` + "[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeEventHubProducerRe captures new EventHubProducerClient(cs, "hub").
+var nodeEventHubProducerRe = regexp.MustCompile("" +
+	`new\s+EventHubProducerClient\s*\([^)]*?,\s*` + "[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeEventHubConsumerRe captures new EventHubConsumerClient(group, cs, "hub").
+var nodeEventHubConsumerRe = regexp.MustCompile("" +
+	`new\s+EventHubConsumerClient\s*\([^)]*?,\s*` + "[\"'`]([^\"'`\\n\\r]+)[\"'`]\\s*\\)")
+
+func synthesizeNodeAzureMessaging(
+	src string,
+	emitTopic func(topicID, topicName string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	if !strings.Contains(src, "service-bus") && !strings.Contains(src, "event-hubs") &&
+		!strings.Contains(src, "createSender") && !strings.Contains(src, "createReceiver") &&
+		!strings.Contains(src, "EventHubProducerClient") && !strings.Contains(src, "EventHubConsumerClient") {
+		return
+	}
+	enclosing := func(offset int) string {
+		return findEnclosingNodeName(src, offset)
+	}
+
+	for _, m := range nodeServiceBusSenderRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-servicebus-js", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range nodeServiceBusReceiverRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-servicebus-js", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range nodeEventHubProducerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-eventhubs-js", "eventhub", emitTopic, emitEdge)
+	}
+	for _, m := range nodeEventHubConsumerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-eventhubs-js", "eventhub", emitTopic, emitEdge)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — azure-servicebus + azure-eventhub
+// ---------------------------------------------------------------------------
+
+// pySBSenderRe captures get_queue_sender(queue_name="orders") and
+// get_topic_sender(topic_name="orders"). Group 1 = name.
+var pySBSenderRe = regexp.MustCompile(`\.get_(?:queue|topic)_sender\s*\(\s*(?:[^)]*?)?(?:queue_name|topic_name)\s*=\s*["']([^"'\n\r]+)["']`)
+
+// pySBReceiverRe captures get_queue_receiver(queue_name="orders") and
+// get_subscription_receiver(topic_name="orders", subscription_name=...).
+var pySBReceiverRe = regexp.MustCompile(`\.get_(?:queue|subscription)_receiver\s*\(\s*(?:[^)]*?)?(?:queue_name|topic_name)\s*=\s*["']([^"'\n\r]+)["']`)
+
+// pyEHProducerRe captures EventHubProducerClient(..., eventhub_name="hub") and
+// the EventHubProducerClient.from_connection_string(..., eventhub_name="hub")
+// factory form.
+var pyEHProducerRe = regexp.MustCompile(`EventHubProducerClient(?:\.\w+)?\s*\([^)]*?eventhub_name\s*=\s*["']([^"'\n\r]+)["']`)
+
+// pyEHConsumerRe captures EventHubConsumerClient(..., eventhub_name="hub") and
+// the .from_connection_string(...) factory form.
+var pyEHConsumerRe = regexp.MustCompile(`EventHubConsumerClient(?:\.\w+)?\s*\([^)]*?eventhub_name\s*=\s*["']([^"'\n\r]+)["']`)
+
+func synthesizePyAzureMessaging(
+	src string,
+	emitTopic func(topicID, topicName string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	if !strings.Contains(src, "azure") && !strings.Contains(src, "ServiceBus") &&
+		!strings.Contains(src, "EventHub") && !strings.Contains(src, "get_queue_sender") &&
+		!strings.Contains(src, "get_topic_sender") && !strings.Contains(src, "get_queue_receiver") &&
+		!strings.Contains(src, "get_subscription_receiver") {
+		return
+	}
+	enclosing := func(offset int) string {
+		return findEnclosingPyName(src, offset)
+	}
+
+	for _, m := range pySBSenderRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-servicebus-python", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range pySBReceiverRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-servicebus-python", "servicebus", emitTopic, emitEdge)
+	}
+	for _, m := range pyEHProducerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), publishesToEdgeKind,
+			"azure-eventhub-python", "eventhub", emitTopic, emitEdge)
+	}
+	for _, m := range pyEHConsumerRe.FindAllStringSubmatchIndex(src, -1) {
+		emitAzure(src[m[2]:m[3]], "Function", enclosing(m[0]), subscribesToEdgeKind,
+			"azure-eventhub-python", "eventhub", emitTopic, emitEdge)
+	}
+}

--- a/internal/engine/azure_messaging_edges_test.go
+++ b/internal/engine/azure_messaging_edges_test.go
@@ -1,0 +1,365 @@
+// Tests for the Azure Service Bus / Event Hubs producer/consumer detection
+// pass (#3674, #3628 area #2 — completes azure broker topology).
+//
+// Value-asserting (not len>0): each case asserts the exact `azure:<name>`
+// MessageTopic ID is emitted AND that the directional edge points at it, so
+// that topic_pass would join a producer in one repo to a consumer in another.
+// A negative case asserts a dynamic (non-literal) name fabricates no topic.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// runAzureMsgDetect is a lightweight in-process driver for the Azure pass.
+func runAzureMsgDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
+	t.Helper()
+	res := applyAzureMessagingEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
+	out := make([]entityResult, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	relOut := make([]relResult, 0, len(rels))
+	for _, r := range rels {
+		relOut = append(relOut, relResult{from: r.FromID, to: r.ToID, kind: r.Kind, props: r.Properties})
+	}
+	return out, relOut
+}
+
+// azureTopicByID finds the emitted SCOPE.MessageTopic with the given
+// canonical azure:<name> ID.
+func azureTopicByID(ents []entityResult, topicID string) *entityResult {
+	for i := range ents {
+		if ents[i].kind == messageTopicKind && ents[i].name == topicID {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// assertPublishesTo asserts an azure:<name> MessageTopic exists and a
+// PUBLISHES_TO edge points at it — i.e. producer side of topic_pass.
+func assertPublishesTo(t *testing.T, ents []entityResult, rels []relResult, name string) {
+	t.Helper()
+	tID := azureTopicID(name)
+	te := azureTopicByID(ents, tID)
+	if te == nil {
+		t.Fatalf("expected SCOPE.MessageTopic %q, ents=%v", tID, ents)
+	}
+	if te.kind != messageTopicKind {
+		t.Fatalf("topic %q kind = %q, want %q", tID, te.kind, messageTopicKind)
+	}
+	if te.props["broker"] != "azure" {
+		t.Fatalf("topic %q broker = %q, want azure", tID, te.props["broker"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	found := false
+	for _, p := range pubs {
+		if strings.Contains(p.to, tID) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected PUBLISHES_TO -> %q, pubs=%v", tID, pubs)
+	}
+}
+
+// assertSubscribesTo asserts an azure:<name> MessageTopic exists and a
+// SUBSCRIBES_TO edge points at it — i.e. consumer side of topic_pass.
+func assertSubscribesTo(t *testing.T, ents []entityResult, rels []relResult, name string) {
+	t.Helper()
+	tID := azureTopicID(name)
+	te := azureTopicByID(ents, tID)
+	if te == nil {
+		t.Fatalf("expected SCOPE.MessageTopic %q, ents=%v", tID, ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	found := false
+	for _, s := range subs {
+		if strings.Contains(s.to, tID) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected SUBSCRIBES_TO -> %q, subs=%v", tID, subs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C# — Azure.Messaging.ServiceBus / EventHubs
+// ---------------------------------------------------------------------------
+
+// TestAzure_CSharp_ServiceBusSender: CreateSender("orders")+SendMessageAsync
+// → producer PUBLISHES_TO azure:orders.
+func TestAzure_CSharp_ServiceBusSender(t *testing.T) {
+	src := `using Azure.Messaging.ServiceBus;
+public class OrderPublisher {
+    public async Task Publish(ServiceBusClient client, string body) {
+        ServiceBusSender sender = client.CreateSender("orders");
+        await sender.SendMessageAsync(new ServiceBusMessage(body));
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "OrderPublisher.cs", src)
+	assertPublishesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_CSharp_ServiceBusReceiver: CreateReceiver("orders") → consumer
+// SUBSCRIBES_TO azure:orders. Paired with the sender above, topic_pass would
+// join them on the shared azure:orders Name.
+func TestAzure_CSharp_ServiceBusReceiver(t *testing.T) {
+	src := `using Azure.Messaging.ServiceBus;
+public class OrderConsumer {
+    public async Task Consume(ServiceBusClient client) {
+        ServiceBusReceiver receiver = client.CreateReceiver("orders");
+        var msg = await receiver.ReceiveMessageAsync();
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "OrderConsumer.cs", src)
+	assertSubscribesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_CSharp_ServiceBusProcessor: CreateProcessor("orders") → consumer.
+func TestAzure_CSharp_ServiceBusProcessor(t *testing.T) {
+	src := `using Azure.Messaging.ServiceBus;
+public class Worker {
+    public void Start(ServiceBusClient client) {
+        var processor = client.CreateProcessor("orders");
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "Worker.cs", src)
+	assertSubscribesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_CSharp_EventHubProducer: EventHubProducerClient(cs,"telemetry")
+// → producer PUBLISHES_TO azure:telemetry.
+func TestAzure_CSharp_EventHubProducer(t *testing.T) {
+	src := `using Azure.Messaging.EventHubs.Producer;
+public class TelemetrySink {
+    public async Task Send(string cs) {
+        var producer = new EventHubProducerClient(cs, "telemetry");
+        await producer.SendAsync(new[] { new EventData(new byte[0]) });
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "TelemetrySink.cs", src)
+	assertPublishesTo(t, ents, rels, "telemetry")
+}
+
+// TestAzure_CSharp_EventHubConsumer: EventHubConsumerClient(grp,cs,"telemetry")
+// → consumer SUBSCRIBES_TO azure:telemetry.
+func TestAzure_CSharp_EventHubConsumer(t *testing.T) {
+	src := `using Azure.Messaging.EventHubs.Consumer;
+public class TelemetryReader {
+    public void Init(string cs) {
+        var consumer = new EventHubConsumerClient("$Default", cs, "telemetry");
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "TelemetryReader.cs", src)
+	assertSubscribesTo(t, ents, rels, "telemetry")
+}
+
+// ---------------------------------------------------------------------------
+// JS / TS — @azure/service-bus + @azure/event-hubs
+// ---------------------------------------------------------------------------
+
+// TestAzure_Node_ServiceBusSender: createSender("orders")+sendMessages → producer.
+func TestAzure_Node_ServiceBusSender(t *testing.T) {
+	src := `const { ServiceBusClient } = require("@azure/service-bus");
+async function publishOrder(client, body) {
+  const sender = client.createSender("orders");
+  await sender.sendMessages({ body });
+}
+`
+	ents, rels := runAzureMsgDetect(t, "javascript", "publish.js", src)
+	assertPublishesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Node_ServiceBusReceiver: createReceiver("orders") → consumer.
+func TestAzure_TS_ServiceBusReceiver(t *testing.T) {
+	src := `import { ServiceBusClient } from "@azure/service-bus";
+async function consumeOrders(client: ServiceBusClient) {
+  const receiver = client.createReceiver("orders");
+  receiver.subscribe({ processMessage: async (m) => {} });
+}
+`
+	ents, rels := runAzureMsgDetect(t, "typescript", "consume.ts", src)
+	assertSubscribesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Node_EventHubProducer: new EventHubProducerClient(cs,"telemetry").
+func TestAzure_Node_EventHubProducer(t *testing.T) {
+	src := `const { EventHubProducerClient } = require("@azure/event-hubs");
+async function emit(cs) {
+  const producer = new EventHubProducerClient(cs, "telemetry");
+  await producer.sendBatch([{ body: "x" }]);
+}
+`
+	ents, rels := runAzureMsgDetect(t, "javascript", "emit.js", src)
+	assertPublishesTo(t, ents, rels, "telemetry")
+}
+
+// TestAzure_Node_EventHubConsumer: new EventHubConsumerClient(grp,cs,"telemetry").
+func TestAzure_Node_EventHubConsumer(t *testing.T) {
+	src := `const { EventHubConsumerClient } = require("@azure/event-hubs");
+async function read(cs) {
+  const consumer = new EventHubConsumerClient("$Default", cs, "telemetry");
+}
+`
+	ents, rels := runAzureMsgDetect(t, "javascript", "read.js", src)
+	assertSubscribesTo(t, ents, rels, "telemetry")
+}
+
+// ---------------------------------------------------------------------------
+// Python — azure-servicebus + azure-eventhub
+// ---------------------------------------------------------------------------
+
+// TestAzure_Py_QueueSender: get_queue_sender(queue_name="orders")+send_messages
+// → producer PUBLISHES_TO azure:orders.
+func TestAzure_Py_QueueSender(t *testing.T) {
+	src := `from azure.servicebus import ServiceBusClient
+
+def publish(client, msg):
+    sender = client.get_queue_sender(queue_name="orders")
+    sender.send_messages(msg)
+`
+	ents, rels := runAzureMsgDetect(t, "python", "publish.py", src)
+	assertPublishesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Py_TopicSender: get_topic_sender(topic_name="orders") → producer.
+func TestAzure_Py_TopicSender(t *testing.T) {
+	src := `from azure.servicebus import ServiceBusClient
+
+def publish(client, msg):
+    sender = client.get_topic_sender(topic_name="orders")
+    sender.send_messages(msg)
+`
+	ents, rels := runAzureMsgDetect(t, "python", "topic.py", src)
+	assertPublishesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Py_QueueReceiver: get_queue_receiver(queue_name="orders") → consumer.
+func TestAzure_Py_QueueReceiver(t *testing.T) {
+	src := `from azure.servicebus import ServiceBusClient
+
+def consume(client):
+    receiver = client.get_queue_receiver(queue_name="orders")
+    for msg in receiver:
+        pass
+`
+	ents, rels := runAzureMsgDetect(t, "python", "consume.py", src)
+	assertSubscribesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Py_SubscriptionReceiver: get_subscription_receiver(topic_name=...)
+// → consumer SUBSCRIBES_TO.
+func TestAzure_Py_SubscriptionReceiver(t *testing.T) {
+	src := `from azure.servicebus import ServiceBusClient
+
+def consume(client):
+    receiver = client.get_subscription_receiver(topic_name="orders", subscription_name="sub1")
+`
+	ents, rels := runAzureMsgDetect(t, "python", "sub.py", src)
+	assertSubscribesTo(t, ents, rels, "orders")
+}
+
+// TestAzure_Py_EventHubProducer: EventHubProducerClient(eventhub_name="telemetry").
+func TestAzure_Py_EventHubProducer(t *testing.T) {
+	src := `from azure.eventhub import EventHubProducerClient
+
+def emit(cs):
+    producer = EventHubProducerClient.from_connection_string(cs, eventhub_name="telemetry")
+    producer.send_batch(producer.create_batch())
+`
+	ents, rels := runAzureMsgDetect(t, "python", "emit.py", src)
+	assertPublishesTo(t, ents, rels, "telemetry")
+}
+
+// TestAzure_Py_EventHubConsumer: EventHubConsumerClient(eventhub_name="telemetry").
+func TestAzure_Py_EventHubConsumer(t *testing.T) {
+	src := `from azure.eventhub import EventHubConsumerClient
+
+def read(cs):
+    consumer = EventHubConsumerClient.from_connection_string(cs, consumer_group="$Default", eventhub_name="telemetry")
+`
+	ents, rels := runAzureMsgDetect(t, "python", "read.py", src)
+	assertSubscribesTo(t, ents, rels, "telemetry")
+}
+
+// ---------------------------------------------------------------------------
+// Cross-side join sanity + negatives
+// ---------------------------------------------------------------------------
+
+// TestAzure_TopicPassWouldJoin asserts a C# producer and a Python consumer
+// emit the SAME azure:orders Name with opposite-direction edges, which is
+// exactly what topic_pass joins across repos.
+func TestAzure_TopicPassWouldJoin(t *testing.T) {
+	prodEnts, prodRels := runAzureMsgDetect(t, "csharp", "P.cs", `using Azure.Messaging.ServiceBus;
+public class P { public async Task Run(ServiceBusClient c){ var s=c.CreateSender("orders"); await s.SendMessageAsync(new ServiceBusMessage("x")); } }`)
+	assertPublishesTo(t, prodEnts, prodRels, "orders")
+
+	consEnts, consRels := runAzureMsgDetect(t, "python", "c.py", `from azure.servicebus import ServiceBusClient
+def consume(client):
+    r = client.get_queue_receiver(queue_name="orders")`)
+	assertSubscribesTo(t, consEnts, consRels, "orders")
+
+	// Same canonical ID on both sides — the only thing topic_pass needs.
+	if azureTopicID("orders") != "azure:orders" {
+		t.Fatalf("canonical id = %q, want azure:orders", azureTopicID("orders"))
+	}
+}
+
+// TestAzure_DynamicName_NoFabrication: a non-literal sender name must NOT
+// fabricate a topic entity or edge (honest-partial).
+func TestAzure_DynamicName_NoFabrication(t *testing.T) {
+	src := `using Azure.Messaging.ServiceBus;
+public class Dyn {
+    public async Task Run(ServiceBusClient client, string queueName) {
+        var sender = client.CreateSender(queueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("x"));
+    }
+}
+`
+	ents, rels := runAzureMsgDetect(t, "csharp", "Dyn.cs", src)
+	for _, e := range ents {
+		if e.kind == messageTopicKind {
+			t.Fatalf("dynamic name fabricated topic %q", e.name)
+		}
+	}
+	if len(relsByKind(rels, publishesToEdgeKind)) != 0 {
+		t.Fatalf("dynamic name fabricated a PUBLISHES_TO edge: %v", rels)
+	}
+}
+
+// TestAzure_TemplateLiteralName_NoFabrication: a JS template-literal name with
+// interpolation must not fabricate a topic.
+func TestAzure_TemplateLiteralName_NoFabrication(t *testing.T) {
+	src := "const { ServiceBusClient } = require(\"@azure/service-bus\");\n" +
+		"async function pub(client, env) {\n" +
+		"  const sender = client.createSender(`orders-${env}`);\n" +
+		"  await sender.sendMessages({ body: 'x' });\n" +
+		"}\n"
+	ents, _ := runAzureMsgDetect(t, "javascript", "dyn.js", src)
+	for _, e := range ents {
+		if e.kind == messageTopicKind {
+			t.Fatalf("template-literal name fabricated topic %q", e.name)
+		}
+	}
+}
+
+// TestAzure_UnsupportedLanguage: a Go file produces nothing (Go is not a
+// dominant Azure messaging SDK target here).
+func TestAzure_UnsupportedLanguage(t *testing.T) {
+	src := `package main
+func main() { client.CreateSender("orders") }`
+	ents, rels := runAzureMsgDetect(t, "go", "main.go", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("unsupported lang emitted ents=%v rels=%v", ents, rels)
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -712,6 +712,18 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// entity ID. Append-only — cannot regress the surrounding pipeline.
 	applyPass(applyPulsarEdges)
 
+	// Azure Service Bus / Event Hubs producer/consumer cross-repo edges
+	// (#3674, #3628 area #2). Completes azure broker topology: before this
+	// pass azure had NO messaging emitter, so its producer→consumer topology
+	// could never form even though the broker-agnostic topic_pass join was
+	// ready. Emits SCOPE.MessageTopic entities keyed `azure:<name>` +
+	// PUBLISHES_TO / SUBSCRIBES_TO edges for Azure.Messaging.ServiceBus /
+	// EventHubs (C#), @azure/service-bus + @azure/event-hubs (JS/TS), and
+	// azure-servicebus + azure-eventhub (Python). Dynamic names are skipped
+	// (honest-partial). Azure EventGrid stays with event_bus_edges.go.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	applyPass(applyAzureMessagingEdges)
+
 	// #727: Real-time event channel synthesis. Three append-only passes
 	// for WebSocket, Server-Sent Events, and GraphQL subscriptions. Each
 	// scans the file directly and emits ChannelEvent / Stream /


### PR DESCRIPTION
## Summary

Completes **azure broker topology** (#3674, #3628 area #2). The broker-topology work found azure had **NO messaging emitter**, so its producer→consumer topology could never form — the broker-agnostic `topic_pass` join was ready, but nothing emitted the `PUBLISHES_TO` / `SUBSCRIBES_TO` edges to an azure-keyed topic.

New append-only detector pass `applyAzureMessagingEdges` emits a synthetic `SCOPE.MessageTopic` keyed `azure:<name>` + a directional edge from the enclosing fn/method — the **exact shape kafka/sqs use**. `topic_pass` auto-joins azure producers and consumers across repos on the shared `azure:<name>` Name (`brokerFromTopicName` already maps it → channel `"azure"`), with zero new matching code.

## Languages (dominant Azure SDK targets)

- **C#** `Azure.Messaging.ServiceBus`: `CreateSender` → producer; `CreateReceiver`/`CreateProcessor`/session variants → consumer. EventHubs `EventHubProducerClient`/`EventHubConsumerClient`.
- **JS/TS** `@azure/service-bus`: `createSender`/`createReceiver`; `@azure/event-hubs` `EventHubProducerClient`/`EventHubConsumerClient`.
- **Python** `azure-servicebus`: `get_queue_sender`/`get_topic_sender` → producer; `get_queue_receiver`/`get_subscription_receiver` → consumer; `azure-eventhub` producer/consumer clients (incl. `.from_connection_string` factory).

**Honest-partial:** dynamic / interpolated names are skipped — no fabricated topic. Azure **EventGrid** stays with `event_bus_edges.go` (`event:eventgrid:*`).

## Producer/consumer edges asserted (value-asserting, not len>0)

- C# `CreateSender("orders")` + `SendMessageAsync` → producer `PUBLISHES_TO` `azure:orders`
- C# `CreateReceiver("orders")` / `CreateProcessor("orders")` → consumer `SUBSCRIBES_TO` `azure:orders`
- EventHubs `EventHubProducerClient(cs,"telemetry")` → `PUBLISHES_TO azure:telemetry`; `EventHubConsumerClient(...,"telemetry")` → `SUBSCRIBES_TO azure:telemetry`
- JS/TS + Python mirror the above (`createSender`/`get_queue_sender` etc.)
- Cross-side: a C# producer and a Python consumer emit the **same** `azure:orders` Name with opposite-direction edges — exactly what `topic_pass` joins across repos
- Negatives: dynamic C# arg `CreateSender(queueName)` and JS template-literal ``createSender(`orders-${env}`)`` → **no** fabricated topic/edge

## Records

Re-stamped `msg.broker.azure-service-bus` (label → "Azure Service Bus / Event Hubs"): `consumer_extraction` / `producer_extraction` / `topic_attribution` `missing` → `partial`, citing `internal/engine/azure_messaging_edges.go`. `coverage validate` 0 errors, `fmt --check` canonical.

## Quality gates

`go test` targeted green (engine + links + types + coverage); `gofmt -l` empty; `go vet` clean.

**DEPLOY-DEFERRED:** no daemon rebuild / reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)