### PR TITLE
dataflow: cross-file + multi-hop (≤3) request→sink propagation (JS/TS, Python)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -28891,7 +28891,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_jsts.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file. Decorator-injected params (NestJS @Body) NOT covered.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested local calls A→B→C, each bound by exact positional index; full chain in hop_path/hop_count props. Cross-file (#3772): when the callee is an imported symbol resolving (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowJSTS); sink resolves to the callee-file entity. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg (helper(x+1)), spread/rest/destructured params, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. Decorator-injected params (NestJS @Body) NOT covered. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -29167,7 +29167,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_jsts.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file. Decorator-injected params (NestJS @Body) NOT covered.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested local calls A→B→C, each bound by exact positional index; full chain in hop_path/hop_count props. Cross-file (#3772): when the callee is an imported symbol resolving (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowJSTS); sink resolves to the callee-file entity. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg (helper(x+1)), spread/rest/destructured params, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. Decorator-injected params (NestJS @Body) NOT covered. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -30416,7 +30416,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_jsts.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file. Decorator-injected params (NestJS @Body) NOT covered.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested local calls A→B→C, each bound by exact positional index; full chain in hop_path/hop_count props. Cross-file (#3772): when the callee is an imported symbol resolving (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowJSTS); sink resolves to the callee-file entity. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg (helper(x+1)), spread/rest/destructured params, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. Decorator-injected params (NestJS @Body) NOT covered. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -30910,7 +30910,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_jsts.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file. Decorator-injected params (NestJS @Body) NOT covered.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested local calls A→B→C, each bound by exact positional index; full chain in hop_path/hop_count props. Cross-file (#3772): when the callee is an imported symbol resolving (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowJSTS); sink resolves to the callee-file entity. Sources req.body/query/params, ctx.request.body. Sinks ORM create/save/insert, res.json/send, axios/fetch. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg (helper(x+1)), spread/rest/destructured params, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. Decorator-injected params (NestJS @Body) NOT covered. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -47353,7 +47353,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_python.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested module-level calls a→b→c, each bound by exact positional index (self/cls-aware); full chain in hop_path/hop_count props. Cross-file (#3772): when the callee resolves (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowPython); sink resolves to the callee-file entity. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg, *args/**kwargs/keyword-arg call sites, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -47626,7 +47626,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_python.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested module-level calls a→b→c, each bound by exact positional index (self/cls-aware); full chain in hop_path/hop_count props. Cross-file (#3772): when the callee resolves (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowPython); sink resolves to the callee-file entity. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg, *args/**kwargs/keyword-arg call sites, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
@@ -48676,7 +48676,7 @@
             "status": "partial",
             "cites": ["internal/links/dataflow_pass.go","internal/substrate/dataflow.go","internal/substrate/dataflow_python.go"],
             "issue": "3740",
-            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + one local-call hop. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL: drops reassignment, branch-merge, collection mutation, dynamic keys, \u003e1 hop, cross-file.",
+            "notes": "SCOPED request-input → sink DATA_FLOWS_TO (#3628 area #22): intra-fn assignment tracking + multi-hop (≤DataFlowMaxHops=3) local-call propagation AND cross-file propagation into imported helpers. Multi-hop: value followed through nested module-level calls a→b→c, each bound by exact positional index (self/cls-aware); full chain in hop_path/hop_count props. Cross-file (#3772): when the callee resolves (via the CALLS graph) to exactly one same-repo function entity, that file is read and the bounded walk continues there (continueDataFlowPython); sink resolves to the callee-file entity. Sources request.data/json/GET/POST + DRF serializer.validated_data (static string keys only). Sinks Model.objects.create/.save/.insert, return Response/JsonResponse, requests/httpx.post. HONEST-PARTIAL (precision-first): drops reassignment, branch-merge, collection mutation, dynamic keys, embedded-arg, *args/**kwargs/keyword-arg call sites, recursion/entity-cycle, the 4th hop, and external/unresolved/ambiguous imports. DEPLOY-DEFERRED (daemon not rebuilt).",
             "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {

--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -72,6 +72,9 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 		// Per-(repo) index of function-like entity names → entity ID, scoped
 		// by source file, used to resolve a sink callee to a real entity.
 		nameIdx := buildDataFlowNameIndex(g)
+		// Cross-file resolver: maps (handler entity, callee name) → the
+		// callee's defining entity in another file via the CALLS graph.
+		xfile := newCrossFileResolver(g)
 
 		fileSet := map[string]bool{}
 		for _, e := range g.Entities {
@@ -91,8 +94,8 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 			if lang == "" {
 				continue
 			}
-			sniff := substrate.DataFlowSnifferFor(lang)
-			if sniff == nil {
+			sniffEx := substrate.DataFlowSnifferExFor(lang)
+			if sniffEx == nil {
 				continue
 			}
 			srcRoot := repoSourcePathFor(g.Repo)
@@ -105,14 +108,23 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 				continue
 			}
 			scanned++
-			flows := sniff(string(content))
-			if len(flows) == 0 {
+			sniffed := sniffEx(string(content))
+			// In-file flows: sink lives in the handler's own file.
+			var rflows []resolvedFlow
+			for _, fl := range sniffed.Flows {
+				rflows = append(rflows, resolvedFlow{DataFlow: fl, SinkFile: file})
+			}
+			// Resolve cross-file boundaries into concrete flows (multi-hop,
+			// bounded). Each resolved flow's HopPath includes the cross-file
+			// callee chain and its sink lives in the resolved file.
+			rflows = append(rflows, resolveCrossFileFlows(g, file, srcRoot, lang, xfile, sniffed.Boundaries)...)
+			if len(rflows) == 0 {
 				continue
 			}
 
 			// Group flows by handler for the property summary.
-			byHandler := map[string][]substrate.DataFlow{}
-			for _, fl := range flows {
+			byHandler := map[string][]resolvedFlow{}
+			for _, fl := range rflows {
 				if fl.Function == "" {
 					continue
 				}
@@ -130,15 +142,17 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 					}
 					return hflows[i].SinkName < hflows[j].SinkName
 				})
+				summaryFlows := make([]substrate.DataFlow, 0, len(hflows))
 				for _, fl := range hflows {
-					l, ok := buildDataFlowLink(g.Repo, file, fromID, fl, nameIdx, rejects)
+					l, ok := buildDataFlowLink(g.Repo, fl.SinkFile, fromID, fl.DataFlow, nameIdx, rejects)
 					if !ok {
 						res.Skipped++
 						continue
 					}
 					links = append(links, l)
+					summaryFlows = append(summaryFlows, fl.DataFlow)
 				}
-				stampDataFlowSummary(g, fromID, hflows)
+				stampDataFlowSummary(g, fromID, summaryFlows)
 			}
 		}
 	}
@@ -186,6 +200,215 @@ func buildDataFlowNameIndex(g *repoGraph) dataFlowNameIndex {
 	return idx
 }
 
