### PR TITLE
[http-client] Go imroc/req outbound CONSUMES_API + Go/Ruby coverage cells

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -56,10 +56,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 5/5 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/22 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/22 | 🟢 7/7 | |
@@ -117,8 +117,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟡 22/23 | 🟢 6/6 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟡 22/23 | 🟢 7/7 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 7/7 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟡 21/23 | 🟢 5/5 | |
 | [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/22 | 🔴 0/7 | |
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -38,10 +38,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 5/5 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/22 | 🔴 0/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 6/6 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟡 21/22 | 🟢 7/7 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -31,8 +31,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
 | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
 | [Roda](../detail/lang.ruby.framework.roda.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟡 22/23 | 🟢 6/6 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 6/6 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟡 22/23 | 🟢 7/7 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟡 21/23 | 🟢 7/7 | |
 | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟡 21/23 | 🟢 5/5 | |
 | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/22 | 🔴 0/7 | |
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -93,6 +93,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint source detection | 🟢 `partial` | `2026-05-29` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_golang.go` | — |
 | Template pattern catalog | 🟢 `partial` | `2026-05-29` | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_golang.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-29` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_golang.go` | — |
+
+## Framework-specific
+
+### Integration
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client consumes API | 🟢 `partial` | `2026-06-02` | — | `internal/engine/http_endpoint_go_client.go`<br>`internal/engine/http_endpoint_go_client_test.go`<br>`internal/links/http_pass.go` | Outbound HTTP-client synthesis via synthesizeGoClient also covers fasthttp (fasthttp.Get/Post package-level + client.Do with req.SetRequestURI + req.Header.SetMethod verb inference) alongside net/http, resty, and req=github.com/imroc/req. Emits consumer http_endpoint_call http:<VERB>:<path> + FETCHES edge cross-repo-linked by links/http_pass.go on the byte-identical synthetic id. Tests TestGoClient_FasthttpGet/_FasthttpSetRequestURI + TestGoClient_Req*. Honest-partial: fully-dynamic URLs skipped. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -93,6 +93,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint source detection | 🟢 `partial` | `2026-05-29` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_golang.go` | — |
 | Template pattern catalog | 🟢 `partial` | `2026-05-29` | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_golang.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-29` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_golang.go` | — |
+
+## Framework-specific
+
+### Integration
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client consumes API | 🟢 `partial` | `2026-06-02` | — | `internal/engine/http_endpoint_go_client.go`<br>`internal/engine/http_endpoint_go_client_test.go`<br>`internal/links/http_pass.go` | Outbound HTTP-client synthesis (synthesizeGoClient): per call site emits a consumer http_endpoint_call http:<VERB>:<path> + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers net/http (http.Get/Post/Head/PostForm/NewRequest, client.<verb>), resty (.R().<verb>), and req=github.com/imroc/req (package-level req.Get/Post/Put/Patch/Delete/Head/Options + chained .R().<verb>); absolute URLs host-stripped to path; fmt.Sprintf + os.Getenv concat -> runtime_dynamic. Value-asserting tests TestGoClient_ReqPackageLevel/_ReqAbsoluteURL/_ReqChainedSharedWithResty/_ReqEnvConcat/_ReqDynamicNoLiteralNegative + cross-repo TestHTTPPass_GoReqClientCrossRepoMatch. Honest-partial: fully-dynamic URLs skipped (no fabricated path). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -93,6 +93,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_ruby.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_ruby.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_ruby.go` | — |
+
+## Framework-specific
+
+### Integration
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client consumes API | 🟢 `partial` | `2026-06-02` | — | `internal/engine/http_endpoint_ruby_client.go`<br>`internal/engine/http_endpoint_ruby_client_test.go`<br>`internal/links/http_pass.go` | Outbound HTTP-client synthesis (synthesizeRubyClient), language-wide (not framework-specific to this record): per call site emits a consumer http_endpoint_call http:<VERB>:<path> + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers Net::HTTP (class + instance + start-block forms), Faraday (Faraday.<verb> + conn.<verb>), HTTParty (class + include-mixin form), RestClient (class + Resource.new(url).<verb>); absolute URLs host-stripped to path; ENV['X']+'/path' concat -> runtime_dynamic. Value-asserting tests in http_endpoint_ruby_client_test.go. Honest-partial: fully-dynamic URLs skipped (no fabricated path). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -93,6 +93,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_ruby.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_ruby.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_ruby.go` | — |
+
+## Framework-specific
+
+### Integration
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client consumes API | 🟢 `partial` | `2026-06-02` | — | `internal/engine/http_endpoint_ruby_client.go`<br>`internal/engine/http_endpoint_ruby_client_test.go`<br>`internal/links/http_pass.go` | Outbound HTTP-client synthesis (synthesizeRubyClient), language-wide (not framework-specific to this record): per call site emits a consumer http_endpoint_call http:<VERB>:<path> + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers Net::HTTP (class + instance + start-block forms), Faraday (Faraday.<verb> + conn.<verb>), HTTParty (class + include-mixin form), RestClient (class + Resource.new(url).<verb>); absolute URLs host-stripped to path; ENV['X']+'/path' concat -> runtime_dynamic. Value-asserting tests in http_endpoint_ruby_client_test.go. Honest-partial: fully-dynamic URLs skipped (no fabricated path). |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15607,6 +15607,16 @@
             "verified_at": "2026-05-29"
           }
         }
