### PR TITLE
feat(dbmap): query-builder → ACCESSES_TABLE (Knex/Drizzle/jOOQ/QueryDSL/SQLAlchemy-Core/AR joins)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -25155,9 +25155,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/rules/java/orms/jooq.yaml","internal/extractors/cross/dbmap/orms.go","internal/extractors/cross/dbmap/query_builders.go","internal/extractors/cross/dbmap/query_builders_test.go"],
+            "notes": "#3628 area #3: jOOQ builder calls dsl.selectFrom(USERS)/insertInto/update/deleteFrom resolve the generated table constant (lower-cased) into SCOPE.DataAccess + ACCESSES_TABLE edges with the right op kind. Proven by TestJOOQSelectFrom/InsertInto/DeleteFrom.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -34075,9 +34076,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "full",
-            "cites": ["internal/engine/orm_queries_jsts.go"],
-            "verified_at": "2026-05-28"
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries_jsts.go","internal/extractors/cross/dbmap/query_builders.go","internal/extractors/cross/dbmap/query_builders_test.go"],
+            "notes": "#3628 area #3: Drizzle db.select().from(users)/db.insert(users) resolve the pgTable/mysqlTable/sqliteTable OBJECT to its declared name literal → ACCESSES_TABLE edges. Partial: cross-file table objects unresolved (skipped, no fabricated edge). Proven by TestDrizzle* in query_builders_test.go.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -34140,8 +34142,9 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go","internal/extractors/cross/dbmap/orms.go","internal/extractors/cross/dbmap/query_builders.go","internal/extractors/cross/dbmap/query_builders_test.go"],
+            "notes": "Driver query attribution via orm_queries_jsts_drivers. #3628 area #3 ADDS table-level access: knex('t')/.from('t')/.into('t') resolve the string-literal table → ACCESSES_TABLE (op from .insert/.update/.del/.truncate); dynamic knex(tableVar) skipped. Proven by TestKnex* in query_builders_test.go.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -50052,8 +50055,9 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/orm_queries_python.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/orm_queries_python.go","internal/extractors/cross/dbmap/orms.go","internal/extractors/cross/dbmap/query_builders.go","internal/extractors/cross/dbmap/query_builders_test.go"],
+            "notes": "ORM session.query attribution via orm_queries_python. #3628 area #3 ADDS the SQLAlchemy Core builder surface: select(table_obj) and table_obj.insert()/update()/delete() resolve the Table('name',...) object to its literal → ACCESSES_TABLE edges. Proven by TestSQLAlchemyCore* in query_builders_test.go.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -52852,8 +52856,9 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/orm_queries.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/orm_queries.go","internal/extractors/cross/dbmap/orms.go","internal/extractors/cross/dbmap/query_builders_test.go"],
+            "notes": "ActiveRecord Model.find/where attribution via orm_queries. #3628 area #3 ADDS association table-access: .joins(:assoc)/.includes/.preload/.eager_load pull the association table into a second ACCESSES_TABLE edge (symbol args only; string/var skipped). Proven by TestActiveRecordJoinsAssociation.",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {

--- a/internal/extractors/cross/dbmap/orms.go
+++ b/internal/extractors/cross/dbmap/orms.go
@@ -692,8 +692,39 @@ func detectActiveRecord(source string) []access {
 			functionQName: enclosingFunc(source, m[0]),
 		})
 	}
+
+	// Association query builders: `.joins(:orders)` / `.includes(:orders)`
+	// pull in a second table via the association name. The association symbol
+	// is conventionally the singular/plural table name; we pluralise it to the
+	// table name (orders → orders, order → orders). Honest-partial: a string
+	// or variable association arg is skipped.
+	for _, m := range arJoinsRE.FindAllStringSubmatchIndex(source, -1) {
+		assoc := source[m[2]:m[3]]
+		table := assoc
+		if !strings.HasSuffix(table, "s") {
+			table += "s"
+		}
+		key := "ar|" + OpSelect + "|" + table
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     OpSelect,
+			orm:           "activerecord",
+			functionQName: enclosingFunc(source, m[0]),
+		})
+	}
 	return out
 }