+// resolvedFlow pairs a substrate flow with the file its SINK lives in. For an
+// in-file flow that is the handler's own file; for a cross-file flow it is the
+// resolved callee's file, so the sink entity is looked up in the right place.
+type resolvedFlow struct {
+	substrate.DataFlow
+	SinkFile string
+}
+
+// crossFileResolver maps (caller entity ID, callee bare name) → the callee's
+// defining entity, using the repo's CALLS graph. A name binds only when the
+// caller has exactly ONE cross-file callee with that name (function-like,
+// defined in a different file) — an ambiguous name is dropped (precision).
+type crossFileResolver struct {
+	// byCaller[callerID][calleeName] = []*entityNode (cross-file callees)
+	byCaller map[string]map[string][]*entityNode
+}
+
+func newCrossFileResolver(g *repoGraph) *crossFileResolver {
+	byID := make(map[string]*entityNode, len(g.Entities))
+	for i := range g.Entities {
+		byID[g.Entities[i].ID] = &g.Entities[i]
+	}
+	r := &crossFileResolver{byCaller: map[string]map[string][]*entityNode{}}
+	for _, e := range g.Edges {
+		if !strings.EqualFold(e.Kind, "calls") {
+			continue
+		}
+		caller := byID[e.FromID]
+		callee := byID[e.ToID]
+		if caller == nil || callee == nil {
+			continue
+		}
+		if callee.Name == "" || callee.SourceFile == "" {
+			continue
+		}
+		if !isFunctionLikeKind(callee.Kind) {
+			continue
+		}
+		// Cross-file only: the callee must live in a different file than the
+		// caller. Same-file calls are handled by the in-file hop walk.
+		if caller.SourceFile == callee.SourceFile {
+			continue
+		}
+		m := r.byCaller[e.FromID]
+		if m == nil {
+			m = map[string][]*entityNode{}
+			r.byCaller[e.FromID] = m
+		}
+		m[callee.Name] = append(m[callee.Name], callee)
+	}
+	return r
+}
+
+// resolve returns the unique cross-file callee entity named `name` reachable
+// from callerID via a CALLS edge, or nil when none or ambiguous (>1 distinct
+// defining entity) — honest-partial precision guard.
+func (r *crossFileResolver) resolve(callerID, name string) *entityNode {
+	cands := r.byCaller[callerID][name]
+	if len(cands) == 0 {
+		return nil
+	}
+	// Distinct by entity ID.
+	first := cands[0]
+	for _, c := range cands[1:] {
+		if c.ID != first.ID {
+			return nil // ambiguous — drop
+		}
+	}
+	return first
+}
+
+// resolveCrossFileFlows resolves each cross-file boundary by following the
+// CALLS edge from the handler entity to the imported callee's defining file,
+// then continuing the bounded hop walk there. Returns the concrete flows
+// reached (sink in the resolved file). Honest-partial throughout: a boundary
+// that cannot be uniquely resolved to a same-repo function entity is dropped,
+// the hop bound (DataFlowMaxHops) is enforced, and entity cycles are stopped.
+func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfile *crossFileResolver, boundaries []substrate.DataFlowBoundary) []resolvedFlow {
+	cont := substrate.DataFlowContinueFor(lang)
+	if cont == nil || len(boundaries) == 0 {
+		return nil
+	}
+	binder := newDataFlowHandlerBinder(g)
+	// File-content cache (avoid re-reading the same callee file).
+	cache := map[string]string{}
+	readFile := func(rel string) (string, bool) {
+		if c, ok := cache[rel]; ok {
+			return c, c != ""
+		}
+		buf, err := os.ReadFile(filepath.Join(srcRoot, rel))
+		if err != nil {
+			cache[rel] = ""
+			return "", false
+		}
+		cache[rel] = string(buf)
+		return string(buf), true
+	}
+
+	var out []resolvedFlow
+	for _, b := range boundaries {
+		// Resolve the handler entity that owns the boundary.
+		callerID := binder.lookup(handlerFile, b.Function)
+		if callerID == "" {
+			continue
+		}
+		// Worklist of (callerEntityID, callee name, argIndex, hopPath, hopsUsed).
+		type job struct {
+			callerID string
+			callee   string
+			argIndex int
+			hopPath  []string
+			hopsUsed int
+		}
+		visited := map[string]bool{callerID: true}
+		work := []job{{callerID: callerID, callee: b.Callee, argIndex: b.ArgIndex, hopPath: append([]string(nil), b.HopPath...), hopsUsed: len(b.HopPath)}}
+
+		for len(work) > 0 {
+			j := work[0]
+			work = work[1:]
+			if j.hopsUsed >= substrate.DataFlowMaxHops {
+				continue // bound exhausted — drop
+			}
+			callee := xfile.resolve(j.callerID, j.callee)
+			if callee == nil {
+				continue // unresolved / external / ambiguous — drop
+			}
+			if visited[callee.ID] {
+				continue // entity cycle — stop, drop
+			}
+			visited[callee.ID] = true // mark before descending (cycle guard)
+			content, ok := readFile(callee.SourceFile)
+			if !ok {
+				continue
+			}
+			// Entering this cross-file callee consumes one hop. The
+			// continuation walks further in-file hops on top of that, bounded
+			// by DataFlowMaxHops via hopsUsed.
+			hopsUsed := j.hopsUsed + 1
+			r := cont(content, callee.Name, j.argIndex, b.SourceField, hopsUsed)
+			// Assemble the full hop path: prior hops + this cross-file callee
+			// + any in-file hops the continuation walked.
+			base := append(append([]string(nil), j.hopPath...), callee.Name)
+			for _, fl := range r.Flows {
+				full := append(append([]string(nil), base...), fl.HopPath...)
+				out = append(out, resolvedFlow{
+					DataFlow: substrate.DataFlow{
+						Function:    b.Function,
+						SourceField: b.SourceField,
+						SourceLine:  b.SourceLine,
+						SinkKind:    fl.SinkKind,
+						SinkName:    fl.SinkName,
+						SinkLine:    fl.SinkLine,
+						HopVia:      base[0],
+						HopPath:     full,
+					},
+					SinkFile: callee.SourceFile,
+				})
+			}
+			// Chase further cross-file hops from the resolved callee, if the
+			// continuation surfaced boundaries and we still have budget. The
+			// shared `visited` set (entity IDs) stops cross-file cycles.
+			for _, nb := range r.Boundaries {
+				nextHops := append(append([]string(nil), base...), nb.HopPath...)
+				if len(nextHops) >= substrate.DataFlowMaxHops {
+					continue
+				}
+				work = append(work, job{
+					callerID: callee.ID,
+					callee:   nb.Callee,
+					argIndex: nb.ArgIndex,
+					hopPath:  nextHops,
+					hopsUsed: len(nextHops),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// dataFlowHandlerBinder resolves (file, function name) → entity ID, scoped to
+// one repo graph. A thin wrapper over the same accumulation the effect binder
+// uses, kept local so the cross-file resolver needn't reach across passes.
+type dataFlowHandlerBinder struct {
+	byFile map[string]map[string]string // file -> name -> entityID
+}
+
+func newDataFlowHandlerBinder(g *repoGraph) *dataFlowHandlerBinder {
+	b := &dataFlowHandlerBinder{byFile: map[string]map[string]string{}}
+	for i := range g.Entities {
+		e := &g.Entities[i]
+		if e.SourceFile == "" || e.Name == "" || !isFunctionLikeKind(e.Kind) {
+			continue
+		}
+		m := b.byFile[e.SourceFile]
+		if m == nil {
+			m = map[string]string{}
+			b.byFile[e.SourceFile] = m
+		}
+		if _, exists := m[e.Name]; !exists {
+			m[e.Name] = e.ID // first wins, deterministic
+		}
+	}
+	return b
+}
+
+func (b *dataFlowHandlerBinder) lookup(file, name string) string {
+	return b.byFile[file][name]
+}
+
 // buildDataFlowLink constructs one DATA_FLOWS_TO link. The TO endpoint is a
 // concrete entity when the sink callee's last identifier names a same-file
 // entity; otherwise a synthetic `sink:` residue (resolvable by the
@@ -216,6 +439,12 @@ func buildDataFlowLink(repo, file, fromID string, fl substrate.DataFlow, nameIdx
 	if fl.HopVia != "" {
 		props["hop_via"] = fl.HopVia
 	}
+	if len(fl.HopPath) > 0 {
+		// Full inter-procedural chain (handler→A→B→sink => "A>B"); marks the
+		// flow as cross-file when the path crosses ≥1 hop the resolver bound.
+		props["hop_path"] = strings.Join(fl.HopPath, ">")
+		props["hop_count"] = fmt.Sprintf("%d", len(fl.HopPath))
+	}
 	return Link{
 		ID:           linkID,
 		Source:       source,
@@ -228,15 +457,22 @@ func buildDataFlowLink(repo, file, fromID string, fl substrate.DataFlow, nameIdx
 	}, true
 }
 
-// dataFlowConfidence assigns a confidence: intra-fn flows with a known
-// field are most certain; one-hop and whole-object pass-through are lower.
+// dataFlowConfidence assigns a confidence: intra-fn flows with a known field
+// are most certain; each inter-procedural hop lowers it, and whole-object
+// pass-through (no field provenance) lowers it further. Confidence decays per
+// hop so a 3-hop cross-file flow ranks below a direct one — precision-first.
 func dataFlowConfidence(fl substrate.DataFlow) float64 {
 	c := 0.85
-	if fl.HopVia != "" {
-		c -= 0.15 // inter-procedural hop is less certain
+	hops := len(fl.HopPath)
+	if hops == 0 && fl.HopVia != "" {
+		hops = 1 // defensive: HopVia set but HopPath unset
 	}
+	c -= 0.12 * float64(hops) // each hop is less certain
 	if fl.SourceField == "" {
 		c -= 0.10 // whole-object pass-through, no field provenance
+	}
+	if c < 0.3 {
+		c = 0.3
 	}
 	return c
 }
@@ -286,7 +522,9 @@ func formatDataFlowSummary(flows []substrate.DataFlow, max int) string {
 			field = "*"
 		}
 		s := fmt.Sprintf("%s->%s(%s)", field, f.SinkName, f.SinkKind)
-		if f.HopVia != "" {
+		if len(f.HopPath) > 0 {
+			s += " via " + strings.Join(f.HopPath, ">")
+		} else if f.HopVia != "" {
 			s += " via " + f.HopVia
 		}
 		parts[i] = s

--- a/internal/links/dataflow_pass_test.go
+++ b/internal/links/dataflow_pass_test.go
@@ -131,3 +131,275 @@ function createUser(req, res) {
 		t.Fatalf("expected NO links for static value, got %+v", links)
 	}
 }
+
+// runDataFlowMultiFile runs the pass over a multi-file fixture with explicit
+// CALLS edges, returning the emitted links.
+func runDataFlowMultiFile(t *testing.T, files map[string]string, entities []entityNode, edges []edgeRef) []Link {
+	t.Helper()
+	root := t.TempDir()
+	for f, c := range files {
+		writeFile(t, root, f, c)
+	}
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: entities,
+		Edges:    edges,
+	}}
+	linksPath := root + "/.archigraph/links.json"
+	if _, err := runDataFlowPass(graphs, Paths{Links: linksPath}, nil); err != nil {
+		t.Fatalf("pass error: %v", err)
+	}
+	return readDataFlowSidecar(t, linksPath)
+}
+
+func TestDataFlowPass_JSTS_CrossFile_DBWrite(t *testing.T) {
+	// handler in handlers.ts calls imported save() defined in svc.ts.
+	handler := `
+import { save } from './svc';
+function h(req, res) {
+  save(req.body.x);
+}
+`
+	svc := `
+export function save(v) {
+  Model.create({ v });
+}
+`
+	files := map[string]string{
+		"src/handlers.ts": handler,
+		"src/svc.ts":      svc,
+	}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/handlers.ts"},
+		{ID: "save", Name: "save", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "create", Name: "create", Kind: "function", SourceFile: "src/svc.ts"},
+	}
+	// CALLS edge: handler h -> save (cross-file).
+	edges := []edgeRef{{FromID: "h", ToID: "save", Kind: "calls"}}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+
+	l := findLink(links, func(l Link) bool {
+		return l.Relation == string(types.RelationshipKindDataFlowsTo) &&
+			l.Properties["sink"] == "Model.create"
+	})
+	if l == nil {
+		t.Fatalf("expected cross-file DATA_FLOWS_TO to Model.create, got %+v", links)
+	}
+	if l.Source != "repo-a::h" {
+		t.Errorf("source = %q, want repo-a::h (origin handler)", l.Source)
+	}
+	if l.Properties["field"] != "x" {
+		t.Errorf("field = %q, want x", l.Properties["field"])
+	}
+	if l.Properties["sink_kind"] != "db_write" {
+		t.Errorf("sink_kind = %q, want db_write", l.Properties["sink_kind"])
+	}
+	if l.Properties["hop_path"] != "save" {
+		t.Errorf("hop_path = %q, want save", l.Properties["hop_path"])
+	}
+	if l.Properties["hop_via"] != "save" {
+		t.Errorf("hop_via = %q, want save", l.Properties["hop_via"])
+	}
+	// The sink must resolve to the real callee-file entity, not a residue.
+	if l.Target != "repo-a::create" {
+		t.Errorf("target = %q, want repo-a::create (sink resolved in svc.ts)", l.Target)
+	}
+}
+
+func TestDataFlowPass_Python_CrossFile_DBWrite(t *testing.T) {
+	views := "" +
+		"from .svc import save\n" +
+		"def handler(request):\n" +
+		"    save(request.data['name'])\n"
+	svc := "" +
+		"def save(v):\n" +
+		"    Account.objects.create(name=v)\n"
+	files := map[string]string{
+		"app/views.py": views,
+		"app/svc.py":   svc,
+	}
+	ents := []entityNode{
+		{ID: "handler", Name: "handler", Kind: "function", SourceFile: "app/views.py"},
+		{ID: "save", Name: "save", Kind: "function", SourceFile: "app/svc.py"},
+	}
+	edges := []edgeRef{{FromID: "handler", ToID: "save", Kind: "calls"}}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+
+	l := findLink(links, func(l Link) bool {
+		return l.Relation == string(types.RelationshipKindDataFlowsTo) &&
+			l.Properties["sink"] == "Account.objects.create"
+	})
+	if l == nil {
+		t.Fatalf("expected cross-file DATA_FLOWS_TO to Account.objects.create, got %+v", links)
+	}
+	if l.Source != "repo-a::handler" {
+		t.Errorf("source = %q, want repo-a::handler", l.Source)
+	}
+	if l.Properties["field"] != "name" {
+		t.Errorf("field = %q, want name", l.Properties["field"])
+	}
+	if l.Properties["hop_path"] != "save" {
+		t.Errorf("hop_path = %q, want save", l.Properties["hop_path"])
+	}
+}
+
+func TestDataFlowPass_JSTS_CrossFile_TwoHop(t *testing.T) {
+	// h -> (cross-file) a -> (in-file) b -> sink. hop_path = a>b.
+	handler := `
+import { a } from './svc';
+function h(req, res) {
+  a(req.body.x);
+}
+`
+	svc := `
+export function a(v) {
+  b(v);
+}
+function b(w) {
+  repo.insert(w);
+}
+`
+	files := map[string]string{
+		"src/h.ts":   handler,
+		"src/svc.ts": svc,
+	}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/h.ts"},
+		{ID: "a", Name: "a", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "b", Name: "b", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "insert", Name: "insert", Kind: "function", SourceFile: "src/svc.ts"},
+	}
+	edges := []edgeRef{{FromID: "h", ToID: "a", Kind: "calls"}}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+	l := findLink(links, func(l Link) bool {
+		return l.Properties["sink"] == "repo.insert"
+	})
+	if l == nil {
+		t.Fatalf("expected cross-file 2-hop flow to repo.insert, got %+v", links)
+	}
+	if l.Properties["hop_path"] != "a>b" {
+		t.Errorf("hop_path = %q, want a>b", l.Properties["hop_path"])
+	}
+	if l.Source != "repo-a::h" {
+		t.Errorf("source = %q, want repo-a::h", l.Source)
+	}
+}
+
+func TestDataFlowPass_Negative_CrossFile_Unresolved_NoEdge(t *testing.T) {
+	// No CALLS edge to an in-repo entity → import is external/unresolved → drop.
+	handler := `
+import { save } from 'external-lib';
+function h(req, res) {
+  save(req.body.x);
+}
+`
+	files := map[string]string{"src/h.ts": handler}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/h.ts"},
+	}
+	links := runDataFlowMultiFile(t, files, ents, nil)
+	if l := findLink(links, func(l Link) bool { return l.Properties["sink"] == "Model.create" }); l != nil {
+		t.Fatalf("expected NO edge for unresolved import, got %+v", *l)
+	}
+	if len(links) != 0 {
+		t.Fatalf("expected zero links, got %+v", links)
+	}
+}
+
+func TestDataFlowPass_Negative_CrossFile_AmbiguousCallee_NoEdge(t *testing.T) {
+	// Two distinct cross-file entities named save → ambiguous → drop.
+	handler := `
+import { save } from './svc';
+function h(req, res) {
+  save(req.body.x);
+}
+`
+	svc := `
+export function save(v) { Model.create({ v }); }
+`
+	other := `
+export function save(v) { Other.create({ v }); }
+`
+	files := map[string]string{
+		"src/h.ts":     handler,
+		"src/svc.ts":   svc,
+		"src/other.ts": other,
+	}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/h.ts"},
+		{ID: "save1", Name: "save", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "save2", Name: "save", Kind: "function", SourceFile: "src/other.ts"},
+	}
+	edges := []edgeRef{
+		{FromID: "h", ToID: "save1", Kind: "calls"},
+		{FromID: "h", ToID: "save2", Kind: "calls"},
+	}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+	if len(links) != 0 {
+		t.Fatalf("expected NO link for ambiguous cross-file callee, got %+v", links)
+	}
+}
+
+func TestDataFlowPass_Negative_CrossFile_FourthHopDropped(t *testing.T) {
+	// h -(xfile)-> a -> b -> c -> sink. That is 4 hops (a,b,c are 3 in-file
+	// after the cross-file entry... a is hop1, b hop2, c hop3, sink in c is
+	// reached at 3 hops -> allowed). To exceed, chain one more: sink in d.
+	handler := `
+import { a } from './svc';
+function h(req, res) {
+  a(req.body.x);
+}
+`
+	svc := `
+export function a(v) { b(v); }
+function b(w) { c(w); }
+function c(z) { d(z); }
+function d(q) { repo.insert(q); }
+`
+	files := map[string]string{"src/h.ts": handler, "src/svc.ts": svc}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/h.ts"},
+		{ID: "a", Name: "a", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "b", Name: "b", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "c", Name: "c", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "d", Name: "d", Kind: "function", SourceFile: "src/svc.ts"},
+	}
+	edges := []edgeRef{{FromID: "h", ToID: "a", Kind: "calls"}}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+	if l := findLink(links, func(l Link) bool { return l.Properties["sink"] == "repo.insert" }); l != nil {
+		t.Fatalf("expected NO flow beyond 3 hops, got %+v", *l)
+	}
+}
+
+func TestDataFlowPass_CrossFile_ThreeHop_Reaches(t *testing.T) {
+	// h -(xfile)-> a -> b -> sink-in-b is 2 hops; sink directly in c via
+	// a->b->c chain = 3 hops (the inclusive bound) must still reach.
+	handler := `
+import { a } from './svc';
+function h(req, res) {
+  a(req.body.x);
+}
+`
+	svc := `
+export function a(v) { b(v); }
+function b(w) { c(w); }
+function c(z) { repo.insert(z); }
+`
+	files := map[string]string{"src/h.ts": handler, "src/svc.ts": svc}
+	ents := []entityNode{
+		{ID: "h", Name: "h", Kind: "function", SourceFile: "src/h.ts"},
+		{ID: "a", Name: "a", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "b", Name: "b", Kind: "function", SourceFile: "src/svc.ts"},
+		{ID: "c", Name: "c", Kind: "function", SourceFile: "src/svc.ts"},
+	}
+	edges := []edgeRef{{FromID: "h", ToID: "a", Kind: "calls"}}
+	links := runDataFlowMultiFile(t, files, ents, edges)
+	l := findLink(links, func(l Link) bool { return l.Properties["sink"] == "repo.insert" })
+	if l == nil {
+		t.Fatalf("expected 3-hop cross-file flow to reach repo.insert, got %+v", links)
+	}
+	if l.Properties["hop_path"] != "a>b>c" {
+		t.Errorf("hop_path = %q, want a>b>c", l.Properties["hop_path"])
+	}
+}

--- a/internal/substrate/dataflow.go
+++ b/internal/substrate/dataflow.go
@@ -2,9 +2,11 @@
 //
 // Per-language sniffers lift, per source file, a set of DataFlow records:
 // a value read from an HTTP request input that reaches a recognised sink
-// (DB write / outbound HTTP call / response body) within a single
-// function body, plus ONE hop into a directly-called local function via
-// positional argument binding.
+// (DB write / outbound HTTP call / response body) through up to
+// DataFlowMaxHops inter-procedural hops via positional argument binding,
+// AND a set of DataFlowBoundary records for tainted values that escape the
+// current file into an imported callee (resolved + continued by the links
+// pass, which owns the import graph — see internal/links/dataflow_pass.go).
 //
 // This is deliberately a SCOPED def→use tracker, NOT a full taint engine.
 // The propagation model is "simple assignment tracking, last-write-wins":
@@ -14,10 +16,27 @@
 //     captured when statically knowable.
 //   - Propagation: `const y = <source>` taints y; a direct pass-through
 //     `sink(<source>)` flows; `helper(y)` where helper is a local function
-//     binds y into helper's matching positional parameter and continues
-//     exactly ONE level deeper.
+//     binds y into helper's matching positional parameter and continues the
+//     walk, up to DataFlowMaxHops levels deep. The chain of callees is
+//     recorded in HopPath.
 //   - Sink: DB write, an argument to a CONSUMES_API outbound call, or a
 //     response-body emission.
+//
+// MULTI-HOP (≤ DataFlowMaxHops): the value is followed through nested local
+// calls A→B→C, each binding by exact positional index. The set of callees
+// already on the active call path is tracked so a recursion / cycle stops
+// the walk (drop, never loop). A hop beyond the bound is dropped.
+//
+// CROSS-FILE: when a tainted value reaches a call whose callee is NOT a
+// function defined in the current file, the sniffer cannot resolve the
+// import (it has no import graph). Instead it records a DataFlowBoundary —
+// the originating handler, the escaping callee name, the tainted positional
+// argument index, the source field, and the hops already consumed. The
+// links pass resolves that callee through the IMPORTS/CALLS edge to a real
+// same-repo entity, reads the defining file, binds the value into the
+// matching parameter, and CONTINUES the same bounded walk there. Only a
+// callee that resolves to a concrete same-repo entity is followed; an
+// external / unresolved import is dropped.
 //
 // HONEST-PARTIAL boundary (precision over recall — this is the bar for a
 // dataflow product). The sniffer DROPS, never fabricates, when it cannot
@@ -25,15 +44,23 @@
 //   - reassignment that breaks the chain (`y = somethingElse` after taint)
 //   - branch/merge of differently-tainted values
 //   - collection / object mutation (`obj.x = tainted`, `arr.push(tainted)`)
-//   - cross-file flow beyond the single one-hop local call
+//   - a call whose argument position is ambiguous (spread `...args`,
+//     destructured / rest parameters) — position cannot be bound exactly
 //   - dynamic field access (`req.body[dynamicKey]`)
-//   - more than one hop of inter-procedural depth
+//   - more than DataFlowMaxHops hops of inter-procedural depth
+//   - recursion / a cycle in the local call graph
 //
 // Per-language sniffers are pure functions over file content, stateless
 // and deterministic, mirroring the def-use / effect-sink substrate.
 package substrate
 
 import "sort"
+
+// DataFlowMaxHops bounds inter-procedural depth (number of call hops a
+// tainted value is followed through, counting cross-file hops). Beyond this
+// bound the walk is dropped — honest-partial. A direct intra-function sink
+// is 0 hops; handler→helper→sink is 1 hop; handler→A→B→sink is 2 hops.
+const DataFlowMaxHops = 3
 
 // DataFlowSinkKind classifies the terminal of a flow.
 type DataFlowSinkKind string
@@ -47,15 +74,15 @@ const (
 	DataFlowSinkResponse DataFlowSinkKind = "response"
 )
 
-// DataFlow is one resolved source→sink flow within a function body
-// (optionally crossing exactly one local-call hop).
+// DataFlow is one resolved source→sink flow originating in a handler,
+// optionally crossing up to DataFlowMaxHops local-call hops.
 type DataFlow struct {
 	// Function is the request handler function the flow ORIGINATES in —
-	// i.e. the function that reads the request input. For a one-hop flow
-	// the sink physically appears inside the callee, but the flow is
+	// i.e. the function that reads the request input. For a multi-hop flow
+	// the sink physically appears inside a callee, but the flow is
 	// attributed to the originating handler so the emitted edge starts at
-	// the entity that owns the untrusted input. The callee name is carried
-	// in HopVia.
+	// the entity that owns the untrusted input. The callee chain is carried
+	// in HopPath.
 	Function string
 
 	// SourceField is the request-input field name when statically known
@@ -77,17 +104,75 @@ type DataFlow struct {
 	// SinkLine is the 1-indexed line of the sink.
 	SinkLine int
 
-	// HopVia, when non-empty, is the name of the local function the value
-	// was passed into (one-hop inter-procedural). Empty for intra-fn flows.
+	// HopVia, when non-empty, is the name of the FIRST local function the
+	// value was passed into. Retained for backward compatibility; it equals
+	// HopPath[0] when HopPath is non-empty. Empty for intra-fn flows.
 	HopVia string
+
+	// HopPath is the ordered chain of callee function names the tainted
+	// value traversed to reach the sink (empty for an intra-fn flow). For a
+	// flow handler→A→B→sink it is ["A","B"]. len(HopPath) ≤ DataFlowMaxHops.
+	HopPath []string
+}
+
+// DataFlowBoundary is a tainted value that ESCAPES the current file: it is
+// passed (by exact positional index) into a callee that is not defined in
+// this file. The sniffer cannot resolve the import — the links pass does,
+// then continues the bounded walk in the resolved file. A boundary is only
+// emitted when the argument position is unambiguous; spread / destructured
+// call sites are dropped, never recorded.
+type DataFlowBoundary struct {
+	// Function is the originating handler (same meaning as DataFlow.Function).
+	Function string
+	// SourceField is the request-input field (may be "").
+	SourceField string
+	// SourceLine is the 1-indexed line of the request-input read.
+	SourceLine int
+	// Callee is the bare name of the escaping function call.
+	Callee string
+	// ArgIndex is the 0-based positional index of the tainted argument at the
+	// call site (already self/cls-agnostic at the call side; the resolver maps
+	// it to the callee's matching parameter).
+	ArgIndex int
+	// HopPath is the chain of local callees already traversed before this
+	// boundary call (the call into Callee is the NEXT hop, counted by the
+	// resolver). For a handler that directly calls an imported fn it is empty.
+	HopPath []string
+	// CallLine is the 1-indexed line of the escaping call (for determinism).
+	CallLine int
+}
+
+// DataFlowResult bundles the in-file flows and the cross-file boundaries a
+// sniffer found.
+type DataFlowResult struct {
+	Flows      []DataFlow
+	Boundaries []DataFlowBoundary
 }
 
 // DataFlowSnifferFn is the contract for per-language dataflow sniffers.
-// Returns every soundly-followed source→sink flow in the file, in source
-// order. Must be deterministic so the pass output is byte-stable.
+// Returns every soundly-followed in-file source→sink flow in the file, in
+// source order. Must be deterministic so the pass output is byte-stable.
+// (In-file flows only; cross-file boundaries are exposed via the *Ex form.)
 type DataFlowSnifferFn func(content string) []DataFlow
 
+// DataFlowSnifferExFn is the extended contract: returns both in-file flows
+// and the cross-file boundaries for the links pass to resolve. Languages
+// that implement cross-file register one of these.
+type DataFlowSnifferExFn func(content string) DataFlowResult
+
+// DataFlowContinueFn continues a bounded hop walk inside a resolved file,
+// starting from a parameter already bound to a tainted value. Used by the
+// links pass for cross-file propagation. fnName is the callee whose body to
+// enter; paramIndex is the 0-based parameter the tainted value binds to;
+// field is the carried source field; hopsUsed is the number of hops already
+// consumed reaching this file (so the continuation respects DataFlowMaxHops).
+// It returns the in-file flows reachable from that binding, plus any further
+// cross-file boundaries (for chained cross-file hops). Deterministic.
+type DataFlowContinueFn func(content, fnName string, paramIndex int, field string, hopsUsed int) DataFlowResult
+
 var dataFlowRegistry = map[string]DataFlowSnifferFn{}
+var dataFlowExRegistry = map[string]DataFlowSnifferExFn{}
+var dataFlowContinueRegistry = map[string]DataFlowContinueFn{}
 
 // RegisterDataFlowSniffer installs a per-language dataflow sniffer.
 func RegisterDataFlowSniffer(lang string, fn DataFlowSnifferFn) {
@@ -97,9 +182,33 @@ func RegisterDataFlowSniffer(lang string, fn DataFlowSnifferFn) {
 	dataFlowRegistry[lang] = fn
 }
 
-// DataFlowSnifferFor returns the registered sniffer for lang, or nil.
+// RegisterDataFlowSnifferEx installs a per-language extended sniffer (in-file
+// flows + cross-file boundaries) AND a continuation function. The in-file
+// flows are also exposed via the legacy DataFlowSnifferFor path so existing
+// callers are unaffected.
+func RegisterDataFlowSnifferEx(lang string, ex DataFlowSnifferExFn, cont DataFlowContinueFn) {
+	if lang == "" || ex == nil || cont == nil {
+		return
+	}
+	dataFlowExRegistry[lang] = ex
+	dataFlowContinueRegistry[lang] = cont
+	// Bridge to the legacy registry so DataFlowSnifferFor keeps working.
+	dataFlowRegistry[lang] = func(content string) []DataFlow { return ex(content).Flows }
+}
+
+// DataFlowSnifferFor returns the registered (in-file) sniffer for lang, or nil.
 func DataFlowSnifferFor(lang string) DataFlowSnifferFn {
 	return dataFlowRegistry[lang]
+}
+
+// DataFlowSnifferExFor returns the extended sniffer for lang, or nil.
+func DataFlowSnifferExFor(lang string) DataFlowSnifferExFn {
+	return dataFlowExRegistry[lang]
+}
+
+// DataFlowContinueFor returns the cross-file continuation fn for lang, or nil.
+func DataFlowContinueFor(lang string) DataFlowContinueFn {
+	return dataFlowContinueRegistry[lang]
 }
 
 // DataFlowLanguages returns the slugs of every registered dataflow

--- a/internal/substrate/dataflow_jsts.go
+++ b/internal/substrate/dataflow_jsts.go
@@ -1,8 +1,9 @@
 // JS/TS request-input → sink dataflow sniffer (#3628 area #22).
 //
-// SCOPED def→use tracking inside one function body, plus one hop into a
-// directly-called local function. See dataflow.go for the contract and the
-// honest-partial boundary.
+// SCOPED def→use tracking inside one function body, followed through up to
+// DataFlowMaxHops local-call hops, PLUS cross-file boundary emission for a
+// tainted value that escapes into an imported (non-local) callee. See
+// dataflow.go for the contract and the honest-partial boundary.
 //
 // Sources recognised:
 //   - req.body.X / req.query.X / req.params.X         (Express / generic)
@@ -22,7 +23,12 @@ import (
 	"strings"
 )
 
-func init() { RegisterDataFlowSniffer("jsts", sniffDataFlowJSTS) }
+func init() {
+	RegisterDataFlowSnifferEx("jsts", sniffDataFlowJSTSEx, continueDataFlowJSTS)
+}
+
+// sniffDataFlowJSTS preserves the legacy in-file-only entry point.
+func sniffDataFlowJSTS(content string) []DataFlow { return sniffDataFlowJSTSEx(content).Flows }
 
 // dfJstsSourceFieldRe captures a request-input read with a STATIC field
 // name. Group 1 = field. Anchored on the canonical receivers. Dynamic
@@ -65,19 +71,69 @@ var dfJstsBareAssignRe = regexp.MustCompile(
 	`^\s*([A-Za-z_$][\w$]*)\s*=\s*([^=].*)$`,
 )
 
-func sniffDataFlowJSTS(content string) []DataFlow {
+// dfJstsSinkSpecs is the ordered sink table reused at every scan depth.
+var dfJstsSinkSpecs = []struct {
+	re   *regexp.Regexp
+	kind DataFlowSinkKind
+}{
+	{dfJstsDBWriteRe, DataFlowSinkDBWrite},
+	{dfJstsRespRe, DataFlowSinkResponse},
+	{dfJstsHTTPCallRe, DataFlowSinkHTTPCall},
+}
+
+func sniffDataFlowJSTSEx(content string) DataFlowResult {
 	if content == "" {
-		return nil
+		return DataFlowResult{}
 	}
 	lines := strings.Split(content, "\n")
 	headers := scanJSTSFuncHeaders(content)
 	bodies := jstsFuncBodies(content, headers)
 
-	var out []DataFlow
+	var res DataFlowResult
 	for _, b := range bodies {
-		out = append(out, analyzeJSTSBody(lines, b, bodies)...)
+		ctx := jstsWalkCtx{
+			origin:  b.Name,
+			bodies:  bodies,
+			lines:   lines,
+			visited: map[string]bool{b.Name: true},
+		}
+		r := walkJSTSBody(ctx, b, map[string]taintInfo{})
+		res.Flows = append(res.Flows, r.Flows...)
+		res.Boundaries = append(res.Boundaries, r.Boundaries...)
 	}
-	return out
+	return res
+}
+
+// continueDataFlowJSTS continues a bounded hop walk inside this file: it
+// binds the tainted value into fnName's paramIndex-th parameter and walks.
+// hopsUsed is the number of hops already consumed reaching this file (so the
+// continuation honours DataFlowMaxHops). The returned flows' Function /
+// SourceField / SourceLine are placeholders; the links pass rewrites them to
+// the true origin handler.
+func continueDataFlowJSTS(content, fnName string, paramIndex int, field string, hopsUsed int) DataFlowResult {
+	if content == "" || hopsUsed >= DataFlowMaxHops {
+		return DataFlowResult{}
+	}
+	lines := strings.Split(content, "\n")
+	headers := scanJSTSFuncHeaders(content)
+	bodies := jstsFuncBodies(content, headers)
+	callee := jstsBodyByName(bodies, fnName)
+	if callee == nil {
+		return DataFlowResult{}
+	}
+	param := jstsParamName(lines, callee.Start, paramIndex)
+	if param == "" {
+		return DataFlowResult{} // ambiguous/destructured param — drop
+	}
+	ctx := jstsWalkCtx{
+		origin:   fnName, // placeholder; links pass rewrites
+		field:    field,
+		hopsUsed: hopsUsed,
+		bodies:   bodies,
+		lines:    lines,
+		visited:  map[string]bool{fnName: true},
+	}
+	return walkJSTSBody(ctx, *callee, map[string]taintInfo{param: {field: field, line: callee.Start}})
 }
 
 // jstsFuncBody is a function's line span (1-indexed, inclusive).
@@ -93,13 +149,34 @@ func jstsFuncBodies(content string, headers []funcHeader) []jstsFuncBody {
 	lines := strings.Split(content, "\n")
 	var out []jstsFuncBody
 	for _, h := range headers {
-		end := jstsMatchBraceEnd(lines, h.Line)
+		// The (?m)^\s* header regex can place a function preceded by a blank
+		// line one line early (the \s* eats the prior newline). Snap Start to
+		// the line that actually contains the function's name token so param
+		// reading and the brace scan are aligned.
+		start := jstsSnapHeaderLine(lines, h.Line, h.Name)
+		end := jstsMatchBraceEnd(lines, start)
 		if end == 0 {
 			continue
 		}
-		out = append(out, jstsFuncBody{Name: h.Name, Start: h.Line, End: end})
+		out = append(out, jstsFuncBody{Name: h.Name, Start: start, End: end})
 	}
 	return out
+}
+
+// jstsSnapHeaderLine returns the 1-indexed line at/after `line` whose text
+// contains `name` followed (ignoring spaces) by `(` — the real header line.
+// Falls back to `line` if not found within a small window.
+func jstsSnapHeaderLine(lines []string, line int, name string) int {
+	for i := line; i <= line+2 && i <= len(lines); i++ {
+		s := lines[i-1]
+		if idx := strings.Index(s, name); idx >= 0 {
+			rest := strings.TrimLeft(s[idx+len(name):], " \t")
+			if strings.HasPrefix(rest, "(") {
+				return i
+			}
+		}
+	}
+	return line
 }
 
 // jstsMatchBraceEnd finds the line of the `}` that closes the first `{`
@@ -126,42 +203,150 @@ func jstsMatchBraceEnd(lines []string, startLine int) int {
 	return 0
 }
 
-// analyzeJSTSBody runs the scoped def→use over a single function body and
-// returns the flows that reach a sink (intra-fn or one-hop).
-func analyzeJSTSBody(lines []string, b jstsFuncBody, all []jstsFuncBody) []DataFlow {
-	// tainted: var name -> source field (may be "" for whole-object).
-	tainted := map[string]taintInfo{}
-	var out []DataFlow
+// jstsWalkCtx threads the bounded multi-hop walk's immutable-ish state.
+// hopPath/visited are COPIED (not shared) on each descent so sibling
+// branches do not pollute one another.
+type jstsWalkCtx struct {
+	origin   string // originating handler name (or placeholder, cross-file)
+	field    string // carried source field provenance ("" if unknown)
+	srcLine  int    // request-source line in the origin handler (0 cross-file)
+	hopsUsed int    // hops already consumed reaching this body
+	bodies   []jstsFuncBody
+	lines    []string
+	visited  map[string]bool // callee names on the active path (cycle guard)
+	hopPath  []string        // ordered callee chain to this body
+}
 
-	for ln := b.Start; ln <= b.End && ln <= len(lines); ln++ {
-		line := lines[ln-1]
+// walkJSTSBody is the unified forward pass over a function body. The taint
+// map is pre-seeded (cross-file continuation) or empty (handler, which reads
+// its request sources here). Returns reached sinks + cross-file boundaries.
+func walkJSTSBody(ctx jstsWalkCtx, b jstsFuncBody, tainted map[string]taintInfo) DataFlowResult {
+	var res DataFlowResult
+	for ln := b.Start; ln <= b.End && ln <= len(ctx.lines); ln++ {
+		line := ctx.lines[ln-1]
 
-		// Chain-breaking reassignment: a bare `name = <expr>` where expr is
-		// NOT a source/tainted reference removes the taint. (honest-partial)
-		if m := dfJstsBareAssignRe.FindStringSubmatch(line); m != nil {
-			name, rhs := m[1], m[2]
-			if _, was := tainted[name]; was && !jstsRHSCarriesTaint(rhs, tainted) {
-				delete(tainted, name)
-				// fall through: a bare assignment is not also a decl below.
-			}
-		}
+		jstsTrackTaint(tainted, line, ln)
 
-		// Propagation via declaration: const y = <source or tainted>.
-		if m := dfJstsConstAssignRe.FindStringSubmatch(line); m != nil {
-			name, rhs := m[1], m[2]
-			if fld, ok := jstsRHSSourceField(rhs, tainted); ok {
-				tainted[name] = taintInfo{field: fld, line: ln}
-				continue
-			}
-			// Declared from a non-source expr: ensure no stale taint.
+		res.Flows = append(res.Flows, jstsDirectSinks(ctx, ln, line, tainted)...)
+
+		r := jstsFollowCalls(ctx, ln, line, tainted)
+		res.Flows = append(res.Flows, r.Flows...)
+		res.Boundaries = append(res.Boundaries, r.Boundaries...)
+	}
+	return res
+}
+
+// jstsTrackTaint applies one line's assignment effects to the taint map.
+func jstsTrackTaint(tainted map[string]taintInfo, line string, ln int) {
+	if m := dfJstsBareAssignRe.FindStringSubmatch(line); m != nil {
+		name, rhs := m[1], m[2]
+		if _, was := tainted[name]; was && !jstsRHSCarriesTaint(rhs, tainted) {
 			delete(tainted, name)
 		}
+	}
+	if m := dfJstsConstAssignRe.FindStringSubmatch(line); m != nil {
+		name, rhs := m[1], m[2]
+		if fld, ok := jstsRHSSourceField(rhs, tainted); ok {
+			tainted[name] = taintInfo{field: fld, line: ln}
+		} else {
+			delete(tainted, name)
+		}
+	}
+}
 
-		// Sinks. A sink fires if any of its argument text references a
-		// source directly or a tainted variable.
-		out = appendJSTSSinkFlows(out, lines, b, ln, line, tainted, all)
+// jstsDirectSinks emits flows for sinks on `line` whose args carry taint.
+func jstsDirectSinks(ctx jstsWalkCtx, ln int, line string, tainted map[string]taintInfo) []DataFlow {
+	var out []DataFlow
+	for _, s := range dfJstsSinkSpecs {
+		for _, m := range s.re.FindAllStringSubmatchIndex(line, -1) {
+			callee := line[m[2]:m[3]]
+			args := jstsCallArgs(ctx.lines, ln, m[2])
+			if fld, ok := jstsArgsTainted(args, tainted); ok {
+				field := ctx.field
+				if field == "" {
+					field = fld
+				}
+				out = append(out, DataFlow{
+					Function:    ctx.origin,
+					SourceField: field,
+					SourceLine:  ctx.srcLine,
+					SinkKind:    s.kind,
+					SinkName:    callee,
+					SinkLine:    ln,
+					HopVia:      firstOf(ctx.hopPath),
+					HopPath:     dupStrings(ctx.hopPath),
+				})
+			}
+		}
 	}
 	return out
+}
+
+// jstsFollowCalls handles each local-call on `line`: if the callee is a
+// function defined in this file and the hop bound + cycle guards allow,
+// recurse into it; otherwise (non-local callee) record a cross-file boundary
+// candidate. Position binding is EXACT — a spread / ambiguous arg drops.
+func jstsFollowCalls(ctx jstsWalkCtx, ln int, line string, tainted map[string]taintInfo) DataFlowResult {
+	var res DataFlowResult
+	for _, call := range jstsLocalCalls(line) {
+		// A spread token anywhere in the arg list makes positions unreliable.
+		if jstsArgsHaveSpread(call.args) {
+			continue
+		}
+		for pos, argExpr := range call.args {
+			if _, ok := jstsExprTainted(argExpr, tainted); !ok {
+				continue
+			}
+			// Require the arg to be EXACTLY the tainted value (not embedded in
+			// a larger expression) so positional binding stays sound.
+			fld, bare := jstsArgBareTaint(argExpr, tainted)
+			if !bare {
+				continue
+			}
+			field := ctx.field
+			if field == "" {
+				field = fld
+			}
+			callee := jstsBodyByName(ctx.bodies, call.name)
+			if callee == nil {
+				// Non-local callee → cross-file boundary candidate (only with
+				// hop budget remaining for the next hop).
+				if ctx.hopsUsed+len(ctx.hopPath) >= DataFlowMaxHops {
+					continue
+				}
+				res.Boundaries = append(res.Boundaries, DataFlowBoundary{
+					Function:    ctx.origin,
+					SourceField: field,
+					SourceLine:  ctx.srcLine,
+					Callee:      call.name,
+					ArgIndex:    pos,
+					HopPath:     dupStrings(ctx.hopPath),
+					CallLine:    ln,
+				})
+				continue
+			}
+			// Local hop. Guards: depth bound, cycle/recursion, param binding.
+			if ctx.hopsUsed+len(ctx.hopPath) >= DataFlowMaxHops {
+				continue // beyond bound — drop
+			}
+			if ctx.visited[callee.Name] {
+				continue // recursion / cycle — stop, drop
+			}
+			param := jstsParamName(ctx.lines, callee.Start, pos)
+			if param == "" {
+				continue // destructured / ambiguous param — drop
+			}
+			child := ctx
+			child.hopPath = append(dupStrings(ctx.hopPath), callee.Name)
+			child.visited = dupVisited(ctx.visited)
+			child.visited[callee.Name] = true
+			child.field = field
+			r := walkJSTSBody(child, *callee, map[string]taintInfo{param: {field: field, line: callee.Start}})
+			res.Flows = append(res.Flows, r.Flows...)
+			res.Boundaries = append(res.Boundaries, r.Boundaries...)
+		}
+	}
+	return res
 }
 
 type taintInfo struct {
@@ -182,7 +367,6 @@ func jstsRHSSourceField(rhs string, tainted map[string]taintInfo) (string, bool)
 	if dfJstsSourceAnyRe.MatchString(rhs) {
 		return "", true
 	}
-	// Reference to an existing tainted var, e.g. `const z = y;`.
 	for name, info := range tainted {
 		if dfReWholeIdent(name).MatchString(rhs) {
 			return info.field, true
@@ -196,93 +380,6 @@ func jstsRHSSourceField(rhs string, tainted map[string]taintInfo) (string, bool)
 func jstsRHSCarriesTaint(rhs string, tainted map[string]taintInfo) bool {
 	_, ok := jstsRHSSourceField(rhs, tainted)
 	return ok
-}
-
-// appendJSTSSinkFlows detects sinks on `line` and, for each, emits a flow
-// if a tainted value or a direct source reaches its argument list. Also
-// performs the single one-hop expansion into a local function call.
-func appendJSTSSinkFlows(out []DataFlow, lines []string, b jstsFuncBody, ln int, line string, tainted map[string]taintInfo, all []jstsFuncBody) []DataFlow {
-	// Direct sinks in this body.
-	for _, s := range []struct {
-		re   *regexp.Regexp
-		kind DataFlowSinkKind
-	}{
-		{dfJstsDBWriteRe, DataFlowSinkDBWrite},
-		{dfJstsRespRe, DataFlowSinkResponse},
-		{dfJstsHTTPCallRe, DataFlowSinkHTTPCall},
-	} {
-		for _, m := range s.re.FindAllStringSubmatchIndex(line, -1) {
-			callee := line[m[2]:m[3]]
-			args := jstsCallArgs(lines, ln, m[2])
-			if fld, ok := jstsArgsTainted(args, tainted); ok {
-				out = append(out, DataFlow{
-					Function:    b.Name,
-					SourceField: fld,
-					SourceLine:  ln,
-					SinkKind:    s.kind,
-					SinkName:    callee,
-					SinkLine:    ln,
-				})
-			}
-		}
-	}
-
-	// One-hop: a call `helper(<tainted-or-source>)` where helper is a local
-	// function. Bind the tainted argument into helper's matching positional
-	// parameter and look for a sink inside helper's body (one level only).
-	for _, call := range jstsLocalCalls(line) {
-		callee := jstsBodyByName(all, call.name)
-		if callee == nil || callee.Name == b.Name {
-			continue
-		}
-		// Which positional args carry taint?
-		for pos, argExpr := range call.args {
-			fld, ok := jstsExprTainted(argExpr, tainted)
-			if !ok {
-				continue
-			}
-			param := jstsParamName(lines, callee.Start, pos)
-			if param == "" {
-				continue
-			}
-			// Scan the callee body for a sink that uses `param` directly.
-			for cln := callee.Start; cln <= callee.End && cln <= len(lines); cln++ {
-				cline := lines[cln-1]
-				out = appendJSTSHopSink(out, lines, b, callee, param, fld, ln, cln, cline)
-			}
-		}
-	}
-	return out
-}
-
-// appendJSTSHopSink emits a one-hop flow when a sink inside the callee uses
-// the bound parameter directly.
-func appendJSTSHopSink(out []DataFlow, lines []string, origin jstsFuncBody, callee *jstsFuncBody, param, fld string, srcLine, cln int, cline string) []DataFlow {
-	for _, s := range []struct {
-		re   *regexp.Regexp
-		kind DataFlowSinkKind
-	}{
-		{dfJstsDBWriteRe, DataFlowSinkDBWrite},
-		{dfJstsRespRe, DataFlowSinkResponse},
-		{dfJstsHTTPCallRe, DataFlowSinkHTTPCall},
-	} {
-		for _, m := range s.re.FindAllStringSubmatchIndex(cline, -1) {
-			callName := cline[m[2]:m[3]]
-			args := jstsCallArgs(lines, cln, m[2])
-			if dfReWholeIdent(param).MatchString(args) {
-				out = append(out, DataFlow{
-					Function:    origin.Name,
-					SourceField: fld,
-					SourceLine:  srcLine,
-					SinkKind:    s.kind,
-					SinkName:    callName,
-					SinkLine:    cln,
-					HopVia:      callee.Name,
-				})
-			}
-		}
-	}
-	return out
 }
 
 // jstsArgsTainted reports whether the argument text references a source
@@ -311,11 +408,58 @@ func jstsExprTainted(expr string, tainted map[string]taintInfo) (string, bool) {
 	return "", false
 }
 
+// jstsArgBareTaint reports whether argExpr is EXACTLY a tainted reference (a
+// request-source read or a bare tainted identifier), not embedded in a
+// larger expression. This precision guard keeps positional binding sound:
+// `helper(x)` / `helper(req.body.x)` bind; `helper(x + 1)` / `helper({x})` /
+// `helper(f(x))` do NOT (drop — honest-partial). Returns the field.
+func jstsArgBareTaint(argExpr string, tainted map[string]taintInfo) (string, bool) {
+	e := strings.TrimSpace(argExpr)
+	if jstsWholeExprIsSource(e) {
+		if m := dfJstsSourceFieldRe.FindStringSubmatch(e); m != nil {
+			if m[1] != "" {
+				return m[1], true
+			}
+			return m[2], true
+		}
+		return "", true
+	}
+	if dfReSimpleIdent.MatchString(e) {
+		if info, ok := tainted[e]; ok {
+			return info.field, true
+		}
+	}
+	return "", false
+}
+
+// jstsWholeExprIsSource reports the expr is SOLELY a request-source access
+// (optionally a member chain) with no surrounding operators.
+func jstsWholeExprIsSource(e string) bool {
+	loc := dfJstsSourceFieldRe.FindStringIndex(e)
+	if loc == nil {
+		loc = dfJstsSourceAnyRe.FindStringIndex(e)
+	}
+	if loc == nil {
+		return false
+	}
+	return strings.TrimSpace(e[:loc[0]]) == "" && strings.TrimSpace(e[loc[1]:]) == ""
+}
+
+// jstsArgsHaveSpread reports whether any argument is a spread (`...x`),
+// which makes positional indices unreliable → the whole call is dropped.
+func jstsArgsHaveSpread(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(strings.TrimSpace(a), "...") {
+			return true
+		}
+	}
+	return false
+}
+
 // jstsCallArgs returns the argument text of the call whose `(` begins at or
 // after byte offset openByte on line ln, spanning until the matching `)`
 // (possibly across lines). Returns the inner text.
 func jstsCallArgs(lines []string, ln, openByte int) string {
-	// Concatenate from the `(` to the matching `)`.
 	var sb strings.Builder
 	depth := 0
 	started := false
@@ -323,7 +467,6 @@ func jstsCallArgs(lines []string, ln, openByte int) string {
 		s := lines[i]
 		start := 0
 		if i == ln-1 {
-			// find the first '(' at/after openByte
 			idx := strings.IndexByte(s[min(openByte, len(s)):], '(')
 			if idx < 0 {
 				return ""
@@ -365,13 +508,20 @@ type jstsLocalCall struct {
 // dfJstsLocalCallRe matches a call to a bare identifier (potential local fn).
 var dfJstsLocalCallRe = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\(`)
 
-// jstsLocalCalls extracts candidate local-function calls on a line with
-// their top-level positional argument expressions.
+// jstsLocalCalls extracts candidate bare-identifier function calls on a line
+// with their top-level positional argument expressions. A method call
+// (`x.foo(`) is skipped — only bare-identifier calls are hop/boundary
+// candidates (a method call cannot be resolved positionally here).
 func jstsLocalCalls(line string) []jstsLocalCall {
 	var out []jstsLocalCall
 	for _, m := range dfJstsLocalCallRe.FindAllStringSubmatchIndex(line, -1) {
 		name := line[m[2]:m[3]]
-		// skip known sink/keyword callees handled directly
+		if m[2] > 0 {
+			prev := strings.TrimRight(line[:m[2]], " \t")
+			if strings.HasSuffix(prev, ".") {
+				continue // method call — not a bare-ident call
+			}
+		}
 		if jstsControlKeyword(name) || name == "require" {
 			continue
 		}
@@ -408,8 +558,9 @@ func jstsSplitArgs(s string) []string {
 }
 
 // jstsParamName returns the name of the pos-th positional parameter of the
-// function whose header is on headerLine. Destructured params are skipped
-// (return "" → no one-hop binding, honest-partial).
+// function whose header is on headerLine. Destructured params return ""
+// (no binding, honest-partial). A rest param (`...rest`) anywhere makes
+// positional binding ambiguous → "".
 func jstsParamName(lines []string, headerLine, pos int) string {
 	if headerLine < 1 || headerLine > len(lines) {
 		return ""
@@ -427,13 +578,17 @@ func jstsParamName(lines []string, headerLine, pos int) string {
 	if pos >= len(params) {
 		return ""
 	}
+	for _, p := range params {
+		if strings.HasPrefix(strings.TrimSpace(p), "...") {
+			return "" // rest param → ambiguous positions
+		}
+	}
 	p := strings.TrimSpace(params[pos])
-	// strip a TS type annotation / default.
 	if i := strings.IndexAny(p, ":="); i >= 0 {
 		p = strings.TrimSpace(p[:i])
 	}
 	if !dfReSimpleIdent.MatchString(p) {
-		return "" // destructured / rest / complex — drop
+		return "" // destructured / complex — drop
 	}
 	return p
 }
@@ -453,6 +608,33 @@ var dfReSimpleIdent = regexp.MustCompile(`^[A-Za-z_$][\w$]*$`)
 // dfReWholeIdent builds a whole-word matcher for a specific identifier.
 func dfReWholeIdent(name string) *regexp.Regexp {
 	return regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+}
+
+// firstOf returns the first element of a slice, or "".
+func firstOf(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}
+
+// dupStrings returns a copy of s (so descents don't alias the parent path).
+func dupStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+// dupVisited returns a shallow copy of the visited set.
+func dupVisited(m map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(m)+1)
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 func dfMin(a, b int) int {

--- a/internal/substrate/dataflow_jsts_test.go
+++ b/internal/substrate/dataflow_jsts_test.go
@@ -121,3 +121,176 @@ function createUser(req, res) {
 		t.Fatalf("expected NO flow when value not request-derived, got %+v", flows)
 	}
 }
+
+// ---- multi-hop (within-file) ----
+
+func TestDataFlowJSTS_TwoHop_LocalChain(t *testing.T) {
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  a(x);
+}
+function a(v) {
+  b(v);
+}
+function b(w) {
+  repo.insert(w);
+}
+`
+	flows := sniffDataFlowJSTSEx(src).Flows
+	got := findFlow(flows, func(f DataFlow) bool {
+		return f.Function == "handler" && f.SinkName == "repo.insert"
+	})
+	if got == nil {
+		t.Fatalf("expected 2-hop flow handler->a->b->repo.insert, got %+v", flows)
+	}
+	if got.SourceField != "x" {
+		t.Errorf("field = %q, want x", got.SourceField)
+	}
+	if len(got.HopPath) != 2 || got.HopPath[0] != "a" || got.HopPath[1] != "b" {
+		t.Errorf("hop_path = %v, want [a b]", got.HopPath)
+	}
+	if got.HopVia != "a" {
+		t.Errorf("hop_via = %q, want a", got.HopVia)
+	}
+}
+
+func TestDataFlowJSTS_ThreeHop_Boundary_Inclusive(t *testing.T) {
+	// handler->a->b->c->sink would be 3 hops which is the max; reachable.
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  a(x);
+}
+function a(v) { b(v); }
+function b(w) { c(w); }
+function c(z) { Model.create(z); }
+`
+	flows := sniffDataFlowJSTSEx(src).Flows
+	got := findFlow(flows, func(f DataFlow) bool { return f.SinkName == "Model.create" })
+	if got == nil {
+		t.Fatalf("expected 3-hop flow to Model.create, got %+v", flows)
+	}
+	if len(got.HopPath) != 3 {
+		t.Errorf("hop_path len = %d (%v), want 3", len(got.HopPath), got.HopPath)
+	}
+}
+
+func TestDataFlowJSTS_Negative_FourthHopDropped(t *testing.T) {
+	// handler->a->b->c->d->sink is 4 hops > DataFlowMaxHops; must NOT reach.
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  a(x);
+}
+function a(v) { b(v); }
+function b(w) { c(w); }
+function c(z) { d(z); }
+function d(q) { Model.create(q); }
+`
+	flows := sniffDataFlowJSTSEx(src).Flows
+	if got := findFlow(flows, func(f DataFlow) bool { return f.SinkName == "Model.create" }); got != nil {
+		t.Fatalf("expected NO flow at 4th hop, got %+v", *got)
+	}
+}
+
+func TestDataFlowJSTS_Negative_RecursionStops(t *testing.T) {
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  rec(x);
+}
+function rec(v) {
+  rec(v);
+  Model.create(v);
+}
+`
+	// The direct sink inside rec at hop 1 is fine; the recursive self-call
+	// must NOT loop or fabricate further flows.
+	flows := sniffDataFlowJSTSEx(src).Flows
+	n := 0
+	for _, f := range flows {
+		if f.SinkName == "Model.create" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 Model.create flow (no recursion blowup), got %d: %+v", n, flows)
+	}
+}
+
+func TestDataFlowJSTS_Negative_EmbeddedArgNotBound(t *testing.T) {
+	// helper(x + 1) is not a clean positional pass — must NOT hop.
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  helper(x + 1);
+}
+function helper(v) { Model.create(v); }
+`
+	flows := sniffDataFlowJSTSEx(src).Flows
+	if got := findFlow(flows, func(f DataFlow) bool { return f.SinkName == "Model.create" }); got != nil {
+		t.Fatalf("expected NO hop for embedded arg, got %+v", *got)
+	}
+}
+
+func TestDataFlowJSTS_Negative_SpreadAmbiguousArg(t *testing.T) {
+	// helper(...args) — spread makes positional binding ambiguous → no hop,
+	// and (cross-file would-be) no boundary either.
+	src := `
+function handler(req, res) {
+  const x = req.body.x;
+  const args = [x];
+  helper(...args);
+}
+function helper(v) { Model.create(v); }
+`
+	res := sniffDataFlowJSTSEx(src)
+	if got := findFlow(res.Flows, func(f DataFlow) bool { return f.SinkName == "Model.create" }); got != nil {
+		t.Fatalf("expected NO hop through spread, got %+v", *got)
+	}
+	if len(res.Boundaries) != 0 {
+		t.Fatalf("expected NO boundary for spread call, got %+v", res.Boundaries)
+	}
+}
+
+// ---- cross-file boundary emission (resolution covered in links tests) ----
+
+func TestDataFlowJSTS_Boundary_ImportedHelper(t *testing.T) {
+	// `save` is not defined in this file → boundary, not a dropped flow.
+	src := `
+import { save } from './svc';
+function handler(req, res) {
+  const x = req.body.name;
+  save(x);
+}
+`
+	res := sniffDataFlowJSTSEx(src)
+	if len(res.Boundaries) != 1 {
+		t.Fatalf("expected 1 cross-file boundary, got %+v", res.Boundaries)
+	}
+	b := res.Boundaries[0]
+	if b.Callee != "save" || b.ArgIndex != 0 || b.Function != "handler" {
+		t.Errorf("boundary = %+v, want callee=save arg=0 fn=handler", b)
+	}
+	if b.SourceField != "name" {
+		t.Errorf("boundary field = %q, want name", b.SourceField)
+	}
+}
+
+func TestDataFlowJSTS_Continue_BindsParamToSink(t *testing.T) {
+	// The continuation entry binds the value into save's param and finds sink.
+	svc := `
+export function save(v) {
+  Model.create({ v });
+}
+`
+	res := continueDataFlowJSTS(svc, "save", 0, "name", 0)
+	got := findFlow(res.Flows, func(f DataFlow) bool { return f.SinkName == "Model.create" })
+	if got == nil {
+		t.Fatalf("expected continuation to reach Model.create, got %+v", res.Flows)
+	}
+	if got.SourceField != "name" {
+		t.Errorf("field = %q, want name", got.SourceField)
+	}
+}

--- a/internal/substrate/dataflow_python.go
+++ b/internal/substrate/dataflow_python.go
@@ -1,8 +1,9 @@
 // Python request-input → sink dataflow sniffer (#3628 area #22).
 //
-// SCOPED def→use tracking inside one function body, plus one hop into a
-// directly-called local (module-level) function. See dataflow.go for the
-// contract and the honest-partial boundary.
+// SCOPED def→use tracking inside one function body, followed through up to
+// DataFlowMaxHops local (module-level) call hops, PLUS cross-file boundary
+// emission for a tainted value that escapes into an imported callee. See
+// dataflow.go for the contract and the honest-partial boundary.
 //
 // Sources recognised (static key only):
 //   - request.data['x'] / request.data.get('x')        (DRF body)
@@ -21,7 +22,12 @@ import (
 	"strings"
 )
 
-func init() { RegisterDataFlowSniffer("python", sniffDataFlowPython) }
+func init() {
+	RegisterDataFlowSnifferEx("python", sniffDataFlowPythonEx, continueDataFlowPython)
+}
+
+// sniffDataFlowPython preserves the legacy in-file-only entry point.
+func sniffDataFlowPython(content string) []DataFlow { return sniffDataFlowPythonEx(content).Flows }
 
 // dfPySourceFieldRe captures a request-input read with a STATIC string
 // key. Group 1/2/3/4 hold the key depending on the access form. Dynamic
@@ -54,25 +60,73 @@ var dfPyHTTPCallRe = regexp.MustCompile(
 	`\b((?:requests|httpx|session|client)\s*\.\s*(?:get|post|put|delete|patch))\s*\(`,
 )
 
-// dfPyAssignRe captures `NAME = <rhs>` (group 1 name, group 2 rhs).
+// dfPyAssignRe captures `NAME = <rhs>` (group 1 indent, 2 name, 3 rhs).
 // Excludes augmented/compare via the `[^=]` after `=`.
 var dfPyAssignRe = regexp.MustCompile(
 	`^(\s*)([A-Za-z_][\w]*)\s*=\s*([^=].*)$`,
 )
 
-func sniffDataFlowPython(content string) []DataFlow {
+// dfPySinkSpecs is the ordered sink table reused at every scan depth.
+var dfPySinkSpecs = []struct {
+	re   *regexp.Regexp
+	kind DataFlowSinkKind
+}{
+	{dfPyDBWriteRe, DataFlowSinkDBWrite},
+	{dfPyRespRe, DataFlowSinkResponse},
+	{dfPyHTTPCallRe, DataFlowSinkHTTPCall},
+}
+
+func sniffDataFlowPythonEx(content string) DataFlowResult {
 	if content == "" {
-		return nil
+		return DataFlowResult{}
 	}
 	lines := strings.Split(content, "\n")
 	headers := scanPyFuncHeaders(content)
 	bodies := pyFuncBodies(lines, headers)
 
-	var out []DataFlow
+	var res DataFlowResult
 	for _, b := range bodies {
-		out = append(out, analyzePyBody(lines, b, bodies)...)
+		ctx := pyWalkCtx{
+			origin:  b.Name,
+			bodies:  bodies,
+			lines:   lines,
+			visited: map[string]bool{b.Name: true},
+		}
+		r := walkPyBody(ctx, b, map[string]taintInfo{})
+		res.Flows = append(res.Flows, r.Flows...)
+		res.Boundaries = append(res.Boundaries, r.Boundaries...)
 	}
-	return out
+	return res
+}
+
+// continueDataFlowPython continues a bounded hop walk inside this file: it
+// binds the tainted value into fnName's paramIndex-th parameter and walks.
+// Function/SourceField/SourceLine on returned flows are placeholders that the
+// links pass rewrites to the true origin handler.
+func continueDataFlowPython(content, fnName string, paramIndex int, field string, hopsUsed int) DataFlowResult {
+	if content == "" || hopsUsed >= DataFlowMaxHops {
+		return DataFlowResult{}
+	}
+	lines := strings.Split(content, "\n")
+	headers := scanPyFuncHeaders(content)
+	bodies := pyFuncBodies(lines, headers)
+	callee := pyBodyByName(bodies, fnName)
+	if callee == nil {
+		return DataFlowResult{}
+	}
+	param := pyParamName(lines, callee.Start, paramIndex)
+	if param == "" {
+		return DataFlowResult{}
+	}
+	ctx := pyWalkCtx{
+		origin:   fnName, // placeholder; links pass rewrites
+		field:    field,
+		hopsUsed: hopsUsed,
+		bodies:   bodies,
+		lines:    lines,
+		visited:  map[string]bool{fnName: true},
+	}
+	return walkPyBody(ctx, *callee, map[string]taintInfo{param: {field: field, line: callee.Start}})
 }
 
 // pyFuncBody is a function's line span (1-indexed, inclusive) with the
@@ -131,32 +185,52 @@ func leadingWS(s string) int {
 	return n
 }
 
-func analyzePyBody(lines []string, b pyFuncBody, all []pyFuncBody) []DataFlow {
-	tainted := map[string]taintInfo{}
-	var out []DataFlow
+// pyWalkCtx threads the bounded multi-hop walk's state. hopPath/visited are
+// COPIED on each descent so sibling branches stay isolated.
+type pyWalkCtx struct {
+	origin   string
+	field    string
+	srcLine  int
+	hopsUsed int
+	bodies   []pyFuncBody
+	lines    []string
+	visited  map[string]bool
+	hopPath  []string
+}
 
-	for ln := b.Start; ln <= b.End && ln <= len(lines); ln++ {
+// walkPyBody is the unified forward pass over a function body.
+func walkPyBody(ctx pyWalkCtx, b pyFuncBody, tainted map[string]taintInfo) DataFlowResult {
+	var res DataFlowResult
+	for ln := b.Start; ln <= b.End && ln <= len(ctx.lines); ln++ {
 		// Only consider lines strictly inside the body (indent > def indent).
 		if ln != b.Start {
-			if strings.TrimSpace(lines[ln-1]) != "" && leadingWS(lines[ln-1]) <= b.Indent {
+			if strings.TrimSpace(ctx.lines[ln-1]) != "" && leadingWS(ctx.lines[ln-1]) <= b.Indent {
 				break
 			}
 		}
-		line := lines[ln-1]
+		line := ctx.lines[ln-1]
 
-		// Assignment propagation / chain-breaking reassignment.
-		if m := dfPyAssignRe.FindStringSubmatch(line); m != nil {
-			name, rhs := m[2], m[3]
-			if fld, ok := pyRHSSourceField(rhs, tainted); ok {
-				tainted[name] = taintInfo{field: fld, line: ln}
-			} else {
-				delete(tainted, name) // reassigned to non-source → drop taint
-			}
-		}
+		pyTrackTaint(tainted, line, ln)
 
-		out = appendPySinkFlows(out, lines, b, ln, line, tainted, all)
+		res.Flows = append(res.Flows, pyDirectSinks(ctx, ln, line, tainted)...)
+
+		r := pyFollowCalls(ctx, ln, line, tainted)
+		res.Flows = append(res.Flows, r.Flows...)
+		res.Boundaries = append(res.Boundaries, r.Boundaries...)
 	}
-	return out
+	return res
+}
+
+// pyTrackTaint applies one line's assignment effects to the taint map.
+func pyTrackTaint(tainted map[string]taintInfo, line string, ln int) {
+	if m := dfPyAssignRe.FindStringSubmatch(line); m != nil {
+		name, rhs := m[2], m[3]
+		if fld, ok := pyRHSSourceField(rhs, tainted); ok {
+			tainted[name] = taintInfo{field: fld, line: ln}
+		} else {
+			delete(tainted, name) // reassigned to non-source → drop taint
+		}
+	}
 }
 
 // pyRHSSourceField returns (field, true) when rhs is a request-input read
@@ -181,80 +255,93 @@ func pyRHSSourceField(rhs string, tainted map[string]taintInfo) (string, bool) {
 	return "", false
 }
 
-func appendPySinkFlows(out []DataFlow, lines []string, b pyFuncBody, ln int, line string, tainted map[string]taintInfo, all []pyFuncBody) []DataFlow {
-	for _, s := range []struct {
-		re   *regexp.Regexp
-		kind DataFlowSinkKind
-	}{
-		{dfPyDBWriteRe, DataFlowSinkDBWrite},
-		{dfPyRespRe, DataFlowSinkResponse},
-		{dfPyHTTPCallRe, DataFlowSinkHTTPCall},
-	} {
+// pyDirectSinks emits flows for sinks on `line` whose args carry taint.
+func pyDirectSinks(ctx pyWalkCtx, ln int, line string, tainted map[string]taintInfo) []DataFlow {
+	var out []DataFlow
+	for _, s := range dfPySinkSpecs {
 		for _, m := range s.re.FindAllStringSubmatchIndex(line, -1) {
 			callee := line[m[2]:m[3]]
-			args := pyCallArgs(lines, ln, m[2])
+			args := pyCallArgs(ctx.lines, ln, m[2])
 			if fld, ok := pyExprTainted(args, tainted); ok {
+				field := ctx.field
+				if field == "" {
+					field = fld
+				}
 				out = append(out, DataFlow{
-					Function:    b.Name,
-					SourceField: fld,
-					SourceLine:  ln,
+					Function:    ctx.origin,
+					SourceField: field,
+					SourceLine:  ctx.srcLine,
 					SinkKind:    s.kind,
 					SinkName:    callee,
 					SinkLine:    ln,
+					HopVia:      firstOf(ctx.hopPath),
+					HopPath:     dupStrings(ctx.hopPath),
 				})
-			}
-		}
-	}
-
-	// One-hop into a local function call helper(tainted).
-	for _, call := range pyLocalCalls(line) {
-		callee := pyBodyByName(all, call.name)
-		if callee == nil || callee.Name == b.Name {
-			continue
-		}
-		for pos, argExpr := range call.args {
-			fld, ok := pyExprTainted(argExpr, tainted)
-			if !ok {
-				continue
-			}
-			param := pyParamName(lines, callee.Start, pos)
-			if param == "" {
-				continue
-			}
-			for cln := callee.Start; cln <= callee.End && cln <= len(lines); cln++ {
-				out = appendPyHopSink(out, lines, b, callee, param, fld, ln, cln, lines[cln-1])
 			}
 		}
 	}
 	return out
 }
 
-func appendPyHopSink(out []DataFlow, lines []string, origin pyFuncBody, callee *pyFuncBody, param, fld string, srcLine, cln int, cline string) []DataFlow {
-	for _, s := range []struct {
-		re   *regexp.Regexp
-		kind DataFlowSinkKind
-	}{
-		{dfPyDBWriteRe, DataFlowSinkDBWrite},
-		{dfPyRespRe, DataFlowSinkResponse},
-		{dfPyHTTPCallRe, DataFlowSinkHTTPCall},
-	} {
-		for _, m := range s.re.FindAllStringSubmatchIndex(cline, -1) {
-			callName := cline[m[2]:m[3]]
-			args := pyCallArgs(lines, cln, m[2])
-			if dfReWholeIdent(param).MatchString(args) {
-				out = append(out, DataFlow{
-					Function:    origin.Name,
-					SourceField: fld,
-					SourceLine:  srcLine,
-					SinkKind:    s.kind,
-					SinkName:    callName,
-					SinkLine:    cln,
-					HopVia:      callee.Name,
-				})
+// pyFollowCalls handles each local-call on `line`: recurse into a local
+// module function (bounded + cycle-guarded) or record a cross-file boundary.
+func pyFollowCalls(ctx pyWalkCtx, ln int, line string, tainted map[string]taintInfo) DataFlowResult {
+	var res DataFlowResult
+	for _, call := range pyLocalCalls(line) {
+		if pyArgsHaveStar(call.args) {
+			continue // *args/**kwargs make positions unreliable — drop
+		}
+		for pos, argExpr := range call.args {
+			if _, ok := pyExprTainted(argExpr, tainted); !ok {
+				continue
 			}
+			// Skip keyword args (`name=value`) for positional binding; only a
+			// bare positional tainted arg binds soundly.
+			fld, bare := pyArgBareTaint(argExpr, tainted)
+			if !bare {
+				continue
+			}
+			field := ctx.field
+			if field == "" {
+				field = fld
+			}
+			callee := pyBodyByName(ctx.bodies, call.name)
+			if callee == nil {
+				if ctx.hopsUsed+len(ctx.hopPath) >= DataFlowMaxHops {
+					continue
+				}
+				res.Boundaries = append(res.Boundaries, DataFlowBoundary{
+					Function:    ctx.origin,
+					SourceField: field,
+					SourceLine:  ctx.srcLine,
+					Callee:      call.name,
+					ArgIndex:    pos,
+					HopPath:     dupStrings(ctx.hopPath),
+					CallLine:    ln,
+				})
+				continue
+			}
+			if ctx.hopsUsed+len(ctx.hopPath) >= DataFlowMaxHops {
+				continue
+			}
+			if ctx.visited[callee.Name] {
+				continue // recursion / cycle — drop
+			}
+			param := pyParamName(ctx.lines, callee.Start, pos)
+			if param == "" {
+				continue
+			}
+			child := ctx
+			child.hopPath = append(dupStrings(ctx.hopPath), callee.Name)
+			child.visited = dupVisited(ctx.visited)
+			child.visited[callee.Name] = true
+			child.field = field
+			r := walkPyBody(child, *callee, map[string]taintInfo{param: {field: field, line: callee.Start}})
+			res.Flows = append(res.Flows, r.Flows...)
+			res.Boundaries = append(res.Boundaries, r.Boundaries...)
 		}
 	}
-	return out
+	return res
 }
 
 // pyExprTainted reports whether expr references a request source or a
@@ -277,6 +364,60 @@ func pyExprTainted(expr string, tainted map[string]taintInfo) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// pyArgBareTaint reports whether argExpr is EXACTLY a tainted value (a
+// request-source read or a bare tainted identifier), not embedded in a
+// larger expression and not a keyword argument. Precision guard for sound
+// positional binding. Returns the field.
+func pyArgBareTaint(argExpr string, tainted map[string]taintInfo) (string, bool) {
+	e := strings.TrimSpace(argExpr)
+	// Reject keyword argument form `name=expr` (a positional binding cannot
+	// be derived from it soundly).
+	if dfPyKwargRe.MatchString(e) {
+		return "", false
+	}
+	if pyWholeExprIsSource(e) {
+		if m := dfPySourceFieldRe.FindStringSubmatch(e); m != nil {
+			for _, g := range m[1:] {
+				if g != "" {
+					return g, true
+				}
+			}
+		}
+		return "", true
+	}
+	if dfReSimpleIdent.MatchString(e) {
+		if info, ok := tainted[e]; ok {
+			return info.field, true
+		}
+	}
+	return "", false
+}
+
+// dfPyKwargRe matches a keyword-argument form `name=...` (but not `==`).
+var dfPyKwargRe = regexp.MustCompile(`^[A-Za-z_][\w]*\s*=[^=]`)
+
+// pyWholeExprIsSource reports the expr is SOLELY a request-source access.
+func pyWholeExprIsSource(e string) bool {
+	loc := dfPySourceFieldRe.FindStringIndex(e)
+	if loc == nil {
+		loc = dfPySourceAnyRe.FindStringIndex(e)
+	}
+	if loc == nil {
+		return false
+	}
+	return strings.TrimSpace(e[:loc[0]]) == "" && strings.TrimSpace(e[loc[1]:]) == ""
+}
+
+// pyArgsHaveStar reports whether any arg is a *args / **kwargs unpack.
+func pyArgsHaveStar(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(strings.TrimSpace(a), "*") {
+			return true
+		}
+	}
+	return false
 }
 
 // pyCallArgs returns the argument text of the call whose `(` begins at/after
@@ -336,6 +477,13 @@ func pyLocalCalls(line string) []pyLocalCall {
 	var out []pyLocalCall
 	for _, m := range dfPyLocalCallRe.FindAllStringSubmatchIndex(line, -1) {
 		name := line[m[2]:m[3]]
+		// skip method calls (`obj.foo(`) and keywords/builtins.
+		if m[2] > 0 {
+			prev := strings.TrimRight(line[:m[2]], " \t")
+			if strings.HasSuffix(prev, ".") {
+				continue
+			}
+		}
 		switch name {
 		case "if", "for", "while", "return", "print", "len", "range", "def", "self":
 			continue
@@ -348,7 +496,7 @@ func pyLocalCalls(line string) []pyLocalCall {
 
 // pyParamName returns the pos-th positional parameter name of the function
 // whose header is on headerLine. A leading `self`/`cls` is skipped so the
-// positional index aligns with call-site args. Complex params → "".
+// positional index aligns with call-site args. Complex / *args params → "".
 func pyParamName(lines []string, headerLine, pos int) string {
 	if headerLine < 1 || headerLine > len(lines) {
 		return ""
@@ -370,6 +518,12 @@ func pyParamName(lines []string, headerLine, pos int) string {
 			params = params[1:]
 		}
 	}
+	// A *args / **kwargs parameter makes positions ambiguous past it.
+	for _, p := range params {
+		if strings.HasPrefix(strings.TrimSpace(p), "*") {
+			return ""
+		}
+	}
 	if pos >= len(params) {
 		return ""
 	}
@@ -377,7 +531,7 @@ func pyParamName(lines []string, headerLine, pos int) string {
 	if i := strings.IndexAny(p, ":="); i >= 0 {
 		p = strings.TrimSpace(p[:i])
 	}
-	if strings.HasPrefix(p, "*") || !dfReSimpleIdent.MatchString(p) {
+	if !dfReSimpleIdent.MatchString(p) {
 		return ""
 	}
 	return p

--- a/internal/substrate/dataflow_python_test.go
+++ b/internal/substrate/dataflow_python_test.go
@@ -102,3 +102,119 @@ func TestDataFlowPython_Negative_ReassignBreaksChain(t *testing.T) {
 		t.Fatalf("expected NO db_write after reassign, got %+v", *got)
 	}
 }
+
+// ---- multi-hop (within-file) ----
+
+func TestDataFlowPython_TwoHop_LocalChain(t *testing.T) {
+	src := "" +
+		"def handler(request):\n" +
+		"    x = request.data['x']\n" +
+		"    a(x)\n" +
+		"\n" +
+		"def a(v):\n" +
+		"    b(v)\n" +
+		"\n" +
+		"def b(w):\n" +
+		"    repo.insert(w)\n"
+	flows := sniffDataFlowPythonEx(src).Flows
+	got := findFlow(flows, func(f DataFlow) bool {
+		return f.Function == "handler" && f.SinkName == "repo.insert"
+	})
+	if got == nil {
+		t.Fatalf("expected 2-hop flow handler->a->b->repo.insert, got %+v", flows)
+	}
+	if got.SourceField != "x" {
+		t.Errorf("field = %q, want x", got.SourceField)
+	}
+	if len(got.HopPath) != 2 || got.HopPath[0] != "a" || got.HopPath[1] != "b" {
+		t.Errorf("hop_path = %v, want [a b]", got.HopPath)
+	}
+}
+
+func TestDataFlowPython_Negative_FourthHopDropped(t *testing.T) {
+	src := "" +
+		"def handler(request):\n" +
+		"    x = request.data['x']\n" +
+		"    a(x)\n" +
+		"\n" +
+		"def a(v):\n    b(v)\n" +
+		"\n" +
+		"def b(w):\n    c(w)\n" +
+		"\n" +
+		"def c(z):\n    d(z)\n" +
+		"\n" +
+		"def d(q):\n    Model.objects.create(name=q)\n"
+	flows := sniffDataFlowPythonEx(src).Flows
+	if got := findFlow(flows, func(f DataFlow) bool { return f.SinkName == "Model.objects.create" }); got != nil {
+		t.Fatalf("expected NO flow at 4th hop, got %+v", *got)
+	}
+}
+
+func TestDataFlowPython_Negative_RecursionStops(t *testing.T) {
+	src := "" +
+		"def handler(request):\n" +
+		"    x = request.data['x']\n" +
+		"    rec(x)\n" +
+		"\n" +
+		"def rec(v):\n" +
+		"    rec(v)\n" +
+		"    repo.insert(v)\n"
+	flows := sniffDataFlowPythonEx(src).Flows
+	n := 0
+	for _, f := range flows {
+		if f.SinkName == "repo.insert" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 repo.insert flow, got %d: %+v", n, flows)
+	}
+}
+
+// ---- cross-file boundary emission ----
+
+func TestDataFlowPython_Boundary_ImportedHelper(t *testing.T) {
+	src := "" +
+		"from .svc import save\n" +
+		"def handler(request):\n" +
+		"    x = request.data['name']\n" +
+		"    save(x)\n"
+	res := sniffDataFlowPythonEx(src)
+	if len(res.Boundaries) != 1 {
+		t.Fatalf("expected 1 cross-file boundary, got %+v", res.Boundaries)
+	}
+	b := res.Boundaries[0]
+	if b.Callee != "save" || b.ArgIndex != 0 || b.Function != "handler" {
+		t.Errorf("boundary = %+v, want callee=save arg=0 fn=handler", b)
+	}
+	if b.SourceField != "name" {
+		t.Errorf("boundary field = %q, want name", b.SourceField)
+	}
+}
+
+func TestDataFlowPython_Continue_BindsParamToSink(t *testing.T) {
+	svc := "" +
+		"def save(v):\n" +
+		"    Model.objects.create(name=v)\n"
+	res := continueDataFlowPython(svc, "save", 0, "name", 0)
+	got := findFlow(res.Flows, func(f DataFlow) bool { return f.SinkName == "Model.objects.create" })
+	if got == nil {
+		t.Fatalf("expected continuation to reach Model.objects.create, got %+v", res.Flows)
+	}
+	if got.SourceField != "name" {
+		t.Errorf("field = %q, want name", got.SourceField)
+	}
+}
+
+func TestDataFlowPython_Negative_KwargArgNotBoundAsBoundary(t *testing.T) {
+	// save(name=x) is a kwarg — positional binding is unsound → drop.
+	src := "" +
+		"from .svc import save\n" +
+		"def handler(request):\n" +
+		"    x = request.data['name']\n" +
+		"    save(name=x)\n"
+	res := sniffDataFlowPythonEx(src)
+	if len(res.Boundaries) != 0 {
+		t.Fatalf("expected NO boundary for kwarg call, got %+v", res.Boundaries)
+	}
+}


### PR DESCRIPTION
Closes #3772 (child of #3628, area #22).

Extends the wave-8 SCOPED `DATA_FLOWS_TO` pass (intra-fn assignment tracking + a single local-call hop) to **bounded multi-hop** and **cross-file** request→sink propagation for **JS/TS + Python**, reusing the existing source/sink/edge definitions. QUALITY-FIRST: a false dataflow edge is treated as worse than a missing one.

## Hop bound
`DataFlowMaxHops = 3` (inclusive). A direct intra-fn sink is 0 hops; `handler→helper→sink` is 1; `handler→A→B→C→sink` is 3 (reachable); the 4th hop is dropped.

## Multi-hop (within a file)
The JS/TS and Python sniffers are refactored from a fixed one-hop expansion to a **bounded recursive walk**. A request-derived value is followed through nested local calls A→B→C, each bound by **exact positional index**, with per-descent copied hop-path / visited sets. The full callee chain is recorded in a new `DataFlow.HopPath` (surfaced as `hop_path` / `hop_count` link props and in the per-entity summary).

## Cross-file resolution
The substrate sniffer cannot see the import graph, so when a tainted value escapes into a **non-local (imported) callee** it emits a `DataFlowBoundary` (callee name + tainted arg index + source field + hops consumed). The links pass resolves that boundary:

- `crossFileResolver` maps `(caller entity, callee name)` → the **unique same-repo function entity** via the existing **CALLS graph**. External / unresolved / ambiguous (>1 distinct entity) → **drop**.
- It reads the resolved callee's file and calls `continueDataFlow*`, which resumes the bounded walk from the bound parameter; the sink is resolved to the **callee-file** entity (not a residue).
- Further cross-file hops are chased via a worklist (entity-cycle guarded, bound enforced); each cross-file entry consumes one hop.

## Precision guards (mandatory)
- Positional binding is **exact** (arg index → param index, self/cls-aware in Python).
- Spread / rest / destructured params, `*args`/`**kwargs`, and **keyword-arg** call sites → drop (no edge, no boundary).
- An argument embedded in a larger expression (`helper(x+1)`, `helper({x})`, `helper(f(x))`) → drop.
- Reassignment to a non-derived value before the sink breaks the chain → drop.
- Recursion / cycle in the local-call graph or the cross-file entity graph → stop, drop.

## Tests (value-asserting, not `len>0`)
2-hop and 3-hop local chains with `hop_path` asserted; 3-hop inclusive reach; 4th-hop drop; recursion stop; embedded-arg & spread drop. Cross-file (JS/TS + Python): resolved `DATA_FLOWS_TO` whose **target is the real callee-file sink entity**, source is the origin handler, `hop_path` captured; cross-file 2-hop (`a>b`) and 3-hop (`a>b>c`); negatives for unresolved import, ambiguous callee, and 4th cross-file hop.

Targeted suites (`internal/substrate/... internal/links/... internal/types/ internal/engine/ tools/coverage/`) green; `go test ./internal/types/` green; `coverage validate` 0 errors + registry canonical; `gofmt -l` empty; `go vet` clean. The jsts/python coverage records' notes are enriched to reflect cross-file + multi-hop (status stays `partial` — honest, no fake flip).

**DEPLOY-DEFERRED**: the live rewrite daemon is not rebuilt as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)