### PR TITLE
[honesty] unify synthesized-edge confidence (resolved/heuristic/inferred) + MCP surface

### DIFF
--- a/internal/links/confidence.go
+++ b/internal/links/confidence.go
@@ -148,3 +148,63 @@ func ScoreString(cat extractionCategory) float64 {
 	}
 	return stringBandLow
 }
+
+// ---------------------------------------------------------------------------
+// Extraction-confidence honesty marker (#3628 roadmap area #23)
+// ---------------------------------------------------------------------------
+//
+// The numeric `confidence` float above is a per-pass *quality score* used for
+// threshold gating and shortest-path weighting. It is orthogonal to the
+// question a graph consumer most often asks: "is this edge grounded in a real
+// tree-sitter-AST match on BOTH sides, or was it synthesised heuristically?"
+//
+// EdgeConfidenceKey carries that categorical honesty marker as a Link property
+// so a consumer can distinguish a fully-matched cross-repo edge from a
+// fuzzy/string/runtime-derived one WITHOUT having to reverse-engineer the
+// numeric band. It is stored under a property (not a top-level field) so it
+// rides through the existing Link.Properties → MCP surface plumbing and never
+// collides with the float `confidence` JSON field.
+//
+// Value vocabulary (exactly three values):
+//
+//   - "resolved"  — both the client/producer and server/consumer endpoints
+//     matched on their canonical id (path-normalised HTTP pairs,
+//     topic pub↔sub on the same channel, gRPC method↔stub,
+//     OpenAPI operationId). Structurally grounded on both sides.
+//   - "heuristic" — only one side is AST-grounded and the match is fuzzy:
+//     TF-IDF label match, string-literal catalog match,
+//     cross-language SAME_AS field-overlap. The edge is a
+//     best-effort guess, not a proven contract.
+//   - "inferred"  — derived from a runtime-dynamic / interpolated value: a
+//     `${apiUrl}`-prefixed call whose static suffix uniquely
+//     matched a backend (dynamic_suffix_match), or a concrete
+//     caller segment filling a producer param slot
+//     (literal_param_fill). One side is real, the other is
+//     reconstructed from a runtime expression.
+//
+// ABSENCE ⇒ resolved: AST-grounded structural edges (CALLS / IMPORTS /
+// DEFINES emitted directly by tree-sitter, and the import_pass) deliberately
+// do NOT stamp this property — stamping every edge would bloat the graph.
+// A consumer MUST treat a missing marker as "resolved".
+const EdgeConfidenceKey = "confidence"
+
+const (
+	// ConfidenceResolved marks an edge whose two endpoints both matched on a
+	// canonical id (the highest-honesty cross-repo class).
+	ConfidenceResolved = "resolved"
+	// ConfidenceHeuristic marks a fuzzy / single-side-grounded synthesised edge.
+	ConfidenceHeuristic = "heuristic"
+	// ConfidenceInferred marks an edge derived from a runtime-dynamic /
+	// interpolated value.
+	ConfidenceInferred = "inferred"
+)
+
+// WithEdgeConfidence stamps the honesty marker on a Link, allocating the
+// Properties map on demand. It is the single mutation point so the property
+// name stays consistent across every pass.
+func (l *Link) WithEdgeConfidence(level string) {
+	if l.Properties == nil {
+		l.Properties = map[string]string{}
+	}
+	l.Properties[EdgeConfidenceKey] = level
+}