+
+// arJoinsRE matches `.joins(:orders)` / `.includes(:orders)` /
+// `.preload(:orders)` — association-name symbol only (string/variable args
+// are intentionally not matched: honest-partial).
+var arJoinsRE = regexp.MustCompile(
+	`(?m)\.(?:joins|includes|preload|eager_load)\s*\(\s*:(\w+)\b`,
+)
 
 // ---------------------------------------------------------------------------
 // Elixir — Ecto
@@ -1097,6 +1128,37 @@ var ormOrder = []ormEntry{
 		name:        "diesel",
 		importHints: []string{"diesel"},
 		detect:      detectDiesel,
+	},
+	// Fluent query BUILDERS (oracle-priority #3, ticket under #3628). These
+	// name the table through a builder call, not a SQL string, so the
+	// raw-SQL scanner misses them. See query_builders.go.
+	{
+		name:        "knex",
+		importHints: []string{"knex"},
+		detect:      detectKnex,
+	},
+	{
+		name:        "drizzle",
+		importHints: []string{"drizzle-orm", "drizzle"},
+		detect:      detectDrizzle,
+	},
+	{
+		name:        "jooq",
+		importHints: []string{"org.jooq", "jooq"},
+		detect:      detectJOOQ,
+	},
+	{
+		name:        "querydsl",
+		importHints: []string{"com.querydsl", "querydsl"},
+		detect:      detectQueryDSL,
+	},
+	{
+		// SQLAlchemy Core builder surface (select(table) / table.insert()).
+		// The ORM `sqlalchemy` entry above keeps the session.query(Model)
+		// surface; both run when the import gate matches.
+		name:        "sqlalchemy_core",
+		importHints: []string{"sqlalchemy"},
+		detect:      detectSQLAlchemyCore,
 	},
 }
 

