### PR TITLE
feat(testmap): import-aware high-confidence gate for TESTS test→SUT edges

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -63293,8 +63293,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63381,8 +63381,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63399,8 +63399,8 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/java/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63417,8 +63417,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63435,8 +63435,8 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/ruby/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63486,7 +63486,11 @@
           "status": "missing"
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3753",
+          "notes": "Mockito when(svc.method()).thenReturn(...) stubs resolve to a medium-confidence TESTS edge on the stubbed production method via testmap mockSetupREs; direct calls on the SUT in @Test bodies resolve high.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63637,8 +63641,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go","internal/engine/tests_imports.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go","internal/engine/tests_imports.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63669,8 +63673,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63757,8 +63761,10 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/java/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3753",
+          "notes": "TestNG @Test methods in *Test.java files route through testmap detectJUnit (filename hint); org.testng import-hint not yet registered, so import-only TestNG files are a known partial miss.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -63793,8 +63799,8 @@
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go","internal/extractors/config/discover_test.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -615,6 +615,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	testType := inferTestType(file.Path)
 	prodFile, prodSymbol := productionFileFromTestPath(file.Path)
 
+	// #3628: the set of named symbols imported by this test file (JS/TS
+	// `import { X }`, Python `from m import X`). resolveCalls uses it to gate the
+	// high-confidence direct-call signal: a call to an imported symbol is the
+	// strongest test→SUT signal; a call to a same-named identifier that was never
+	// imported is held at medium so it is never a high-confidence false link. An
+	// empty set (Go same-package, wildcard imports, no named imports) disables
+	// the gate, preserving existing behaviour.
+	importedSyms := extractNamedImports(source)
+
 	// Issue #2080: emit ONE SCOPE.Pattern entity per test function.
 	// buildCollapsedEntity folds all resolved production calls into a single
 	// record with multiple embedded TESTS edges (FromID="" → entity owns the