--- a/internal/links/edge_confidence_test.go
+++ b/internal/links/edge_confidence_test.go
@@ -1,0 +1,202 @@
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// edge_confidence_test.go asserts the #3628 extraction-confidence honesty
+// marker is stamped with the correct value for each synthesised edge family.
+//
+// The three values are asserted VALUE-by-VALUE against real end-to-end pass
+// output (not len>0): a fully cross-repo-matched HTTP pair must be "resolved",
+// a runtime-dynamic `${apiUrl}`-derived call must be "inferred", and a fuzzy
+// string-literal match must be "heuristic".
+
+// TestEdgeConfidence_ResolvedHTTPPair: a consumer caller and a producer handler
+// matched on the same canonical (verb, path) id → confidence=resolved.
+func TestEdgeConfidence_ResolvedHTTPPair(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "UserView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "loadUser", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadUser",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gconf-resolved", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gconf-resolved-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := findLink(doc.Links, func(l Link) bool {
+		return l.Method == MethodHTTP && l.Source == "frontend::fn1" && l.Target == "backend::h1"
+	})
+	if hit == nil {
+		t.Fatalf("expected matched HTTP pair frontend::fn1 → backend::h1; got %+v", doc.Links)
+	}
+	if got := hit.Properties[EdgeConfidenceKey]; got != ConfidenceResolved {
+		t.Errorf("confidence: want %q (both endpoints matched on canonical id), got %q",
+			ConfidenceResolved, got)
+	}
+}
+
+// TestEdgeConfidence_InferredDynamicSuffix: a `${apiUrl}/schedule/import` call
+// whose static suffix uniquely matched a backend → confidence=inferred.
+func TestEdgeConfidence_InferredDynamicSuffix(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "ScheduleViewSet", "kind": "Controller", "source_file": "core/views/schedule_viewset.py"},
+			{
+				"id": "ep1", "name": "http:POST:/api/v1/schedule/import", "kind": "http_endpoint",
+				"source_file": "core/views/schedule_viewset.py",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/api/v1/schedule/import",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "importSchedule", "kind": "Function", "source_file": "src/stores/schedule/scheduleServiceV2.js"},
+			{
+				"id": "ep2", "name": "http:POST:/{apiUrl}/schedule/import", "kind": "http_endpoint",
+				"source_file": "src/stores/schedule/scheduleServiceV2.js",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/{apiUrl}/schedule/import",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"url_kind": "dynamic_baseurl", "dynamic_baseurl": "true",
+					"source_caller": "Function:importSchedule",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gconf-inferred", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gconf-inferred-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := findLink(doc.Links, func(l Link) bool {
+		return l.Method == MethodHTTP && l.Source == "frontend::fn1" && l.Target == "backend::h1"
+	})
+	if hit == nil {
+		t.Fatalf("expected dynamic_suffix_match link frontend::fn1 → backend::h1; got %+v", doc.Links)
+	}
+	// Guard: this MUST be the runtime-dynamic strategy, otherwise the value
+	// assertion below would be meaningless.
+	if got := hit.Properties["resolve_strategy"]; got != "dynamic_suffix_match" {
+		t.Fatalf("precondition: want resolve_strategy=dynamic_suffix_match, got %q", got)
+	}
+	if got := hit.Properties[EdgeConfidenceKey]; got != ConfidenceInferred {
+		t.Errorf("confidence: want %q (runtime-dynamic URL-derived), got %q",
+			ConfidenceInferred, got)
+	}
+}
+
+// TestEdgeConfidence_HeuristicStringMatch: two repos sharing a string literal
+// (an HTTP path catalog match) → confidence=heuristic.
+func TestEdgeConfidence_HeuristicStringMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	mkRepo := func(name string) {
+		dir := filepath.Join(root, name, "src")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "h.go"),
+			[]byte("package main\nvar p = \"/api/v1/orders/{id}\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		writeFixture(t, root, fixtureGraph{
+			Repo: name,
+			Entities: []map[string]any{
+				{"id": name + "_e", "name": "Handler", "kind": "function", "source_file": "src/h.go"},
+			},
+		})
+	}
+	mkRepo("alpha")
+	mkRepo("beta")
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gconf-heuristic", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gconf-heuristic-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := findLink(doc.Links, func(l Link) bool {
+		return l.Method == MethodString && l.Identifier != nil && *l.Identifier == "/api/v1/orders/{id}"
+	})
+	if hit == nil {
+		t.Fatalf("expected string match link for /api/v1/orders/{id}; got %+v", doc.Links)
+	}
+	if got := hit.Properties[EdgeConfidenceKey]; got != ConfidenceHeuristic {
+		t.Errorf("confidence: want %q (fuzzy string-literal match), got %q",
+			ConfidenceHeuristic, got)
+	}
+}
+
+// TestEdgeConfidence_ImportPassUnstamped documents the absence⇒resolved
+// contract: AST-grounded import_pass links deliberately do NOT carry the
+// marker, so a consumer treats a missing value as "resolved".
+func TestEdgeConfidence_WithEdgeConfidenceSetter(t *testing.T) {
+	var l Link
+	l.WithEdgeConfidence(ConfidenceResolved)
+	if l.Properties[EdgeConfidenceKey] != ConfidenceResolved {
+		t.Fatalf("setter did not stamp marker: %+v", l.Properties)
+	}
+	// Idempotent re-stamp must overwrite, not append a second key.
+	l.WithEdgeConfidence(ConfidenceHeuristic)
+	if l.Properties[EdgeConfidenceKey] != ConfidenceHeuristic {
+		t.Fatalf("setter did not overwrite: %+v", l.Properties)
+	}
+	if len(l.Properties) != 1 {
+		t.Fatalf("setter must reuse the same key; got %d props: %+v", len(l.Properties), l.Properties)
+	}
+}
+
+// findLink returns the first link matching pred, or nil.
+func findLink(links []Link, pred func(Link) bool) *Link {
+	for i := range links {
+		if pred(links[i]) {
+			return &links[i]
+		}
+	}
+	return nil
+}

