### PR TITLE
feat(engine): scheduled-job schedule + handler breadth (node-schedule / APScheduler-decorator / whenever / rufus / Hangfire)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -61688,6 +61688,20 @@
       }
     },
     {
+      "id": "msg.apscheduler",
+      "category": "message_broker",
+      "language": "python",
+      "label": "APScheduler (Python advanced scheduler)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "#3628 area: scheduler.add_job(fn, 'cron'/'interval', ...) and the @scheduler.scheduled_job('cron'|'interval', hour=.., minutes=..) decorator form both emit a SCOPE.ScheduledJob (apscheduler:\u003cpath\u003e:\u003chandler\u003e) carrying the trigger + cron/interval kwargs as schedule, with a TRIGGERS edge to the handler function. Honest-partial: dynamic handler refs and date-trigger args not fully normalized."
+        }
+      }
+    },
+    {
       "id": "msg.broker.amqp",
       "category": "message_broker",
       "language": "multi",
@@ -62149,6 +62163,20 @@
       }
     },
     {
+      "id": "msg.hangfire-recurring",
+      "category": "message_broker",
+      "language": "csharp",
+      "label": "Hangfire RecurringJob (.NET scheduled jobs)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "#3628 area: RecurringJob.AddOrUpdate(\"id\", () =\u003e Type.Method(), SCHEDULE) and the generic AddOrUpdate\u003cT\u003e(\"id\", x =\u003e x.Method(), SCHEDULE) form emit a SCOPE.ScheduledJob (hangfire_recurring:\u003cid\u003e) carrying the schedule (Cron.* factory or literal cron string) with a TRIGGERS edge to the handler method. Complements custom_csharp_hangfire which records a SCOPE.Pattern node but drops the schedule. Honest-partial: enqueue (BackgroundJob.Enqueue/Schedule) producer edges stay in the custom extractor; dynamic schedules not parsed."
+        }
+      }
+    },
+    {
       "id": "msg.kafka-streams",
       "category": "message_broker",
       "language": "multi",
@@ -62159,6 +62187,20 @@
         },
         "producer_extraction": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "msg.node-schedule",
+      "category": "message_broker",
+      "language": "jsts",
+      "label": "node-schedule (Node scheduled jobs)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "#3628 area: schedule.scheduleJob('EXPR', handler) emits a SCOPE.ScheduledJob (node_schedule:\u003cpath\u003e:\u003cexpr\u003e) carrying the cron string as schedule, with a TRIGGERS edge to the named handler. Honest-partial: inline function literals and RecurrenceRule object rules yield the job node but no handler edge / no schedule string."
         }
       }
     },
@@ -62210,6 +62252,20 @@
           "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
           "issue": "3628",
           "notes": "epic #3628 jobs cross-link: producer ENQUEUES and consumer TRIGGERS both reference the same resque:\u003cJob\u003e SCOPE.ScheduledJob node, so a Resque.enqueue(Job) caller and the Job's self.perform join on one node (same shape as Sidekiq). Honest-partial: cross-file join requires the job class def to be indexed."
+        }
+      }
+    },
+    {
+      "id": "msg.rufus-scheduler",
+      "category": "message_broker",
+      "language": "ruby",
+      "label": "rufus-scheduler (Ruby in-process scheduler)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "#3628 area: scheduler.cron/every/interval/in/at 'EXPR' do ... end emits a SCOPE.ScheduledJob (rufus:\u003cpath\u003e:\u003cexpr\u003e) carrying '\u003ckind\u003e \u003cexpr\u003e' as schedule and a TRIGGERS edge to the first bare method call in the block body. Honest-partial: block-body handler is a heuristic first-call proxy; multi-statement blocks pick the first call."
         }
       }
     },
@@ -62322,6 +62378,20 @@
           "status": "partial",
           "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "msg.whenever",
+      "category": "message_broker",
+      "language": "ruby",
+      "label": "whenever (Ruby cron / config/schedule.rb)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/engine/scheduled_jobs_edges_test.go"],
+          "issue": "3628",
+          "notes": "#3628 area: every \u003cinterval\u003e do runner/rake/command '...' end blocks in config/schedule.rb emit a SCOPE.ScheduledJob (whenever:\u003cpath\u003e:\u003cschedule\u003e) carrying the interval/cron as schedule and a TRIGGERS edge to the first runner/rake/command descriptor. Honest-partial: only config/schedule.rb files are scanned; multi-line job bodies use the first descriptor as handler proxy."
         }
       }
     },

