### PR TITLE
realtime: cross-link socket.io client emit/on → server WS handler (http:WS:)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -61560,8 +61560,9 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/http_endpoint_ws_client.go","internal/engine/websocket_edges.go"],
+          "notes": "(epic #3628 realtime cross-link): in addition to the connection-level WS_CONNECTS edge (ws:\u003cchannel\u003e identity), the socket.io CLIENT side now ALSO emits event-level consumer-side http_endpoint_call entities keyed BYTE-IDENTICALLY to the realtime producer endpoint shape http:WS:/\u003ccanonical event\u003e — socket.emit('chat:message') and socket.on('notify') run through the SAME canonicalizeRealtimePath('websocket',...) as the producer so 'chat:message' collapses to http:WS:/chat{message} on both sides and the Name-based cross-repo HTTP linker joins client emit/subscribe to the server socket.on handler with no new linker code. ws_role (emit|subscribe) folded into the framework label; source_caller drives the FETCHES edge. Honest-partial: dynamic event names, native ws.send (no event), and SERVER files are skipped.",
+          "verified_at": "2026-06-02"
         },
         "producer_extraction": {
           "status": "full",

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1279,6 +1279,17 @@ func synthesizeFetchAxios(content string, emit emitFn, state *clientSynthState) 
 		synthesizeGraphQLClientCalls(content, funcsGQL, emit)
 	}
 
+	// WebSocket / Socket.IO client operations (socket.emit / socket.on on a
+	// socket.io-client connection) emit event-level http_endpoint_call entities
+	// keyed to the server endpoint shape http:WS:/<canonical event> (realtime
+	// cross-link, epic #3628). Runs before the REST early-exit guard since a WS
+	// client file may contain none of the fetch/axios markers.
+	if strings.Contains(content, "io(") || strings.Contains(content, "io.connect(") ||
+		strings.Contains(content, "socket.io-client") {
+		funcsWS := indexJSEnclosingFunctions(content)
+		synthesizeWSClientCalls(content, funcsWS, emit)
+	}
+
 	if !strings.Contains(content, "fetch(") &&
 		!strings.Contains(content, "axios.") &&
 		!strings.Contains(content, "axios(") &&

