### PR TITLE
feat(observability): INSTRUMENTS breadth for ddtrace/Sentry/Prometheus/New Relic (Python)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1580,7 +1580,11 @@
           "status": "missing"
         },
         "trace_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
+          "notes": "#3628 area #11: ddtrace span-creation sites in Python emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub). Decorator @tracer.wrap() defaults the span name to the function name; @tracer.wrap(name=\"...\")/resource=\"...\" use the explicit name; manual tracer.trace(\"op\") body calls carry the first positional name. Honest-partial: dynamic span names emit traced=true+dynamic=true without a fabricated name; only Python is covered (Go ddtrace.StartSpan / JS not yet).",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -1661,7 +1665,11 @@
           "status": "missing"
         },
         "trace_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
+          "notes": "#3628 area #11: New Relic Python agent trace decorators emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub). @newrelic.agent.function_trace() / @function_trace() / @background_task() / @web_transaction() default the span name to the function name; name=\"...\" uses the explicit name. Honest-partial: dynamic names emit traced=true+dynamic=true without fabrication; only Python is covered.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -1699,8 +1707,10 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml","internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
+          "notes": "#3628 area #11: prometheus_client Python metrics emit INSTRUMENTS edges (enclosing op -\u003e metric:\u003cname\u003e stub). A module-level metric declaration X = Counter|Gauge|Summary|Histogram|Info|Enum(\"name\", ...) is registered, then @X.time()/@X.count_exceptions()/@X.track_inprogress() decorators and X.inc()/dec()/observe()/set() body calls resolve to metric:name with the metric name captured. Honest-partial: a non-literal metric name yields traced=true+dynamic=true; a .inc()/.time() on a variable that is NOT a known module-level metric is NOT emitted (precision). Only Python is covered.",
+          "verified_at": "2026-06-02"
         },
         "trace_extraction": {
           "status": "not_applicable"
@@ -1720,7 +1730,11 @@
           "status": "missing"
         },
         "trace_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
+          "notes": "#3628 area #11: Sentry Python performance-tracing sites emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub). Bare @sentry_sdk.trace / @sentry.trace decorators key the span on the function name; sentry_sdk.start_transaction(...) / start_span(...) body calls take the name from name=/op=/description= kwargs. Honest-partial: dynamic names emit traced=true+dynamic=true without fabrication; only Python is covered.",
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -189,9 +189,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// don't use the pattern).
 	constReg := buildModuleConstRegistry(root, file.Content, importMap)
 
+	// Issue #3762 — pre-scan module-level Prometheus metric declarations
+	// (`X = Summary("name", ...)`) so the observability pass can resolve
+	// `@X.time()` decorators / `X.inc()` body calls to a metric name. Returns
+	// nil when no metric is declared (zero cost for non-Prometheus files).
+	metricReg := buildPyMetricRegistry(root, file.Content)
+
 	// Walk top-level children.
 	walkBeforeCount := len(entities)
-	walkNode(root, file, "", &entities, &functionCount, &classCount, importMap, constReg)
+	walkNode(root, file, "", &entities, &functionCount, &classCount, importMap, constReg, metricReg)
 
 	// Issue #699b — emit CONTAINS edges from the file entity to every
 	// top-level class (SCOPE.Component/class) and module-level function
