### PR TITLE
feat(config): DEPENDS_ON_CONFIG key consumption for Ruby/PHP/.NET

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -7261,8 +7261,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -7505,8 +7508,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -7707,8 +7713,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -7905,8 +7914,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -8103,8 +8115,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -8330,8 +8345,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -8561,8 +8579,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -8724,8 +8745,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -8939,8 +8963,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "missing",
@@ -9143,8 +9170,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -9354,8 +9384,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -9581,8 +9614,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -9731,8 +9767,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -9820,8 +9859,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -9909,8 +9951,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -10059,8 +10104,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/csharp/config_consumer.go","internal/extractors/csharp/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "IConfiguration indexer/GetValue/GetConnectionString + Environment.GetEnvironmentVariable -\u003e config:\u003ckey\u003e (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -40233,8 +40281,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "missing",
@@ -40433,8 +40484,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -40665,8 +40719,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -40897,8 +40954,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -41116,8 +41176,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "missing",
@@ -41316,8 +41379,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -41548,8 +41614,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -41767,8 +41836,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "missing",
@@ -41967,8 +42039,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -42199,8 +42274,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -42431,8 +42509,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -42663,8 +42744,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -42899,8 +42983,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -43131,8 +43218,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -43363,8 +43453,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/php/config_consumer.go","internal/extractors/php/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "getenv/$_ENV + Laravel env()/config() -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -50919,8 +51012,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -51137,8 +51233,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -51356,8 +51455,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -51575,8 +51677,11 @@
             "issue": "3621"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3621"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "missing",
