### PR TITLE
[protocol] SOAP + JSON-RPC client cross-link

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -62734,10 +62734,18 @@
       "label": "JSON-RPC",
       "capabilities": {
         "cross_repo_linkage": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_jsonrpc.go","internal/links/http_pass.go"],
+          "issue": "3750",
+          "notes": "#3628 — client/server synthetics keyed http:JSONRPC:/jsonrpc/\u003cmethod\u003e join via the Name-based HTTP linker; round-trip covered in TestHTTPPass_JSONRPCCrossRepoMatch. JS jayson + Python ServerProxy clients; jayson method-map + register_function producers. Partial: dynamic method names honest-partial skipped",
+          "verified_at": "2026-06-02"
         },
         "method_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_jsonrpc.go"],
+          "issue": "3750",
+          "notes": "#3628 — literal method names from client.request('m') / ServerProxy.\u003cm\u003e() and jayson method-map / register_function keys; dynamic names skipped",
+          "verified_at": "2026-06-02"
         },
         "service_extraction": {
           "status": "missing"
@@ -62809,13 +62817,25 @@
       "label": "SOAP / WSDL",
       "capabilities": {
         "cross_repo_linkage": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_soap.go","internal/links/http_pass.go"],
+          "issue": "3750",
+          "notes": "#3628 — client/server synthetics keyed http:SOAP:/soap/\u003cService\u003e/\u003cOp\u003e (+ service-less alias) join via the Name-based HTTP linker; round-trip covered in TestHTTPPass_SOAPCrossRepoMatch. Python zeep + JS node-soap + Java JAX-WS-port clients; JAX-WS @WebService/@WebMethod producers. Partial: client-side service binding is service-less honest-partial; dynamic op names skipped",
+          "verified_at": "2026-06-02"
         },
         "method_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_soap.go"],
+          "issue": "3750",
+          "notes": "#3628 — operation names from zeep client.service.\u003cOp\u003e(), node-soap client.\u003cOp\u003eAsync(), JAX-WS port.\u003cop\u003e(), and @WebMethod(operationName=) producers; dynamic op names skipped",
+          "verified_at": "2026-06-02"
         },
         "service_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_soap.go"],
