### PR TITLE
Stamp endpoint rate-limit / throttle posture on the route op

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2342,6 +2342,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -2578,6 +2583,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -2814,6 +2824,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -3059,6 +3074,11 @@
             "status": "partial",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -3304,6 +3324,11 @@
             "status": "full",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -3549,6 +3574,11 @@
             "status": "full",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -3933,6 +3963,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -4169,6 +4204,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -4431,6 +4471,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "low-level network/event library; no HTTP middleware pipeline"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -4752,6 +4797,11 @@
             "status": "full",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -4997,6 +5047,11 @@
             "status": "partial",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -5242,6 +5297,11 @@
             "status": "partial",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -5831,6 +5891,11 @@
             "status": "partial",
             "cites": ["internal/custom/cpp/auth_middleware.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -6076,6 +6141,11 @@
             "cites": ["internal/custom/cpp/restinio_middleware.go"],
             "notes": "non_matched_request_handler, make_chain\u003cH1,H2,...\u003e, request_handler chaining detected; regex/partial",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -7414,6 +7484,11 @@
             "status": "full",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "verified_at": "2026-05-28"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -7659,6 +7734,11 @@
             "status": "full",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "notes": "app.UseMiddleware\u003cT\u003e typed registrations, inline app.Use() lambda middleware, IMiddleware class + InvokeAsync detection, [ServiceFilter]/[TypeFilter]/IActionFilter-based MVC filter coverage."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -8509,6 +8589,11 @@
             "status": "partial",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "notes": "Carter app.MapCarter()/AddCarter() pipeline wiring detected; ICarterModule.AddRoutes already covers route registration. Middleware wiring is the AddCarter/MapCarter registration surface."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -8757,6 +8842,11 @@
             "status": "partial",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "notes": "FastEndpoints AddFastEndpoints()/UseFastEndpoints() pipeline wiring and IGlobalPreProcessor/IGlobalPostProcessor/IPreProcessor/IPostProcessor class declarations detected."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -9161,6 +9251,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -9376,6 +9471,11 @@
             "status": "partial",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "notes": "NancyFX DefaultNancyBootstrapper subclass, RequestStartup/ApplicationStartup overrides, and this.Before += / this.After += module pipeline hook registrations detected."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -9834,6 +9934,11 @@
             "status": "partial",
             "cites": ["internal/custom/csharp/middleware_extra.go","internal/custom/csharp/middleware_extra_test.go"],
             "notes": "ServiceStack AppHostBase subclass, Plugins.Add\u003cT\u003e(), GlobalRequestFilters.Add, and Pre/PostResponseFilters pipeline registration patterns detected."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -11438,6 +11543,11 @@
             "status": "partial",
             "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/substrate/taint_sites_elixir.go"],
             "notes": "Absinthe.Middleware.* module uses detected via engine YAML; plug pipeline middleware tracked via taint substrate"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -11687,6 +11797,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "Ash is a resource/action framework without HTTP middleware; middleware layer handled by Plug/Phoenix integration"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -11929,6 +12044,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "Bandit is a raw HTTP/2 server with no middleware pipeline; pipeline is Plug-layer concern"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -12201,6 +12321,11 @@
             "status": "partial",
             "cites": ["internal/substrate/taint_sites_elixir.go"],
             "notes": "Cowboy middleware defined via stream_handlers; taint substrate tracks conn access patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -12444,6 +12569,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -12797,6 +12927,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -12992,6 +13127,11 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "not_applicable"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -13229,6 +13369,11 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "not_applicable"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -13480,6 +13625,11 @@
             "status": "full",
             "cites": ["internal/custom/elixir/phoenix.go"],
             "notes": "phoenixExtractor parses pipeline :name do...end blocks into ordered plug chains (plug_chain, plug_order per step) and binds scopes to pipelines via pipe_through [:a,:b]; module + function plugs captured. Tests assert exact :browser chain order + protect_from_forgery index + pipe_through 'api -\u003e auth' binding."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -13946,6 +14096,11 @@
             "status": "full",
             "cites": ["internal/custom/elixir/plug.go"],
             "notes": "plugExtractor captures the ordered Plug.Builder/Plug.Router plug chain with plug_order per step (plug :name and plug Module). Test asserts Plug.Logger order 0 within builder chain."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -14189,6 +14344,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -14396,6 +14556,11 @@
             "issue": "3511",
             "notes": "BaseUrl/JSON Tesla plug middleware parsed for base-url only; full middleware-chain modeling pending (#3511)",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -15169,6 +15334,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -15411,6 +15581,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -15657,6 +15832,11 @@
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
             "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -15906,6 +16086,11 @@
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
             "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -16148,6 +16333,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -16404,6 +16594,11 @@
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
             "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -16639,6 +16834,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3628"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -16950,6 +17150,11 @@
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
             "notes": "balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -17194,6 +17399,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/go_zero.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -17654,6 +17864,11 @@
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "notes": "gorilla-mux .Use() chain scanned via shared middleware_auth_extend pass; one SCOPE.Pattern per middleware in registration order (mw_order); TestGorillaMuxMiddlewareAuthExtend proves ordering + auth classification",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -17899,6 +18114,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3613"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -18108,6 +18328,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -18351,6 +18576,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/huma.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -18593,6 +18823,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -18834,6 +19069,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/kratos.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -19076,6 +19316,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -19332,6 +19577,11 @@
             "status": "partial",
             "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -19564,6 +19814,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3628"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -27546,6 +27801,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/adonisjs_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -28712,6 +28972,13 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/express_middleware.ts"],
             "verified_at": "2026-05-28"