@@ -51770,8 +51875,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -51992,8 +52100,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -52218,8 +52329,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "partial",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...]/ENV.fetch -\u003e config:\u003ckey\u003e covered; Rails.application.credentials not yet extracted (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -52453,8 +52567,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",
@@ -52680,8 +52797,11 @@
             "verified_at": "2026-05-28"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3641"
+            "status": "full",
+            "cites": ["internal/extractor/config_key.go","internal/extractors/ruby/config_consumer.go","internal/extractors/ruby/config_consumer_test.go"],
+            "issue": "3641",
+            "notes": "ENV[...], ENV.fetch -\u003e config:\u003ckey\u003e DEPENDS_ON_CONFIG edges (issue #3641)",
+            "verified_at": "2026-06-02"
           },
           "constant_propagation": {
             "status": "full",

--- a/internal/extractors/csharp/config_consumer.go
+++ b/internal/extractors/csharp/config_consumer.go
@@ -1,0 +1,261 @@
+// config_consumer.go — supplemental pass that emits DEPENDS_ON_CONFIG edges
+// from .NET / C# code that reads a configuration key to a shared config-key
+// entity (issue #3641, epic #3625).
+//
+// Detected reader shapes (literal keys only — honest-partial):
+//
+//	Configuration["ConnectionStrings:Default"]   → config:ConnectionStrings:Default
+//	_configuration["App:Url"]                     → config:App:Url   (element access)
+//	Configuration.GetValue<int>("App:Port")       → config:App:Port  (GetValue)
+//	Configuration.GetConnectionString("Default")  → config:Default   (named conn)
+//	Environment.GetEnvironmentVariable("PATH")    → config:PATH      (env var)
+//
+// Dynamic keys — Configuration[key], GetValue<T>(name) — are NOT emitted; only
+// literal string keys are recorded so the graph never fabricates a missing key.
+//
+// Each read produces a SCOPE.Config / config_key entity (shared, file-agnostic
+// node) and a DEPENDS_ON_CONFIG edge from the enclosing method (or the file
+// entity at type/file scope) to it, mirroring the Go/Java/JS config_consumer
+// shape at config-KEY granularity so config:<key>'s inbound edges are the
+// config-change blast radius.
+
+package csharp
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitConfigConsumerEdges scans every method / constructor body (and type/file
+// scope) for config-read shapes and appends config-key entities +
+// DEPENDS_ON_CONFIG edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var reads []extractor.ConfigRead
+
+	var walk func(n *sitter.Node, enclosingType, enclosing string)
+	walk = func(n *sitter.Node, enclosingType, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration":
+			cls := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), cls, enclosing)
+			}
+			return
+		case "method_declaration", "constructor_declaration":
+			leaf := childFieldText(n, "name", src)
+			name := leaf
+			if enclosingType != "" && leaf != "" {
+				name = enclosingType + "." + leaf
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingType, name)
+			}
+			return
+		case "invocation_expression":
+			if key, pat := csharpInvocationConfigKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: pat})
+			}
+		case "element_access_expression":
+			if key := csharpElementAccessConfigKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: "configuration_indexer"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingType, enclosing)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitConfigReads(entities, "csharp", reads)
+}
+
+// csharpInvocationConfigKey returns the literal config key + detector label for
+// a supported method invocation, or ("","") otherwise.
+//
+//	<cfg>.GetValue<T>("k") / <cfg>.GetValue("k")       → "get_value"
+//	<cfg>.GetConnectionString("name")                  → "get_connection_string"
+//	<cfg>.GetSection("k") / <cfg>.GetRequiredSection   → "get_section"
+//	Environment.GetEnvironmentVariable("X")            → "env_var"
+func csharpInvocationConfigKey(call *sitter.Node, src []byte) (string, string) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return "", ""
+	}
+	nameNode := fn.ChildByFieldName("name")
+	if nameNode == nil {
+		return "", ""
+	}
+	// `GetValue<int>(...)` parses the name as a generic_name; the method
+	// identifier is its leading identifier child.
+	method := nodeText(nameNode, src)
+	if nameNode.Type() == "generic_name" {
+		for i := 0; i < int(nameNode.ChildCount()); i++ {
+			ch := nameNode.Child(i)
+			if ch != nil && ch.Type() == "identifier" {
+				method = nodeText(ch, src)
+				break
+			}
+		}
+	}
+	obj := fn.ChildByFieldName("expression")
+	recv := ""
+	if obj != nil {
+		recv = strings.TrimSpace(nodeText(obj, src))
+	}
+
+	pattern := ""
+	switch method {
+	case "GetValue", "GetSection", "GetRequiredSection", "GetConnectionString":
+		// Gate on a receiver that looks like an IConfiguration handle.
+		if csharpLooksLikeConfig(recv) {
+			switch method {
+			case "GetConnectionString":
+				pattern = "get_connection_string"
+			case "GetValue":
+				pattern = "get_value"
+			default:
+				pattern = "get_section"
+			}
+		}
+	case "GetEnvironmentVariable":
+		if recv == "Environment" || strings.HasSuffix(recv, ".Environment") {
+			pattern = "env_var"
+		}
+	}
+	if pattern == "" {
+		return "", ""
+	}
+
+	key := csharpFirstStringArg(call.ChildByFieldName("arguments"), src)
+	if key == "" {
+		return "", ""
+	}
+	return key, pattern
+}
+
+// csharpElementAccessConfigKey returns the config key for a
+// Configuration["KEY"] / _config["KEY"] element-access expression with a
+// literal string index, or "".
+func csharpElementAccessConfigKey(n *sitter.Node, src []byte) string {
+	exprNode := n.ChildByFieldName("expression")
+	if exprNode == nil {
+		// expression is the first child when the field is unnamed.
+		if n.NamedChildCount() > 0 {
+			exprNode = n.NamedChild(0)
+		}
+	}
+	if exprNode == nil {
+		return ""
+	}
+	recv := strings.TrimSpace(nodeText(exprNode, src))
+	if !csharpLooksLikeConfig(recv) {
+		return ""
+	}
+	// The subscript lives in the bracketed_argument_list child.
+	var bracket *sitter.Node
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		if n.NamedChild(i).Type() == "bracketed_argument_list" {
+			bracket = n.NamedChild(i)
+			break
+		}
+	}
+	if bracket == nil {
+		return ""
+	}
+	return csharpFirstStringArg(bracket, src)
+}
+
+// csharpLooksLikeConfig reports whether recv looks like an IConfiguration
+// handle. We accept the canonical names plus common field/property idioms
+// (Configuration, _configuration, _config, config, configuration) so the
+// detection stays precise without cross-file type resolution.
+func csharpLooksLikeConfig(recv string) bool {
+	if recv == "" || strings.ContainsAny(recv, "().[]{}") {
+		// Strip a leading "this." so `this._config` still matches.
+		trimmed := strings.TrimPrefix(recv, "this.")
+		if trimmed == recv || strings.ContainsAny(trimmed, "().[]{}") {
+			return false
+		}
+		recv = trimmed
+	}
+	switch recv {
+	case "Configuration", "configuration", "_configuration",
+		"_config", "config", "Config", "Settings", "_settings":
+		return true
+	}
+	return strings.HasSuffix(recv, "Configuration") || strings.HasSuffix(recv, "configuration")
+}
+
+// csharpFirstStringArg returns the literal content of the first string argument
+// in an argument_list / bracketed_argument_list node, or "" when the first
+// argument is missing or non-literal (dynamic) — honest-partial.
+func csharpFirstStringArg(args *sitter.Node, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		arg := args.NamedChild(i)
+		if arg.Type() != "argument" {
+			continue
+		}
+		// Unwrap the argument to its inner expression.
+		inner := arg
+		if arg.NamedChildCount() == 1 {
+			inner = arg.NamedChild(0)
+		}
+		if s := csharpStringLiteral(inner, src); s != "" {
+			return s
+		}
+		// First positional argument is non-literal → dynamic, skip.
+		return ""
+	}
+	return ""
+}
+
+// csharpStringLiteral extracts the literal content of a C# string node,
+// dropping the surrounding quotes. Handles regular, verbatim (@"..."), and
+// interpolated strings — returns "" for an interpolated string carrying an
+// `interpolation` part (dynamic), honest-partial.
+func csharpStringLiteral(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Type() {
+	case "string_literal", "verbatim_string_literal", "raw_string_literal":
+		raw := strings.TrimSpace(nodeText(node, src))
+		return csharpUnquote(raw)
+	case "interpolated_string_expression":
+		// Any interpolation child => dynamic key, skip.
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			if node.NamedChild(i).Type() == "interpolation" {
+				return ""
+			}
+		}
+		return csharpUnquote(strings.TrimSpace(nodeText(node, src)))
+	}
+	return ""
+}
+
+// csharpUnquote strips a leading verbatim/interpolation marker ('@' / '$') and
+// the surrounding double-quotes from a C# string literal's raw text.
+func csharpUnquote(raw string) string {
+	raw = strings.TrimLeft(raw, "@$")
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}