--- a/internal/links/grpc_pass.go
+++ b/internal/links/grpc_pass.go
@@ -226,7 +226,7 @@ func runGRPCPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 
 				ident := name // "grpc:ServiceName/MethodName"
 				ch := grpcChannel
-				fresh = append(fresh, Link{
+				grpcLink := Link{
 					ID:           id,
 					Source:       source,
 					Target:       target,
@@ -240,7 +240,11 @@ func runGRPCPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						{client.sourceFile},
 						{server.sourceFile},
 					},
-				})
+				}
+				// #3628 — client stub and server impl matched on the same
+				// canonical grpc:Service/Method id; both sides AST-grounded. resolved.
+				grpcLink.WithEdgeConfidence(ConfidenceResolved)
+				fresh = append(fresh, grpcLink)
 			}
 		}
 	}

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -1637,6 +1637,12 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						}
 						link.Properties["intra_repo"] = "true"
 					}
+					// #3628 — honesty marker. Every link emitted from this block
+					// pairs an AST-grounded consumer caller with an AST-grounded
+					// producer handler matched on the canonical (verb, path) id —
+					// even through prefix/case/param normalisation, both sides are
+					// real endpoints. That is the highest-honesty `resolved` class.
+					link.WithEdgeConfidence(ConfidenceResolved)
 					fresh = append(fresh, link)
 				} // end for _, c := range consumersByRepo[cRepo]
 			}
@@ -1770,6 +1776,9 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						MatchQuality: quality,
 						Properties:   map[string]string{"resolve_strategy": "case_style_normalized"},
 					}
+					// #3628 — both endpoints are AST-grounded; only the casing
+					// style of the route segments differed. resolved.
+					link.WithEdgeConfidence(ConfidenceResolved)
 					fresh = append(fresh, link)
 				}
 			}
@@ -1883,6 +1892,9 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						MatchQuality: matchQualityAnyFallback,
 						Properties:   map[string]string{"normalization": "url_pattern"},
 					}
+					// #3628 — both endpoints AST-grounded; only path-param syntax
+					// (or a trailing query string) differed. resolved.
+					link.WithEdgeConfidence(ConfidenceResolved)
 					fresh = append(fresh, link)
 				}
 			}
@@ -2007,6 +2019,11 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						MatchQuality: quality,
 						Properties:   props,
 					}
+					// #3628 — the producer side is AST-grounded, but the consumer's
+					// concrete segment is *interpreted* as the value filling a
+					// producer param slot. That binding is reconstructed, not
+					// proven from a real param on the call side. inferred.
+					link.WithEdgeConfidence(ConfidenceInferred)
 					fresh = append(fresh, link)
 				}
 			}
