### PR TITLE
feat(observability): INSTRUMENTS breadth for Go+JS ddtrace/Sentry/Prometheus

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1581,9 +1581,9 @@
         },
         "trace_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/python/observability.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
-          "notes": "#3628 area #11: ddtrace span-creation sites in Python emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub). Decorator @tracer.wrap() defaults the span name to the function name; @tracer.wrap(name=\"...\")/resource=\"...\" use the explicit name; manual tracer.trace(\"op\") body calls carry the first positional name. Honest-partial: dynamic span names emit traced=true+dynamic=true without a fabricated name; only Python is covered (Go ddtrace.StartSpan / JS not yet).",
+          "cites": ["internal/extractors/golang/observability.go","internal/extractors/javascript/observability.go","internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3768",
+          "notes": "#3628 area #11: ddtrace span-creation sites now emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub) in Python, Go and JS/TS. Python (#3762): @tracer.wrap()/tracer.trace(\"op\"). Go: tracer.StartSpan(\"web.request\") and tracer.StartSpanFromContext(ctx, \"op\") take the first string-literal arg as the span name. JS/TS dd-trace: tracer.trace('op', cb) / tracer.wrap('op', fn) take the first string-literal arg. Honest-partial: dynamic span names emit traced=true+dynamic=true keyed on the enclosing fn without a fabricated name; .StartSpan/.trace on a non-tracer receiver is not emitted (precision).",
           "verified_at": "2026-06-02"
         }
       }
@@ -1707,9 +1707,9 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml","internal/extractors/python/observability.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
-          "notes": "#3628 area #11: prometheus_client Python metrics emit INSTRUMENTS edges (enclosing op -\u003e metric:\u003cname\u003e stub). A module-level metric declaration X = Counter|Gauge|Summary|Histogram|Info|Enum(\"name\", ...) is registered, then @X.time()/@X.count_exceptions()/@X.track_inprogress() decorators and X.inc()/dec()/observe()/set() body calls resolve to metric:name with the metric name captured. Honest-partial: a non-literal metric name yields traced=true+dynamic=true; a .inc()/.time() on a variable that is NOT a known module-level metric is NOT emitted (precision). Only Python is covered.",
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml","internal/extractors/golang/observability.go","internal/extractors/javascript/observability.go","internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3768",
+          "notes": "#3628 area #11: prometheus client metrics emit INSTRUMENTS edges (enclosing op -\u003e metric:\u003cname\u003e stub) in Python, Go and JS/TS. Python (#3762): module-level X = Counter|Gauge|Summary|Histogram(\"name\") + @X.time()/X.inc()/observe(). Go: a metric var bound to prometheus.New{Counter,Gauge,Summary,Histogram}[Vec](prometheus.*Opts{Name:\"x\"}) (package- or fn-scope) resolves .Inc()/Dec()/Add()/Sub()/Observe()/Set() body calls to metric:x. JS/TS prom-client: a var bound to new client.{Counter,Gauge,Histogram,Summary}({name:'x'}) resolves .inc()/.dec()/.set()/.observe()/.startTimer() body calls to metric:x. Honest-partial: a non-literal metric name yields traced=true+dynamic=true; a metric method on a variable that is NOT a known metric declaration is NOT emitted (precision).",
           "verified_at": "2026-06-02"
         },
         "trace_extraction": {
@@ -1731,9 +1731,9 @@
         },
         "trace_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/python/observability.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/3762",
-          "notes": "#3628 area #11: Sentry Python performance-tracing sites emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub). Bare @sentry_sdk.trace / @sentry.trace decorators key the span on the function name; sentry_sdk.start_transaction(...) / start_span(...) body calls take the name from name=/op=/description= kwargs. Honest-partial: dynamic names emit traced=true+dynamic=true without fabrication; only Python is covered.",
+          "cites": ["internal/extractors/golang/observability.go","internal/extractors/javascript/observability.go","internal/extractors/python/observability.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3768",
+          "notes": "#3628 area #11: Sentry performance-tracing sites emit INSTRUMENTS edges (enclosing op -\u003e span:\u003cname\u003e stub) in Python, Go and JS/TS. Python (#3762): @sentry_sdk.trace, start_transaction/start_span. Go: sentry.StartSpan(ctx, \"op\") takes the first string-literal arg as the span name. JS/TS: Sentry.startSpan({name:'op'}, cb) / Sentry.startTransaction({name:'op'}) / startInactiveSpan take the `name` property of the first object-literal arg. Honest-partial: dynamic names emit traced=true+dynamic=true keyed on the enclosing fn without fabrication; .StartSpan on a non-sentry receiver is not emitted.",
           "verified_at": "2026-06-02"
         }
       }

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -900,6 +900,12 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string, structFiel
 	// for the target name in the package directory).
 	intraFileFuncs := collectIntraFileFuncNames(nodes, src)
 
+	// Issue #3628 area #11 — non-OTel observability (ddtrace/Sentry/Prometheus).
+	// Build the file-level Prometheus metric registry once so `reqs.Inc()` body
+	// calls resolve to the metric declared by `reqs := prometheus.NewCounter(...)`
+	// anywhere in the file (package- or function-scope). nil when no metric.
+	metricReg := buildGoMetricRegistry(root, src)
+
 	var records []types.EntityRecord
 	funcCount := 0
 
@@ -1058,6 +1064,12 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string, structFiel
 		// bare function/method name used to key dynamic-name stubs.
 		relationships = append(relationships,
 			goTracingSpanEdges(bodyNode, nameText, fromID, src)...)
