### PR TITLE
[jobs] Resque + RQ producer↔consumer ENQUEUES cross-link

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -47924,8 +47924,10 @@
           },
           "task_routing": {
             "status": "partial",
-            "cites": ["internal/custom/python/rq.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/python/rq.go","internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+            "issue": "3628",
+            "notes": "epic #3628 jobs cross-link: queue.enqueue(my_func) / enqueue_call(func=\"mod.my_func\") dispatch sites now emit an ENQUEUES edge from the enclosing function to Function:\u003cmy_func\u003e (the consumer), joining producer to handler. Honest-partial: dynamic callables (e.g. enqueue(getattr(...))) are skipped; cross-queue routing by name not modelled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Schedule": {
@@ -61462,6 +61464,32 @@
           "cites": ["internal/engine/realtime_endpoint_synthesis.go"],
           "notes": "Topic pattern captured verbatim as route_path (room:*); wildcard segments not expanded.",
           "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
+      "id": "msg.resque",
+      "category": "message_broker",
+      "language": "ruby",
+      "label": "Resque (Ruby task queue)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "epic #3628 jobs cross-link: a Ruby class declaring @queue = :name AND def self.perform becomes a SCOPE.ScheduledJob (resque:\u003cJob\u003e) with a TRIGGERS edge to perform (the consumer). Honest-partial: requires both @queue and self.perform in one file; dynamic class refs not resolved."
+        },
+        "producer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "epic #3628 jobs cross-link: Resque.enqueue/enqueue_to/enqueue_in dispatch sites emit an ENQUEUES edge from the enclosing Ruby method to the job entity (SCOPE.ScheduledJob resque:\u003cJob\u003e), joined on the shared resque:\u003cJob\u003e id with the consumer side. Honest-partial: enqueue target resolves only when the job class def is in the indexed group; dynamic class names not resolved."
+        },
+        "topic_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "epic #3628 jobs cross-link: producer ENQUEUES and consumer TRIGGERS both reference the same resque:\u003cJob\u003e SCOPE.ScheduledJob node, so a Resque.enqueue(Job) caller and the Job's self.perform join on one node (same shape as Sidekiq). Honest-partial: cross-file join requires the job class def to be indexed."
         }
       }
     },

--- a/internal/engine/scheduled_jobs_edges.go
+++ b/internal/engine/scheduled_jobs_edges.go
@@ -114,6 +114,13 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		relationships = synthesizeCeleryCallSiteEdges(src, path, seenJob, relationships)
 		synthesizePyAPScheduler(src, path, emitJob)
 		synthesizePyScheduleLib(src, path, emitJob)
+		// #3628 area: RQ (Redis Queue) enqueue→handler cross-link. A
+		// `queue.enqueue(my_func)` / `enqueue_call(func="mod.my_func")` dispatch
+		// site ENQUEUES the named callable; the callable's own def IS the
+		// consumer, so we emit an ENQUEUES edge from the enclosing function to
+		// Function:<callable> directly (mirroring Celery's TRIGGERS target
+		// convention). No synthetic queue node: the function is the rendezvous.
+		relationships = synthesizeRQEnqueueEdges(src, relationships)
 	case "javascript", "typescript":
 		synthesizeNodeCron(src, path, emitJob)
 		synthesizeNodeBull(src, path, emitJob)
@@ -131,6 +138,13 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		// to those IDs and appends the caller→job ENQUEUES edges.
 		synthesizeRubySidekiq(src, path, emitJob)
 		relationships = synthesizeSidekiqEnqueueEdges(src, seenJob, relationships)
+		// #3628 area: Resque jobs + ENQUEUES edges. synthesizeRubyResque emits
+		// a SCOPE.ScheduledJob (resque:<Job>) with a TRIGGERS edge to the job's
+		// `self.perform` handler; synthesizeResqueEnqueueEdges resolves
+		// `Resque.enqueue(Job, …)` dispatch sites to that job ID and appends the
+		// caller→job ENQUEUES edges. Same join shape as Sidekiq.
+		synthesizeRubyResque(src, path, emitJob)
+		relationships = synthesizeResqueEnqueueEdges(src, seenJob, relationships)
 	}
 
 	// YAML-based detectors run regardless of `lang` because the language