--- a/internal/engine/http_endpoint_ws_client.go
+++ b/internal/engine/http_endpoint_ws_client.go
@@ -1,0 +1,199 @@
+// WebSocket / Socket.IO client-side (consumer) synthetic http_endpoint_call
+// emission for realtime cross-repo matching (epic #3628 area #7, realtime).
+//
+// The realtime-endpoint-synthesis pass (realtime_endpoint_synthesis.go) emits
+// one PRODUCER-side synthetic per server handler. For a socket.io server
+// `socket.on('chat:message', ...)` it emits:
+//
+//	http:WS:/<canonicalised event>     e.g. socket.on('chat:message')
+//	                                   → canonical "/chat{message}"
+//	                                   → id  http:WS:/chat{message}
+//
+// using the synthetic verb WS, with the event name first prefixed by `/` and
+// then run through canonicalizeRealtimePath("websocket", ...) — the SAME
+// canonicaliser the realtime pass uses (so a `:`-bearing event like
+// `chat:message` collapses to `/chat{message}`, matching the server byte for
+// byte). The REST/GraphQL consumer passes never modelled WS clients, so a
+// browser / Node socket.io CLIENT emitted NOTHING at the event level. The only
+// realtime client record was the single WS_CONNECTS edge (websocket_edges.go),
+// which keys on a *different* `ws:<channel>` identity space and can never join
+// the per-event `http:WS:` server endpoints above.
+//
+// This pass closes that gap. For every socket.io client operation it recognises
+// the event name and emits a consumer-side http_endpoint_call whose ID EXACTLY
+// matches the server endpoint shape:
+//
+//	socket.emit('chat:message', payload)  →  http_endpoint_call  http:WS:/chat{message}
+//	socket.on('notify', cb)               →  http_endpoint_call  http:WS:/notify
+//
+// Because the ID is identical to the server-side definition's ID, the existing
+// Name-based cross-repo HTTP linker (links/http_pass.go) joins them on reindex
+// with NO new linker code — exactly like the REST and GraphQL consumer passes.
+// `socket.emit(...)` is a publish (client → server handler), `socket.on(...)`
+// is a subscription (server → client); both map onto the same event endpoint
+// identity, so both are emitted as consumer-side calls and distinguished by the
+// `ws_role` property (emit | subscribe).
+//
+// Recognised client idioms (JS/TS only — the dominant case):
+//
+//   - socket.io-client connection bound to a var:
+//     const socket = io(url) / io.connect(url) / io("/namespace")
+//     → the var name is resolved, and `<var>.emit('e')` / `<var>.on('e')`
+//     calls on it are extracted.
+//   - the conventional bare identifiers `socket` / `sock` / `client` are also
+//     accepted as socket handles when a client connection marker is present in
+//     the file, matching the server pass's symmetric identifier set.
+//
+// FETCHES edge: the enclosing function at the call site is recorded as
+// `source_caller` (Function:<name>); ResolveHTTPEndpointHandlers turns that
+// into the FETCHES edge — same mechanism as every other consumer pass.
+//
+// Honest-partial / non-fabrication rules:
+//   - Dynamic event names (`socket.emit(eventName, …)`, template literals) are
+//     SKIPPED — no event string, no fabricated endpoint.
+//   - Lifecycle events (connect/disconnect/error/…) are skipped — they are not
+//     application channels and the server pass skips them too.
+//   - Native `WebSocket`'s `ws.send(...)` carries no event name → skipped
+//     (the WS_CONNECTS pass already records the URL-level connection).
+//   - SERVER files (those containing a socket.io server-create marker or an
+//     `io.on('connection', …)` handler) are skipped entirely: their
+//     `socket.on(...)` handlers are the PRODUCER side, already emitted by the
+//     realtime pass. This pass is strictly the client (consumer) side.
+//
+// Refs epic #3628 (realtime cross-link), realtime_endpoint_synthesis.go (#3682).
+
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// wsClientVerb is the synthetic HTTP verb used for all WebSocket realtime
+// endpoints, matching the server side (realtimeVerbWS == "WS").
+const wsClientVerb = "WS"
+
+// wsClientConnectMarkerRe detects a socket.io-client (or native WebSocket)
+// CONNECTION in the file — the signal that `<var>.emit/.on` calls are talking
+// to a remote server rather than being server-side handler registrations.
+var wsClientConnectMarkerRe = regexp.MustCompile(
+	`(?:^|[^\w$.])io(?:\.connect)?\s*\(|\bfrom\s+['"]socket\.io-client['"]|require\(\s*['"]socket\.io-client['"]\s*\)`,
+)
+
+// wsServerCreateMarkerRe detects a socket.io SERVER create in the file. When
+// present we treat the file as a server and let the realtime producer pass own
+// its `socket.on(...)` handlers, so this client pass does not double-emit.
+var wsServerCreateMarkerRe = regexp.MustCompile(
+	`new\s+(?:Server|SocketIOServer)\s*\(|socket\.io\.attach|require\(\s*['"]socket\.io['"]\s*\)|from\s+['"]socket\.io['"]|\.on\s*\(\s*['"]connection['"]`,
+)
+
+// wsClientSocketAssignRe captures a socket-handle variable bound to an io(...)
+// / io.connect(...) call: `const socket = io(url)`. Capture 1 = var name.
+var wsClientSocketAssignRe = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*io(?:\.connect)?\s*\(`,
+)
+
+// wsClientEmitOnRe captures `<recv>.emit('event'` and `<recv>.on('event'` where
+// <recv> is the socket handle. Capture 1 = receiver ident, 2 = method
+// (emit|on), 3 = event name. The event must be a string literal — dynamic
+// names (bare identifiers / template literals) do not match and are skipped.
+var wsClientEmitOnRe = regexp.MustCompile(
+	`\b([A-Za-z_$][\w$]*)\s*\.\s*(emit|on)\s*\(\s*['"]([^'"\r\n]+)['"]`,
+)
+
+// wsClientLifecycleEvents are socket.io lifecycle/reserved events that do not
+// represent application channels (mirrors the realtime producer pass).
+var wsClientLifecycleEvents = map[string]bool{
+	"connect": true, "connection": true, "disconnect": true,
+	"disconnecting": true, "connect_error": true, "error": true,
+	"reconnect": true, "reconnect_attempt": true, "reconnect_error": true,
+	"reconnect_failed": true, "ping": true, "pong": true,
+}
+
+// synthesizeWSClientCalls scans a JS/TS file for socket.io CLIENT event
+// publishes (`socket.emit('e')`) and subscriptions (`socket.on('e')`) and emits
+// one http_endpoint_call per distinct (event, role), keyed to match the server
+// endpoint shape http:WS:/<canonical event>, plus a source_caller for the
+// FETCHES edge.
+//
+// It is invoked from synthesizeFetchAxios so it shares the JS/TS dispatch.
+func synthesizeWSClientCalls(content string, funcs []jsFuncSpan, emit emitFn) {
+	// File-signal gate: require a socket.io-client connection marker so this is
+	// a no-op on ordinary REST/React files and on socket.io SERVER files.
+	if !wsClientConnectMarkerRe.MatchString(content) {
+		return
+	}
+	// Server files own their socket.on(...) handlers via the realtime producer
+	// pass; do not double-emit the same event as a consumer here.
+	if wsServerCreateMarkerRe.MatchString(content) {
+		return
+	}
+
+	// Resolve the set of identifiers that hold a socket.io client connection.
+	// Conventional bare handles are also accepted (the file already passed the
+	// client-connection gate), matching the server pass's identifier set.
+	socketVars := map[string]bool{
+		"socket": true, "sock": true, "client": true, "s": true,
+	}
+	for _, m := range wsClientSocketAssignRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 {
+			socketVars[m[1]] = true
+		}
+	}
+
+	// Per-(role,event) dedup within the file: the canonical id already dedups
+	// at the emit layer per side, but we also avoid re-attributing the same
+	// event to a different caller twice when the literal repeats verbatim.
+	seen := map[string]bool{}
+
+	for _, m := range wsClientEmitOnRe.FindAllStringSubmatchIndex(content, -1) {
+		// Groups: m[2:4] recv, m[4:6] method, m[6:8] event.
+		if len(m) < 8 {
+			continue
+		}
+		recv := content[m[2]:m[3]]
+		method := content[m[4]:m[5]]
+		event := content[m[6]:m[7]]
+
+		if !socketVars[recv] {
+			continue
+		}
+		if wsClientLifecycleEvents[event] {
+			continue
+		}
+		// Honest-partial: reject anything that is not a stable literal event.
+		if event == "" || strings.ContainsAny(event, "${`") || event == "*" {
+			continue
+		}
+
+		// Byte-identical id parity: run the event through the SAME canonicaliser
+		// the realtime producer pass uses (event prefixed with `/`).
+		canonical := canonicalizeRealtimePath("websocket", "/"+strings.TrimPrefix(event, "/"))
+		if canonical == "" {
+			continue
+		}
+
+		role := "emit"
+		if method == "on" {
+			role = "subscribe"
+		}
+		dedupKey := role + "\x00" + canonical
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+
+		caller := enclosingJSFuncAt(funcs, m[0])
+		framework := "socket.io-client"
+		// The emit closure stamps verb/path/framework/source_caller and the
+		// canonical http:WS:<path> id. The ws_role is folded into the framework
+		// label so the existing emitFn signature is preserved without a schema
+		// change; emit | subscribe is recoverable from `framework`.
+		if role == "subscribe" {
+			framework = "socket.io-client:subscribe"
+		} else {
+			framework = "socket.io-client:emit"
+		}
+		emit(wsClientVerb, canonical, framework, "Function", caller)
+	}
+}

--- a/internal/engine/http_endpoint_ws_client_test.go
+++ b/internal/engine/http_endpoint_ws_client_test.go
@@ -1,0 +1,241 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// wsCallEntity finds the http_endpoint_call with the given ID, or nil.
+func wsCallEntity(res *DetectResult, id string) *entityForTest {
+	for i := range res.Entities {
+		e := res.Entities[i]
+		if e.ID == id && e.Kind == httpEndpointCallKind {
+			return &entityForTest{
+				id:           e.ID,
+				name:         e.Name,
+				qn:           e.QualifiedName,
+				patternType:  e.Properties["pattern_type"],
+				sourceCaller: e.Properties["source_caller"],
+				verb:         e.Properties["verb"],
+				framework:    e.Properties["framework"],
+			}
+		}
+	}
+	return nil
+}
+
+func wsCallIDs(res *DetectResult) []string {
+	var got []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind {
+			got = append(got, e.ID)
+		}
+	}
+	sort.Strings(got)
+	return got
+}
+
+// serverWSDefID runs the realtime producer pass on a socket.io SERVER fixture
+// for the given event and returns the http:WS: definition ID it emits. This is
+// the parity oracle: the client side must produce a byte-identical ID.
+func serverWSDefID(t *testing.T, event string) string {
+	t.Helper()
+	src := "import { Server } from 'socket.io';\n" +
+		"const io = new Server(httpServer);\n" +
+		"io.on('connection', (socket) => {\n" +
+		"  socket.on('" + event + "', (m) => { handle(m); });\n" +
+		"});\n"
+	_, res := runDetect(t, "typescript", "server.ts", src)
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind &&
+			e.Properties["verb"] == "WS" &&
+			e.Properties["event"] == event {
+			return e.ID
+		}
+	}
+	t.Fatalf("realtime producer pass emitted no WS definition for event %q", event)
+	return ""
+}
+
+// TestSynth_WSClient_EmitMatchesServerID is the core parity-oracle test: a
+// client `socket.emit('chat:message', m)` must emit a client-call whose ID
+// EXACTLY matches the server-side handler endpoint
+// (socket.on('chat:message')), including the `:`→`{}` canonicalisation, so the
+// cross-repo linker joins them.
+func TestSynth_WSClient_EmitMatchesServerID(t *testing.T) {
+	wantID := serverWSDefID(t, "chat:message")
+	if wantID != "http:WS:/chat{message}" {
+		t.Fatalf("server id parity oracle changed: got %q", wantID)
+	}
+
+	src := `
+import { io } from 'socket.io-client';
+
+const socket = io('https://api.example.com');
+
+function ChatBox() {
+  function send(m) {
+    socket.emit('chat:message', m);
+  }
+  return send;
+}
+`
+	_, res := runDetect(t, "typescript", "ChatBox.tsx", src)
+
+	e := wsCallEntity(res, wantID)
+	if e == nil {
+		t.Fatalf("missing client-call %q matching server endpoint shape (got calls: %v)",
+			wantID, wsCallIDs(res))
+	}
+	if e.verb != "WS" {
+		t.Errorf("verb = %q, want WS (must match server synthetic verb)", e.verb)
+	}
+	if e.patternType != "http_endpoint_client_synthesis" {
+		t.Errorf("pattern_type = %q, want http_endpoint_client_synthesis", e.patternType)
+	}
+	if e.framework != "socket.io-client:emit" {
+		t.Errorf("framework = %q, want socket.io-client:emit (publish role)", e.framework)
+	}
+	if e.sourceCaller != "Function:send" {
+		t.Errorf("source_caller = %q, want Function:send (drives FETCHES edge)", e.sourceCaller)
+	}
+	if e.qn != wantID {
+		t.Errorf("qualified_name = %q, want %q", e.qn, wantID)
+	}
+}
+
+// TestSynth_WSClient_OnIsSubscription proves `socket.on('notify', cb)` emits a
+// subscription-role client-call keyed to the server endpoint shape.
+func TestSynth_WSClient_OnIsSubscription(t *testing.T) {
+	wantID := serverWSDefID(t, "notify") // http:WS:/notify
+
+	src := `
+import { io } from 'socket.io-client';
+const socket = io('/realtime');
+
+function Bell() {
+  socket.on('notify', (payload) => render(payload));
+}
+`
+	_, res := runDetect(t, "typescript", "Bell.tsx", src)
+
+	e := wsCallEntity(res, wantID)
+	if e == nil {
+		t.Fatalf("missing subscription client-call %q (got: %v)", wantID, wsCallIDs(res))
+	}
+	if e.framework != "socket.io-client:subscribe" {
+		t.Errorf("framework = %q, want socket.io-client:subscribe (subscription role)", e.framework)
+	}
+	if e.sourceCaller != "Function:Bell" {
+		t.Errorf("source_caller = %q, want Function:Bell", e.sourceCaller)
+	}
+}
+
+// TestSynth_WSClient_FetchesEdge proves the source_caller resolves into a real
+// FETCHES edge from the enclosing component to the WS client-call, end-to-end
+// through ResolveHTTPEndpointHandlers.
+func TestSynth_WSClient_FetchesEdge(t *testing.T) {
+	wantID := serverWSDefID(t, "order:created") // http:WS:/order{created}
+
+	src := `
+import { io } from 'socket.io-client';
+const socket = io('https://orders.example.com');
+
+function OrdersFeed() {
+  socket.emit('order:created', { id: 1 });
+}
+`
+	_, res := runDetect(t, "typescript", "OrdersFeed.tsx", src)
+
+	call := wsCallEntity(res, wantID)
+	if call == nil {
+		t.Fatalf("missing client-call %q (got: %v)", wantID, wsCallIDs(res))
+	}
+	if call.sourceCaller != "Function:OrdersFeed" {
+		t.Fatalf("source_caller = %q, want Function:OrdersFeed", call.sourceCaller)
+	}
+
+	caller := types.EntityRecord{
+		Kind:       "Function",
+		Name:       "OrdersFeed",
+		SourceFile: "OrdersFeed.tsx",
+		Language:   "typescript",
+	}
+	merged := append([]types.EntityRecord{caller}, res.Entities...)
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.CallerResolved < 1 {
+		t.Errorf("expected >=1 caller_resolved, got %d", stats.CallerResolved)
+	}
+	foundFetch := false
+	for _, e := range out {
+		for _, r := range e.Relationships {
+			if r.Kind == "FETCHES" && r.ToID == "http_endpoint_call:"+wantID {
+				if r.FromID != "Function:OrdersFeed" {
+					t.Errorf("FETCHES from = %q, want Function:OrdersFeed", r.FromID)
+				}
+				foundFetch = true
+			}
+		}
+	}
+	if !foundFetch {
+		t.Errorf("expected FETCHES edge Function:OrdersFeed → http_endpoint_call:%s", wantID)
+	}
+}
+
+// TestSynth_WSClient_DynamicEventSkipped is the honest-partial negative: a
+// dynamic event name (bare identifier or template literal) must NOT fabricate
+// an endpoint.
+func TestSynth_WSClient_DynamicEventSkipped(t *testing.T) {
+	src := "import { io } from 'socket.io-client';\n" +
+		"const socket = io('/x');\n" +
+		"function send(eventName, room) {\n" +
+		"  socket.emit(eventName, {});\n" +
+		"  socket.emit(`room:${room}`, {});\n" +
+		"}\n"
+	_, res := runDetect(t, "typescript", "dyn.ts", src)
+	if ids := wsCallIDs(res); len(ids) != 0 {
+		t.Errorf("dynamic event names must emit no WS client-call, got: %v", ids)
+	}
+}
+
+// TestSynth_WSClient_NonSocketEmitterIgnored is the negative for a plain Node
+// EventEmitter on an unrelated var: there is no socket.io-client connection in
+// the file, so `.emit('data')` must NOT be treated as a WS publish.
+func TestSynth_WSClient_NonSocketEmitterIgnored(t *testing.T) {
+	src := `
+import { EventEmitter } from 'events';
+const bus = new EventEmitter();
+
+function publish() {
+  bus.emit('data', 42);
+}
+`
+	_, res := runDetect(t, "typescript", "bus.ts", src)
+	if ids := wsCallIDs(res); len(ids) != 0 {
+		t.Errorf("EventEmitter.emit without a socket.io-client connection must emit nothing, got: %v", ids)
+	}
+}
+
+// TestSynth_WSClient_ServerFileNotDoubleEmitted proves a socket.io SERVER file
+// (new Server + io.on('connection')) does NOT additionally emit a CLIENT-side
+// http_endpoint_call for its handlers — the realtime producer pass owns those.
+// We assert no http_endpoint_call (consumer) entity is produced; the producer
+// definition is allowed.
+func TestSynth_WSClient_ServerFileNotDoubleEmitted(t *testing.T) {
+	src := `
+import { Server } from 'socket.io';
+const io = new Server(httpServer);
+io.on('connection', (socket) => {
+  socket.on('chat:message', (m) => handle(m));
+});
+`
+	_, res := runDetect(t, "typescript", "server.ts", src)
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind &&
+			e.Properties["framework"] == "socket.io-client:subscribe" {
+			t.Errorf("server file must not emit a CLIENT subscribe call, got %q", e.ID)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3738 (epic #3628 realtime area #7).

## Gap
`realtime_endpoint_synthesis.go` (#3682) emits PRODUCER-side `http:WS:/<event>` endpoints for socket.io server `socket.on(...)` handlers. The socket.io CLIENT side emitted nothing at the event level — only the connection-level `WS_CONNECTS` edge in `websocket_edges.go`, which keys on a *different* `ws:<channel>` identity space and can never join the per-event `http:WS:` server endpoints. So `socket.emit('chat:message')` / `socket.on('notify')` never cross-linked to their server handler. (Verified genuine gap — unlike sibling already-done tasks graphql-client #3667 / grpc-client #3686.)

## Fix
New pass `internal/engine/http_endpoint_ws_client.go` — `synthesizeWSClientCalls`, dispatched from `synthesizeFetchAxios` exactly like the GraphQL client pass. Emits a consumer-side `http_endpoint_call` per (event, role) keyed **byte-identically** to the server endpoint shape.

### ID shape (byte-identical parity)
The event is prefixed with `/` and run through the **same** `canonicalizeRealtimePath("websocket", …)` the producer uses, then `httproutes.SyntheticID("WS", …)`:

| client call | http_endpoint_call id | framework |
|---|---|---|
| `socket.emit('chat:message', m)` | `http:WS:/chat{message}` | `socket.io-client:emit` |
| `socket.on('notify', cb)` | `http:WS:/notify` | `socket.io-client:subscribe` |
| `socket.emit('order:created', …)` | `http:WS:/order{created}` | `socket.io-client:emit` |

Note the `:`→`{}` canonicalisation (`chat:message` → `/chat{message}`) is applied identically on both sides — that was the load-bearing detail. ID == Name == the server definition's ID, so the existing Name-based cross-repo HTTP linker joins client emit/subscribe to the server `socket.on` handler **with no new linker code** (same mechanism as REST/GraphQL consumers). `source_caller` drives the FETCHES edge via `ResolveHTTPEndpointHandlers`.

## Honest-partial / non-fabrication
- Dynamic event names (bare ident / template literal) → skipped.
- Native `WebSocket` `ws.send(...)` (no event name) → skipped.
- SERVER files (socket.io server-create / `io.on('connection')`) → skipped; producer pass owns those handlers (no double-emit).
- Non-socket `EventEmitter.emit` with no client connection in file → skipped.

## Tests
`http_endpoint_ws_client_test.go` — 6 tests, all green:
- **Parity oracle**: runs the producer pass on a server fixture, asserts the client emits the *identical* `http:WS:/chat{message}` ID.
- `socket.on` → subscription-role call.
- FETCHES edge proven end-to-end through `ResolveHTTPEndpointHandlers`.
- 3 negatives: dynamic event, non-socket `EventEmitter.emit`, server-file no-double-emit.

`go test` targeted green (`engine`, `links/...`, `types`, `tools/coverage`); `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## Coverage
`docs/coverage/registry.json` — `msg.websocket` consumer_extraction cites `http_endpoint_ws_client.go` + note documenting the event-level cross-link.

**DEPLOY-DEFERRED** — the live daemon serves the rewrite agent; no reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)