--- a/internal/engine/scheduled_jobs_edges.go
+++ b/internal/engine/scheduled_jobs_edges.go
@@ -121,9 +121,16 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		// Function:<callable> directly (mirroring Celery's TRIGGERS target
 		// convention). No synthetic queue node: the function is the rendezvous.
 		relationships = synthesizeRQEnqueueEdges(src, relationships)
+		// #3628 area: APScheduler decorator form
+		// `@scheduler.scheduled_job('cron', hour=2)` above a def. The add_job
+		// call form is handled by synthesizePyAPScheduler above; the decorator
+		// names the handler directly (the decorated def) and carries the trigger.
+		synthesizePyAPSchedulerDecorator(src, path, emitJob)
 	case "javascript", "typescript":
 		synthesizeNodeCron(src, path, emitJob)
 		synthesizeNodeBull(src, path, emitJob)
+		// #3628 area: node-schedule `schedule.scheduleJob('0 0 * * *', fn)`.
+		synthesizeNodeSchedule(src, path, emitJob)
 	case "java", "kotlin":
 		synthesizeJavaSpringScheduled(src, path, lang, emitJob)
 		synthesizeJavaQuartz(src, path, lang, emitJob)
@@ -145,6 +152,18 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		// caller→job ENQUEUES edges. Same join shape as Sidekiq.
 		synthesizeRubyResque(src, path, emitJob)
 		relationships = synthesizeResqueEnqueueEdges(src, seenJob, relationships)
+		// #3628 area: whenever (config/schedule.rb `every 1.day do runner ... end`)
+		// and rufus-scheduler (`scheduler.cron '0 22 * * *' do ... end`).
+		synthesizeRubyWhenever(src, path, emitJob)
+		synthesizeRubyRufus(src, path, emitJob)
+	case "csharp":
+		// #3628 area: Hangfire recurring jobs
+		// `RecurringJob.AddOrUpdate("id", () => T.Method(), Cron.Daily)` and
+		// `RecurringJob.AddOrUpdate<T>("id", x => x.Method(), "0 2 * * *")`. The
+		// existing custom_csharp_hangfire extractor emits a SCOPE.Pattern node
+		// but drops the Cron schedule; here we emit the unified SCOPE.ScheduledJob
+		// node carrying the schedule + a TRIGGERS edge to the handler method.
+		synthesizeCSharpHangfireRecurring(src, path, emitJob)
 	}
 
 	// YAML-based detectors run regardless of `lang` because the language