--- a/internal/extractors/cross/dbmap/query_builders.go
+++ b/internal/extractors/cross/dbmap/query_builders.go
@@ -1,0 +1,417 @@
+// Package dbmap — fluent query-builder table detection (oracle-priority
+// area #3 of #3628).
+//
+// The ORM detectors in orms.go resolve a table either from a raw-SQL string
+// literal (FROM/INTO/UPDATE) or from a model class that names a table. Fluent
+// query BUILDERS are different: they name the table through a builder call and
+// never produce a SQL string at the call site. This file adds detectors for
+// the common builders that the raw-SQL scanner misses entirely:
+//
+//   - Knex (JS/TS)        knex('users').where(...).insert(...)
+//   - Drizzle (TS)        db.select().from(users) — table OBJECT resolved
+//     back to its pgTable('users', …) declaration
+//   - jOOQ (Java)         dsl.selectFrom(USERS) — generated table constant
+//   - QueryDSL (Java)     queryFactory.selectFrom(user) — Q-type instance
+//   - SQLAlchemy Core     select(users), users.insert() — Table('users', …)
+//
+// Every detector resolves a STATIC table-name literal (or a static
+// builder-constant → table-name mapping) and emits an `access` exactly like
+// the ORM detectors, so the SCOPE.DataAccess entity + ACCESSES_TABLE edge are
+// byte-for-byte consistent with raw-SQL-derived ones (same entity-id shape,
+// same edge Kind, same property set via buildEntity).
+//
+// Honest-partial contract: a dynamic table reference (a variable, not a
+// literal) yields NO edge. `knex(tableVar)`, `select(unknownTbl)` resolve to
+// nothing rather than fabricating a table.
+package dbmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// JS/TS — Knex query builder
+// ---------------------------------------------------------------------------
+
+// knexBuilderRE matches the builder-entry call `knex('users')` /
+// `knex("users")` and the chained terminal verb that determines the
+// operation. The table name MUST be a string literal — a bare identifier
+// (`knex(tableVar)`) does not match group 1 and is skipped (honest-partial).
+//
+//	knex('users').where({ id }).first()        → SELECT users
+//	knex('users').insert({ ... })              → INSERT users
+//	knex('users').where(...).update({ ... })   → UPDATE users
+//	knex('users').where(...).del()             → DELETE users
+//
+// The verb is found independently by knexVerbRE over the remainder of the
+// statement so chained where()/join() between the entry and the terminal verb
+// do not break the match.
+var knexBuilderRE = regexp.MustCompile(
+	`(?m)\bknex\s*\(\s*['"]([A-Za-z_][\w.]*)['"]\s*\)`,
+)
+
+// knexFromRE matches the `.from('users')` / `.into('users')` table source
+// used when the builder is entered via knex.select()/knex.queryBuilder().
+//
+//	knex.select('*').from('orders')   → SELECT orders
+var knexFromRE = regexp.MustCompile(
+	`(?m)\.(?:from|into|table)\s*\(\s*['"]([A-Za-z_][\w.]*)['"]\s*\)`,
+)
+
+// knexVerbRE captures the mutating verb that follows a builder entry so the
+// operation can be classified. Read is the default when no mutating verb is
+// present on the statement.
+var knexVerbRE = regexp.MustCompile(
+	`\.(insert|update|del|delete|truncate)\s*\(`,
+)
+
+// knexStatementEnd finds the end of the JS statement (the next `;` or
+// newline-with-no-trailing-dot) so a verb on a LATER statement is not
+// attributed to this builder entry. Coarse but adequate: query builders are
+// near-universally single fluent expressions.
+func knexOpFrom(stmt string) string {
+	if m := knexVerbRE.FindStringSubmatch(stmt); len(m) >= 2 {
+		switch m[1] {
+		case "insert":
+			return OpInsert
+		case "update":
+			return OpUpdate
+		case "del", "delete":
+			return OpDelete
+		case "truncate":
+			return OpTruncate
+		}
+	}
+	return OpSelect
+}
+
+// detectKnex scans for knex builder entries and resolves the table from the
+// string-literal argument. It runs for both `knex('t')` and the
+// `.from('t')`/`.into('t')` builder-source forms.
+func detectKnex(source string) []access {
+	var out []access
+	seen := map[string]bool{}
+
+	emit := func(table string, pos int, stmt string) {
+		table = strings.ToLower(table)
+		op := knexOpFrom(stmt)
+		key := "knex|" + op + "|" + table
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     op,
+			orm:           "knex",
+			functionQName: enclosingFunc(source, pos),
+		})
+	}
+
+	for _, m := range knexBuilderRE.FindAllStringSubmatchIndex(source, -1) {
+		table := source[m[2]:m[3]]
+		stmt := knexStatement(source, m[1])
+		emit(table, m[0], stmt)
+	}
+	for _, m := range knexFromRE.FindAllStringSubmatchIndex(source, -1) {
+		table := source[m[2]:m[3]]
+		stmt := knexStatement(source, m[1])
+		emit(table, m[0], stmt)
+	}
+	return out
+}
+
+// knexStatement returns the slice from `start` to the end of the current
+// fluent statement (terminating at the first `;` or a newline that is not
+// immediately continued by a `.`). Used to scope the verb search.
+func knexStatement(source string, start int) string {
+	end := len(source)
+	for i := start; i < len(source); i++ {
+		c := source[i]
+		if c == ';' {
+			end = i
+			break
+		}
+		if c == '\n' {
+			// Continue past the newline only if the next non-space char is a
+			// dot (method chain continuation).
+			j := i + 1
+			for j < len(source) && (source[j] == ' ' || source[j] == '\t') {
+				j++
+			}
+			if j < len(source) && source[j] == '.' {
+				continue
+			}
+			end = i
+			break
+		}
+	}
+	return source[start:end]
+}
+
+// ---------------------------------------------------------------------------
+// TS — Drizzle ORM (query builder over table OBJECTS)
+// ---------------------------------------------------------------------------
+
+// Drizzle declares tables with `export const users = pgTable('users', {...})`
+// (or mysqlTable / sqliteTable). Queries reference the JS table OBJECT, not a
+// string: `db.select().from(users)` / `db.insert(users)`. We resolve the
+// object identifier back to the declared table-name literal.
+var drizzleTableDeclRE = regexp.MustCompile(
+	`(?m)\b(?:export\s+)?const\s+(\w+)\s*=\s*(?:pg|mysql|sqlite)Table\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// db.select()....from(orders) / db.insert(users).values(...) /
+// db.update(users).set(...) / db.delete(users)
+var drizzleFromRE = regexp.MustCompile(
+	`(?m)\.from\s*\(\s*(\w+)\s*\)`,
+)
+var drizzleWriteRE = regexp.MustCompile(
+	`(?m)\bdb\s*\.\s*(insert|update|delete)\s*\(\s*(\w+)\s*\)`,
+)
+
+func detectDrizzle(source string) []access {
+	tableByObj := map[string]string{}
+	for _, m := range drizzleTableDeclRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			tableByObj[m[1]] = m[2]
+		}
+	}
+	if len(tableByObj) == 0 {
+		// No resolvable table object in this file — honest-partial: skip
+		// rather than guess the object name is the table name.
+		return nil
+	}
+
+	var out []access
+	seen := map[string]bool{}
+	emit := func(obj string, op string, pos int) {
+		table, ok := tableByObj[obj]
+		if !ok {
+			return // dynamic / cross-file table object — skip.
+		}
+		key := "drizzle|" + op + "|" + table
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     op,
+			orm:           "drizzle",
+			functionQName: enclosingFunc(source, pos),
+		})
+	}
+
+	for _, m := range drizzleFromRE.FindAllStringSubmatchIndex(source, -1) {
+		emit(source[m[2]:m[3]], OpSelect, m[0])
+	}
+	for _, m := range drizzleWriteRE.FindAllStringSubmatchIndex(source, -1) {
+		verb := source[m[2]:m[3]]
+		var op string
+		switch verb {
+		case "insert":
+			op = OpInsert
+		case "update":
+			op = OpUpdate
+		case "delete":
+			op = OpDelete
+		}
+		emit(source[m[4]:m[5]], op, m[0])
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Java — jOOQ (generated table constants)
+// ---------------------------------------------------------------------------
+
+// jOOQ generates a constant per table (e.g. `Tables.USERS` or a static-imported
+// `USERS`) and queries read like `dsl.selectFrom(USERS)` /
+// `dsl.insertInto(USERS)` / `dsl.update(USERS)` / `dsl.deleteFrom(USERS)`.
+// The constant name maps to the table by lower-casing it (the jOOQ codegen
+// default), which is the best static resolution available without the
+// generated sources.
+var jooqCallRE = regexp.MustCompile(
+	`(?m)\.(selectFrom|insertInto|update|deleteFrom|truncate)\s*\(\s*(?:[\w.]+\.)?([A-Z][A-Z0-9_]*)\b`,
+)
+
+func jooqOp(verb string) string {
+	switch verb {
+	case "selectFrom":
+		return OpSelect
+	case "insertInto":
+		return OpInsert
+	case "update":
+		return OpUpdate
+	case "deleteFrom":
+		return OpDelete
+	case "truncate":
+		return OpTruncate
+	}
+	return ""
+}
+
+func detectJOOQ(source string) []access {
+	var out []access
+	seen := map[string]bool{}
+	for _, m := range jooqCallRE.FindAllStringSubmatchIndex(source, -1) {
+		verb := source[m[2]:m[3]]
+		constant := source[m[4]:m[5]]
+		op := jooqOp(verb)
+		if op == "" {
+			continue
+		}
+		table := strings.ToLower(constant)
+		key := "jooq|" + op + "|" + table
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     op,
+			orm:           "jooq",
+			functionQName: enclosingFunc(source, m[0]),
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Java — QueryDSL (generated Q-type instances)
+// ---------------------------------------------------------------------------
+
+// QueryDSL generates a `QUser` class with a static `user` instance. Queries
+// read `queryFactory.selectFrom(user)` / `.from(qOrder)`. The instance name is
+// the entity name (often un-prefixed); we resolve the table by stripping a
+// leading `q`/`Q` and lower-casing + pluralising the entity name, mirroring
+// the JPA default-table convention already used by detectJPA.
+var querydslCallRE = regexp.MustCompile(
+	`(?m)\b(?:selectFrom|from|update|delete)\s*\(\s*(q[A-Z]\w*|[a-z]\w*)\s*\)`,
+)
+
+// querydslImportHint distinguishes QueryDSL files (com.querydsl.*) so the Q-type
+// heuristic does not fire on unrelated `.from(x)` calls. Enforced by the
+// import gate in ormOrder; here we additionally require the matched identifier
+// to look like a Q-instance (lower-camel entity name).
+func detectQueryDSL(source string) []access {
+	var out []access
+	seen := map[string]bool{}
+	for _, m := range querydslCallRE.FindAllStringSubmatchIndex(source, -1) {
+		ident := source[m[2]:m[3]]
+		// Resolve the entity name: a QUser-style instance is conventionally
+		// the lower-camel entity name (`user`, `orderItem`). Strip an optional
+		// leading `q` prefix used by some teams (`qUser`).
+		entity := ident
+		if strings.HasPrefix(entity, "q") && len(entity) > 1 &&
+			entity[1] >= 'A' && entity[1] <= 'Z' {
+			entity = strings.ToLower(entity[1:2]) + entity[2:]
+		}
+		table := modelNameToTable(strings.Title(entity))
+		// Operation: QueryDSL fetches are reads; mutations use update/delete
+		// clauses. Classify from the verb token preceding the identifier.
+		op := OpSelect
+		pre := source[maxInt(0, m[0]-12):m[0]]
+		switch {
+		case strings.Contains(pre, "update"):
+			op = OpUpdate
+		case strings.Contains(pre, "delete"):
+			op = OpDelete
+		}
+		key := "querydsl|" + op + "|" + table
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     op,
+			orm:           "querydsl",
+			functionQName: enclosingFunc(source, m[0]),
+		})
+	}
+	return out
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Python — SQLAlchemy Core (Table objects + functional construct)
+// ---------------------------------------------------------------------------
+
+// SQLAlchemy Core defines tables as `users = Table('users', metadata, …)` and
+// queries them via the functional construct `select(users)` or the table
+// method builders `users.insert()` / `users.update()` / `users.delete()`.
+// The existing detectSQLAlchemy handles only the ORM `session.query(Model)`
+// surface; this resolves the Core builder surface.
+var saCoreTableDeclRE = regexp.MustCompile(
+	`(?m)\b(\w+)\s*=\s*Table\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// select(users) / select([users]) — functional read construct.
+var saCoreSelectRE = regexp.MustCompile(
+	`(?m)\bselect\s*\(\s*\[?\s*(\w+)\b`,
+)
+
+// users.insert() / users.update() / users.delete() — table method builders.
+var saCoreWriteRE = regexp.MustCompile(
+	`(?m)\b(\w+)\.(insert|update|delete)\s*\(`,
+)
+
+func detectSQLAlchemyCore(source string) []access {
+	tableByObj := map[string]string{}
+	for _, m := range saCoreTableDeclRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			tableByObj[m[1]] = m[2]
+		}
+	}
+	if len(tableByObj) == 0 {
+		return nil // no Core Table() objects → nothing to resolve.
+	}
+
+	var out []access
+	seen := map[string]bool{}
+	emit := func(obj, op string, pos int) {
+		table, ok := tableByObj[obj]
+		if !ok {
+			return // not a known Table object → skip (dynamic / ORM model).
+		}
+		key := "sacore|" + op + "|" + table
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, access{
+			table:         table,
+			operation:     op,
+			orm:           "sqlalchemy_core",
+			functionQName: enclosingFunc(source, pos),
+		})
+	}
+
+	for _, m := range saCoreSelectRE.FindAllStringSubmatchIndex(source, -1) {
+		emit(source[m[2]:m[3]], OpSelect, m[0])
+	}
+	for _, m := range saCoreWriteRE.FindAllStringSubmatchIndex(source, -1) {
+		obj := source[m[2]:m[3]]
+		verb := source[m[4]:m[5]]
+		var op string
+		switch verb {
+		case "insert":
+			op = OpInsert
+		case "update":
+			op = OpUpdate
+		case "delete":
+			op = OpDelete
+		}
+		emit(obj, op, m[0])
+	}
+	return out
+}

