### PR TITLE
[authz] endpoint protection: Go gin/echo + Rails/Devise controller (Closes #3734)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15186,9 +15186,9 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
-            "notes": "heuristic substring catalog (jwt/oauth/basic/session/rbac/api_key/auth) against .Use() chain expressions; auth_kind + dedicated auth:NAME pattern emitted; fixture tests prove jwt/basic/oauth classification per-framework",
-            "verified_at": "2026-05-30"
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go","internal/custom/golang/route_auth.go","internal/custom/golang/route_auth_test.go"],
+            "notes": "Two layers. (1) #3734 endpoint-protection stamping (route_auth.go): binds auth middleware to the route SCOPE.Operation op and stamps the #3696 flat contract (auth_required/auth_method=middleware/auth_guard/auth_kind/auth_confidence). Echo passes trailing middleware after the handler (e.GET('/admin', h, jwtMiddleware) -\u003e /admin auth_required, kind=jwt, HIGH), group-level (g := e.Group('/admin', jwtMiddleware) -\u003e routes on g auth_required, HIGH), engine-wide .Use() -\u003e MEDIUM. Value-asserting tests TestEchoTrailingMiddlewareAuth/TestEchoGroupAuth + negatives (/public,/login not stamped). (2) #3213 .Use() chain pattern catalog (jwt/oauth/basic/session/rbac/api_key/auth). Honest-partial: dynamic/conditional middleware and roles/scopes from opaque guards not modelled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -15962,9 +15962,9 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
-            "notes": "heuristic substring catalog (jwt/oauth/basic/session/rbac/api_key/auth) against .Use() chain expressions; auth_kind + dedicated auth:NAME pattern emitted; fixture tests prove jwt/basic/oauth classification per-framework",
-            "verified_at": "2026-05-30"
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go","internal/custom/golang/route_auth.go","internal/custom/golang/route_auth_test.go"],
+            "notes": "Two layers. (1) #3734 endpoint-protection stamping (route_auth.go): binds auth middleware to the route SCOPE.Operation op and stamps the #3696 flat contract (auth_required/auth_method=middleware/auth_guard/auth_kind/auth_confidence). Group-level (authorized := r.Group('/', AuthRequired()) -\u003e routes on the group var auth_required, HIGH), inline route middleware (r.GET('/admin', JWTAuth(), h) -\u003e that route auth_required, HIGH, kind from classifyAuthMiddleware), engine-wide .Use(jwt.New()) -\u003e MEDIUM inheritance. Value-asserting tests TestGinGroupAuth/TestGinInlineRouteAuth/TestGinEngineWideAuth + negatives (unprotected /health,/public not stamped). (2) #3213 .Use() chain pattern catalog (jwt/oauth/basic/session/rbac/api_key/auth) for middleware Pattern entities. Honest-partial: dynamic/conditional middleware and roles/scopes from opaque guards not modelled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -51510,8 +51510,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/custom/ruby/auth.go","internal/custom/ruby/auth_deep_test.go"],
-            "notes": "Deep Rails auth (Devise/Pundit/CanCanCan) extraction to TS/JS bar. Devise: devise_for route registration, authenticate_\u003cmodel\u003e! before_action with mechanism+auth_required, devise modules with authenticatable flag, \u003cmodel\u003e_signed_in? helpers, require_login. Pundit: class FooPolicy name extraction, per-action (update?/create?/show?) entity with action+policy_class properties, authorize calls with mechanism=pundit+auth_required=true, include Pundit::Authorization. CanCanCan: Ability class sentinel, per-rule can/cannot :action Resource with action+resource+permission+in_ability_class properties, authorize! and load_and_authorize_resource with mechanism=cancancan. General: before_action :require_auth/:check_authentication/:verify_auth. Value-asserting tests in auth_deep_test.go assert SPECIFIC properties (mechanism, action, resource, auth_required, authenticatable, policy_class) across 13 test cases covering all four frameworks plus combined scenarios. Honest remainder: cross-file dataflow (e.g. inferring which controller actions are protected by a controller-level before_action) and roles/scopes extraction not modelled.",
+            "cites": ["internal/custom/ruby/auth.go","internal/custom/ruby/auth_deep_test.go","internal/custom/ruby/controller_auth.go","internal/custom/ruby/controller_auth_test.go"],
+            "notes": "#3734 endpoint-protection: controller_auth.go (custom_ruby_controller_auth) resolves a controller-level before_action :authenticate_user! (Devise) / :require_login / CanCanCan load_and_authorize_resource and stamps the #3696 flat contract (auth_required/auth_method/auth_guard/auth_confidence) on one SCOPE.Operation/endpoint per controller ACTION (controller#action handler); only:/except: + skip_before_action honoured; per-action Pundit authorize -\u003e MEDIUM. Closes the prior honest remainder (which actions a controller-level before_action protects). Tests TestControllerAuth* incl negative _Unprotected. Plus deep Rails auth (Devise/Pundit/CanCanCan) extraction to TS/JS bar. Devise: devise_for route registration, authenticate_\u003cmodel\u003e! before_action with mechanism+auth_required, devise modules with authenticatable flag, \u003cmodel\u003e_signed_in? helpers, require_login. Pundit: class FooPolicy name extraction, per-action (update?/create?/show?) entity with action+policy_class properties, authorize calls with mechanism=pundit+auth_required=true, include Pundit::Authorization. CanCanCan: Ability class sentinel, per-rule can/cannot :action Resource with action+resource+permission+in_ability_class properties, authorize! and load_and_authorize_resource with mechanism=cancancan. General: before_action :require_auth/:check_authentication/:verify_auth. Value-asserting tests in auth_deep_test.go assert SPECIFIC properties (mechanism, action, resource, auth_required, authenticatable, policy_class) across 13 test cases covering all four frameworks plus combined scenarios. Honest remainder: cross-file dataflow (e.g. inferring which controller actions are protected by a controller-level before_action) and roles/scopes extraction not modelled.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/golang/echo.go
+++ b/internal/custom/golang/echo.go
@@ -73,6 +73,11 @@ func (e *echoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		entities = append(entities, ent)
 	}
 