+          "issue": "3750",
+          "notes": "#3628 — JAX-WS @WebService serviceName/name attribute (else class name) on the producer side; client side is service-less honest-partial",
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/engine/http_endpoint_jsonrpc.go
+++ b/internal/engine/http_endpoint_jsonrpc.go
@@ -1,0 +1,321 @@
+// JSON-RPC (and XML-RPC) server-side (producer) + client-side (consumer)
+// synthetic http_endpoint emission for cross-repo matching (epic #3628,
+// "[protocol] SOAP + JSON-RPC client cross-link").
+//
+// Like the SOAP pass (http_endpoint_soap.go) this reuses the existing
+// Name-based cross-repo HTTP linker (links/http_pass.go): a consumer-side
+// `http_endpoint_call` whose ID is byte-for-byte identical to a producer-side
+// `http_endpoint_definition` joins with NO new linker code.
+//
+// Canonical JSON-RPC id
+// ---------------------
+// We adopt the synthetic verb JSONRPC and the canonical path
+//
+//	/jsonrpc/<method>
+//
+// giving the id  http:JSONRPC:/jsonrpc/<method>. JSON-RPC method names are flat
+// strings (often dotted, e.g. `user.get`); the dotted form is preserved as a
+// single path segment so producer and consumer ids match exactly.
+//
+// Producer side (server)
+// ----------------------
+//   - JS/TS jayson: `jayson.server({ <method>: fn, … })` /
+//     `new jayson.Server({ … })` — each method key in the method map →
+//     http:JSONRPC:/jsonrpc/<method>.
+//   - Python: a method registered on an xmlrpc/jsonrpc dispatcher via
+//     `server.register_function(fn, "<name>")` → http:JSONRPC:/jsonrpc/<name>.
+//
+// Consumer side (client)
+// ----------------------
+//   - JS/TS jayson: `client.request('<method>', params)` → the first string-
+//     literal argument is the method name.
+//   - Python: `ServerProxy(url).<method>(...)` (xmlrpc.client / jsonrpclib) →
+//     the attribute accessed on the proxy handle is the remote method.
+//
+// Honest-partial / non-fabrication
+//   - Dynamic method names (variable / template literal / non-literal first
+//     arg to .request) are SKIPPED — no string, no fabricated endpoint.
+//   - Proxy accessor/lifecycle names (close, system.*, __*) are skipped.
+//   - All passes are file-signal gated so they no-op on ordinary files.
+
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// jsonRPCVerb is the synthetic HTTP verb shared by the JSON-RPC producer and
+// all consumer passes so their ids join.
+const jsonRPCVerb = "JSONRPC"
+
+// jsonRPCCanonical returns the canonical, slash-normalised endpoint path for a
+// JSON-RPC method. FrameworkExpress only normalises slashes here (the method is
+// a single, param-free segment), matching the SOAP/GraphQL/WS passes.
+func jsonRPCCanonical(method string) string {
+	return httproutes.Canonicalize(httproutes.FrameworkExpress, "/jsonrpc/"+method)
+}
+
+// isDynamicJSONRPCName reports whether a method token is a stable string
+// literal. Anything carrying interpolation/template/whitespace markers is
+// dynamic → honest-partial skip.
+func isDynamicJSONRPCName(name string) bool {
+	return name == "" || strings.ContainsAny(name, "${}`+ \t\r\n(")
+}
+
+// jsonRPCReservedMethod is the set of method names that are NOT application
+// JSON-RPC methods — proxy accessors and JSON-RPC system/introspection methods.
+var jsonRPCReservedMethod = map[string]bool{
+	"close": true, "request": true, "notify": true, "batch": true,
+	"system.listMethods": true, "system.methodHelp": true,
+	"system.methodSignature": true, "system.multicall": true,
+}
+
+// ---------------------------------------------------------------------------
+// Producer side — JS/TS jayson server
+// ---------------------------------------------------------------------------
+
+// jsonRPCServerOpenRE locates the opening of a jayson server method-map call:
+//
+//	jayson.server({ add: fn, subtract: fn })
+//	new jayson.Server({ ... })
+//
+// The match END is positioned at (or just before) the method-map `{`; the
+// synthesizer then balance-scans the object so nested function bodies don't
+// truncate the body the way a `[^}]*` regex would.
+var jsonRPCServerOpenRE = regexp.MustCompile(
+	`(?:jayson\s*\.\s*server|new\s+jayson\s*\.\s*Server)\s*\(\s*`)
+
+// jsonRPCTopLevelKeyRE captures an object-literal key `<name>:` (bare ident or
+// quoted, possibly dotted). Applied ONLY to the depth-1 slices of a method map
+// (nested function bodies are skipped by the balanced walk), so it never picks
+// up an identifier from inside a handler body. Capture 1 = quoted key, 2 = bare.
+var jsonRPCTopLevelKeyRE = regexp.MustCompile(
+	`^['"]([A-Za-z_$][\w$.]*)['"]\s*:|^([A-Za-z_$][\w$]*)\s*:`)
+
+// synthesizeJSJSONRPCServer scans a JS/TS file for a jayson server method map
+// and emits one producer-side http_endpoint_definition per top-level method
+// key, keyed http:JSONRPC:/jsonrpc/<method>.
+func synthesizeJSJSONRPCServer(content string, emit emitFn) {
+	if !strings.Contains(content, "jayson") {
+		return
+	}
+	seen := map[string]bool{}
+	for _, loc := range jsonRPCServerOpenRE.FindAllStringIndex(content, -1) {
+		// The next non-space byte at loc[1] must be the method-map `{`.
+		open := loc[1]
+		for open < len(content) && (content[open] == ' ' || content[open] == '\t' ||
+			content[open] == '\n' || content[open] == '\r') {
+			open++
+		}
+		if open >= len(content) || content[open] != '{' {
+			continue
+		}
+		close := findMatchingBrace(content, open)
+		if close < 0 {
+			continue
+		}
+		for _, method := range jsonRPCTopLevelKeys(content[open+1 : close]) {
+			if isDynamicJSONRPCName(method) || jsonRPCReservedMethod[method] {
+				continue
+			}
+			if seen[method] {
+				continue
+			}
+			seen[method] = true
+			emit(jsonRPCVerb, jsonRPCCanonical(method), "jayson", "Method", method)
+		}
+	}
+}
+
+// jsonRPCTopLevelKeys walks an object-literal body and returns the keys defined
+// at depth 0 (directly under the method-map braces). Nested object literals,
+// parenthesised argument lists, and string literals are skipped so a key name
+// inside a handler body is never mistaken for a method-map entry.
+func jsonRPCTopLevelKeys(body string) []string {
+	var out []string
+	i, n := 0, len(body)
+	atEntryStart := true // true when the next ident:`:` is a depth-0 key
+	for i < n {
+		c := body[i]
+		switch {
+		case c == '{' || c == '(' || c == '[':
+			// Skip a balanced nested block.
+			open, closeByte := c, matchingCloser(c)
+			depth := 0
+			for i < n {
+				if body[i] == open {
+					depth++
+				} else if body[i] == closeByte {
+					depth--
+					if depth == 0 {
+						i++
+						break
+					}
+				}
+				i++
+			}
+			atEntryStart = false
+		case c == ',':
+			atEntryStart = true
+			i++
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		default:
+			if atEntryStart {
+				if km := jsonRPCTopLevelKeyRE.FindStringSubmatch(body[i:]); km != nil {
+					method := km[1]
+					if method == "" {
+						method = km[2]
+					}
+					if method != "" {
+						out = append(out, method)
+					}
+				}
+			}
+			atEntryStart = false
+			i++
+		}
+	}
+	return out
+}
+
+// matchingCloser returns the closing bracket byte for an opening bracket.
+func matchingCloser(open byte) byte {
+	switch open {
+	case '{':
+		return '}'
+	case '(':
+		return ')'
+	case '[':
+		return ']'
+	}
+	return open
+}
+
+// ---------------------------------------------------------------------------
+// Producer side — Python register_function
+// ---------------------------------------------------------------------------
+
+// jsonRPCPyRegisterRE matches `<server>.register_function(fn, "name")` and
+// captures the explicit registered name (capture 1). The single-arg form
+// `register_function(fn)` (name defaults to fn.__name__) is honest-partial
+// skipped — the wire name is not statically present.
+var jsonRPCPyRegisterRE = regexp.MustCompile(
+	`\.\s*register_function\s*\(\s*[^,]+,\s*['"]([A-Za-z_][\w.]*)['"]\s*\)`)
+
+// synthesizePyJSONRPCServer scans a Python file for xmlrpc/jsonrpc
+// `register_function(fn, "name")` registrations and emits one producer-side
+// http_endpoint_definition per registered name.
+func synthesizePyJSONRPCServer(content string, emit emitFn) {
+	if !strings.Contains(content, "register_function") {
+		return
+	}
+	seen := map[string]bool{}
+	for _, m := range jsonRPCPyRegisterRE.FindAllStringSubmatch(content, -1) {
+		method := m[1]
+		if isDynamicJSONRPCName(method) || jsonRPCReservedMethod[method] {
+			continue
+		}
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		emit(jsonRPCVerb, jsonRPCCanonical(method), "xmlrpc", "Method", method)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer side — JS/TS jayson client
+// ---------------------------------------------------------------------------
+
+// jsonRPCJSRequestRE matches `<handle>.request('<method>', …)` — the jayson /
+// generic JSON-RPC client request idiom. Capture 1 = the string-literal method
+// name (single arg). A non-literal first argument does not match and is skipped.
+var jsonRPCJSRequestRE = regexp.MustCompile(
+	`\.\s*request\s*\(\s*['"]([A-Za-z_$][\w$.]*)['"]`)
+
+// synthesizeJSJSONRPCClient scans a JS/TS file for jayson `client.request(
+// '<method>', params)` calls and emits one consumer-side http_endpoint_call per
+// method, keyed http:JSONRPC:/jsonrpc/<method>.
+func synthesizeJSJSONRPCClient(content string, funcs []jsFuncSpan, emit emitFn) {
+	if !strings.Contains(content, ".request(") {
+		return
+	}
+	// Require a JSON-RPC client signal so this is a no-op on REST `.request(`
+	// (e.g. graphql-request, supertest) callers.
+	if !strings.Contains(content, "jayson") && !strings.Contains(content, "jsonrpc") &&
+		!strings.Contains(content, "json-rpc") {
+		return
+	}
+	seen := map[string]bool{}
+	for _, m := range jsonRPCJSRequestRE.FindAllStringSubmatchIndex(content, -1) {
+		method := content[m[2]:m[3]]
+		if isDynamicJSONRPCName(method) || jsonRPCReservedMethod[method] {
+			continue
+		}
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		caller := enclosingJSFuncAt(funcs, m[0])
+		emit(jsonRPCVerb, jsonRPCCanonical(method), "jayson", "Function", caller)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer side — Python ServerProxy
+// ---------------------------------------------------------------------------
+
+// jsonRPCPyProxyAssignRE captures a variable bound to an xmlrpc/jsonrpc
+// ServerProxy: `proxy = ServerProxy(url)` / `s = xmlrpc.client.ServerProxy(url)`
+// / `c = jsonrpclib.Server(url)`. Capture 1 = handle var name.
+var jsonRPCPyProxyAssignRE = regexp.MustCompile(
+	`([A-Za-z_]\w*)\s*=\s*(?:[\w.]*\bServerProxy|jsonrpclib\s*\.\s*Server|[\w.]*\bServer)\s*\(`)
+
+// jsonRPCPyProxyCallRE matches `<handle>.<method>(` on a resolved proxy handle.
+// Capture 1 = handle ident, 2 = method name (may be dotted, e.g. `user.get`,
+// which xmlrpc supports via nested _Method proxies — captured greedily here).
+var jsonRPCPyProxyCallRE = regexp.MustCompile(
+	`\b([A-Za-z_]\w*)\s*\.\s*([A-Za-z_][\w.]*)\s*\(`)
+
+// synthesizePyJSONRPCClient scans a Python file for xmlrpc/jsonrpc
+// `ServerProxy(url).<method>()` calls and emits one consumer-side
+// http_endpoint_call per method, keyed http:JSONRPC:/jsonrpc/<method>.
+func synthesizePyJSONRPCClient(content string, emit emitFn) {
+	if !strings.Contains(content, "ServerProxy") && !strings.Contains(content, "jsonrpclib") {
+		return
+	}
+	proxyVars := map[string]bool{}
+	for _, m := range jsonRPCPyProxyAssignRE.FindAllStringSubmatch(content, -1) {
+		if m[1] != "" {
+			proxyVars[m[1]] = true
+		}
+	}
+	if len(proxyVars) == 0 {
+		return
+	}
+	funcs := indexPyEnclosingFunctions(content)
+	seen := map[string]bool{}
+	for _, m := range jsonRPCPyProxyCallRE.FindAllStringSubmatchIndex(content, -1) {
+		handle := content[m[2]:m[3]]
+		method := content[m[4]:m[5]]
+		if !proxyVars[handle] {
+			continue
+		}
+		// Drop a trailing dot artifact and reject dunder/system accessors.
+		method = strings.TrimRight(method, ".")
+		if isDynamicJSONRPCName(method) || jsonRPCReservedMethod[method] ||
+			strings.HasPrefix(method, "_") {
+			continue
+		}
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		caller := enclosingPyFuncAt(funcs, m[0])
+		emit(jsonRPCVerb, jsonRPCCanonical(method), "jsonrpc", "Function", caller)
+	}
+}

--- a/internal/engine/http_endpoint_soap.go
+++ b/internal/engine/http_endpoint_soap.go
@@ -1,0 +1,355 @@
+// SOAP server-side (producer) + client-side (consumer) synthetic http_endpoint
+// emission for cross-repo matching (epic #3628, "[protocol] SOAP + JSON-RPC
+// client cross-link").
+//
+// Background — the cross-repo client-link mechanism
+// -------------------------------------------------
+// The REST / GraphQL / WS consumer passes all share one trick: they emit a
+// synthetic `http_endpoint_call` whose ID is byte-for-byte identical to the
+// PRODUCER-side `http_endpoint_definition` for the same logical operation. The
+// existing Name-based cross-repo HTTP linker (links/http_pass.go) then joins
+// the two with NO new linker code, because it pairs synthetics across repos by
+// their canonical `http:<VERB>:<path>` Name.
+//
+// Before this pass SOAP was invisible to that machinery. The Jakarta custom
+// extractor (internal/custom/java/jakarta_ee_advanced.go) records a
+// `@WebService` class and its `@WebMethod`s as plain SCOPE.Service /
+// SCOPE.Operation structural entities — useful locally, but they live in a
+// different ID space and can never join a client call.
+//
+// Canonical SOAP id
+// -----------------
+// We adopt the synthetic verb SOAP and the canonical path
+//
+//	/soap/<Service>/<Operation>
+//
+// giving the id  http:SOAP:/soap/<Service>/<Operation>. Both the producer
+// (server) and consumer (client) sides emit this exact shape so they join.
+// When the service binding name is not statically resolvable on the client
+// side (the dominant case — the operation is invoked on a generated port /
+// dynamic proxy whose WSDL service name is not in the file) we honest-partial
+// to a service-less id  http:SOAP:/soap/<Operation>, and the server side ALSO
+// registers that service-less alias so a client that only knows the operation
+// still links.
+//
+// Producer side (server)
+// ----------------------
+//   - Java JAX-WS: `@WebService` class + `@WebMethod` (or any public method on
+//     the annotated endpoint interface/class). Service name = the explicit
+//     `@WebService(name="…"/serviceName="…")` attribute when present, else the
+//     class name. Each operation → http:SOAP:/soap/<Service>/<op> AND the
+//     service-less alias http:SOAP:/soap/<op>.
+//
+// Consumer side (client)
+// ----------------------
+//   - Python zeep: `client.service.<Op>(...)` on a zeep.Client. The service
+//     binding name is not in the call expression, so these honest-partial to
+//     http:SOAP:/soap/<Op>.
+//   - JS/TS node-soap: `soap.createClient(...)` + `client.<Op>Async(...)` /
+//     `client.<Op>(...)`. The `Async` suffix (node-soap's promise convention)
+//     is stripped to recover the WSDL operation name. Service-less id.
+//   - Java JAX-WS generated port: `port.<op>(...)` where `port` was obtained
+//     from `service.get<Port>()` / a `@WebServiceRef`-injected proxy. We
+//     resolve the port handle variables and emit http:SOAP:/soap/<op>.
+//
+// Honest-partial / non-fabrication
+//   - Dynamic operation names (variable / template) are SKIPPED — no string,
+//     no fabricated endpoint.
+//   - Java/Python lifecycle/accessor calls on the handle (getPort, getClass,
+//     toString, close, …) are skipped — they are not SOAP operations.
+//   - The client passes are file-signal gated (zeep / soap.createClient /
+//     a resolvable JAX-WS port) so they no-op on ordinary files.
+
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// soapVerb is the synthetic HTTP verb used for every SOAP operation endpoint,
+// shared by the producer and all consumer passes so their ids join.
+const soapVerb = "SOAP"
+
+// soapEndpointPath builds the canonical SOAP path for a (service, operation)
+// pair. When service is empty the service-less honest-partial form is used.
+func soapEndpointPath(service, op string) string {
+	if service == "" {
+		return "/soap/" + op
+	}
+	return "/soap/" + service + "/" + op
+}
+
+// soapCanonical returns the canonical, slash-normalised path for the given
+// (service, op). FrameworkExpress is a no-op canonicaliser for our paths (no
+// path params) — it only normalises slashes, matching the GraphQL/WS passes.
+func soapCanonical(service, op string) string {
+	return httproutes.Canonicalize(httproutes.FrameworkExpress, soapEndpointPath(service, op))
+}
+
+// soapNonOperationCall is the set of handle method names that are NOT SOAP
+// operations — JVM/Python object accessors and zeep/node-soap lifecycle calls.
+// Used by the client passes to avoid fabricating an endpoint from e.g.
+// `port.toString()` or `client.wsdl`.
+var soapNonOperationCall = map[string]bool{
+	"toString": true, "hashCode": true, "equals": true, "getClass": true,
+	"wait": true, "notify": true, "notifyAll": true, "clone": true,
+	"close": true, "getPort": true, "create": true, "getClient": true,
+	"describe": true, "setOptions": true, "addSoapHeader": true,
+	"on": true, "wsdl": true,
+}
+
+// isDynamicSOAPName reports whether an extracted operation/service token is a
+// stable string literal we can safely build an endpoint from. Anything carrying
+// interpolation/template markers is dynamic → honest-partial skip.
+func isDynamicSOAPName(name string) bool {
+	return name == "" || strings.ContainsAny(name, "${}`+ \t\r\n(")
+}
+
+// ---------------------------------------------------------------------------
+// Producer side — Java JAX-WS @WebService / @WebMethod
+// ---------------------------------------------------------------------------
+
+// soapWebServiceClassRE matches a `@WebService`-annotated class or interface and
+// captures (1) the optional annotation attribute block and (2) the type name.
+var soapWebServiceClassRE = regexp.MustCompile(
+	`(?s)@WebService\b\s*(\([^)]*\))?[^{};]*?\b(?:class|interface)\s+(\w+)`)
+
+// soapWSNameAttrRE extracts `name="…"` or `serviceName="…"` from a @WebService
+// attribute block; serviceName is preferred when both are present.
+var (
+	soapWSNameAttrRE        = regexp.MustCompile(`\bname\s*=\s*"([^"]+)"`)
+	soapWSServiceNameAttrRE = regexp.MustCompile(`\bserviceName\s*=\s*"([^"]+)"`)
+)
+
+// soapWebMethodRE matches a `@WebMethod`-annotated Java method and captures the
+// method name. The optional `operationName="…"` attribute (captured separately)
+// overrides the method name as the WSDL operation when present.
+var soapWebMethodRE = regexp.MustCompile(
+	`(?s)@WebMethod\b\s*(\([^)]*\))?[^;{]*?\b\w[\w<>\[\],.\s]*?\s+(\w+)\s*\(`)
+
+var soapOperationNameAttrRE = regexp.MustCompile(`\boperationName\s*=\s*"([^"]+)"`)
+
+// synthesizeJavaSOAPServer scans a Java file for JAX-WS `@WebService` endpoints
+// and emits one producer-side http_endpoint_definition per `@WebMethod`
+// operation, keyed http:SOAP:/soap/<Service>/<op> AND the service-less alias
+// http:SOAP:/soap/<op> so a client that only knows the operation still joins.
+//
+// It is invoked from applyHTTPEndpointSynthesis (case "java").
+func synthesizeJavaSOAPServer(content string, emit emitFn) {
+	if !strings.Contains(content, "@WebService") {
+		return
+	}
+	// Locate every @WebService type and the byte span of its class body so each
+	// @WebMethod can be attributed to the right service. We use a simple
+	// scan: an operation belongs to the nearest preceding @WebService class.
+	type svc struct {
+		name  string
+		start int
+	}
+	var services []svc
+	for _, m := range soapWebServiceClassRE.FindAllStringSubmatchIndex(content, -1) {
+		attr := ""
+		if m[2] >= 0 {
+			attr = content[m[2]:m[3]]
+		}
+		typeName := content[m[4]:m[5]]
+		name := typeName
+		if sm := soapWSServiceNameAttrRE.FindStringSubmatch(attr); len(sm) == 2 {
+			name = sm[1]
+		} else if nm := soapWSNameAttrRE.FindStringSubmatch(attr); len(nm) == 2 {
+			name = nm[1]
+		}
+		services = append(services, svc{name: name, start: m[0]})
+	}
+	if len(services) == 0 {
+		return
+	}
+
+	serviceFor := func(pos int) string {
+		name := services[0].name
+		for _, s := range services {
+			if s.start <= pos {
+				name = s.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+
+	seen := map[string]bool{}
+	for _, m := range soapWebMethodRE.FindAllStringSubmatchIndex(content, -1) {
+		attr := ""
+		if m[2] >= 0 {
+			attr = content[m[2]:m[3]]
+		}
+		opName := content[m[4]:m[5]]
+		if om := soapOperationNameAttrRE.FindStringSubmatch(attr); len(om) == 2 {
+			opName = om[1]
+		}
+		if isDynamicSOAPName(opName) || soapNonOperationCall[opName] {
+			continue
+		}
+		service := serviceFor(m[0])
+		// Emit the fully-qualified service/op endpoint.
+		if !seen[service+"\x00"+opName] {
+			seen[service+"\x00"+opName] = true
+			emit(soapVerb, soapCanonical(service, opName), "jaxws", "Method", service+"."+opName)
+		}
+		// Emit the service-less alias so a client that only knows the operation
+		// name (the common honest-partial client case) joins.
+		if !seen["\x00"+opName] {
+			seen["\x00"+opName] = true
+			emit(soapVerb, soapCanonical("", opName), "jaxws", "Method", service+"."+opName)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer side — Python zeep
+// ---------------------------------------------------------------------------
+
+// soapPyZeepCallRE matches `<handle>.service.<Op>(` where <handle> is a zeep
+// Client instance. Capture 1 = handle ident, 2 = operation name.
+var soapPyZeepCallRE = regexp.MustCompile(
+	`\b([A-Za-z_][\w]*)\s*\.\s*service\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+
+// synthesizePySOAPClient scans a Python file for zeep `client.service.<Op>(...)`
+// SOAP calls and emits one consumer-side http_endpoint_call per operation,
+// keyed http:SOAP:/soap/<Op> (service-less honest-partial — the WSDL service
+// binding name is not present at the call site).
+func synthesizePySOAPClient(content string, emit emitFn) {
+	if !strings.Contains(content, "zeep") && !strings.Contains(content, ".service.") {
+		return
+	}
+	funcs := indexPyEnclosingFunctions(content)
+	seen := map[string]bool{}
+	for _, m := range soapPyZeepCallRE.FindAllStringSubmatchIndex(content, -1) {
+		op := content[m[4]:m[5]]
+		if isDynamicSOAPName(op) || soapNonOperationCall[op] {
+			continue
+		}
+		if seen[op] {
+			continue
+		}
+		seen[op] = true
+		caller := enclosingPyFuncAt(funcs, m[0])
+		emit(soapVerb, soapCanonical("", op), "zeep", "Function", caller)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer side — JS/TS node-soap
+// ---------------------------------------------------------------------------
+
+// soapJSOpCallRE matches `<handle>.<Op>(` / `<handle>.<Op>Async(` on a node-soap
+// client. Capture 1 = handle ident, 2 = operation (possibly with Async suffix).
+var soapJSOpCallRE = regexp.MustCompile(
+	`\b([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*?)(Async)?\s*\(`)
+
+// soapJSClientVarRE captures the variable bound to the node-soap client in the
+// `soap.createClient(url, (err, client) => {…})` callback or
+// `await soap.createClientAsync(url)` assignment. Capture 1 = callback client
+// param, 2 = awaited-assignment var name.
+var soapJSClientVarRE = regexp.MustCompile(
+	`createClient(?:Async)?\s*\([^)]*?\(\s*[A-Za-z_$][\w$]*\s*,\s*([A-Za-z_$][\w$]*)\s*\)` +
+		`|(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+\w+\.createClientAsync`)
+
+// synthesizeJSSOAPClient scans a JS/TS file for node-soap operation calls and
+// emits one consumer-side http_endpoint_call per operation, service-less
+// (http:SOAP:/soap/<Op>). The `Async` promise-suffix is stripped to recover the
+// WSDL operation name.
+func synthesizeJSSOAPClient(content string, funcs []jsFuncSpan, emit emitFn) {
+	if !strings.Contains(content, "createClient") || !strings.Contains(content, "soap") {
+		return
+	}
+	// Resolve the set of node-soap client handle identifiers in the file.
+	clientVars := map[string]bool{"client": true, "soapClient": true}
+	for _, m := range soapJSClientVarRE.FindAllStringSubmatch(content, -1) {
+		if m[1] != "" {
+			clientVars[m[1]] = true
+		}
+		if m[2] != "" {
+			clientVars[m[2]] = true
+		}
+	}
+	seen := map[string]bool{}
+	for _, m := range soapJSOpCallRE.FindAllStringSubmatchIndex(content, -1) {
+		handle := content[m[2]:m[3]]
+		op := content[m[4]:m[5]]
+		if !clientVars[handle] {
+			continue
+		}
+		if isDynamicSOAPName(op) || soapNonOperationCall[op] {
+			continue
+		}
+		if seen[op] {
+			continue
+		}
+		seen[op] = true
+		caller := enclosingJSFuncAt(funcs, m[0])
+		emit(soapVerb, soapCanonical("", op), "node-soap", "Function", caller)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Consumer side — Java JAX-WS generated port
+// ---------------------------------------------------------------------------
+
+// soapJavaPortAssignRE captures a JAX-WS port handle: a variable obtained from
+// `service.get<Port>()` or `new <Service>().get<Port>()`, or a field/param
+// annotated `@WebServiceRef`. Capture 1 = var from a getPort assignment,
+// 2 = field name from a @WebServiceRef declaration.
+var soapJavaPortAssignRE = regexp.MustCompile(
+	`(?:[\w.<>\[\] ]+\s+)?([A-Za-z_]\w*)\s*=\s*[\w.]*\bget\w*Port\w*\s*\(\s*\)` +
+		`|@WebServiceRef\b[^;]*?\b(\w+)\s*;`)
+
+// soapJavaPortCallRE matches `<handle>.<op>(` on a resolved port handle.
+// Capture 1 = handle ident, 2 = operation name.
+var soapJavaPortCallRE = regexp.MustCompile(
+	`\b([A-Za-z_]\w*)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+
+// synthesizeJavaSOAPClient scans a Java file for JAX-WS generated-port operation
+// invocations and emits one consumer-side http_endpoint_call per operation,
+// service-less (http:SOAP:/soap/<op>). Only calls on a resolved port handle
+// (getPort assignment or @WebServiceRef field) are considered, so ordinary
+// method calls are not mistaken for SOAP operations.
+func synthesizeJavaSOAPClient(content string, emit emitFn) {
+	// Gate: require a JAX-WS port acquisition signal in the file.
+	if !strings.Contains(content, "Port") && !strings.Contains(content, "@WebServiceRef") {
+		return
+	}
+	portVars := map[string]bool{}
+	for _, m := range soapJavaPortAssignRE.FindAllStringSubmatch(content, -1) {
+		if m[1] != "" {
+			portVars[m[1]] = true
+		}
+		if m[2] != "" {
+			portVars[m[2]] = true
+		}
+	}
+	if len(portVars) == 0 {
+		return
+	}
+	methods := indexJavaEnclosingMethods(content)
+	seen := map[string]bool{}
+	for _, m := range soapJavaPortCallRE.FindAllStringSubmatchIndex(content, -1) {
+		handle := content[m[2]:m[3]]
+		op := content[m[4]:m[5]]
+		if !portVars[handle] {
+			continue
+		}
+		if isDynamicSOAPName(op) || soapNonOperationCall[op] {
+			continue
+		}
+		if seen[op] {
+			continue
+		}
+		seen[op] = true
+		caller := enclosingJavaMethodAt(methods, m[0])
+		emit(soapVerb, soapCanonical("", op), "jaxws-client", "Function", caller)
+	}
+}

--- a/internal/engine/http_endpoint_soap_jsonrpc_test.go
+++ b/internal/engine/http_endpoint_soap_jsonrpc_test.go
@@ -1,0 +1,310 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+)
+
+// findEndpointEntity returns the http_endpoint_definition or http_endpoint_call
+// entity with the given ID and kind, or nil.
+func findEndpointEntity(res *DetectResult, id, kind string) *entityForTest {
+	for i := range res.Entities {
+		e := res.Entities[i]
+		if e.ID == id && e.Kind == kind {
+			return &entityForTest{
+				id:           e.ID,
+				name:         e.Name,
+				qn:           e.QualifiedName,
+				patternType:  e.Properties["pattern_type"],
+				sourceCaller: e.Properties["source_caller"],
+				verb:         e.Properties["verb"],
+				framework:    e.Properties["framework"],
+			}
+		}
+	}
+	return nil
+}
+
+// callIDs returns the sorted list of http_endpoint_call IDs in res (for
+// diagnostics on failure).
+func callIDs(res *DetectResult) []string {
+	var got []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind {
+			got = append(got, e.ID)
+		}
+	}
+	sort.Strings(got)
+	return got
+}
+
+// defIDs returns the sorted list of http_endpoint_definition IDs in res.
+func defIDs(res *DetectResult) []string {
+	var got []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind {
+			got = append(got, e.ID)
+		}
+	}
+	sort.Strings(got)
+	return got
+}
+
+// hasFetchesEdge reports whether a FETCHES edge targets the given endpoint ID.
+func hasFetchesEdge(res *DetectResult, toID string) bool {
+	for _, r := range res.Relationships {
+		if r.Kind == fetchesEdgeKind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// SOAP
+// ---------------------------------------------------------------------------
+
+// TestSynth_SOAP_JavaServer_WebMethod asserts the JAX-WS producer emits both the
+// fully-qualified service/op endpoint and the service-less alias.
+func TestSynth_SOAP_JavaServer_WebMethod(t *testing.T) {
+	src := `
+package com.acme.ws;
+import javax.jws.WebService;
+import javax.jws.WebMethod;
+
+@WebService(serviceName = "UserService")
+public class UserEndpoint {
+    @WebMethod
+    public User GetUser(int id) { return null; }
+
+    @WebMethod
+    public void DeleteUser(int id) {}
+}
+`
+	_, res := runDetect(t, "java", "UserEndpoint.java", src)
+
+	for _, want := range []string{
+		"http:SOAP:/soap/UserService/GetUser",
+		"http:SOAP:/soap/GetUser", // service-less alias
+		"http:SOAP:/soap/UserService/DeleteUser",
+		"http:SOAP:/soap/DeleteUser",
+	} {
+		if findEndpointEntity(res, want, httpEndpointDefinitionKind) == nil {
+			t.Errorf("missing SOAP producer endpoint %q (got defs: %v)", want, defIDs(res))
+		}
+	}
+	e := findEndpointEntity(res, "http:SOAP:/soap/UserService/GetUser", httpEndpointDefinitionKind)
+	if e != nil && e.verb != "SOAP" {
+		t.Errorf("verb = %q, want SOAP", e.verb)
+	}
+}
+
+// TestSynth_SOAP_PyZeepClient is the cross-repo parity oracle: a zeep
+// `client.service.GetUser(id)` must emit a client-call whose ID matches the
+// server's service-less alias (http:SOAP:/soap/GetUser).
+func TestSynth_SOAP_PyZeepClient(t *testing.T) {
+	src := `
+from zeep import Client
+
+def fetch_user(uid):
+    client = Client("http://svc/users?wsdl")
+    return client.service.GetUser(uid)
+`
+	_, res := runDetect(t, "python", "client.py", src)
+
+	const wantID = "http:SOAP:/soap/GetUser"
+	e := findEndpointEntity(res, wantID, httpEndpointCallKind)
+	if e == nil {
+		t.Fatalf("missing SOAP client-call %q (got calls: %v)", wantID, callIDs(res))
+	}
+	if e.verb != "SOAP" {
+		t.Errorf("verb = %q, want SOAP", e.verb)
+	}
+	if e.sourceCaller != "Function:fetch_user" {
+		t.Errorf("source_caller = %q, want Function:fetch_user", e.sourceCaller)
+	}
+	if !hasFetchesEdge(res, wantID) {
+		t.Errorf("missing FETCHES edge → %q", wantID)
+	}
+}
+
+// TestSynth_SOAP_PyZeepClient_DynamicSkipped is the negative case: a dynamic
+// operation name (attribute via getattr-style / variable) must NOT fabricate an
+// endpoint. zeep dynamic dispatch `getattr(client.service, op)()` carries no
+// literal op, so no `client.service.<literal>(` match exists.
+func TestSynth_SOAP_PyZeepClient_DynamicSkipped(t *testing.T) {
+	src := `
+from zeep import Client
+
+def call(op, uid):
+    client = Client("http://svc?wsdl")
+    method = getattr(client.service, op)
+    return method(uid)
+`
+	_, res := runDetect(t, "python", "dyn.py", src)
+	for _, id := range callIDs(res) {
+		if len(id) >= 10 && id[:10] == "http:SOAP:" {
+			t.Errorf("fabricated SOAP endpoint from dynamic op: %q", id)
+		}
+	}
+}
+
+// TestSynth_SOAP_JSNodeSoapClient asserts node-soap `client.GetUserAsync(...)`
+// strips the Async suffix and emits http:SOAP:/soap/GetUser.
+func TestSynth_SOAP_JSNodeSoapClient(t *testing.T) {
+	src := `
+const soap = require('soap');
+
+async function getUser(id) {
+  const client = await soap.createClientAsync('http://svc?wsdl');
+  return client.GetUserAsync({ id });
+}
+`
+	_, res := runDetect(t, "javascript", "soapClient.js", src)
+
+	const wantID = "http:SOAP:/soap/GetUser"
+	e := findEndpointEntity(res, wantID, httpEndpointCallKind)
+	if e == nil {
+		t.Fatalf("missing SOAP client-call %q (got calls: %v)", wantID, callIDs(res))
+	}
+	if e.framework != "node-soap" {
+		t.Errorf("framework = %q, want node-soap", e.framework)
+	}
+}
+
+// TestSynth_SOAP_JavaPortClient asserts a JAX-WS generated-port operation call
+// on a resolved port handle emits http:SOAP:/soap/<op>.
+func TestSynth_SOAP_JavaPortClient(t *testing.T) {
+	src := `
+package com.acme.client;
+public class Caller {
+    public String run() {
+        UserService service = new UserService();
+        UserPort port = service.getUserPort();
+        return port.GetUser(42);
+    }
+}
+`
+	_, res := runDetect(t, "java", "Caller.java", src)
+
+	const wantID = "http:SOAP:/soap/GetUser"
+	if findEndpointEntity(res, wantID, httpEndpointCallKind) == nil {
+		t.Fatalf("missing SOAP client-call %q (got calls: %v)", wantID, callIDs(res))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC
+// ---------------------------------------------------------------------------
+
+// TestSynth_JSONRPC_JaysonServer asserts a jayson server method map emits one
+// producer endpoint per method, including a dotted method name.
+func TestSynth_JSONRPC_JaysonServer(t *testing.T) {
+	src := `
+const jayson = require('jayson');
+const server = jayson.server({
+  add: function (args, cb) { cb(null, args[0] + args[1]); },
+  'user.get': function (args, cb) { cb(null, {}); },
+});
+`
+	_, res := runDetect(t, "javascript", "server.js", src)
+
+	for _, want := range []string{
+		"http:JSONRPC:/jsonrpc/add",
+		"http:JSONRPC:/jsonrpc/user.get",
+	} {
+		if findEndpointEntity(res, want, httpEndpointDefinitionKind) == nil {
+			t.Errorf("missing JSON-RPC producer endpoint %q (got defs: %v)", want, defIDs(res))
+		}
+	}
+}
+
+// TestSynth_JSONRPC_JaysonClient is the parity oracle: `client.request('add', …)`
+// must emit a client-call matching the server method endpoint.
+func TestSynth_JSONRPC_JaysonClient(t *testing.T) {
+	src := `
+const jayson = require('jayson');
+const client = jayson.client.http('http://svc:3000');
+
+function compute() {
+  return client.request('add', [1, 2]);
+}
+`
+	_, res := runDetect(t, "javascript", "client.js", src)
+
+	const wantID = "http:JSONRPC:/jsonrpc/add"
+	e := findEndpointEntity(res, wantID, httpEndpointCallKind)
+	if e == nil {
+		t.Fatalf("missing JSON-RPC client-call %q (got calls: %v)", wantID, callIDs(res))
+	}
+	if e.verb != "JSONRPC" {
+		t.Errorf("verb = %q, want JSONRPC", e.verb)
+	}
+	if e.sourceCaller != "Function:compute" {
+		t.Errorf("source_caller = %q, want Function:compute", e.sourceCaller)
+	}
+	if !hasFetchesEdge(res, wantID) {
+		t.Errorf("missing FETCHES edge → %q", wantID)
+	}
+}
+
+// TestSynth_JSONRPC_JaysonClient_DynamicSkipped is the negative case: a dynamic
+// method name (variable first arg) must NOT fabricate an endpoint.
+func TestSynth_JSONRPC_JaysonClient_DynamicSkipped(t *testing.T) {
+	src := `
+const jayson = require('jayson');
+const client = jayson.client.http('http://svc');
+
+function call(method, params) {
+  return client.request(method, params);
+}
+`
+	_, res := runDetect(t, "javascript", "dyn.js", src)
+	for _, id := range callIDs(res) {
+		if len(id) >= 13 && id[:13] == "http:JSONRPC:" {
+			t.Errorf("fabricated JSON-RPC endpoint from dynamic method: %q", id)
+		}
+	}
+}
+
+// TestSynth_JSONRPC_PyServerProxyClient asserts xmlrpc `ServerProxy(url).<m>()`
+// emits http:JSONRPC:/jsonrpc/<m> matching a `register_function` producer.
+func TestSynth_JSONRPC_PyServerProxyClient(t *testing.T) {
+	src := `
+from xmlrpc.client import ServerProxy
+
+def total():
+    proxy = ServerProxy("http://svc:8000")
+    return proxy.add(1, 2)
+`
+	_, res := runDetect(t, "python", "rpc_client.py", src)
+
+	const wantID = "http:JSONRPC:/jsonrpc/add"
+	e := findEndpointEntity(res, wantID, httpEndpointCallKind)
+	if e == nil {
+		t.Fatalf("missing JSON-RPC client-call %q (got calls: %v)", wantID, callIDs(res))
+	}
+	if e.sourceCaller != "Function:total" {
+		t.Errorf("source_caller = %q, want Function:total", e.sourceCaller)
+	}
+}
+
+// TestSynth_JSONRPC_PyServer asserts `server.register_function(fn, "name")`
+// emits a producer endpoint matching the ServerProxy client shape.
+func TestSynth_JSONRPC_PyServer(t *testing.T) {
+	src := `
+from xmlrpc.server import SimpleXMLRPCServer
+
+def add(a, b):
+    return a + b
+
+server = SimpleXMLRPCServer(("0.0.0.0", 8000))
+server.register_function(add, "add")
+`
+	_, res := runDetect(t, "python", "rpc_server.py", src)
+
+	const wantID = "http:JSONRPC:/jsonrpc/add"
+	if findEndpointEntity(res, wantID, httpEndpointDefinitionKind) == nil {
+		t.Fatalf("missing JSON-RPC producer endpoint %q (got defs: %v)", wantID, defIDs(res))
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -488,6 +488,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	}
 	emitClientRuntime := makeRuntimeEmit()
 
+	// soapClientEmit adapts the plain 5-arg emitFn used by the SOAP / JSON-RPC
+	// consumer passes (#3628) onto emitClientRuntime so they emit the same
+	// http_endpoint_call entity + FETCHES edge as every other consumer pass.
+	// These protocols carry no runtime-dynamic URL, so runtimeDynamic is false.
+	soapClientEmit := func(method, canonicalPath, framework, refKind, refName string) {
+		emitClientRuntime(method, canonicalPath, framework, refKind, refName, false)
+	}
+
 	// Phase 1 deliberately emits synthetic entities WITHOUT producer-side
 	// handler→endpoint edges. The referenced entity is recorded as a
 	// property (`source_handler`) so a follow-up pass can resolve it
@@ -520,6 +528,11 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
+		// SOAP (epic #3628): JAX-WS @WebService/@WebMethod producer endpoints
+		// and JAX-WS generated-port client calls, keyed http:SOAP:/soap/...
+		// so they cross-link via the existing Name-based HTTP linker.
+		synthesizeJavaSOAPServer(string(content), emit)
+		synthesizeJavaSOAPClient(string(content), soapClientEmit)
 	case "python":
 		// #2980 — ASGI frameworks (Sanic / Litestar / Robyn) run BEFORE
 		// Flask / FastAPI. Sanic's `@app.route` / `@app.get` shape overlaps
@@ -591,6 +604,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// aiohttp / urllib / session-style HTTP client calls.
 		// Now emits FETCHES edges at extraction time.
 		synthesizePyClientWithRuntime(string(content), emitClientRuntime)
+		// SOAP + JSON-RPC (epic #3628): zeep `client.service.<Op>()` SOAP calls
+		// and xmlrpc/jsonrpc `register_function` producers + `ServerProxy(...)`
+		// client calls, keyed http:SOAP:/soap/... and http:JSONRPC:/jsonrpc/...
+		// so they cross-link via the existing Name-based HTTP linker.
+		synthesizePySOAPClient(string(content), soapClientEmit)
+		synthesizePyJSONRPCServer(string(content), emit)
+		synthesizePyJSONRPCClient(string(content), soapClientEmit)
 	case "javascript", "typescript":
 		// Capture the producer-side entity count before the JS/TS backend
 		// synthesizers run so #2852 can resolve auth_coverage over exactly the
@@ -727,6 +747,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 			last.Properties["polymorphic_subscript"] = polySubscript
 		}
 		synthesizeFetchAxiosWithRuntime(string(content), emitJSClientRuntime)
+		// SOAP + JSON-RPC (epic #3628): node-soap `client.<Op>Async()` SOAP
+		// calls, jayson server method maps (producer) + `client.request('m')`
+		// client calls, keyed http:SOAP:/soap/... and http:JSONRPC:/jsonrpc/...
+		// so they cross-link via the existing Name-based HTTP linker.
+		jstsRPCFuncs := indexJSEnclosingFunctions(string(content))
+		synthesizeJSSOAPClient(string(content), jstsRPCFuncs, soapClientEmit)
+		synthesizeJSJSONRPCServer(string(content), emit)
+		synthesizeJSJSONRPCClient(string(content), jstsRPCFuncs, soapClientEmit)
 	case "go":
 		// Producer side: Gin / Echo / Chi route registrations. #722.
 		synthesizeGoRouters(string(content), emit)

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -3791,3 +3791,145 @@ func TestHTTPPass_DynamicSuffix_RuntimeStaysUnlinked(t *testing.T) {
 		}
 	}
 }
+
+// TestHTTPPass_SOAPCrossRepoMatch verifies the SOAP cross-link round-trip
+// (epic #3628): a zeep client `client.service.GetUser(id)` (service-less id
+// http:SOAP:/soap/GetUser) joins to a JAX-WS producer's service-less alias.
+func TestHTTPPass_SOAPCrossRepoMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "user-soap-svc",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "GetUser", "kind": "Method", "source_file": "ws/UserEndpoint.java"},
+			{
+				"id": "ep1", "name": "http:SOAP:/soap/GetUser", "kind": "http_endpoint",
+				"source_file": "ws/UserEndpoint.java",
+				"properties": map[string]any{
+					"verb":         "SOAP",
+					"path":         "/soap/GetUser",
+					"framework":    "jaxws",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "billing-svc",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "fetch_user", "kind": "Function", "source_file": "client.py"},
+			{
+				"id": "ep2", "name": "http:SOAP:/soap/GetUser", "kind": "http_endpoint",
+				"source_file": "client.py",
+				"properties": map[string]any{
+					"verb":          "SOAP",
+					"path":          "/soap/GetUser",
+					"framework":     "zeep",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetch_user",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g-soap", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g-soap-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected a cross-repo SOAP link zeep client → JAX-WS endpoint; got %+v", doc.Links)
+	}
+	if hit.Source != "billing-svc::fn1" {
+		t.Errorf("source: want billing-svc::fn1 (zeep caller), got %s", hit.Source)
+	}
+	if hit.Target != "user-soap-svc::h1" {
+		t.Errorf("target: want user-soap-svc::h1 (JAX-WS handler), got %s", hit.Target)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "http:SOAP:/soap/GetUser" {
+		t.Errorf("identifier: want http:SOAP:/soap/GetUser, got %v", hit.Identifier)
+	}
+}
+
+// TestHTTPPass_JSONRPCCrossRepoMatch verifies the JSON-RPC cross-link round-trip
+// (epic #3628): a jayson client `client.request('add', …)` joins to a jayson
+// server method-map producer on http:JSONRPC:/jsonrpc/add.
+func TestHTTPPass_JSONRPCCrossRepoMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "math-rpc-svc",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "add", "kind": "Method", "source_file": "server.js"},
+			{
+				"id": "ep1", "name": "http:JSONRPC:/jsonrpc/add", "kind": "http_endpoint",
+				"source_file": "server.js",
+				"properties": map[string]any{
+					"verb":         "JSONRPC",
+					"path":         "/jsonrpc/add",
+					"framework":    "jayson",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "gateway-svc",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "compute", "kind": "Function", "source_file": "client.js"},
+			{
+				"id": "ep2", "name": "http:JSONRPC:/jsonrpc/add", "kind": "http_endpoint",
+				"source_file": "client.js",
+				"properties": map[string]any{
+					"verb":          "JSONRPC",
+					"path":          "/jsonrpc/add",
+					"framework":     "jayson",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:compute",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g-jsonrpc", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g-jsonrpc-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected a cross-repo JSON-RPC link jayson client → jayson server; got %+v", doc.Links)
+	}
+	if hit.Source != "gateway-svc::fn1" {
+		t.Errorf("source: want gateway-svc::fn1 (jayson caller), got %s", hit.Source)
+	}
+	if hit.Target != "math-rpc-svc::h1" {
+		t.Errorf("target: want math-rpc-svc::h1 (jayson handler), got %s", hit.Target)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "http:JSONRPC:/jsonrpc/add" {
+		t.Errorf("identifier: want http:JSONRPC:/jsonrpc/add, got %v", hit.Identifier)
+	}
+}


### PR DESCRIPTION
Closes #3750 (child of #3628).

The httpclient cross-linker had no SOAP or JSON-RPC client→server linkage (GraphQL was already done). This builds the gap by mirroring the GraphQL/WS consumer-pass pattern: emit producer + consumer synthetic `http_endpoint` entities whose canonical IDs match byte-for-byte, so the existing Name-based cross-repo HTTP linker (`internal/links/http_pass.go`) joins them with **no new linker code**.

## ID shapes
- **SOAP**: `http:SOAP:/soap/<Service>/<Operation>` (+ service-less alias `http:SOAP:/soap/<Operation>` so a client that only knows the op still joins)
- **JSON-RPC**: `http:JSONRPC:/jsonrpc/<method>` (dotted method names preserved as a single segment)

## Producer (server) side
- **SOAP**: Java JAX-WS `@WebService` / `@WebMethod` (`serviceName`/`name` attr → service, else class name; `operationName=` honored)
- **JSON-RPC**: JS jayson server method map (`jayson.server({ … })`, balanced-brace top-level key walk); Python `register_function(fn, "name")`

## Consumer (client) side
- **SOAP**: Python zeep `client.service.<Op>()`; JS node-soap `client.<Op>Async()` (Async suffix stripped); Java JAX-WS generated port `port.<op>()` (port-handle resolved from `getPort()` / `@WebServiceRef`)
- **JSON-RPC**: JS jayson `client.request('method', …)`; Python `ServerProxy(url).<method>()` (xmlrpc / jsonrpclib)

## Honest-partial / non-fabrication
- Dynamic op/method names (variable, template literal, getattr-style dispatch, non-literal `.request` first arg) → skipped, no fabrication
- Object accessors / lifecycle / JSON-RPC `system.*` methods filtered
- Client SOAP service binding is service-less honest-partial (WSDL service name not at call site)

## Tests
- `internal/engine/http_endpoint_soap_jsonrpc_test.go` — value-asserting server+client parity per language (`client.service.GetUser` → `http:SOAP:/soap/GetUser`; `client.request('add')` → `http:JSONRPC:/jsonrpc/add`) + negative dynamic-name cases
- `internal/links/http_pass_test.go` — cross-repo round-trip joins: `TestHTTPPass_SOAPCrossRepoMatch`, `TestHTTPPass_JSONRPCCrossRepoMatch`
- Targeted suites green: `internal/engine` `internal/links/...` `internal/types` `tools/coverage`; `coverage validate` ok; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean

## Coverage
`protocol.soap.*` (cross_repo_linkage / method_attribution / service_extraction) and `protocol.jsonrpc.*` (cross_repo_linkage / method_attribution) lifted missing→partial with extractor cites + tracking issue #3750. `protocol.jsonrpc.service_extraction` stays honestly `missing` (JSON-RPC has no service concept).

No new entity Kind — reuses `http_endpoint_definition` / `http_endpoint_call` and the SOAP/JSONRPC synthetic verbs.

**DEPLOY-DEFERRED**: no daemon rebuild/reindex in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)