@@ -622,7 +631,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// many @pytest.mark.parametrize parameter sets the test function has.
 	out := make([]types.EntityRecord, 0, len(tests))
 	for _, tf := range tests {
-		called := resolveCalls(tf, prodFile, prodSymbol)
+		called := resolveCalls(tf, prodFile, prodSymbol, importedSyms)
 		if len(called) == 0 {
 			continue
 		}

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -3135,7 +3135,7 @@ func TestJestCaseQNameScrubbing(t *testing.T) {
 
 func TestResolveCalls_EmptyBodyFallsBackToConvention(t *testing.T) {
 	tf := testFunction{qname: "TestFoo", body: ""}
-	calls := resolveCalls(tf, "foo.go", "Foo")
+	calls := resolveCalls(tf, "foo.go", "Foo", nil)
 	if len(calls) != 1 || calls[0].confidence != "low" || calls[0].qname != "Foo" {
 		t.Errorf("empty body fallback broken: %+v", calls)
 	}
@@ -3143,7 +3143,7 @@ func TestResolveCalls_EmptyBodyFallsBackToConvention(t *testing.T) {
 
 func TestResolveCalls_NoConventionUsesNameStrip(t *testing.T) {
 	tf := testFunction{qname: "TestCompute", body: ""}
-	calls := resolveCalls(tf, "", "")
+	calls := resolveCalls(tf, "", "", nil)
 	if len(calls) != 1 || calls[0].qname != "Compute" {
 		t.Errorf("strip fallback broken: %+v", calls)
 	}
@@ -3154,7 +3154,7 @@ func TestResolveCalls_DeduplicatesAcrossPasses(t *testing.T) {
 		qname: "TestAll",
 		body:  `Foo() ; mock.On("Foo", 1)`,
 	}
-	calls := resolveCalls(tf, "x.go", "X")
+	calls := resolveCalls(tf, "x.go", "X", nil)
 	var fooCount int
 	for _, c := range calls {
 		if c.qname == "Foo" {
@@ -3171,7 +3171,7 @@ func TestResolveCalls_DeduplicatesAcrossPasses(t *testing.T) {
 
 func TestResolveCalls_SkipsShortIdents(t *testing.T) {
 	tf := testFunction{qname: "TestShort", body: "a(); bb(); Cc(); LongName();"}
-	calls := resolveCalls(tf, "x.go", "X")
+	calls := resolveCalls(tf, "x.go", "X", nil)
 	for _, c := range calls {
 		if len(c.qname) < 3 {
 			t.Errorf("short ident leaked: %q", c.qname)

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -95,6 +95,99 @@ func extractImportTokens(source string) map[string]bool {
 	return out
 }
 
+// namedImportRE captures the *named symbols* brought into scope by an import
+// statement (as opposed to importTokenRE, which captures the module path). The
+// set it produces is used by the resolver to gate the high-confidence direct
+// -call signal: a call to an imported symbol is the strongest test→SUT signal,
+// whereas a call to a same-named identifier that was never imported is more
+// likely a local/builtin collision and is held at medium.
+//
+// Covered styles (one capture group = the brace/parenthesised symbol list):
+//
+//	JS/TS:  import { UserService, createOrder } from '../user-service'
+//	JS/TS:  import UserService from './user-service'          (default — group 2)
+//	Python: from app.users import create_user, UserService
+//	Python: from app.users import (create_user, UserService)
+var namedImportBraceRE = regexp.MustCompile(
+	`(?m)\bimport\s*\{([^}]*)\}\s*from\b`,
+)
+
+// pyFromImportRE captures the symbol list of a Python `from x import a, b` /
+// `from x import (a, b)` statement. Group 1 = the comma-separated names.
+var pyFromImportRE = regexp.MustCompile(
+	`(?m)^\s*from\s+[\w.]+\s+import\s+\(?([^()\n#]+)\)?`,
+)
+
+// jsDefaultImportRE captures a JS/TS default import binding:
+// `import UserService from './user-service'`. Group 1 = the binding name.
+var jsDefaultImportRE = regexp.MustCompile(
+	`(?m)\bimport\s+([A-Za-z_$][\w$]*)\s*(?:,\s*\{[^}]*\}\s*)?from\b`,
+)
+
+// extractNamedImports returns the set of symbol names brought into scope by the
+// file's import statements (JS/TS named + default imports, Python from-imports).
+// Names are kept in their original case. An empty set means "no named imports
+// were recognised" — in that case the resolver does NOT gate on imports (so Go
+// same-package calls, wildcard imports, etc. keep their existing behaviour).
+//
+// Aliases (`import { A as B }`, `from x import a as b`) record the LOCAL binding
+// (B / b) — that is the name the test body actually calls.
+func extractNamedImports(source string) map[string]bool {
+	out := map[string]bool{}
+	addList := func(list string) {
+		for _, raw := range strings.Split(list, ",") {
+			name := strings.TrimSpace(raw)
+			if name == "" || name == "*" {
+				continue
+			}
+			// `A as B` → bind B (the local name used in the body).
+			if idx := strings.Index(name, " as "); idx >= 0 {
+				name = strings.TrimSpace(name[idx+len(" as "):])
+			}
+			// Strip a `type ` prefix (TS `import { type Foo }`).
+			name = strings.TrimPrefix(name, "type ")
+			name = strings.TrimSpace(name)
+			// Keep only plain identifiers.
+			if name != "" && isPlainIdent(name) {
+				out[name] = true
+			}
+		}
+	}
+	for _, m := range namedImportBraceRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 2 {
+			addList(m[1])
+		}
+	}
+	for _, m := range pyFromImportRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 2 {
+			addList(m[1])
+		}
+	}
+	for _, m := range jsDefaultImportRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 2 && isPlainIdent(m[1]) {
+			out[m[1]] = true
+		}
+	}
+	return out
+}
+
+// isPlainIdent reports whether s is a single bare identifier (no dots, spaces,
+// braces, or operators) — the only form we record as an imported symbol.
+func isPlainIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_', r == '$':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // matchesAnyImport reports whether any hint appears in the token set
 // (substring match tolerant to nested import paths).
 func matchesAnyImport(tokens map[string]bool, hints []string) bool {

--- a/internal/extractors/cross/testmap/import_gate_test.go
+++ b/internal/extractors/cross/testmap/import_gate_test.go
@@ -1,0 +1,236 @@
+package testmap
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #3628 — import-aware high-confidence gate for the direct-call TESTS signal.
+//
+// These tests assert the precision boundary: a direct call to an *imported*
+// symbol is the strongest test→SUT signal and stays high; a direct call to a
+// same-named identifier that was never imported is held at MEDIUM so it is
+// never a high-confidence false link; a symbol that is imported but never
+// called produces NO edge to that symbol.
+// ---------------------------------------------------------------------------
+
+// extractNamedImports — symbol-list parsing across JS/TS + Python forms.
+func TestExtractNamedImports_Forms(t *testing.T) {
+	src := `
+import { UserService, createOrder } from '../user-service';
+import { type Foo, Bar as Baz } from './x';
+import DefaultThing from './default-thing';
+from app.users import create_user, UserService
+from app.orders import (place_order, cancel_order)
+from app.aliased import real_name as aliased_name
+`
+	got := extractNamedImports(src)
+	want := []string{
+		"UserService", "createOrder", "Foo", "Baz", "DefaultThing",
+		"create_user", "place_order", "cancel_order", "aliased_name",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("expected imported symbol %q in set %v", w, keys(got))
+		}
+	}
+	// Alias source name must NOT leak — only the local binding is recorded.
+	if got["Bar"] {
+		t.Errorf("alias source name Bar should not be recorded (only Baz)")
+	}
+	if got["real_name"] {
+		t.Errorf("alias source name real_name should not be recorded (only aliased_name)")
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// POSITIVE: imported symbol called in body → high-confidence TESTS edge, with
+// FROM = test entity (its own scope:testcoverage ref) and TO bound to the
+// imported SUT symbol.
+func TestImportGate_ImportedSymbolCalled_StaysHigh(t *testing.T) {
+	src := `
+import { UserService } from '../user-service';
+describe('UserService', () => {
+  it('creates a user', () => {
+    const svc = new UserService();
+    UserService.create({ name: 'a' });
+  });
+});`
+	recs := runExtract(t, "src/user-service.test.ts", "typescript", src)
+	rec := mustEntityTesting(t, recs, "UserService")
+	var edge *struct{ from, to, conf string }
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "TESTS" && rel.Properties["tested"] == "UserService" {
+				edge = &struct{ from, to, conf string }{rel.FromID, rel.ToID, rel.Properties["confidence"]}
+			}
+		}
+	}
+	if edge == nil {
+		t.Fatalf("no TESTS edge to UserService; entities=%d", len(recs))
+	}
+	if edge.conf != "high" {
+		t.Errorf("imported+called UserService: confidence=%q, want high", edge.conf)
+	}
+	// FROM must be the test entity's own ref (scope:testcoverage:...), not empty.
+	if edge.from == "" {
+		t.Errorf("TESTS edge FROM id is empty")
+	}
+	if edge.from != rec.Properties["ref"] {
+		t.Errorf("TESTS edge FROM=%q, want entity ref %q", edge.from, rec.Properties["ref"])
+	}
+	// TO must resolve to the SUT symbol under the production file path.
+	if edge.to == "" {
+		t.Errorf("TESTS edge TO id is empty")
+	}
+}
+
+// NEGATIVE (precision): a symbol that is NOT imported but is called with a
+// matching name must be held at MEDIUM — never emitted as a high-confidence
+// false link. Here `OtherThing` is called but only `UserService` is imported.
+func TestImportGate_NonImportedCall_HeldAtMedium(t *testing.T) {
+	src := `
+import { UserService } from '../user-service';
+describe('mixed', () => {
+  it('calls both', () => {
+    UserService.create();
+    OtherThing.doStuff();
+  });
+});`
+	recs := runExtract(t, "src/thing.test.ts", "typescript", src)
+	var userConf, otherConf string
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			switch rel.Properties["tested"] {
+			case "UserService.create":
+				userConf = rel.Properties["confidence"]
+			case "OtherThing.doStuff":
+				otherConf = rel.Properties["confidence"]
+			}
+		}
+	}
+	if userConf != "high" {
+		t.Errorf("imported UserService.create: confidence=%q, want high", userConf)
+	}
+	if otherConf == "high" {
+		t.Errorf("non-imported OtherThing.doStuff must NOT be high (got %q) — false-link guard", otherConf)
+	}
+	if otherConf != "medium" {
+		t.Errorf("non-imported OtherThing.doStuff: confidence=%q, want medium", otherConf)
+	}
+}
+
+// NEGATIVE (precision): a symbol that is imported but NEVER called produces no
+// TESTS edge naming it. Only the called import (createOrder) is linked.
+func TestImportGate_ImportedButNotCalled_NoEdge(t *testing.T) {
+	src := `
+import { createOrder, UnusedHelper } from '../orders';
+describe('orders', () => {
+  it('places an order', () => {
+    createOrder({ id: 1 });
+  });
+});`
+	recs := runExtract(t, "src/orders.test.ts", "typescript", src)
+	var sawUnused, sawCreate string
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			switch rel.Properties["tested"] {
+			case "UnusedHelper":
+				sawUnused = rel.Properties["confidence"]
+			case "createOrder":
+				sawCreate = rel.Properties["confidence"]
+			}
+		}
+	}
+	if sawUnused != "" {
+		t.Errorf("imported-but-never-called UnusedHelper must produce NO edge, got confidence=%q", sawUnused)
+	}
+	if sawCreate != "high" {
+		t.Errorf("imported+called createOrder: confidence=%q, want high", sawCreate)
+	}
+}
+
+// pytest: `from app.users import create_user` + call → high; an un-imported
+// same-named call stays at medium.
+func TestImportGate_Pytest_ImportedCallHigh(t *testing.T) {
+	src := `
+from app.users import create_user
+
+def test_create_user():
+    create_user(name="a")
+    legacy_helper()
+`
+	recs := runExtract(t, "tests/test_users.py", "python", src)
+	var createConf, legacyConf string
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			switch rel.Properties["tested"] {
+			case "create_user":
+				createConf = rel.Properties["confidence"]
+			case "legacy_helper":
+				legacyConf = rel.Properties["confidence"]
+			}
+		}
+	}
+	if createConf != "high" {
+		t.Errorf("imported+called create_user: confidence=%q, want high", createConf)
+	}
+	if legacyConf == "high" {
+		t.Errorf("non-imported legacy_helper must NOT be high (got %q)", legacyConf)
+	}
+}
+
+// Go same-package: no named imports of the SUT → gate is disabled, the
+// direct-call signal remains HIGH (regression guard for the disabled path).
+func TestImportGate_GoSamePackage_GateDisabled_StaysHigh(t *testing.T) {
+	src := `package config
+import "testing"
+func TestParseConfig(t *testing.T) {
+    ParseConfig("a.yaml")
+}`
+	recs := runExtract(t, "config/config_test.go", "go", src)
+	var conf string
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "TESTS" && rel.Properties["tested"] == "ParseConfig" {
+				conf = rel.Properties["confidence"]
+			}
+		}
+	}
+	if conf != "high" {
+		t.Errorf("Go same-package ParseConfig: confidence=%q, want high (gate must be disabled when no named SUT imports)", conf)
+	}
+}
+
+// mustEntityTesting returns the entity that has at least one TESTS edge to the
+// subject, failing the test otherwise.
+func mustEntityTesting(t *testing.T, recs []types.EntityRecord, subject string) types.EntityRecord {
+	t.Helper()
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "TESTS" && rel.Properties["tested"] == subject {
+				return r
+			}
+		}
+	}
+	t.Fatalf("no entity with a TESTS edge to %q (got %d entities)", subject, len(recs))
+	return types.EntityRecord{}
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -507,6 +507,18 @@ func tailIdent(qname string) string {
 	return qname[idx+1:]
 }
 