@@ -1146,6 +1165,273 @@ func synthesizeGitHubActionsSchedule(
 		expr := strings.TrimSpace(m[1])
 		jobID := "gh_actions_schedule:" + path + ":" + expr
 		emitJob(jobID, jobName, expr, "github_actions_schedule", nil)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — APScheduler decorator form (#3628 area)
+// ---------------------------------------------------------------------------
+//
+// APScheduler also supports a decorator style that names the handler directly:
+//
+//	@scheduler.scheduled_job('cron', hour=2, minute=30)
+//	def nightly_cleanup():
+//	    ...
+//	@sched.scheduled_job('interval', minutes=5)
+//	def poll():
+//	    ...
+//
+// The decorated def IS the handler; the first positional arg is the trigger
+// type ('cron'/'interval'/'date') and the trailing kwargs refine the schedule.
+// This complements synthesizePyAPScheduler which handles the add_job(...) form.
+
+// pyAPSchedulerDecoratorRe matches `@<var>.scheduled_job('<trigger>', ...)`
+// immediately above a `def <name>(`. Group 1 = trigger type, group 2 = the
+// remainder of the decorator args (kwargs), group 3 = handler function name.
+var pyAPSchedulerDecoratorRe = regexp.MustCompile(`(?m)@\w+\.scheduled_job\s*\(\s*['"](\w+)['"]([^\n]*)\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+// pyAPSchedulerKwargRe captures both cron kwargs (singular: hour, minute) and
+// interval kwargs (plural: minutes, seconds, hours, weeks). Used by the
+// decorator form, whose 'interval' trigger uses the plural kwargs.
+var pyAPSchedulerKwargRe = regexp.MustCompile(`(?:hours?|minutes?|seconds?|days?|weeks?|day_of_week|month)\s*=\s*[^,)]+`)
+
+func synthesizePyAPSchedulerDecorator(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "scheduled_job") {
+		return
+	}
+	for _, m := range pyAPSchedulerDecoratorRe.FindAllStringSubmatch(src, -1) {
+		trigger := m[1]
+		argsTail := m[2]
+		handler := m[3]
+		schedule := trigger
+		// Collect cron/interval kwargs to form a human-readable schedule string.
+		var parts []string
+		for _, km := range pyAPSchedulerKwargRe.FindAllString(argsTail, -1) {
+			parts = append(parts, strings.TrimSpace(km))
+		}
+		if len(parts) > 0 {
+			schedule = trigger + "(" + strings.Join(parts, ", ") + ")"
+		}
+		jobID := "apscheduler:" + path + ":" + handler
+		emitJob(jobID, handler, schedule, "apscheduler", map[string]string{
+			"trigger_type": trigger,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node — node-schedule (#3628 area)
+// ---------------------------------------------------------------------------
+//
+//	schedule.scheduleJob('0 0 * * *', function() { ... });
+//	schedule.scheduleJob('0 2 * * *', cleanup);
+//	sched.scheduleJob({ hour: 0 }, fn);   // object rule — schedule unknown
+//
+// The first arg is a cron-string (or a RecurrenceRule object), the second the
+// handler. We capture the string-literal cron form with its handler; object-rule
+// forms are honest-partial (schedule omitted) but still yield a job node when a
+// named handler is present.
+
+// nodeScheduleJobStrRe matches `<var>.scheduleJob('EXPR', handler)` where EXPR
+// is a string literal. Group 1 = cron expression, group 2 = handler (optional /
+// empty for an inline function literal).
+var nodeScheduleJobStrRe = regexp.MustCompile(`\.scheduleJob\s*\(\s*['"\x60]([^'"\x60\n\r]+)['"\x60]\s*,\s*(\w+)?`)
+
+func synthesizeNodeSchedule(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "scheduleJob") {
+		return
+	}
+	for _, m := range nodeScheduleJobStrRe.FindAllStringSubmatch(src, -1) {
+		expr := m[1]
+		handler := m[2]
+		// `function`/`async` indicate an inline function literal — anonymous.
+		if handler == "function" || handler == "async" {
+			handler = ""
+		}
+		jobID := "node_schedule:" + path + ":" + expr
+		emitJob(jobID, handler, expr, "node_schedule", nil)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ruby — whenever (config/schedule.rb) (#3628 area)
+// ---------------------------------------------------------------------------
+//
+// The `whenever` gem declares cron jobs in config/schedule.rb:
+//
+//	every 1.day, at: '4:30 am' do
+//	  runner 'CleanupJob.perform'
+//	  rake 'db:cleanup'
+//	  command 'backup.sh'
+//	end
+//	every '0 0 * * *' do
+//	  runner 'Report.generate'
+//	end
+//
+// The `every <interval> do` header is the schedule; the body's runner/rake/
+// command line is the handler. We capture the first job-defining line in each
+// block as the handler proxy.
+
+// reRubyWheneverEvery matches an `every <interval> do` header. Group 1 = the
+// interval/cron expression (everything between `every ` and the trailing `do`,
+// trimmed). Handles `every 1.day, at: '4:30 am' do` and `every '0 0 * * *' do`.
+var reRubyWheneverEvery = regexp.MustCompile(`(?m)^\s*every\s+(.+?)\s+do\b`)
+
+// reRubyWheneverJob matches the first runner/rake/command/script line that
+// names the work. Group 1 = job descriptor (string literal contents).
+var reRubyWheneverJob = regexp.MustCompile(`(?m)^\s*(?:runner|rake|command|script)\s+['"]([^'"]+)['"]`)
+
+func synthesizeRubyWhenever(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	// whenever schedules live in schedule.rb; guard on filename + `every` keyword
+	// so a generic Enumerable `every` in app code does not fabricate jobs.
+	if !strings.HasSuffix(path, "schedule.rb") {
+		return
+	}
+	if !strings.Contains(src, "every") {
+		return
+	}
+	headers := reRubyWheneverEvery.FindAllStringSubmatchIndex(src, -1)
+	for i, h := range headers {
+		schedule := strings.TrimSpace(src[h[2]:h[3]])
+		// Scope the handler search to this block (up to the next `every` header).
+		blockEnd := len(src)
+		if i+1 < len(headers) {
+			blockEnd = headers[i+1][0]
+		}
+		handler := ""
+		if jm := reRubyWheneverJob.FindStringSubmatch(src[h[1]:blockEnd]); len(jm) >= 2 {
+			handler = jm[1]
+		}
+		jobID := "whenever:" + path + ":" + schedule
+		emitJob(jobID, handler, schedule, "whenever", map[string]string{
+			"task_descriptor": handler,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ruby — rufus-scheduler (#3628 area)
+// ---------------------------------------------------------------------------
+//
+//	scheduler.cron '0 22 * * *' do
+//	  nightly_backup
+//	end
+//	scheduler.every '5m' do ... end
+//	scheduler.interval '10s' do ... end
+//	scheduler.in '10d' do ... end
+//
+// The first string-literal arg is the schedule; the block body's first bare
+// method call is the handler proxy.
+
+// reRubyRufusSchedule matches a rufus `scheduler.<kind> 'EXPR' do` header.
+// Group 1 = kind (cron/every/interval/in/at), group 2 = schedule expression.
+var reRubyRufusSchedule = regexp.MustCompile(`(?m)\bscheduler\.(cron|every|interval|in|at)\s+['"]([^'"]+)['"]\s*(?:,[^\n]*)?\s+do\b`)
+
+// reRubyRufusHandler matches the first bare identifier call on the line after a
+// rufus header. Group 1 = method name. Kept simple: a leading-word call.
+var reRubyRufusHandler = regexp.MustCompile(`(?m)^\s*([a-z_][\w]*)\s*(?:\(|$)`)
+
+func synthesizeRubyRufus(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "scheduler.") {
+		return
+	}
+	headers := reRubyRufusSchedule.FindAllStringSubmatchIndex(src, -1)
+	for i, h := range headers {
+		kind := src[h[2]:h[3]]
+		expr := src[h[4]:h[5]]
+		schedule := kind + " " + expr
+		// Look at the block body (up to the next rufus header) for a handler.
+		blockEnd := len(src)
+		if i+1 < len(headers) {
+			blockEnd = headers[i+1][0]
+		}
+		handler := ""
+		if hm := reRubyRufusHandler.FindStringSubmatch(src[h[1]:blockEnd]); len(hm) >= 2 {
+			cand := hm[1]
+			// Skip Ruby keywords that can start a block body.
+			if cand != "end" && cand != "do" && cand != "puts" {
+				handler = cand
+			}
+		}
+		jobID := "rufus:" + path + ":" + expr
+		emitJob(jobID, handler, schedule, "rufus_scheduler", map[string]string{
+			"trigger_type": kind,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// .NET — Hangfire RecurringJob (#3628 area)
+// ---------------------------------------------------------------------------
+//
+//	RecurringJob.AddOrUpdate("daily-report", () => Reports.Generate(), Cron.Daily);
+//	RecurringJob.AddOrUpdate("purge", () => Jobs.Purge(), "0 2 * * *");
+//	RecurringJob.AddOrUpdate<IEmailSender>("welcome", x => x.Send(), Cron.Hourly);
+//
+// The unified SCOPE.ScheduledJob node carries the schedule (the `Cron.*` factory
+// call OR a literal cron string) and TRIGGERS the handler method. This augments
+// the custom_csharp_hangfire extractor, which records a SCOPE.Pattern node but
+// drops the schedule expression.
+
+// reCSharpHangfireRecurringStatic matches the static-lambda recurring form:
+//
+//	RecurringJob.AddOrUpdate("id", () => Type.Method(...), SCHEDULE)
+//
+// Group 1 = job id, group 2 = type, group 3 = method, group 4 = schedule (the
+// trailing arg up to the closing paren).
+var reCSharpHangfireRecurringStatic = regexp.MustCompile(
+	`RecurringJob\.AddOrUpdate\s*\(\s*["']([^"']+)["']\s*,\s*\(\s*\)\s*=>\s*\w+\.(\w+)\s*\([^)]*\)\s*,\s*([^)\n;]+)\)`,
+)
+
+// reCSharpHangfireRecurringTyped matches the typed-lambda recurring form:
+//
+//	RecurringJob.AddOrUpdate<IType>("id", x => x.Method(...), SCHEDULE)
+//
+// Group 1 = job id, group 2 = method, group 3 = schedule.
+var reCSharpHangfireRecurringTyped = regexp.MustCompile(
+	`RecurringJob\.AddOrUpdate\s*<\s*\w+\s*>\s*\(\s*["']([^"']+)["']\s*,\s*\w+\s*=>\s*\w+\.(\w+)\s*\([^)]*\)\s*,\s*([^)\n;]+)\)`,
+)
+
+// normalizeHangfireSchedule trims the trailing schedule arg. `Cron.Daily()` and
+// `Cron.Daily` are normalized identically (the trailing `()` is dropped).
+func normalizeHangfireSchedule(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimSuffix(s, "()")
+	return strings.TrimSpace(s)
+}
+
+func synthesizeCSharpHangfireRecurring(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "RecurringJob") {
+		return
+	}
+	for _, m := range reCSharpHangfireRecurringStatic.FindAllStringSubmatch(src, -1) {
+		jobName, method, schedule := m[1], m[2], normalizeHangfireSchedule(m[3])
+		jobID := "hangfire_recurring:" + jobName
+		emitJob(jobID, method, schedule, "hangfire", map[string]string{
+			"job_name": jobName,
+		})
+	}
+	for _, m := range reCSharpHangfireRecurringTyped.FindAllStringSubmatch(src, -1) {
+		jobName, method, schedule := m[1], m[2], normalizeHangfireSchedule(m[3])
+		jobID := "hangfire_recurring:" + jobName
+		emitJob(jobID, method, schedule, "hangfire", map[string]string{
+			"job_name": jobName,
+		})
 	}
 }
 

--- a/internal/engine/scheduled_jobs_edges_test.go
+++ b/internal/engine/scheduled_jobs_edges_test.go
@@ -722,3 +722,240 @@ def dispatch(name):
 		t.Errorf("expected no rq ENQUEUES edge for dynamic callable, got %v", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #3628 area — breadth additions: node-schedule, APScheduler decorator,
+// whenever, rufus-scheduler, Hangfire RecurringJob.
+// ---------------------------------------------------------------------------
+
+// triggersEdgeFor returns the TRIGGERS edge whose FromID names jobID (suffix
+// match on the canonical "SCOPE.ScheduledJob:<jobID>" FromID), or nil.
+func triggersEdgeFor(rels []types.RelationshipRecord, jobID string) *types.RelationshipRecord {
+	want := scheduledJobKind + ":" + jobID
+	for i := range rels {
+		if rels[i].Kind == triggersEdgeKind && rels[i].FromID == want {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// jobWithSchedule returns the first ScheduledJob of framework whose schedule
+// property equals want, or nil.
+func jobWithSchedule(ents []types.EntityRecord, framework, want string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == scheduledJobKind && e.Properties["framework"] == framework &&
+			e.Properties["schedule"] == want {
+			return e
+		}
+	}
+	return nil
+}
+
+// Node — node-schedule: schedule.scheduleJob('0 2 * * *', cleanup) →
+// ScheduledJob(schedule='0 2 * * *') TRIGGERS cleanup.
+func TestScheduledJobs_NodeSchedule_StringCron(t *testing.T) {
+	src := `const schedule = require('node-schedule');
+schedule.scheduleJob('0 2 * * *', cleanup);
+`
+	ents, rels := runScheduledDetect(t, "javascript", "jobs.js", src)
+	job := jobWithSchedule(ents, "node_schedule", "0 2 * * *")
+	if job == nil {
+		t.Fatalf("expected node_schedule job with schedule='0 2 * * *', got %v",
+			scheduledJobsByFramework(ents, "node_schedule"))
+	}
+	if job.Properties["handler"] != "cleanup" {
+		t.Errorf("expected handler=cleanup, got %q", job.Properties["handler"])
+	}
+	if e := triggersEdgeFor(rels, "node_schedule:jobs.js:0 2 * * *"); e == nil {
+		t.Errorf("expected TRIGGERS edge to cleanup, got none in %v", triggersEdges(rels))
+	} else if e.ToID != "Function:cleanup" {
+		t.Errorf("expected TRIGGERS → Function:cleanup, got %q", e.ToID)
+	}
+}
+
+// Node — node-schedule inline function literal: handler is anonymous → job
+// node still emitted with the schedule, but no TRIGGERS edge.
+func TestScheduledJobs_NodeSchedule_InlineFunc(t *testing.T) {
+	src := `schedule.scheduleJob('30 1 * * *', function() { doWork(); });`
+	ents, rels := runScheduledDetect(t, "typescript", "cron.ts", src)
+	job := jobWithSchedule(ents, "node_schedule", "30 1 * * *")
+	if job == nil {
+		t.Fatalf("expected node_schedule job node even for inline fn")
+	}
+	if job.Properties["handler"] != "" {
+		t.Errorf("expected empty handler for inline fn, got %q", job.Properties["handler"])
+	}
+	if len(triggersEdges(rels)) != 0 {
+		t.Errorf("expected no TRIGGERS edge for anonymous handler, got %v", triggersEdges(rels))
+	}
+}
+
+// Python — APScheduler decorator: @scheduler.scheduled_job('cron', hour=2) on
+// nightly() → schedule carries cron kwargs, TRIGGERS nightly.
+func TestScheduledJobs_PyAPScheduler_Decorator(t *testing.T) {
+	src := `from apscheduler.schedulers.background import BackgroundScheduler
+scheduler = BackgroundScheduler()
+
+@scheduler.scheduled_job('cron', hour=2, minute=30)
+def nightly():
+    pass
+`
+	ents, rels := runScheduledDetect(t, "python", "sched.py", src)
+	jobs := scheduledJobsByFramework(ents, "apscheduler")
+	var job *types.EntityRecord
+	for i := range jobs {
+		if jobs[i].Properties["handler"] == "nightly" {
+			job = &jobs[i]
+		}
+	}
+	if job == nil {
+		t.Fatalf("expected apscheduler job for handler=nightly, got %v", jobs)
+	}
+	if !strings.Contains(job.Properties["schedule"], "hour=2") ||
+		!strings.HasPrefix(job.Properties["schedule"], "cron(") {
+		t.Errorf("expected schedule like cron(hour=2, minute=30), got %q", job.Properties["schedule"])
+	}
+	if job.Properties["trigger_type"] != "cron" {
+		t.Errorf("expected trigger_type=cron, got %q", job.Properties["trigger_type"])
+	}
+	if e := triggersEdgeFor(rels, "apscheduler:sched.py:nightly"); e == nil || e.ToID != "Function:nightly" {
+		t.Errorf("expected TRIGGERS → Function:nightly, got %v", e)
+	}
+}
+
+// Python — APScheduler interval decorator: schedule='interval(minutes=5)'.
+func TestScheduledJobs_PyAPScheduler_DecoratorInterval(t *testing.T) {
+	src := `@sched.scheduled_job('interval', minutes=5)
+def poll():
+    pass
+`
+	ents, _ := runScheduledDetect(t, "python", "poll.py", src)
+	jobs := scheduledJobsByFramework(ents, "apscheduler")
+	if len(jobs) == 0 {
+		t.Fatalf("expected an apscheduler interval job, got none")
+	}
+	got := jobs[0].Properties["schedule"]
+	if !strings.Contains(got, "interval") || !strings.Contains(got, "minutes=5") {
+		t.Errorf("expected interval(minutes=5) schedule, got %q", got)
+	}
+}
+
+// Ruby — whenever: every '0 0 * * *' do; runner 'Report.generate'; end →
+// schedule='0 0 * * *' TRIGGERS Report.generate.
+func TestScheduledJobs_RubyWhenever_Cron(t *testing.T) {
+	src := `every '0 0 * * *' do
+  runner 'Report.generate'
+end
+
+every 1.day, at: '4:30 am' do
+  rake 'db:cleanup'
+end
+`
+	ents, _ := runScheduledDetect(t, "ruby", "config/schedule.rb", src)
+	job := jobWithSchedule(ents, "whenever", "'0 0 * * *'")
+	if job == nil {
+		t.Fatalf("expected whenever job schedule='0 0 * * *', got %v",
+			scheduledJobsByFramework(ents, "whenever"))
+	}
+	if job.Properties["handler"] != "Report.generate" {
+		t.Errorf("expected handler=Report.generate, got %q", job.Properties["handler"])
+	}
+	// Second block: interval schedule + rake handler.
+	jobs := scheduledJobsByFramework(ents, "whenever")
+	foundCleanup := false
+	for _, j := range jobs {
+		if j.Properties["handler"] == "db:cleanup" {
+			foundCleanup = true
+		}
+	}
+	if !foundCleanup {
+		t.Errorf("expected a whenever job with handler=db:cleanup, got %v", jobs)
+	}
+}
+
+// Negative: a generic `every` outside config/schedule.rb must not fabricate a
+// whenever job (e.g. Enumerable#every in app code).
+func TestScheduledJobs_RubyWhenever_NonScheduleFile_NoJob(t *testing.T) {
+	src := `every 3.times do
+  puts "hi"
+end
+`
+	ents, _ := runScheduledDetect(t, "ruby", "app/models/widget.rb", src)
+	if got := scheduledJobsByFramework(ents, "whenever"); len(got) != 0 {
+		t.Errorf("expected no whenever jobs outside schedule.rb, got %v", got)
+	}
+}
+
+// Ruby — rufus-scheduler: scheduler.cron '0 22 * * *' do nightly_backup end →
+// schedule='cron 0 22 * * *' TRIGGERS nightly_backup.
+func TestScheduledJobs_RubyRufus_Cron(t *testing.T) {
+	src := `require 'rufus-scheduler'
+scheduler = Rufus::Scheduler.new
+scheduler.cron '0 22 * * *' do
+  nightly_backup
+end
+`
+	ents, rels := runScheduledDetect(t, "ruby", "jobs.rb", src)
+	jobs := scheduledJobsByFramework(ents, "rufus_scheduler")
+	if len(jobs) == 0 {
+		t.Fatalf("expected a rufus job, got none")
+	}
+	job := jobs[0]
+	if job.Properties["schedule"] != "cron 0 22 * * *" {
+		t.Errorf("expected schedule='cron 0 22 * * *', got %q", job.Properties["schedule"])
+	}
+	if job.Properties["handler"] != "nightly_backup" {
+		t.Errorf("expected handler=nightly_backup, got %q", job.Properties["handler"])
+	}
+	if e := triggersEdgeFor(rels, "rufus:jobs.rb:0 22 * * *"); e == nil || e.ToID != "Function:nightly_backup" {
+		t.Errorf("expected TRIGGERS → Function:nightly_backup, got %v", e)
+	}
+}
+
+// .NET — Hangfire RecurringJob static lambda with Cron.* factory:
+// RecurringJob.AddOrUpdate("daily", () => Reports.Generate(), Cron.Daily) →
+// schedule='Cron.Daily' TRIGGERS Generate.
+func TestScheduledJobs_CSharpHangfire_RecurringCronFactory(t *testing.T) {
+	src := `using Hangfire;
+public class Startup {
+  public void Configure() {
+    RecurringJob.AddOrUpdate("daily-report", () => Reports.Generate(), Cron.Daily);
+  }
+}
+`
+	ents, rels := runScheduledDetect(t, "csharp", "Startup.cs", src)
+	job := jobWithSchedule(ents, "hangfire", "Cron.Daily")
+	if job == nil {
+		t.Fatalf("expected hangfire job schedule='Cron.Daily', got %v",
+			scheduledJobsByFramework(ents, "hangfire"))
+	}
+	if job.Properties["handler"] != "Generate" {
+		t.Errorf("expected handler=Generate, got %q", job.Properties["handler"])
+	}
+	if job.Properties["job_name"] != "daily-report" {
+		t.Errorf("expected job_name=daily-report, got %q", job.Properties["job_name"])
+	}
+	if e := triggersEdgeFor(rels, "hangfire_recurring:daily-report"); e == nil || e.ToID != "Function:Generate" {
+		t.Errorf("expected TRIGGERS → Function:Generate, got %v", e)
+	}
+}
+
+// .NET — Hangfire RecurringJob with literal cron string + typed lambda:
+// RecurringJob.AddOrUpdate<IPurger>("purge", x => x.Run(), "0 2 * * *").
+func TestScheduledJobs_CSharpHangfire_RecurringLiteralCronTyped(t *testing.T) {
+	src := `RecurringJob.AddOrUpdate<IPurger>("purge", x => x.Run(), "0 2 * * *");`
+	ents, rels := runScheduledDetect(t, "csharp", "Jobs.cs", src)
+	job := jobWithSchedule(ents, "hangfire", "\"0 2 * * *\"")
+	if job == nil {
+		t.Fatalf("expected hangfire job with literal cron schedule, got %v",
+			scheduledJobsByFramework(ents, "hangfire"))
+	}
+	if job.Properties["handler"] != "Run" {
+		t.Errorf("expected handler=Run, got %q", job.Properties["handler"])
+	}
+	if e := triggersEdgeFor(rels, "hangfire_recurring:purge"); e == nil || e.ToID != "Function:Run" {
+		t.Errorf("expected TRIGGERS → Function:Run, got %v", e)
+	}
+}


### PR DESCRIPTION
Closes #3760 (child of #3628).

Extends the unified `SCOPE.ScheduledJob` + `TRIGGERS` contract in `internal/engine/scheduled_jobs_edges.go` to schedulers it did not yet cover. Each new detector captures the **cron/interval expression as the `schedule` property** and emits a **TRIGGERS edge to the resolvable handler**, matching the existing celery/node-cron/Spring contract (entity id `<framework>:<...>`, edge `SCOPE.ScheduledJob:<id> -TRIGGERS-> Function:<handler>`).

### Schedulers added
| Lang | Scheduler | Form | schedule property |
|---|---|---|---|
| JS/TS | node-schedule | `schedule.scheduleJob('0 2 * * *', cleanup)` | `0 2 * * *` |
| Python | APScheduler **decorator** | `@scheduler.scheduled_job('cron', hour=2, minute=30)` | `cron(hour=2, minute=30)` |
| Python | APScheduler interval | `@sched.scheduled_job('interval', minutes=5)` | `interval(minutes=5)` |
| Ruby | whenever | `every '0 0 * * *' do runner 'Report.generate' end` | `'0 0 * * *'` |
| Ruby | rufus-scheduler | `scheduler.cron '0 22 * * *' do nightly_backup end` | `cron 0 22 * * *` |
| .NET | Hangfire RecurringJob | `RecurringJob.AddOrUpdate("daily", () => Reports.Generate(), Cron.Daily)` | `Cron.Daily` |

The existing `custom_csharp_hangfire` extractor recorded a `SCOPE.Pattern` node but **dropped the `Cron.*` schedule** — this adds the unified `SCOPE.ScheduledJob` node carrying it.

### Already covered (left as-is, verified before building)
celery / celery-beat, node-cron, BullMQ repeatable, Spring & Quarkus `@Scheduled`, Quartz, Go robfig/cron, sidekiq-cron, Resque, RQ, k8s CronJob, GitHub Actions, AWS EventBridge.

### Tests (value-asserting)
Each test asserts the **`schedule` property AND the handler TRIGGERS edge target** (not `len>0`). Negatives included:
- node-schedule inline `function(){}` -> job node, **no** TRIGGERS edge
- `every 3.times do` outside `config/schedule.rb` -> **no** whenever job

### Schedule-property note
`schedule` carries the raw literal as written (e.g. quotes preserved for Ruby/C# string literals: `'0 0 * * *'`, `"0 2 * * *"`; factory calls normalized `Cron.Daily()`->`Cron.Daily`). Honest-partial: anonymous/inline handlers and object-rule schedules omit the edge or schedule string; dynamic refs skipped.

### Coverage
Five new honest-partial records: `msg.node-schedule`, `msg.whenever`, `msg.rufus-scheduler`, `msg.hangfire-recurring`, `msg.apscheduler` (cite the extractor + tests).

### Verification
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green
- `gofmt -l` empty, `go vet` clean
- `coverage validate`: `ok: 635 record(s)`, **0 errors**; `coverage fmt --check`: canonical

**DEPLOY-DEFERRED**: extractor-only; requires a daemon rebuild + reindex to surface in the live graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)