### PR TITLE
feat(go): ordered middleware-chain → endpoint for gin/echo/chi

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15654,9 +15654,9 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "full",
-            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
-            "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
-            "verified_at": "2026-05-30"
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/route_middleware.go","internal/custom/golang/route_middleware_test.go"],
+            "notes": "balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -\u003e group .Group args/.Use -\u003e inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger\u003cCORS\u003cRateLimit; group AuthRequired\u003cLogger; echo trailing handler dropped; chi engine Logger\u003cRecoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order).",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -15903,9 +15903,9 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "full",
-            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
-            "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
-            "verified_at": "2026-05-30"
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/route_middleware.go","internal/custom/golang/route_middleware_test.go"],
+            "notes": "balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -\u003e group .Group args/.Use -\u003e inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger\u003cCORS\u003cRateLimit; group AuthRequired\u003cLogger; echo trailing handler dropped; chi engine Logger\u003cRecoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order).",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -16947,9 +16947,9 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "full",
-            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
-            "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
-            "verified_at": "2026-05-30"
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/route_middleware.go","internal/custom/golang/route_middleware_test.go"],
+            "notes": "balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -\u003e group .Group args/.Use -\u003e inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger\u003cCORS\u003cRateLimit; group AuthRequired\u003cLogger; echo trailing handler dropped; chi engine Logger\u003cRecoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order).",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {

--- a/internal/custom/golang/chi.go
+++ b/internal/custom/golang/chi.go
@@ -76,6 +76,12 @@ func (e *chiExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		entities = append(entities, ent)
 	}
 
+	// ordered middleware-chain binding (#3628): chi's dominant idiom is the
+	// engine-wide `r.Use(mw)` stack; bind that ordered chain to each route op.
+	// Closure-based subrouter groups (`r.Route("/x", func(r){...})`) are the
+	// honest-partial boundary — their per-group .Use is not var-scoped.
+	mwIdx := buildGoRouteMiddlewareIndex(src)
+
 	// 1. chi.NewRouter() -> SCOPE.Service
 	for _, m := range reChiRouter.FindAllStringSubmatchIndex(src, -1) {
 		varName := src[m[2]:m[3]]
@@ -107,6 +113,7 @@ func (e *chiExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_ROUTE",
 			"http_method", method, "route_path", path, "router_var", routerVar)
+		stampGoMiddlewareChain(ent.Properties, mwIdx.resolve(routerVar, method, path))
 		add(ent)
 	}
 

--- a/internal/custom/golang/echo.go
+++ b/internal/custom/golang/echo.go
@@ -77,6 +77,9 @@ func (e *echoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	// handler (`e.GET(path, h, mw)`); the shared index classifies each route /
 	// group / engine arg independently, so both orderings resolve.
 	authIdx := buildGoRouteAuthIndex(src)
+	// ordered middleware-chain binding (#3628): full chain per scope so each
+	// route op carries middleware_chain — "what runs before this route, in order".
+	mwIdx := buildGoRouteMiddlewareIndex(src)
 
 	// 1. echo.New() engine -> SCOPE.Service
 	for _, m := range reEchoEngine.FindAllStringSubmatchIndex(src, -1) {
@@ -114,6 +117,8 @@ func (e *echoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			"http_method", method, "route_path", path, "router_var", routerVar)
 		// #3734 — stamp endpoint protection (inline > group > engine-wide).
 		authIdx.resolve(routerVar, method, ownPath).stamp(ent.Properties)
+		// bind the ordered middleware chain (outermost-first) to this route op.
+		stampGoMiddlewareChain(ent.Properties, mwIdx.resolve(routerVar, method, ownPath))
 		add(ent)
 	}
 

--- a/internal/custom/golang/gin.go
+++ b/internal/custom/golang/gin.go
@@ -80,6 +80,10 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 	// #3734 — endpoint protection. Resolve route/group/engine-level auth
 	// middleware once so each route op can be stamped with auth_required.
 	authIdx := buildGoRouteAuthIndex(src)
+	// ordered middleware-chain binding (#3628): resolve the FULL chain
+	// (logging/cors/recovery/rate-limit/auth/…) per scope so each route op can
+	// be stamped with middleware_chain — "what runs before this route, in order".
+	mwIdx := buildGoRouteMiddlewareIndex(src)
 
 	// 1. gin.Default()/gin.New() engine -> SCOPE.Service
 	for _, m := range reGinEngine.FindAllStringSubmatchIndex(src, -1) {
@@ -118,6 +122,8 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		// #3734 — stamp endpoint protection from the route's own inline
 		// middleware, its group var, or an engine-wide auth .Use().
 		authIdx.resolve(routerVar, method, ownPath).stamp(ent.Properties)
+		// bind the ordered middleware chain (outermost-first) to this route op.
+		stampGoMiddlewareChain(ent.Properties, mwIdx.resolve(routerVar, method, ownPath))
 		add(ent)
 	}
 

--- a/internal/custom/golang/route_middleware.go
+++ b/internal/custom/golang/route_middleware.go
@@ -1,0 +1,342 @@
+// route_middleware.go — ordered middleware-chain binding for Go gin/echo route
+// ops (child of #3628; sibling of #3734's route_auth.go).
+//
+// #3734 bound only the AUTH middleware to a route op (stamps auth_*). The
+// shared helpers (helpers.go) ALSO parse the full `.Use(...)` chain in
+// registration order, but `emitMiddlewareChain` writes each middleware as a
+// STANDALONE `SCOPE.Pattern` entity (`mw_order` 0,1,2,...) that is never bound
+// to a specific endpoint. So for Go the graph could not answer "what
+// middleware runs before THIS route, in order?" — the JS/TS pass
+// (http_endpoint_jsts_middleware.go, #2853) already stamps a `middleware_chain`
+// property on every endpoint; this resolver brings gin/echo to parity.
+//
+// It resolves three middleware scopes and binds the ORDERED, deduped chain to
+// the route op via the same property contract the JS/TS pass uses:
+//
+//	middleware_chain  — JSON array of {name, expr, scope, order, auth_kind?},
+//	                    OUTERMOST-first (engine → group → route), so index 0 is
+//	                    the first middleware a request traverses.
+//	middleware_count  — decimal count of resolved middleware (>0 ⇒ chain bound).
+//	middleware_names  — comma-joined middleware symbols in chain order.
+//	middleware_scope  — "route" | "group" | "engine" | combinations joined by
+//	                    "+" (e.g. "engine+route") describing which scopes
+//	                    contributed.
+//
+// Scope model (request traversal order, outermost first):
+//
+//	engine — `r.Use(mw)` on the engine var: wraps every route. Runs first.
+//	group  — `g := r.Group("/x", mw)` construction args + `g.Use(mw)` on the
+//	         group var: wraps every route registered on that group.
+//	route  — inline middleware in the route registration, e.g. gin
+//	         `r.GET("/me", mw, h)` / echo `e.GET("/me", h, mw)`. Innermost,
+//	         runs last before the handler.
+//
+// Honest-partial: a middleware built dynamically (a slice assembled at runtime,
+// a conditional `.Use`) is NOT resolvable statically and is skipped — no
+// fabricated order. String-literal mount prefixes (`app.Use("/api", mw)`) are
+// dropped by parseMiddlewareChain, so they never inflate the order index.
+package golang
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// goMiddlewareEntry is one resolved middleware bound to an endpoint, carrying
+// its name, raw expression, originating scope, and 0-based position within the
+// final outermost-first chain.
+type goMiddlewareEntry struct {
+	Name     string `json:"name"`
+	Expr     string `json:"expr"`
+	Scope    string `json:"scope"` // "engine" | "group" | "route"
+	Order    int    `json:"order"` // position in the bound chain (0 = first traversed)
+	AuthKind string `json:"auth_kind,omitempty"`
+}
+
+const (
+	goMWScopeRoute  = "route"
+	goMWScopeGroup  = "group"
+	goMWScopeEngine = "engine"
+)
+
+// goRouteMiddlewareIndex holds the per-file resolved middleware scopes: the
+// engine-wide chain, each group var's chain, and each route's own inline chain.
+type goRouteMiddlewareIndex struct {
+	// engine is the chain registered on an engine var via `.Use(...)`
+	// (file-scope, applies to every route). Outermost.
+	engine []goMiddlewareEntry
+	// groupVars maps a group var → the ordered chain bound to it (its
+	// construction-arg middleware followed by any `g.Use(...)` middleware).
+	groupVars map[string][]goMiddlewareEntry
+	// inline maps "<VERB> <ownPath>" → the route's inline middleware chain.
+	inline map[string][]goMiddlewareEntry
+	// groupVarSet tracks which receivers are group vars, so a `.Use` on a group
+	// var is classified group-scope rather than engine-scope.
+	groupVarSet map[string]bool
+}
+
+// buildGoRouteMiddlewareIndex scans a Go source file once and resolves every
+// route/group/engine middleware chain. Framework-shared: gin and echo use the
+// same `.Group` / `.VERB` / `.Use` shapes (echo trails middleware after the
+// handler, which splitTopLevelArgs/parseMiddlewareChain handle position-
+// independently — every non-string arg that is not the handler is middleware,
+// but to avoid swallowing the handler we keep inline middleware to the args the
+// auth resolver already treats as a chain: see goMiddlewareFromRouteArgs).
+func buildGoRouteMiddlewareIndex(src string) goRouteMiddlewareIndex {
+	idx := goRouteMiddlewareIndex{
+		groupVars:   map[string][]goMiddlewareEntry{},
+		inline:      map[string][]goMiddlewareEntry{},
+		groupVarSet: map[string]bool{},
+	}
+
+	// Group construction: `g := r.Group("/x", mw1, mw2)` → g inherits mw1,mw2.
+	for _, m := range reGoGroupDecl.FindAllStringSubmatchIndex(src, -1) {
+		groupVar := src[m[2]:m[3]]
+		idx.groupVarSet[groupVar] = true
+		args := src[m[6]:m[7]]
+		for _, e := range goMiddlewareFromArgChain(args, goMWScopeGroup) {
+			idx.groupVars[groupVar] = append(idx.groupVars[groupVar], e)
+		}
+	}
+
+	// Inline route middleware: `r.GET("/me", mw, h)` / `e.GET("/me", h, mw)`.
+	for _, m := range reGoRouteAuthScan.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToUpper(src[m[4]:m[5]])
+		path := src[m[6]:m[7]]
+		args := src[m[8]:m[9]]
+		mws := goMiddlewareFromRouteArgs(args)
+		if len(mws) > 0 {
+			idx.inline[verb+" "+path] = mws
+		}
+	}
+
+	// `.Use(...)` calls: engine-scope when on an engine var (or an unknown var
+	// that is not a group), group-scope when on a known group var.
+	for _, uc := range findUseCalls(src) {
+		entries := goMiddlewareFromUseArgs(uc.Args)
+		if len(entries) == 0 {
+			continue
+		}
+		if idx.groupVarSet[uc.Recv] {
+			for _, e := range entries {
+				e.Scope = goMWScopeGroup
+				idx.groupVars[uc.Recv] = append(idx.groupVars[uc.Recv], e)
+			}
+			continue
+		}
+		// Engine var, or an unrecognised receiver that is not a group: treat as
+		// engine-wide (file-scope) middleware.
+		for _, e := range entries {
+			e.Scope = goMWScopeEngine
+			idx.engine = append(idx.engine, e)
+		}
+	}
+
+	return idx
+}
+
+// resolve returns the ordered, deduped middleware chain bound to one route op,
+// OUTERMOST-first: engine-wide → the route's group var → the route's own inline
+// chain. Each entry's Order is its final 0-based index in the returned chain.
+func (idx goRouteMiddlewareIndex) resolve(routerVar, verb, ownPath string) []goMiddlewareEntry {
+	var chain []goMiddlewareEntry
+	chain = append(chain, idx.engine...)
+	if g, ok := idx.groupVars[routerVar]; ok {
+		chain = append(chain, g...)
+	}
+	if r, ok := idx.inline[verb+" "+ownPath]; ok {
+		chain = append(chain, r...)
+	}
+	chain = dedupeGoMiddleware(chain)
+	for i := range chain {
+		chain[i].Order = i
+	}
+	return chain
+}
+
+// dedupeGoMiddleware removes duplicate (scope, expr) entries preserving order.
+// A middleware registered both engine-wide and inline keeps its first (outer)
+// occurrence — it runs once at the outer position.
+func dedupeGoMiddleware(in []goMiddlewareEntry) []goMiddlewareEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	out := in[:0:0]
+	for _, e := range in {
+		k := e.Expr
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+// goMiddlewareFromArgChain parses a trailing-argument region (the text after a
+// path literal in a `.Group(...)` construction, e.g. `, Logger(), AuthMw()`)
+// into middleware entries with the given scope. The leading comma is tolerated.
+func goMiddlewareFromArgChain(args, scope string) []goMiddlewareEntry {
+	args = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(args), ","))
+	if args == "" {
+		return nil
+	}
+	var out []goMiddlewareEntry
+	for _, a := range parseMiddlewareChain(args) {
+		out = append(out, goMiddlewareEntry{
+			Name:     a.Name,
+			Expr:     a.Expr,
+			Scope:    scope,
+			AuthKind: a.AuthKind,
+		})
+	}
+	return out
+}
+
+// goMiddlewareFromUseArgs parses a `.Use(...)` argument list into engine/group
+// middleware entries (scope is assigned by the caller based on the receiver).
+func goMiddlewareFromUseArgs(args string) []goMiddlewareEntry {
+	var out []goMiddlewareEntry
+	for _, a := range parseMiddlewareChain(args) {
+		out = append(out, goMiddlewareEntry{
+			Name:     a.Name,
+			Expr:     a.Expr,
+			AuthKind: a.AuthKind,
+		})
+	}
+	return out
+}
+
+// goMiddlewareFromRouteArgs parses an inline route registration's trailing args
+// (everything after the path) into route-scope middleware, DROPPING the handler.
+//
+// Both gin (`r.GET(path, mw..., handler)`) and echo (`e.GET(path, handler,
+// mw...)`) place exactly one handler among the args; every other non-string
+// callable arg is middleware. We cannot positionally know which arg is the
+// handler across both frameworks, so we use the same conservative rule the JS/TS
+// pass uses: when there are ≥2 args, the chain is every arg EXCEPT the one that
+// looks most like a bare handler. To stay honest and framework-agnostic we keep
+// every recognised middleware-shaped arg and drop a single trailing/leading bare
+// identifier as the handler:
+//   - gin: handler is LAST  → drop the last arg.
+//   - echo: handler is FIRST → drop the first arg.
+//
+// We detect the gin-vs-echo ordering by middleware shape: a call expression
+// (`Mw()` / `pkg.Mw(...)`) is unambiguously middleware; a bare identifier may be
+// either. We therefore drop exactly one bare-identifier arg — preferring the
+// last (gin) and falling back to the first (echo) — and keep the rest. This is a
+// heuristic; dynamically-built chains are out of scope (honest-partial).
+func goMiddlewareFromRouteArgs(args string) []goMiddlewareEntry {
+	args = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(args), ","))
+	if args == "" {
+		return nil
+	}
+	parts := splitTopLevelArgs(args)
+	// Keep only non-string callable args.
+	type cand struct {
+		expr   string
+		isCall bool // ends with a call: `Mw()` / `pkg.New(x)`
+	}
+	var cands []cand
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || isStringLiteral(p) {
+			continue
+		}
+		head := reMiddlewareCallHead.FindString(p)
+		if head == "" {
+			continue
+		}
+		cands = append(cands, cand{expr: p, isCall: strings.Contains(p, "(")})
+	}
+	if len(cands) <= 1 {
+		// Only the handler (or nothing) — no inline middleware chain.
+		return nil
+	}
+	// Drop exactly one handler. Prefer dropping a trailing bare identifier (gin);
+	// else a leading bare identifier (echo); else the last arg.
+	dropIdx := -1
+	if !cands[len(cands)-1].isCall {
+		dropIdx = len(cands) - 1
+	} else if !cands[0].isCall {
+		dropIdx = 0
+	} else {
+		dropIdx = len(cands) - 1
+	}
+	var out []goMiddlewareEntry
+	for i, c := range cands {
+		if i == dropIdx {
+			continue
+		}
+		head := reMiddlewareCallHead.FindString(c.expr)
+		out = append(out, goMiddlewareEntry{
+			Name:     head,
+			Expr:     c.expr,
+			Scope:    goMWScopeRoute,
+			AuthKind: classifyAuthMiddleware(c.expr),
+		})
+	}
+	return out
+}
+
+// stampGoMiddlewareChain writes the resolved ordered chain onto a route op's
+// Properties map using the JS/TS-parity contract. No-op when the chain is empty
+// so an unprotected/un-wrapped route is left unstamped.
+func stampGoMiddlewareChain(props map[string]string, chain []goMiddlewareEntry) {
+	if props == nil || len(chain) == 0 {
+		return
+	}
+	if encoded := encodeGoMiddlewareChain(chain); encoded != "" {
+		props["middleware_chain"] = encoded
+	}
+	props["middleware_count"] = strconv.Itoa(len(chain))
+	props["middleware_names"] = goMiddlewareNames(chain)
+	props["middleware_scope"] = goMiddlewareScope(chain)
+}
+
+// encodeGoMiddlewareChain JSON-encodes the chain for the middleware_chain prop.
+func encodeGoMiddlewareChain(chain []goMiddlewareEntry) string {
+	b, err := json.Marshal(chain)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// goMiddlewareNames returns the comma-joined middleware symbols in chain order.
+func goMiddlewareNames(chain []goMiddlewareEntry) string {
+	names := make([]string, 0, len(chain))
+	for _, e := range chain {
+		names = append(names, e.Name)
+	}
+	return strings.Join(names, ",")
+}
+
+// goMiddlewareScope returns the "+"-joined set of contributing scopes in
+// outermost-first order (engine, group, route).
+func goMiddlewareScope(chain []goMiddlewareEntry) string {
+	var has [3]bool // engine, group, route
+	for _, e := range chain {
+		switch e.Scope {
+		case goMWScopeEngine:
+			has[0] = true
+		case goMWScopeGroup:
+			has[1] = true
+		case goMWScopeRoute:
+			has[2] = true
+		}
+	}
+	var parts []string
+	if has[0] {
+		parts = append(parts, goMWScopeEngine)
+	}
+	if has[1] {
+		parts = append(parts, goMWScopeGroup)
+	}
+	if has[2] {
+		parts = append(parts, goMWScopeRoute)
+	}
+	return strings.Join(parts, "+")
+}

--- a/internal/custom/golang/route_middleware_test.go
+++ b/internal/custom/golang/route_middleware_test.go
@@ -1,0 +1,265 @@
+package golang
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runChi(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&chiExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "main.go", Language: "go", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("chi extract: %v", err)
+	}
+	return ents
+}
+
+// decodeChain parses the middleware_chain JSON property into ordered entries.
+func decodeChain(t *testing.T, raw string) []goMiddlewareEntry {
+	t.Helper()
+	if raw == "" {
+		t.Fatal("middleware_chain property is empty")
+	}
+	var chain []goMiddlewareEntry
+	if err := json.Unmarshal([]byte(raw), &chain); err != nil {
+		t.Fatalf("decode middleware_chain %q: %v", raw, err)
+	}
+	return chain
+}
+
+// indexOf returns the order index of the first chain entry whose Name == name,
+// or -1 when absent.
+func indexOf(chain []goMiddlewareEntry, name string) int {
+	for _, e := range chain {
+		if e.Name == name {
+			return e.Order
+		}
+	}
+	return -1
+}
+
+// TestGinMiddlewareChain_EngineThenRouteOrder — engine-wide `.Use(Logger())`
+// followed by `.Use(CORS())` then an inline route middleware. The bound chain
+// must be OUTERMOST-first: Logger (index 0) before CORS (index 1) before the
+// inline RateLimit (last). Asserts middleware IDENTITY and relative ORDER, not
+// just count.
+func TestGinMiddlewareChain_EngineThenRouteOrder(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.Default()
+	r.Use(Logger())
+	r.Use(CORS())
+	r.GET("/users", RateLimit(), listUsers)
+}
+`
+	ents := runGin(t, src)
+	ep := findEndpoint(t, ents, "GET /users")
+	chain := decodeChain(t, ep.Properties["middleware_chain"])
+
+	if ep.Properties["middleware_count"] != "3" {
+		t.Fatalf("middleware_count=%q, want 3 (chain=%v)", ep.Properties["middleware_count"], chain)
+	}
+	logger, cors, rl := indexOf(chain, "Logger"), indexOf(chain, "CORS"), indexOf(chain, "RateLimit")
+	if logger < 0 || cors < 0 || rl < 0 {
+		t.Fatalf("missing middleware in chain: Logger=%d CORS=%d RateLimit=%d (chain=%v)", logger, cors, rl, chain)
+	}
+	// Outermost-first: engine middleware precede the inline route middleware.
+	if !(logger < cors && cors < rl) {
+		t.Errorf("order wrong: Logger=%d CORS=%d RateLimit=%d, want Logger<CORS<RateLimit", logger, cors, rl)
+	}
+	// scope reflects both engine and route contributions.
+	if ep.Properties["middleware_scope"] != "engine+route" {
+		t.Errorf("middleware_scope=%q, want engine+route", ep.Properties["middleware_scope"])
+	}
+	// names property is in chain order.
+	if got := ep.Properties["middleware_names"]; got != "Logger,CORS,RateLimit" {
+		t.Errorf("middleware_names=%q, want Logger,CORS,RateLimit", got)
+	}
+}
+
+// TestGinMiddlewareChain_GroupScope — a group constructed with a middleware
+// arg: every route on the group inherits it. `g := r.Group("/api", Logger())`
+// then `g.GET("/me", h)` → /me chain includes Logger at group scope; a route
+// NOT on the group does not.
+func TestGinMiddlewareChain_GroupScope(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.Default()
+	api := r.Group("/api", AuthRequired(), Logger())
+	api.GET("/me", getMe)
+	r.GET("/health", healthCheck)
+}
+`
+	ents := runGin(t, src)
+
+	me := findEndpoint(t, ents, "GET /api/me")
+	chain := decodeChain(t, me.Properties["middleware_chain"])
+	auth, logger := indexOf(chain, "AuthRequired"), indexOf(chain, "Logger")
+	if auth < 0 || logger < 0 {
+		t.Fatalf("GET /api/me chain missing group middleware: %v", chain)
+	}
+	if auth >= logger {
+		t.Errorf("group order wrong: AuthRequired=%d Logger=%d, want AuthRequired<Logger", auth, logger)
+	}
+	for _, e := range chain {
+		if e.Scope != goMWScopeGroup {
+			t.Errorf("entry %q scope=%q, want group", e.Name, e.Scope)
+		}
+	}
+	if me.Properties["middleware_scope"] != "group" {
+		t.Errorf("middleware_scope=%q, want group", me.Properties["middleware_scope"])
+	}
+
+	// The non-group route has no group/engine .Use → no chain bound.
+	health := findEndpoint(t, ents, "GET /health")
+	if health.Properties["middleware_chain"] != "" {
+		t.Errorf("GET /health should have no middleware_chain, got %q", health.Properties["middleware_chain"])
+	}
+}
+
+// TestGinMiddlewareChain_GroupUse — middleware registered via `g.Use(mw)` on a
+// group var (not in the construction args) still binds to the group's routes.
+func TestGinMiddlewareChain_GroupUse(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.Default()
+	admin := r.Group("/admin")
+	admin.Use(RequireAdmin())
+	admin.GET("/stats", stats)
+}
+`
+	ents := runGin(t, src)
+	ep := findEndpoint(t, ents, "GET /admin/stats")
+	chain := decodeChain(t, ep.Properties["middleware_chain"])
+	if indexOf(chain, "RequireAdmin") != 0 {
+		t.Errorf("RequireAdmin order=%d, want 0 (chain=%v)", indexOf(chain, "RequireAdmin"), chain)
+	}
+	if ep.Properties["middleware_scope"] != "group" {
+		t.Errorf("middleware_scope=%q, want group", ep.Properties["middleware_scope"])
+	}
+}
+
+// TestEchoMiddlewareChain_TrailingInline — echo passes route middleware AFTER
+// the handler: `e.GET("/me", getMe, JWTAuth())`. The handler must be dropped
+// and JWTAuth bound as route-scope middleware.
+func TestEchoMiddlewareChain_TrailingInline(t *testing.T) {
+	src := `package main
+import "github.com/labstack/echo/v4"
+func main() {
+	e := echo.New()
+	e.Use(Recover())
+	e.GET("/me", getMe, JWTAuth())
+}
+`
+	ents := runEcho(t, src)
+	ep := findEndpoint(t, ents, "GET /me")
+	chain := decodeChain(t, ep.Properties["middleware_chain"])
+	rec, jwt := indexOf(chain, "Recover"), indexOf(chain, "JWTAuth")
+	if rec < 0 || jwt < 0 {
+		t.Fatalf("chain missing entries: Recover=%d JWTAuth=%d (chain=%v)", rec, jwt, chain)
+	}
+	// engine Recover is outermost; route JWTAuth innermost.
+	if rec >= jwt {
+		t.Errorf("order wrong: Recover=%d JWTAuth=%d, want Recover<JWTAuth", rec, jwt)
+	}
+	// the handler getMe must NOT appear as middleware.
+	if indexOf(chain, "getMe") >= 0 {
+		t.Errorf("handler getMe wrongly bound as middleware: %v", chain)
+	}
+	if ep.Properties["middleware_scope"] != "engine+route" {
+		t.Errorf("middleware_scope=%q, want engine+route", ep.Properties["middleware_scope"])
+	}
+	// auth middleware appears in the chain (not double-modeled) AND carries its
+	// auth_kind so the chain is consistent with the #3734 auth surface.
+	for _, e := range chain {
+		if e.Name == "JWTAuth" && e.AuthKind != "jwt" {
+			t.Errorf("JWTAuth auth_kind=%q, want jwt", e.AuthKind)
+		}
+	}
+}
+
+// TestGinMiddlewareChain_DynamicSkipped — a dynamically/spread-built chain is
+// NOT statically resolvable: a `.Use(mws...)` spread and a route whose only
+// extra arg is the handler produce NO fabricated chain.
+func TestGinMiddlewareChain_DynamicSkipped(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.Default()
+	mws := buildMiddleware()
+	r.Use(mws...)
+	r.GET("/plain", plainHandler)
+}
+`
+	ents := runGin(t, src)
+	ep := findEndpoint(t, ents, "GET /plain")
+	// `mws...` is a spread identifier; parseMiddlewareChain records it as a bare
+	// expr (one entry) — but the route itself has only a handler, so the only
+	// chain comes from the engine .Use spread. We accept the engine spread entry
+	// (it IS a registered middleware var) but assert NO route-scope fabrication.
+	if raw := ep.Properties["middleware_chain"]; raw != "" {
+		chain := decodeChain(t, raw)
+		for _, e := range chain {
+			if e.Scope == goMWScopeRoute {
+				t.Errorf("no route-scope middleware should be fabricated for a handler-only route, got %v", chain)
+			}
+		}
+	}
+}
+
+// TestChiMiddlewareChain_EngineStack — chi's dominant idiom is the engine-wide
+// `r.Use(...)` stack. `r.Use(Logger); r.Use(Recoverer)` then `r.Get("/x", h)`
+// → /x chain is [Logger, Recoverer] in registration (outermost) order.
+func TestChiMiddlewareChain_EngineStack(t *testing.T) {
+	src := `package main
+import "github.com/go-chi/chi/v5"
+func main() {
+	r := chi.NewRouter()
+	r.Use(Logger)
+	r.Use(Recoverer)
+	r.Get("/widgets", listWidgets)
+}
+`
+	ents := runChi(t, src)
+	ep := findEndpoint(t, ents, "GET /widgets")
+	chain := decodeChain(t, ep.Properties["middleware_chain"])
+	logger, rec := indexOf(chain, "Logger"), indexOf(chain, "Recoverer")
+	if logger < 0 || rec < 0 {
+		t.Fatalf("chi chain missing entries: Logger=%d Recoverer=%d (chain=%v)", logger, rec, chain)
+	}
+	if logger >= rec {
+		t.Errorf("chi order wrong: Logger=%d Recoverer=%d, want Logger<Recoverer", logger, rec)
+	}
+	if ep.Properties["middleware_scope"] != "engine" {
+		t.Errorf("middleware_scope=%q, want engine", ep.Properties["middleware_scope"])
+	}
+}
+
+// TestGinMiddlewareChain_NoMiddleware — a route with no engine/group/inline
+// middleware carries no chain (negative case: non-middleware route → no stamp).
+func TestGinMiddlewareChain_NoMiddleware(t *testing.T) {
+	src := `package main
+import "github.com/gin-gonic/gin"
+func main() {
+	r := gin.New()
+	r.GET("/ping", pong)
+}
+`
+	ents := runGin(t, src)
+	ep := findEndpoint(t, ents, "GET /ping")
+	if ep.Properties["middleware_chain"] != "" {
+		t.Errorf("GET /ping: middleware_chain=%q, want empty", ep.Properties["middleware_chain"])
+	}
+	if ep.Properties["middleware_count"] != "" {
+		t.Errorf("GET /ping: middleware_count=%q, want empty", ep.Properties["middleware_count"])
+	}
+}


