### PR TITLE
feat(engine): feature-flag provider breadth — Split.io / Unleash-React / generic wrappers

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16249,7 +16249,7 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {
@@ -23422,7 +23422,7 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {
@@ -27663,7 +27663,7 @@
             "status": "missing",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "feature_flag_gating:#3706-not-yet-extracted",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {
@@ -30659,7 +30659,7 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {
@@ -45844,7 +45844,7 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {
@@ -52250,7 +52250,7 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/OpenFeature/Flipper/Flagsmith)",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
             "verified_at": "2026-06-02"
           },
           "fs_effect": {

--- a/internal/engine/feature_flag_edges.go
+++ b/internal/engine/feature_flag_edges.go
@@ -29,11 +29,22 @@
 //     getStringValue / getNumberValue / getObjectValue
 //   - Flipper      : Flipper.enabled?(:key) / :key.to_sym (Ruby)
 //   - Flagsmith    : flagsmith.has_feature("key") / is_feature_enabled("key")
+//   - Split.io     : client.getTreatment("split-name") /
+//     getTreatmentWithConfig / getTreatments (the treatment family is
+//     Split-specific)
+//   - Unleash-React: useFlag("key") / useFlagsStatus — the @unleash/proxy-client
+//     React hook
+//   - Generic/custom : getFlag("key") / feature_enabled("key") /
+//     featureEnabled("key") / isFeatureEnabled("key") — FF-specific custom
+//     wrappers, distinct enough from arbitrary code to attribute
 //
 // Honest-partial: only LITERAL string/symbol flag keys are emitted. A dynamic
-// key (`variation(k, ...)`, `isEnabled(flagName)`) yields NO edge and NO
-// fabricated flag entity — the same disposition config-read uses for dynamic
-// settings.
+// key (`variation(k, ...)`, `isEnabled(flagName)`, `getTreatment(name)`) yields
+// NO edge and NO fabricated flag entity — the same disposition config-read uses
+// for dynamic settings. Bare subscript access (`flags['x']`) is deliberately
+// NOT matched: a `flags[...]` map index is far too common in ordinary code to
+// attribute to a feature flag without import context, so it is skipped rather
+// than risk false positives.
 //
 // Append-only — never modifies existing entities or edges, so this pass
 // cannot regress the surrounding pipeline on files that contain no flag
@@ -62,7 +73,7 @@ const featureFlagPatternType = "feature_flag_gating"
 // flagHit is one detected flag-check call site.
 type flagHit struct {
 	key    string // literal flag key (symbol leading ':' already stripped)
-	sdk    string // detecting SDK: launchdarkly | unleash | openfeature | flipper | flagsmith
+	sdk    string // detecting SDK: launchdarkly | unleash | unleash-react | openfeature | flipper | flagsmith | split | custom
 	method string // the SDK call/method observed
 	caller string // enclosing-function name ("" → file scope)
 	line   int    // 1-indexed source line
@@ -151,6 +162,50 @@ var flagSDKMatchers = []flagSDKMatcher{
 		),
 		sdk:    "flagsmith",
 		method: "has_feature",
+	},
+
+	// Split.io. client.getTreatment("split-name") /
+	// getTreatmentWithConfig("split-name") / getTreatments(...) (plural takes
+	// a list, not a single literal — excluded). The `getTreatment` family is
+	// Split-specific, so the method name alone is a reliable signal without a
+	// receiver constraint. Split keys are conventionally called "splits"; we
+	// store the literal as the flag key so a split shares the converged node
+	// identity with any other provider checking the same key string.
+	{
+		re: regexp.MustCompile(
+			`(?i)\bgetTreatment(?:WithConfig)?\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "split",
+		method: "getTreatment",
+	},
+
+	// Unleash React proxy client hook: useFlag("beta-ui") /
+	// useFlag('beta-ui'). useFlagsStatus()/useVariant("x") are related; only
+	// the single-literal-key shape is attributed. Distinct from the server
+	// isEnabled matcher above (different call name) so both can fire in a
+	// codebase mixing client+server SDKs.
+	{
+		re: regexp.MustCompile(
+			`(?i)\buseFlag\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "unleash-react",
+		method: "useFlag",
+	},
+
+	// Generic / custom feature-flag wrappers. getFlag("key") /
+	// feature_enabled("key") / featureEnabled("key"). These method names are
+	// FF-specific enough to attribute. isFeatureEnabled / isEnabled are
+	// already handled by the Unleash matcher above (first-match-wins), so this
+	// matcher targets the getFlag + feature_enabled shapes it does not cover.
+	{
+		re: regexp.MustCompile(
+			`(?i)\b(?:getFlag|feature_?enabled)\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "custom",
+		method: "getFlag",
 	},
 }
 

--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -230,6 +230,186 @@ def banner(self):
 	}
 }
 
+// Split.io: client.getTreatment("exp-pricing") → feature:exp-pricing,
+// attributed to the enclosing function, SDK subtype "split".
+func TestFeatureFlag_Split_getTreatment(t *testing.T) {
+	src := `
+function pricing() {
+  const t = client.getTreatment("exp-pricing");
+  return t === "on" ? newPrice() : oldPrice();
+}
+`
+	flags, edges := runFlagPass("javascript", "pricing.js", src)
+	flag, ok := findFlag(flags, "exp-pricing")
+	if !ok {
+		t.Fatalf("expected feature:exp-pricing entity, got %v", flags)
+	}
+	if flag.ID != "feature:exp-pricing" {
+		t.Errorf("flag ID = %q, want feature:exp-pricing", flag.ID)
+	}
+	if flag.Subtype != "split" {
+		t.Errorf("flag SDK = %q, want split", flag.Subtype)
+	}
+	g, ok := findGate(edges, "exp-pricing")
+	if !ok {
+		t.Fatalf("expected GATED_BY for exp-pricing, got %v", edges)
+	}
+	if g.From != "Function:pricing" || g.To != "feature:exp-pricing" {
+		t.Errorf("edge = %+v, want Function:pricing -> feature:exp-pricing", g)
+	}
+	if g.SDK != "split" {
+		t.Errorf("GATED_BY sdk = %q, want split", g.SDK)
+	}
+}
+
+// Split.io getTreatmentWithConfig is part of the same treatment family.
+func TestFeatureFlag_Split_getTreatmentWithConfig(t *testing.T) {
+	src := `
+function home() {
+  const r = splitClient.getTreatmentWithConfig('home-banner', attrs);
+  return r.treatment;
+}
+`
+	flags, edges := runFlagPass("typescript", "home.ts", src)
+	if _, ok := findFlag(flags, "home-banner"); !ok {
+		t.Fatalf("expected feature:home-banner entity, got %v", flags)
+	}
+	g, ok := findGate(edges, "home-banner")
+	if !ok || g.From != "Function:home" || g.To != "feature:home-banner" {
+		t.Fatalf("edge = %+v ok=%v, want Function:home -> feature:home-banner", g, ok)
+	}
+}
+
+// Unleash React proxy hook: useFlag("beta-ui") → feature:beta-ui, SDK subtype
+// "unleash-react".
+func TestFeatureFlag_UnleashReact_useFlag(t *testing.T) {
+	src := `
+function Nav() {
+  const beta = useFlag("beta-ui");
+  return beta ? <NewNav/> : <OldNav/>;
+}
+`
+	flags, edges := runFlagPass("typescript", "Nav.tsx", src)
+	flag, ok := findFlag(flags, "beta-ui")
+	if !ok {
+		t.Fatalf("expected feature:beta-ui entity, got %v", flags)
+	}
+	if flag.Subtype != "unleash-react" {
+		t.Errorf("flag SDK = %q, want unleash-react", flag.Subtype)
+	}
+	g, ok := findGate(edges, "beta-ui")
+	if !ok || g.From != "Function:Nav" || g.To != "feature:beta-ui" {
+		t.Fatalf("edge = %+v ok=%v, want Function:Nav -> feature:beta-ui", g, ok)
+	}
+}
+
+// Generic custom wrapper: getFlag("legacy-import") → feature:legacy-import,
+// SDK subtype "custom".
+func TestFeatureFlag_Custom_getFlag(t *testing.T) {
+	src := `
+function importer() {
+  if (flags.getFlag("legacy-import")) {
+    return legacyImport();
+  }
+}
+`
+	flags, edges := runFlagPass("javascript", "importer.js", src)
+	flag, ok := findFlag(flags, "legacy-import")
+	if !ok {
+		t.Fatalf("expected feature:legacy-import entity, got %v", flags)
+	}
+	if flag.Subtype != "custom" {
+		t.Errorf("flag SDK = %q, want custom", flag.Subtype)
+	}
+	if g, ok := findGate(edges, "legacy-import"); !ok || g.From != "Function:importer" {
+		t.Fatalf("edge = %+v ok=%v, want Function:importer", g, ok)
+	}
+}
+
+// Generic custom wrapper, snake_case Python: feature_enabled("new-report").
+func TestFeatureFlag_Custom_feature_enabled_python(t *testing.T) {
+	src := `
+def report(user):
+    if feature_enabled("new-report"):
+        return new_report(user)
+    return old_report(user)
+`
+	flags, edges := runFlagPass("python", "report.py", src)
+	if _, ok := findFlag(flags, "new-report"); !ok {
+		t.Fatalf("expected feature:new-report entity, got %v", flags)
+	}
+	g, ok := findGate(edges, "new-report")
+	if !ok || g.From != "Function:report" || g.To != "feature:new-report" {
+		t.Fatalf("edge = %+v ok=%v, want Function:report -> feature:new-report", g, ok)
+	}
+}
+
+// CONVERGENCE: Split.io and LaunchDarkly checking the SAME key string in two
+// functions converge on ONE flag node (cross-provider key identity), with two
+// distinct GATED_BY edges. The first provider to detect the key wins the
+// Subtype, but the node id `feature:<key>` is shared.
+func TestFeatureFlag_Convergence_CrossProvider_SameKey(t *testing.T) {
+	src := `
+function a() {
+  return client.variation("shared-key", user, false);
+}
+function b() {
+  return client.getTreatment("shared-key");
+}
+`
+	flags, edges := runFlagPass("javascript", "shared.js", src)
+	n := 0
+	for _, f := range flags {
+		if f.Name == "shared-key" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected exactly 1 shared-key node (cross-provider convergence), got %d", n)
+	}
+	froms := map[string]bool{}
+	for _, e := range edges {
+		if e.Flag == "shared-key" && e.To != "feature:shared-key" {
+			t.Errorf("convergence: edge To = %q, want feature:shared-key", e.To)
+		}
+		if e.Flag == "shared-key" {
+			froms[e.From] = true
+		}
+	}
+	if !froms["Function:a"] || !froms["Function:b"] {
+		t.Errorf("expected GATED_BY from both a and b, got %v", froms)
+	}
+}
+
+// NEGATIVE: Split.io getTreatment with a dynamic (non-literal) key must NOT
+// fabricate a flag entity or edge.
+func TestFeatureFlag_Split_DynamicKey_NoFabrication(t *testing.T) {
+	src := `
+function gate(splitName) {
+  return client.getTreatment(splitName);
+}
+`
+	flags, edges := runFlagPass("javascript", "gate.js", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("dynamic Split key should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// NEGATIVE: a bare `flags['x']` subscript on an unrelated object must NOT be
+// treated as a feature-flag check — it is too common in ordinary code and the
+// pass deliberately does not match subscript access.
+func TestFeatureFlag_Subscript_NotAFlag(t *testing.T) {
+	src := `
+function f(flags) {
+  return flags['enabled'] && flags['x-value'];
+}
+`
+	flags, edges := runFlagPass("javascript", "sub.js", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("bare subscript should yield no flag output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
 // NEGATIVE: a dynamic flag key (bare identifier argument) must NOT fabricate
 // a flag entity or edge.
 func TestFeatureFlag_DynamicKey_NoFabrication(t *testing.T) {


### PR DESCRIPTION
Closes #3764 (parent epic #3628, area #17).

Extends the wave-6 `applyFeatureFlagEdges` pass (#3706) with three more provider/pattern families. Same node + edge contract as wave-6 — keys converge across providers.

## Providers / patterns added
| Provider | Pattern matched | SDK subtype |
|---|---|---|
| **Split.io** | `client.getTreatment("split")`, `getTreatmentWithConfig("split")` | `split` |
| **Unleash (React proxy)** | `useFlag("key")` hook | `unleash-react` |
| **Generic / custom** | `getFlag("key")`, `feature_enabled("key")` / `featureEnabled("key")` | `custom` |

(`isFeatureEnabled` / `isEnabled` were already covered by the wave-6 Unleash matcher; LaunchDarkly `variation` family, OpenFeature `get*Value`, Flipper, Flagsmith already covered.)

## Flag-node convention (unchanged)
- Node id `feature:<literal-key>` — a key checked by two providers converges on ONE node. Asserted by `TestFeatureFlag_Convergence_CrossProvider_SameKey` (Split + LaunchDarkly on `shared-key` → one node, two edges).
- `GATED_BY(enclosing fn → feature:<key>)`, deduped per (caller, key). First-matcher-wins per offset; first provider to detect a key wins the Subtype.

## GATED_BY edges asserted (value-asserting, not len>0)
- `Function:pricing → feature:exp-pricing` (Split getTreatment, JS)
- `Function:home → feature:home-banner` (Split getTreatmentWithConfig, TS)
- `Function:Nav → feature:beta-ui` (Unleash-React useFlag, TSX)
- `Function:importer → feature:legacy-import` (custom getFlag, JS)
- `Function:report → feature:new-report` (custom feature_enabled, Python)
- convergence: `Function:a` + `Function:b → feature:shared-key`

## Honest-partial
- Dynamic keys (`getTreatment(splitName)`) emit nothing — negative test.
- Bare `flags['x']` subscript NOT matched (too noisy without import context) — negative test.

## Verification
- `go test ./internal/engine/ ./internal/types/` green (8 new tests pass).
- `gofmt -l` empty; `go vet ./internal/engine/` clean.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.

## Coverage records
Enriched the per-language flagship `feature_flag_gating` notes (go/java/jsts/python/ruby) to list the expanded provider set. No status flips — the capability is the same language-agnostic regex pass, and the per-framework `missing` cells represent unverified-per-framework, which this change does not establish.

**DEPLOY-DEFERRED**: extractor change; takes effect on next indexer rebuild/reindex. No daemon/index/mcp action in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)