+
+		// Issue #3628 area #11 — non-OTel observability: ddtrace tracer.StartSpan/
+		// StartSpanFromContext, Sentry sentry.StartSpan, Prometheus metric
+		// mutations on known metric vars → INSTRUMENTS span:/metric: stubs.
+		relationships = append(relationships,
+			goObservabilityEdges(bodyNode, nameText, fromID, metricReg, src)...)
 
 		rec := types.EntityRecord{
 			Name:               name,

--- a/internal/extractors/golang/issue_observability_test.go
+++ b/internal/extractors/golang/issue_observability_test.go
@@ -1,0 +1,244 @@
+// issue_observability_test.go — value-asserting tests for the non-OTel
+// observability INSTRUMENTS breadth (epic #3628, area #11): Go ddtrace
+// tracer.StartSpan / StartSpanFromContext, Sentry sentry.StartSpan, and
+// Prometheus metric mutations on declared metric vars.
+package golang_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// obsEdges returns every INSTRUMENTS edge on the operation entity whose bare
+// name == fnName.
+func obsEdges(recs []interface{}, fnName string) []types.RelationshipRecord {
+	e, ok := findGoEnt(recs, fnName)
+	if !ok {
+		return nil
+	}
+	var out []types.RelationshipRecord
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func findObsEdge(edges []types.RelationshipRecord, toID string) (types.RelationshipRecord, bool) {
+	for _, r := range edges {
+		if r.ToID == toID {
+			return r, true
+		}
+	}
+	return types.RelationshipRecord{}, false
+}
+
+func TestObservability_GoDdtraceStartSpan(t *testing.T) {
+	src := `package p
+
+func handle() {
+	span := tracer.StartSpan("web.request")
+	_ = span
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "handle")
+	e, ok := findObsEdge(edges, "span:web.request")
+	if !ok {
+		t.Fatalf("expected INSTRUMENTS(handle -> span:web.request), got %#v", edges)
+	}
+	if e.Properties["library"] != "ddtrace" {
+		t.Errorf("library = %q, want ddtrace", e.Properties["library"])
+	}
+	if e.Properties["api"] != "tracer.StartSpan" {
+		t.Errorf("api = %q, want tracer.StartSpan", e.Properties["api"])
+	}
+	if e.Properties["span_name"] != "web.request" {
+		t.Errorf("span_name = %q, want web.request", e.Properties["span_name"])
+	}
+	if e.Properties["traced"] != "true" {
+		t.Errorf("traced = %q, want true", e.Properties["traced"])
+	}
+	if e.Properties["dynamic"] == "true" {
+		t.Errorf("static span must not be dynamic")
+	}
+}
+
+func TestObservability_GoDdtraceStartSpanFromContext(t *testing.T) {
+	src := `package p
+
+func handle(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "db.query")
+	_ = span
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "handle")
+	e, ok := findObsEdge(edges, "span:db.query")
+	if !ok {
+		t.Fatalf("expected INSTRUMENTS(handle -> span:db.query), got %#v", edges)
+	}
+	if e.Properties["api"] != "tracer.StartSpanFromContext" {
+		t.Errorf("api = %q, want tracer.StartSpanFromContext", e.Properties["api"])
+	}
+	if e.Properties["span_name"] != "db.query" {
+		t.Errorf("span_name = %q, want db.query", e.Properties["span_name"])
+	}
+}
+
+func TestObservability_GoSentryStartSpan(t *testing.T) {
+	src := `package p
+
+func checkout(ctx context.Context) {
+	span := sentry.StartSpan(ctx, "checkout.op")
+	_ = span
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "checkout")
+	e, ok := findObsEdge(edges, "span:checkout.op")
+	if !ok {
+		t.Fatalf("expected INSTRUMENTS(checkout -> span:checkout.op), got %#v", edges)
+	}
+	if e.Properties["library"] != "sentry" {
+		t.Errorf("library = %q, want sentry", e.Properties["library"])
+	}
+	if e.Properties["api"] != "sentry.StartSpan" {
+		t.Errorf("api = %q, want sentry.StartSpan", e.Properties["api"])
+	}
+	if e.Properties["span_name"] != "checkout.op" {
+		t.Errorf("span_name = %q, want checkout.op", e.Properties["span_name"])
+	}
+}
+
+func TestObservability_GoPrometheusCounterInc(t *testing.T) {
+	src := `package p
+
+func serve() {
+	c := prometheus.NewCounter(prometheus.CounterOpts{Name: "reqs"})
+	c.Inc()
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "serve")
+	e, ok := findObsEdge(edges, "metric:reqs")
+	if !ok {
+		t.Fatalf("expected INSTRUMENTS(serve -> metric:reqs), got %#v", edges)
+	}
+	if e.Properties["library"] != "prometheus" {
+		t.Errorf("library = %q, want prometheus", e.Properties["library"])
+	}
+	if e.Properties["api"] != "metric.Inc" {
+		t.Errorf("api = %q, want metric.Inc", e.Properties["api"])
+	}
+	if e.Properties["metric_name"] != "reqs" {
+		t.Errorf("metric_name = %q, want reqs", e.Properties["metric_name"])
+	}
+}
+
+func TestObservability_GoPrometheusFileLevelObserve(t *testing.T) {
+	// Metric declared at package scope, observed inside a handler.
+	src := `package p
+
+var latency = prometheus.NewHistogram(prometheus.HistogramOpts{Name: "latency_seconds"})
+
+func record(d float64) {
+	latency.Observe(d)
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "record")
+	e, ok := findObsEdge(edges, "metric:latency_seconds")
+	if !ok {
+		t.Fatalf("expected INSTRUMENTS(record -> metric:latency_seconds), got %#v", edges)
+	}
+	if e.Properties["api"] != "metric.Observe" {
+		t.Errorf("api = %q, want metric.Observe", e.Properties["api"])
+	}
+	if e.Properties["metric_name"] != "latency_seconds" {
+		t.Errorf("metric_name = %q, want latency_seconds", e.Properties["metric_name"])
+	}
+}
+
+func TestObservability_GoDynamicSpanName(t *testing.T) {
+	// Non-literal span name → dynamic stub keyed on the enclosing fn, no fabrication.
+	src := `package p
+
+func handle(op string) {
+	span := tracer.StartSpan(op)
+	_ = span
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "handle")
+	e, ok := findObsEdge(edges, "span:handle")
+	if !ok {
+		t.Fatalf("expected dynamic INSTRUMENTS(handle -> span:handle), got %#v", edges)
+	}
+	if e.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic = %q, want true", e.Properties["dynamic"])
+	}
+	if e.Properties["span_name"] != "" {
+		t.Errorf("dynamic span must NOT carry a fabricated span_name, got %q", e.Properties["span_name"])
+	}
+	if _, ok := findObsEdge(edges, "span:op"); ok {
+		t.Errorf("must not fabricate span:op from a variable arg")
+	}
+}
+
+func TestObservability_GoUnknownVarIncNoEdge(t *testing.T) {
+	// .Inc() on a variable that is NOT a known metric → no edge (precision).
+	src := `package p
+
+func serve(notametric Widget) {
+	notametric.Inc()
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "serve")
+	if len(edges) != 0 {
+		t.Fatalf("expected NO INSTRUMENTS edges for .Inc() on unknown var, got %#v", edges)
+	}
+}
+
+func TestObservability_GoNonTracerStartSpanNoEdge(t *testing.T) {
+	// .StartSpan on a receiver that is not `tracer`/`sentry` → no edge.
+	src := `package p
+
+func handle() {
+	span := other.StartSpan("nope")
+	_ = span
+}
+`
+	recs, err := extractFrom(src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	edges := obsEdges(recs, "handle")
+	if _, ok := findObsEdge(edges, "span:nope"); ok {
+		t.Fatalf("must not emit span for StartSpan on a non-tracer/non-sentry receiver: %#v", edges)
+	}
+}

--- a/internal/extractors/golang/observability.go
+++ b/internal/extractors/golang/observability.go
@@ -1,0 +1,392 @@
+// observability.go — Issue (epic #3628, area #11): non-OpenTelemetry
+// observability/instrumentation breadth for Go.
+//
+// Extends the wave-5 INSTRUMENTS edge (OpenTelemetry, #3689, tracing.go) to the
+// dominant non-OTel Go instrumentation libraries, stamping the SAME edge
+// contract used by tracing.go / the Python wave-9 observability.go:
+//
+//	FROM = enclosing operation entity (function/method)
+//	TO   = synthetic instrumentation stub
+//	         "span:<name>"   for trace/transaction spans
+//	         "metric:<name>" for metrics
+//	Kind = INSTRUMENTS
+//	Properties: library, api, line, traced=true (+ span_name|metric_name, dynamic)
+//
+// Libraries in scope (matched on library-reserved API names so the receiver
+// identifier need not be type-resolved):
+//
+//	Datadog dd-trace-go (gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer)
+//	  span := tracer.StartSpan("web.request")
+//	  span, ctx := tracer.StartSpanFromContext(ctx, "web.request")
+//	    → span name = first string-literal argument.
+//
+//	Sentry (github.com/getsentry/sentry-go)
+//	  span := sentry.StartSpan(ctx, "operation")
+//	    → span name = first string-literal argument after the ctx.
+//
+//	Prometheus client (github.com/prometheus/client_golang/prometheus)
+//	  reqs := prometheus.NewCounter(prometheus.CounterOpts{Name: "reqs"})
+//	  reqs.Inc() / lat.Observe(d)
+//	    → metric:<Name> resolved from the Name field of the *Opts struct
+//	      literal passed to the New<Kind> constructor.
+//
+// Honest-partial rule (#3689/#3762): a dynamic span/metric name (variable,
+// expression, non-literal) emits traced=true + dynamic=true keyed on the
+// enclosing function ("span:<fn>" / "metric:<fn>") rather than fabricating a
+// name. A Prometheus body call (`.Inc()` / `.Observe()`) on a variable that is
+// NOT a known function- or file-level metric is NOT emitted (could be any
+// unrelated receiver).
+//
+// The walk is panic-tolerant so the primary extraction pipeline is unaffected.
+package golang
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// goInstrHit captures one non-OTel instrumentation site (span or metric).
+type goInstrHit struct {
+	name    string // static span/metric name; "" when dynamic
+	library string // "ddtrace" | "sentry" | "prometheus"
+	api     string // library-facing API token (e.g. "tracer.StartSpan")
+	kind    string // "span" | "metric"
+	line    int    // 1-indexed source line
+	dynamic bool   // true when the name is non-literal / unresolved
+}
+
+// goMetricRegistry maps a Go variable name to the Prometheus metric name
+// declared by a `prometheus.New<Kind>(...Opts{Name: "x"})` constructor assigned
+// to it, e.g. `reqs := prometheus.NewCounter(prometheus.CounterOpts{Name:"reqs"})`
+// → {"reqs":"reqs"}. A variable bound to a metric constructor whose Name field
+// is non-literal (or absent) maps to "" (known-metric, dynamic-name).
+type goMetricRegistry map[string]string
+
+// goPrometheusMetricCtors is the set of prometheus client constructor function
+// names whose argument is a *Opts struct literal carrying a `Name` field.
+var goPrometheusMetricCtors = map[string]bool{
+	"NewCounter":      true,
+	"NewGauge":        true,
+	"NewSummary":      true,
+	"NewHistogram":    true,
+	"NewCounterVec":   true,
+	"NewGaugeVec":     true,
+	"NewSummaryVec":   true,
+	"NewHistogramVec": true,
+}
+
+// goPrometheusMetricMethods is the set of prometheus metric mutation methods
+// that instrument code via a body call on a known metric variable.
+var goPrometheusMetricMethods = map[string]bool{
+	"Inc":              true,
+	"Dec":              true,
+	"Add":              true,
+	"Sub":              true,
+	"Observe":          true,
+	"Set":              true,
+	"SetToCurrentTime": true,
+}
+
+// buildGoMetricRegistry scans a function body and the file root for short-var /
+// var declarations binding a Prometheus metric constructor to a variable, and
+// returns a name→metric-name map. Both `reqs := prometheus.NewCounter(...)` and
+// file-level `var reqs = prometheus.NewCounter(...)` are honoured so a metric
+// declared once at package scope and mutated inside a handler resolves. Returns
+// nil when no metric is declared (zero cost for non-Prometheus files).
+func buildGoMetricRegistry(root *sitter.Node, src []byte) goMetricRegistry {
+	if root == nil {
+		return nil
+	}
+	var reg goMetricRegistry
+	defer func() { _ = recover() }()
+
+	add := func(varName string, call *sitter.Node) {
+		if varName == "" || call == nil {
+			return
+		}
+		ctor := goCallSelectorLeaf(call, src)
+		if !goPrometheusMetricCtors[ctor] {
+			return
+		}
+		metricName, ok := goPrometheusOptsName(call, src)
+		if !ok {
+			return // not a recognisable prometheus ctor call shape
+		}
+		if reg == nil {
+			reg = make(goMetricRegistry)
+		}
+		reg[varName] = metricName // "" when the Name field is dynamic/absent
+	}
+
+	// Short-var declarations: `reqs := prometheus.NewCounter(...)` (any scope).
+	for _, decl := range findAll(root, "short_var_declaration") {
+		left := decl.ChildByFieldName("left")
+		right := decl.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		// Single LHS target bound to a single constructor call.
+		if left.NamedChildCount() != 1 {
+			continue
+		}
+		varName := nodeText(left.NamedChild(0), src)
+		call := firstCallExpr(right)
+		add(varName, call)
+	}
+
+	// var declarations: `var reqs = prometheus.NewCounter(...)` (any scope).
+	for _, spec := range findAll(root, "var_spec") {
+		nameNode := spec.ChildByFieldName("name")
+		valueNode := spec.ChildByFieldName("value")
+		if nameNode == nil || valueNode == nil {
+			continue
+		}
+		// Only handle the single-name single-value form: `var x = New...(...)`.
+		// A multi-name spec (`var a, b = ...`) exposes the names as an
+		// identifier_list — skip it (ambiguous binding).
+		if nameNode.Type() != "identifier" {
+			continue
+		}
+		call := firstCallExpr(valueNode)
+		if call == nil {
+			continue
+		}
+		add(nodeText(nameNode, src), call)
+	}
+
+	return reg
+}
+
+// goCallSelectorLeaf returns the trailing method/function name of a
+// call_expression whose function is a selector (`prometheus.NewCounter` →
+// "NewCounter") or a bare identifier (`NewCounter(...)` → "NewCounter").
+func goCallSelectorLeaf(call *sitter.Node, src []byte) string {
+	if call == nil || call.Type() != "call_expression" {
+		return ""
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return ""
+	}
+	switch fn.Type() {
+	case "identifier":
+		return nodeText(fn, src)
+	case "selector_expression":
+		if field := fn.ChildByFieldName("field"); field != nil {
+			return nodeText(field, src)
+		}
+	}
+	return ""
+}
+
+// goPrometheusOptsName extracts the `Name` field value from the *Opts struct
+// literal passed as the (only) argument of a prometheus.New<Kind> constructor
+// call. Returns (name, true) when the call shape is a recognised composite
+// literal argument; (name="", true) when the Name field is present but
+// non-literal or absent (dynamic); (..., false) when the argument is not a
+// composite literal at all (not a recognisable ctor → skip).
+func goPrometheusOptsName(call *sitter.Node, src []byte) (string, bool) {
+	args := call.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() < 1 {
+		return "", false
+	}
+	arg := args.NamedChild(0)
+	if arg == nil {
+		return "", false
+	}
+	// Argument is a composite_literal: `prometheus.CounterOpts{Name: "x"}`.
+	if arg.Type() != "composite_literal" {
+		return "", false
+	}
+	// The composite literal's field set lives in its `literal_value` child.
+	body := firstChildOfType(arg, "literal_value")
+	if body == nil {
+		return "", true // recognised ctor, but no field body → dynamic name
+	}
+	for _, kv := range findAll(body, "keyed_element") {
+		// keyed_element: <key> ':' <value>. The grammar exposes two literal_element
+		// children (key, value); take the first as key, second as value.
+		if kv.NamedChildCount() < 2 {
+			continue
+		}
+		keyNode := kv.NamedChild(0)
+		valNode := kv.NamedChild(1)
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		if nodeText(unwrapLiteralElement(keyNode), src) != "Name" {
+			continue
+		}
+		v := unwrapLiteralElement(valNode)
+		if v != nil && v.Type() == "interpreted_string_literal" {
+			return goStripStringLiteral(nodeText(v, src)), true
+		}
+		return "", true // Name present but dynamic
+	}
+	return "", true // recognised ctor with body but no Name field → dynamic
+}
+
+// unwrapLiteralElement returns the single meaningful child of a literal_element
+// wrapper node (tree-sitter Go wraps composite-literal keys/values in
+// literal_element), or the node itself when it is not a wrapper.
+func unwrapLiteralElement(n *sitter.Node) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == "literal_element" && n.NamedChildCount() == 1 {
+		return n.NamedChild(0)
+	}
+	return n
+}
+
+// extractGoInstrHits collects every non-OTel instrumentation site (span or
+// metric) from a function/method body. metricReg resolves Prometheus metric
+// variables to metric names. enclosingName keys dynamic stubs.
+func extractGoInstrHits(body *sitter.Node, enclosingName string, metricReg goMetricRegistry, src []byte) []goInstrHit {
+	if body == nil {
+		return nil
+	}
+	var hits []goInstrHit
+	defer func() { _ = recover() }()
+
+	for _, call := range findAll(body, "call_expression") {
+		if h, ok := goBodyInstrHit(call, enclosingName, metricReg, src); ok {
+			hits = append(hits, h)
+		}
+	}
+	return hits
+}
+
+// goBodyInstrHit inspects a call_expression for a ddtrace / Sentry span-start or
+// a Prometheus metric mutation. Returns false when the call is not an
+// instrumentation call.
+func goBodyInstrHit(call *sitter.Node, enclosingName string, metricReg goMetricRegistry, src []byte) (goInstrHit, bool) {
+	if call == nil || call.Type() != "call_expression" {
+		return goInstrHit{}, false
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "selector_expression" {
+		return goInstrHit{}, false
+	}
+	field := fn.ChildByFieldName("field")
+	if field == nil {
+		return goInstrHit{}, false
+	}
+	leaf := nodeText(field, src)
+	recv := ""
+	if op := fn.ChildByFieldName("operand"); op != nil && op.Type() == "identifier" {
+		recv = nodeText(op, src)
+	}
+	args := call.ChildByFieldName("arguments")
+	line := int(call.StartPoint().Row) + 1
+
+	// Datadog ddtrace: tracer.StartSpan("web.request") — first string arg is the
+	// span name. tracer.StartSpanFromContext(ctx, "web.request") — span name is
+	// the FIRST string-literal argument (ctx is first positional but not a string).
+	if recv == "tracer" && (leaf == "StartSpan" || leaf == "StartSpanFromContext") {
+		h := goInstrHit{library: "ddtrace", api: "tracer." + leaf, kind: "span", line: line}
+		if name := goFirstStringArg(args, src); name != "" {
+			h.name = name
+		} else {
+			h.dynamic = true
+		}
+		return h, true
+	}
+
+	// Sentry: sentry.StartSpan(ctx, "operation") — span name is the first
+	// string-literal argument after the context.
+	if recv == "sentry" && leaf == "StartSpan" {
+		h := goInstrHit{library: "sentry", api: "sentry.StartSpan", kind: "span", line: line}
+		if name := goFirstStringArg(args, src); name != "" {
+			h.name = name
+		} else {
+			h.dynamic = true
+		}
+		return h, true
+	}
+
+	// Prometheus body mutation: reqs.Inc() / lat.Observe(d) — only when the
+	// receiver is a known metric variable.
+	if goPrometheusMetricMethods[leaf] && recv != "" {
+		if metricName, known := metricReg[recv]; known {
+			h := goInstrHit{library: "prometheus", api: "metric." + leaf, kind: "metric", line: line}
+			if metricName != "" {
+				h.name = metricName
+			} else {
+				h.dynamic = true
+			}
+			return h, true
+		}
+	}
+
+	return goInstrHit{}, false
+}
+
+// goFirstStringArg returns the value of the first string-literal positional
+// argument in args, or "" when none is a string literal.
+func goFirstStringArg(args *sitter.Node, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		ch := args.NamedChild(i)
+		if ch != nil && ch.Type() == "interpreted_string_literal" {
+			return goStripStringLiteral(nodeText(ch, src))
+		}
+	}
+	return ""
+}
+
+// goObservabilityEdges returns the INSTRUMENTS edges for every non-OTel
+// instrumentation site (ddtrace, Sentry, Prometheus) found in body. metricReg
+// resolves Prometheus metric variables to metric names. enclosingName keys
+// dynamic stubs. fromID is the enclosing operation entity ID.
+func goObservabilityEdges(body *sitter.Node, enclosingName, fromID string, metricReg goMetricRegistry, src []byte) []types.RelationshipRecord {
+	hits := extractGoInstrHits(body, enclosingName, metricReg, src)
+	if len(hits) == 0 {
+		return nil
+	}
+	out := make([]types.RelationshipRecord, 0, len(hits))
+	seen := make(map[string]bool)
+	for _, h := range hits {
+		props := map[string]string{
+			"library": h.library,
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		prefix := h.kind + ":"
+		var toID string
+		if h.dynamic || h.name == "" {
+			props["dynamic"] = "true"
+			toID = prefix + enclosingName
+		} else {
+			if h.kind == "metric" {
+				props["metric_name"] = h.name
+			} else {
+				props["span_name"] = h.name
+			}
+			toID = prefix + h.name
+		}
+		// Dedup on (library, api, toID); dynamic sites additionally key on line so
+		// distinct dynamic sites both survive.
+		key := h.library + "|" + h.api + "|" + toID
+		if h.dynamic || h.name == "" {
+			key += "|" + strconv.Itoa(h.line)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+	return out
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -208,6 +208,11 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// so that callTarget can rewrite CALLS-to-hook-result edges.
 	x.hookVarToModule = x.buildHookVarToModule(root)
 
+	// Issue #3628 area #11 (non-OTel observability) — build the prom-client
+	// metric-variable map before walk() so that stampObservability can resolve
+	// `<var>.inc()/.observe()/.startTimer()` body calls to metric:<name>.
+	x.metricVars = x.buildMetricVars(root)
+
 	// Phase 2 of #2658 — build the navigation hook-var table before walk()
 	// so that extractNavigationCall can detect hook-rename bindings like
 	// `const nav = useNavigation(); nav.navigate('X')`.
@@ -520,6 +525,17 @@ type extractor struct {
 	// a first-class graph fact for the Express/Fastify family.
 	// Nil when no schema-lib imports are present (fast-path).
 	schemaLibDTOs map[string]string
+
+	// metricVars — Issue #3628 area #11 (non-OTel observability). Built once
+	// per file in buildMetricVars (called from Extract before walk). Maps a
+	// variable name bound to a prom-client metric constructor
+	// (`new client.Counter({name:'orders'})`) to the declared metric name. A
+	// constructor with a non-literal / absent name maps to "" (known-metric,
+	// dynamic-name). When a function body calls `<var>.inc()/.observe()/
+	// .startTimer()` on one of these vars, stampObservability emits an
+	// INSTRUMENTS edge → metric:<name>. Nil when no prom-client metric is
+	// declared in the file (fast-path).
+	metricVars map[string]string
 }
 
 // dispatchMapInfo records the handlers registered in a Record<string, Fn>