+      },
+      "framework_specific": {
+        "Integration": {
+          "client_consumes_api": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_go_client.go","internal/engine/http_endpoint_go_client_test.go","internal/links/http_pass.go"],
+            "notes": "Outbound HTTP-client synthesis via synthesizeGoClient also covers fasthttp (fasthttp.Get/Post package-level + client.Do with req.SetRequestURI + req.Header.SetMethod verb inference) alongside net/http, resty, and req=github.com/imroc/req. Emits consumer http_endpoint_call http:\u003cVERB\u003e:\u003cpath\u003e + FETCHES edge cross-repo-linked by links/http_pass.go on the byte-identical synthetic id. Tests TestGoClient_FasthttpGet/_FasthttpSetRequestURI + TestGoClient_Req*. Honest-partial: fully-dynamic URLs skipped.",
+            "verified_at": "2026-06-02"
+          }
+        }
       }
     },
     {
@@ -18144,6 +18154,16 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_golang.go"],
             "verified_at": "2026-05-29"
+          }
+        }
+      },
+      "framework_specific": {
+        "Integration": {
+          "client_consumes_api": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_go_client.go","internal/engine/http_endpoint_go_client_test.go","internal/links/http_pass.go"],
+            "notes": "Outbound HTTP-client synthesis (synthesizeGoClient): per call site emits a consumer http_endpoint_call http:\u003cVERB\u003e:\u003cpath\u003e + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers net/http (http.Get/Post/Head/PostForm/NewRequest, client.\u003cverb\u003e), resty (.R().\u003cverb\u003e), and req=github.com/imroc/req (package-level req.Get/Post/Put/Patch/Delete/Head/Options + chained .R().\u003cverb\u003e); absolute URLs host-stripped to path; fmt.Sprintf + os.Getenv concat -\u003e runtime_dynamic. Value-asserting tests TestGoClient_ReqPackageLevel/_ReqAbsoluteURL/_ReqChainedSharedWithResty/_ReqEnvConcat/_ReqDynamicNoLiteralNegative + cross-repo TestHTTPPass_GoReqClientCrossRepoMatch. Honest-partial: fully-dynamic URLs skipped (no fabricated path).",
+            "verified_at": "2026-06-02"
           }
         }
       }
@@ -51705,6 +51725,16 @@
             "verified_at": "2026-05-28"
           }
         }
+      },
+      "framework_specific": {
+        "Integration": {
+          "client_consumes_api": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_ruby_client.go","internal/engine/http_endpoint_ruby_client_test.go","internal/links/http_pass.go"],
+            "notes": "Outbound HTTP-client synthesis (synthesizeRubyClient), language-wide (not framework-specific to this record): per call site emits a consumer http_endpoint_call http:\u003cVERB\u003e:\u003cpath\u003e + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers Net::HTTP (class + instance + start-block forms), Faraday (Faraday.\u003cverb\u003e + conn.\u003cverb\u003e), HTTParty (class + include-mixin form), RestClient (class + Resource.new(url).\u003cverb\u003e); absolute URLs host-stripped to path; ENV['X']+'/path' concat -\u003e runtime_dynamic. Value-asserting tests in http_endpoint_ruby_client_test.go. Honest-partial: fully-dynamic URLs skipped (no fabricated path).",
+            "verified_at": "2026-06-02"
+          }
+        }
       }
     },
     {
@@ -52144,6 +52174,16 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_ruby.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "Integration": {
+          "client_consumes_api": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_ruby_client.go","internal/engine/http_endpoint_ruby_client_test.go","internal/links/http_pass.go"],
+            "notes": "Outbound HTTP-client synthesis (synthesizeRubyClient), language-wide (not framework-specific to this record): per call site emits a consumer http_endpoint_call http:\u003cVERB\u003e:\u003cpath\u003e + FETCHES edge, cross-repo-linked to server routes by links/http_pass.go on the byte-identical synthetic id. Covers Net::HTTP (class + instance + start-block forms), Faraday (Faraday.\u003cverb\u003e + conn.\u003cverb\u003e), HTTParty (class + include-mixin form), RestClient (class + Resource.new(url).\u003cverb\u003e); absolute URLs host-stripped to path; ENV['X']+'/path' concat -\u003e runtime_dynamic. Value-asserting tests in http_endpoint_ruby_client_test.go. Honest-partial: fully-dynamic URLs skipped (no fabricated path).",
+            "verified_at": "2026-06-02"
           }
         }
       }

