### PR TITLE
feat(cache): CACHES/INVALIDATES breadth — Django + Go (ristretto/groupcache)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1076,15 +1076,15 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
+          "cites": ["internal/custom/golang/caching.go","internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
           "issue": "3692",
-          "notes": "CACHES (read-through/write) + INVALIDATES (evict) edges from function/method to cache region/key. Cross-language consistent target ref cache:\u003cfw\u003e:\u003cregion\u003e."
+          "notes": "CACHES (read-through/write) + INVALIDATES (evict) edges from function/method/call-site to cache region/key. Cross-language consistent target ref cache:\u003cfw\u003e:\u003cregion\u003e — Set/Get/Delete and @Cacheable/@CacheEvict of the same literal key converge on one region node so what-invalidates-what is traversable."
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
+          "cites": ["internal/custom/golang/caching.go","internal/custom/java/caching.go","internal/custom/javascript/caching.go","internal/custom/python/caching.go","internal/custom/ruby/caching.go"],
           "issue": "3692",
-          "notes": "Cache-region/key SCOPE.Datastore nodes from Spring @Cacheable/@CacheEvict/@CachePut, Python lru_cache/Flask-Caching/cachetools, Rails.cache.fetch/delete, NestJS @CacheKey + cache-manager. Dynamic keys honest-partial."
+          "notes": "Cache-region/key SCOPE.Datastore nodes from Spring @Cacheable/@CacheEvict/@CachePut, Python lru_cache/Flask-Caching/cachetools + Django low-level cache.get/set/delete and @cache_page, Rails.cache.fetch/delete, NestJS @CacheKey + cache-manager, Go ristretto Set/Get/Del + groupcache NewGroup/Get. Dynamic keys honest-partial."
         }
       }
     },