--- a/internal/extractors/csharp/config_consumer_test.go
+++ b/internal/extractors/csharp/config_consumer_test.go
@@ -1,0 +1,160 @@
+package csharp_test
+
+// config_consumer_test.go — value-asserting tests for the C# / .NET config-read
+// pass (issue #3641, epic #3625). Asserts the SPECIFIC config key + edge.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractCSharpRecords(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("csharp")
+	if !ok {
+		t.Fatal("csharp extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "cfg.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	return recs
+}
+
+func csharpConfigKeysFrom(recs []types.EntityRecord, from string) map[string]bool {
+	keys := map[string]bool{}
+	for i := range recs {
+		e := &recs[i]
+		match := (from == "" && e.Kind == "SCOPE.Component" && e.Subtype == "file") ||
+			(from != "" && e.Name == from)
+		if !match {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" {
+				keys[r.Properties["config_key"]] = true
+			}
+		}
+	}
+	return keys
+}
+
+func csharpHasConfigKeyEntity(recs []types.EntityRecord, key string) bool {
+	for i := range recs {
+		e := &recs[i]
+		if e.Kind == "SCOPE.Config" && e.Subtype == "config_key" && e.Properties["config_key"] == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCSharpConfigConsumer_IndexerAndGetters(t *testing.T) {
+	src := `
+class StartupService {
+    void Configure() {
+        var a = Configuration["App:Url"];
+        var b = Configuration.GetValue<int>("App:Port");
+        var c = _configuration.GetConnectionString("Default");
+    }
+}
+`
+	recs := extractCSharpRecords(t, src)
+	keys := csharpConfigKeysFrom(recs, "StartupService.Configure")
+	for _, want := range []string{"App:Url", "App:Port", "Default"} {
+		if !keys[want] {
+			t.Errorf("expected DEPENDS_ON_CONFIG(StartupService.Configure → %s); got %v", want, keys)
+		}
+	}
+	if !csharpHasConfigKeyEntity(recs, "App:Url") {
+		t.Error("expected SCOPE.Config/config_key entity for App:Url")
+	}
+}
+
+func TestCSharpConfigConsumer_EnvironmentVariable(t *testing.T) {
+	src := `
+class Loader {
+    void Load() {
+        var p = Environment.GetEnvironmentVariable("DATABASE_URL");
+    }
+}
+`
+	recs := extractCSharpRecords(t, src)
+	keys := csharpConfigKeysFrom(recs, "Loader.Load")
+	if !keys["DATABASE_URL"] {
+		t.Errorf("expected DATABASE_URL via Environment.GetEnvironmentVariable; got %v", keys)
+	}
+}
+
+// Negative: a dynamic (variable) key must NOT produce an edge — honest-partial.
+func TestCSharpConfigConsumer_DynamicKeySkipped(t *testing.T) {
+	src := `
+class Reader {
+    void Read(string name) {
+        var a = Configuration[name];
+        var b = Configuration.GetValue<int>(name);
+        var c = Environment.GetEnvironmentVariable(name);
+    }
+}
+`
+	recs := extractCSharpRecords(t, src)
+	keys := csharpConfigKeysFrom(recs, "Reader.Read")
+	if len(keys) != 0 {
+		t.Errorf("dynamic key must be skipped; got %v", keys)
+	}
+}
+
+// Cross-language convergence: the C# config-key entity ID for DATABASE_URL must
+// equal the constant ID extractor.ConfigKeyEntity produces for any language, so
+// a Node `process.env.DATABASE_URL` and a C# Environment read of the same key
+// land on ONE shared SCOPE.Config node ("who depends on DATABASE_URL").
+func TestCSharpConfigConsumer_CrossLanguageConvergence(t *testing.T) {
+	src := `
+class Loader {
+    void Load() {
+        var p = Environment.GetEnvironmentVariable("DATABASE_URL");
+    }
+}
+`
+	recs := extractCSharpRecords(t, src)
+
+	// The DEPENDS_ON_CONFIG edge's ToID must equal the canonical target ID.
+	wantTarget := extractor.ConfigKeyTargetID("DATABASE_URL")
+	var foundEdge bool
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" && r.ToID == wantTarget {
+				foundEdge = true
+			}
+		}
+	}
+	if !foundEdge {
+		t.Fatalf("C# edge ToID must be the cross-language target ID %q", wantTarget)
+	}
+
+	// The emitted config-key entity ID must match what a Node/Python/Go
+	// extractor would compute for the same key (synthetic SourceFile dedup).
+	csharpKeyID := ""
+	for i := range recs {
+		e := &recs[i]
+		if e.Kind == "SCOPE.Config" && e.Subtype == "config_key" && e.Properties["config_key"] == "DATABASE_URL" {
+			csharpKeyID = e.ID
+		}
+	}
+	nodeKeyID := extractor.ConfigKeyEntity("DATABASE_URL", "javascript").ID
+	if csharpKeyID == "" {
+		t.Fatal("no DATABASE_URL config-key entity emitted by C# extractor")
+	}
+	if csharpKeyID != nodeKeyID {
+		t.Errorf("cross-language convergence broken: C# key ID %q != Node key ID %q", csharpKeyID, nodeKeyID)
+	}
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -72,6 +72,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	root := file.Tree.RootNode()
 	imports := collectImportNames(root, file.Content)
 	walk(root, file, "", nil, imports, &entities)