+	// #3734 — endpoint protection. Echo passes trailing middleware after the
+	// handler (`e.GET(path, h, mw)`); the shared index classifies each route /
+	// group / engine arg independently, so both orderings resolve.
+	authIdx := buildGoRouteAuthIndex(src)
+
 	// 1. echo.New() engine -> SCOPE.Service
 	for _, m := range reEchoEngine.FindAllStringSubmatchIndex(src, -1) {
 		varName := src[m[2]:m[3]]
@@ -98,14 +103,17 @@ func (e *echoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	for _, m := range reEchoRoute.FindAllStringSubmatchIndex(src, -1) {
 		routerVar := src[m[2]:m[3]]
 		method := strings.ToUpper(src[m[4]:m[5]])
-		path := src[m[6]:m[7]]
+		ownPath := src[m[6]:m[7]]
+		path := ownPath
 		if gp, ok := groupPaths[routerVar]; ok {
 			path = gp + path
 		}
 		name := method + " " + path
 		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "echo", "provenance", "INFERRED_FROM_ECHO_ROUTE",
-			"http_method", method, "route_path", path)
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		// #3734 — stamp endpoint protection (inline > group > engine-wide).
+		authIdx.resolve(routerVar, method, ownPath).stamp(ent.Properties)
 		add(ent)
 	}
 

--- a/internal/custom/golang/gin.go
+++ b/internal/custom/golang/gin.go
@@ -77,6 +77,10 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		entities = append(entities, ent)
 	}
 