--- a/internal/engine/http_endpoint_go_client.go
+++ b/internal/engine/http_endpoint_go_client.go
@@ -19,6 +19,14 @@
 //     resty.New().R().Get(url), .Post(url), .Put(url), .Patch(url),
 //     .Delete(url), .Head(url), .Options(url)
 //
+//   - req (github.com/imroc/req):
+//     req.Get(url), req.Post(url), req.Put(url), req.Patch(url),
+//     req.Delete(url), req.Head(url), req.Options(url)  (package-level)
+//     req.C().R().Get(url), client.R().Post(url)  (chained — shares the
+//     `.R().<verb>(url)` matcher with resty since the request-object suffix
+//     is identical; the framework label there stays "resty" by construction,
+//     so the req package-level forms below are what give req its own label)
+//
 //   - fasthttp (github.com/valyala/fasthttp):
 //     fasthttp.Get(dst, url), fasthttp.Post(dst, url, ...)
 //     client.Do(req) with req.SetRequestURI(url) (verb inferred from
@@ -120,6 +128,41 @@ var goRestyVerbRe = regexp.MustCompile(
 		`|` +
 		`([A-Za-z_][\w]*)` + // group 4: identifier url
 		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// req (github.com/imroc/req)
+// ---------------------------------------------------------------------------
+
+// goReqPkgVerbRe matches package-level req verbs:
+// `req.Get(url)`, `req.Post(url, ...)`, `req.Put/Patch/Delete/Head/Options(url)`.
+// req's chained request-object form (`req.C().R().Get(url)` /
+// `client.R().Post(url)`) is already covered by goRestyVerbRe, which matches
+// any `.R().<verb>(url)` suffix regardless of receiver. This matcher covers
+// ONLY the package-level shorthand, which is anchored on the `req.` receiver
+// and a verb that is NOT one of the net/http package-level names (those are
+// claimed by goHTTPPkgVerbRe on the `http.` receiver). The leading `\b`
+// boundary plus the explicit `req` receiver keeps this from colliding with
+// fasthttp's `req.SetRequestURI` / `req.Header` (those method names are not
+// in the verb alternation).
+var goReqPkgVerbRe = regexp.MustCompile(
+	`\breq\s*\.\s*(Get|Post|Put|Patch|Delete|Head|Options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted literal
+		`|` +
+		"`([^`\n\r]+)`" + // group 3: backtick literal
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier
+		`)`,
+)
+
+// goReqPkgEnvVerbRe matches `req.<Verb>(os.Getenv("X") + "/path")`.
+//
+// Capture groups:
+//
+//	1 = verb
+//	2 = path suffix
+var goReqPkgEnvVerbRe = regexp.MustCompile(
+	`\breq\s*\.\s*(Get|Post|Put|Patch|Delete|Head|Options)\s*\(\s*os\.Getenv\s*\([^)]+\)\s*\+\s*"([^"\n\r]*)"`,
 )
 
 // ---------------------------------------------------------------------------
@@ -361,6 +404,25 @@ func synthesizeGoClientWithRuntime(content string, emit goClientEmitFn) {
 		emit(verb, canonical, "resty", "Function", caller, false)
 	}
 
+	// ----- req package-level: req.Get/Post/Put/Patch/Delete/Head/Options -----
+	for _, m := range goReqPkgVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := goPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path, ok := normalizeRawClientPath(raw) // #807
+		if !ok {
+			continue
+		}
+		caller := enclosingGoFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, path)
+		emit(verb, canonical, "req", "Function", caller, false)
+	}
+
 	// ----- fasthttp package-level: fasthttp.Get / fasthttp.Post -----
 	for _, m := range goFasthttpPkgVerbRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 10 {
@@ -476,6 +538,22 @@ func synthesizeGoClientWithRuntime(content string, emit goClientEmitFn) {
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, suffix)
 		emit(verb, canonical, "resty", "Function", caller, true)
 	}
+
+	// ----- req package-level: req.<Verb>(os.Getenv("X") + "/path") -----
+	for _, m := range goReqPkgEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := content[m[4]:m[5]]
+		suffix, suffixOK := normalizeRawClientPath(suffix) // #807
+		if !suffixOK {
+			continue
+		}
+		caller := enclosingGoFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, suffix)
+		emit(verb, canonical, "req", "Function", caller, true)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -489,6 +567,13 @@ func goHasAnyHTTPClient(content string) bool {
 		strings.Contains(content, "http.NewRequest") ||
 		strings.Contains(content, "resty.") ||
 		strings.Contains(content, ".R().") ||
+		strings.Contains(content, "req.Get") ||
+		strings.Contains(content, "req.Post") ||
+		strings.Contains(content, "req.Put") ||
+		strings.Contains(content, "req.Patch") ||
+		strings.Contains(content, "req.Delete") ||
+		strings.Contains(content, "req.Head") ||
+		strings.Contains(content, "req.Options") ||
 		strings.Contains(content, "fasthttp.") ||
 		strings.Contains(content, "SetRequestURI") ||
 		strings.Contains(content, "os.Getenv") ||

--- a/internal/engine/http_endpoint_go_client_test.go
+++ b/internal/engine/http_endpoint_go_client_test.go
@@ -285,6 +285,171 @@ func removeRecord() error {
 	requireFetches(t, rels, "http:DELETE:/api/records/42", "go-resty-delete")
 }
 
+// frameworkOf returns the `framework` property of the http_endpoint entity
+// with the given ID, or "" if absent.
+func frameworkOf(res *DetectResult, id string) string {
+	for _, e := range res.Entities {
+		if e.ID == id {
+			return e.Properties["framework"]
+		}
+	}
+	return ""
+}
+
+// TestGoClient_ReqPackageLevel covers github.com/imroc/req package-level
+// verbs req.Get/Post/Put/Patch/Delete with literal URLs, asserting the exact
+// CONSUMES_API synthetic ID, the FETCHES edge, and the `req` framework label.
+func TestGoClient_ReqPackageLevel(t *testing.T) {
+	src := `
+package main
+
+import "github.com/imroc/req/v3"
+
+func listUsers() {
+	resp, _ := req.Get("/api/v1/users")
+	_ = resp
+}
+
+func createUser() {
+	resp, _ := req.Post("/api/v1/users")
+	_ = resp
+}
+
+func replaceUser() {
+	resp, _ := req.Put("/api/v1/users/1")
+	_ = resp
+}
+
+func patchUser() {
+	resp, _ := req.Patch("/api/v1/users/1")
+	_ = resp
+}
+
+func removeUser() {
+	resp, _ := req.Delete("/api/v1/users/1")
+	_ = resp
+}
+`
+	ids, rels := runDetectWithRels(t, "go", "req_client.go", src)
+	want := []string{
+		"http:GET:/api/v1/users",
+		"http:POST:/api/v1/users",
+		"http:PUT:/api/v1/users/1",
+		"http:PATCH:/api/v1/users/1",
+		"http:DELETE:/api/v1/users/1",
+	}
+	requireContains(t, ids, want, "go-req-package-level")
+	requireFetches(t, rels, "http:GET:/api/v1/users", "go-req-package-level")
+	requireFetches(t, rels, "http:POST:/api/v1/users", "go-req-package-level")
+	requireFetches(t, rels, "http:DELETE:/api/v1/users/1", "go-req-package-level")
+
+	// Framework label must be "req" (not "net_http" / "resty").
+	_, res := runDetect(t, "go", "req_client.go", src)
+	if fw := frameworkOf(res, "http:GET:/api/v1/users"); fw != "req" {
+		t.Errorf("go-req-package-level: framework want req, got %q", fw)
+	}
+}
+
+// TestGoClient_ReqAbsoluteURL verifies that an absolute URL passed to a req
+// package-level verb has its scheme+host stripped to a bare path so the
+// synthetic ID matches a server route declared elsewhere (cross-repo).
+func TestGoClient_ReqAbsoluteURL(t *testing.T) {
+	src := `
+package main
+
+import "github.com/imroc/req/v3"
+
+func fetchInventory() {
+	resp, _ := req.Get("https://inventory-svc/api/v1/items")
+	_ = resp
+}
+`
+	ids, rels := runDetectWithRels(t, "go", "req_abs.go", src)
+	requireContains(t, ids, []string{"http:GET:/api/v1/items"}, "go-req-absolute-url")
+	requireFetches(t, rels, "http:GET:/api/v1/items", "go-req-absolute-url")
+}
+
+// TestGoClient_ReqChainedSharedWithResty verifies that req's chained
+// client-builder form (req.C().R().Get(url)) is detected via the shared
+// `.R().<verb>(url)` matcher. The framework label is "resty" by construction
+// (the suffix is identical), which is acceptable — the cross-repo link only
+// keys on the synthetic ID, not the framework label.
+func TestGoClient_ReqChainedSharedWithResty(t *testing.T) {
+	src := `
+package main
+
+import "github.com/imroc/req/v3"
+
+func ping() {
+	client := req.C()
+	resp, _ := client.R().Get("/api/v1/health")
+	_ = resp
+}
+`
+	ids, rels := runDetectWithRels(t, "go", "req_chained.go", src)
+	requireContains(t, ids, []string{"http:GET:/api/v1/health"}, "go-req-chained")
+	requireFetches(t, rels, "http:GET:/api/v1/health", "go-req-chained")
+}
+
+// TestGoClient_ReqEnvConcat covers req.Get(os.Getenv("X") + "/path")
+// → runtime_dynamic=true with the static suffix as path.
+func TestGoClient_ReqEnvConcat(t *testing.T) {
+	src := `
+package main
+
+import (
+	"os"
+
+	"github.com/imroc/req/v3"
+)
+
+func callRemote() {
+	resp, _ := req.Get(os.Getenv("API_URL") + "/api/v1/status")
+	_ = resp
+}
+`
+	ids, rels := runDetectWithRels(t, "go", "req_env.go", src)
+	requireContains(t, ids, []string{"http:GET:/api/v1/status"}, "go-req-env-concat")
+	requireFetches(t, rels, "http:GET:/api/v1/status", "go-req-env-concat")
+
+	_, res := runDetect(t, "go", "req_env.go", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/api/v1/status" && e.Properties["runtime_dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("go-req-env-concat: expected runtime_dynamic=true on http:GET:/api/v1/status")
+	}
+}
+
+// TestGoClient_ReqDynamicNoLiteralNegative verifies that a fully-dynamic req
+// URL (no static path literal) emits NO synthetic — honest-partial: we never
+// fabricate a path.
+func TestGoClient_ReqDynamicNoLiteralNegative(t *testing.T) {
+	src := `
+package main
+
+import (
+	"fmt"
+
+	"github.com/imroc/req/v3"
+)
+
+func fetchDynamic(id int) {
+	resp, _ := req.Get(fmt.Sprintf("%d", id))
+	_ = resp
+}
+`
+	ids, _ := runDetectWithRels(t, "go", "req_dynamic.go", src)
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			t.Errorf("go-req-dynamic-negative: unexpected synthetic %q from fully-dynamic req URL", id)
+		}
+	}
+}
+
 // TestGoClient_ClientDelete covers client.Delete on a net/http client instance.
 func TestGoClient_ClientDelete(t *testing.T) {
 	src := `

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -675,6 +675,82 @@ func TestHTTPPass_StaticPathsUnaffected(t *testing.T) {
 	}
 }
 
+// TestHTTPPass_GoReqClientCrossRepoMatch verifies that a Go consumer synthetic
+// emitted by the github.com/imroc/req package-level extractor
+// (synthesizeGoClientWithRuntime → http_endpoint_call "http:GET:/api/v1/users",
+// framework "req") cross-repo-links to a Go server route exposing the same
+// canonical (verb, path). This is the cross-repo orphan-gap the req extension
+// closes: the consumer is a Go `.go` file, the producer is a Go handler, and
+// they join purely on the byte-identical synthetic ID — no framework-label
+// coupling. Mirrors TestHTTPPass_ProducerConsumerMatch with both sides Go.
+func TestHTTPPass_GoReqClientCrossRepoMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "users-svc",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "ListUsers", "kind": "Function", "source_file": "handlers/users.go"},
+			{
+				"id": "ep1", "name": "http:GET:/api/v1/users", "kind": "http_endpoint",
+				"source_file": "handlers/users.go",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/api/v1/users",
+					"framework":    "gin",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders-svc",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "listUsers", "kind": "Function", "source_file": "client/users.go"},
+			{
+				"id": "ep2", "name": "http:GET:/api/v1/users", "kind": "http_endpoint",
+				"source_file": "client/users.go",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/api/v1/users",
+					"framework":     "req",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:listUsers",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g-go-req", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g-go-req-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected a cross-repo http link for the Go req client → Go route; got %+v", doc.Links)
+	}
+	if hit.Source != "orders-svc::fn1" {
+		t.Errorf("source: want orders-svc::fn1 (resolved Go req caller), got %s", hit.Source)
+	}
+	if hit.Target != "users-svc::h1" {
+		t.Errorf("target: want users-svc::h1 (resolved Go handler), got %s", hit.Target)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "http:GET:/api/v1/users" {
+		t.Errorf("identifier: want http:GET:/api/v1/users, got %v", hit.Identifier)
+	}
+}
+
 // TestHTTPPass_MixedStaticAndParam verifies mixed paths like /api/v1/users/{pk}
 // match /api/v1/users/{userId} correctly.
 func TestHTTPPass_MixedStaticAndParam(t *testing.T) {


### PR DESCRIPTION
Closes #3736 (child of #3628).

## What
Extends outbound HTTP-client (CONSUMES_API / `http_endpoint_call`) extraction so the **github.com/imroc/req** Go library's outbound calls link cross-repo, and records the previously-untracked outbound-client coverage for Go/Ruby http_backend frameworks.

### Audit finding
The Go (`synthesizeGoClient`: net/http, resty, fasthttp) and Ruby (`synthesizeRubyClient`: Net::HTTP, Faraday, HTTParty, RestClient) consumer-side synthesizers **already existed and were wired** in `http_endpoint_synthesis.go`. The one named-but-uncovered library was Go's `imroc/req` package-level form; its chained `req.C().R().<verb>` form was already covered by the shared `.R().<verb>` matcher.

### The contract (matched byte-for-byte)
Each call site emits a consumer `http_endpoint_call` with id `http:<VERB>:<path>` + a `FETCHES` edge from the enclosing function. `internal/links/http_pass.go` joins consumer↔producer across repos on the identical synthetic id. Absolute URLs are host-stripped (`https://svc/api/x` → `/api/x`); `fmt.Sprintf` / `os.Getenv` concatenation → `runtime_dynamic=true`; fully-dynamic URLs are **skipped** (honest-partial — no fabricated path).

## Libs / verbs added
- **Go / imroc/req** (framework label `req`): package-level `req.Get`, `req.Post`, `req.Put`, `req.Patch`, `req.Delete`, `req.Head`, `req.Options`; `os.Getenv` concat variant. Chained `req.C().R().<verb>` already handled.

## CONSUMES_API ids asserted (value-asserting tests)
- `req.Get("/api/v1/users")` → `http:GET:/api/v1/users` (+ POST/PUT/PATCH/DELETE), `framework=req`, FETCHES edge
- `req.Get("https://inventory-svc/api/v1/items")` → `http:GET:/api/v1/items` (host stripped)
- `req.C().R().Get("/api/v1/health")` → `http:GET:/api/v1/health`
- `req.Get(os.Getenv("API_URL") + "/api/v1/status")` → `http:GET:/api/v1/status` + `runtime_dynamic=true`
- negative: `req.Get(fmt.Sprintf("%d", id))` → no synthetic
- **cross-repo join**: `TestHTTPPass_GoReqClientCrossRepoMatch` — Go req client `http:GET:/api/v1/users` links to a Go server route (`cross_repo_resolved=1`)

## Coverage
Adds `framework_specific` `Integration/client_consumes_api` cells (status `partial`) to `lang.go.framework.net-http`, `lang.go.framework.fasthttp`, `lang.ruby.framework.rails`, `lang.ruby.framework.sinatra`, citing the client extractors + `http_pass.go`. Used `framework_specific` (excluded from the grouped completeness gate) rather than a new `http_backend` taxonomy lane, which would have forced the cell onto all ~120 http_backend records.

## Gates
- `go test` targeted (engine, links, types, coverage): green
- `coverage validate`: 0 errors (advisory warnings only); `coverage fmt --check`: canonical
- `gofmt -l`: empty; `go vet`: clean

## DEPLOY-DEFERRED
Indexer change. No live-daemon rebuild/reindex in this PR; needs a coordinated daemon rebuild + reindex before it affects served graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)