+	// Issue #3641 (epic #3625) — config-key consumption edges
+	// (Configuration["X"] / GetValue / GetConnectionString /
+	// Environment.GetEnvironmentVariable) → shared SCOPE.Config config_key nodes.
+	emitConfigConsumerEdges(root, file.Content, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "csharp")
 	extractor.TagEntitiesLanguage(entities, "csharp")

--- a/internal/extractors/php/config_consumer.go
+++ b/internal/extractors/php/config_consumer.go
@@ -1,0 +1,200 @@
+// config_consumer.go — supplemental pass that emits DEPENDS_ON_CONFIG edges
+// from PHP / Laravel code that reads a configuration key to a shared config-key
+// entity (issue #3641, epic #3625).
+//
+// Detected reader shapes (literal keys only — honest-partial):
+//
+//	getenv('DATABASE_URL')           → config:DATABASE_URL   (env_getenv)
+//	$_ENV['DATABASE_URL']            → config:DATABASE_URL   (env_superglobal)
+//	env('APP_KEY')                   → config:APP_KEY        (laravel_env)
+//	config('app.timezone')           → config:app.timezone  (laravel_config)
+//
+// Dynamic keys — getenv($var), env($name), config($key), $_ENV[$var] — are NOT
+// emitted; only literal string keys are recorded so the graph never fabricates
+// a missing key.
+//
+// Each read produces a SCOPE.Config / config_key entity (shared, file-agnostic
+// node) and a DEPENDS_ON_CONFIG edge from the enclosing function / method (or
+// the file entity at top level) to it, mirroring the Go/Java/JS config_consumer
+// shape at config-KEY granularity so config:<key>'s inbound edges are the
+// config-change blast radius.
+
+package php
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitConfigConsumerEdges scans every function / method body (and file scope)
+// for config-read shapes and appends config-key entities + DEPENDS_ON_CONFIG
+// edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var reads []extractor.ConfigRead
+
+	var walk func(n *sitter.Node, enclosingClass, enclosing string)
+	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration", "interface_declaration", "trait_declaration":
+			cls := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), cls, enclosing)
+			}
+			return
+		case "method_declaration":
+			leaf := childFieldText(n, "name", src)
+			name := leaf
+			if enclosingClass != "" && leaf != "" {
+				name = enclosingClass + "." + leaf
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, name)
+			}
+			return
+		case "function_definition":
+			leaf := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, leaf)
+			}
+			return
+		case "function_call_expression":
+			if key, pat := phpFunctionCallConfigKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: pat})
+			}
+		case "subscript_expression":
+			if key := phpSuperglobalEnvKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: "env_superglobal"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingClass, enclosing)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitConfigReads(entities, "php", reads)
+}
+
+// phpFunctionCallConfigKey returns the literal config key + detector label when
+// the call is one of the supported reader functions with a literal first
+// string argument, or ("","") otherwise.
+//
+//	getenv('X')          → "env_getenv"
+//	env('X')             → "laravel_env"     (Laravel global helper)
+//	config('app.x')      → "laravel_config"  (Laravel global helper)
+func phpFunctionCallConfigKey(call *sitter.Node, src []byte) (string, string) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "name" {
+		return "", ""
+	}
+	pattern := ""
+	switch strings.TrimSpace(string(src[fn.StartByte():fn.EndByte()])) {
+	case "getenv":
+		pattern = "env_getenv"
+	case "env":
+		pattern = "laravel_env"
+	case "config":
+		pattern = "laravel_config"
+	default:
+		return "", ""
+	}
+	key := phpFirstStringArg(call.ChildByFieldName("arguments"), src)
+	if key == "" {
+		return "", ""
+	}
+	return key, pattern
+}
+
+// phpSuperglobalEnvKey returns the config key for a $_ENV['X'] (or
+// $_SERVER['X']) subscript expression with a literal string index, or "".
+//
+// tree-sitter-php shape: (subscript_expression (variable_name) (string ...)).
+func phpSuperglobalEnvKey(n *sitter.Node, src []byte) string {
+	// The subscripted object is the first child; the index is field "index" in
+	// most grammar revisions, else the last named child.
+	var obj *sitter.Node
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		obj = n.NamedChild(i)
+		break
+	}
+	if obj == nil || obj.Type() != "variable_name" {
+		return ""
+	}
+	recv := strings.TrimSpace(string(src[obj.StartByte():obj.EndByte()]))
+	if recv != "$_ENV" && recv != "$_SERVER" {
+		return ""
+	}
+	idx := n.ChildByFieldName("index")
+	if idx == nil {
+		// Fallback: the index is the second named child.
+		if n.NamedChildCount() >= 2 {
+			idx = n.NamedChild(1)
+		}
+	}
+	if idx == nil {
+		return ""
+	}
+	return phpStringLiteral(idx, src)
+}
+
+// phpFirstStringArg returns the literal content of the first string argument in
+// an `arguments` node, or "" when the first argument is missing or non-literal
+// (dynamic) — honest-partial.
+func phpFirstStringArg(args *sitter.Node, src []byte) string {
+	if args == nil || args.NamedChildCount() == 0 {
+		return ""
+	}
+	first := args.NamedChild(0)
+	if first == nil {
+		return ""
+	}
+	// The argument node may wrap the literal (grammar revisions differ); unwrap
+	// a single-child `argument` node to its inner expression.
+	if first.Type() == "argument" && first.NamedChildCount() == 1 {
+		first = first.NamedChild(0)
+	}
+	return phpStringLiteral(first, src)
+}
+
+// phpStringLiteral extracts the literal content of a PHP string node, dropping
+// the surrounding quotes. Returns "" for an interpolated (encapsed) string that
+// contains a variable / expression — honest-partial, no fabrication.
+func phpStringLiteral(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Type() {
+	case "string", "encapsed_string":
+		// Reject interpolation: any non-text child means a dynamic segment.
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			ct := node.NamedChild(i).Type()
+			if ct != "string_content" && ct != "string_value" && ct != "escape_sequence" {
+				return ""
+			}
+		}
+		raw := strings.TrimSpace(string(src[node.StartByte():node.EndByte()]))
+		if len(raw) >= 2 {
+			q := raw[0]
+			if (q == '"' || q == '\'') && raw[len(raw)-1] == q {
+				return raw[1 : len(raw)-1]
+			}
+		}
+		return raw
+	}
+	return ""
+}