+	// #3734 — endpoint protection. Resolve route/group/engine-level auth
+	// middleware once so each route op can be stamped with auth_required.
+	authIdx := buildGoRouteAuthIndex(src)
+
 	// 1. gin.Default()/gin.New() engine -> SCOPE.Service
 	for _, m := range reGinEngine.FindAllStringSubmatchIndex(src, -1) {
 		varName := src[m[2]:m[3]]
@@ -101,7 +105,8 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 	for _, m := range reGinRoute.FindAllStringSubmatchIndex(src, -1) {
 		routerVar := src[m[2]:m[3]]
 		method := strings.ToUpper(src[m[4]:m[5]])
-		path := src[m[6]:m[7]]
+		ownPath := src[m[6]:m[7]]
+		path := ownPath
 		// Resolve group prefix
 		if gp, ok := groupPaths[routerVar]; ok {
 			path = gp + path
@@ -110,6 +115,9 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "gin", "provenance", "INFERRED_FROM_GIN_ROUTE",
 			"http_method", method, "route_path", path, "router_var", routerVar)
+		// #3734 — stamp endpoint protection from the route's own inline
+		// middleware, its group var, or an engine-wide auth .Use().
+		authIdx.resolve(routerVar, method, ownPath).stamp(ent.Properties)
 		add(ent)
 	}
 

--- a/internal/custom/golang/route_auth.go
+++ b/internal/custom/golang/route_auth.go
@@ -1,0 +1,202 @@
+// route_auth.go — endpoint-protection stamping for Go gin/echo route ops
+// (#3734, child of #3628 area #6; sibling of #3696's Python auth_endpoint.go).
+//
+// #3696 established the flat per-endpoint auth contract: stamp the route
+// `SCOPE.Operation/endpoint` entity itself with
+//
+//	auth_required   — "true" | "false"
+//	auth_method     — "middleware"
+//	auth_guard      — the recognised auth-middleware symbol (MCP signal key)
+//	auth_kind       — coarse kind (jwt/oauth/basic/session/rbac/api_key/auth)
+//	auth_confidence — "high" (route/group-direct) | "medium" (engine-wide .Use)
+//
+// gin/echo already emit auth *Pattern* entities for `.Use(...)` chains
+// (helpers.go), but never bind the protection to a specific route op, and the
+// route regexes stop at the path — so inline route middleware
+// (`e.GET("/me", h, jwtMiddleware)`) is invisible. This resolver closes that
+// gap by binding two route-level signals to the endpoint op:
+//
+//	group-level — a route group constructed with an auth middleware argument,
+//	              e.g. `authorized := r.Group("/", AuthRequired())` (gin) /
+//	              `g := e.Group("/admin", jwtMiddleware)` (echo). Every route
+//	              registered on that group var inherits auth_required (HIGH —
+//	              the binding is direct to the group the route is on).
+//	inline      — an auth middleware passed in a route registration's argument
+//	              chain after the path, e.g. `r.GET("/me", AuthRequired(), h)` /
+//	              `e.GET("/admin", h, jwtMiddleware)` (echo accepts trailing
+//	              middleware). HIGH — bound to the exact route.
+//
+// A weaker engine-wide `.Use(authMw)` registration applies to every route on
+// that engine; we surface it at MEDIUM confidence only when no stronger
+// route/group signal is present, mirroring the JS/TS app-level inheritance.
+//
+// Honest-partial: middleware resolved dynamically (a slice built at runtime, a
+// conditional `.Use`) is out of scope; auth classification reuses the heuristic
+// classifyAuthMiddleware catalog (helpers.go), so this is `partial`-grade
+// data-flow, consistent with the rest of the Go auth surface.
+package golang
+
+import (
+	"regexp"
+	"strings"
+)
+
+// goRouteAuth is the resolved auth posture for one route op.
+type goRouteAuth struct {
+	Required   bool
+	Guard      string // the recognised auth-middleware symbol (evidence)
+	Kind       string // coarse auth kind from classifyAuthMiddleware
+	Confidence string // "high" | "medium"
+	found      bool
+}
+
+// stamp writes the resolved posture onto a route op's Properties map using the
+// #3696 flat contract. No-op when no auth signal was found (leaves the op's
+// posture unstamped — the default-deny/allow decision is the consumer's).
+func (a goRouteAuth) stamp(props map[string]string) {
+	if props == nil || !a.found {
+		return
+	}
+	props["auth_required"] = "true"
+	props["auth_method"] = "middleware"
+	props["auth_confidence"] = a.Confidence
+	if a.Guard != "" {
+		props["auth_guard"] = a.Guard
+	}
+	if a.Kind != "" {
+		props["auth_kind"] = a.Kind
+	}
+}
+
+// reGoGroupDecl matches a route-group construction with its full argument list:
+//
+//	authorized := r.Group("/", AuthRequired())
+//	g := e.Group("/admin", jwtMiddleware, logger)
+//
+// Group 1 = the new group var, group 2 = the path literal, group 3 = the raw
+// trailing args (middleware chain, may be empty). The args region is captured
+// up to the line end; balanced-paren trimming happens in the caller.
+var reGoGroupDecl = regexp.MustCompile(
+	`(?m)(\w+)\s*:?=\s*\w+\.Group\s*\(\s*"([^"]*)"\s*((?:,[^\n\r]*)?)\)`,
+)
+
+// reGoRouteAuthScan matches a route registration and captures everything after
+// the path so the inline middleware chain (between path and handler) can be
+// inspected:
+//
+//	r.GET("/me", AuthRequired(), getMe)
+//	e.POST("/admin", h, jwtMiddleware)
+//
+// Group 1 = router var, 2 = verb, 3 = path, 4 = the trailing args (everything
+// after the path up to the registration's close paren, captured line-bounded).
+var reGoRouteAuthScan = regexp.MustCompile(
+	`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|Any)\s*\(\s*"([^"]*)"\s*((?:,[^\n\r]*)?)\)`,
+)
+
+// goRouteAuthIndex holds the per-file resolved auth signals: which group vars
+// are auth-protected, which (verb,path) routes carry inline auth middleware,
+// and whether the engine has a global auth `.Use`.
+type goRouteAuthIndex struct {
+	// groupVars maps a group var → its resolved group-level auth posture.
+	groupVars map[string]goRouteAuth
+	// inline maps "<VERB> <path>" (the route's *own* path, pre-prefix) → posture.
+	inline map[string]goRouteAuth
+	// engineWide is the MEDIUM posture from an engine-level `.Use(authMw)`, or a
+	// zero value when none was found.
+	engineWide goRouteAuth
+}
+
+// buildGoRouteAuthIndex scans a Go source file once and resolves every
+// route-level / group-level / engine-level auth signal. It is framework-shared
+// (gin and echo use identical .Group / .VERB / .Use shapes).
+func buildGoRouteAuthIndex(src string) goRouteAuthIndex {
+	idx := goRouteAuthIndex{
+		groupVars: map[string]goRouteAuth{},
+		inline:    map[string]goRouteAuth{},
+	}
+
+	// Group-level: `g := r.Group("/x", authMw)` → g is protected.
+	for _, m := range reGoGroupDecl.FindAllStringSubmatchIndex(src, -1) {
+		groupVar := src[m[2]:m[3]]
+		args := src[m[6]:m[7]]
+		if a, ok := authFromArgChain(args); ok {
+			a.Confidence = "high"
+			idx.groupVars[groupVar] = a
+		}
+	}
+
+	// Inline route middleware: `r.GET("/me", authMw, h)` → that route protected.
+	for _, m := range reGoRouteAuthScan.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToUpper(src[m[4]:m[5]])
+		path := src[m[6]:m[7]]
+		args := src[m[8]:m[9]]
+		if a, ok := authFromArgChain(args); ok {
+			a.Confidence = "high"
+			idx.inline[verb+" "+path] = a
+		}
+	}
+
+	// Engine-wide `.Use(authMw)` → MEDIUM inheritance for every route.
+	for _, uc := range findUseCalls(src) {
+		for _, mw := range parseMiddlewareChain(uc.Args) {
+			if mw.AuthKind != "" {
+				idx.engineWide = goRouteAuth{
+					Required: true, found: true, Confidence: "medium",
+					Guard: mw.Name, Kind: mw.AuthKind,
+				}
+				break
+			}
+		}
+		if idx.engineWide.found {
+			break
+		}
+	}
+
+	return idx
+}
+
+// resolve returns the auth posture for one route op, applying precedence:
+// inline route middleware (HIGH) > the route's group var (HIGH) > engine-wide
+// `.Use` (MEDIUM) > none. `routerVar` is the var the route was registered on
+// (may be a protected group var); `verb`+`ownPath` identify the route's own
+// registration (the un-prefixed path the inline index is keyed by).
+func (idx goRouteAuthIndex) resolve(routerVar, verb, ownPath string) goRouteAuth {
+	if a, ok := idx.inline[verb+" "+ownPath]; ok && a.found {
+		return a
+	}
+	if a, ok := idx.groupVars[routerVar]; ok && a.found {
+		return a
+	}
+	if idx.engineWide.found {
+		return idx.engineWide
+	}
+	return goRouteAuth{}
+}
+
+// authFromArgChain inspects a trailing-argument region (the text after a path
+// literal, e.g. `, AuthRequired(), getMe`) for a recognised auth middleware and
+// returns the first match's posture. The leading comma and the final handler
+// are tolerated — each top-level arg is classified independently.
+func authFromArgChain(args string) (goRouteAuth, bool) {
+	args = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(args), ","))
+	if args == "" {
+		return goRouteAuth{}, false
+	}
+	for _, part := range splitTopLevelArgs(args) {
+		part = strings.TrimSpace(part)
+		if part == "" || isStringLiteral(part) {
+			continue
+		}
+		if kind := classifyAuthMiddleware(part); kind != "" {
+			head := reMiddlewareCallHead.FindString(part)
+			if head == "" {
+				head = part
+			}
+			return goRouteAuth{
+				Required: true, found: true,
+				Guard: head, Kind: kind,
+			}, true
+		}
+	}
+	return goRouteAuth{}, false
+}