+          },
+          "rate_limit_stamping": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_ratelimit.go","internal/engine/http_endpoint_jsts_ratelimit_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "express-rate-limit / express-slow-down: resolves windowMs+max to a human rate and stamps rate_limited/rate_limit/rate_limit_scope (route|app)/rate_limit_source on the endpoint op. Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter defined but never applied to a route is not stamped.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -28991,6 +29258,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/fastify_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -29268,6 +29540,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/feathers_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -29968,6 +30245,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/hapi_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -30240,6 +30522,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/hono_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -30734,6 +31021,13 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/koa_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_ratelimit.go","internal/engine/http_endpoint_jsts_ratelimit_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "express-rate-limit / express-slow-down: resolves windowMs+max to a human rate and stamps rate_limited/rate_limit/rate_limit_scope (route|app)/rate_limit_source on the endpoint op. Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter defined but never applied to a route is not stamped.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -31050,6 +31344,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/marblejs_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -31538,6 +31837,11 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/nestjs_middleware.ts"],
             "verified_at": "2026-05-28"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -32335,6 +32639,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/polka_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -32592,6 +32901,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3619"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -33646,6 +33960,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_middleware.go","internal/engine/http_endpoint_jsts_middleware_test.go","testdata/fixtures/typescript/restify_middleware.ts"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -33908,6 +34227,11 @@
           "middleware_coverage": {
             "status": "not_applicable",
             "notes": "Sails does not attach middleware to individual endpoints; its global middleware pipeline is the declarative `order` array under `middleware` in config/http.js. Covered by the framework_specific Middleware Pipeline / middleware_order_recognition cell (ParseSailsMiddlewareOrder)."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -34893,6 +35217,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3619"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -40205,6 +40534,11 @@
             "status": "full",
             "cites": ["internal/custom/lua/kong.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -40411,6 +40745,11 @@
             "status": "full",
             "cites": ["internal/custom/lua/kong.go"],
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -40616,6 +40955,11 @@
             "status": "full",
             "cites": ["internal/custom/lua/middleware.go"],
             "notes": "Lapis middleware chain: before_filter/app:before (phase=before) + app:after filters with chain_index ordering, error_handler/on_error, lapis.flow pipeline. value-asserting tests in extractors_test.go."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -40862,6 +41206,11 @@
             "status": "full",
             "cites": ["internal/custom/lua/middleware.go"],
             "notes": "OpenResty middleware chain: nginx phase directives (init/init_worker/rewrite/access/content/header_filter/body_filter/log _by_lua) emitted with chain_index (textual order) + phase_order (canonical request-lifecycle rank) so the ordered chain is reconstructable; Kong plugin handler phases. value-asserting test TestLuaMiddlewareOrdering asserts specific phase_order ranks."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -41560,6 +41909,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -41770,6 +42124,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -42019,6 +42378,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -42268,6 +42632,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -42511,6 +42880,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -42721,6 +43095,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -42968,6 +43347,11 @@
             "status": "full",
             "cites": ["internal/custom/php/laravel_authval.go"],
             "notes": "Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route -\u003emiddleware() attachment and -\u003ewithoutMiddleware() exclusion"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -43219,6 +43603,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -43429,6 +43818,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -43678,6 +44072,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -43927,6 +44326,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -44176,6 +44580,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -44427,6 +44836,11 @@
             "cites": ["internal/custom/php/symfony.go"],
             "notes": "EventSubscriberInterface implementors with getSubscribedEvents() event name extraction; addListener/addSubscriber kernel event registration; kernel event names emitted as SCOPE.Pattern",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -44682,6 +45096,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -44931,6 +45350,11 @@
             "status": "partial",
             "cites": ["internal/custom/php/frameworks.go"],
             "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -45949,6 +46373,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -46209,6 +46638,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3620"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -46431,6 +46865,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -46916,6 +47355,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -47180,6 +47624,11 @@
             "cites": ["internal/custom/python/django.go"],
             "notes": "django.go extracts *Middleware class definitions (djangoMiddlewareClassRe) + process_request/process_response/process_view/process_exception hook methods. Partial because: Django MIDDLEWARE settings list (settings.py list of dotted paths) is not parsed; new-style __call__-based middleware is detected via class name but __call__ method is not specifically emitted; mixin-based middleware (MiddlewareMixin subclass) is covered. Test: TestDjango_Middleware.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -47453,6 +47902,11 @@
             "cites": ["internal/engine/django_imports_rewrite.go"],
             "notes": "Django import rewriting provides coverage for stock Django middleware (SecurityMiddleware, SessionMiddleware etc.) via class-name rewriting. Partial because: DRF DEFAULT_AUTHENTICATION_CLASSES / DEFAULT_THROTTLE_CLASSES in settings.py are not parsed; custom DRF middleware (BaseAuthentication subclasses used as middleware) is not detected; no MIDDLEWARE_CLASSES list parsing. DRF has no dedicated middleware extractor.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -47965,6 +48419,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -48228,6 +48687,13 @@
             "cites": ["internal/custom/python/fastapi.go","internal/custom/python/http_middleware.go"],
             "notes": "@app.middleware('http') decorator extracted by fastapi.go (faMiddlewareRe); app.add_middleware(Cls, ...) extracted via starletteAddMiddlewareRe in http_middleware.go for Starlette/FastAPI. Tests: TestFastAPI_Middleware (decorator form), TestFastAPI_FullFixture_Middleware (fixture). Covers both ASGI middleware registration patterns used in FastAPI.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "full",
+            "cites": ["internal/custom/python/fastapi.go","internal/custom/python/rate_limit_endpoint.go","internal/custom/python/rate_limit_endpoint_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "slowapi @limiter.limit(\"5/minute\") stamps rate_limited/rate_limit/rate_limit_source on the route op. DRF @throttle_classes resolver (rate from a co-located custom throttle's rate attr; settings-driven built-ins → honest-partial) shared via resolvePyEndpointRateLimit.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -48503,6 +48969,13 @@
             "cites": ["internal/custom/python/flask.go"],
             "notes": "flask.go extracts @app.before_request / @app.after_request / @app.teardown_request / @bp.before_app_request decorators as request_hook pattern entities — these ARE Flask's middleware mechanism (no traditional middleware class in Flask; hooks are the canonical approach). Test: TestFlask_RequestHook proves before_request hook extraction with hook_type property.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "full",
+            "cites": ["internal/custom/python/flask.go","internal/custom/python/rate_limit_endpoint.go","internal/custom/python/rate_limit_endpoint_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "flask-limiter @limiter.limit(\"100/hour\") and django-ratelimit @ratelimit(key='ip', rate='5/m') stamp rate_limited/rate_limit/rate_limit_scope/rate_limit_source on the route op.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -48779,6 +49252,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3620"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -48993,6 +49471,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -49295,6 +49778,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -49560,6 +50048,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -49827,6 +50320,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -50091,6 +50589,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -50561,6 +51064,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -50825,6 +51333,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -51092,6 +51605,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -51356,6 +51874,11 @@
             "cites": ["internal/custom/python/http_middleware.go"],
             "issue": "3054",
             "verified_at": "2026-05-29"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -52781,6 +53304,11 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/middleware.go"],
             "notes": "Rack use and Cuba before/after blocks. Part of #3282."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -53014,6 +53542,11 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "not_applicable"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -53252,6 +53785,11 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/middleware.go"],
             "notes": "Rack use, Rails before/after_action, Grape before/after hooks, Sinatra before/after blocks, Roda plugins, Cuba before/after. Part of #3282."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -53490,6 +54028,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "3621"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -53700,6 +54243,11 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/middleware.go"],
             "notes": "Rack use via Hanami::Application, config.middleware.use. Part of #3282."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -53939,6 +54487,11 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/middleware.go"],
             "notes": "Rack use, config.middleware.use, Padrino before/after blocks. Part of #3282."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -54178,6 +54731,11 @@
           "middleware_coverage": {
             "status": "full",
             "cites": ["internal/custom/ruby/middleware.go","internal/custom/ruby/middleware_test.go"]
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -54434,6 +54992,11 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/middleware.go"],
             "notes": "Roda plugin :name declarations and Rack use. Part of #3282."
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -54676,6 +55239,11 @@
             "cites": ["internal/custom/ruby/middleware.go","internal/custom/ruby/middleware_test.go","internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go"],
             "notes": "Covers: use Rack::X Rack middleware, before do / after do filters, before '/path' do scoped filters, helpers do blocks, custom Rack middleware class detection (initialize(app)+call(env)). Full idiomatic Sinatra middleware surface. Closes #3344.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -55674,6 +56242,11 @@
             "cites": ["internal/custom/rust/actix_web.go","internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
             "notes": "custom Transform\u003cS,ServiceRequest\u003e impls + .wrap() registrations captured with middleware_name/middleware_trait",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -55913,6 +56486,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -56132,6 +56710,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go","internal/custom/rust/axum.go"],
             "notes": ".layer/.route_layer + tower ServiceBuilder ordered layer chains enumerated in source order (layer_order + layer_order_list)",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -56377,6 +56960,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
             "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but gotham layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -56623,6 +57211,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
             "notes": "hyper services compose via tower ServiceBuilder::new().layer() chains, enumerated in order (layer_order + layer_chain) by the shared tower matcher",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -56897,6 +57490,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
             "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but poem layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -57169,6 +57767,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go","internal/custom/rust/rocket.go"],
             "notes": "impl Fairing for X middleware captured with middleware_name + middleware_trait=Fairing; .attach() registration captured",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -57414,6 +58017,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
             "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but salvo layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -57806,6 +58414,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
             "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -58045,6 +58658,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -58269,6 +58887,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
             "notes": "ServiceBuilder::new().layer(..).layer(..) chains enumerated in source order: per-layer layer_order plus a layer_chain entity with layer_count + layer_order_list",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -58508,6 +59131,11 @@
           "middleware_coverage": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -58725,6 +59353,11 @@
             "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
             "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but warp layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {
@@ -63753,6 +64386,11 @@
             "cites": ["internal/custom/swift/vapor.go","internal/custom/swift/vapor_extended.go"],
             "notes": "vapor.go extracts Middleware protocol conformances (struct/class conforming to Middleware); vapor_extended.go extracts .grouped(XMiddleware, YMiddleware) middleware chains from route group definitions; proven by TestVaporRouteCollection and TestVaporExtendedMiddleware.",
             "verified_at": "2026-05-30"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
+            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
         "Type System": {

--- a/internal/custom/python/fastapi.go
+++ b/internal/custom/python/fastapi.go
@@ -38,7 +38,10 @@ var (
 	faRouteDecoratorRe = regexp.MustCompile(
 		`(?m)@(\w+)\.(get|post|put|delete|patch|head|options|trace)\s*` +
 			`\(\s*(?:r)?["']([^"']*)["']((?:[^()]|\([^()]*\))*)\)\s*\n` +
-			`(?:\s*(?:#[^\n]*)?\n)*` +
+			// Tolerate intervening blank / comment lines and stacked sibling
+			// decorators (e.g. slowapi `@limiter.limit("5/minute")`) between the
+			// route decorator and `def` so the route is still recognised.
+			`(?:[ \t]*(?:#[^\n]*|@[^\n]*)?\n)*` +
 			`\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	faDependsParamRe = regexp.MustCompile(`=\s*Depends\s*\(\s*(\w+)\s*\)`)
 	faAPIRouterRe    = regexp.MustCompile(`(?m)(\w+)\s*=\s*APIRouter\s*\(([^)]*)\)`)
@@ -90,6 +93,10 @@ func (e *FastAPIExtractor) Extract(ctx context.Context, file extractor.FileInput
 		// dependencies, and the decorator args for a `dependencies=[...]` kwarg.
 		sig := pyCallArgRegion(source, idx[1])
 		resolveFastAPIRouteAuth(sig, decoratorArgs).stamp(props)
+		// #3628 rate-limit child — slowapi `@limiter.limit("5/minute")` is a
+		// sibling decorator stacked with the route decorator (the route regex
+		// can't include it), so scan the preceding decorator window.
+		resolvePyEndpointRateLimit(decoratorWindow(source, idx[0], idx[1]), source).stamp(props)
 		out = append(out, entity(handlerName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 

--- a/internal/custom/python/flask.go
+++ b/internal/custom/python/flask.go
@@ -25,10 +25,10 @@ func (e *FlaskExtractor) Language() string { return "python_flask" }
 
 var (
 	flRouteDecoratorRe = regexp.MustCompile(
-		`(?m)@(\w+)\.route\s*\(\s*(?:r)?["']([^"']*)["']([^)]*)\)(?:\s*\n(?:\s*@\w+(?:\([^)]*\))?\s*\n)*)\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+		`(?m)@(\w+)\.route\s*\(\s*(?:r)?["']([^"']*)["']([^)]*)\)(?:\s*\n(?:\s*@[\w.]+(?:\([^)]*\))?\s*\n)*)\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	flRouteMethodsRe    = regexp.MustCompile(`methods\s*=\s*\[([^\]]+)\]`)
 	flHTTPMethodDecorRe = regexp.MustCompile(
-		`(?m)@(\w+)\.(get|post|put|patch|delete|options|head)\s*\(\s*(?:r)?["']([^"']*)["']([^)]*)\)(?:\s*\n(?:\s*@\w+(?:\([^)]*\))?\s*\n)*)\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+		`(?m)@(\w+)\.(get|post|put|patch|delete|options|head)\s*\(\s*(?:r)?["']([^"']*)["']([^)]*)\)(?:\s*\n(?:\s*@[\w.]+(?:\([^)]*\))?\s*\n)*)\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	flBlueprintRe       = regexp.MustCompile(`(?m)(\w+)\s*=\s*Blueprint\s*\(\s*["'](\w+)["']([^)]*)\)`)
 	flURLPrefixRe       = regexp.MustCompile(`url_prefix\s*=\s*["']([^"']*)["']`)
 	flRegBlueprintRe    = regexp.MustCompile(`(?m)(\w+)\.register_blueprint\s*\(\s*(\w+)([^)]*)\)`)
@@ -80,6 +80,10 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		// Flask-Login / Flask-Security auth decorator (the route decorator itself
 		// is never an auth decorator, so it can't false-positive).
 		resolveFlaskDecoratorAuth(source[idx[0]:idx[1]]).stamp(props)
+		// #3628 rate-limit child — flask-limiter `@limiter.limit("100/hour")` /
+		// django-ratelimit `@ratelimit(rate='5/m')` may be stacked above the
+		// route decorator, so widen to the full preceding decorator block.
+		resolvePyEndpointRateLimit(decoratorWindow(source, idx[0], idx[1]), source).stamp(props)
 		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
@@ -92,6 +96,7 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		line := lineOf(source, idx[0])
 		props := map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": httpMethod, "blueprint": appVar}
 		resolveFlaskDecoratorAuth(source[idx[0]:idx[1]]).stamp(props)
+		resolvePyEndpointRateLimit(decoratorWindow(source, idx[0], idx[1]), source).stamp(props)
 		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 

--- a/internal/custom/python/helpers.go
+++ b/internal/custom/python/helpers.go
@@ -37,3 +37,35 @@ func entity(name, kind, subtype, sourceFile string, startLine int, props map[str
 func allMatchesIndex(re *regexp.Regexp, source string) [][]int {
 	return re.FindAllStringSubmatchIndex(source, -1)
 }
+
+// decoratorWindow returns the contiguous block of stacked decorator lines that
+// immediately precede the byte offset `at` (the start of a route decorator
+// match), plus everything from there up to `end`. It walks backwards over
+// consecutive `@…` / comment / blank lines so a sibling decorator such as
+// slowapi's `@limiter.limit("5/minute")` — which the route regex cannot include
+// in its own match (the regex tail only permits comments before `def`) — is
+// still visible to the rate-limit resolver. Used for endpoint-level throttle
+// stamping (#3628 rate-limit child).
+func decoratorWindow(source string, at, end int) string {
+	if at < 0 || at > len(source) || end < at || end > len(source) {
+		return ""
+	}
+	start := at
+	// Walk back line-by-line while the preceding line is a decorator, comment,
+	// or blank line (the conventional stacked-decorator block).
+	for start > 0 {
+		// Find the start of the line that ends just before `start`.
+		lineEnd := start - 1 // index of the '\n' terminating the previous line
+		if lineEnd < 0 || source[lineEnd] != '\n' {
+			break
+		}
+		lineStart := strings.LastIndexByte(source[:lineEnd], '\n') + 1
+		line := strings.TrimSpace(source[lineStart:lineEnd])
+		if line == "" || strings.HasPrefix(line, "@") || strings.HasPrefix(line, "#") {
+			start = lineStart
+			continue
+		}
+		break
+	}
+	return source[start:end]
+}

--- a/internal/custom/python/rate_limit_endpoint.go
+++ b/internal/custom/python/rate_limit_endpoint.go
@@ -1,0 +1,225 @@
+// rate_limit_endpoint.go — endpoint rate-limit / throttle stamping for Python
+// web frameworks (child of #3628, "[api] endpoint rate-limit / throttle
+// stamping").
+//
+// A `rate_limit` SCOPE.Pattern node already records "this file uses a rate
+// limiter" (internal/patterns/rate_limit_extractor.go). This file attributes
+// the limiter to the SPECIFIC route endpoint and resolves the numeric rate,
+// stamping the flat property contract the auth resolver (auth_endpoint.go) uses
+// so the graph answers "which endpoints are throttled and at what rate?":
+//
+//	rate_limited      — "true" when a throttle applies to the endpoint.
+//	rate_limit        — human rate "100/min" / "5/minute" when statically
+//	                    resolvable; OMITTED (honest-partial) when the rate is
+//	                    config-/settings-driven (e.g. a DRF throttle class whose
+//	                    rate lives in REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']).
+//	rate_limit_scope  — "user" | "anon" | "ip" | "endpoint" — the throttle key.
+//	rate_limit_source — the recognised throttle symbol / decorator (evidence).
+//
+// Supported surfaces:
+//
+//	slowapi (FastAPI/Starlette) — `@limiter.limit("5/minute")` on the route.
+//	django-ratelimit            — `@ratelimit(key='ip', rate='5/m')`.
+//	DRF                         — `@throttle_classes([UserRateThrottle])` /
+//	                              `throttle_classes = [UserRateThrottle]`; the
+//	                              rate is resolved when a co-located throttle
+//	                              subclass declares `rate = '1000/day'`,
+//	                              otherwise honest-partial (rate omitted).
+//	flask-limiter               — `@limiter.limit("100/hour")` on the view.
+package python
+
+import (
+	"regexp"
+	"strings"
+)
+
+// pyRateLimit is the resolved throttle posture for one route endpoint.
+type pyRateLimit struct {
+	Rate   string // "5/minute", "1000/day", … or "" (honest-partial)
+	Scope  string // "user" | "anon" | "ip" | "endpoint" | ""
+	Source string // evidence symbol / decorator
+	found  bool
+}
+
+// stamp writes the resolved posture onto an endpoint Properties map. No-op when
+// no throttle signal was recognised (never fabricates rate_limited=false).
+func (r pyRateLimit) stamp(props map[string]string) {
+	if props == nil || !r.found {
+		return
+	}
+	props["rate_limited"] = "true"
+	if r.Rate != "" {
+		props["rate_limit"] = r.Rate
+	}
+	if r.Scope != "" {
+		props["rate_limit_scope"] = r.Scope
+	}
+	if r.Source != "" {
+		props["rate_limit_source"] = r.Source
+	}
+}
+
+// pyLimiterDecoratorRe captures slowapi / flask-limiter `@limiter.limit("…")`
+// (any receiver name ending in a `.limit(` call). Group 1 = receiver, group 2 =
+// the rate string.
+var pyLimiterDecoratorRe = regexp.MustCompile(
+	`@\s*([A-Za-z_][\w.]*)\.limit\s*\(\s*["']([^"']+)["']`)
+
+// pyRatelimitDecoratorRe captures django-ratelimit `@ratelimit(key='ip',
+// rate='5/m')` (also matches the `@ratelimit(...)` import-aliased form). Group 1
+// = the full argument list.
+var pyRatelimitDecoratorRe = regexp.MustCompile(
+	`@\s*(?:[\w.]*\.)?ratelimit\s*\(([^)]*)\)`)
+
+// pyRatelimitRateKwRe / pyRatelimitKeyKwRe pull the rate= and key= kwargs out of
+// a django-ratelimit decorator argument list.
+var (
+	pyRatelimitRateKwRe = regexp.MustCompile(`\brate\s*=\s*["']([^"']+)["']`)
+	pyRatelimitKeyKwRe  = regexp.MustCompile(`\bkey\s*=\s*["']([^"']+)["']`)
+)
+
+// pyThrottleClassesRe captures DRF `@throttle_classes([UserRateThrottle])` and
+// the assignment form `throttle_classes = [UserRateThrottle]`. Group 1 = the
+// raw class list.
+var pyThrottleClassesRe = regexp.MustCompile(
+	`(?:@throttle_classes\s*\(\s*|throttle_classes\s*=\s*)\[([^\]]*)\]`)
+
+// pyThrottleRateAttrRe captures a throttle subclass's `rate = '1000/day'`
+// attribute, used to resolve a co-located custom throttle's rate. Group 1 = the
+// rate string.
+var pyThrottleRateAttrRe = regexp.MustCompile(`\brate\s*=\s*["']([^"']+)["']`)
+
+// drfBuiltinThrottleScope maps the built-in DRF throttle classes to their scope
+// key. The rate of these lives in settings (DEFAULT_THROTTLE_RATES), so it is
+// honest-partial (rate omitted) unless a co-located subclass declares it.
+var drfBuiltinThrottleScope = map[string]string{
+	"UserRateThrottle":   "user",
+	"AnonRateThrottle":   "anon",
+	"ScopedRateThrottle": "endpoint",
+}
+
+// normalizeRatelimitScope maps a django-ratelimit `key=` value to the scope
+// vocabulary. `ip` / `user` / `header:…` → ip/user/endpoint.
+func normalizeRatelimitScope(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	switch {
+	case key == "ip" || strings.HasPrefix(key, "ip"):
+		return "ip"
+	case key == "user" || strings.HasPrefix(key, "user"):
+		return "user"
+	case key == "":
+		return ""
+	default:
+		return "endpoint"
+	}
+}
+
+// resolveSlowapiRateLimit scans a decorator block for a slowapi / flask-limiter
+// `@<limiter>.limit("rate")` decorator.
+func resolveSlowapiRateLimit(decoratorBlock string) pyRateLimit {
+	if m := pyLimiterDecoratorRe.FindStringSubmatch(decoratorBlock); m != nil {
+		return pyRateLimit{
+			Rate:   strings.TrimSpace(m[2]),
+			Source: m[1] + ".limit",
+			found:  true,
+		}
+	}
+	return pyRateLimit{}
+}
+
+// resolveDjangoRatelimit scans a decorator block for a django-ratelimit
+// `@ratelimit(key=…, rate=…)` decorator.
+func resolveDjangoRatelimit(decoratorBlock string) pyRateLimit {
+	m := pyRatelimitDecoratorRe.FindStringSubmatch(decoratorBlock)
+	if m == nil {
+		return pyRateLimit{}
+	}
+	r := pyRateLimit{Source: "ratelimit", found: true}
+	if rm := pyRatelimitRateKwRe.FindStringSubmatch(m[1]); rm != nil {
+		r.Rate = strings.TrimSpace(rm[1])
+	}
+	if km := pyRatelimitKeyKwRe.FindStringSubmatch(m[1]); km != nil {
+		r.Scope = normalizeRatelimitScope(km[1])
+	}
+	return r
+}
+
+// resolveDRFThrottle scans a decorator/body block for DRF throttle_classes and,
+// when a co-located throttle subclass in `source` declares a `rate`, resolves
+// it. `source` is the whole file so a custom throttle's rate attribute can be
+// found; pass "" to skip rate resolution (built-in throttles → honest-partial).
+func resolveDRFThrottle(block, source string) pyRateLimit {
+	m := pyThrottleClassesRe.FindStringSubmatch(block)
+	if m == nil {
+		return pyRateLimit{}
+	}
+	classes := splitThrottleClasses(m[1])
+	if len(classes) == 0 {
+		return pyRateLimit{}
+	}
+	r := pyRateLimit{Source: classes[0], found: true}
+	// Scope from a recognised built-in.
+	if scope, ok := drfBuiltinThrottleScope[classes[0]]; ok {
+		r.Scope = scope
+	}
+	// Resolve the rate from a co-located custom throttle subclass:
+	//   class BurstRateThrottle(UserRateThrottle): rate = '60/min'
+	if source != "" {
+		if rate := drfThrottleRateForClass(source, classes[0]); rate != "" {
+			r.Rate = rate
+		}
+	}
+	return r
+}
+
+// drfThrottleRateForClass finds `class <name>(...): ... rate = '…'` in source
+// and returns the rate, or "" when the class is not locally defined / has no
+// literal rate (honest-partial).
+func drfThrottleRateForClass(source, className string) string {
+	classRe := regexp.MustCompile(`class\s+` + regexp.QuoteMeta(className) + `\s*\([^)]*\)\s*:`)
+	loc := classRe.FindStringIndex(source)
+	if loc == nil {
+		return ""
+	}
+	// Look at the class body (next ~400 chars) for a `rate = '…'` attribute.
+	end := loc[1] + 400
+	if end > len(source) {
+		end = len(source)
+	}
+	body := source[loc[1]:end]
+	// Stop at the next top-level `class`/`def` at column 0 to avoid bleeding.
+	if cut := regexp.MustCompile(`\n(?:class|def)\s`).FindStringIndex(body); cut != nil {
+		body = body[:cut[0]]
+	}
+	if rm := pyThrottleRateAttrRe.FindStringSubmatch(body); rm != nil {
+		return strings.TrimSpace(rm[1])
+	}
+	return ""
+}
+
+// splitThrottleClasses splits a `[A, B, C]` class list into trimmed symbols.
+func splitThrottleClasses(raw string) []string {
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// resolvePyEndpointRateLimit is the unified resolver: it tries each recognised
+// surface against the supplied decorator block, returning the first match.
+// `source` is the whole file (for DRF custom-throttle rate resolution).
+func resolvePyEndpointRateLimit(decoratorBlock, source string) pyRateLimit {
+	if r := resolveSlowapiRateLimit(decoratorBlock); r.found {
+		return r
+	}
+	if r := resolveDjangoRatelimit(decoratorBlock); r.found {
+		return r
+	}
+	if r := resolveDRFThrottle(decoratorBlock, source); r.found {
+		return r
+	}
+	return pyRateLimit{}
+}

--- a/internal/custom/python/rate_limit_endpoint_test.go
+++ b/internal/custom/python/rate_limit_endpoint_test.go
@@ -1,0 +1,171 @@
+package python
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pyEndpointProps runs the named framework extractor and indexes the emitted
+// route endpoints by handler name.
+func pyEndpointProps(t *testing.T, ex extractor.Extractor, path, src string) map[string]types.EntityRecord {
+	t.Helper()
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	out := map[string]types.EntityRecord{}
+	for _, e := range ents {
+		if e.Subtype == "endpoint" {
+			out[e.Name] = e
+		}
+	}
+	return out
+}
+
+// slowapi @limiter.limit("5/minute") on a FastAPI route → rate_limit="5/minute".
+func TestRateLimit_SlowapiFastAPI(t *testing.T) {
+	src := `
+from fastapi import FastAPI
+from slowapi import Limiter
+
+app = FastAPI()
+limiter = Limiter(key_func=lambda: "x")
+
+@app.get("/read")
+@limiter.limit("5/minute")
+async def read(request):
+    return {}
+
+@app.get("/free")
+async def free(request):
+    return {}
+`
+	eps := pyEndpointProps(t, &FastAPIExtractor{}, "main.py", src)
+	read, ok := eps["read"]
+	if !ok {
+		t.Fatalf("read endpoint not emitted (got %v)", keysOf(eps))
+	}
+	if read.Properties["rate_limited"] != "true" {
+		t.Errorf("read: rate_limited=%q, want true", read.Properties["rate_limited"])
+	}
+	if read.Properties["rate_limit"] != "5/minute" {
+		t.Errorf("read: rate_limit=%q, want 5/minute", read.Properties["rate_limit"])
+	}
+	if read.Properties["rate_limit_source"] != "limiter.limit" {
+		t.Errorf("read: rate_limit_source=%q, want limiter.limit", read.Properties["rate_limit_source"])
+	}
+	// Negative: a route without a limiter is not stamped.
+	free := eps["free"]
+	if free.Properties["rate_limited"] != "" {
+		t.Errorf("free: rate_limited=%q, want empty (not fabricated)", free.Properties["rate_limited"])
+	}
+}
+
+// flask-limiter @limiter.limit("100/hour") on a Flask route.
+func TestRateLimit_FlaskLimiter(t *testing.T) {
+	src := `
+from flask import Flask
+from flask_limiter import Limiter
+
+app = Flask(__name__)
+limiter = Limiter(app)
+
+@app.route("/ping")
+@limiter.limit("100/hour")
+def ping():
+    return "ok"
+`
+	eps := pyEndpointProps(t, &FlaskExtractor{}, "app.py", src)
+	ping, ok := eps["ping"]
+	if !ok {
+		t.Fatalf("ping endpoint not emitted (got %v)", keysOf(eps))
+	}
+	if ping.Properties["rate_limited"] != "true" || ping.Properties["rate_limit"] != "100/hour" {
+		t.Errorf("ping: limited=%q rate=%q, want true 100/hour",
+			ping.Properties["rate_limited"], ping.Properties["rate_limit"])
+	}
+}
+
+// django-ratelimit @ratelimit(key='ip', rate='5/m') on a Flask-shaped route
+// (the decorator resolver is framework-agnostic; exercised via Flask here).
+func TestRateLimit_DjangoRatelimitDecorator(t *testing.T) {
+	src := `
+from flask import Flask
+from django_ratelimit.decorators import ratelimit
+
+app = Flask(__name__)
+
+@app.route("/limited")
+@ratelimit(key='ip', rate='5/m')
+def limited():
+    return "ok"
+`
+	eps := pyEndpointProps(t, &FlaskExtractor{}, "app.py", src)
+	e, ok := eps["limited"]
+	if !ok {
+		t.Fatalf("limited endpoint not emitted (got %v)", keysOf(eps))
+	}
+	if e.Properties["rate_limited"] != "true" {
+		t.Errorf("limited: rate_limited=%q, want true", e.Properties["rate_limited"])
+	}
+	if e.Properties["rate_limit"] != "5/m" {
+		t.Errorf("limited: rate_limit=%q, want 5/m", e.Properties["rate_limit"])
+	}
+	if e.Properties["rate_limit_scope"] != "ip" {
+		t.Errorf("limited: rate_limit_scope=%q, want ip", e.Properties["rate_limit_scope"])
+	}
+}
+
+// DRF throttle_classes resolver unit tests (value-asserting).
+func TestResolveDRFThrottle(t *testing.T) {
+	// Built-in throttle: scope resolved, rate honest-partial (lives in settings).
+	block := `@throttle_classes([UserRateThrottle])`
+	r := resolveDRFThrottle(block, "")
+	if !r.found {
+		t.Fatalf("UserRateThrottle: not found")
+	}
+	if r.Scope != "user" {
+		t.Errorf("UserRateThrottle: scope=%q, want user", r.Scope)
+	}
+	if r.Rate != "" {
+		t.Errorf("UserRateThrottle: rate=%q, want empty (settings-driven, honest-partial)", r.Rate)
+	}
+	if r.Source != "UserRateThrottle" {
+		t.Errorf("source=%q, want UserRateThrottle", r.Source)
+	}
+
+	// Custom throttle subclass declaring rate='1000/day' → resolved.
+	source := `
+class DailyThrottle(UserRateThrottle):
+    rate = '1000/day'
+
+class V(APIView):
+    throttle_classes = [DailyThrottle]
+`
+	r2 := resolveDRFThrottle(`throttle_classes = [DailyThrottle]`, source)
+	if !r2.found || r2.Rate != "1000/day" {
+		t.Errorf("DailyThrottle: found=%v rate=%q, want true 1000/day", r2.found, r2.Rate)
+	}
+}
+
+// Negative: a non-throttle decorator block yields no rate-limit posture.
+func TestResolveRateLimit_NoMarker(t *testing.T) {
+	if r := resolvePyEndpointRateLimit(`@app.get("/x")\n@cache(60)`, ""); r.found {
+		t.Errorf("non-throttle decorators: found=true, want false (rate_limited must be absent)")
+	}
+}
+
+func keysOf(m map[string]types.EntityRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/engine/http_endpoint_jsts_ratelimit.go
+++ b/internal/engine/http_endpoint_jsts_ratelimit.go
@@ -1,0 +1,257 @@
+// Cross-framework rate-limit / throttle stamping for the JS/TS backend-HTTP
+// frameworks (child of #3628, "[api] endpoint rate-limit / throttle stamping").
+//
+// This pass answers "which endpoints are throttled and at what rate?" by
+// resolving a per-endpoint rate-limit posture from static middleware signals
+// and stamping it onto the route op with the same FLAT-property model the auth
+// pass (http_endpoint_jsts_auth.go, #2852) and the deprecation pass use. It
+// adds NO parallel node — a separate `rate_limit` SCOPE.Pattern entity already
+// exists (internal/patterns/rate_limit_extractor.go) for the "this file uses a
+// rate limiter" signal; this pass attributes the limiter to the SPECIFIC
+// endpoint and resolves the numeric rate, which the pattern node cannot do.
+//
+// Recognised express-rate-limit (and the API-compatible express-slow-down /
+// rate-limiter-flexible Express middleware) shapes:
+//
+//   - a limiter binding: `const limiter = rateLimit({ windowMs: 60000, max: 100 })`
+//     — captured so its resolved rate can be attached wherever the binding is
+//     applied.
+//   - app/router-level application: `app.use(limiter)` — applies to every
+//     endpoint registered in the same file scope.
+//   - route-level application: `router.get('/x', limiter, handler)` — applies to
+//     that one endpoint (strongest signal).
+//   - an inline limiter passed directly to a route, e.g.
+//     `app.get('/x', rateLimit({ windowMs: 60000, max: 100 }), h)`.
+//
+// Output (stamped only on producer-side http_endpoint_definition entities):
+//
+//	rate_limited      — "true" when a limiter applies to the endpoint.
+//	rate_limit        — human rate "100/60s" when windowMs+max resolve
+//	                    statically; OMITTED (honest-partial) when the limiter is
+//	                    config-/env-driven and cannot be resolved without
+//	                    fabrication.
+//	rate_limit_scope  — "route" | "app" (where the limiter was applied).
+//	rate_limit_source — the recognised limiter symbol / library (evidence key).
+//
+// Refs the #3628 rate-limit child ticket.
+package engine
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsRateLimitFactoryNames are the express-rate-limit-compatible factory calls.
+// All accept an options object with `windowMs` + `max` (express-rate-limit,
+// express-slow-down) so the same resolver handles them.
+var jsRateLimitFactoryNames = map[string]bool{
+	"ratelimit":     true, // express-rate-limit default export
+	"ratelimiter":   true, // common alias
+	"slowdown":      true, // express-slow-down
+	"ratelimiterrl": true, // rate-limiter-flexible express helper (rare alias)
+}
+
+// jsRateLimitFactoryCallRe captures a limiter factory call + its options-object
+// body, e.g. `rateLimit({ windowMs: 60000, max: 100 })`. Group 1 = factory
+// name, group 2 = the brace body (may be empty for arg-less / spread configs).
+var jsRateLimitFactoryCallRe = regexp.MustCompile(
+	`\b([A-Za-z_$][\w$]*)\s*\(\s*\{([^{}]*)\}\s*\)`)
+
+// jsRateLimitBindingRe captures `const limiter = rateLimit({...})` so a named
+// binding can be resolved back to its rate when applied elsewhere. Group 1 =
+// the binding identifier, group 2 = factory name, group 3 = options body.
+var jsRateLimitBindingRe = regexp.MustCompile(
+	`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\s*\(\s*\{([^{}]*)\}\s*\)`)
+
+// jsRateLimitWindowRe / jsRateLimitMaxRe pull the numeric windowMs / max out of
+// an options body. windowMs may be a bare ms number or a simple `n * unit`
+// arithmetic product (`15 * 60 * 1000`); max is a bare integer.
+var (
+	jsRateLimitWindowRe = regexp.MustCompile(`\bwindowMs\s*:\s*([0-9][0-9_*\s]*[0-9]|[0-9]+)`)
+	jsRateLimitMaxRe    = regexp.MustCompile(`\b(?:max|limit|points)\s*:\s*([0-9]+)`)
+)
+
+// jsRateLimitNamesLower is the set of binding identifiers that conventionally
+// hold a rate limiter, used to recognise an applied limiter whose factory call
+// is in another module (imported) and therefore not resolvable to a rate.
+var jsRateLimitNameHintRe = regexp.MustCompile(`(?i)(rate.?limit|throttl|slow.?down|limiter)`)
+
+// jsRateLimiter is a resolved limiter: its evidence symbol and (when static)
+// human-readable rate.
+type jsRateLimiter struct {
+	source string // evidence symbol / library
+	rate   string // "100/60s" or "" when unresolved
+}
+
+// resolveJSRate turns a windowMs + max options body into a human rate string,
+// or "" when either is missing / non-numeric (honest-partial).
+func resolveJSRate(optsBody string) string {
+	wm := jsRateLimitWindowRe.FindStringSubmatch(optsBody)
+	mx := jsRateLimitMaxRe.FindStringSubmatch(optsBody)
+	if wm == nil || mx == nil {
+		return ""
+	}
+	windowMs := evalJSNumberProduct(wm[1])
+	if windowMs <= 0 {
+		return ""
+	}
+	max, err := strconv.Atoi(strings.TrimSpace(mx[1]))
+	if err != nil || max <= 0 {
+		return ""
+	}
+	// Render the window in seconds ("100/60s") — the canonical express-rate-limit
+	// representation, which keeps windowMs:60000 ⇒ "60s" (not "1m") so the rate
+	// is read back exactly as configured. Sub-second windows fall back to ms.
+	seconds := windowMs / 1000
+	if seconds <= 0 || windowMs%1000 != 0 {
+		return strconv.Itoa(max) + "/" + strconv.Itoa(windowMs) + "ms"
+	}
+	return strconv.Itoa(max) + "/" + strconv.Itoa(seconds) + "s"
+}
+
+// evalJSNumberProduct evaluates a bare integer or a `n * n * n` product (with
+// optional `_` digit separators), returning 0 on any non-numeric token.
+func evalJSNumberProduct(expr string) int {
+	expr = strings.ReplaceAll(expr, "_", "")
+	parts := strings.Split(expr, "*")
+	product := 1
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n <= 0 {
+			return 0
+		}
+		product *= n
+	}
+	return product
+}
+
+// recognizeRateLimitFactory reports whether arg is an express-rate-limit-style
+// limiter application (a factory call or a binding that looks like a limiter),
+// returning the resolved limiter. Returns ok=false for non-limiter args.
+func recognizeRateLimitFactory(arg string, bindings map[string]jsRateLimiter) (jsRateLimiter, bool) {
+	raw := strings.TrimSpace(arg)
+	if raw == "" {
+		return jsRateLimiter{}, false
+	}
+	// A named binding applied directly, e.g. `app.use(limiter)`.
+	if lim, ok := bindings[raw]; ok {
+		return lim, true
+	}
+	// An inline factory call, e.g. `rateLimit({ windowMs, max })`.
+	if fm := jsRateLimitFactoryCallRe.FindStringSubmatch(raw); fm != nil {
+		if jsRateLimitFactoryNames[strings.ToLower(fm[1])] {
+			return jsRateLimiter{source: fm[1], rate: resolveJSRate(fm[2])}, true
+		}
+	}
+	// A bare identifier whose name strongly implies a rate limiter but whose
+	// factory call lives in another (imported) module — honest-partial: mark
+	// limited, omit the rate.
+	if !strings.ContainsAny(raw, "({[") && jsRateLimitNameHintRe.MatchString(raw) {
+		return jsRateLimiter{source: symbolHead(raw)}, true
+	}
+	return jsRateLimiter{}, false
+}
+
+// indexJSRateLimitBindings collects `const x = rateLimit({...})` bindings so an
+// applied binding resolves to its rate.
+func indexJSRateLimitBindings(content string) map[string]jsRateLimiter {
+	out := map[string]jsRateLimiter{}
+	for _, m := range jsRateLimitBindingRe.FindAllStringSubmatch(content, -1) {
+		if !jsRateLimitFactoryNames[strings.ToLower(m[2])] {
+			continue
+		}
+		out[m[1]] = jsRateLimiter{source: m[2], rate: resolveJSRate(m[3])}
+	}
+	return out
+}
+
+// applyJSTSRateLimit resolves and stamps rate_limited / rate_limit /
+// rate_limit_scope / rate_limit_source on every JS/TS synthetic backend
+// endpoint emitted for this file. It mutates Properties in place and never adds
+// or removes entities. `before` is the entity-slice length captured before the
+// JS/TS synthesizers ran (same window the auth pass uses).
+func applyJSTSRateLimit(content, path string, entities []types.EntityRecord, before int) {
+	if len(content) == 0 || before >= len(entities) {
+		return
+	}
+	bindings := indexJSRateLimitBindings(content)
+
+	// App/router-level limiter: `app.use(limiter)` / `app.use(rateLimit({...}))`.
+	// Applies to every endpoint in file scope.
+	var appLimiter (jsRateLimiter)
+	appLimiterSet := false
+	for _, m := range jsAppUseRe.FindAllStringSubmatchIndex(content, -1) {
+		arg := content[m[4]:m[5]]
+		if lim, ok := recognizeRateLimitFactory(strings.TrimSpace(arg), bindings); ok {
+			appLimiter = lim
+			appLimiterSet = true
+			break
+		}
+	}
+
+	// Route-level limiters indexed by (verb, canonical path).
+	routeLimiters := map[string]jsRateLimiter{}
+	for _, m := range jsRouteRegistrationRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		switch verb {
+		case "DEL":
+			verb = "DELETE"
+		case "OPTS":
+			verb = "OPTIONS"
+		}
+		raw := content[m[6]:m[7]]
+		rest := content[m[8]:m[9]]
+		var found jsRateLimiter
+		ok := false
+		for _, a := range splitTopLevelArgs(rest) {
+			if lim, isLim := recognizeRateLimitFactory(strings.TrimSpace(a), bindings); isLim {
+				found, ok = lim, true
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		if canonical == "" {
+			continue
+		}
+		routeLimiters[verb+" "+canonical] = found
+	}
+
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		verb := strings.ToUpper(e.Properties["verb"])
+		canonical := e.Properties["path"]
+		key := verb + " " + canonical
+
+		if lim, ok := routeLimiters[key]; ok {
+			stampJSRateLimit(e.Properties, lim, "route")
+			continue
+		}
+		if appLimiterSet {
+			stampJSRateLimit(e.Properties, appLimiter, "app")
+		}
+	}
+}
+
+// stampJSRateLimit writes the flat rate-limit property contract onto an
+// endpoint Properties map. The rate is omitted when it could not be resolved
+// statically (honest-partial — never fabricated).
+func stampJSRateLimit(props map[string]string, lim jsRateLimiter, scope string) {
+	props["rate_limited"] = "true"
+	props["rate_limit_scope"] = scope
+	if lim.source != "" {
+		props["rate_limit_source"] = lim.source
+	}
+	if lim.rate != "" {
+		props["rate_limit"] = lim.rate
+	}
+}

--- a/internal/engine/http_endpoint_jsts_ratelimit_test.go
+++ b/internal/engine/http_endpoint_jsts_ratelimit_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import "testing"
+
+// rlProps reuses the auth pass test harness (full detector run) and projects
+// the rate-limit property contract for each synthetic endpoint.
+func rlProps(t *testing.T, language, path, content string) map[string]rateLimitEndpoint {
+	t.Helper()
+	raw := authProps(t, language, path, content)
+	out := map[string]rateLimitEndpoint{}
+	for k, e := range raw {
+		out[k] = rateLimitEndpoint{
+			limited: e.Properties["rate_limited"],
+			rate:    e.Properties["rate_limit"],
+			scope:   e.Properties["rate_limit_scope"],
+			source:  e.Properties["rate_limit_source"],
+		}
+	}
+	return out
+}
+
+type rateLimitEndpoint struct {
+	limited, rate, scope, source string
+}
+
+func mustEndpoint(t *testing.T, eps map[string]rateLimitEndpoint, key string) rateLimitEndpoint {
+	t.Helper()
+	e, ok := eps[key]
+	if !ok {
+		keys := make([]string, 0, len(eps))
+		for k := range eps {
+			keys = append(keys, k)
+		}
+		t.Fatalf("endpoint %q not synthesised (got %v)", key, keys)
+	}
+	return e
+}
+
+// Route-level limiter resolves windowMs+max → human rate, stamped on exactly
+// the endpoint it is applied to.
+func TestRateLimit_ExpressRouteLevel(t *testing.T) {
+	src := `
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const app = express();
+const limiter = rateLimit({ windowMs: 60000, max: 100 });
+app.get('/api/x', limiter, (req, res) => res.send('x'));
+app.get('/api/open', (req, res) => res.send('ok'));
+`
+	eps := rlProps(t, "typescript", "app.ts", src)
+	x := mustEndpoint(t, eps, "GET /api/x")
+	if x.limited != "true" {
+		t.Fatalf("GET /api/x: rate_limited=%q, want true", x.limited)
+	}
+	if x.rate != "100/60s" {
+		t.Errorf("GET /api/x: rate_limit=%q, want 100/60s", x.rate)
+	}
+	if x.scope != "route" {
+		t.Errorf("GET /api/x: scope=%q, want route", x.scope)
+	}
+	// Negative: an endpoint with no limiter is not stamped.
+	open := mustEndpoint(t, eps, "GET /api/open")
+	if open.limited != "" {
+		t.Errorf("GET /api/open: rate_limited=%q, want empty (not fabricated)", open.limited)
+	}
+}
+
+// Inline factory call applied directly to a route, with a `15 * 60 * 1000`
+// windowMs arithmetic product → 900s.
+func TestRateLimit_ExpressInlineProductWindow(t *testing.T) {
+	src := `
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const app = express();
+app.post('/login', rateLimit({ windowMs: 15 * 60 * 1000, max: 5 }), (req, res) => res.end());
+`
+	eps := rlProps(t, "typescript", "app.ts", src)
+	login := mustEndpoint(t, eps, "POST /login")
+	if login.limited != "true" || login.rate != "5/900s" {
+		t.Errorf("POST /login: limited=%q rate=%q, want true 5/900s", login.limited, login.rate)
+	}
+}
+
+// App-level `app.use(limiter)` applies to every endpoint in file scope.
+func TestRateLimit_ExpressAppLevel(t *testing.T) {
+	src := `
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const app = express();
+const apiLimiter = rateLimit({ windowMs: 3600000, max: 1000 });
+app.use(apiLimiter);
+app.get('/a', (req, res) => res.end());
+app.get('/b', (req, res) => res.end());
+`
+	eps := rlProps(t, "typescript", "app.ts", src)
+	for _, key := range []string{"GET /a", "GET /b"} {
+		e := mustEndpoint(t, eps, key)
+		if e.limited != "true" {
+			t.Errorf("%s: rate_limited=%q, want true", key, e.limited)
+		}
+		if e.rate != "1000/3600s" {
+			t.Errorf("%s: rate_limit=%q, want 1000/3600s", key, e.rate)
+		}
+		if e.scope != "app" {
+			t.Errorf("%s: scope=%q, want app", key, e.scope)
+		}
+	}
+}
+
+// Negative: a limiter defined but never applied to any route → no stamp.
+func TestRateLimit_ExpressDefinedButNotApplied(t *testing.T) {
+	src := `
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const app = express();
+const limiter = rateLimit({ windowMs: 60000, max: 100 });
+app.get('/free', (req, res) => res.end());
+`
+	eps := rlProps(t, "typescript", "app.ts", src)
+	free := mustEndpoint(t, eps, "GET /free")
+	if free.limited != "" {
+		t.Errorf("GET /free: rate_limited=%q, want empty (limiter never applied)", free.limited)
+	}
+}
+
+// Honest-partial: an imported limiter binding (factory call not in this file)
+// → rate_limited=true with rate omitted, never fabricated.
+func TestRateLimit_ExpressImportedLimiterHonestPartial(t *testing.T) {
+	src := `
+const express = require('express');
+const { rateLimiter } = require('./middleware');
+const app = express();
+app.get('/imported', rateLimiter, (req, res) => res.end());
+`
+	eps := rlProps(t, "typescript", "app.ts", src)
+	e := mustEndpoint(t, eps, "GET /imported")
+	if e.limited != "true" {
+		t.Errorf("GET /imported: rate_limited=%q, want true", e.limited)
+	}
+	if e.rate != "" {
+		t.Errorf("GET /imported: rate_limit=%q, want empty (unresolved, honest-partial)", e.rate)
+	}
+}
+
+// Unit-level rate resolution.
+func TestResolveJSRate(t *testing.T) {
+	cases := []struct{ body, want string }{
+		{"windowMs: 60000, max: 100", "100/60s"},
+		{"windowMs: 1000, max: 5", "5/1s"},
+		{"windowMs: 3600000, max: 1000", "1000/3600s"},
+		{"windowMs: 15 * 60 * 1000, max: 5", "5/900s"},
+		{"max: 100", ""},        // no window → unresolved
+		{"windowMs: 60000", ""}, // no max → unresolved
+		{"windowMs: 500, max: 2", "2/500ms"},
+	}
+	for _, c := range cases {
+		if got := resolveJSRate(c.body); got != c.want {
+			t.Errorf("resolveJSRate(%q)=%q, want %q", c.body, got, c.want)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -725,6 +725,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// middleware_scope. Shares the jstsAuthBefore window so it only sees the
 		// producer http_endpoint_definition entities this file emitted.
 		applyJSTSMiddlewareCoverage(string(content), path, entities, jstsAuthBefore)
+		// #3628 rate-limit child — stamp rate_limited / rate_limit /
+		// rate_limit_scope / rate_limit_source on the producer-side endpoints
+		// when an express-rate-limit-style limiter is applied (app.use(limiter)
+		// or a route-level limiter arg). Resolves windowMs+max → human rate
+		// where statically available; honest-partial (rate omitted) for
+		// config-driven limiters. Shares the jstsAuthBefore window.
+		applyJSTSRateLimit(string(content), path, entities, jstsAuthBefore)
 		// Consumer side (#721): fetch / axios / generic *Client
 		// HTTP client calls. Now emits FETCHES edges at extraction time.
 		//

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -94,6 +94,7 @@ subcategories:
       - handler_attribution
       - auth_coverage
       - middleware_coverage
+      - rate_limit_stamping
       - route_extraction
       - request_validation
       - tests_linkage
@@ -146,7 +147,7 @@ subcategories:
       - name: Validation
         keys: [request_validation, dto_extraction]
       - name: Middleware
-        keys: [middleware_coverage]
+        keys: [middleware_coverage, rate_limit_stamping]
       - name: Type System
         keys: [interface_extraction, type_alias_extraction, enum_extraction, type_extraction]
       - name: DI


### PR DESCRIPTION
Closes #3778. Child of #3628.

## Problem
Rate-limiting was modelled only as a standalone `rate_limit` SCOPE.Pattern node (`internal/patterns/rate_limit_extractor.go`) — a file-level "uses a limiter" signal. Endpoints carried **no** rate-limit info, so the graph could not answer *"which endpoints are throttled and at what rate?"*. (Verified: pre-change, no endpoint op carried any `rate_*` property.)

## Approach
Two passes stamp a flat property contract on the **existing** `http_endpoint_definition` op — matching the auth-protection model (#2852) — with **no parallel node**:

| property | meaning |
|---|---|
| `rate_limited` | `"true"` when a throttle applies |
| `rate_limit` | human rate (`100/60s`, `5/minute`, `1000/day`); **omitted** (honest-partial) when config-/settings-driven |
| `rate_limit_scope` | `route`\|`app` (JS/TS) or `user`\|`anon`\|`ip`\|`endpoint` (Python throttle key) |
| `rate_limit_source` | recognised limiter symbol / library (evidence) |

### JS/TS — `internal/engine/http_endpoint_jsts_ratelimit.go`
express-rate-limit / express-slow-down: `app.use(limiter)` (app scope) and `router.get('/x', limiter, h)` (route scope). Resolves `windowMs`+`max` → human rate (incl. `15 * 60 * 1000` products). Imported/config-driven limiter → `rate_limited=true`, rate omitted. Limiter defined but never applied → no stamp. Wired into `http_endpoint_synthesis.go` sharing the existing `jstsAuthBefore` window.

### Python — `internal/custom/python/rate_limit_endpoint.go`
slowapi `@limiter.limit("5/minute")`, flask-limiter `@limiter.limit("100/hour")`, django-ratelimit `@ratelimit(key='ip', rate='5/m')`, DRF `@throttle_classes([...])` / `throttle_classes = [...]` (rate resolved from a co-located custom throttle's `rate` attr; built-in throttles → honest-partial since the rate lives in settings). Wired into `fastapi.go` + `flask.go`. The FastAPI/Flask route regexes were widened to tolerate stacked sibling decorators (e.g. `@limiter.limit` between `@app.get` and `def`) — previously such routes weren't even recognised.

## Stamped endpoints asserted (value-asserting tests)
- express route-level `rateLimit({windowMs:60000,max:100})` on `/api/x` → `rate_limited=true`, `rate_limit=100/60s`, `scope=route`; sibling `/api/open` **unstamped**.
- express inline `windowMs: 15 * 60 * 1000, max: 5` on `POST /login` → `5/900s`.
- express `app.use(apiLimiter)` (`windowMs:3600000,max:1000`) → both `/a` & `/b` `1000/3600s`, `scope=app`.
- negative: limiter defined but unapplied → no stamp; imported limiter → `rate_limited=true`, rate omitted.
- slowapi `@limiter.limit("5/minute")` on `read` → `rate_limit=5/minute`, `source=limiter.limit`; `free` unstamped.
- flask-limiter `@limiter.limit("100/hour")` → `100/hour`.
- django-ratelimit `@ratelimit(key='ip', rate='5/m')` → `rate_limit=5/m`, `scope=ip`.
- DRF `@throttle_classes([UserRateThrottle])` → `scope=user`, rate omitted; custom `DailyThrottle(rate='1000/day')` → `1000/day`.
- negative: non-throttle decorator → no posture.

## Coverage
New `rate_limit_stamping` lane (Middleware group, `http_backend`): **full** for express / koa / fastapi / flask; **missing** + #3778 backfilled across all `http_backend` records to keep the fully-backfilled taxonomy validate-green. `coverage validate` 0 errors, `fmt --check` canonical.

## Validation
`go test` (engine, custom/python, tools/coverage, types, patterns) green; `go vet` clean; `gofmt -l` empty; `go test ./internal/types/` green; `coverage validate` 0 errors + canonical.

## Future work
Java (Resilience4j / bucket4j `@RateLimiter`) and Go (gin tollbooth / `golang.org/x/time/rate`) — filed as `missing` cells under #3778.

**DEPLOY-DEFERRED**: requires a coordinated live-daemon rebuild + reindex before the new props/lane appear in the served graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)