+// headIdent returns the first `.` segment of a dotted name — the receiver of a
+// method call (`UserService` in `UserService.create`). For a bare identifier it
+// returns the identifier unchanged. Used by the import-aware gate to test
+// whether the call's receiver symbol was imported into the test file.
+func headIdent(qname string) string {
+	idx := strings.IndexByte(qname, '.')
+	if idx < 0 {
+		return qname
+	}
+	return qname[:idx]
+}
+
 // resolveCalls returns the list of (production function, confidence) pairs
 // derived from a single test function body.
 //
@@ -518,7 +530,16 @@ func tailIdent(qname string) string {
 // one low-confidence mapping to `convSymbol` (the naming-convention guess).
 // If `convSymbol` is empty a low-confidence mapping is still emitted
 // targeting the test function's stripped name (e.g. `TestGetUser` → `GetUser`).
-func resolveCalls(tf testFunction, prodFile, convSymbol string) []testedCall {
+//
+// importedSyms is the set of named symbols the test file imports (JS/TS
+// `import { X }`, Python `from m import X`). When this set is NON-EMPTY it gates
+// the direct-call signal for QUALITY (#3628): a call to an *imported* symbol is
+// the strongest test→SUT signal and stays high; a direct call to a head symbol
+// that was never imported (a probable local/builtin name collision) is held at
+// medium so it is never a high-confidence false link. An empty set disables the
+// gate entirely (Go same-package, wildcard imports, conventions with no named
+// imports) — behaviour is then identical to the pre-#3628 resolver.
+func resolveCalls(tf testFunction, prodFile, convSymbol string, importedSyms map[string]bool) []testedCall {
 	seen := map[string]string{} // qname → confidence
 
 	upgrade := func(qname, conf string) {
@@ -534,7 +555,10 @@ func resolveCalls(tf testFunction, prodFile, convSymbol string) []testedCall {
 		seen[qname] = conf
 	}
 
-	// Pass 1: direct calls → high.
+	gateImports := len(importedSyms) > 0
+
+	// Pass 1: direct calls → high (held at medium when import-aware and the
+	// receiver symbol was not imported).
 	for _, m := range directCallRE.FindAllStringSubmatch(tf.body, -1) {
 		if len(m) < 2 {
 			continue
@@ -550,7 +574,20 @@ func resolveCalls(tf testFunction, prodFile, convSymbol string) []testedCall {
 		if len(tail) < 3 {
 			continue
 		}
-		upgrade(qname, "high")
+		conf := "high"
+		if gateImports {
+			// The receiver of the call expression is the symbol that must have
+			// been imported: for `UserService.create()` it is `UserService`;
+			// for a bare `createOrder()` it is `createOrder`. If neither the
+			// receiver nor the whole dotted name was imported, hold the edge at
+			// medium rather than emitting a high-confidence link to a
+			// possibly-unrelated local. (#3628)
+			head := headIdent(qname)
+			if !importedSyms[head] && !importedSyms[qname] {
+				conf = "medium"
+			}
+		}
+		upgrade(qname, conf)
 	}
 
 	// Pass 2: mock targets → medium (may upgrade to high if already present).


### PR DESCRIPTION
Closes #3753 (child of #3628).

## Verify-or-build finding
The graph-quality calibration audit flagged "test entities present but ZERO TESTS edges" as a top under-extraction. Investigation shows the cross-language test→production mapper `internal/extractors/cross/testmap/` **already emits** `TESTS` edges (test entity → SUT entity) for all target frameworks — Jest/Vitest, pytest, JUnit (4/5), Go testing, RSpec — plus ~20 others (Minitest, Mockito, TestNG, xUnit/NUnit/MSTest, PHPUnit/Pest, Kotlin/kotest, Scala, Rust, Swift, Elixir, Lua, C/C++). The engine pass `internal/engine/tests_edges.go` additionally multi-hops Django/FastAPI/Flask HTTP test-client calls through `ROUTES_TO` to the ViewSet handler.

So presence was **already built**; the genuine gap was **precision** and **registry under-reporting**.

## Resolution signals (existing, documented here)
- **high** — direct call to a production identifier in the test body
- **medium** — mock target (`when(svc.x())`, `mock.On`, `jest.spyOn`, RSpec `allow().to receive`)
- **medium** — RSpec/Minitest/JUnit/C# describe-subject / class-under-test linkage
- **low** — naming-convention fallback

## Built: import-aware high-confidence gate (precision boundary)
- Extract the test file's **named imported symbols** (JS/TS `import { X }` + default imports; Python `from m import X`, alias-aware → records the local binding).
- When that set is non-empty: a direct call to an **imported** symbol stays **high**; a direct call to a same-named identifier that was **never imported** is held at **medium** — never a high-confidence false link.
- Empty set (Go same-package, wildcard imports, no named imports) **disables** the gate → existing behaviour preserved (regression-guarded by test).

This is exactly the audit's boundary: prefer imported-symbol-called-in-body over name-only; imported-but-never-called → no edge; called-but-not-imported → no false high link.

## TESTS edges asserted (value-asserting, FROM + TO)
- `import { UserService }` + `UserService.create()` → **high** TESTS edge; FROM = test entity's `scope:testcoverage:` ref, TO = SUT id under the prod file.
- Mixed body: imported `UserService.create` → high; non-imported `OtherThing.doStuff` → **medium** (asserted NOT high).
- `import { createOrder, UnusedHelper }`, only `createOrder()` called → edge to `createOrder` (high), **no edge** to `UnusedHelper`.
- pytest `from app.users import create_user` + call → high; un-imported `legacy_helper()` → not high.
- Go `config_test.go` `TestParseConfig` calling `ParseConfig` (same package, no named import) → **high** (gate disabled).
- `extractNamedImports` parses JS named/default + Python from-imports, drops alias source names.

## Coverage registry
- Enriched `target_extraction` cites on full records (jest, vitest, pytest, junit5, go-testing, rspec) to cite the cross-language emitter + resolver.
- mockito: `missing` → `partial` (mock-target resolution yields medium TESTS edges).
- junit4/testng/minitest: kept `partial`, added emitter cite + honest scope notes; testng/mockito linked to #3753.
- `coverage fmt --check` canonical; `coverage validate` 0 errors.

## Validation
- `go test ./internal/extractors/cross/testmap/ ./internal/engine/ ./internal/types/ ./internal/custom/... ./internal/links/... ./tools/coverage/` — green
- `gofmt -l` empty; `go vet` clean

## DEPLOY-DEFERRED
The extractor change requires a daemon rebuild + reindex to take effect; deferred to the next coordinated daemon update (the live daemon serves the rewrite agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)