@@ -775,6 +789,240 @@ func synthesizeSidekiqEnqueueEdges(
 				"dispatch_method": src[idx[4]:idx[5]],
 			},
 		})
+	}
+	return relationships
+}
+
+// ---------------------------------------------------------------------------
+// Ruby — Resque jobs + ENQUEUES (#3628 area)
+// ---------------------------------------------------------------------------
+//
+// A Resque job is a Ruby class that defines a class method `self.perform`
+// (Resque pops a job off the queue and calls `Job.perform(*args)`). The class
+// usually declares `@queue = :name`, but the perform method is the consumer.
+// We model the job as a SCOPE.ScheduledJob entity keyed `resque:<Job>` (stable
+// across files, no path) with a TRIGGERS edge to `perform`, exactly mirroring
+// the Sidekiq shape so a `Resque.enqueue(Job)` dispatch in another file joins.
+//
+// Dispatch happens at `Resque.enqueue(Job, …)` / `Resque.enqueue_to(queue,
+// Job, …)` / `Resque.enqueue_in(sec, Job, …)` call sites; each ENQUEUES work
+// onto the queue. We emit an ENQUEUES edge from the enclosing Ruby method to
+// the job entity.
+
+// rubyResqueJobID is the canonical job-entity ID for a Resque job class.
+// Stable across files (no path) so an enqueue dispatch in one file resolves to
+// the job class defined in another — same convention as rubySidekiqWorkerJobID.
+func rubyResqueJobID(jobClass string) string {
+	return "resque:" + jobClass
+}
+
+// reRubyResqueQueueDecl matches `@queue = :name` / `@queue = "name"`, the
+// idiomatic Resque queue declaration that distinguishes a Resque job class
+// from an arbitrary class with a self.perform method. Group 1 = queue name.
+var reRubyResqueQueueDecl = regexp.MustCompile(`(?m)^\s*@queue\s*=\s*[:'"]([A-Za-z0-9_]+)`)
+
+// reRubyResqueSelfPerform matches the `def self.perform` class method that
+// Resque invokes when running the job.
+var reRubyResqueSelfPerform = regexp.MustCompile(`(?m)^\s*def\s+self\.perform\b`)
+
+// reRubyResqueDispatch captures `Resque.enqueue(Job, …)`,
+// `Resque.enqueue_to(:q, Job, …)` and `Resque.enqueue_in(sec, Job, …)`
+// dispatch sites. Group 1 = dispatch method, group 2 = job class. For the
+// _to / _in forms the job class is the second positional arg, so we tolerate a
+// leading non-class argument before the class name.
+var reRubyResqueDispatch = regexp.MustCompile(`Resque\.(enqueue|enqueue_to|enqueue_in)\s*\(\s*(?:[^,()]+,\s*)?([A-Z][A-Za-z0-9_:]*)`)
+
+// synthesizeRubyResque emits a SCOPE.ScheduledJob entity (resque:<Job>) with a
+// TRIGGERS edge to `perform` for each Resque job class — a class that both
+// declares `@queue` AND defines `def self.perform`. Both markers are required
+// to avoid flagging arbitrary classes. Registers job IDs into seenJob (via
+// emitJob) so the ENQUEUES pass can resolve dispatch targets.
+func synthesizeRubyResque(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "@queue") || !strings.Contains(src, "self.perform") {
+		return
+	}
+	if !reRubyResqueSelfPerform.MatchString(src) {
+		return
+	}
+	// Attribute each `@queue =` declaration to the class declared above it,
+	// reusing the Sidekiq class-resolution regex.
+	for _, qloc := range reRubyResqueQueueDecl.FindAllStringSubmatchIndex(src, -1) {
+		queueName := src[qloc[2]:qloc[3]]
+		classMatches := reRubySidekiqClass.FindAllStringSubmatch(src[:qloc[0]], -1)
+		if len(classMatches) == 0 {
+			continue
+		}
+		jobClass := classMatches[len(classMatches)-1][1]
+		jobID := rubyResqueJobID(jobClass)
+		emitJob(jobID, "perform", "", "resque", map[string]string{
+			"job_class":  jobClass,
+			"queue_name": queueName,
+			"job_type":   "queue",
+		})
+	}
+}
+
+// synthesizeResqueEnqueueEdges emits ENQUEUES edges from the enclosing Ruby
+// method of each `Resque.enqueue*` dispatch site to the job entity. Only emits
+// when the job ID is present in knownJobs (the seenJob map) — preventing
+// phantom-node creation when the job class is defined in another, un-indexed
+// file. Dedupes on (caller, jobID).
+func synthesizeResqueEnqueueEdges(
+	src string,
+	knownJobs map[string]bool,
+	relationships []types.RelationshipRecord,
+) []types.RelationshipRecord {
+	if !strings.Contains(src, "Resque.enqueue") {
+		return relationships
+	}
+	seenEdge := map[string]bool{}
+	for _, idx := range reRubyResqueDispatch.FindAllStringSubmatchIndex(src, -1) {
+		dispatchMethod := src[idx[2]:idx[3]]
+		jobClass := src[idx[4]:idx[5]]
+		jobID := rubyResqueJobID(jobClass)
+		if !knownJobs[jobID] {
+			continue
+		}
+		caller := rubyEnclosingMethod(src, idx[0])
+		if caller == "" {
+			caller = "module"
+		}
+		key := caller + "|" + jobID
+		if seenEdge[key] {
+			continue
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: "SCOPE.Operation:" + caller,
+			ToID:   scheduledJobKind + ":" + jobID,
+			Kind:   string(types.RelationshipKindEnqueues),
+			Properties: map[string]string{
+				"framework":       "resque",
+				"pattern_type":    "resque_enqueue_synthesis",
+				"job_class":       jobClass,
+				"dispatch_method": dispatchMethod,
+			},
+		})
+	}
+	return relationships
+}
+
+// ---------------------------------------------------------------------------
+// Python — RQ (Redis Queue) enqueue→handler ENQUEUES (#3628 area)
+// ---------------------------------------------------------------------------
+//
+// RQ dispatches a job by handing the consumer callable directly to enqueue:
+//
+//	queue.enqueue(send_email, to, subject)          # callable reference
+//	queue.enqueue_call(func="workers.email.gen")    # dotted string
+//	queue.enqueue_call(func=generate_report)        # callable reference
+//
+// The callable IS the consumer (RQ's Worker just pops the job and calls it),
+// so unlike Sidekiq/Resque there is no separate worker class to model — we
+// emit an ENQUEUES edge straight from the enclosing function to
+// Function:<callable>, the same target convention Celery's TRIGGERS uses.
+// Honest-partial: dynamic callables (e.g. `enqueue(getattr(mod, name))`) yield
+// no static name and are skipped.
+
+// reRQEnqueueRef matches `queue.enqueue(callable` with a bare callable arg.
+// Group 1 = queue var, group 2 = callable (possibly dotted). We exclude the
+// _call form and string literals: a `'` / `"` immediately after `(` means a
+// job-id string, not a callable, so the leading char class rejects quotes.
+var reRQEnqueueRef = regexp.MustCompile(`(?m)(\w+)\.enqueue\s*\(\s*([A-Za-z_][\w.]*)`)
+
+// reRQEnqueueCallStr matches `queue.enqueue_call(func="module.fn")`.
+// Group 1 = dotted function path.
+var reRQEnqueueCallStr = regexp.MustCompile(`(?m)\w+\.enqueue_call\s*\([^)]*func\s*=\s*["']([^"']+)["']`)
+
+// reRQEnqueueCallRef matches `queue.enqueue_call(func=callable_ref)`.
+// Group 1 = callable (possibly dotted).
+var reRQEnqueueCallRef = regexp.MustCompile(`(?m)\w+\.enqueue_call\s*\([^)]*func\s*=\s*([A-Za-z_][\w.]*)`)
+
+// rqCallableShortName returns the last dotted segment of a callable reference
+// (`workers.email.send` → `send`), the bare function name the consumer def is
+// keyed on. Returns "" for an empty or trailing-dot input.
+func rqCallableShortName(callable string) string {
+	parts := strings.Split(callable, ".")
+	return parts[len(parts)-1]
+}
+
+// synthesizeRQEnqueueEdges emits ENQUEUES edges from the enclosing Python
+// function of each RQ enqueue dispatch site to Function:<callable>. Dedupes on
+// (caller, target). The producer-side `.enqueue_call` matches are stripped from
+// the bare `.enqueue` scan via the distinct method name, so a single call site
+// never double-emits.
+func synthesizeRQEnqueueEdges(
+	src string,
+	relationships []types.RelationshipRecord,
+) []types.RelationshipRecord {
+	if !strings.Contains(src, ".enqueue") {
+		return relationships
+	}
+	// RQ-only guard: require an rq import so a generic `q.enqueue(x)` on an
+	// unrelated object in non-RQ code does not fabricate an edge.
+	if !strings.Contains(src, "from rq") && !strings.Contains(src, "import rq") &&
+		!strings.Contains(src, "rq.") {
+		return relationships
+	}
+
+	seenEdge := map[string]bool{}
+	// emit attributes an ENQUEUES edge. callEnd is the byte offset just past the
+	// captured callable; when the next non-space char is '(' the "callable" is
+	// actually a nested call (e.g. `getattr(mod, name)`), i.e. the real target
+	// is computed dynamically — honest-partial, so we skip it.
+	emit := func(callerOffset, callEnd int, callable string) {
+		j := callEnd
+		for j < len(src) && (src[j] == ' ' || src[j] == '\t') {
+			j++
+		}
+		if j < len(src) && src[j] == '(' {
+			return
+		}
+		short := rqCallableShortName(callable)
+		if short == "" {
+			return
+		}
+		caller := enclosingFunction(src, callerOffset)
+		if caller == "" {
+			return
+		}
+		if caller == short {
+			return // self-enqueue inside the callable's own def
+		}
+		key := caller + "|" + short
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: "SCOPE.Operation:" + caller,
+			ToID:   "Function:" + short,
+			Kind:   string(types.RelationshipKindEnqueues),
+			Properties: map[string]string{
+				"framework":    "rq",
+				"pattern_type": "rq_enqueue_synthesis",
+				"callable":     callable,
+			},
+		})
+	}
+
+	// enqueue_call(func="…") / func=ref — handle first so the bare enqueue
+	// scan below can skip these spans is unnecessary (distinct method name).
+	for _, m := range reRQEnqueueCallStr.FindAllStringSubmatchIndex(src, -1) {
+		// String func= is always a literal name, never a nested call: pass the
+		// match end so the '(' guard is a no-op (next char is '"').
+		emit(m[0], m[3], src[m[2]:m[3]])
+	}
+	for _, m := range reRQEnqueueCallRef.FindAllStringSubmatchIndex(src, -1) {
+		emit(m[0], m[3], src[m[2]:m[3]])
+	}
+	// bare enqueue(callable). reRQEnqueueRef matches `.enqueue(` but NOT
+	// `.enqueue_call(` because `_call` is not consumed by `\s*\(`.
+	for _, m := range reRQEnqueueRef.FindAllStringSubmatchIndex(src, -1) {
+		emit(m[0], m[5], src[m[4]:m[5]])
 	}
 	return relationships
 }