--- a/internal/extractors/cross/dbmap/query_builders_test.go
+++ b/internal/extractors/cross/dbmap/query_builders_test.go
@@ -1,0 +1,248 @@
+package dbmap
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Knex (JS/TS)
+// ---------------------------------------------------------------------------
+
+func TestKnexInsertWrite(t *testing.T) {
+	src := `const knex = require('knex')(config);
+async function addUser(x) {
+  return knex('users').insert(x);
+}`
+	recs := runExtract(t, "user.js", "javascript", src)
+	r := findByOpTable(t, recs, OpInsert, "users")
+	if r.Properties["orm"] != "knex" {
+		t.Errorf("orm=%q, want knex", r.Properties["orm"])
+	}
+	if r.Properties["function_ref"] != "addUser" {
+		t.Errorf("function_ref=%q, want addUser", r.Properties["function_ref"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestKnexWhereSelect(t *testing.T) {
+	src := `import knex from 'knex';
+function getUser(id) { return knex('users').where({ id }).first(); }`
+	recs := runExtract(t, "u.ts", "typescript", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	assertAccessesTableEdge(t, r)
+}
+
+func TestKnexFromSelect(t *testing.T) {
+	src := `const knex = require('knex')(cfg);
+function list() { return knex.select('*').from('orders'); }`
+	recs := runExtract(t, "o.js", "javascript", src)
+	r := findByOpTable(t, recs, OpSelect, "orders")
+	if r.Properties["orm"] != "knex" {
+		t.Errorf("orm=%q, want knex", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestKnexUpdateWrite(t *testing.T) {
+	src := `import knex from 'knex';
+function rename(id) { return knex('users').where({ id }).update({ name: 'x' }); }`
+	recs := runExtract(t, "u.ts", "typescript", src)
+	r := findByOpTable(t, recs, OpUpdate, "users")
+	assertAccessesTableEdge(t, r)
+}
+
+func TestKnexDeleteWrite(t *testing.T) {
+	src := `import knex from 'knex';
+function rm(id) { return knex('sessions').where({ id }).del(); }`
+	recs := runExtract(t, "s.ts", "typescript", src)
+	r := findByOpTable(t, recs, OpDelete, "sessions")
+	assertAccessesTableEdge(t, r)
+}
+
+// Negative: dynamic table variable must NOT fabricate a table edge.
+func TestKnexDynamicTableNoEdge(t *testing.T) {
+	src := `import knex from 'knex';
+function q(tableVar, x) { return knex(tableVar).insert(x); }`
+	recs := runExtract(t, "d.ts", "typescript", src)
+	for _, r := range recs {
+		if r.Kind == KindDataAccess && r.Properties["orm"] == "knex" {
+			t.Fatalf("fabricated knex table edge from dynamic var: %+v", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Drizzle (TS)
+// ---------------------------------------------------------------------------
+
+func TestDrizzleSelectFromRead(t *testing.T) {
+	src := `import { pgTable } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', { id: serial('id') });
+function all() { return db.select().from(users); }`
+	recs := runExtract(t, "q.ts", "typescript", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	if r.Properties["orm"] != "drizzle" {
+		t.Errorf("orm=%q, want drizzle", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestDrizzleInsertWrite(t *testing.T) {
+	src := `import { pgTable } from 'drizzle-orm/pg-core';
+export const accounts = pgTable('accounts', {});
+function add(v) { return db.insert(accounts).values(v); }`
+	recs := runExtract(t, "a.ts", "typescript", src)
+	r := findByOpTable(t, recs, OpInsert, "accounts")
+	assertAccessesTableEdge(t, r)
+}
+
+// Table-name literal differs from object identifier — resolution must use the
+// declared literal, not the variable name.
+func TestDrizzleTableNameLiteralResolved(t *testing.T) {
+	src := `import { pgTable } from 'drizzle-orm';
+export const userTbl = pgTable('app_users', {});
+function all() { return db.select().from(userTbl); }`
+	recs := runExtract(t, "q.ts", "typescript", src)
+	findByOpTable(t, recs, OpSelect, "app_users")
+}
+
+// Negative: unknown table object → no edge.
+func TestDrizzleUnknownObjectNoEdge(t *testing.T) {
+	src := `import { pgTable } from 'drizzle-orm';
+export const users = pgTable('users', {});
+function all() { return db.select().from(mysteryTbl); }`
+	recs := runExtract(t, "q.ts", "typescript", src)
+	for _, r := range recs {
+		if r.Properties["table"] == "mysterytbl" || r.Properties["table"] == "mysteryTbl" {
+			t.Fatalf("fabricated drizzle edge for unknown object: %+v", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// jOOQ (Java)
+// ---------------------------------------------------------------------------
+
+func TestJOOQSelectFrom(t *testing.T) {
+	src := `import org.jooq.DSLContext;
+import static com.app.Tables.USERS;
+class Repo {
+  void list(DSLContext dsl) { dsl.selectFrom(USERS).fetch(); }
+}`
+	recs := runExtract(t, "Repo.java", "java", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	if r.Properties["orm"] != "jooq" {
+		t.Errorf("orm=%q, want jooq", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestJOOQInsertInto(t *testing.T) {
+	src := `import org.jooq.DSLContext;
+class Repo { void add(DSLContext dsl) { dsl.insertInto(Tables.ACCOUNTS).execute(); } }`
+	recs := runExtract(t, "Repo.java", "java", src)
+	findByOpTable(t, recs, OpInsert, "accounts")
+}
+
+func TestJOOQDeleteFrom(t *testing.T) {
+	src := `import org.jooq.DSLContext;
+class Repo { void rm(DSLContext dsl) { dsl.deleteFrom(SESSIONS).execute(); } }`
+	recs := runExtract(t, "Repo.java", "java", src)
+	findByOpTable(t, recs, OpDelete, "sessions")
+}
+
+// ---------------------------------------------------------------------------
+// QueryDSL (Java)
+// ---------------------------------------------------------------------------
+
+func TestQueryDSLSelectFrom(t *testing.T) {
+	src := `import com.querydsl.jpa.impl.JPAQueryFactory;
+class Repo {
+  void list(JPAQueryFactory queryFactory) {
+    queryFactory.selectFrom(user).fetch();
+  }
+}`
+	recs := runExtract(t, "Repo.java", "java", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	if r.Properties["orm"] != "querydsl" {
+		t.Errorf("orm=%q, want querydsl", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestQueryDSLQPrefixInstance(t *testing.T) {
+	src := `import com.querydsl.core.types.dsl.PathBuilder;
+class Repo { void list(JPAQueryFactory qf) { qf.selectFrom(qOrder).fetch(); } }`
+	recs := runExtract(t, "Repo.java", "java", src)
+	findByOpTable(t, recs, OpSelect, "orders")
+}
+
+// ---------------------------------------------------------------------------
+// SQLAlchemy Core (Python)
+// ---------------------------------------------------------------------------
+
+func TestSQLAlchemyCoreSelectRead(t *testing.T) {
+	src := `from sqlalchemy import Table, select, MetaData
+metadata = MetaData()
+users = Table('users', metadata)
+def all_users(conn):
+    return conn.execute(select(users))`
+	recs := runExtract(t, "q.py", "python", src)
+	r := findByOpTable(t, recs, OpSelect, "users")
+	if r.Properties["orm"] != "sqlalchemy_core" {
+		t.Errorf("orm=%q, want sqlalchemy_core", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestSQLAlchemyCoreUpdateWrite(t *testing.T) {
+	src := `from sqlalchemy import Table, MetaData
+metadata = MetaData()
+users = Table('users', metadata)
+def touch(conn):
+    return conn.execute(users.update().values(seen=True))`
+	recs := runExtract(t, "q.py", "python", src)
+	r := findByOpTable(t, recs, OpUpdate, "users")
+	if r.Properties["orm"] != "sqlalchemy_core" {
+		t.Errorf("orm=%q, want sqlalchemy_core", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}
+
+func TestSQLAlchemyCoreInsertWrite(t *testing.T) {
+	src := `from sqlalchemy import Table, MetaData
+accounts = Table('accounts', MetaData())
+def add(conn, v):
+    return conn.execute(accounts.insert().values(v))`
+	recs := runExtract(t, "q.py", "python", src)
+	findByOpTable(t, recs, OpInsert, "accounts")
+}
+
+// Table-name literal differs from the python variable — resolution uses the
+// declared literal.
+func TestSQLAlchemyCoreLiteralResolved(t *testing.T) {
+	src := `from sqlalchemy import Table, select, MetaData
+user_tbl = Table('app_users', MetaData())
+def all(conn):
+    return conn.execute(select(user_tbl))`
+	recs := runExtract(t, "q.py", "python", src)
+	findByOpTable(t, recs, OpSelect, "app_users")
+}
+
+// ---------------------------------------------------------------------------
+// ActiveRecord association joins (Ruby)
+// ---------------------------------------------------------------------------
+
+func TestActiveRecordJoinsAssociation(t *testing.T) {
+	src := `require 'activerecord'
+class User < ApplicationRecord
+  def with_orders
+    User.joins(:orders).where(active: true)
+  end
+end`
+	recs := runExtract(t, "user.rb", "ruby", src)
+	// Association table pulled in by joins(:orders).
+	r := findByOpTable(t, recs, OpSelect, "orders")
+	if r.Properties["orm"] != "activerecord" {
+		t.Errorf("orm=%q, want activerecord", r.Properties["orm"])
+	}
+	assertAccessesTableEdge(t, r)
+}


### PR DESCRIPTION
Closes #3748 (child of #3628, oracle-priority area #3 — data-access table extraction).

## Problem
Raw-SQL `ACCESSES_TABLE` extraction already exists in `internal/extractors/cross/dbmap` (py/go/java, wave-5 #3698). The gap: **fluent query BUILDERS** name the table through a builder call and never produce a SQL string at the call site, so the raw-SQL scanner misses them.

## Builders added (table name + read/write op kind where derivable)
| Builder | Lang | Resolution |
|---|---|---|
| **Knex** | JS/TS | `knex('users').insert/update/del`; `.from('t')`/`.into('t')` — string literal |
| **Drizzle** | TS | `db.select().from(users)`/`db.insert(users)` — table OBJECT → `pgTable('name', …)` decl |
| **jOOQ** | Java | `dsl.selectFrom(USERS)`/`insertInto`/`update`/`deleteFrom` — constant (lower-cased) |
| **QueryDSL** | Java | `queryFactory.selectFrom(user)` — Q-instance → entity → table |
| **SQLAlchemy Core** | Python | `select(users)`/`users.insert()/update()/delete()` — `Table('name', …)` object |
| **ActiveRecord** | Ruby | `.joins(:assoc)`/`.includes`/`.preload`/`.eager_load` → association table edge |

## Contract
All new detectors live in `query_builders.go`, are import-gated like every other dbmap detector, and emit `SCOPE.DataAccess` + `ACCESSES_TABLE` edges **byte-consistent** with the raw-SQL path (same entity-id shape, edge Kind, property set via `buildEntity`). No new Kind registered.

**Honest-partial:** dynamic table refs (`knex(tableVar)`, unknown Drizzle/SA objects, cross-file table objects) yield **no** edge rather than a fabricated one.

## Tests (value-asserting — table id + op kind, not len>0)
`knex('users').insert(x)` → ACCESSES_TABLE users (write); `db.select().from(users)` → users (read); `users.update()` → users (write); `dsl.selectFrom(USERS)` → users; `.joins(:orders)` → orders. Negative: `knex(tableVar)` / unknown Drizzle object → no edge.

- `go test` targeted (dbmap, engine, types, coverage): green
- `go test ./internal/types/`: green (no new Kind)
- `coverage validate`: 0 errors; `coverage fmt --check`: canonical
- `gofmt -l`: empty; `go vet`: clean

## Coverage
Enriched existing `query_attribution` cells (jsts knex/drizzle, java jooq, python sqlalchemy, ruby activerecord) citing the extractor; jOOQ bumped partial→full for the table-access surface. No fabricated downgrades on untouched frameworks.

## DEPLOY-DEFERRED
Requires a coordinated live-daemon rebuild + reindex; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)