@@ -552,6 +558,7 @@ func walkNode(
 	classCount *int,
 	imports pythonImportMap,
 	constReg moduleConstRegistry,
+	metricReg pyMetricRegistry,
 ) {
 	if node == nil {
 		return
@@ -597,7 +604,7 @@ func walkNode(
 			if body != nil {
 				before := len(*out)
 				for i := range int(body.ChildCount()) {
-					walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports, constReg)
+					walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports, constReg, metricReg)
 				}
 				// Issue #526 — class-attribute assignments (DRF ViewSet
 				// `serializer_class = ...`, Django Model `title =
@@ -721,6 +728,10 @@ func walkNode(
 			// Issue #3689 — stamp OpenTelemetry span-creation sites (no decorator
 			// parent for a bare function_definition).
 			stampPythonTracingSpans(node, nil, selfName, file.Content, out, funcIdx)
+			// Issue #3762 — stamp non-OTel instrumentation (ddtrace/Sentry/
+			// Prometheus/New Relic). Bare function → no decorator parent; body
+			// calls (tracer.trace, METRIC.inc, …) are still scanned.
+			stampPythonObservability(node, nil, selfName, metricReg, file.Content, out, funcIdx)
 		}
 		return // do not recurse into function body for nested definitions
 
@@ -751,6 +762,9 @@ func walkNode(
 				// both the body and the decorator list (node is the
 				// decorated_definition wrapping inner).
 				stampPythonTracingSpans(inner, node, selfName, file.Content, out, decoratedFuncIdx)
+				// Issue #3762 — stamp non-OTel instrumentation (ddtrace/Sentry/
+				// Prometheus/New Relic) from the decorator list + body.
+				stampPythonObservability(inner, node, selfName, metricReg, file.Content, out, decoratedFuncIdx)
 			}
 		case "class_definition":
 			rec := buildClass(inner, file)
@@ -778,7 +792,7 @@ func walkNode(
 				if body != nil {
 					before := len(*out)
 					for i := range int(body.ChildCount()) {
-						walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports, constReg)
+						walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports, constReg, metricReg)
 					}
 					// Issue #526 — see the bare class_definition branch.
 					extractClassFields(body, file, childParent, out)
@@ -840,7 +854,7 @@ func walkNode(
 	default:
 		// Recurse into all other node types.
 		for i := range int(node.ChildCount()) {
-			walkNode(node.Child(i), file, parentClass, out, funcCount, classCount, imports, constReg)
+			walkNode(node.Child(i), file, parentClass, out, funcCount, classCount, imports, constReg, metricReg)
 		}
 	}
 }

--- a/internal/extractors/python/issue3762_observability_test.go
+++ b/internal/extractors/python/issue3762_observability_test.go
@@ -1,0 +1,346 @@
+// Package python_test — issue #3762 (epic #3628, area #11): verifies the
+// non-OpenTelemetry observability pass emits INSTRUMENTS edges for Datadog
+// ddtrace, Sentry, Prometheus, and New Relic, carrying the span/metric name and
+// the operation it instruments. Mirrors the OTel contract in
+// issue3689_tracing_test.go.
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// instrEdge returns the first INSTRUMENTS edge on entity entName whose ToID
+// matches wantToID, or nil.
+func instrEdge(ents []types.EntityRecord, entName, wantToID string) *types.RelationshipRecord {
+	e := findEntPy(ents, entName)
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// dumpInstr logs every INSTRUMENTS edge on entName (test-failure aid).
+func dumpInstr(t *testing.T, ents []types.EntityRecord, entName string) {
+	t.Helper()
+	if e := findEntPy(ents, entName); e != nil {
+		for _, r := range e.Relationships {
+			if r.Kind == "INSTRUMENTS" {
+				t.Logf("  INSTRUMENTS → %s (props=%v)", r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// --- Datadog ddtrace --------------------------------------------------------
+
+// TestObs_Ddtrace_WrapDecorator_DefaultsToFnName verifies `@tracer.wrap()` on
+// `checkout()` instruments span:checkout (ddtrace defaults the span name to the
+// decorated function name).
+func TestObs_Ddtrace_WrapDecorator_DefaultsToFnName(t *testing.T) {
+	src := `
+@tracer.wrap()
+def checkout(cart):
+    return pay(cart)
+`
+	ents := extractPy(t, src, "shop.py")
+	r := instrEdge(ents, "checkout", "span:checkout")
+	if r == nil {
+		dumpInstr(t, ents, "checkout")
+		t.Fatal("INSTRUMENTS edge checkout → span:checkout not found")
+	}
+	if r.Properties["library"] != "ddtrace" {
+		t.Errorf("library=%q, want ddtrace", r.Properties["library"])
+	}
+	if r.Properties["api"] != "tracer.wrap" {
+		t.Errorf("api=%q, want tracer.wrap", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "checkout" {
+		t.Errorf("span_name=%q, want checkout", r.Properties["span_name"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+	if r.Properties["dynamic"] != "" {
+		t.Errorf("dynamic=%q, want empty", r.Properties["dynamic"])
+	}
+}
+
+// TestObs_Ddtrace_WrapDecorator_ExplicitName verifies `@tracer.wrap(name="pay")`
+// uses the explicit name over the fn name.
+func TestObs_Ddtrace_WrapDecorator_ExplicitName(t *testing.T) {
+	src := `
+@tracer.wrap(name="pay.op")
+def checkout(cart):
+    return 1
+`
+	ents := extractPy(t, src, "shop.py")
+	r := instrEdge(ents, "checkout", "span:pay.op")
+	if r == nil {
+		dumpInstr(t, ents, "checkout")
+		t.Fatal("INSTRUMENTS edge checkout → span:pay.op not found")
+	}
+	if r.Properties["span_name"] != "pay.op" {
+		t.Errorf("span_name=%q, want pay.op", r.Properties["span_name"])
+	}
+}
+
+// TestObs_Ddtrace_ManualTrace_Body verifies the manual `tracer.trace("db.query")`
+// body call instruments span:db.query.
+func TestObs_Ddtrace_ManualTrace_Body(t *testing.T) {
+	src := `
+def fetch():
+    with tracer.trace("db.query"):
+        return run()
+`
+	ents := extractPy(t, src, "repo.py")
+	r := instrEdge(ents, "fetch", "span:db.query")
+	if r == nil {
+		dumpInstr(t, ents, "fetch")
+		t.Fatal("INSTRUMENTS edge fetch → span:db.query not found")
+	}
+	if r.Properties["api"] != "tracer.trace" {
+		t.Errorf("api=%q, want tracer.trace", r.Properties["api"])
+	}
+	if r.Properties["library"] != "ddtrace" {
+		t.Errorf("library=%q, want ddtrace", r.Properties["library"])
+	}
+}
+
+// --- Sentry -----------------------------------------------------------------
+
+// TestObs_Sentry_TraceDecorator verifies `@sentry_sdk.trace` on `handler()`
+// instruments span:handler.
+func TestObs_Sentry_TraceDecorator(t *testing.T) {
+	src := `
+@sentry_sdk.trace
+def handler(req):
+    return 1
+`
+	ents := extractPy(t, src, "h.py")
+	r := instrEdge(ents, "handler", "span:handler")
+	if r == nil {
+		dumpInstr(t, ents, "handler")
+		t.Fatal("INSTRUMENTS edge handler → span:handler not found")
+	}
+	if r.Properties["library"] != "sentry" {
+		t.Errorf("library=%q, want sentry", r.Properties["library"])
+	}
+	if r.Properties["api"] != "trace" {
+		t.Errorf("api=%q, want trace", r.Properties["api"])
+	}
+}
+
+// TestObs_Sentry_StartTransaction_Body verifies `sentry_sdk.start_transaction(
+// name="checkout")` instruments span:checkout.
+func TestObs_Sentry_StartTransaction_Body(t *testing.T) {
+	src := `
+def process():
+    with sentry_sdk.start_transaction(name="checkout", op="task"):
+        work()
+`
+	ents := extractPy(t, src, "p.py")
+	r := instrEdge(ents, "process", "span:checkout")
+	if r == nil {
+		dumpInstr(t, ents, "process")
+		t.Fatal("INSTRUMENTS edge process → span:checkout not found")
+	}
+	if r.Properties["api"] != "start_transaction" {
+		t.Errorf("api=%q, want start_transaction", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "checkout" {
+		t.Errorf("span_name=%q, want checkout", r.Properties["span_name"])
+	}
+}
+
+// --- Prometheus -------------------------------------------------------------
+
+// TestObs_Prometheus_TimeDecorator_CapturesMetricName verifies a module-level
+// `REQUEST_TIME = Summary("request_seconds", ...)` plus `@REQUEST_TIME.time()`
+// on `handler()` instruments metric:request_seconds.
+func TestObs_Prometheus_TimeDecorator_CapturesMetricName(t *testing.T) {
+	src := `
+REQUEST_TIME = Summary("request_seconds", "Time spent")
+
+@REQUEST_TIME.time()
+def handler(req):
+    return 1
+`
+	ents := extractPy(t, src, "m.py")
+	r := instrEdge(ents, "handler", "metric:request_seconds")
+	if r == nil {
+		dumpInstr(t, ents, "handler")
+		t.Fatal("INSTRUMENTS edge handler → metric:request_seconds not found")
+	}
+	if r.Properties["library"] != "prometheus" {
+		t.Errorf("library=%q, want prometheus", r.Properties["library"])
+	}
+	if r.Properties["api"] != "metric.time" {
+		t.Errorf("api=%q, want metric.time", r.Properties["api"])
+	}
+	if r.Properties["metric_name"] != "request_seconds" {
+		t.Errorf("metric_name=%q, want request_seconds", r.Properties["metric_name"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+}
+
+// TestObs_Prometheus_CounterInc_Body verifies a module-level Counter plus a
+// `REQUESTS.inc()` body call instruments metric:http_requests_total.
+func TestObs_Prometheus_CounterInc_Body(t *testing.T) {
+	src := `
+REQUESTS = Counter("http_requests_total", "Total")
+
+def handle(req):
+    REQUESTS.inc()
+    return 1
+`
+	ents := extractPy(t, src, "c.py")
+	r := instrEdge(ents, "handle", "metric:http_requests_total")
+	if r == nil {
+		dumpInstr(t, ents, "handle")
+		t.Fatal("INSTRUMENTS edge handle → metric:http_requests_total not found")
+	}
+	if r.Properties["api"] != "metric.inc" {
+		t.Errorf("api=%q, want metric.inc", r.Properties["api"])
+	}
+	if r.Properties["metric_name"] != "http_requests_total" {
+		t.Errorf("metric_name=%q, want http_requests_total", r.Properties["metric_name"])
+	}
+}
+
+// TestObs_Prometheus_UnknownVar_NoEdge is the precision negative: `.inc()` on a
+// variable that is NOT a known module-level metric produces NO edge.
+func TestObs_Prometheus_UnknownVar_NoEdge(t *testing.T) {
+	src := `
+def handle(counter):
+    counter.inc()
+    return 1
+`
+	ents := extractPy(t, src, "u.py")
+	e := findEntPy(ents, "handle")
+	if e == nil {
+		t.Fatal("entity handle not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on non-metric .inc(): → %s", r.ToID)
+		}
+	}
+}
+
+// --- New Relic --------------------------------------------------------------
+
+// TestObs_NewRelic_FunctionTrace_DefaultsToFnName verifies
+// `@newrelic.agent.function_trace()` on `worker()` instruments span:worker.
+func TestObs_NewRelic_FunctionTrace_DefaultsToFnName(t *testing.T) {
+	src := `
+@newrelic.agent.function_trace()
+def worker(job):
+    return run(job)
+`
+	ents := extractPy(t, src, "nr.py")
+	r := instrEdge(ents, "worker", "span:worker")
+	if r == nil {
+		dumpInstr(t, ents, "worker")
+		t.Fatal("INSTRUMENTS edge worker → span:worker not found")
+	}
+	if r.Properties["library"] != "newrelic" {
+		t.Errorf("library=%q, want newrelic", r.Properties["library"])
+	}
+	if r.Properties["api"] != "function_trace" {
+		t.Errorf("api=%q, want function_trace", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "worker" {
+		t.Errorf("span_name=%q, want worker", r.Properties["span_name"])
+	}
+}
+
+// TestObs_NewRelic_FunctionTrace_ExplicitName verifies `@function_trace(
+// name="batch")` uses the explicit name.
+func TestObs_NewRelic_FunctionTrace_ExplicitName(t *testing.T) {
+	src := `
+@function_trace(name="batch")
+def worker(job):
+    return 1
+`
+	ents := extractPy(t, src, "nr2.py")
+	r := instrEdge(ents, "worker", "span:batch")
+	if r == nil {
+		dumpInstr(t, ents, "worker")
+		t.Fatal("INSTRUMENTS edge worker → span:batch not found")
+	}
+	if r.Properties["span_name"] != "batch" {
+		t.Errorf("span_name=%q, want batch", r.Properties["span_name"])
+	}
+}
+
+// --- Honest-partial + negatives ---------------------------------------------
+
+// TestObs_Sentry_DynamicName_NoFabrication verifies a dynamic transaction name
+// emits traced+dynamic, NO fabricated span_name, keyed on the enclosing fn.
+func TestObs_Sentry_DynamicName_NoFabrication(t *testing.T) {
+	src := `
+def run(op_name):
+    with sentry_sdk.start_transaction(name=op_name):
+        work()
+`
+	ents := extractPy(t, src, "d.py")
+	r := instrEdge(ents, "run", "span:run")
+	if r == nil {
+		dumpInstr(t, ents, "run")
+		t.Fatal("INSTRUMENTS edge run → span:run not found for dynamic name")
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if _, ok := r.Properties["span_name"]; ok {
+		t.Errorf("span_name must be absent for dynamic name; got %q", r.Properties["span_name"])
+	}
+}
+
+// TestObs_NonInstrumentDecorator_NoEdge verifies an unrelated decorator (e.g.
+// `@app.route`) produces NO INSTRUMENTS edge (no false positives).
+func TestObs_NonInstrumentDecorator_NoEdge(t *testing.T) {
+	src := `
+@app.route("/health")
+def health():
+    return "ok"
+`
+	ents := extractPy(t, src, "r.py")
+	e := findEntPy(ents, "health")
+	if e == nil {
+		t.Fatal("entity health not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on @app.route fn: → %s", r.ToID)
+		}
+	}
+}
+
+// TestObs_Plain_NoEdge verifies a plain undecorated function produces no edge.
+func TestObs_Plain_NoEdge(t *testing.T) {
+	src := `
+def plain(x):
+    return x + 1
+`
+	ents := extractPy(t, src, "p.py")
+	e := findEntPy(ents, "plain")
+	if e == nil {
+		t.Fatal("entity plain not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			t.Errorf("unexpected INSTRUMENTS edge on plain fn: → %s", r.ToID)
+		}
+	}
+}

--- a/internal/extractors/python/observability.go
+++ b/internal/extractors/python/observability.go
@@ -1,0 +1,506 @@
+// observability.go — Issue #3762 (epic #3628, area #11): non-OpenTelemetry
+// observability/instrumentation breadth for Python.
+//
+// Extends the wave-5 INSTRUMENTS edge (OpenTelemetry, issue #3689) to the
+// dominant non-OTel Python instrumentation libraries, stamping the SAME edge
+// contract used by tracing.go:
+//
+//	FROM = enclosing operation entity (function/method)
+//	TO   = synthetic instrumentation stub
+//	         "span:<name>"   for trace/transaction spans
+//	         "metric:<name>" for metrics
+//	Kind = INSTRUMENTS
+//	Properties: library, api, line, traced=true (+ span_name|metric_name, dynamic)
+//
+// Libraries in scope (all decorator- or call-based, matched on library-reserved
+// API names so the receiver identifier need not be resolved):
+//
+//	Datadog ddtrace
+//	  @tracer.wrap()                       # span name defaults to the fn name
+//	  @tracer.wrap(name="checkout")        # explicit name
+//	  tracer.trace("db.query")             # manual span (body call)
+//
+//	Sentry
+//	  @sentry_sdk.trace                    # bare decorator → span = fn name
+//	  sentry_sdk.start_transaction(name="checkout")   # transaction (body call)
+//	  sentry_sdk.start_span(description="db.query")
+//
+//	Prometheus client
+//	  REQUEST_TIME = Summary("request_seconds", "...")   # module-level metric
+//	  @REQUEST_TIME.time()                 # → metric:request_seconds
+//	  @LATENCY.count_exceptions()
+//	  COUNTER.inc() / HIST.observe(x)      # body calls on a known metric var
+//
+//	New Relic
+//	  @newrelic.agent.function_trace()     # span name defaults to the fn name
+//	  @function_trace(name="checkout")     # explicit name
+//	  @background_task()
+//
+// Honest-partial rule (#3689/#3762): a dynamic span/metric name (variable,
+// attribute, f-string, call) emits traced=true + dynamic=true keyed on the
+// enclosing function ("span:<fn>" / "metric:<fn>") rather than fabricating a
+// name. A Prometheus decorator/body-call on a variable that is NOT a known
+// module-level metric is NOT emitted (could be any unrelated object).
+//
+// The walk is panic-tolerant so the primary extraction pipeline is unaffected.
+package python
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pyInstrHit captures one non-OTel instrumentation site (span or metric).
+type pyInstrHit struct {
+	name    string // static span/metric name; "" when dynamic
+	library string // "ddtrace" | "sentry" | "prometheus" | "newrelic"
+	api     string // library-facing API token (e.g. "tracer.wrap", "Summary.time")
+	kind    string // "span" | "metric"
+	line    int    // 1-indexed source line
+	dynamic bool   // true when the name is non-literal / unresolved
+}
+
+// pyMetricRegistry maps a module-level Python variable name to the metric name
+// declared by a Prometheus metric constructor assigned to it, e.g.
+// `REQUEST_TIME = Summary("request_seconds", ...)` → {"REQUEST_TIME":"request_seconds"}.
+// A variable assigned to a metric constructor with a non-literal first arg maps
+// to "" (known-metric, dynamic-name).
+type pyMetricRegistry map[string]string
+
+// pyPrometheusMetricCtors is the set of prometheus_client metric constructor
+// names whose first positional argument is the metric name.
+var pyPrometheusMetricCtors = map[string]bool{
+	"Counter":   true,
+	"Gauge":     true,
+	"Summary":   true,
+	"Histogram": true,
+	"Info":      true,
+	"Enum":      true,
+}
+
+// pyPrometheusInstrumentMethods is the set of prometheus_client metric methods
+// that instrument code: the `.time()` / `.count_exceptions()` decorators and the
+// `.inc()` / `.observe()` / `.set()` body calls. The bool value is true when the
+// method is a decorator form (used as `@METRIC.time()`), false when it is a
+// body-call form.
+var pyPrometheusInstrumentMethods = map[string]bool{
+	"time":             true, // decorator (Summary/Histogram)
+	"count_exceptions": true, // decorator (Counter/Gauge)
+	"track_inprogress": true, // decorator (Gauge)
+	"inc":              true, // body call
+	"dec":              true, // body call
+	"observe":          true, // body call
+	"set":              true, // body call
+}
+
+// buildPyMetricRegistry scans module-level assignments for Prometheus metric
+// constructors and returns a name→metric-name map. Only top-level (module-scope)
+// assignments are considered; the registry is used to resolve `@METRIC.time()`
+// decorators and `METRIC.inc()` body calls to a metric name. Returns nil when no
+// metric is declared (zero cost for files that don't use Prometheus).
+func buildPyMetricRegistry(root *sitter.Node, src []byte) pyMetricRegistry {
+	if root == nil {
+		return nil
+	}
+	var reg pyMetricRegistry
+	defer func() { _ = recover() }()
+
+	// Only scan direct module-level statements (expression_statement →
+	// assignment). Nested/conditional metric definitions are out of honest scope.
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		stmt := root.NamedChild(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			asn := stmt.NamedChild(j)
+			if asn == nil || asn.Type() != "assignment" {
+				continue
+			}
+			left := asn.ChildByFieldName("left")
+			right := asn.ChildByFieldName("right")
+			if left == nil || right == nil || left.Type() != "identifier" {
+				continue
+			}
+			if right.Type() != "call" {
+				continue
+			}
+			ctor := pyCallFunctionName(right, src)
+			if !pyPrometheusMetricCtors[ctor] {
+				continue
+			}
+			varName := nodeText(left, src)
+			// First positional arg of the metric ctor is the metric name.
+			args := right.ChildByFieldName("arguments")
+			nameNode := firstPositionalArg(args)
+			metricName := ""
+			if nameNode != nil && nameNode.Type() == "string" {
+				metricName = pythonLiteralValue(nameNode, src)
+			}
+			if reg == nil {
+				reg = make(pyMetricRegistry)
+			}
+			reg[varName] = metricName // "" when the name is dynamic
+		}
+	}
+	return reg
+}
+
+// pyCallFunctionName returns the bare callee name of a `call` node, handling both
+// a plain identifier callee (`Summary(...)`) and an attribute callee
+// (`prom.Summary(...)` → "Summary"). Returns "" when the callee is neither.
+func pyCallFunctionName(call *sitter.Node, src []byte) string {
+	if call == nil || call.Type() != "call" {
+		return ""
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return ""
+	}
+	switch fn.Type() {
+	case "identifier":
+		return nodeText(fn, src)
+	case "attribute":
+		if attr := fn.ChildByFieldName("attribute"); attr != nil {
+			return nodeText(attr, src)
+		}
+	}
+	return ""
+}
+
+// extractPyInstrHits collects every non-OTel instrumentation site for a function
+// from its decorators (decoratorParent, when non-nil) and its body. metricReg
+// resolves Prometheus metric variables to metric names.
+func extractPyInstrHits(funcNode, decoratorParent *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
+	if funcNode == nil {
+		return nil
+	}
+	var hits []pyInstrHit
+	defer func() { _ = recover() }()
+
+	// --- Decorator forms -----------------------------------------------------
+	if decoratorParent != nil {
+		for i := 0; i < int(decoratorParent.ChildCount()); i++ {
+			ch := decoratorParent.Child(i)
+			if ch == nil || ch.Type() != "decorator" {
+				continue
+			}
+			hits = append(hits, pyDecoratorInstrHits(ch, enclosingName, metricReg, src)...)
+		}
+	}
+
+	// --- Body call forms -----------------------------------------------------
+	body := funcNode.ChildByFieldName("body")
+	if body != nil {
+		for _, call := range findAll(body, "call") {
+			if h, ok := pyBodyInstrHit(call, metricReg, src); ok {
+				hits = append(hits, h)
+			}
+		}
+	}
+	return hits
+}
+
+// pyDecoratorInstrHits returns instrumentation hits for a single decorator node
+// (@... attached to a function). Handles ddtrace `@tracer.wrap`, Sentry
+// `@sentry_sdk.trace`, New Relic `@function_trace`/`@background_task`/
+// `@newrelic.agent.function_trace`, and Prometheus `@METRIC.time()`.
+func pyDecoratorInstrHits(dec *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
+	// A decorator child is either an `attribute`/`identifier` (bare @x.y / @x)
+	// or a `call` (@x(...)). Resolve the dotted path of the decorator callee and
+	// its argument list (when present).
+	var calleeNode *sitter.Node // identifier/attribute being applied
+	var argsNode *sitter.Node   // argument_list when the decorator is a call
+
+	for i := 0; i < int(dec.ChildCount()); i++ {
+		ch := dec.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "call":
+			calleeNode = ch.ChildByFieldName("function")
+			argsNode = ch.ChildByFieldName("arguments")
+		case "attribute", "identifier":
+			if calleeNode == nil {
+				calleeNode = ch
+			}
+		}
+	}
+	if calleeNode == nil {
+		return nil
+	}
+
+	leaf := pyAttrLeaf(calleeNode, src)     // last dotted segment
+	dotted := pyDottedPath(calleeNode, src) // full dotted path
+	line := int(dec.StartPoint().Row) + 1
+
+	// Prometheus: @METRIC.time() / @METRIC.count_exceptions() — the receiver of
+	// the leaf method must be a known module-level metric variable.
+	if pyPrometheusInstrumentMethods[leaf] {
+		if recv := pyAttrReceiverName(calleeNode, src); recv != "" {
+			if metricName, known := metricReg[recv]; known {
+				h := pyInstrHit{library: "prometheus", api: "metric." + leaf, kind: "metric", line: line}
+				if metricName != "" {
+					h.name = metricName
+				} else {
+					h.dynamic = true
+				}
+				return []pyInstrHit{h}
+			}
+		}
+		return nil
+	}
+
+	// Datadog ddtrace: @tracer.wrap(...) — span name from name= kwarg else fn.
+	if leaf == "wrap" {
+		h := pyInstrHit{library: "ddtrace", api: "tracer.wrap", kind: "span", line: line}
+		if name := pyKeywordStringArg(argsNode, "name", src); name != "" {
+			h.name = name
+		} else if name := pyKeywordStringArg(argsNode, "resource", src); name != "" {
+			h.name = name
+		} else {
+			h.name = enclosingName // ddtrace defaults the span name to the fn name
+		}
+		return []pyInstrHit{h}
+	}
+
+	// New Relic: @newrelic.agent.function_trace(...) / @function_trace(...) /
+	// @background_task(...). Span name from name= kwarg else fn.
+	if leaf == "function_trace" || leaf == "background_task" || leaf == "web_transaction" {
+		h := pyInstrHit{library: "newrelic", api: leaf, kind: "span", line: line}
+		if name := pyKeywordStringArg(argsNode, "name", src); name != "" {
+			h.name = name
+		} else {
+			h.name = enclosingName
+		}
+		return []pyInstrHit{h}
+	}
+
+	// Sentry: @sentry_sdk.trace / @sentry.trace (bare decorator) → span = fn.
+	if leaf == "trace" && (dotted == "sentry_sdk.trace" || dotted == "sentry.trace") {
+		return []pyInstrHit{{library: "sentry", api: "trace", kind: "span", name: enclosingName, line: line}}
+	}
+
+	return nil
+}
+
+// pyBodyInstrHit inspects a body `call` node for a manual span/transaction start
+// (ddtrace `tracer.trace(...)`, Sentry `start_transaction`/`start_span`) or a
+// Prometheus metric mutation (`METRIC.inc()` / `.observe()` / `.set()` on a known
+// metric var). Returns false when the call is not an instrumentation call.
+func pyBodyInstrHit(call *sitter.Node, metricReg pyMetricRegistry, src []byte) (pyInstrHit, bool) {
+	if call == nil || call.Type() != "call" {
+		return pyInstrHit{}, false
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "attribute" {
+		return pyInstrHit{}, false
+	}
+	leaf := pyAttrLeaf(fn, src)
+	dotted := pyDottedPath(fn, src)
+	args := call.ChildByFieldName("arguments")
+	line := int(call.StartPoint().Row) + 1
+
+	// Datadog ddtrace manual span: tracer.trace("op") — first positional arg.
+	if leaf == "trace" && dotted != "sentry_sdk.trace" && dotted != "sentry.trace" {
+		recv := pyAttrReceiverName(fn, src)
+		if recv == "tracer" || recv == "_tracer" {
+			h := pyInstrHit{library: "ddtrace", api: "tracer.trace", kind: "span", line: line}
+			if name := pyFirstPositionalString(args, src); name != "" {
+				h.name = name
+			} else {
+				h.dynamic = true
+			}
+			return h, true
+		}
+		return pyInstrHit{}, false
+	}
+
+	// Sentry transactions/spans: name= or description= keyword carries the name.
+	if leaf == "start_transaction" || leaf == "start_span" {
+		h := pyInstrHit{library: "sentry", api: leaf, kind: "span", line: line}
+		name := pyKeywordStringArg(args, "name", src)
+		if name == "" {
+			name = pyKeywordStringArg(args, "op", src)
+		}
+		if name == "" {
+			name = pyKeywordStringArg(args, "description", src)
+		}
+		if name != "" {
+			h.name = name
+		} else {
+			h.dynamic = true
+		}
+		return h, true
+	}
+
+	// Prometheus body mutation: METRIC.inc()/dec()/observe()/set() — only when
+	// the leaf is a body-call method AND the receiver is a known metric var.
+	if pyPrometheusInstrumentMethods[leaf] && leaf != "time" && leaf != "count_exceptions" && leaf != "track_inprogress" {
+		if recv := pyAttrReceiverName(fn, src); recv != "" {
+			if metricName, known := metricReg[recv]; known {
+				h := pyInstrHit{library: "prometheus", api: "metric." + leaf, kind: "metric", line: line}
+				if metricName != "" {
+					h.name = metricName
+				} else {
+					h.dynamic = true
+				}
+				return h, true
+			}
+		}
+	}
+
+	return pyInstrHit{}, false
+}
+
+// pyAttrLeaf returns the last dotted segment of an identifier/attribute node:
+// `tracer.wrap` → "wrap", `newrelic.agent.function_trace` → "function_trace",
+// a bare `foo` → "foo".
+func pyAttrLeaf(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "identifier":
+		return nodeText(n, src)
+	case "attribute":
+		if a := n.ChildByFieldName("attribute"); a != nil {
+			return nodeText(a, src)
+		}
+	}
+	return ""
+}
+
+// pyAttrReceiverName returns the identifier name of the immediate receiver of an
+// attribute node: `REQUEST_TIME.time` → "REQUEST_TIME". Returns "" when the
+// receiver is not a bare identifier (e.g. a nested attribute or a call).
+func pyAttrReceiverName(n *sitter.Node, src []byte) string {
+	if n == nil || n.Type() != "attribute" {
+		return ""
+	}
+	obj := n.ChildByFieldName("object")
+	if obj == nil || obj.Type() != "identifier" {
+		return ""
+	}
+	return nodeText(obj, src)
+}
+
+// pyDottedPath renders the full dotted path of an identifier/attribute node:
+// `sentry_sdk.trace` → "sentry_sdk.trace". Non-identifier receivers terminate
+// the path. Returns the leaf alone when the path cannot be fully rendered.
+func pyDottedPath(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "identifier":
+		return nodeText(n, src)
+	case "attribute":
+		obj := n.ChildByFieldName("object")
+		attr := n.ChildByFieldName("attribute")
+		if attr == nil {
+			return ""
+		}
+		left := pyDottedPath(obj, src)
+		if left == "" {
+			return nodeText(attr, src)
+		}
+		return left + "." + nodeText(attr, src)
+	}
+	return ""
+}
+
+// pyFirstPositionalString returns the value of the first positional argument when
+// it is a string literal, else "".
+func pyFirstPositionalString(args *sitter.Node, src []byte) string {
+	nameNode := firstPositionalArg(args)
+	if nameNode != nil && nameNode.Type() == "string" {
+		return pythonLiteralValue(nameNode, src)
+	}
+	return ""
+}
+
+// pyKeywordStringArg returns the string-literal value of the keyword argument
+// named key in args (`name="checkout"` → "checkout"), or "" when absent / not a
+// string literal.
+func pyKeywordStringArg(args *sitter.Node, key string, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil || ch.Type() != "keyword_argument" {
+			continue
+		}
+		nameNode := ch.ChildByFieldName("name")
+		valNode := ch.ChildByFieldName("value")
+		if nameNode == nil || valNode == nil {
+			continue
+		}
+		if nodeText(nameNode, src) != key {
+			continue
+		}
+		if valNode.Type() == "string" {
+			return pythonLiteralValue(valNode, src)
+		}
+		return "" // keyword present but non-literal → caller treats as absent
+	}
+	return ""
+}
+
+// stampPythonObservability emits INSTRUMENTS edges on the entity at index idx for
+// every non-OTel instrumentation site (ddtrace, Sentry, Prometheus, New Relic)
+// found in funcNode's decorators and body. metricReg resolves Prometheus metric
+// variables to metric names. enclosingName keys dynamic stubs and supplies the
+// default span name for name-defaulting decorators (ddtrace/New Relic/Sentry).
+func stampPythonObservability(funcNode, decoratorParent *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte, out *[]types.EntityRecord, idx int) {
+	if funcNode == nil || out == nil || idx < 0 || idx >= len(*out) {
+		return
+	}
+	hits := extractPyInstrHits(funcNode, decoratorParent, enclosingName, metricReg, src)
+	if len(hits) == 0 {
+		return
+	}
+	e := &(*out)[idx]
+	seen := make(map[string]bool)
+	for _, h := range hits {
+		props := map[string]string{
+			"library": h.library,
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		prefix := h.kind + ":"
+		var toID string
+		if h.dynamic || h.name == "" {
+			props["dynamic"] = "true"
+			toID = prefix + enclosingName
+		} else {
+			if h.kind == "metric" {
+				props["metric_name"] = h.name
+			} else {
+				props["span_name"] = h.name
+			}
+			toID = prefix + h.name
+		}
+		// Dedup on (library, api, toID) so repeated identical sites collapse; a
+		// dynamic site keys on line so distinct dynamic sites both survive.
+		key := h.library + "|" + h.api + "|" + toID
+		if h.dynamic || h.name == "" {
+			key += "|" + strconv.Itoa(h.line)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		e.Relationships = append(e.Relationships, types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+}


### PR DESCRIPTION
Closes #3762 (child of epic #3628, area #11).

Extends the wave-5 `INSTRUMENTS` edge (OpenTelemetry, #3689) to the dominant **non-OTel** Python instrumentation libraries, reusing the exact same edge contract so the graph stays consistent:

- **FROM** = enclosing operation entity (function/method)
- **TO** = synthetic stub `span:<name>` (traces) or `metric:<name>` (metrics)
- **Kind** = `INSTRUMENTS`; props `library`, `api`, `line`, `traced=true` (+ `span_name`|`metric_name`, `dynamic`)

## Libraries (Python)
| Library | Forms | Name source |
|---|---|---|
| **Datadog ddtrace** | `@tracer.wrap()`, `@tracer.wrap(name=/resource=)`, `tracer.trace("op")` body | fn name default / kwarg / first positional |
| **Sentry** | bare `@sentry_sdk.trace`/`@sentry.trace`, `start_transaction(...)`/`start_span(...)` body | fn name / `name=`,`op=`,`description=` |
| **Prometheus** | `X = Counter\|Gauge\|Summary\|Histogram\|Info\|Enum("name")` + `@X.time()`/`@X.count_exceptions()`/`@X.track_inprogress()` + `X.inc()/dec()/observe()/set()` body | metric name from the module-level declaration |
| **New Relic** | `@newrelic.agent.function_trace()`/`@function_trace()`/`@background_task()`/`@web_transaction()` | fn name default / `name=` |

## Name-property note
Trace/transaction spans carry `span_name`; metrics carry `metric_name`. Prometheus metric names are resolved via a module-level metric registry (var → metric name) built once per file and threaded through `walkNode`.

## Honest-partial / precision
- Dynamic span/metric names (variable, attribute, call) → `traced=true`+`dynamic=true`, **no fabricated name**, keyed on the enclosing fn (`span:<fn>`/`metric:<fn>`).
- A Prometheus `.inc()`/`.time()` on a variable that is **not** a known module-level metric → **no edge** (precision over recall).

## Tests (13, value-asserting)
Assert exact span/metric **name + target + library + api** per library, plus negatives: Sentry dynamic-name no-fabrication, Prometheus unknown-var no-edge, `@app.route` non-instrumentation no-edge, plain-fn no-edge.

## Scope
Python only this round; Go ddtrace `StartSpan` and JS Sentry/Prometheus deferred. OTel multi-lang already shipped in #3689; this PR leaves `tracing.go` untouched and runs `observability.go` as a parallel pass.

## Verification (sandbox-isolated)
- `go test ./internal/extractors/python/ ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `go test ./internal/types/` — green (INSTRUMENTS kind already registered, reused)
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical
- `gofmt -l` — empty; `go vet` — clean

**DEPLOY-DEFERRED**: no daemon rebuild / reindex / MCP install performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)