--- a/internal/engine/scheduled_jobs_edges_test.go
+++ b/internal/engine/scheduled_jobs_edges_test.go
@@ -528,3 +528,197 @@ end
 		t.Errorf("expected no ENQUEUES edges for plain class, got %v", enqueuesEdges(rels))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Ruby — Resque jobs + ENQUEUES edges (#3628 area)
+// ---------------------------------------------------------------------------
+
+// enqueuesByFramework filters ENQUEUES edges by their framework property.
+func enqueuesByFramework(rels []types.RelationshipRecord, framework string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range enqueuesEdges(rels) {
+		if r.Properties["framework"] == framework {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// A Resque job class (@queue + def self.perform) becomes a ScheduledJob with a
+// TRIGGERS edge to perform, and `Resque.enqueue(Job)` emits an ENQUEUES edge
+// from the enclosing method to the job — joined on resque:<Job>.
+func TestScheduledJobs_RubyResque_EnqueuesEdge(t *testing.T) {
+	src := `class EmailJob
+  @queue = :emails
+
+  def self.perform(user_id)
+    # send the email
+  end
+end
+
+class SignupService
+  def register(user)
+    Resque.enqueue(EmailJob, user.id)
+  end
+end
+`
+	ents, rels := runScheduledDetect(t, "ruby", "app/jobs/email_job.rb", src)
+
+	jobs := scheduledJobsByFramework(ents, "resque")
+	if len(jobs) != 1 {
+		t.Fatalf("expected exactly 1 resque ScheduledJob, got %d (%v)", len(jobs), ents)
+	}
+	if jobs[0].Name != "resque:EmailJob" {
+		t.Errorf("expected job ID resque:EmailJob, got %q", jobs[0].Name)
+	}
+	if jobs[0].Properties["queue_name"] != "emails" {
+		t.Errorf("expected queue_name=emails, got %q", jobs[0].Properties["queue_name"])
+	}
+
+	// TRIGGERS: job -> perform handler.
+	var gotTrigger bool
+	for _, e := range triggersEdges(rels) {
+		if e.FromID == scheduledJobKind+":resque:EmailJob" && e.ToID == "Function:perform" {
+			gotTrigger = true
+		}
+	}
+	if !gotTrigger {
+		t.Errorf("expected TRIGGERS resque:EmailJob -> Function:perform, got %v", triggersEdges(rels))
+	}
+
+	// ENQUEUES: caller `register` -> job, joined on resque:EmailJob.
+	enq := enqueuesByFramework(rels, "resque")
+	if len(enq) != 1 {
+		t.Fatalf("expected exactly 1 resque ENQUEUES edge, got %d (%v)", len(enq), enq)
+	}
+	e := enq[0]
+	if e.FromID != "SCOPE.Operation:register" {
+		t.Errorf("expected ENQUEUES from SCOPE.Operation:register, got %q", e.FromID)
+	}
+	if e.ToID != scheduledJobKind+":resque:EmailJob" {
+		t.Errorf("expected ENQUEUES to %s:resque:EmailJob, got %q", scheduledJobKind, e.ToID)
+	}
+	if e.Properties["dispatch_method"] != "enqueue" {
+		t.Errorf("expected dispatch_method=enqueue, got %q", e.Properties["dispatch_method"])
+	}
+}
+
+// Resque.enqueue_in(sec, Job, …) — the job class is the 2nd positional arg.
+func TestScheduledJobs_RubyResque_EnqueueIn(t *testing.T) {
+	src := `class ReportJob
+  @queue = "reports"
+  def self.perform(id); end
+end
+
+class Caller
+  def schedule
+    Resque.enqueue_in(60, ReportJob, 7)
+  end
+end
+`
+	_, rels := runScheduledDetect(t, "ruby", "app/jobs/report_job.rb", src)
+	enq := enqueuesByFramework(rels, "resque")
+	if len(enq) != 1 {
+		t.Fatalf("expected 1 resque ENQUEUES edge, got %d (%v)", len(enq), enq)
+	}
+	if enq[0].ToID != scheduledJobKind+":resque:ReportJob" {
+		t.Errorf("expected ENQUEUES to resque:ReportJob, got %q", enq[0].ToID)
+	}
+	if enq[0].Properties["dispatch_method"] != "enqueue_in" {
+		t.Errorf("expected dispatch_method=enqueue_in, got %q", enq[0].Properties["dispatch_method"])
+	}
+}
+
+// Negative: a Resque.enqueue dispatch whose job class is NOT a known job (no
+// @queue/self.perform def in scope) must not fabricate an ENQUEUES edge.
+func TestScheduledJobs_RubyResque_UnknownJob_NoEdge(t *testing.T) {
+	src := `class Caller
+  def go
+    Resque.enqueue(SomeUnindexedJob, 1)
+  end
+end
+`
+	_, rels := runScheduledDetect(t, "ruby", "app/caller.rb", src)
+	if got := enqueuesByFramework(rels, "resque"); len(got) != 0 {
+		t.Errorf("expected no resque ENQUEUES edge for unknown job, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — RQ enqueue→handler ENQUEUES (#3628 area)
+// ---------------------------------------------------------------------------
+
+// queue.enqueue(my_func) links the producer's enclosing function to the
+// consumer Function:my_func.
+func TestScheduledJobs_PyRQ_EnqueueRef(t *testing.T) {
+	src := `from rq import Queue
+from redis import Redis
+from workers.email import send_email
+
+q = Queue("emails", connection=Redis())
+
+def notify_user(user_id):
+    q.enqueue(send_email, "user@example.com", "hi")
+`
+	_, rels := runScheduledDetect(t, "python", "api/notifications.py", src)
+	enq := enqueuesByFramework(rels, "rq")
+	if len(enq) != 1 {
+		t.Fatalf("expected exactly 1 rq ENQUEUES edge, got %d (%v)", len(enq), enq)
+	}
+	e := enq[0]
+	if e.FromID != "SCOPE.Operation:notify_user" {
+		t.Errorf("expected ENQUEUES from notify_user, got %q", e.FromID)
+	}
+	if e.ToID != "Function:send_email" {
+		t.Errorf("expected ENQUEUES to Function:send_email, got %q", e.ToID)
+	}
+}
+
+// queue.enqueue_call(func="workers.email.generate_report") resolves the dotted
+// string to the consumer's short name.
+func TestScheduledJobs_PyRQ_EnqueueCallString(t *testing.T) {
+	src := `import rq
+
+def request_report(report_id):
+    report_queue.enqueue_call(func="workers.email.generate_report", args=[report_id])
+`
+	_, rels := runScheduledDetect(t, "python", "api/reports.py", src)
+	enq := enqueuesByFramework(rels, "rq")
+	if len(enq) != 1 {
+		t.Fatalf("expected exactly 1 rq ENQUEUES edge, got %d (%v)", len(enq), enq)
+	}
+	if enq[0].FromID != "SCOPE.Operation:request_report" {
+		t.Errorf("expected ENQUEUES from request_report, got %q", enq[0].FromID)
+	}
+	if enq[0].ToID != "Function:generate_report" {
+		t.Errorf("expected ENQUEUES to Function:generate_report, got %q", enq[0].ToID)
+	}
+}
+
+// Negative: a `.enqueue` call in a file with no rq import must not emit an
+// edge (guards against generic queue objects in non-RQ code).
+func TestScheduledJobs_PyRQ_NoImport_NoEdge(t *testing.T) {
+	src := `def handler():
+    some_other_queue.enqueue(do_work, 1)
+`
+	_, rels := runScheduledDetect(t, "python", "svc/worker.py", src)
+	if got := enqueuesByFramework(rels, "rq"); len(got) != 0 {
+		t.Errorf("expected no rq ENQUEUES edge without rq import, got %v", got)
+	}
+}
+
+// Negative: enqueue with a dynamic (non-identifier) callable must not fabricate
+// an edge — honest-partial on dynamic dispatch.
+func TestScheduledJobs_PyRQ_DynamicCallable_NoEdge(t *testing.T) {
+	src := `from rq import Queue
+
+def dispatch(name):
+    q.enqueue(getattr(mod, name), 1)
+`
+	_, rels := runScheduledDetect(t, "python", "svc/dyn.py", src)
+	// The captured token `getattr` is immediately followed by `(`, so it is a
+	// nested call (dynamic dispatch), not a callable reference — no edge.
+	if got := enqueuesByFramework(rels, "rq"); len(got) != 0 {
+		t.Errorf("expected no rq ENQUEUES edge for dynamic callable, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #3744 (child of epic #3628).

## Audit-first (no duplication)
Grepped `ENQUEUES`/`SCOPE.Queue`/`bullmq`/`sidekiq`/`celery` in `internal/`. Already wired with a working producer↔consumer join (left untouched):

| Lib | Producer | Consumer | Join id |
|---|---|---|---|
| BullMQ/Bee (JS/TS) | `new Queue`/`q.add` PUBLISHES_TO | `new Worker`/`q.process` SUBSCRIBES_TO | `SCOPE.Queue:bullmq:<name>` (via `topic_pass.go`) |
| Sidekiq (Ruby) | `Worker.perform_async` ENQUEUES | `perform` TRIGGERS | `SCOPE.ScheduledJob:sidekiq:<Worker>` |
| Celery (Python) | `.delay`/`.apply_async`/`send_task` PUBLISHES_TO | handler TRIGGERS | `SCOPE.ScheduledJob:celery:...` |

## Gaps built here
- **Resque (Ruby)** — was entirely unextracted. `@queue` + `def self.perform` → `SCOPE.ScheduledJob:resque:<Job>` + TRIGGERS→perform; `Resque.enqueue/enqueue_to/enqueue_in(Job,…)` → ENQUEUES to the same node. **Join id: `resque:<Job>`.**
- **RQ (Python)** — the existing `rq.go` extractor emitted producer/consumer entities but the `task_id` was a dead property with no edge. Now `queue.enqueue(fn)` / `enqueue_call(func="mod.fn")` / `enqueue_call(func=ref)` → ENQUEUES from the enclosing function to **`Function:<fn>`** (the consumer def is the rendezvous, same target convention as Celery TRIGGERS).

All in `internal/engine/scheduled_jobs_edges.go` (append-only pass).

## Honest-partial
- Dynamic job/queue/callable names skipped (RQ nested-call guard rejects `enqueue(getattr(...))`; rq-import guard prevents false positives on generic `.enqueue`).
- Cross-file Resque join requires the job class def to be indexed (same as Sidekiq). RQ joins globally on `Function:<name>`.

## Joined queue ids asserted by tests
- `SCOPE.ScheduledJob:resque:EmailJob` — `register` ENQUEUES it; `self.perform` TRIGGERS it.
- `SCOPE.ScheduledJob:resque:ReportJob` — via `enqueue_in(60, ReportJob, 7)` (2nd-arg class).
- `Function:send_email` / `Function:generate_report` — RQ `enqueue(send_email)` / `enqueue_call(func="workers.email.generate_report")`.
- Negatives: unknown Resque job → no edge; no rq import → no edge; dynamic callable → no edge.

## Checks
- `go test ./internal/engine/ ./internal/links/... ./internal/types/ ./tools/coverage/` green
- `coverage validate` 0 errors; `coverage fmt --check` canonical (localized diff, no whole-file re-serialize)
- `gofmt -l` empty; `go vet` clean

## Coverage
New `msg.resque` record (consumer/producer/topic_attribution = partial); `lang.python.framework.rq` `task_routing` now cites the ENQUEUES pass.

**DEPLOY-DEFERRED**: append-only extractor change; takes effect on next live-daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)