@@ -2150,6 +2167,10 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						"dynamic_suffix":    suffixKey,
 						"dynamic_prefix":    "stripped",
 						"suffix_static_seg": strconv.Itoa(leadingStatic),
+						// #3628 — the consumer URL was a runtime-dynamic
+						// `${apiUrl}/x/y` expression; only the static suffix was
+						// matched after stripping the runtime base. inferred.
+						EdgeConfidenceKey: ConfidenceInferred,
 					},
 				}
 				fresh = append(fresh, link)

--- a/internal/links/label_pass.go
+++ b/internal/links/label_pass.go
@@ -449,6 +449,10 @@ func runLabelPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pas
 					Identifier:   strPtr(label),
 					DiscoveredAt: now,
 				}
+				// #3628 — label_pass is a TF-IDF + kind-compatibility fuzzy
+				// match over shared labels; a statistical guess, not a proven
+				// endpoint contract. heuristic.
+				link.WithEdgeConfidence(ConfidenceHeuristic)
 				if raw >= labelLinkThreshold {
 					freshLinks = append(freshLinks, link)
 				} else {

--- a/internal/links/openapi_pass.go
+++ b/internal/links/openapi_pass.go
@@ -396,6 +396,10 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 						},
 						MatchQuality: openAPISpecMatchQuality,
 					}
+					// #3628 — consumer call and producer operation both matched
+					// through the shared OpenAPI spec operationId; both sides
+					// AST-grounded against a declared contract. resolved.
+					link.WithEdgeConfidence(ConfidenceResolved)
 					fresh = append(fresh, link)
 				}
 			}

--- a/internal/links/sameas_pass.go
+++ b/internal/links/sameas_pass.go
@@ -369,6 +369,10 @@ func runSameAsPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 					Identifier:   &ident,
 					DiscoveredAt: now,
 				}
+				// #3628 — SAME_AS pairs two cross-language models by name +
+				// Jaccard field-overlap. Even heavily gated, it is a fuzzy
+				// identity guess, not a structural binding. heuristic.
+				link.WithEdgeConfidence(ConfidenceHeuristic)
 				if overlap >= sameAsMinFieldOverlap {
 					freshLinks = append(freshLinks, link)
 				} else {

--- a/internal/links/string_pass.go
+++ b/internal/links/string_pass.go
@@ -462,6 +462,11 @@ func runStringPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 						{fmt.Sprintf("%s:%d", hb.file, hb.line)},
 					},
 				}
+				// #3628 — string_pass matches two endpoints by a shared string
+				// literal (ARN, topic name, URL path, redis key, …). The match is
+				// a name collision, not a proven contract, and each side is
+				// independently AST-grounded only as a literal. heuristic.
+				link.WithEdgeConfidence(ConfidenceHeuristic)
 				if conf >= stringLinkThreshold {
 					freshLinks = append(freshLinks, link)
 				} else {

--- a/internal/links/topic_pass.go
+++ b/internal/links/topic_pass.go
@@ -345,7 +345,7 @@ func runTopicPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pas
 
 				ident := name
 				ch := broker
-				fresh = append(fresh, Link{
+				topicLink := Link{
 					ID:           id,
 					Source:       source,
 					Target:       target,
@@ -359,7 +359,11 @@ func runTopicPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pas
 						{pub.sourceFile},
 						{sub.sourceFile},
 					},
-				})
+				}
+				// #3628 — publisher and subscriber both matched on the same
+				// canonical topic/channel name; both sides AST-grounded. resolved.
+				topicLink.WithEdgeConfidence(ConfidenceResolved)
+				fresh = append(fresh, topicLink)
 			}
 		}
 	}