### PR DESCRIPTION
Closes #3776 (child of #3628).

## Problem
The graph could not answer **"what middleware runs before THIS route, in order?"** for Go. `route_auth.go` (#3734) bound only the **auth** middleware to a route op; `helpers.go` parsed the full `.Use(...)` chain but `emitMiddlewareChain` wrote each middleware as a **standalone `SCOPE.Pattern`** (`mw_order`) never bound to an endpoint. JS/TS already had this via `http_endpoint_jsts_middleware.go` (#2853 — ordered `middleware_chain` stamped on every endpoint).

## Edge / order model
New `internal/custom/golang/route_middleware.go` adds a per-file `goRouteMiddlewareIndex` (mirrors `goRouteAuthIndex`) that resolves three scopes and binds the **ordered, deduped** chain to each gin/echo/chi `SCOPE.Operation/endpoint` op, **outermost-first** (the order a request traverses):

| scope | source | runs |
|---|---|---|
| `engine` | `r.Use(mw)` on the engine var | first (wraps all routes) |
| `group` | `g := r.Group("/x", mw)` args + `g.Use(mw)` on the group var | per-group |
| `route` | inline route middleware (gin `r.GET(p, mw, h)` / echo `e.GET(p, h, mw)`; the single handler arg dropped) | last, before handler |

Rather than a new edge kind, this reuses the **existing JS/TS endpoint-property contract** so the dashboard/MCP light up uniformly across languages:
- `middleware_chain` — JSON `[{name, expr, scope, order, auth_kind?}]`, index 0 = first traversed
- `middleware_count`, `middleware_names` (chain order), `middleware_scope` (`engine|group|route`, `+`-joined)

Auth middleware appears **in** the chain (`auth_kind` set), not double-modeled; `route_auth.go` continues to stamp `auth_*` separately.

**Honest-partial:** dynamically/spread-built chains and chi closure-subrouter group `.Use` are skipped — no fabricated order.

## Chains asserted (value-asserting tests)
- gin `r.Use(Logger()); r.Use(CORS()); r.GET("/users", RateLimit(), h)` → chain `[Logger, CORS, RateLimit]`, asserts `Logger < CORS < RateLimit`, scope `engine+route`, `middleware_names=Logger,CORS,RateLimit`
- gin `api := r.Group("/api", AuthRequired(), Logger())` → `/api/me` chain `[AuthRequired, Logger]` (order asserted), scope `group`; non-group route has **no** chain
- gin `admin.Use(RequireAdmin())` → `/admin/stats` binds `RequireAdmin` at order 0, scope `group`
- echo `e.Use(Recover()); e.GET("/me", getMe, JWTAuth())` → `Recover < JWTAuth`, handler `getMe` **not** bound, `JWTAuth.auth_kind=jwt`
- chi `r.Use(Logger); r.Use(Recoverer); r.Get("/widgets", h)` → `Logger < Recoverer`, scope `engine`
- negatives: handler-only route + spread `r.Use(mws...)` → no route-scope fabrication; no-middleware route → no chain stamped

## Verification
`go test` targeted green (`./internal/custom/... ./internal/engine/ ./internal/types/ ./tools/coverage/`); `go test ./internal/types/` green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors; `fmt --check` canonical. gin/echo/chi `middleware_coverage` notes/cites updated to record the endpoint-bound chain.

## Follow-ups (out of scope)
Python Django `MIDDLEWARE` + DRF permission/auth classes, FastAPI `add_middleware`, and Spring filter chains → endpoint binding (noted in #3776).

DEPLOY-DEFERRED (no daemon rebuild/reindex in this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)