--- a/internal/custom/golang/route_auth_test.go
+++ b/internal/custom/golang/route_auth_test.go
@@ -1,0 +1,194 @@
+package golang
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findEndpoint returns the first endpoint op whose name matches "<VERB> <path>".
+func findEndpoint(t *testing.T, ents []types.EntityRecord, name string) types.EntityRecord {
+	t.Helper()
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "endpoint" && e.Name == name {
+			return e
+		}
+	}
+	t.Fatalf("endpoint %q not found among %d entities", name, len(ents))
+	return types.EntityRecord{}
+}
+
+func runGin(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&ginExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "main.go", Language: "go", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("gin extract: %v", err)
+	}
+	return ents
+}
+
+func runEcho(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&echoExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "main.go", Language: "go", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("echo extract: %v", err)
+	}
+	return ents
+}
+
+// TestGinGroupAuth — the canonical acceptance case from #3734:
+// `authorized := r.Group("/", AuthRequired())` + `authorized.GET("/me")`
+// → GET / /me is auth_required, guard recorded; an unprotected route is NOT.
+func TestGinGroupAuth(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.Default()
+	r.GET("/health", healthCheck)
+	authorized := r.Group("/", AuthRequired())
+	authorized.GET("/me", getMe)
+	authorized.POST("/orders", createOrder)
+}
+`
+	ents := runGin(t, src)
+
+	me := findEndpoint(t, ents, "GET //me")
+	if me.Properties["auth_required"] != "true" {
+		t.Errorf("GET /me: auth_required=%q, want true (props: %v)", me.Properties["auth_required"], me.Properties)
+	}
+	if me.Properties["auth_guard"] != "AuthRequired" {
+		t.Errorf("GET /me: auth_guard=%q, want AuthRequired", me.Properties["auth_guard"])
+	}
+	if me.Properties["auth_method"] != "middleware" {
+		t.Errorf("GET /me: auth_method=%q, want middleware", me.Properties["auth_method"])
+	}
+	if me.Properties["auth_confidence"] != "high" {
+		t.Errorf("GET /me: auth_confidence=%q, want high", me.Properties["auth_confidence"])
+	}
+
+	orders := findEndpoint(t, ents, "POST //orders")
+	if orders.Properties["auth_required"] != "true" {
+		t.Errorf("POST /orders: auth_required=%q, want true", orders.Properties["auth_required"])
+	}
+
+	// Negative: the unprotected /health route (registered on the raw engine,
+	// no auth .Use, no group) must NOT be marked protected.
+	health := findEndpoint(t, ents, "GET /health")
+	if health.Properties["auth_required"] == "true" {
+		t.Errorf("GET /health: auth_required=true, want unprotected (props: %v)", health.Properties)
+	}
+}
+
+// TestGinInlineRouteAuth — inline route middleware binds to that exact route.
+func TestGinInlineRouteAuth(t *testing.T) {
+	src := `package main
+func main() {
+	r := gin.Default()
+	r.GET("/admin", JWTAuth(), adminHandler)
+	r.GET("/public", publicHandler)
+}
+`
+	ents := runGin(t, src)
+
+	admin := findEndpoint(t, ents, "GET /admin")
+	if admin.Properties["auth_required"] != "true" {
+		t.Errorf("GET /admin: auth_required=%q, want true (props: %v)", admin.Properties["auth_required"], admin.Properties)
+	}
+	if admin.Properties["auth_kind"] != "jwt" {
+		t.Errorf("GET /admin: auth_kind=%q, want jwt", admin.Properties["auth_kind"])
+	}
+	if admin.Properties["auth_guard"] != "JWTAuth" {
+		t.Errorf("GET /admin: auth_guard=%q, want JWTAuth", admin.Properties["auth_guard"])
+	}
+
+	pub := findEndpoint(t, ents, "GET /public")
+	if pub.Properties["auth_required"] == "true" {
+		t.Errorf("GET /public: auth_required=true, want unprotected")
+	}
+}
+
+// TestGinEngineWideAuth — an engine-level `.Use(authMw)` gives MEDIUM coverage
+// to every route that has no stronger signal.
+func TestGinEngineWideAuth(t *testing.T) {
+	src := `package main
+func main() {
+	r := gin.Default()
+	r.Use(jwt.New(cfg))
+	r.GET("/me", getMe)
+}
+`
+	ents := runGin(t, src)
+	me := findEndpoint(t, ents, "GET /me")
+	if me.Properties["auth_required"] != "true" {
+		t.Errorf("GET /me: auth_required=%q, want true via engine-wide .Use (props: %v)", me.Properties["auth_required"], me.Properties)
+	}
+	if me.Properties["auth_confidence"] != "medium" {
+		t.Errorf("GET /me: auth_confidence=%q, want medium (engine-wide)", me.Properties["auth_confidence"])
+	}
+	if me.Properties["auth_kind"] != "jwt" {
+		t.Errorf("GET /me: auth_kind=%q, want jwt", me.Properties["auth_kind"])
+	}
+}
+
+// TestEchoTrailingMiddlewareAuth — echo passes middleware AFTER the handler:
+// `e.GET("/admin", h, jwtMiddleware)` → /admin auth_required, kind=jwt.
+func TestEchoTrailingMiddlewareAuth(t *testing.T) {
+	src := `package main
+func main() {
+	e := echo.New()
+	e.GET("/admin", adminHandler, jwtMiddleware)
+	e.GET("/public", publicHandler)
+}
+`
+	ents := runEcho(t, src)
+
+	admin := findEndpoint(t, ents, "GET /admin")
+	if admin.Properties["auth_required"] != "true" {
+		t.Errorf("GET /admin: auth_required=%q, want true (props: %v)", admin.Properties["auth_required"], admin.Properties)
+	}
+	if admin.Properties["auth_kind"] != "jwt" {
+		t.Errorf("GET /admin: auth_kind=%q, want jwt", admin.Properties["auth_kind"])
+	}
+	if admin.Properties["auth_confidence"] != "high" {
+		t.Errorf("GET /admin: auth_confidence=%q, want high", admin.Properties["auth_confidence"])
+	}
+
+	pub := findEndpoint(t, ents, "GET /public")
+	if pub.Properties["auth_required"] == "true" {
+		t.Errorf("GET /public: auth_required=true, want unprotected")
+	}
+}
+
+// TestEchoGroupAuth — `g := e.Group("/admin", jwtMiddleware)` protects routes
+// registered on g; the full prefixed path is composed but inline keying uses
+// the route's own path.
+func TestEchoGroupAuth(t *testing.T) {
+	src := `package main
+func main() {
+	e := echo.New()
+	g := e.Group("/admin", jwtMiddleware)
+	g.GET("/users", listUsers)
+	e.GET("/login", login)
+}
+`
+	ents := runEcho(t, src)
+
+	users := findEndpoint(t, ents, "GET /admin/users")
+	if users.Properties["auth_required"] != "true" {
+		t.Errorf("GET /admin/users: auth_required=%q, want true via group (props: %v)", users.Properties["auth_required"], users.Properties)
+	}
+	if users.Properties["auth_kind"] != "jwt" {
+		t.Errorf("GET /admin/users: auth_kind=%q, want jwt", users.Properties["auth_kind"])
+	}
+
+	login := findEndpoint(t, ents, "GET /login")
+	if login.Properties["auth_required"] == "true" {
+		t.Errorf("GET /login: auth_required=true, want unprotected")
+	}
+}

--- a/internal/custom/ruby/controller_auth.go
+++ b/internal/custom/ruby/controller_auth.go
@@ -1,0 +1,412 @@
+// controller_auth.go — Rails controller endpoint-protection stamping
+// (#3734, child of #3628 area #6; sibling of #3696's Python auth_endpoint.go).
+//
+// #3696 established the flat per-endpoint auth contract — stamp the route
+// `SCOPE.Operation/endpoint` op itself with `auth_required` / `auth_method` /
+// `auth_guard` / `auth_roles`. The Rails routing extractor (rails_routes.go)
+// emits route ops from config/routes.rb, but a route's auth posture lives in
+// the *controller* (`before_action :authenticate_user!`), a different file.
+// The rails Auth registry note named this exact gap as the honest remainder:
+// "inferring which controller actions are protected by a controller-level
+// before_action ... not modelled."
+//
+// This extractor closes it *in-file*: for each ActionController subclass it
+// resolves the controller-level Devise `before_action :authenticate_<model>!`
+// (honouring `only:` / `except:` scoping), plus Pundit / CanCanCan guards, and
+// emits one protection op per controller action — a
+// `SCOPE.Operation/endpoint` carrying the controller#action handler ref and the
+// #3696 flat contract. The route extractor's routes.rb op and this controller
+// op share the same `controller#action` handler key, so the security dashboard
+// and archigraph_auth_coverage resolve the same posture from either side.
+//
+// Recognised guards:
+//
+//	Devise    — `before_action :authenticate_user!` / `:authenticate_admin!`
+//	            → every action of the controller (modulo only:/except:) is
+//	            auth_required, method=before_action, guard=authenticate_<m>!.
+//	            `skip_before_action :authenticate_user!, only: [:index]` removes
+//	            the named actions from the protected set (honest scoping).
+//	require_*  — `before_action :require_login` / `:authenticate` (Sorcery /
+//	            Clearance / hand-rolled) → same posture, guard = the symbol.
+//	Pundit     — `before_action :verify_authorized` / per-action `authorize @x`
+//	            inside an action body → method=pundit, guard=authorize.
+//	CanCanCan  — `load_and_authorize_resource` (controller-level) → all actions
+//	            protected; `authorize_resource only: [...]` honoured.
+//
+// Honest-partial: roles/scopes are not synthesised from opaque policy objects
+// (Pundit policies / CanCanCan abilities are out-of-file); a `before_action`
+// whose method is resolved dynamically is out of scope. Confidence is "high"
+// for a direct controller-level authenticate guard, "medium" for a per-action
+// authorize call (the action is protected but the guard is body-local).
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_ruby_controller_auth", &railsControllerAuthExtractor{})
+}
+
+type railsControllerAuthExtractor struct{}
+
+func (e *railsControllerAuthExtractor) Language() string {
+	return "custom_ruby_controller_auth"
+}
+
+var (
+	// class FooController < ApplicationController / < ActionController::Base
+	caClassRe = regexp.MustCompile(
+		`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*Controller)\b[^\n]*`)
+
+	// before_action :authenticate_user! [, only: [...] | except: [...]]
+	// Trailing options are captured with [ \t]* (NOT \s*) so the option region
+	// never bleeds across the newline into the following line.
+	caAuthenticateRe = regexp.MustCompile(
+		`(?m)^[ \t]*before_action\s+:authenticate_([a-z_]+)![ \t]*([^\n\r]*)$`)
+
+	// before_action :require_login / :authenticate / :require_auth / etc.
+	caRequireAuthRe = regexp.MustCompile(
+		`(?m)^[ \t]*before_action\s+:(require_login|login_required|require_auth|authenticate|require_user|authorize_user|check_authentication|verify_authorized)\b[ \t]*([^\n\r]*)$`)
+
+	// skip_before_action :authenticate_user!, only: [:index]
+	caSkipRe = regexp.MustCompile(
+		`(?m)^[ \t]*skip_before_action\s+:(?:authenticate_[a-z_]+!|require_login|login_required|authenticate)[ \t]*([^\n\r]*)$`)
+
+	// controller-level CanCanCan: load_and_authorize_resource [only: [...]]
+	caCanCanResourceRe = regexp.MustCompile(
+		`(?m)^[ \t]*(load_and_authorize_resource|authorize_resource)\b[ \t]*([^\n\r]*)$`)
+
+	// def action_name  — a controller action method declaration.
+	caActionDefRe = regexp.MustCompile(`(?m)^\s*def\s+([a-z_][a-z0-9_]*[!?]?)\s*(?:\(|$)`)
+
+	// per-action Pundit authorize call inside a method body: authorize @post
+	caPunditAuthorizeRe = regexp.MustCompile(`(?m)^\s*authorize\s+[@a-z_]`)
+
+	// only:/except: option lists, reused from the routes parser shape.
+	caOnlyRe   = regexp.MustCompile(`\bonly:\s*(?:\[([^\]]*)\]|:(\w+))`)
+	caExceptRe = regexp.MustCompile(`\bexcept:\s*(?:\[([^\]]*)\]|:(\w+))`)
+)
+
+// caControllerLevelAuth is the resolved controller-wide auth posture.
+type caControllerLevelAuth struct {
+	required   bool
+	guard      string
+	method     string // "before_action" | "cancancan"
+	confidence string
+	onlyset    map[string]bool // when non-nil, ONLY these actions are protected
+	exceptset  map[string]bool // these actions are NOT protected
+	// skips maps action name → true when a skip_before_action removed it.
+	skips map[string]bool
+}
+
+func (e *railsControllerAuthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/ruby")
+	_, span := tracer.Start(ctx, "indexer.rails_controller_auth.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "ruby" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: must look like a controller with an auth guard.
+	if !strings.Contains(src, "Controller") ||
+		!(strings.Contains(src, "before_action") ||
+			strings.Contains(src, "load_and_authorize_resource") ||
+			strings.Contains(src, "authorize_resource") ||
+			strings.Contains(src, "authorize ")) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, cls := range caClassRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[cls[2]:cls[3]]
+		body := caClassBody(src, cls[1])
+		bodyStart := cls[1]
+
+		level := resolveControllerLevelAuth(body)
+		actions := caCollectActions(body)
+		if len(actions) == 0 {
+			continue
+		}
+
+		resource := caControllerResource(className)
+
+		for _, act := range actions {
+			posture := caResolveAction(level, body, act.name)
+			if !posture.required {
+				continue
+			}
+			handler := resource + "#" + act.name
+			ln := lineOf(src, bodyStart+act.off)
+			ent := makeEntity(handler, "SCOPE.Operation", "endpoint", file.Path, file.Language, ln)
+			setProps(&ent, "framework", "rails",
+				"provenance", "INFERRED_FROM_RAILS_CONTROLLER_AUTH",
+				"controller", className,
+				"controller_action", handler,
+				"action", act.name)
+			posture.stamp(ent.Properties)
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// caActionPosture is the resolved posture for a single controller action.
+type caActionPosture struct {
+	required   bool
+	guard      string
+	method     string
+	confidence string
+}
+
+func (p caActionPosture) stamp(props map[string]string) {
+	if !p.required {
+		return
+	}
+	props["auth_required"] = "true"
+	props["auth_method"] = p.method
+	props["auth_confidence"] = p.confidence
+	if p.guard != "" {
+		props["auth_guard"] = p.guard
+	}
+}
+
+// resolveControllerLevelAuth scans a controller body for the controller-wide
+// auth guard (the first authenticate/require/cancancan before_action) plus the
+// skip set. Returns required=false when no controller-level guard is present.
+func resolveControllerLevelAuth(body string) caControllerLevelAuth {
+	var a caControllerLevelAuth
+	a.skips = map[string]bool{}
+
+	if m := caAuthenticateRe.FindStringSubmatch(body); m != nil {
+		a.required = true
+		a.guard = "authenticate_" + m[1] + "!"
+		a.method = "before_action"
+		a.confidence = "high"
+		a.applyScope(m[2])
+	} else if m := caRequireAuthRe.FindStringSubmatch(body); m != nil {
+		a.required = true
+		a.guard = m[1]
+		a.method = "before_action"
+		a.confidence = "high"
+		a.applyScope(m[2])
+	} else if m := caCanCanResourceRe.FindStringSubmatch(body); m != nil {
+		a.required = true
+		a.guard = m[1]
+		a.method = "cancancan"
+		a.confidence = "high"
+		a.applyScope(m[2])
+	}
+
+	// skip_before_action removes named actions from the protected set. The
+	// `only:` list names the actions to skip; a bare skip (no only:/except:)
+	// removes the guard from ALL actions (the "*" sentinel).
+	for _, m := range caSkipRe.FindAllStringSubmatch(body, -1) {
+		opts := m[1]
+		hasScope := false
+		if om := caOnlyRe.FindStringSubmatch(opts); om != nil {
+			hasScope = true
+			for _, act := range caParseActionList(om[1] + om[2]) {
+				a.skips[act] = true
+			}
+		}
+		if em := caExceptRe.FindStringSubmatch(opts); em != nil {
+			// skip ... except: [:x] → skip everything but x. Modelled as a
+			// full skip (honest-partial: per-action except on skip is rare).
+			hasScope = true
+			a.skips["*"] = true
+			_ = em
+		}
+		if !hasScope {
+			a.skips["*"] = true
+		}
+	}
+	return a
+}
+
+// applyScope records only:/except: action filters from a before_action option
+// string onto the posture.
+func (a *caControllerLevelAuth) applyScope(opts string) {
+	if m := caOnlyRe.FindStringSubmatch(opts); m != nil {
+		a.onlyset = map[string]bool{}
+		for _, act := range caParseActionList(m[1] + m[2]) {
+			a.onlyset[act] = true
+		}
+	}
+	if m := caExceptRe.FindStringSubmatch(opts); m != nil {
+		a.exceptset = map[string]bool{}
+		for _, act := range caParseActionList(m[1] + m[2]) {
+			a.exceptset[act] = true
+		}
+	}
+}
+
+// caResolveAction combines the controller-level guard, its only:/except: scope,
+// any skip_before_action, and a per-action Pundit authorize call into the final
+// posture for one action.
+func caResolveAction(level caControllerLevelAuth, body, action string) caActionPosture {
+	// Controller-level guard with scoping honoured.
+	if level.required {
+		protected := true
+		if level.onlyset != nil {
+			protected = level.onlyset[action]
+		}
+		if level.exceptset != nil && level.exceptset[action] {
+			protected = false
+		}
+		if level.skips["*"] || level.skips[action] {
+			protected = false
+		}
+		if protected {
+			return caActionPosture{
+				required: true, guard: level.guard,
+				method: level.method, confidence: level.confidence,
+			}
+		}
+	}
+
+	// Per-action Pundit authorize inside the action body (medium — the guard is
+	// body-local, not a declarative before_action).
+	if caActionBodyHasAuthorize(body, action) {
+		return caActionPosture{
+			required: true, guard: "authorize",
+			method: "pundit", confidence: "medium",
+		}
+	}
+
+	return caActionPosture{}
+}
+
+// caActionEntry is one action method declaration in a controller body.
+type caActionEntry struct {
+	name string
+	off  int // byte offset within the controller body of the `def` line
+}
+
+// caCollectActions returns the controller's public action methods in source
+// order. Private helpers below a `private` keyword are excluded (they are not
+// routable actions).
+func caCollectActions(body string) []caActionEntry {
+	privAt := caPrivateOffset(body)
+	var out []caActionEntry
+	for _, m := range caActionDefRe.FindAllStringSubmatchIndex(body, -1) {
+		if privAt >= 0 && m[0] >= privAt {
+			break
+		}
+		out = append(out, caActionEntry{name: body[m[2]:m[3]], off: m[0]})
+	}
+	return out
+}
+
+// caPrivateOffset returns the byte offset of a top-level `private` keyword in a
+// controller body, or -1 when absent.
+func caPrivateOffset(body string) int {
+	re := regexp.MustCompile(`(?m)^\s*private\s*$`)
+	if loc := re.FindStringIndex(body); loc != nil {
+		return loc[0]
+	}
+	return -1
+}
+
+// caActionBodyHasAuthorize reports whether the named action's method body
+// contains a Pundit `authorize` call. Scans from the action's `def` to its
+// matching `end` (heuristic: the next top-level `def` or the body end).
+func caActionBodyHasAuthorize(body, action string) bool {
+	defRe := regexp.MustCompile(`(?m)^\s*def\s+` + regexp.QuoteMeta(action) + `\b`)
+	loc := defRe.FindStringIndex(body)
+	if loc == nil {
+		return false
+	}
+	rest := body[loc[1]:]
+	if nxt := caActionDefRe.FindStringIndex(rest); nxt != nil {
+		rest = rest[:nxt[0]]
+	}
+	return caPunditAuthorizeRe.MatchString(rest)
+}
+
+// caClassBody returns the source of a controller class body starting at offset
+// `from` (just after the class declaration line) to the matching class `end`.
+// Heuristic: scan to the next top-level `class`/`module` declaration or EOF —
+// sufficient for the one-controller-per-file Rails convention.
+func caClassBody(src string, from int) string {
+	rest := src[from:]
+	if nxt := regexp.MustCompile(`(?m)^\s*class\s+[A-Z]`).FindStringIndex(rest); nxt != nil {
+		return rest[:nxt[0]]
+	}
+	return rest
+}
+
+// caControllerResource maps a controller class name to the routes.rb resource
+// segment used in the controller#action handler key: `Admin::UsersController`
+// → `admin/users`, `PostsController` → `posts`.
+func caControllerResource(className string) string {
+	className = strings.TrimSuffix(className, "Controller")
+	parts := strings.Split(className, "::")
+	for i, p := range parts {
+		parts[i] = caUnderscore(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// caUnderscore converts a CamelCase identifier to snake_case
+// (`UsersV2` → `users_v2`).
+func caUnderscore(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r + ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// caParseActionList parses a Ruby symbol list ("`:index, :show`" or "`show`")
+// into bare action names, sorted for determinism.
+func caParseActionList(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		p := strings.TrimSpace(part)
+		p = strings.TrimPrefix(p, ":")
+		p = strings.Trim(p, "\"' \t")
+		if p != "" && p != "only" && p != "except" {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/custom/ruby/controller_auth_test.go
+++ b/internal/custom/ruby/controller_auth_test.go
@@ -1,0 +1,262 @@
+package ruby
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runControllerAuth(t *testing.T, src string) map[string]types.EntityRecord {
+	t.Helper()
+	ents, err := (&railsControllerAuthExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "app/controllers/users_controller.rb", Language: "ruby", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("controller_auth extract: %v", err)
+	}
+	out := map[string]types.EntityRecord{}
+	for _, e := range ents {
+		out[e.Properties["controller_action"]] = e
+	}
+	return out
+}
+
+// TestControllerAuthDeviseAllActions — the canonical #3734 case:
+// `before_action :authenticate_user!` → every action auth_required.
+func TestControllerAuthDeviseAllActions(t *testing.T) {
+	src := `class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+
+  def show
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+
+	for _, h := range []string{"users#index", "users#show"} {
+		e, ok := eps[h]
+		if !ok {
+			t.Fatalf("missing protected op for %s (got %v)", h, keysOf(eps))
+		}
+		if e.Properties["auth_required"] != "true" {
+			t.Errorf("%s: auth_required=%q, want true", h, e.Properties["auth_required"])
+		}
+		if e.Properties["auth_guard"] != "authenticate_user!" {
+			t.Errorf("%s: auth_guard=%q, want authenticate_user!", h, e.Properties["auth_guard"])
+		}
+		if e.Properties["auth_method"] != "before_action" {
+			t.Errorf("%s: auth_method=%q, want before_action", h, e.Properties["auth_method"])
+		}
+		if e.Properties["auth_confidence"] != "high" {
+			t.Errorf("%s: auth_confidence=%q, want high", h, e.Properties["auth_confidence"])
+		}
+	}
+}
+
+// TestControllerAuthOnlyScope — `only: [:edit, :update]` protects ONLY those.
+func TestControllerAuthOnlyScope(t *testing.T) {
+	src := `class PostsController < ApplicationController
+  before_action :authenticate_user!, only: [:edit, :update]
+
+  def index
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+
+	if _, ok := eps["posts#edit"]; !ok {
+		t.Errorf("posts#edit should be protected by only: scope (got %v)", keysOf(eps))
+	}
+	if _, ok := eps["posts#update"]; !ok {
+		t.Errorf("posts#update should be protected by only: scope")
+	}
+	// Negative: index is NOT in only: → must not be emitted as protected.
+	if _, ok := eps["posts#index"]; ok {
+		t.Errorf("posts#index: auth_required, want unprotected (outside only: scope)")
+	}
+}
+
+// TestControllerAuthExceptScope — `except: [:index]` protects all but index.
+func TestControllerAuthExceptScope(t *testing.T) {
+	src := `class ArticlesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+
+  def index
+  end
+
+  def show
+  end
+
+  def create
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+
+	if _, ok := eps["articles#create"]; !ok {
+		t.Errorf("articles#create should be protected (not in except:)")
+	}
+	if _, ok := eps["articles#index"]; ok {
+		t.Errorf("articles#index: protected, want unprotected (in except:)")
+	}
+	if _, ok := eps["articles#show"]; ok {
+		t.Errorf("articles#show: protected, want unprotected (in except:)")
+	}
+}
+
+// TestControllerAuthSkip — `skip_before_action :authenticate_user!, only: [:index]`
+// removes index from a fully-protected controller.
+func TestControllerAuthSkip(t *testing.T) {
+	src := `class DashboardController < ApplicationController
+  before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: [:index]
+
+  def index
+  end
+
+  def settings
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+
+	if _, ok := eps["dashboard#settings"]; !ok {
+		t.Errorf("dashboard#settings should remain protected")
+	}
+	if _, ok := eps["dashboard#index"]; ok {
+		t.Errorf("dashboard#index: protected, want unprotected (skip_before_action)")
+	}
+}
+
+// TestControllerAuthUnprotected — a controller with no auth guard emits nothing
+// (negative case: no false-positive protection).
+func TestControllerAuthUnprotected(t *testing.T) {
+	src := `class PublicController < ApplicationController
+  def index
+  end
+
+  def about
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	if len(eps) != 0 {
+		t.Errorf("unprotected controller emitted %d protection ops, want 0 (%v)", len(eps), keysOf(eps))
+	}
+}
+
+// TestControllerAuthCanCanCan — controller-level load_and_authorize_resource
+// protects all actions with method=cancancan.
+func TestControllerAuthCanCanCan(t *testing.T) {
+	src := `class ProjectsController < ApplicationController
+  load_and_authorize_resource
+
+  def index
+  end
+
+  def destroy
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["projects#destroy"]
+	if !ok {
+		t.Fatalf("projects#destroy should be protected by cancancan (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_method"] != "cancancan" {
+		t.Errorf("projects#destroy: auth_method=%q, want cancancan", e.Properties["auth_method"])
+	}
+	if e.Properties["auth_guard"] != "load_and_authorize_resource" {
+		t.Errorf("projects#destroy: auth_guard=%q, want load_and_authorize_resource", e.Properties["auth_guard"])
+	}
+}
+
+// TestControllerAuthPunditPerAction — a per-action `authorize @x` protects only
+// that action at medium confidence; an action without it stays unprotected.
+func TestControllerAuthPunditPerAction(t *testing.T) {
+	src := `class ReportsController < ApplicationController
+  def index
+  end
+
+  def show
+    @report = Report.find(params[:id])
+    authorize @report
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["reports#show"]
+	if !ok {
+		t.Fatalf("reports#show should be protected by per-action authorize (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_method"] != "pundit" {
+		t.Errorf("reports#show: auth_method=%q, want pundit", e.Properties["auth_method"])
+	}
+	if e.Properties["auth_confidence"] != "medium" {
+		t.Errorf("reports#show: auth_confidence=%q, want medium", e.Properties["auth_confidence"])
+	}
+	if _, ok := eps["reports#index"]; ok {
+		t.Errorf("reports#index: protected, want unprotected (no authorize call)")
+	}
+}
+
+// TestControllerAuthNamespaced — Admin::UsersController → admin/users handler.
+func TestControllerAuthNamespaced(t *testing.T) {
+	src := `class Admin::UsersController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["admin/users#index"]
+	if !ok {
+		t.Fatalf("admin/users#index expected (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_guard"] != "authenticate_admin!" {
+		t.Errorf("admin/users#index: auth_guard=%q, want authenticate_admin!", e.Properties["auth_guard"])
+	}
+}
+
+// TestControllerAuthPrivateExcluded — private helper methods are not actions.
+func TestControllerAuthPrivateExcluded(t *testing.T) {
+	src := `class OrdersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+
+  private
+
+  def set_order
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	if _, ok := eps["orders#index"]; !ok {
+		t.Errorf("orders#index should be protected")
+	}
+	if _, ok := eps["orders#set_order"]; ok {
+		t.Errorf("orders#set_order: emitted, want excluded (private helper, not an action)")
+	}
+}
+
+func keysOf(m map[string]types.EntityRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #3734 (child of #3628 area #6; sibling of #3696).

Extends the #3696 endpoint-protection contract — stamp `auth_required` / `auth_method` / `auth_guard` / `auth_confidence` directly on the route `SCOPE.Operation/endpoint` op — to the two framework families that previously emitted only auth *Pattern* entities and never bound protection to the route.

## Frameworks that now mark endpoint protection

### Go gin/echo — `internal/custom/golang/route_auth.go` (new)
`buildGoRouteAuthIndex` resolves three route-level signals and stamps the endpoint op, precedence **inline > group-var > engine-wide `.Use`**:
- **group-level**: `authorized := r.Group("/", AuthRequired())` → every route on the group var `auth_required` (HIGH).
- **inline route middleware**: `r.GET("/admin", JWTAuth(), h)` and echo's trailing form `e.GET("/admin", h, jwtMiddleware)` → that route `auth_required` (HIGH), `auth_kind` from the shared `classifyAuthMiddleware` catalog.
- **engine-wide** `.Use(jwt.New())` → MEDIUM inheritance when no stronger signal.

Wired into `gin.go` + `echo.go` route emission; reuses `helpers.go` parsers. No double-emit (the existing `.Use` Pattern layer is untouched).

### Rails/Devise — `internal/custom/ruby/controller_auth.go` (new `custom_ruby_controller_auth`)
For each ActionController subclass, resolves the controller-level `before_action :authenticate_<model>!` (Devise) / `:require_login` / CanCanCan `load_and_authorize_resource`, and emits one endpoint protection op per controller **action** (`controller#action` handler) stamped with the flat contract. `only:`/`except:` scoping and `skip_before_action` are honoured; per-action Pundit `authorize @x` protects just that action (MEDIUM). **Closes the rails Auth registry's declared honest remainder** ('inferring which controller actions are protected by a controller-level before_action').

### Express/passport — already covered
`http_endpoint_jsts_auth.go` already stamps `passport.authenticate('jwt')` route-level (HIGH) + app-level (MEDIUM), `requireAuth`/`ensureAuthenticated`, `@UseGuards`/`@Roles`. Verified against `http_endpoint_jsts_auth_test.go` + `express_auth.ts` — no change needed.

## Protected endpoints asserted (value-asserting, with negatives)
- gin: `authorized := r.Group("/", AuthRequired())` + `authorized.GET("/me")` → **/me auth_required=true, guard=AuthRequired, method=middleware, confidence=high**; `/health` (raw engine) → **unprotected**.
- gin inline: `r.GET("/admin", JWTAuth(), h)` → **/admin auth_required, kind=jwt, guard=JWTAuth**; `/public` unprotected.
- gin engine-wide: `r.Use(jwt.New())` → `/me` **auth_required, confidence=medium, kind=jwt**.
- echo: `e.GET("/admin", h, jwtMiddleware)` → **/admin auth_required, kind=jwt**; group `e.Group("/admin", jwtMiddleware)` → **/admin/users auth_required**.
- Rails: `before_action :authenticate_user!` → controller actions **auth_required, guard=authenticate_user!**; `only:`/`except:`/`skip_before_action` scoping enforced; `load_and_authorize_resource` → method=cancancan; per-action `authorize` → method=pundit medium; unprotected controller → **0 ops**; `Admin::UsersController` → `admin/users#index`; private helpers excluded.

## Discipline
- Targeted `go test` green: `internal/custom/golang`, `internal/custom/ruby`, `internal/engine`, `internal/types`, `tools/coverage`.
- `gofmt -l` empty; `go vet` clean.
- `coverage validate`: 0 errors (warnings unchanged); `coverage fmt --check`: canonical. Registry gin/echo/rails Auth cites+notes updated, status stays `full`.

**DEPLOY-DEFERRED**: no live-daemon rebuild/reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)