--- a/internal/mcp/edge_confidence_test.go
+++ b/internal/mcp/edge_confidence_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// edge_confidence_test.go asserts the MCP read-side surface for the #3628
+// extraction-confidence honesty marker. The neighbors handler emits
+// l.EdgeConfidence() under the "confidence" key for every cross-repo overlay
+// edge; these tests pin the value-mapping and the absence⇒resolved contract
+// that the handler relies on.
+
+func TestCrossRepoLink_EdgeConfidence_StampedValues(t *testing.T) {
+	cases := []struct {
+		name string
+		prop string
+		want string
+	}{
+		{"resolved", "resolved", "resolved"},
+		{"heuristic", "heuristic", "heuristic"},
+		{"inferred", "inferred", "inferred"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := CrossRepoLink{
+				Source:     "frontend::fn1",
+				Target:     "backend::h1",
+				Kind:       "calls",
+				Properties: map[string]string{edgeConfidenceProp: tc.prop},
+			}
+			if got := l.EdgeConfidence(); got != tc.want {
+				t.Errorf("EdgeConfidence() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCrossRepoLink_EdgeConfidence_AbsentDefaultsResolved pins the honesty
+// contract: an AST-grounded structural edge (import_pass) carries no marker,
+// and a consumer MUST read that absence as "resolved".
+func TestCrossRepoLink_EdgeConfidence_AbsentDefaultsResolved(t *testing.T) {
+	// No Properties at all.
+	if got := (CrossRepoLink{Kind: "import"}).EdgeConfidence(); got != "resolved" {
+		t.Errorf("absent marker: want resolved, got %q", got)
+	}
+	// Properties present but no confidence key.
+	l := CrossRepoLink{Properties: map[string]string{"resolve_strategy": "exact"}}
+	if got := l.EdgeConfidence(); got != "resolved" {
+		t.Errorf("no-confidence-key: want resolved, got %q", got)
+	}
+}
+
+// TestCrossRepoLink_Properties_RoundTrip verifies the on-disk links-pass
+// "properties" object (where the marker is stamped) deserialises into the
+// MCP-side CrossRepoLink struct so the neighbors handler can read it.
+func TestCrossRepoLink_Properties_RoundTrip(t *testing.T) {
+	const data = `[{"source":"frontend::fn1","target":"backend::h1","relation":"calls",
+		"method":"http","properties":{"confidence":"heuristic","resolve_strategy":"exact"}}]`
+	path := filepath.Join(t.TempDir(), "g-links.json")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	links, err := readLinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("want 1 link, got %d", len(links))
+	}
+	if got := links[0].EdgeConfidence(); got != "heuristic" {
+		t.Errorf("round-tripped confidence: want heuristic, got %q", got)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -194,6 +194,12 @@ type CrossRepoLink struct {
 	Confidence float64 `json:"confidence,omitempty"`
 	Channel    string  `json:"channel,omitempty"`
 	Method     string  `json:"method,omitempty"`
+	// Properties carries the on-disk links-pass annotations (resolve_strategy,
+	// normalization, and — since #3628 — the categorical extraction-confidence
+	// honesty marker under the "confidence" key). Surfaced read-side via
+	// EdgeConfidence() so MCP consumers can tell a fully-resolved cross-repo
+	// edge from a heuristically-/runtime-synthesised one.
+	Properties map[string]string `json:"properties,omitempty"`
 }
 
 // EffectiveKind returns the link's relation, preferring the explicit "kind"
@@ -203,6 +209,26 @@ func (l CrossRepoLink) EffectiveKind() string {
 		return l.Kind
 	}
 	return l.Relation
+}
+
+// edgeConfidenceProp is the Properties key under which the links layer stamps
+// the categorical honesty marker (mirrors links.EdgeConfidenceKey; duplicated
+// here to avoid an MCP→links import edge for a single string constant).
+const edgeConfidenceProp = "confidence"
+
+// EdgeConfidence returns the extraction-confidence honesty marker for this
+// cross-repo edge (#3628): "resolved" (both endpoints matched on a canonical
+// id), "heuristic" (fuzzy / single-side-grounded), or "inferred" (derived from
+// a runtime-dynamic value). Per the honesty contract, an absent marker means
+// the edge is structurally grounded, so this returns "resolved" as the
+// default — AST-grounded passes (import_pass) deliberately do not stamp it.
+func (l CrossRepoLink) EdgeConfidence() string {
+	if l.Properties != nil {
+		if v := l.Properties[edgeConfidenceProp]; v != "" {
+			return v
+		}
+	}
+	return "resolved"
 }
 
 // LoadedRepo is one repo's graph plus index plus mtime tracking.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1610,6 +1610,10 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 				"depth":      1,
 				"cross_repo": true,
 				"kind":       l.Kind,
+				// #3628 — extraction-confidence honesty marker so a consumer can
+				// tell a fully-resolved cross-repo edge from a heuristic /
+				// inferred one. Absent on-disk ⇒ "resolved" (see EdgeConfidence).
+				"confidence": l.EdgeConfidence(),
 			})
 		}
 	}


### PR DESCRIPTION
Closes #3742 (child of epic #3628, roadmap area #23).

## What & why
Synthesised cross-repo edges previously shared the on-disk shape of tree-sitter-AST-grounded structural edges, so a graph consumer could not tell a fully-resolved edge from a heuristically-synthesised one. This pass adds ONE categorical honesty marker — property `confidence` with exactly three values — stamped on the heuristic edge families. AST-grounded structural edges stay implicit (absence ⇒ resolved) so the graph is not bloated.

## Audit (existing confidence-ish signals — none gave a categorical honesty class)
- numeric `confidence` float (`internal/types`, #2769) — a quality SCORE, not honesty.
- per-pass numeric bands (`internal/links/confidence.go`).
- `auth_confidence` HIGH/MEDIUM (engine); `runtime_dynamic=true` (http-client synthetics).

These are left in place (orthogonal; migrating would be breaking). The new marker is the unified honesty layer.

## Edge families now carrying `confidence`
| Pass / strategy | Match basis | value |
|---|---|---|
| http_pass: exact / prefix_stripped / mount_prefix / case_style / param_normalized / url_pattern / graphql_root | both endpoints matched on canonical (verb,path) id | `resolved` |
| topic_pass | same canonical topic/channel | `resolved` |
| grpc_pass | same grpc:Service/Method id | `resolved` |
| openapi_pass | shared spec operationId | `resolved` |
| http_pass literal_param_fill | concrete caller segment reconstructed into a producer param slot | `inferred` |
| http_pass dynamic_suffix_match | runtime-dynamic `${apiUrl}` URL; only static suffix matched | `inferred` |
| string_pass | fuzzy string-literal catalog match | `heuristic` |
| label_pass | TF-IDF + kind-compat fuzzy | `heuristic` |
| sameas_pass | cross-language Jaccard field-overlap | `heuristic` |
| import_pass (structural) | tree-sitter AST | unstamped ⇒ `resolved` |

## Value vocabulary
`resolved` / `heuristic` / `inferred` — centralised in `internal/links/confidence.go` (`EdgeConfidenceKey`, `Confidence*` consts, `Link.WithEdgeConfidence`).

## MCP surface
- `CrossRepoLink` gains `Properties` + `EdgeConfidence()` (returns stamped value, or `resolved` when absent per the honesty contract).
- `archigraph_get_neighbors` emits `"confidence"` on every cross-repo overlay edge.

## Tests (value-asserting, not len>0)
- `internal/links/edge_confidence_test.go`: matched HTTP pair → `resolved`; `${apiUrl}` dynamic-suffix → `inferred` (guarded by a resolve_strategy precondition); shared string literal → `heuristic`; setter idempotency.
- `internal/mcp/edge_confidence_test.go`: `EdgeConfidence()` value mapping; absent ⇒ `resolved`; on-disk `properties` round-trip via `readLinks`.

## Gates
`go test ./internal/links/ ./internal/mcp/ ./internal/types/ ./tools/coverage/` green; `go vet` clean; `gofmt -l` empty; `coverage validate` 0 errors; `coverage fmt --check` canonical (registry untouched — no new resolve strategy, only an annotation).

DEPLOY-DEFERRED: read path is additive; takes effect after the next live-daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)