--- a/internal/custom/golang/caching.go
+++ b/internal/custom/golang/caching.go
@@ -1,0 +1,206 @@
+package golang
+
+// caching.go — Go in-process cache-topology extraction ([cache] breadth child
+// of epic #3628). Cross-language consistent with the Spring cache-region node
+// (internal/custom/java/caching.go), the Python cache-region node
+// (internal/custom/python/caching.go), the Rails cache-region node
+// (internal/custom/ruby/caching.go), and the JS cache-region node
+// (internal/custom/javascript/caching.go). Two dominant Go cache abstractions:
+//
+//	ristretto (dgraph-io/ristretto):
+//	  cache.Set("user:1", v, 1)   → call-site CACHES region "user:1"  (write)
+//	  cache.Get("user:1")         → CACHES region "user:1"            (read)
+//	  cache.Del("user:1")         → INVALIDATES region "user:1"       (evict)
+//
+//	groupcache (golang/groupcache):
+//	  groupcache.NewGroup("users", ...) → declares region "users"
+//	  group.Get(ctx, "user:1", dest)    → CACHES region "user:1"      (read)
+//
+// Entity/edge shape (identical to the other languages so a Set and a Del on the
+// same literal key converge on ONE region node — the whole value of the model):
+//
+//	target  : SCOPE.Datastore  subtype "cache_region"
+//	          Ref  "cache:<framework>:<region>"   (sites converge on one node)
+//	carrier : SCOPE.Operation  the cache call-site
+//	edge    : CACHES | INVALIDATES   carrier → region
+//
+// Honest-partial: a non-literal first argument (a variable / interpolated key)
+// is dynamic — the edge is emitted against a "<dynamic>" region with
+// dynamic="true" so the intent stays traversable, mirroring the existing
+// JS/Rails convention. A non-cache `.Get`/`.Set` on an unrelated map/struct is
+// NOT matched: the file must import a known cache library (ristretto or
+// groupcache) for any call-site to count.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_caching", &goCachingExtractor{})
+}
+
+type goCachingExtractor struct{}
+
+func (e *goCachingExtractor) Language() string { return "custom_go_caching" }
+
+var (
+	// reGoCacheOp matches a ristretto-style cache op. Group 1 = receiver
+	// (any identifier — gated on a cache import); Group 2 = verb; Group 3 = the
+	// first-argument string literal body, which is OPTIONAL: a variable key
+	// (`cache.Set(k, v, 1)`) matches with group 3 absent → honest-partial. The
+	// receiver is intentionally broad because ristretto caches are plain values
+	// (`cache.Set(...)`); the import gate below prevents map/struct false hits.
+	reGoCacheOp = regexp.MustCompile(
+		`\b(\w+)\.(Set|Get|Del|Delete)\s*\(\s*(?:"([^"]*)")?`)
+
+	// reGroupGet matches a groupcache `group.Get(ctx, "key", dest)` read — the
+	// key is the SECOND argument (the first is a context). Group 1 = receiver;
+	// Group 2 = the optional key literal body (absent when the key is dynamic).
+	reGroupGet = regexp.MustCompile(
+		`\b(\w+)\.Get\s*\(\s*[A-Za-z_]\w*\s*,\s*(?:"([^"]*)")?`)
+
+	// reGroupNew matches groupcache.NewGroup("users", ...) — declares a region.
+	// Group 1 = the region name literal body.
+	reGroupNew = regexp.MustCompile(
+		`groupcache\.NewGroup\s*\(\s*"([^"]*)"`)
+)
+
+func goCacheRef(framework, region string) string {
+	return "cache:" + framework + ":" + region
+}
+
+// goCacheEdge classifies a ristretto verb into (relType, mode).
+func goCacheEdge(verb string) (relType, mode string) {
+	switch verb {
+	case "Del", "Delete":
+		return "INVALIDATES", "evict"
+	case "Set":
+		return "CACHES", "write"
+	default: // Get
+		return "CACHES", "read"
+	}
+}
+
+func (e *goCachingExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.go_caching")
+	_, span := tracer.Start(ctx, "custom.go_caching")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Import gate: a Go file only participates if it actually pulls in a known
+	// in-process cache library. This is what stops `someMap.Get("x")` /
+	// `cfg.Set("x")` on unrelated values from emitting phantom cache edges.
+	hasRistretto := strings.Contains(src, "ristretto")
+	hasGroupcache := strings.Contains(src, "groupcache")
+	if !hasRistretto && !hasGroupcache {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenRegion := make(map[string]bool)
+	seenOwner := make(map[string]bool)
+
+	emitRegion := func(framework, region string, dynamic bool, line int) string {
+		ref := goCacheRef(framework, region)
+		if !seenRegion[ref] {
+			seenRegion[ref] = true
+			ent := makeEntity(region, "SCOPE.Datastore", "cache_region", file.Path, file.Language, line)
+			setProps(&ent, "framework", framework, "region", region,
+				"cache_kind", "region", "language", "go",
+				"provenance", "INFERRED_FROM_GO_CACHE")
+			if dynamic {
+				setProps(&ent, "dynamic", "true")
+			}
+			out = append(out, ent)
+		}
+		return ref
+	}
+
+	// emitOp appends the carrier call-site with its CACHES/INVALIDATES edge.
+	emitOp := func(framework, carrier, region, relType, mode string, dynamic bool, line int) {
+		ownerKey := framework + ":" + carrier + ":" + region + ":" + itoa(line)
+		if seenOwner[ownerKey] {
+			return
+		}
+		seenOwner[ownerKey] = true
+
+		ref := emitRegion(framework, region, dynamic, line)
+		ent := makeEntity(carrier, "SCOPE.Operation", "cache_method", file.Path, file.Language, line)
+		setProps(&ent, "framework", framework, "cache_mode", mode,
+			"provenance", "INFERRED_FROM_GO_CACHE")
+		if dynamic {
+			setProps(&ent, "dynamic", "true")
+		}
+		edgeProps := map[string]string{
+			"framework": framework, "region": region, "mode": mode, "language": "go",
+		}
+		if dynamic {
+			edgeProps["dynamic"] = "true"
+		}
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: ref, Kind: relType, Properties: edgeProps,
+		})
+		out = append(out, ent)
+	}
+
+	// 0. groupcache.NewGroup("users", ...) — declares a region up front so a
+	// later group.Get against a dynamic key still converges on the named region
+	// (best-effort: the read key, not the group name, is the convergence unit,
+	// but a declared region is worth recording as a node).
+	if hasGroupcache {
+		for _, m := range reGroupNew.FindAllStringSubmatchIndex(src, -1) {
+			name := submatch(src, m, 2)
+			if strings.TrimSpace(name) == "" {
+				continue
+			}
+			emitRegion("groupcache", name, false, lineOf(src, m[0]))
+		}
+
+		// groupcache reads: group.Get(ctx, "key", dest).
+		for _, m := range reGroupGet.FindAllStringSubmatchIndex(src, -1) {
+			recv := submatch(src, m, 2)
+			rawKey := submatch(src, m, 4)
+			region, dynamic := normaliseGoCacheKey(rawKey, m[4] >= 0)
+			emitOp("groupcache", recv+".Get", region, "CACHES", "read", dynamic, lineOf(src, m[0]))
+		}
+	}
+
+	// 1. ristretto-style Set/Get/Del with a literal first-argument key.
+	if hasRistretto {
+		for _, m := range reGoCacheOp.FindAllStringSubmatchIndex(src, -1) {
+			recv := submatch(src, m, 2)
+			verb := submatch(src, m, 4)
+			rawKey := submatch(src, m, 6)
+			region, dynamic := normaliseGoCacheKey(rawKey, m[6] >= 0)
+			relType, mode := goCacheEdge(verb)
+			emitOp("ristretto", recv+"."+verb, region, relType, mode, dynamic, lineOf(src, m[0]))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// normaliseGoCacheKey resolves the captured first-argument key. matched reports
+// whether a string-literal group actually participated (vs. a variable key,
+// where the literal group did not match at all). A literal "user:1" is a
+// concrete region; a non-literal key is honest-partial "<dynamic>".
+func normaliseGoCacheKey(raw string, matched bool) (region string, dynamic bool) {
+	if !matched || strings.TrimSpace(raw) == "" {
+		return "<dynamic>", true
+	}
+	return raw, false
+}

--- a/internal/custom/golang/caching_test.go
+++ b/internal/custom/golang/caching_test.go
@@ -1,0 +1,144 @@
+package golang_test
+
+// caching_test.go — value-asserting tests for the custom_go_caching extractor
+// ([cache] breadth, epic #3628). Asserts the actual cache region + CACHES /
+// INVALIDATES edge (region id + edge kind), not len>0.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runGoCaching(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_go_caching")
+	if !ok {
+		t.Fatal("custom_go_caching not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "cache.go", Language: "go", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func goEdge(ents []types.EntityRecord, kind, wantRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.ToID == wantRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func goHasRegion(ents []types.EntityRecord, ref string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Subtype == "cache_region" {
+			if "cache:"+e.Properties["framework"]+":"+e.Properties["region"] == ref {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ristretto Set + Del on the SAME literal key converge: CACHES(Set→region) AND
+// INVALIDATES(Del→region) on the one "cache:ristretto:user:1" node.
+func TestGoCaching_Ristretto_SetDel_Converge(t *testing.T) {
+	src := `
+import "github.com/dgraph-io/ristretto"
+
+func warm(cache *ristretto.Cache, v User) { cache.Set("user:1", v, 1) }
+func evict(cache *ristretto.Cache)        { cache.Del("user:1") }
+`
+	ents := runGoCaching(t, src)
+	ref := "cache:ristretto:user:1"
+	if !goHasRegion(ents, ref) {
+		t.Fatalf("expected ristretto cache region %q", ref)
+	}
+	c := goEdge(ents, "CACHES", ref)
+	if c == nil {
+		t.Fatalf("expected cache.Set CACHES region user:1")
+	}
+	if c.Properties["mode"] != "write" {
+		t.Errorf("Set mode = %q, want write", c.Properties["mode"])
+	}
+	i := goEdge(ents, "INVALIDATES", ref)
+	if i == nil {
+		t.Fatalf("expected cache.Del INVALIDATES region user:1 (converging on same node)")
+	}
+	if i.Properties["mode"] != "evict" {
+		t.Errorf("Del mode = %q, want evict", i.Properties["mode"])
+	}
+}
+
+func TestGoCaching_Ristretto_Get_Read(t *testing.T) {
+	src := `
+import "github.com/dgraph-io/ristretto"
+func read(cache *ristretto.Cache) { cache.Get("profile") }
+`
+	ents := runGoCaching(t, src)
+	e := goEdge(ents, "CACHES", "cache:ristretto:profile")
+	if e == nil {
+		t.Fatalf("expected cache.Get CACHES region profile")
+	}
+	if e.Properties["mode"] != "read" {
+		t.Errorf("Get mode = %q, want read", e.Properties["mode"])
+	}
+}
+
+func TestGoCaching_Groupcache_NewGroupAndGet(t *testing.T) {
+	src := `
+import "github.com/golang/groupcache"
+
+var users = groupcache.NewGroup("users", 64<<20, getter)
+
+func read(ctx context.Context) { users.Get(ctx, "user:1", dest) }
+`
+	ents := runGoCaching(t, src)
+	if !goHasRegion(ents, "cache:groupcache:users") {
+		t.Fatalf("expected declared groupcache region users")
+	}
+	if goEdge(ents, "CACHES", "cache:groupcache:user:1") == nil {
+		t.Fatalf("expected group.Get CACHES region user:1")
+	}
+}
+
+// Honest-partial: a variable (dynamic) key yields a <dynamic> region, not a
+// concrete one.
+func TestGoCaching_Ristretto_DynamicKey_Partial(t *testing.T) {
+	src := `
+import "github.com/dgraph-io/ristretto"
+func warm(cache *ristretto.Cache, k string, v User) { cache.Set(k, v, 1) }
+`
+	ents := runGoCaching(t, src)
+	if goEdge(ents, "CACHES", "cache:ristretto:<dynamic>") == nil {
+		t.Fatalf("expected honest-partial <dynamic> CACHES edge for variable key")
+	}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Subtype == "cache_region" &&
+			e.Properties["region"] == "<dynamic>" && e.Properties["dynamic"] != "true" {
+			t.Fatalf("dynamic region must be marked dynamic")
+		}
+	}
+}
+
+// Negative: a non-cache `.Set`/`.Get` on an unrelated value in a file with NO
+// cache import must emit no edges (import gate).
+func TestGoCaching_NoCacheImport_NoEdge(t *testing.T) {
+	src := `
+func f(m map[string]int) { m["x"] = 1; _ = config.Get("y") }
+`
+	ents := runGoCaching(t, src)
+	if len(ents) != 0 {
+		t.Fatalf("non-cache file should emit no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/python/caching.go
+++ b/internal/custom/python/caching.go
@@ -27,10 +27,17 @@ package python
 //	carrier : the decorated function operation (owner of the edge)
 //	edge    : CACHES   owner → region
 //
-// Python has no first-class declarative eviction decorator (eviction is an
-// imperative `cache.delete(...)` call already modelled as a redis WRITES_TO
-// op), so this extractor only emits CACHES; INVALIDATES is owned by the Java
-// (@CacheEvict) and Rails (Rails.cache.delete) passes.
+// Django cache framework (django.core.cache) is also covered here:
+//
+//	cache.get('k') / cache.set('k', v) / caches['x'].get('k')
+//	    → call-site CACHES region 'k'   (low-level cache API)
+//	cache.delete('k')                   → INVALIDATES region 'k'
+//	@cache_page(60)  on a view          → view CACHES region '<request_path>'
+//	                                      (per-URL page cache; dynamic region)
+//
+// So unlike the decorator-only idioms above, Django DOES emit INVALIDATES
+// (cache.delete), converging Set/Get/Delete of the same literal key on one
+// region node — matching the Spring @Cacheable/@CacheEvict convergence.
 
 import (
 	"context"
@@ -78,7 +85,32 @@ var (
 	// flaskKeyPrefixRe pulls key_prefix='view/%s' out of a Flask-Caching body.
 	// Group 1 = the key-prefix literal body.
 	flaskKeyPrefixRe = regexp.MustCompile(`key_prefix\s*=\s*["']([^"']*)["']`)
+
+	// djangoCacheOpRe matches a Django low-level cache op. Group 1 = receiver
+	// (`cache` or a `caches['x']` subscript); Group 2 = verb; Group 3 = the
+	// OPTIONAL first-argument string-literal key (absent → variable key →
+	// dynamic). The receiver alternation accepts both the default `cache` handle
+	// and an aliased `caches['default']` handle.
+	djangoCacheOpRe = regexp.MustCompile(
+		`(?m)\b(cache|caches\[[^\]]*\])\.(get|set|add|delete|get_or_set|incr|decr)\s*\(\s*(?:["']([^"']*)["'])?`)
+
+	// djangoCachePageRe matches @cache_page(60) on a view. Group 1 = decorated
+	// function name. The per-URL page cache region is the request path → dynamic.
+	djangoCachePageRe = regexp.MustCompile(
+		`(?m)@(?:\w+\.)?cache_page\s*\([^)]*\)\s*\n(?:\s*@[^\n]*\n)*\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 )
+
+// djangoCacheEdge classifies a Django low-level cache verb into (relType, mode).
+func djangoCacheEdge(verb string) (relType, mode string) {
+	switch verb {
+	case "delete":
+		return string(types.RelationshipKindInvalidates), "evict"
+	case "set", "add", "incr", "decr":
+		return string(types.RelationshipKindCaches), "write"
+	default: // get, get_or_set
+		return string(types.RelationshipKindCaches), "read_through"
+	}
+}
 
 // cacheRegionRef builds the stable target ref so multiple decorated functions
 // that share a region converge on one node (mirrors redisKeyspaceRef).
@@ -128,8 +160,13 @@ func (e *CachingExtractor) Extract(ctx context.Context, file extractor.FileInput
 	// function carrier with its CACHES edge already attached. Region is appended
 	// BEFORE the owner so the owner is the last element — no live pointer is held
 	// across a slice append (which would reallocate and silently drop the edge).
-	emitCache := func(framework, fn, region, mode string, dynamic bool, line int) {
-		ownerRef := fmt.Sprintf("cache_fn:%s:%s:%d", framework, file.Path, line)
+	// emitEdge is the general form: it appends the region target (if new) and a
+	// carrier operation with a relType (CACHES|INVALIDATES) edge to that region.
+	// patternType distinguishes the decorator idioms from the imperative
+	// low-level Django call-sites. ownerSuffix disambiguates multiple ops that
+	// land on the same line (e.g. get then set).
+	emitEdge := func(framework, fn, region, mode, relType, patternType, ownerSuffix string, dynamic bool, line int) {
+		ownerRef := fmt.Sprintf("cache_fn:%s:%s:%d:%s", framework, file.Path, line, ownerSuffix)
 		if seenOwner[ownerRef] {
 			return
 		}
@@ -152,14 +189,20 @@ func (e *CachingExtractor) Extract(ctx context.Context, file extractor.FileInput
 				"cache_mode":   mode,
 				"cached_fn":    fn,
 				"language":     "python",
-				"pattern_type": "cache_decorator",
+				"pattern_type": patternType,
 			})
 		owner.Relationships = append(owner.Relationships, types.RelationshipRecord{
 			ToID:       targetRef,
-			Kind:       string(types.RelationshipKindCaches),
+			Kind:       relType,
 			Properties: edgeProps,
 		})
 		out = append(out, owner)
+	}
+
+	// emitCache is the decorator-idiom shorthand: always a CACHES edge.
+	emitCache := func(framework, fn, region, mode string, dynamic bool, line int) {
+		emitEdge(framework, fn, region, mode, string(types.RelationshipKindCaches),
+			"cache_decorator", "", dynamic, line)
 	}
 
 	// 1. @lru_cache / @cache — in-process memoisation. Region = function qualname.
@@ -195,6 +238,34 @@ func (e *CachingExtractor) Extract(ctx context.Context, file extractor.FileInput
 		}
 		fn := source[m[4]:m[5]]
 		emitCache("cachetools", fn, "fn:"+fn, "in_process", false, line)
+	}
+
+	// 4. Django low-level cache API — cache.get/set/delete/... with a literal
+	// key. Same literal key on get/set/delete converges on one region node, so
+	// INVALIDATES (delete) maps onto the same node a CACHES (set/get) populates.
+	for _, m := range djangoCacheOpRe.FindAllStringSubmatchIndex(source, -1) {
+		recv := source[m[2]:m[3]]
+		verb := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		region := ""
+		dynamic := false
+		if m[6] >= 0 && strings.TrimSpace(source[m[6]:m[7]]) != "" {
+			region = source[m[6]:m[7]]
+		} else {
+			region = "<dynamic>"
+			dynamic = true
+		}
+		relType, mode := djangoCacheEdge(verb)
+		emitEdge("django", recv+"."+verb, region, mode, relType,
+			"cache_call", verb, dynamic, line)
+	}
+
+	// 5. @cache_page(...) per-URL page cache. Region is the request path → dynamic.
+	for _, m := range djangoCachePageRe.FindAllStringSubmatchIndex(source, -1) {
+		fn := source[m[2]:m[3]]
+		line := lineOf(source, m[0])
+		emitEdge("django", fn, "<request_path>", "read_through",
+			string(types.RelationshipKindCaches), "cache_decorator", "cache_page", true, line)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))

--- a/internal/custom/python/caching_test.go
+++ b/internal/custom/python/caching_test.go
@@ -141,3 +141,114 @@ def get_user(uid):
 		}
 	}
 }
+
+// findInvalidatesEdge returns the INVALIDATES edge whose target == wantRef.
+func findInvalidatesEdge(ents []types.EntityRecord, wantRef string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindInvalidates) && r.ToID == wantRef {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// Django low-level cache: cache.set + cache.delete on the SAME literal key must
+// converge — CACHES(set→region:users) AND INVALIDATES(delete→region:users) on
+// the one "cache:django:users" node. This convergence is the whole value.
+func TestPyCaching_Django_SetDelete_Converge(t *testing.T) {
+	src := `
+from django.core.cache import cache
+
+def cache_users(users):
+    cache.set('users', users, 300)
+
+def evict_users():
+    cache.delete('users')
+`
+	ents := runPyCaching(t, src)
+	ref := "cache:django:users"
+	if !hasCacheRegion(ents, ref) {
+		t.Fatalf("expected django cache region %q", ref)
+	}
+	cE := findCachesEdge(ents, ref)
+	if cE == nil {
+		t.Fatalf("expected cache.set CACHES region users")
+	}
+	if cE.Properties["mode"] != "write" {
+		t.Errorf("set mode = %q, want write", cE.Properties["mode"])
+	}
+	iE := findInvalidatesEdge(ents, ref)
+	if iE == nil {
+		t.Fatalf("expected cache.delete INVALIDATES region users (converging on the same node)")
+	}
+	if iE.Properties["mode"] != "evict" {
+		t.Errorf("delete mode = %q, want evict", iE.Properties["mode"])
+	}
+}
+
+func TestPyCaching_Django_Get_ReadThrough(t *testing.T) {
+	src := `
+from django.core.cache import cache
+def read():
+    return cache.get('profile')
+`
+	ents := runPyCaching(t, src)
+	e := findCachesEdge(ents, "cache:django:profile")
+	if e == nil {
+		t.Fatalf("expected cache.get CACHES region profile")
+	}
+	if e.Properties["mode"] != "read_through" {
+		t.Errorf("get mode = %q, want read_through", e.Properties["mode"])
+	}
+}
+
+func TestPyCaching_Django_CachesSubscript(t *testing.T) {
+	src := `
+from django.core.cache import caches
+def read():
+    return caches['default'].get('sess')
+`
+	ents := runPyCaching(t, src)
+	if findCachesEdge(ents, "cache:django:sess") == nil {
+		t.Fatalf("expected caches['default'].get CACHES region sess")
+	}
+}
+
+func TestPyCaching_Django_CachePage_Dynamic(t *testing.T) {
+	src := `
+@cache_page(60 * 15)
+def my_view(request):
+    return render(request)
+`
+	ents := runPyCaching(t, src)
+	e := findCachesEdge(ents, "cache:django:<request_path>")
+	if e == nil {
+		t.Fatalf("expected @cache_page CACHES the per-URL page region")
+	}
+	if e.Properties["dynamic"] != "true" {
+		t.Errorf("@cache_page region should be dynamic (per-URL)")
+	}
+}
+
+// Negative: a dynamic (variable) cache key must NOT mint a concrete region.
+func TestPyCaching_Django_DynamicKey_NoConcreteRegion(t *testing.T) {
+	src := `
+from django.core.cache import cache
+def read(uid):
+    return cache.get(uid)
+`
+	ents := runPyCaching(t, src)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Datastore" && e.Subtype == "cache_region" {
+			if e.Properties["region"] != "<dynamic>" {
+				t.Fatalf("variable key should yield <dynamic> region, got %q", e.Properties["region"])
+			}
+			if e.Properties["dynamic"] != "true" {
+				t.Fatalf("variable-key region must be marked dynamic")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #3766 (child of epic #3628).

Extends the wave-6 cache-topology model — CACHES (read-through/write) + INVALIDATES (evict) edges converging on a shared `cache:<fw>:<region>` SCOPE.Datastore node — to the abstractions still missing it.

## Verify-first (already done, left as-is + cited)
| Abstraction | Extractor |
|---|---|
| Spring `@Cacheable`/`@CacheEvict`/`@CachePut` | `internal/custom/java/caching.go` |
| `Rails.cache.fetch/read/write/delete/delete_matched` | `internal/custom/ruby/caching.go` |
| NestJS `@CacheKey` + cache-manager `wrap/set/get/del` | `internal/custom/javascript/caching.go` |
| Python `lru_cache`/`cache`/cachetools + Flask-Caching | `internal/custom/python/caching.go` |

## Built here (the gaps)
- **Django (Python)** — low-level cache API `cache.get/set/add/delete/get_or_set/incr/decr`, `caches['x'].<op>`, and `@cache_page`. `cache.delete` → **INVALIDATES**; set/get → **CACHES**; **the same literal key converges on one region node**. `@cache_page` → per-URL dynamic region.
- **Go** — new `internal/custom/golang/caching.go` (`custom_go_caching`): ristretto `Set/Get/Del`, groupcache `NewGroup`/`group.Get`. **Import-gated** so a plain `map`/struct `.Get`/`.Set` never emits a phantom edge. Dynamic (variable) keys are honest-partial (`<dynamic>`, `dynamic=true`).

## Region-convergence note (the whole value)
A `cache.set('users')` and a `cache.delete('users')` — or a ristretto `Set("user:1")` and `Del("user:1")` — land on the **one** region node, so "what invalidates what" is directly traversable. Asserted explicitly:
- Django: `CACHES(cache.set → cache:django:users)` **AND** `INVALIDATES(cache.delete → cache:django:users)`
- Go: `CACHES(cache.Set → cache:ristretto:user:1)` **AND** `INVALIDATES(cache.Del → cache:ristretto:user:1)`
- groupcache: `NewGroup("users")` region + `CACHES(group.Get → cache:groupcache:user:1)`

## Quality
Value-asserting tests (region id + edge kind + convergence, not len>0) + negatives (dynamic key → `<dynamic>` only; non-cache file → no entities). `go test` targeted green, `go test ./internal/types/` green, `coverage validate` 0 errors + `fmt --check` canonical, gofmt/vet clean. Coverage `db.cache` enriched (Go cite + Django/ristretto/groupcache notes).

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)