--- a/internal/extractors/php/config_consumer_test.go
+++ b/internal/extractors/php/config_consumer_test.go
@@ -1,0 +1,114 @@
+package php_test
+
+// config_consumer_test.go — value-asserting tests for the PHP config-read pass
+// (issue #3641, epic #3625). Asserts the SPECIFIC config key + edge, not len>0.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractPHPRecords(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("php")
+	if !ok {
+		t.Fatal("php extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "cfg.php",
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	return recs
+}
+
+func phpConfigKeysFrom(recs []types.EntityRecord, from string) map[string]bool {
+	keys := map[string]bool{}
+	for i := range recs {
+		e := &recs[i]
+		match := (from == "" && e.Kind == "SCOPE.Component" && e.Subtype == "file") ||
+			(from != "" && e.Name == from)
+		if !match {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" {
+				keys[r.Properties["config_key"]] = true
+			}
+		}
+	}
+	return keys
+}
+
+func phpHasConfigKeyEntity(recs []types.EntityRecord, key string) bool {
+	for i := range recs {
+		e := &recs[i]
+		if e.Kind == "SCOPE.Config" && e.Subtype == "config_key" && e.Properties["config_key"] == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPHPConfigConsumer_GetenvAndSuperglobal(t *testing.T) {
+	src := `<?php
+class Db {
+    public function connect(): void {
+        $url = getenv('DATABASE_URL');
+        $host = $_ENV['REDIS_HOST'];
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	keys := phpConfigKeysFrom(recs, "Db.connect")
+	if !keys["DATABASE_URL"] {
+		t.Errorf("expected DEPENDS_ON_CONFIG(Db.connect → DATABASE_URL); got %v", keys)
+	}
+	if !keys["REDIS_HOST"] {
+		t.Errorf("expected DEPENDS_ON_CONFIG(Db.connect → REDIS_HOST) via $_ENV; got %v", keys)
+	}
+	if !phpHasConfigKeyEntity(recs, "DATABASE_URL") {
+		t.Error("expected SCOPE.Config/config_key entity for DATABASE_URL")
+	}
+}
+
+func TestPHPConfigConsumer_LaravelHelpers(t *testing.T) {
+	src := `<?php
+function boot(): void {
+    $key = env('APP_KEY');
+    $tz = config('app.timezone');
+}
+`
+	recs := extractPHPRecords(t, src)
+	keys := phpConfigKeysFrom(recs, "boot")
+	if !keys["APP_KEY"] {
+		t.Errorf("expected APP_KEY via Laravel env(); got %v", keys)
+	}
+	if !keys["app.timezone"] {
+		t.Errorf("expected app.timezone via Laravel config(); got %v", keys)
+	}
+}
+
+// Negative: a dynamic (variable) key must NOT produce an edge — honest-partial.
+func TestPHPConfigConsumer_DynamicKeySkipped(t *testing.T) {
+	src := `<?php
+function read(string $name): void {
+    getenv($name);
+    env($name);
+    $x = $_ENV[$name];
+}
+`
+	recs := extractPHPRecords(t, src)
+	keys := phpConfigKeysFrom(recs, "read")
+	if len(keys) != 0 {
+		t.Errorf("dynamic key must be skipped; got %v", keys)
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -65,7 +65,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	walk(file.Tree.RootNode(), file, "", &entities)
+	root := file.Tree.RootNode()
+	walk(root, file, "", &entities)
+	// Issue #3641 (epic #3625) — config-key consumption edges
+	// (getenv / $_ENV / Laravel env() / config()) → shared SCOPE.Config nodes.
+	emitConfigConsumerEdges(root, file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")

--- a/internal/extractors/ruby/config_consumer.go
+++ b/internal/extractors/ruby/config_consumer.go
@@ -1,0 +1,154 @@
+// config_consumer.go — supplemental pass that emits DEPENDS_ON_CONFIG edges
+// from Ruby methods that read a configuration key to a shared config-key
+// entity (issue #3641, epic #3625).
+//
+// Detected reader shapes (literal keys only — honest-partial):
+//
+//	ENV['DATABASE_URL']              → config:DATABASE_URL   (element reference)
+//	ENV["DATABASE_URL"]              → config:DATABASE_URL
+//	ENV.fetch('REDIS_URL')           → config:REDIS_URL      (fetch, w/ default)
+//	ENV.fetch('REDIS_URL', 'x')      → config:REDIS_URL
+//
+// Dynamic keys — ENV[var], ENV.fetch(var) — are NOT emitted; only literal
+// string keys are recorded so the graph never fabricates a missing key.
+//
+// Each read produces a SCOPE.Config / config_key entity (shared, file-agnostic
+// node) and a DEPENDS_ON_CONFIG edge from the enclosing method (or the file
+// entity at top level) to it, mirroring the Go/Java/JS config_consumer shape at
+// config-KEY granularity so config:<key>'s inbound edges are the config-change
+// blast radius.
+
+package ruby
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitConfigConsumerEdges scans every method / singleton_method body (and the
+// top level) for config-read shapes and appends config-key entities +
+// DEPENDS_ON_CONFIG edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var reads []extractor.ConfigRead
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "method", "singleton_method":
+			// Method bodies attach reads to the bare method Name (matching the
+			// entity Name emitted by buildMethod).
+			name := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), name)
+			}
+			return
+		case "element_reference":
+			// ENV['KEY'] / ENV["KEY"].
+			if key := rubyEnvElementKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: "env"})
+			}
+		case "call":
+			// ENV.fetch('KEY' [, default]).
+			if key := rubyEnvFetchKey(n, src); key != "" {
+				reads = append(reads, extractor.ConfigRead{Key: key, FromName: enclosing, Pattern: "env_fetch"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitConfigReads(entities, "ruby", reads)
+}
+
+// rubyEnvElementKey returns the config key for an ENV['KEY'] element reference
+// with a literal string index, or "" otherwise.
+//
+// tree-sitter-ruby shape: (element_reference object: (constant) (string ...)).
+func rubyEnvElementKey(n *sitter.Node, src []byte) string {
+	obj := n.ChildByFieldName("object")
+	if obj == nil || strings.TrimSpace(rubyNodeText(obj, src)) != "ENV" {
+		return ""
+	}
+	// The index is the first string argument child after the object.
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch == obj {
+			continue
+		}
+		if ch.Type() == "string" {
+			return rubyStringContent(ch, src)
+		}
+		// Non-literal index (variable / expression) → dynamic, skip.
+		return ""
+	}
+	return ""
+}
+
+// rubyEnvFetchKey returns the config key for an ENV.fetch('KEY' [, default])
+// call with a literal first string argument, or "" otherwise.
+func rubyEnvFetchKey(n *sitter.Node, src []byte) string {
+	recv := n.ChildByFieldName("receiver")
+	method := n.ChildByFieldName("method")
+	if recv == nil || method == nil {
+		return ""
+	}
+	if strings.TrimSpace(rubyNodeText(recv, src)) != "ENV" {
+		return ""
+	}
+	if rubyNodeText(method, src) != "fetch" {
+		return ""
+	}
+	args := n.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	first := args.NamedChild(0)
+	if first == nil || first.Type() != "string" {
+		return "" // no literal first arg → dynamic, skip
+	}
+	return rubyStringContent(first, src)
+}
+
+// rubyStringContent extracts the literal content of a tree-sitter-ruby string
+// node, dropping the surrounding quotes. Returns "" for an interpolated string
+// (one carrying an `interpolation` child) — honest-partial, no fabrication.
+func rubyStringContent(strNode *sitter.Node, src []byte) string {
+	for i := 0; i < int(strNode.NamedChildCount()); i++ {
+		if strNode.NamedChild(i).Type() == "interpolation" {
+			return "" // dynamic content → skip
+		}
+	}
+	raw := rubyNodeText(strNode, src)
+	raw = strings.TrimSpace(raw)
+	if len(raw) >= 2 {
+		q := raw[0]
+		if (q == '"' || q == '\'') && raw[len(raw)-1] == q {
+			return raw[1 : len(raw)-1]
+		}
+	}
+	return raw
+}
+
+// rubyNodeText returns the raw source text spanned by node.
+func rubyNodeText(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	return string(src[node.StartByte():node.EndByte()])
+}

--- a/internal/extractors/ruby/config_consumer_test.go
+++ b/internal/extractors/ruby/config_consumer_test.go
@@ -1,0 +1,123 @@
+package ruby_test
+
+// config_consumer_test.go — value-asserting tests for the Ruby config-read pass
+// (issue #3641, epic #3625). Asserts the SPECIFIC config key + edge, not len>0.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractRubyRecords(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("ruby")
+	if !ok {
+		t.Fatal("ruby extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "cfg.rb",
+		Content:  []byte(src),
+		Language: "ruby",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	return recs
+}
+
+// configKeysFrom returns the set of config keys read by the entity whose
+// Name == from (use "" for file scope, matched by Subtype="file").
+func configKeysFrom(recs []types.EntityRecord, from string) map[string]bool {
+	keys := map[string]bool{}
+	for i := range recs {
+		e := &recs[i]
+		match := (from == "" && e.Kind == "SCOPE.Component" && e.Subtype == "file") ||
+			(from != "" && e.Name == from)
+		if !match {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" {
+				keys[r.Properties["config_key"]] = true
+			}
+		}
+	}
+	return keys
+}
+
+func hasConfigKeyEntity(recs []types.EntityRecord, key string) bool {
+	for i := range recs {
+		e := &recs[i]
+		if e.Kind == "SCOPE.Config" && e.Subtype == "config_key" && e.Properties["config_key"] == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRubyConfigConsumer_EnvElementReference(t *testing.T) {
+	src := `
+def connect
+  url = ENV['DATABASE_URL']
+  host = ENV["REDIS_HOST"]
+end
+`
+	recs := extractRubyRecords(t, src)
+	keys := configKeysFrom(recs, "connect")
+	if !keys["DATABASE_URL"] {
+		t.Errorf("expected DEPENDS_ON_CONFIG(connect → DATABASE_URL); got %v", keys)
+	}
+	if !keys["REDIS_HOST"] {
+		t.Errorf("expected DEPENDS_ON_CONFIG(connect → REDIS_HOST); got %v", keys)
+	}
+	if !hasConfigKeyEntity(recs, "DATABASE_URL") {
+		t.Error("expected SCOPE.Config/config_key entity for DATABASE_URL")
+	}
+}
+
+func TestRubyConfigConsumer_EnvFetch(t *testing.T) {
+	src := `
+def settings
+  ENV.fetch('SECRET_KEY')
+  ENV.fetch('PORT', '3000')
+end
+`
+	recs := extractRubyRecords(t, src)
+	keys := configKeysFrom(recs, "settings")
+	if !keys["SECRET_KEY"] {
+		t.Errorf("expected SECRET_KEY via ENV.fetch; got %v", keys)
+	}
+	if !keys["PORT"] {
+		t.Errorf("expected PORT via ENV.fetch with default; got %v", keys)
+	}
+}
+
+// Negative: a dynamic (variable) key must NOT produce an edge — honest-partial.
+func TestRubyConfigConsumer_DynamicKeySkipped(t *testing.T) {
+	src := `
+def read(name)
+  ENV[name]
+  ENV.fetch(name)
+end
+`
+	recs := extractRubyRecords(t, src)
+	keys := configKeysFrom(recs, "read")
+	if len(keys) != 0 {
+		t.Errorf("dynamic key must be skipped; got %v", keys)
+	}
+}
+
+// Interpolated string keys are dynamic → skipped.
+func TestRubyConfigConsumer_InterpolatedKeySkipped(t *testing.T) {
+	src := "def read(p)\n  ENV[\"PREFIX_#{p}\"]\nend\n"
+	recs := extractRubyRecords(t, src)
+	keys := configKeysFrom(recs, "read")
+	if len(keys) != 0 {
+		t.Errorf("interpolated key must be skipped; got %v", keys)
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -43,7 +43,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	walk(file.Tree.RootNode(), file, &entities)
+	root := file.Tree.RootNode()
+	walk(root, file, &entities)
+	// Issue #3641 (epic #3625) — config-key consumption edges
+	// (ENV['X'] / ENV.fetch('X')) → shared SCOPE.Config config_key nodes.
+	emitConfigConsumerEdges(root, file.Content, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")


### PR DESCRIPTION
Closes #3758 · Parent epic #3628 · Builds on #3641 / #3625.

## What
Extends the config-key consumption topology (`SCOPE.Config / config_key` nodes + `DEPENDS_ON_CONFIG` edges, wave-4) to the three remaining languages that lacked it — **Ruby, PHP, and C#/.NET**. A function/method reading a literal config key now links to a shared, file-agnostic config-key node, enabling cross-language "what depends on this config key" blast-radius queries.

Reuses the existing `extractor.EmitConfigReads` / `ConfigKeyEntity` / `ConfigKeyTargetID` contract (`internal/extractor/config_key.go`) — **no new entity kinds** (`SCOPE.Config` + `DEPENDS_ON_CONFIG` already registered).

## Verify-or-build findings
Already implemented before this PR (verified by grep + reading the extractors): **Go, Java, JS/TS** all emit config-key edges via their `config_consumer.go`. Python uses the older settings.py `config_module` shape. Only **Ruby / PHP / C#** were missing — built here.

## Patterns (literal keys only — dynamic/interpolated keys skipped, honest-partial)
| Lang | Patterns | Detector labels |
|------|----------|-----------------|
| Ruby | `ENV['X']`, `ENV["X"]`, `ENV.fetch('X' [, default])` | `env`, `env_fetch` |
| PHP  | `getenv('X')`, `$_ENV['X']`/`$_SERVER['X']`, Laravel `env('X')`, `config('app.x')` | `env_getenv`, `env_superglobal`, `laravel_env`, `laravel_config` |
| C#   | `Configuration["X"]`, `GetValue<T>("X")`, `GetConnectionString("X")`, `GetSection("X")`, `Environment.GetEnvironmentVariable("X")` | `configuration_indexer`, `get_value`, `get_connection_string`, `get_section`, `env_var` |

## Config-key edges asserted (value-asserting tests, not len>0)
- Ruby: `connect()` reading `ENV['DATABASE_URL']` → `DEPENDS_ON_CONFIG(connect → config:DATABASE_URL)`; `ENV.fetch('SECRET_KEY')` → `SECRET_KEY`
- PHP: `Db.connect` → `DATABASE_URL` (getenv) + `REDIS_HOST` ($_ENV); `boot` → `APP_KEY` (env) + `app.timezone` (config)
- C#: `StartupService.Configure` → `App:Url`, `App:Port`, `Default`; `Loader.Load` → `DATABASE_URL`
- Negative: dynamic `ENV[var]` / `getenv($name)` / `Configuration[name]` / interpolated keys emit **no edge**
- **Cross-language convergence**: the C# `config:DATABASE_URL` entity ID equals the Node/Go/Python ID for the same key (`ConfigKeyEntity` synthetic SourceFile dedup) — asserted on both the edge `ToID` and the entity `ID`.

## Coverage
`config_consumption` flipped `missing → full` for all **PHP** (15) and **C#** (16) framework cells and **Ruby** (8), citing the new extractors. **rails** left `partial` — `Rails.application.credentials` not yet extracted (honest). `coverage validate`: 0 errors, exit 0; `coverage fmt --check`: canonical.

## Checks
- Targeted `go test` green: `extractors/{ruby,php,csharp}`, `extractor`, `types`, `tools/coverage`
- `go test ./internal/types/` green (no new kinds)
- `gofmt -l` empty · `go vet` clean

## DEPLOY-DEFERRED
Live daemon serves the rewrite agent; this PR is not deployed/reindexed here. Doc regeneration (`coverage gen`) deferred — registry is the source of truth and pre-existing doc drift is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)