@@ -816,6 +832,10 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	x.stampBranchConditions(body)
 	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
 	x.stampTracingSpans(body)
+	// Issue #3628 area #11 — stamp non-OTel observability sites (Sentry
+	// startSpan/startTransaction, dd-trace tracer.trace/wrap, prom-client
+	// metric mutations) as INSTRUMENTS edges alongside the OTel pass.
+	x.stampObservability(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so handleVariableDeclarator suppresses non-addressable
@@ -938,6 +958,10 @@ func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBi
 	x.stampBranchConditions(body)
 	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
 	x.stampTracingSpans(body)
+	// Issue #3628 area #11 — stamp non-OTel observability sites (Sentry
+	// startSpan/startTransaction, dd-trace tracer.trace/wrap, prom-client
+	// metric mutations) as INSTRUMENTS edges alongside the OTel pass.
+	x.stampObservability(body)
 }
 
 // isNativeScriptStateSetter recognises the NativeScript Observable
@@ -1104,6 +1128,10 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 	x.stampBranchConditions(body)
 	// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS edges).
 	x.stampTracingSpans(body)
+	// Issue #3628 area #11 — stamp non-OTel observability sites (Sentry
+	// startSpan/startTransaction, dd-trace tracer.trace/wrap, prom-client
+	// metric mutations) as INSTRUMENTS edges alongside the OTel pass.
+	x.stampObservability(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so nested const declarations inside this arrow
@@ -1456,6 +1484,10 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		x.stampBranchConditions(body)
 		// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS).
 		x.stampTracingSpans(body)
+		// Issue #3628 area #11 — stamp non-OTel observability sites (Sentry
+		// startSpan/startTransaction, dd-trace tracer.trace/wrap, prom-client
+		// metric mutations) as INSTRUMENTS edges alongside the OTel pass.
+		x.stampObservability(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// arrow body are not emitted as addressable entities (#1748).
@@ -1497,6 +1529,10 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		x.stampBranchConditions(body)
 		// Issue #3689 — stamp OpenTelemetry span-creation sites (INSTRUMENTS).
 		x.stampTracingSpans(body)
+		// Issue #3628 area #11 — stamp non-OTel observability sites (Sentry
+		// startSpan/startTransaction, dd-trace tracer.trace/wrap, prom-client
+		// metric mutations) as INSTRUMENTS edges alongside the OTel pass.
+		x.stampObservability(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// function-expression body are not emitted as addressable entities (#1748).

--- a/internal/extractors/javascript/issue_observability_test.go
+++ b/internal/extractors/javascript/issue_observability_test.go
@@ -1,0 +1,208 @@
+// issue_observability_test.go — value-asserting tests for the non-OTel
+// observability INSTRUMENTS breadth (epic #3628, area #11): JS/TS Sentry
+// startSpan/startTransaction, dd-trace tracer.trace/wrap, and prom-client
+// metric mutations on declared metric vars.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsObsEdge returns the first INSTRUMENTS edge on the named entity matching
+// wantToID, or nil.
+func jsObsEdge(ents []types.EntityRecord, entName, wantToID string) *types.RelationshipRecord {
+	e := findByNameRel(ents, entName)
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "INSTRUMENTS" && r.ToID == wantToID {
+			return r
+		}
+	}
+	return nil
+}
+
+// jsObsEdges returns all INSTRUMENTS edges on the named entity.
+func jsObsEdges(ents []types.EntityRecord, entName string) []types.RelationshipRecord {
+	e := findByNameRel(ents, entName)
+	if e == nil {
+		return nil
+	}
+	var out []types.RelationshipRecord
+	for _, r := range e.Relationships {
+		if r.Kind == "INSTRUMENTS" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestObservability_JSSentryStartSpan(t *testing.T) {
+	src := `
+function process() {
+  Sentry.startSpan({ name: 'checkout' }, () => {});
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "process", "span:checkout")
+	if r == nil {
+		t.Fatalf("expected INSTRUMENTS(process -> span:checkout), got %#v", jsObsEdges(ents, "process"))
+	}
+	if r.Properties["library"] != "sentry" {
+		t.Errorf("library=%q, want sentry", r.Properties["library"])
+	}
+	if r.Properties["api"] != "Sentry.startSpan" {
+		t.Errorf("api=%q, want Sentry.startSpan", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "checkout" {
+		t.Errorf("span_name=%q, want checkout", r.Properties["span_name"])
+	}
+	if r.Properties["traced"] != "true" {
+		t.Errorf("traced=%q, want true", r.Properties["traced"])
+	}
+}
+
+func TestObservability_JSSentryStartTransaction(t *testing.T) {
+	src := `
+function pay() {
+  const tx = Sentry.startTransaction({ name: 'payment' });
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "pay", "span:payment")
+	if r == nil {
+		t.Fatalf("expected INSTRUMENTS(pay -> span:payment), got %#v", jsObsEdges(ents, "pay"))
+	}
+	if r.Properties["api"] != "Sentry.startTransaction" {
+		t.Errorf("api=%q, want Sentry.startTransaction", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "payment" {
+		t.Errorf("span_name=%q, want payment", r.Properties["span_name"])
+	}
+}
+
+func TestObservability_JSDatadogTrace(t *testing.T) {
+	src := `
+function handle() {
+  tracer.trace('web.request', () => {});
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "handle", "span:web.request")
+	if r == nil {
+		t.Fatalf("expected INSTRUMENTS(handle -> span:web.request), got %#v", jsObsEdges(ents, "handle"))
+	}
+	if r.Properties["library"] != "dd-trace" {
+		t.Errorf("library=%q, want dd-trace", r.Properties["library"])
+	}
+	if r.Properties["api"] != "tracer.trace" {
+		t.Errorf("api=%q, want tracer.trace", r.Properties["api"])
+	}
+	if r.Properties["span_name"] != "web.request" {
+		t.Errorf("span_name=%q, want web.request", r.Properties["span_name"])
+	}
+}
+
+func TestObservability_JSPromClientCounterInc(t *testing.T) {
+	src := `
+const orders = new client.Counter({ name: 'orders' });
+function serve() {
+  orders.inc();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "serve", "metric:orders")
+	if r == nil {
+		t.Fatalf("expected INSTRUMENTS(serve -> metric:orders), got %#v", jsObsEdges(ents, "serve"))
+	}
+	if r.Properties["library"] != "prom-client" {
+		t.Errorf("library=%q, want prom-client", r.Properties["library"])
+	}
+	if r.Properties["api"] != "metric.inc" {
+		t.Errorf("api=%q, want metric.inc", r.Properties["api"])
+	}
+	if r.Properties["metric_name"] != "orders" {
+		t.Errorf("metric_name=%q, want orders", r.Properties["metric_name"])
+	}
+}
+
+func TestObservability_JSPromClientHistogramStartTimer(t *testing.T) {
+	src := `
+const lat = new Histogram({ name: 'http_latency' });
+function record() {
+  const end = lat.startTimer();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "record", "metric:http_latency")
+	if r == nil {
+		t.Fatalf("expected INSTRUMENTS(record -> metric:http_latency), got %#v", jsObsEdges(ents, "record"))
+	}
+	if r.Properties["api"] != "metric.startTimer" {
+		t.Errorf("api=%q, want metric.startTimer", r.Properties["api"])
+	}
+	if r.Properties["metric_name"] != "http_latency" {
+		t.Errorf("metric_name=%q, want http_latency", r.Properties["metric_name"])
+	}
+}
+
+func TestObservability_JSDynamicSpanNameNoFabrication(t *testing.T) {
+	// Dynamic span name (variable in `name`) → dynamic stub on the enclosing fn.
+	src := `
+function handle(op) {
+  Sentry.startSpan({ name: op }, () => {});
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	r := jsObsEdge(ents, "handle", "span:handle")
+	if r == nil {
+		t.Fatalf("expected dynamic INSTRUMENTS(handle -> span:handle), got %#v", jsObsEdges(ents, "handle"))
+	}
+	if r.Properties["dynamic"] != "true" {
+		t.Errorf("dynamic=%q, want true", r.Properties["dynamic"])
+	}
+	if r.Properties["span_name"] != "" {
+		t.Errorf("dynamic span must NOT carry a fabricated span_name, got %q", r.Properties["span_name"])
+	}
+	if jsObsEdge(ents, "handle", "span:op") != nil {
+		t.Errorf("must not fabricate span:op from a variable name")
+	}
+}
+
+func TestObservability_JSUnknownVarIncNoEdge(t *testing.T) {
+	// .inc() on a variable that is NOT a known prom-client metric → no edge.
+	src := `
+function serve() {
+  counter.inc();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if edges := jsObsEdges(ents, "serve"); len(edges) != 0 {
+		t.Fatalf("expected NO INSTRUMENTS edges for .inc() on unknown var, got %#v", edges)
+	}
+}
+
+func TestObservability_JSNonTracerTraceNoEdge(t *testing.T) {
+	// `.trace` on a receiver that is not `tracer` → no edge (precision).
+	src := `
+function handle() {
+  logger.trace('not a span');
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if jsObsEdge(ents, "handle", "span:not a span") != nil {
+		t.Fatalf("must not emit a span for logger.trace(...): %#v", jsObsEdges(ents, "handle"))
+	}
+}

--- a/internal/extractors/javascript/observability.go
+++ b/internal/extractors/javascript/observability.go
@@ -1,0 +1,353 @@
+// observability.go — Issue (epic #3628, area #11): non-OpenTelemetry
+// observability/instrumentation breadth for JS/TS.
+//
+// Extends the wave-5 INSTRUMENTS edge (OpenTelemetry, #3689, tracing.go) to the
+// dominant non-OTel JS/TS instrumentation libraries, stamping the SAME edge
+// contract used by tracing.go / the Python+Go observability.go passes:
+//
+//	FROM = enclosing operation entity (function/method/arrow)
+//	TO   = synthetic instrumentation stub
+//	         "span:<name>"   for trace/transaction spans
+//	         "metric:<name>" for metrics
+//	Kind = INSTRUMENTS
+//	Properties: library, api, line, traced=true (+ span_name|metric_name, dynamic)
+//
+// Libraries in scope (matched on library-reserved API names so the receiver
+// identifier need not be type-resolved):
+//
+//	Sentry (@sentry/node, @sentry/browser, …)
+//	  Sentry.startSpan({ name: 'checkout' }, cb)
+//	  Sentry.startTransaction({ name: 'checkout' })
+//	    → span name = the `name` property of the first object-literal argument.
+//
+//	Datadog dd-trace
+//	  tracer.trace('op', cb)
+//	  tracer.wrap('op', fn)
+//	    → span name = the first string-literal argument.
+//
+//	prom-client
+//	  const orders = new client.Counter({ name: 'orders_total' });
+//	  orders.inc() / lat.observe(v) / end = hist.startTimer()
+//	    → metric:<name> resolved from the `name` property of the metric
+//	      constructor's options object.
+//
+// Honest-partial rule (#3689/#3762): a dynamic span/metric name (variable,
+// expression, template literal) emits traced=true + dynamic=true keyed on the
+// enclosing function ("span:<fn>" / "metric:<fn>") rather than fabricating a
+// name. A prom-client body call (`.inc()` / `.observe()` / `.startTimer()`) on a
+// variable that is NOT a known module-level metric is NOT emitted (could be any
+// unrelated receiver).
+//
+// The walk is panic-tolerant so the primary extraction pipeline is unaffected.
+package javascript
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsInstrHit captures one non-OTel instrumentation site (span or metric).
+type jsInstrHit struct {
+	name    string // static span/metric name; "" when dynamic
+	library string // "sentry" | "dd-trace" | "prom-client"
+	api     string // library-facing API token (e.g. "Sentry.startSpan")
+	kind    string // "span" | "metric"
+	line    int    // 1-indexed source line
+	dynamic bool   // true when the name is non-literal / unresolved
+}
+
+// jsSentrySpanMethods is the set of Sentry SDK methods that open a span /
+// transaction whose name lives in the `name` property of the first object arg.
+var jsSentrySpanMethods = map[string]bool{
+	"startSpan":         true,
+	"startTransaction":  true,
+	"startInactiveSpan": true,
+}
+
+// jsPromClientCtors is the set of prom-client metric constructor names. The
+// constructor's options object carries the `name` property.
+var jsPromClientCtors = map[string]bool{
+	"Counter":   true,
+	"Gauge":     true,
+	"Histogram": true,
+	"Summary":   true,
+}
+
+// jsPromClientMethods is the set of prom-client metric mutation/observation
+// methods that instrument code via a body call on a known metric variable.
+var jsPromClientMethods = map[string]bool{
+	"inc":        true,
+	"dec":        true,
+	"set":        true,
+	"observe":    true,
+	"startTimer": true,
+}
+
+// buildMetricVars scans the file for `<var> = new <ctor>({ name: '...' })`
+// prom-client metric declarations and returns a var→metric-name map. A metric
+// whose `name` property is non-literal (or absent) maps to "" (known-metric,
+// dynamic-name). Returns nil when no prom-client metric is declared (fast-path).
+func (x *extractor) buildMetricVars(root *sitter.Node) map[string]string {
+	if root == nil {
+		return nil
+	}
+	var reg map[string]string
+	defer func() { _ = recover() }()
+
+	for _, vd := range findAllNodes(root, "variable_declarator") {
+		nameNode := vd.ChildByFieldName("name")
+		valNode := vd.ChildByFieldName("value")
+		if nameNode == nil || valNode == nil || nameNode.Type() != "identifier" {
+			continue
+		}
+		if valNode.Type() != "new_expression" {
+			continue
+		}
+		ctor := x.newExprConstructorName(valNode)
+		if !jsPromClientCtors[ctor] {
+			continue
+		}
+		metricName, ok := x.metricCtorName(valNode)
+		if !ok {
+			continue // not a recognisable {name: ...} options shape
+		}
+		if reg == nil {
+			reg = make(map[string]string)
+		}
+		reg[x.nodeText(nameNode)] = metricName // "" when name is dynamic/absent
+	}
+	return reg
+}
+
+// newExprConstructorName returns the trailing name of a new_expression's
+// constructor: `new client.Counter(...)` → "Counter", `new Counter(...)` →
+// "Counter". Returns "" when the constructor is neither an identifier nor a
+// member_expression.
+func (x *extractor) newExprConstructorName(newExpr *sitter.Node) string {
+	if newExpr == nil || newExpr.Type() != "new_expression" {
+		return ""
+	}
+	ctor := newExpr.ChildByFieldName("constructor")
+	if ctor == nil {
+		// Fall back to the first non-arguments named child for grammars that do
+		// not expose the constructor as a field.
+		for i := 0; i < int(newExpr.NamedChildCount()); i++ {
+			ch := newExpr.NamedChild(i)
+			if ch != nil && ch.Type() != "arguments" {
+				ctor = ch
+				break
+			}
+		}
+	}
+	if ctor == nil {
+		return ""
+	}
+	switch ctor.Type() {
+	case "identifier":
+		return x.nodeText(ctor)
+	case "member_expression":
+		if p := ctor.ChildByFieldName("property"); p != nil {
+			return x.nodeText(p)
+		}
+	}
+	return ""
+}
+
+// metricCtorName extracts the metric name from the `name` property of the
+// options object passed to a prom-client metric constructor. Returns
+// (name, true) when the options object is present; (name="", true) when the
+// `name` property is absent or non-literal (dynamic); (..., false) when there is
+// no object argument at all.
+func (x *extractor) metricCtorName(newExpr *sitter.Node) (string, bool) {
+	args := newExpr.ChildByFieldName("arguments")
+	if args == nil {
+		return "", false
+	}
+	obj := firstMeaningfulArg(args)
+	if obj == nil || obj.Type() != "object" {
+		return "", false
+	}
+	if name, ok := x.objectStringProp(obj, "name"); ok {
+		return name, true
+	}
+	return "", true // options object present but no literal `name` → dynamic
+}
+
+// objectStringProp returns the string-literal value of the property named key in
+// an object literal. The bool is true when a property with that key exists; when
+// true and the value is non-literal the returned string is "".
+func (x *extractor) objectStringProp(obj *sitter.Node, key string) (string, bool) {
+	if obj == nil || obj.Type() != "object" {
+		return "", false
+	}
+	for i := 0; i < int(obj.NamedChildCount()); i++ {
+		pair := obj.NamedChild(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		k := pair.ChildByFieldName("key")
+		v := pair.ChildByFieldName("value")
+		if k == nil || v == nil {
+			continue
+		}
+		if x.nodeText(k) != key {
+			continue
+		}
+		if v.Type() == "string" {
+			return stringLiteralValue(x.nodeText(v)), true
+		}
+		return "", true // key present but value is non-literal → dynamic
+	}
+	return "", false
+}
+
+// extractObservabilityHits walks a function/method/arrow body and returns one
+// jsInstrHit per non-OTel instrumentation site (Sentry span/transaction,
+// dd-trace tracer.trace/wrap, prom-client metric mutation).
+func (x *extractor) extractObservabilityHits(body *sitter.Node) []jsInstrHit {
+	if body == nil {
+		return nil
+	}
+	var hits []jsInstrHit
+	defer func() { _ = recover() }()
+
+	for _, call := range findAllNodes(body, "call_expression") {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_expression" {
+			continue
+		}
+		propNode := fn.ChildByFieldName("property")
+		objNode := fn.ChildByFieldName("object")
+		if propNode == nil {
+			continue
+		}
+		method := x.nodeText(propNode)
+		recv := ""
+		if objNode != nil && objNode.Type() == "identifier" {
+			recv = x.nodeText(objNode)
+		}
+		args := call.ChildByFieldName("arguments")
+		line := int(call.StartPoint().Row) + 1
+
+		// Sentry: Sentry.startSpan({name:'op'}, cb) / startTransaction({name:'op'}).
+		if recv == "Sentry" && jsSentrySpanMethods[method] {
+			h := jsInstrHit{library: "sentry", api: "Sentry." + method, kind: "span", line: line}
+			if name, ok := x.firstArgObjectName(args); ok && name != "" {
+				h.name = name
+			} else {
+				h.dynamic = true
+			}
+			hits = append(hits, h)
+			continue
+		}
+
+		// Datadog dd-trace: tracer.trace('op', cb) / tracer.wrap('op', fn).
+		if recv == "tracer" && (method == "trace" || method == "wrap") {
+			h := jsInstrHit{library: "dd-trace", api: "tracer." + method, kind: "span", line: line}
+			if name := x.firstArgString(args); name != "" {
+				h.name = name
+			} else {
+				h.dynamic = true
+			}
+			hits = append(hits, h)
+			continue
+		}
+
+		// prom-client metric mutation: <metricVar>.inc()/.observe()/.startTimer().
+		if jsPromClientMethods[method] && recv != "" {
+			if metricName, known := x.metricVars[recv]; known {
+				h := jsInstrHit{library: "prom-client", api: "metric." + method, kind: "metric", line: line}
+				if metricName != "" {
+					h.name = metricName
+				} else {
+					h.dynamic = true
+				}
+				hits = append(hits, h)
+			}
+		}
+	}
+	return hits
+}
+
+// firstArgObjectName returns the string `name` property of the first
+// object-literal argument in args. The bool is false when the first arg is not
+// an object literal at all.
+func (x *extractor) firstArgObjectName(args *sitter.Node) (string, bool) {
+	if args == nil {
+		return "", false
+	}
+	first := firstMeaningfulArg(args)
+	if first == nil || first.Type() != "object" {
+		return "", false
+	}
+	return x.objectStringProp(first, "name")
+}
+
+// firstArgString returns the value of the first string-literal argument in args,
+// or "" when the first meaningful argument is not a string literal.
+func (x *extractor) firstArgString(args *sitter.Node) string {
+	if args == nil {
+		return ""
+	}
+	first := firstMeaningfulArg(args)
+	if first != nil && first.Type() == "string" {
+		return stringLiteralValue(x.nodeText(first))
+	}
+	return ""
+}
+
+// stampObservability emits INSTRUMENTS edges on the last entity appended to
+// x.entities for every non-OTel instrumentation site found in body. Called
+// immediately after a function/method/arrow entity is emitted, alongside
+// stampTracingSpans (the OTel pass).
+func (x *extractor) stampObservability(body *sitter.Node) {
+	if body == nil || len(x.entities) == 0 {
+		return
+	}
+	hits := x.extractObservabilityHits(body)
+	if len(hits) == 0 {
+		return
+	}
+	last := &x.entities[len(x.entities)-1]
+	enclosing := last.Name
+	seen := make(map[string]bool)
+	for _, h := range hits {
+		props := map[string]string{
+			"library": h.library,
+			"api":     h.api,
+			"line":    strconv.Itoa(h.line),
+			"traced":  "true",
+		}
+		prefix := h.kind + ":"
+		var toID string
+		if h.dynamic || h.name == "" {
+			props["dynamic"] = "true"
+			toID = prefix + enclosing
+		} else {
+			if h.kind == "metric" {
+				props["metric_name"] = h.name
+			} else {
+				props["span_name"] = h.name
+			}
+			toID = prefix + h.name
+		}
+		// Dedup on (library, api, toID); dynamic sites additionally key on line so
+		// distinct dynamic sites both survive.
+		key := h.library + "|" + h.api + "|" + toID
+		if h.dynamic || h.name == "" {
+			key += "|" + strconv.Itoa(h.line)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		last.Relationships = append(last.Relationships, types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindInstruments),
+			Properties: props,
+		})
+	}
+}


### PR DESCRIPTION
Closes #3768 (child of epic #3628, area #11).

Completes the non-OpenTelemetry observability/INSTRUMENTS breadth for the **Go** and **JS/TS** vendors that the wave-9 Python pass (#3762) and OTel multi-lang pass (#3689) explicitly deferred. Mirrors the Python wave-9 edge contract byte-for-byte so Go/JS vendor spans converge with the Python ones.

## Edge contract (unchanged from #3689/#3762)
`INSTRUMENTS`: enclosing op -> `span:<name>` / `metric:<name>` stub; props `library`/`api`/`line`/`traced` (+ `span_name`|`metric_name`/`dynamic`).

## Vendors / languages added
**Go** (`internal/extractors/golang/observability.go`)
- **ddtrace**: `tracer.StartSpan("web.request")`, `tracer.StartSpanFromContext(ctx, "op")` -> span name = first string-literal arg.
- **Sentry**: `sentry.StartSpan(ctx, "op")`.
- **Prometheus**: var bound to `prometheus.New{Counter,Gauge,Summary,Histogram}[Vec](prometheus.*Opts{Name:"x"})` (package- or fn-scope) resolves `.Inc()/Dec()/Add()/Sub()/Observe()/Set()` -> `metric:x`.

**JS/TS** (`internal/extractors/javascript/observability.go`)
- **Sentry**: `Sentry.startSpan({name:'op'}, cb)` / `Sentry.startTransaction({name:'op'})` / `startInactiveSpan`.
- **prom-client**: `new client.{Counter,Gauge,Histogram,Summary}({name:'x'})` + `.inc()/.dec()/.set()/.observe()/.startTimer()` -> `metric:x`.
- **dd-trace**: `tracer.trace('op', cb)` / `tracer.wrap('op', fn)`.

## INSTRUMENTS edges asserted by tests
- Go `tracer.StartSpan("web.request")` in `handle` -> `INSTRUMENTS(handle -> span:web.request)` (library=ddtrace, api=tracer.StartSpan).
- Go `tracer.StartSpanFromContext(ctx,"db.query")` -> `span:db.query`.
- Go `sentry.StartSpan(ctx,"checkout.op")` -> `span:checkout.op` (library=sentry).
- Go `c:=NewCounter({Name:"reqs"})`+`c.Inc()` in `serve` -> `metric:reqs` (api=metric.Inc); package-level `latency` + `latency.Observe(d)` -> `metric:latency_seconds`.
- JS `Sentry.startSpan({name:'checkout'},...)` -> `span:checkout`; `startTransaction({name:'payment'})` -> `span:payment`.
- JS `tracer.trace('web.request',...)` -> `span:web.request` (library=dd-trace).
- prom-client `new Counter({name:'orders'})`+`.inc()` -> `metric:orders`; `new Histogram({name:'http_latency'})`+`.startTimer()` -> `metric:http_latency`.

**Negatives**: dynamic name var -> `span:<fn>` dynamic=true, no fabricated name; `.Inc()`/`.inc()` on an unknown var -> no edge; `.StartSpan`/`.trace` on a non-tracer/non-sentry receiver -> no edge.

## Honest-partial
Dynamic span/metric names emit `traced=true`+`dynamic=true` keyed on the enclosing fn (no fabrication); metric methods on unknown vars and span methods on non-vendor receivers are not emitted (precision). Both walks are panic-tolerant.

## Validation
- 16 value-asserting tests (8 Go, 8 JS), all green.
- Targeted: `go test ./internal/extractors/... ./internal/engine/ ./internal/types/ ./tools/coverage/` green.
- `go vet` clean; `gofmt -l` empty.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.
- Coverage rows `infra.observability.{datadog,sentry,prometheus}` now cite the Go+JS extractors alongside Python.

**DEPLOY-DEFERRED**: extractor + coverage only; no daemon rebuild/reindex in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)