### PR TITLE
feat(integration): third-party SDK → SCOPE.ExternalService DEPENDS_ON_SERVICE

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -1,46 +1,47 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # platform
 
-**Total**: 37 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 31 · **python**: 1 · **ruby**: 1
+**Total**: 38 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 32 · **python**: 1 · **ruby**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Dependency attribution | Env resolution | File parsing | Resource extraction | Shared data coupling | Status | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | — | ✅ | — | — | ✅ | |
-| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | — | ✅ | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | — | ✅ | — | ✅ | |
-| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | — | — | 🟢 | — | 🟢 | |
+| Language | Name | Dependency attribution | Env resolution | External service dependency | File parsing | Resource extraction | Shared data coupling | Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | — | — | ✅ | — | — | ✅ | |
+| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | — | ✅ | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | — | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | — | 🟢 | — | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |

--- a/docs/coverage/detail/analysis.integration.third-party-sdk.md
+++ b/docs/coverage/detail/analysis.integration.third-party-sdk.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `analysis.integration.third-party-sdk` — Third-party SDK service dependencies (DEPENDS_ON_SERVICE)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [platform](../by-category/platform.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| External service dependency | 🟢 `partial` | `2026-06-02` | 3628 | `internal/extractor/external_service.go`<br>`internal/extractor/external_service_test.go`<br>`internal/extractors/javascript/external_service.go`<br>`internal/extractors/javascript/external_service_test.go`<br>`internal/extractors/python/external_service.go`<br>`internal/extractors/python/external_service_test.go`<br>`internal/types/kinds.go` | #3628 area: SDK-LEVEL named third-party integration detection, distinct from raw HTTP-client CONSUMES_API (path-level). Each language extractor emits a DEPENDS_ON_SERVICE edge from the calling function/method to a synthetic SCOPE.ExternalService node (Name "service:<name>") so every call site of a service converges on ONE node and the graph answers "what third-party services does this codebase integrate with, and where?". The shared dictionary + node/edge builders live in internal/extractor/external_service.go (ServiceForImportSource, AWSServiceFromArg, ExternalServiceEntity, ExternalServiceTargetID, EmitServiceDependencyEdges). Service dictionary covers stripe, twilio, sendgrid, openai, slack, sentry, firebase, algolia, and the AWS family (aws-s3/ses/sns/sqs/dynamodb/lambda/... via boto3 client/resource literal arg or @aws-sdk v3 client class name). Python pass (internal/extractors/python/external_service.go): import-gated attribute-chain + from-import constructor detection; AWS service resolved from the boto3.client/resource string literal. JS/TS pass (internal/extractors/javascript/external_service.go): import-gated `new Stripe()` + local-var-back-reference (stripe.charges.create), default-import receiver (sgMail.send), namespace init (Sentry.init), @aws-sdk client-class -> aws-<svc>. Optional `operation` edge property records the SDK call. PRECISION-FIRST / honest-partial: a dynamic boto3 service string -> aws-generic; an unrecognised SDK or a bare .create()/.send() on a non-imported object emits NO edge. PARTIAL because only python + javascript/typescript lanes are implemented (java/go/ruby/php and the long tail of SDKs are future lanes), and recall within a lane is deliberately bounded to import-rooted shapes. DEPLOY-DEFERRED: extractor + kinds land here; live-daemon reindex is a separate coordinated step. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update analysis.integration.third-party-sdk ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -44,6 +44,21 @@
       }
     },
     {
+      "id": "analysis.integration.third-party-sdk",
+      "category": "platform",
+      "language": "multi",
+      "label": "Third-party SDK service dependencies (DEPENDS_ON_SERVICE)",
+      "capabilities": {
+        "external_service_dependency": {
+          "status": "partial",
+          "cites": ["internal/extractor/external_service.go","internal/extractor/external_service_test.go","internal/extractors/javascript/external_service.go","internal/extractors/javascript/external_service_test.go","internal/extractors/python/external_service.go","internal/extractors/python/external_service_test.go","internal/types/kinds.go"],
+          "issue": "3628",
+          "notes": "#3628 area: SDK-LEVEL named third-party integration detection, distinct from raw HTTP-client CONSUMES_API (path-level). Each language extractor emits a DEPENDS_ON_SERVICE edge from the calling function/method to a synthetic SCOPE.ExternalService node (Name \"service:\u003cname\u003e\") so every call site of a service converges on ONE node and the graph answers \"what third-party services does this codebase integrate with, and where?\". The shared dictionary + node/edge builders live in internal/extractor/external_service.go (ServiceForImportSource, AWSServiceFromArg, ExternalServiceEntity, ExternalServiceTargetID, EmitServiceDependencyEdges). Service dictionary covers stripe, twilio, sendgrid, openai, slack, sentry, firebase, algolia, and the AWS family (aws-s3/ses/sns/sqs/dynamodb/lambda/... via boto3 client/resource literal arg or @aws-sdk v3 client class name). Python pass (internal/extractors/python/external_service.go): import-gated attribute-chain + from-import constructor detection; AWS service resolved from the boto3.client/resource string literal. JS/TS pass (internal/extractors/javascript/external_service.go): import-gated `new Stripe()` + local-var-back-reference (stripe.charges.create), default-import receiver (sgMail.send), namespace init (Sentry.init), @aws-sdk client-class -\u003e aws-\u003csvc\u003e. Optional `operation` edge property records the SDK call. PRECISION-FIRST / honest-partial: a dynamic boto3 service string -\u003e aws-generic; an unrecognised SDK or a bare .create()/.send() on a non-imported object emits NO edge. PARTIAL because only python + javascript/typescript lanes are implemented (java/go/ruby/php and the long tail of SDKs are future lanes), and recall within a lane is deliberately bounded to import-rooted shapes. DEPLOY-DEFERRED: extractor + kinds land here; live-daemon reindex is a separate coordinated step.",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "api-spec.openapi-ingestion",
       "category": "protocol",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 150
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 151
 
 ## Coverage by language
 
@@ -33,14 +33,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 12 | 0 | 8 | 4 |
-| [Platform / k8s](by-category/platform.md) | 31 | 20 | 11 | 0 |
+| [Platform / k8s](by-category/platform.md) | 32 | 20 | 12 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 21 | 9 | 10 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 11 | 4 | 4 | 3 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 110 | 41 | 42 | 27 |
+| **Total** | 111 | 41 | 43 | 27 |
 
 ## Languages with extractor support, no records yet
 
@@ -68,4 +68,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 224 frameworks · 111 tools · 155 ORMs · 150 other
+Total: 224 frameworks · 111 tools · 155 ORMs · 151 other

--- a/internal/extractor/external_service.go
+++ b/internal/extractor/external_service.go
@@ -1,0 +1,297 @@
+package extractor
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// external_service.go — shared, cross-language helpers for the third-party
+// integration topology (epic #3628). It mirrors the config-key model in
+// config_key.go and the exception-type model in exception_flow.go.
+//
+// The capability answers one question a rewrite (or an architecture review)
+// needs: "what well-known third-party services does this codebase integrate
+// with via their official SDKs, and where?" — e.g. Stripe, Twilio, SendGrid,
+// AWS S3/SES/SNS/SQS/DynamoDB, OpenAI, Slack, Sentry, Firebase, Algolia.
+//
+// To make every call site of a service converge on ONE graph node, each
+// language extractor emits:
+//
+//   - one SCOPE.ExternalService / subtype="external_service" entity per
+//     distinct normalized service name, with a SYNTHETIC constant SourceFile
+//     (ExternalServiceSourceFile) so EntityRecord.ComputeID (SourceFile+Kind+
+//     Name) collapses the same service across files AND languages into a
+//     single node. A Stripe charge created in billing.py and another in
+//     webhooks.js therefore share one "service:stripe" node, and that node's
+//     inbound-DEPENDS_ON_SERVICE set is the codebase's full Stripe footprint.
+//
+//   - one DEPENDS_ON_SERVICE edge (calling function → service node) carried
+//     as a structural-ref ToID (ExternalServiceTargetID) that the resolver
+//     binds via the byQualifiedName exact-match tier (the entity's
+//     QualifiedName is set equal to that ToID).
+//
+// Precision-first / honest-partial: this is SDK-level (NAMED services), NOT
+// raw HTTP-client path extraction (CONSUMES_API). An edge is emitted only when
+// the SDK import/symbol context is recognised — never on a bare `.create()` /
+// `.send()` on an unknown object. A dynamic boto3 service string
+// (`boto3.client(svc_var)`) maps to the generic "aws-generic" service; an
+// unrecognised SDK is skipped. The detection of these shapes lives in each
+// language extractor; this file owns the SERVICE DICTIONARY plus the node/edge
+// construction so the convergence invariant is identical everywhere.
+
+// ExternalServiceSourceFile is the synthetic, constant SourceFile assigned to
+// every external-service entity so identical service names converge to a
+// single graph node under EntityRecord.ComputeID (SourceFile+Kind+Name).
+const ExternalServiceSourceFile = "<external-service>"
+
+// Canonical service names. Centralised so language extractors and tests refer
+// to one source of truth; the AWS family keeps the `aws-<svc>` shape and
+// AWSGeneric is the honest-partial fallback for a dynamic boto3 service arg.
+const (
+	ServiceStripe       = "stripe"
+	ServiceTwilio       = "twilio"
+	ServiceSendGrid     = "sendgrid"
+	ServiceOpenAI       = "openai"
+	ServiceSlack        = "slack"
+	ServiceSentry       = "sentry"
+	ServiceFirebase     = "firebase"
+	ServiceAlgolia      = "algolia"
+	ServiceAWSGeneric   = "aws-generic"
+	awsServicePrefix    = "aws-"
+	externalServiceName = "service:"
+)
+
+// ExternalServiceName returns the canonical entity Name for a service. The
+// "service:" prefix namespaces the node so it never collides with a same-named
+// code symbol, e.g. "service:stripe", "service:aws-s3".
+func ExternalServiceName(service string) string {
+	return externalServiceName + service
+}
+
+// ExternalServiceTargetID returns the structural-ref ToID for a
+// DEPENDS_ON_SERVICE edge pointing at a service entity. Shape:
+//
+//	scope:externalservice:<service>
+//
+// This value is ALSO stored as the service entity's QualifiedName, so the
+// resolver's byQualifiedName exact-match tier (internal/resolve/refs.go) binds
+// the edge to that entity without any new linker code. Constant across
+// languages so a Python `stripe.Charge.create()` and a JS `stripe.charges.
+// create()` resolve to the same node.
+func ExternalServiceTargetID(service string) string {
+	return "scope:externalservice:" + service
+}
+
+// AWSServiceFromArg maps a literal AWS service string (the first arg to
+// boto3.client/resource or an aws-sdk client name) to the canonical
+// "aws-<svc>" service name, or "" if the token is not a recognised AWS
+// service. Only the curated, common set is recognised — precision over recall.
+//
+//	"s3"        -> "aws-s3"
+//	"ses"       -> "aws-ses"
+//	"sns"       -> "aws-sns"
+//	"sqs"       -> "aws-sqs"
+//	"dynamodb"  -> "aws-dynamodb"
+func AWSServiceFromArg(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	// Strip surrounding quotes left by a literal-string token.
+	s = strings.Trim(s, "'\"`")
+	switch s {
+	case "s3", "ses", "sesv2", "sns", "sqs", "dynamodb", "lambda", "kinesis",
+		"secretsmanager", "ssm", "cloudwatch", "kms", "eventbridge", "events":
+		if s == "sesv2" {
+			return awsServicePrefix + "ses"
+		}
+		if s == "events" {
+			return awsServicePrefix + "eventbridge"
+		}
+		return awsServicePrefix + s
+	}
+	return ""
+}
+
+// ServiceForImportSource maps an SDK import source module / package to its
+// canonical service name, or "" if the import is not a recognised
+// external-service SDK. This is the IMPORT side of the dictionary: it gates
+// symbol-based detection so a bare local `stripe` variable that was never
+// imported from the `stripe` package never fabricates an edge.
+//
+// Matching is by the leading dotted/slashed segment so submodules resolve too
+// (`twilio.rest` -> twilio, `@slack/web-api` -> slack, `firebase-admin/
+// firestore` -> firebase).
+func ServiceForImportSource(source string) string {
+	s := strings.ToLower(strings.TrimSpace(source))
+	s = strings.Trim(s, "'\"`")
+	if s == "" {
+		return ""
+	}
+	// Normalise separators and take the first meaningful segment(s).
+	s = strings.ReplaceAll(s, "\\", "/")
+	// Scoped npm package: keep "@scope/pkg" as the lookup key, else first seg.
+	var head string
+	switch {
+	case strings.HasPrefix(s, "@"):
+		parts := strings.SplitN(s, "/", 3)
+		if len(parts) >= 2 {
+			head = parts[0] + "/" + parts[1]
+		} else {
+			head = s
+		}
+	default:
+		// take first path/dotted segment
+		seg := s
+		if i := strings.IndexAny(seg, "/."); i >= 0 {
+			seg = seg[:i]
+		}
+		head = seg
+	}
+	// AWS SDK v3 ships one package per service under the @aws-sdk scope
+	// (@aws-sdk/client-s3, @aws-sdk/client-ses, …). Recognise the scope and let
+	// the caller derive the concrete service from the client constructor name.
+	if strings.HasPrefix(head, "@aws-sdk/") || head == "@aws-sdk" {
+		return awsServicePrefix
+	}
+	switch head {
+	case "stripe":
+		return ServiceStripe
+	case "twilio":
+		return ServiceTwilio
+	case "sendgrid", "@sendgrid/mail", "@sendgrid/client":
+		return ServiceSendGrid
+	case "openai":
+		return ServiceOpenAI
+	case "slack_sdk", "slackclient", "@slack/web-api", "@slack/bolt":
+		return ServiceSlack
+	case "sentry_sdk", "@sentry/node", "@sentry/browser", "@sentry/react", "sentry":
+		return ServiceSentry
+	case "firebase_admin", "firebase-admin", "firebase", "@firebase/app":
+		return ServiceFirebase
+	case "algoliasearch":
+		return ServiceAlgolia
+	case "boto3", "botocore", "@aws-sdk", "aws-sdk":
+		// AWS is recognised at import time but the concrete service requires
+		// the client/service-name argument; callers use AWSServiceFromArg.
+		return awsServicePrefix // sentinel "aws-" meaning "AWS, service TBD"
+	}
+	return ""
+}
+
+// IsAWSImportSentinel reports whether ServiceForImportSource returned the bare
+// "aws-" sentinel — meaning the import is an AWS SDK but the concrete service
+// must still be resolved from the client/service-name argument.
+func IsAWSImportSentinel(service string) bool {
+	return service == awsServicePrefix
+}
+
+// ExternalServiceEntity builds the SCOPE.ExternalService / external_service
+// entity for a single normalized service name. The entity is deliberately
+// file-agnostic (synthetic SourceFile) so it is the shared integration
+// convergence node, and its QualifiedName equals the edge ToID so
+// DEPENDS_ON_SERVICE edges resolve via byQualifiedName.
+func ExternalServiceEntity(service, lang string) types.EntityRecord {
+	e := types.EntityRecord{
+		Name:          ExternalServiceName(service),
+		QualifiedName: ExternalServiceTargetID(service),
+		Kind:          string(types.EntityKindExternalService),
+		Subtype:       "external_service",
+		Language:      lang,
+		SourceFile:    ExternalServiceSourceFile,
+		StartLine:     1,
+		EndLine:       1,
+		Signature:     ExternalServiceName(service),
+		Properties: map[string]string{
+			"service": service,
+		},
+	}
+	if vendor := serviceVendor(service); vendor != "" {
+		e.Properties["vendor"] = vendor
+	}
+	e.ID = e.ComputeID()
+	return e
+}
+
+// serviceVendor returns the umbrella vendor for a service ("aws" for the
+// aws-* family) or "" when the service IS the vendor.
+func serviceVendor(service string) string {
+	if strings.HasPrefix(service, awsServicePrefix) {
+		return "aws"
+	}
+	return ""
+}
+
+// ServiceCall is one resolved external-service SDK call detected by a language
+// extractor: the canonical service name, the Name of the enclosing function/
+// method, and the optional operation token (e.g. "charges.create",
+// "put_object") captured for the edge property.
+type ServiceCall struct {
+	Service   string // canonical service name (stripe, aws-s3, ...)
+	FromName  string // enclosing function/method Name; "" => file entity
+	Operation string // optional SDK operation, e.g. "charges.create"
+}
+
+// EmitServiceDependencyEdges appends, to *entities, the external-service
+// entities and DEPENDS_ON_SERVICE edges for the given detections.
+//
+// entities[0] MUST be the file entity (every language extractor appends it
+// first). Edges whose FromName is "" — or whose FromName has no matching host
+// entity — attach to the file entity (index 0) as a conservative fallback so
+// the edge is never silently dropped. Identical service names converge to one
+// service entity (deduped by name) and one edge per (FromName, service) tuple
+// (the first operation seen for that tuple wins).
+//
+// Returns the number of DEPENDS_ON_SERVICE edges emitted. Safe with nil/empty
+// input. Detections whose Service is empty are skipped — precision over recall.
+func EmitServiceDependencyEdges(entities *[]types.EntityRecord, lang string, calls []ServiceCall) int {
+	if entities == nil || len(*entities) == 0 || len(calls) == 0 {
+		return 0
+	}
+
+	hostByName := map[string]int{}
+	for i := range *entities {
+		hostByName[(*entities)[i].Name] = i
+	}
+
+	seenEdge := map[string]bool{}
+	seenSvc := map[string]bool{}
+	var newEntities []types.EntityRecord
+	emitted := 0
+
+	for _, c := range calls {
+		service := strings.TrimSpace(c.Service)
+		if service == "" || service == awsServicePrefix {
+			continue // unresolved / sentinel — drop
+		}
+
+		hostIdx := 0 // file entity by default
+		if c.FromName != "" {
+			if idx, ok := hostByName[c.FromName]; ok {
+				hostIdx = idx
+			}
+		}
+
+		edgeKey := c.FromName + "\x00" + service
+		if !seenEdge[edgeKey] {
+			seenEdge[edgeKey] = true
+			props := map[string]string{"service": service}
+			if c.Operation != "" {
+				props["operation"] = c.Operation
+			}
+			(*entities)[hostIdx].Relationships = append((*entities)[hostIdx].Relationships,
+				types.RelationshipRecord{
+					ToID:       ExternalServiceTargetID(service),
+					Kind:       string(types.RelationshipKindDependsOnService),
+					Properties: props,
+				})
+			emitted++
+		}
+
+		if !seenSvc[service] {
+			seenSvc[service] = true
+			newEntities = append(newEntities, ExternalServiceEntity(service, lang))
+		}
+	}
+
+	*entities = append(*entities, newEntities...)
+	return emitted
+}

--- a/internal/extractor/external_service_test.go
+++ b/internal/extractor/external_service_test.go
@@ -1,0 +1,114 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestServiceForImportSource(t *testing.T) {
+	cases := map[string]string{
+		"stripe":             ServiceStripe,
+		"twilio.rest":        ServiceTwilio,
+		"@sendgrid/mail":     ServiceSendGrid,
+		"openai":             ServiceOpenAI,
+		"@slack/web-api":     ServiceSlack,
+		"slack_sdk":          ServiceSlack,
+		"@sentry/node":       ServiceSentry,
+		"firebase-admin":     ServiceFirebase,
+		"algoliasearch":      ServiceAlgolia,
+		"boto3":              awsServicePrefix, // sentinel
+		"@aws-sdk/client-s3": awsServicePrefix, // sentinel
+		"express":            "",               // not an external service
+		"./local/util":       "",
+	}
+	for in, want := range cases {
+		if got := ServiceForImportSource(in); got != want {
+			t.Errorf("ServiceForImportSource(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAWSServiceFromArg(t *testing.T) {
+	cases := map[string]string{
+		`"s3"`:      "aws-s3",
+		"ses":       "aws-ses",
+		"sesv2":     "aws-ses",
+		"sns":       "aws-sns",
+		"sqs":       "aws-sqs",
+		"dynamodb":  "aws-dynamodb",
+		"events":    "aws-eventbridge",
+		"frobulate": "", // unknown service → drop
+	}
+	for in, want := range cases {
+		if got := AWSServiceFromArg(in); got != want {
+			t.Errorf("AWSServiceFromArg(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestEmitServiceDependencyEdges_Converge: two calls to the same service from
+// different functions produce ONE service node and one edge each.
+func TestEmitServiceDependencyEdges_Converge(t *testing.T) {
+	entities := []types.EntityRecord{
+		{Name: "file.py", Kind: string(types.EntityKindOperation)},
+		{Name: "charge", Kind: string(types.EntityKindFunction)},
+		{Name: "refund", Kind: string(types.EntityKindFunction)},
+	}
+	calls := []ServiceCall{
+		{Service: ServiceStripe, FromName: "charge", Operation: "Charge.create"},
+		{Service: ServiceStripe, FromName: "refund", Operation: "Refund.create"},
+	}
+	n := EmitServiceDependencyEdges(&entities, "python", calls)
+	if n != 2 {
+		t.Fatalf("emitted %d edges, want 2", n)
+	}
+	// Exactly one stripe service entity appended.
+	svcCount := 0
+	for i := range entities {
+		if entities[i].Kind == string(types.EntityKindExternalService) {
+			svcCount++
+			if entities[i].QualifiedName != ExternalServiceTargetID(ServiceStripe) {
+				t.Errorf("service QualifiedName = %q, want %q",
+					entities[i].QualifiedName, ExternalServiceTargetID(ServiceStripe))
+			}
+		}
+	}
+	if svcCount != 1 {
+		t.Errorf("expected 1 service node, got %d", svcCount)
+	}
+	// Edge targets converge on the same ToID.
+	want := ExternalServiceTargetID(ServiceStripe)
+	for _, name := range []string{"charge", "refund"} {
+		found := false
+		for i := range entities {
+			if entities[i].Name != name {
+				continue
+			}
+			for _, r := range entities[i].Relationships {
+				if r.Kind == string(types.RelationshipKindDependsOnService) && r.ToID == want {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("missing DEPENDS_ON_SERVICE(%s -> stripe)", name)
+		}
+	}
+}
+
+// TestEmitServiceDependencyEdges_DropsSentinelAndEmpty: the bare "aws-"
+// sentinel and empty services never produce an edge.
+func TestEmitServiceDependencyEdges_DropsSentinelAndEmpty(t *testing.T) {
+	entities := []types.EntityRecord{
+		{Name: "file.py", Kind: string(types.EntityKindOperation)},
+		{Name: "f", Kind: string(types.EntityKindFunction)},
+	}
+	calls := []ServiceCall{
+		{Service: awsServicePrefix, FromName: "f"},
+		{Service: "", FromName: "f"},
+	}
+	if n := EmitServiceDependencyEdges(&entities, "python", calls); n != 0 {
+		t.Fatalf("emitted %d edges, want 0 (sentinel + empty dropped)", n)
+	}
+}

--- a/internal/extractors/javascript/external_service.go
+++ b/internal/extractors/javascript/external_service.go
@@ -1,0 +1,233 @@
+// external_service.go — supplemental pass that emits DEPENDS_ON_SERVICE edges
+// from JS/TS functions / methods to a shared SCOPE.ExternalService node (epic
+// #3628). It lets the graph answer "what third-party services does this
+// codebase integrate with, and where?" — SDK-level, NAMED services (Stripe,
+// Twilio, SendGrid, AWS S3/SES/SNS/SQS/DynamoDB, OpenAI, Slack, Sentry,
+// Firebase, Algolia), distinct from raw HTTP-client CONSUMES_API.
+//
+// Detected shapes (import-gated — honest-partial, precision-first):
+//
+//	import Stripe from "stripe";
+//	const stripe = new Stripe(key); stripe.charges.create(...)  → stripe
+//	import sgMail from "@sendgrid/mail"; sgMail.send(...)        → sendgrid
+//	import { S3Client } from "@aws-sdk/client-s3";
+//	const c = new S3Client(...); c.send(cmd)                     → aws-s3
+//	import { WebClient } from "@slack/web-api"; new WebClient()  → slack
+//	import * as Sentry from "@sentry/node"; Sentry.init(...)     → sentry
+//
+// Recognition is rooted at the SDK IMPORT, two ways:
+//
+//  1. A `new <Ctor>(...)` where <Ctor> is (or was imported from) a recognised
+//     SDK module. The variable it is assigned to is remembered so subsequent
+//     method calls on that variable (`stripe.charges.create()`) attribute back
+//     to the same service.
+//  2. A call whose receiver-root identifier IS an imported SDK binding
+//     (`sgMail.send()`, `Sentry.init()`).
+//
+// Intentionally DROPPED: a `.create()` / `.send()` on a non-SDK object, or a
+// `new X()` whose class is not an SDK import.
+//
+// All node/edge construction lives in extractor.EmitServiceDependencyEdges; the
+// SERVICE DICTIONARY lives in extractor.ServiceForImportSource /
+// AWSServiceFromArg.
+
+package javascript
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// emitServiceDependencyEdges scans the AST for SDK construction / call shapes
+// rooted at a recognised external-service import and appends external-service
+// entities + DEPENDS_ON_SERVICE edges to x.entities. x.entities[0] MUST be the
+// file entity. Safe with an empty tree or no imports.
+func (x *extractor) emitServiceDependencyEdges(root *sitter.Node) {
+	if root == nil || len(x.entities) == 0 || len(x.importByLocal) == 0 {
+		return
+	}
+
+	// localVarService maps a local variable name to the service its value was
+	// constructed from (`const stripe = new Stripe(...)` → "stripe"). Populated
+	// as we walk so later `stripe.charges.create()` calls attribute correctly.
+	localVarService := map[string]string{}
+
+	var calls []extreg.ServiceCall
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "function_declaration", "generator_function_declaration":
+			enclosing = x.nodeText(n.ChildByFieldName("name"))
+		case "method_definition":
+			enclosing = x.nodeText(n.ChildByFieldName("name"))
+		case "variable_declarator":
+			// const <name> = new <SDKCtor>(...) — remember the binding.
+			nameNode := n.ChildByFieldName("name")
+			valNode := n.ChildByFieldName("value")
+			if nameNode != nil && valNode != nil {
+				switch valNode.Type() {
+				case "arrow_function", "function", "function_expression":
+					enclosing = x.nodeText(nameNode)
+				case "new_expression":
+					if svc, op := x.jsNewExpressionService(valNode); svc != "" {
+						localVarService[x.nodeText(nameNode)] = svc
+						calls = append(calls, extreg.ServiceCall{
+							Service: svc, FromName: enclosing, Operation: op,
+						})
+					}
+				}
+			}
+		case "new_expression":
+			// A `new <SDKCtor>(...)` not captured by a declarator (e.g. used
+			// inline) still signals an integration.
+			if n.Parent() == nil || n.Parent().Type() != "variable_declarator" {
+				if svc, op := x.jsNewExpressionService(n); svc != "" {
+					calls = append(calls, extreg.ServiceCall{
+						Service: svc, FromName: enclosing, Operation: op,
+					})
+				}
+			}
+		case "call_expression":
+			if svc, op := x.jsCallService(n, localVarService); svc != "" {
+				calls = append(calls, extreg.ServiceCall{
+					Service: svc, FromName: enclosing, Operation: op,
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extreg.EmitServiceDependencyEdges(&x.entities, x.language, calls)
+}
+
+// jsNewExpressionService resolves `new <Ctor>(...)` to a service name when
+// <Ctor> is (or was imported from) a recognised SDK module. Returns the service
+// and an operation token ("new <Ctor>"), or "" when not an SDK constructor.
+//
+// For AWS client constructors (`new S3Client(...)`, `new SESClient(...)`) the
+// service is derived from the constructor name suffix, since aws-sdk v3 names
+// the service in the class.
+func (x *extractor) jsNewExpressionService(newNode *sitter.Node) (string, string) {
+	ctor := newNode.ChildByFieldName("constructor")
+	if ctor == nil {
+		return "", ""
+	}
+	rootName := ""
+	switch ctor.Type() {
+	case "identifier", "type_identifier":
+		rootName = x.nodeText(ctor)
+	case "member_expression":
+		// new AWS.S3() / new mod.Stripe()
+		if obj := ctor.ChildByFieldName("object"); obj != nil && obj.Type() == "identifier" {
+			rootName = x.nodeText(obj)
+		}
+		if prop := ctor.ChildByFieldName("property"); prop != nil {
+			if svc := awsServiceFromCtorName(x.nodeText(prop)); svc != "" {
+				if x.importedServiceRoot(rootName) != "" {
+					return svc, "new " + x.nodeText(prop)
+				}
+			}
+		}
+	default:
+		return "", ""
+	}
+	if rootName == "" {
+		return "", ""
+	}
+	// AWS v3 client classes (S3Client, SESClient, …) — service from class name.
+	if svc := awsServiceFromCtorName(rootName); svc != "" {
+		if b, ok := x.importByLocal[rootName]; ok && extreg.IsAWSImportSentinel(extreg.ServiceForImportSource(b.importPath)) {
+			return svc, "new " + rootName
+		}
+	}
+	// Non-AWS SDK default/named import (`new Stripe`, `new WebClient`, …).
+	if svc := x.importedServiceRoot(rootName); svc != "" && !extreg.IsAWSImportSentinel(svc) {
+		return svc, "new " + rootName
+	}
+	return "", ""
+}
+
+// jsCallService resolves a call_expression to a service when its receiver root
+// is either a known SDK import binding (`sgMail.send`, `Sentry.init`) or a
+// local variable previously constructed from an SDK (`stripe.charges.create`).
+// Returns the service and the dotted operation tail, or "" when no SDK root.
+func (x *extractor) jsCallService(call *sitter.Node, localVarService map[string]string) (string, string) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return "", ""
+	}
+	root, tail := x.jsMemberRootAndTail(fn)
+	if root == "" {
+		return "", ""
+	}
+	// Local variable constructed from an SDK?
+	if svc, ok := localVarService[root]; ok {
+		return svc, tail
+	}
+	// Direct SDK import binding used as the receiver root?
+	if svc := x.importedServiceRoot(root); svc != "" && !extreg.IsAWSImportSentinel(svc) {
+		return svc, tail
+	}
+	return "", ""
+}
+
+// importedServiceRoot returns the canonical service name for a local identifier
+// that is bound to a recognised external-service import, or "" otherwise. AWS
+// imports return the bare "aws-" sentinel (caller resolves the concrete
+// service from the constructor / client name).
+func (x *extractor) importedServiceRoot(local string) string {
+	if local == "" {
+		return ""
+	}
+	b, ok := x.importByLocal[local]
+	if !ok {
+		return ""
+	}
+	return extreg.ServiceForImportSource(b.importPath)
+}
+
+// jsMemberRootAndTail flattens a member_expression into its ROOT identifier and
+// the dotted property tail. For `stripe.charges.create` it returns ("stripe",
+// "charges.create"); for `sgMail.send` it returns ("sgMail", "send"). Returns
+// ("", "") when the chain does not root at a plain identifier.
+func (x *extractor) jsMemberRootAndTail(member *sitter.Node) (string, string) {
+	var parts []string
+	node := member
+	for node != nil && node.Type() == "member_expression" {
+		prop := node.ChildByFieldName("property")
+		if prop == nil {
+			return "", ""
+		}
+		parts = append([]string{x.nodeText(prop)}, parts...)
+		node = node.ChildByFieldName("object")
+	}
+	if node == nil || node.Type() != "identifier" {
+		return "", ""
+	}
+	return x.nodeText(node), strings.Join(parts, ".")
+}
+
+// awsServiceFromCtorName maps an aws-sdk v3 client class name to the canonical
+// aws-<svc> service, or "" when the name is not a recognised AWS client class.
+//
+//	"S3Client"        -> "aws-s3"
+//	"SESClient"       -> "aws-ses"
+//	"SNSClient"       -> "aws-sns"
+//	"SQSClient"       -> "aws-sqs"
+//	"DynamoDBClient"  -> "aws-dynamodb"
+//	"S3"              -> "aws-s3"     (aws-sdk v2 service class)
+func awsServiceFromCtorName(name string) string {
+	n := strings.TrimSpace(name)
+	n = strings.TrimSuffix(n, "Client")
+	return extreg.AWSServiceFromArg(n)
+}

--- a/internal/extractors/javascript/external_service_test.go
+++ b/internal/extractors/javascript/external_service_test.go
@@ -1,0 +1,157 @@
+package javascript_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func jsSvcEdge(recs []types.EntityRecord, fromName, service string) bool {
+	want := extreg.ExternalServiceTargetID(service)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindDependsOnService) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jsSvcNode(recs []types.EntityRecord, service string) (string, int) {
+	want := extreg.ExternalServiceName(service)
+	id, count := "", 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExternalService) && recs[i].Name == want {
+			id = recs[i].ID
+			count++
+		}
+	}
+	return id, count
+}
+
+// TestJSService_StripeConstructThenCall: `new Stripe(key)` + `stripe.charges.
+// create()` resolves the local var back to the stripe service.
+func TestJSService_StripeConstructThenCall(t *testing.T) {
+	src := []byte(`import Stripe from "stripe";
+
+function pay(amount) {
+  const stripe = new Stripe("sk_test");
+  return stripe.charges.create({ amount });
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+
+	if !jsSvcEdge(recs, "pay", "stripe") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(pay -> stripe)")
+	}
+	if id, n := jsSvcNode(recs, "stripe"); id == "" || n != 1 {
+		t.Errorf("expected exactly 1 stripe node, got id=%q n=%d", id, n)
+	}
+}
+
+// TestJSService_SendGrid: a default-import receiver call `sgMail.send()`.
+func TestJSService_SendGrid(t *testing.T) {
+	src := []byte(`import sgMail from "@sendgrid/mail";
+
+function email(to) {
+  return sgMail.send({ to, subject: "hi" });
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsSvcEdge(recs, "email", "sendgrid") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(email -> sendgrid)")
+	}
+}
+
+// TestJSService_AWSS3Client: `new S3Client()` from @aws-sdk → aws-s3.
+func TestJSService_AWSS3Client(t *testing.T) {
+	src := []byte(`import { S3Client } from "@aws-sdk/client-s3";
+
+function upload() {
+  const client = new S3Client({});
+  return client;
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsSvcEdge(recs, "upload", "aws-s3") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(upload -> aws-s3)")
+	}
+	if id, _ := jsSvcNode(recs, "aws-s3"); id == "" {
+		t.Errorf("missing SCOPE.ExternalService:aws-s3 node")
+	}
+}
+
+// TestJSService_SentryNamespaceInit: `import * as Sentry` + `Sentry.init()`.
+func TestJSService_SentryNamespaceInit(t *testing.T) {
+	src := []byte(`import * as Sentry from "@sentry/node";
+
+function boot() {
+  Sentry.init({ dsn: "x" });
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsSvcEdge(recs, "boot", "sentry") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(boot -> sentry)")
+	}
+}
+
+// TestJSService_Convergence: two functions, one Stripe node.
+func TestJSService_Convergence(t *testing.T) {
+	src := []byte(`import Stripe from "stripe";
+
+function chargeIt() {
+  const s = new Stripe("k");
+  return s.charges.create({});
+}
+
+function refundIt() {
+  const s = new Stripe("k");
+  return s.refunds.create({});
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsSvcEdge(recs, "chargeIt", "stripe") || !jsSvcEdge(recs, "refundIt", "stripe") {
+		t.Fatalf("both functions must depend on stripe")
+	}
+	if _, n := jsSvcNode(recs, "stripe"); n != 1 {
+		t.Errorf("expected exactly 1 stripe node, got %d", n)
+	}
+}
+
+// TestJSService_NonSDKReceiver_NoEdge: `.create()` on a non-SDK local object
+// must NOT emit an edge.
+func TestJSService_NonSDKReceiver_NoEdge(t *testing.T) {
+	src := []byte(`function handler(repo) {
+  return repo.charges.create({ amount: 10 });
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindDependsOnService) {
+				t.Fatalf("unexpected DEPENDS_ON_SERVICE on non-SDK receiver: %s -> %s",
+					recs[i].Name, r.ToID)
+			}
+		}
+	}
+}
+
+// TestTSService_Stripe: same flow under the TypeScript grammar.
+func TestTSService_Stripe(t *testing.T) {
+	src := []byte(`import Stripe from "stripe";
+
+function pay(amount: number) {
+  const stripe = new Stripe("sk");
+  return stripe.charges.create({ amount });
+}
+`)
+	recs := extract(t, src, "typescript", parseTS(t, src))
+	if !jsSvcEdge(recs, "pay", "stripe") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(pay -> stripe) [typescript]")
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -341,6 +341,17 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		x.emitExceptionFlowEdges(root)
 	}()
 
+	// Third-party integration topology (epic #3628) — DEPENDS_ON_SERVICE edges
+	// from functions/methods to a shared SCOPE.ExternalService node for
+	// recognised SDK construction / call shapes (new Stripe(); stripe.charges.
+	// create(); sgMail.send(); new S3Client().send()). Import-gated and
+	// precision-first: non-SDK receivers emit no edge. Runs after walk so
+	// enclosing entities exist.
+	func() {
+		defer func() { _ = recover() }()
+		x.emitServiceDependencyEdges(root)
+	}()
+
 	// Third pass (#713): platform-variant and test-file relationship emission.
 	// Detects React Native platform-specific file naming (.ios.tsx,
 	// .android.tsx, .tablet.tsx, …) and emits PLATFORM_VARIANT_OF edges.

--- a/internal/extractors/python/external_service.go
+++ b/internal/extractors/python/external_service.go
@@ -1,0 +1,250 @@
+// external_service.go — supplemental pass that emits DEPENDS_ON_SERVICE edges
+// from Python functions / methods to a shared SCOPE.ExternalService node (epic
+// #3628). It lets the graph answer "what third-party services does this
+// codebase integrate with, and where?" — SDK-level, NAMED services (Stripe,
+// Twilio, SendGrid, AWS S3/SES/SNS/SQS/DynamoDB, OpenAI, Slack, Sentry,
+// Firebase, Algolia), distinct from raw HTTP-client CONSUMES_API.
+//
+// Detected shapes (import-gated — honest-partial, precision-first):
+//
+//	import stripe; stripe.Charge.create(...)      → stripe   op "Charge.create"
+//	import boto3;  boto3.client("s3").put_object  → aws-s3   op "put_object"
+//	import boto3;  boto3.resource("dynamodb")     → aws-dynamodb
+//	from twilio.rest import Client; Client(...)   → twilio
+//	import sendgrid; sendgrid.SendGridAPIClient() → sendgrid
+//	import openai; openai.ChatCompletion.create() → openai   op "ChatCompletion.create"
+//	from slack_sdk import WebClient; WebClient()  → slack
+//	import sentry_sdk; sentry_sdk.init(...)       → sentry
+//
+// Intentionally DROPPED (would mislead integration analysis):
+//
+//	boto3.client(service_var)                     dynamic service arg → aws-generic
+//	a local `.create()` on a non-SDK object       (receiver not an SDK import)
+//
+// All node/edge construction (convergence on one node per service via a
+// synthetic SourceFile) lives in extractor.EmitServiceDependencyEdges; the
+// SERVICE DICTIONARY lives in extractor.ServiceForImportSource /
+// AWSServiceFromArg.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitServiceDependencyEdges scans every function / method body for SDK call
+// shapes rooted at a recognised external-service import and appends
+// external-service entities + DEPENDS_ON_SERVICE edges.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input. SDK calls at module scope attach to the file entity.
+func emitServiceDependencyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	imports := buildPythonImportMap(root, file)
+	if len(imports) == 0 {
+		return // no imports → nothing SDK-rooted can exist
+	}
+	src := file.Content
+
+	var calls []extractor.ServiceCall
+
+	var stack []string
+	current := func() string {
+		if len(stack) == 0 {
+			return ""
+		}
+		return stack[len(stack)-1]
+	}
+
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			cls := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				cls = nodeText(nn, src)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			stack = append(stack, childCls)
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "function_definition":
+			leaf := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				leaf = nodeText(nn, src)
+			}
+			emitted := leaf
+			if parentClass != "" && leaf != "" {
+				emitted = parentClass + "." + leaf
+			}
+			stack = append(stack, emitted)
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), parentClass)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "decorated_definition":
+			if inner := n.ChildByFieldName("definition"); inner != nil {
+				walk(inner, parentClass)
+			}
+			return
+		case "call":
+			if sc, ok := pyServiceCall(n, src, imports, current()); ok {
+				calls = append(calls, sc)
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitServiceDependencyEdges(entities, "python", calls)
+}
+
+// pyServiceCall inspects a `call` node and, when its receiver chain roots at a
+// recognised external-service SDK import, returns the resolved ServiceCall.
+//
+// Two recognition paths:
+//
+//  1. The call's function is an attribute chain (`stripe.Charge.create`,
+//     `boto3.client`, `sentry_sdk.init`) whose ROOT identifier is bound to a
+//     recognised SDK import. The dotted tail after the root becomes the
+//     operation. For AWS the concrete service comes from the first literal
+//     string argument of `client(...)` / `resource(...)`.
+//
+//  2. The call's function is a bare identifier (`Client(...)`,
+//     `WebClient(...)`, `SendGridAPIClient(...)`) that was `from <sdk> import`
+//     -ed from a recognised SDK source module — a constructor invocation.
+//
+// Returns ok=false when no recognised SDK root is found (so non-SDK
+// `.create()` / `.send()` calls never fabricate an edge).
+func pyServiceCall(call *sitter.Node, src []byte, imports pythonImportMap, from string) (extractor.ServiceCall, bool) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return extractor.ServiceCall{}, false
+	}
+
+	switch fn.Type() {
+	case "attribute":
+		root, tail := pyAttributeRootAndTail(fn, src)
+		if root == "" {
+			return extractor.ServiceCall{}, false
+		}
+		binding, ok := imports[root]
+		if !ok {
+			return extractor.ServiceCall{}, false
+		}
+		svc := extractor.ServiceForImportSource(binding.sourceModule)
+		if svc == "" {
+			return extractor.ServiceCall{}, false
+		}
+		if extractor.IsAWSImportSentinel(svc) {
+			// boto3.client("s3") / boto3.resource("dynamodb") — the concrete
+			// AWS service is the first literal string arg. A dynamic arg maps
+			// to aws-generic (honest-partial); an unrecognised literal drops.
+			if tail == "client" || tail == "resource" {
+				resolved := pyAWSServiceFromCall(call, src)
+				return extractor.ServiceCall{Service: resolved, FromName: from, Operation: tail}, resolved != ""
+			}
+			// Other boto3.* calls without an explicit service — generic.
+			return extractor.ServiceCall{Service: extractor.ServiceAWSGeneric, FromName: from, Operation: tail}, true
+		}
+		return extractor.ServiceCall{Service: svc, FromName: from, Operation: tail}, true
+
+	case "identifier":
+		// Constructor / function imported `from <sdk> import <Name>`.
+		name := strings.TrimSpace(nodeText(fn, src))
+		binding, ok := imports[name]
+		if !ok || binding.plainModule {
+			return extractor.ServiceCall{}, false
+		}
+		svc := extractor.ServiceForImportSource(binding.sourceModule)
+		if svc == "" || extractor.IsAWSImportSentinel(svc) {
+			// AWS via `from <x> import` is unusual; require the attribute path.
+			return extractor.ServiceCall{}, false
+		}
+		return extractor.ServiceCall{Service: svc, FromName: from, Operation: name}, true
+	}
+	return extractor.ServiceCall{}, false
+}
+
+// pyAttributeRootAndTail flattens an attribute chain into its ROOT identifier
+// and the dotted tail after it. For `stripe.Charge.create` it returns
+// ("stripe", "Charge.create"); for `boto3.client` it returns ("boto3",
+// "client"). Returns ("", "") when the chain does not root at a plain
+// identifier (e.g. a subscript or call in the middle).
+func pyAttributeRootAndTail(attr *sitter.Node, src []byte) (string, string) {
+	var parts []string
+	node := attr
+	for node != nil && node.Type() == "attribute" {
+		a := node.ChildByFieldName("attribute")
+		if a == nil {
+			return "", ""
+		}
+		parts = append([]string{strings.TrimSpace(nodeText(a, src))}, parts...)
+		node = node.ChildByFieldName("object")
+	}
+	if node == nil || node.Type() != "identifier" {
+		return "", "" // root is not a plain identifier → not an SDK module ref
+	}
+	root := strings.TrimSpace(nodeText(node, src))
+	return root, strings.Join(parts, ".")
+}
+
+// pyAWSServiceFromCall resolves the AWS service from a boto3.client(...) /
+// boto3.resource(...) call: the first positional argument, when a string
+// literal, is mapped via AWSServiceFromArg. A non-literal (dynamic variable)
+// argument yields aws-generic; an unrecognised literal yields "" (drop).
+func pyAWSServiceFromCall(call *sitter.Node, src []byte) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return extractor.ServiceAWSGeneric
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "string":
+			lit := pyStringLiteralValue(a, src)
+			if svc := extractor.AWSServiceFromArg(lit); svc != "" {
+				return svc
+			}
+			return "" // recognised AWS import but unknown service literal → drop
+		case "keyword_argument":
+			// service_name="s3"
+			if v := a.ChildByFieldName("value"); v != nil && v.Type() == "string" {
+				if svc := extractor.AWSServiceFromArg(pyStringLiteralValue(v, src)); svc != "" {
+					return svc
+				}
+			}
+			continue
+		default:
+			// First positional is a dynamic variable → honest-partial generic.
+			return extractor.ServiceAWSGeneric
+		}
+	}
+	return extractor.ServiceAWSGeneric
+}

--- a/internal/extractors/python/external_service_test.go
+++ b/internal/extractors/python/external_service_test.go
@@ -1,0 +1,203 @@
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// svcEdge reports whether the entity Named fromName has a DEPENDS_ON_SERVICE
+// relationship whose ToID targets the given service.
+func svcEdge(recs []types.EntityRecord, fromName, service string) bool {
+	want := extractor.ExternalServiceTargetID(service)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindDependsOnService) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// svcNodeID returns the synthetic service node ID, or "" if absent.
+func svcNodeID(recs []types.EntityRecord, service string) string {
+	want := extractor.ExternalServiceName(service)
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExternalService) && recs[i].Name == want {
+			return recs[i].ID
+		}
+	}
+	return ""
+}
+
+// svcOperation returns the `operation` property on the DEPENDS_ON_SERVICE edge
+// from fromName to service, or "" if absent.
+func svcOperation(recs []types.EntityRecord, fromName, service string) string {
+	want := extractor.ExternalServiceTargetID(service)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindDependsOnService) && r.ToID == want {
+				return r.Properties["operation"]
+			}
+		}
+	}
+	return ""
+}
+
+// TestPyService_Stripe asserts an explicit edge + node id, not just len>0.
+func TestPyService_Stripe(t *testing.T) {
+	src := `import stripe
+
+def pay(amount):
+    return stripe.Charge.create(amount=amount, currency="usd")
+`
+	recs := extractPy(t, src, "billing.py")
+
+	if !svcEdge(recs, "pay", "stripe") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(pay -> stripe)")
+	}
+	if svcNodeID(recs, "stripe") == "" {
+		t.Errorf("missing SCOPE.ExternalService:stripe node")
+	}
+	if op := svcOperation(recs, "pay", "stripe"); op != "Charge.create" {
+		t.Errorf("operation = %q, want Charge.create", op)
+	}
+}
+
+// TestPyService_AWSS3FromLiteral: the AWS service is resolved from the literal
+// arg to boto3.client(...).
+func TestPyService_AWSS3FromLiteral(t *testing.T) {
+	src := `import boto3
+
+def upload(key, body):
+    s3 = boto3.client("s3")
+    return s3.put_object(Key=key, Body=body)
+`
+	recs := extractPy(t, src, "store.py")
+
+	if !svcEdge(recs, "upload", "aws-s3") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(upload -> aws-s3)")
+	}
+	if svcNodeID(recs, "aws-s3") == "" {
+		t.Errorf("missing SCOPE.ExternalService:aws-s3 node")
+	}
+	// Must NOT mis-resolve to aws-generic when a literal is present.
+	if svcEdge(recs, "upload", "aws-generic") {
+		t.Errorf("unexpected aws-generic edge when literal 's3' present")
+	}
+}
+
+// TestPyService_AWSDynamoResource: boto3.resource("dynamodb") → aws-dynamodb.
+func TestPyService_AWSDynamoResource(t *testing.T) {
+	src := `import boto3
+
+def get_table():
+    return boto3.resource("dynamodb")
+`
+	recs := extractPy(t, src, "db.py")
+	if !svcEdge(recs, "get_table", "aws-dynamodb") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(get_table -> aws-dynamodb)")
+	}
+}
+
+// TestPyService_Convergence: two functions using Stripe converge on ONE node.
+func TestPyService_Convergence(t *testing.T) {
+	src := `import stripe
+
+def charge(a):
+    return stripe.Charge.create(amount=a)
+
+def refund(c):
+    return stripe.Refund.create(charge=c)
+`
+	recs := extractPy(t, src, "pay.py")
+
+	if !svcEdge(recs, "charge", "stripe") || !svcEdge(recs, "refund", "stripe") {
+		t.Fatalf("both functions must depend on stripe")
+	}
+	// Exactly one stripe node.
+	n := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExternalService) &&
+			recs[i].Name == extractor.ExternalServiceName("stripe") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected exactly 1 stripe service node, got %d", n)
+	}
+}
+
+// TestPyService_TwilioConstructor: `from twilio.rest import Client; Client(...)`
+// resolves via the import source module.
+func TestPyService_TwilioConstructor(t *testing.T) {
+	src := `from twilio.rest import Client
+
+def notify(sid, token):
+    client = Client(sid, token)
+    return client
+`
+	recs := extractPy(t, src, "sms.py")
+	if !svcEdge(recs, "notify", "twilio") {
+		t.Fatalf("missing DEPENDS_ON_SERVICE(notify -> twilio)")
+	}
+}
+
+// TestPyService_DynamicAWSArg_Generic: a dynamic boto3 service string maps to
+// aws-generic (honest-partial), never a concrete service.
+func TestPyService_DynamicAWSArg_Generic(t *testing.T) {
+	src := `import boto3
+
+def make(svc):
+    return boto3.client(svc)
+`
+	recs := extractPy(t, src, "dyn.py")
+	if !svcEdge(recs, "make", "aws-generic") {
+		t.Fatalf("dynamic boto3.client(svc) should map to aws-generic")
+	}
+	if svcEdge(recs, "make", "aws-s3") {
+		t.Errorf("must not fabricate a concrete aws service from a variable arg")
+	}
+}
+
+// TestPyService_NonSDKReceiver_NoEdge: a local `.create()` on a non-SDK object
+// produces NO edge — the negative invariant.
+func TestPyService_NonSDKReceiver_NoEdge(t *testing.T) {
+	src := `def handler(repo):
+    return repo.charges.create(amount=10)
+
+class Charge:
+    @staticmethod
+    def create(**kw):
+        return kw
+`
+	recs := extractPy(t, src, "local.py")
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindDependsOnService) {
+				t.Fatalf("unexpected DEPENDS_ON_SERVICE edge on non-SDK receiver: %s -> %s",
+					recs[i].Name, r.ToID)
+			}
+		}
+	}
+}
+
+// TestPyService_NoImport_NoEdge: a bare `stripe.Charge.create` with NO stripe
+// import must not fabricate an edge (import-gated).
+func TestPyService_NoImport_NoEdge(t *testing.T) {
+	src := `def pay():
+    return stripe.Charge.create(amount=10)
+`
+	recs := extractPy(t, src, "noimp.py")
+	if svcEdge(recs, "pay", "stripe") {
+		t.Fatalf("emitted stripe edge without a stripe import")
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -334,6 +334,17 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitExceptionFlowEdges(root, file, &entities)
 	}()
 
+	// Epic #3628 — third-party integration pass. Emits DEPENDS_ON_SERVICE
+	// edges from functions/methods to a shared SCOPE.ExternalService node for
+	// recognised SDK call shapes (stripe.Charge.create, boto3.client("s3")…).
+	// Import-gated and precision-first: dynamic / non-SDK receivers emit no
+	// edge. Runs after primary entity emission so enclosing function/method
+	// entities exist to attach edges to.
+	func() {
+		defer func() { _ = recover() }()
+		emitServiceDependencyEdges(root, file, &entities)
+	}()
+
 	// Issue #1884 — supplemental package-module pass (Wave 1).
 	// Emits one Module entity per Python package boundary (__init__.py or
 	// plain .py module) so docgen can seed per-package pages and flow

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -176,6 +176,22 @@ const (
 	// names across files/languages into one node. See
 	// internal/extractor/exception_flow.go.
 	EntityKindExceptionType EntityKind = "SCOPE.ExceptionType"
+
+	// EntityKindExternalService is a synthetic, file-agnostic node representing a
+	// single well-known third-party service a codebase integrates with via its
+	// official SDK — e.g. "stripe", "twilio", "sendgrid", "aws-s3", "aws-ses",
+	// "openai", "slack", "sentry", "firebase", "algolia". It is the convergence
+	// point for the third-party-integration capability (epic #3628): every
+	// function that calls a recognised SDK entry-point gets a DEPENDS_ON_SERVICE
+	// edge to the SAME service node, so the graph answers "what third-party
+	// services does this codebase integrate with, and where?" (a service's
+	// inbound DEPENDS_ON_SERVICE edges are its call sites). Distinct from raw
+	// HTTP-client CONSUMES_API (path-level): this is SDK-level, NAMED services.
+	// Like SCOPE.ExceptionType/SCOPE.Config it carries a constant synthetic
+	// SourceFile (ExternalServiceSourceFile) so EntityRecord.ComputeID
+	// (SourceFile+Kind+Name) collapses the same service across files/languages
+	// into one node. See internal/extractor/external_service.go.
+	EntityKindExternalService EntityKind = "SCOPE.ExternalService"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -245,6 +261,7 @@ func AllEntityKinds() []EntityKind {
 		EntityKindModelEvent,
 		// #3628 error-flow: synthetic exception-type convergence node.
 		EntityKindExceptionType,
+		EntityKindExternalService,
 	}
 }
 
@@ -940,6 +957,28 @@ const (
 	// internal/extractor/exception_flow.go.
 	RelationshipKindThrows  RelationshipKind = "THROWS"
 	RelationshipKindCatches RelationshipKind = "CATCHES"
+
+	// #3628 third-party integration: a function/method calls a recognised
+	// external-service SDK entry-point.
+	//
+	//   DEPENDS_ON_SERVICE : function/method → SCOPE.ExternalService node
+	//                        (Name "service:<name>") it integrates with. The
+	//                        target service is identified from the SDK
+	//                        import/symbol context, NOT a bare method name:
+	//                          Python  `stripe.Charge.create(...)`         → stripe
+	//                                  `boto3.client("s3").put_object(...)` → aws-s3
+	//                          JS/TS   `new Stripe(key); stripe.charges.create()` → stripe
+	//                                  `sgMail.send(...)`                    → sendgrid
+	//                                  `new S3Client(...).send(cmd)`         → aws-s3
+	//                        Optional edge property `operation` carries the SDK
+	//                        call (e.g. "charges.create", "put_object").
+	//
+	// Precision-first / honest-partial: a dynamic boto3 service string
+	// (`boto3.client(svc_var)`) resolves to aws-generic; an unrecognised SDK or
+	// a bare `.create()`/`.send()` on a non-SDK object emits NO edge — a wrong
+	// integration edge would mislead "what services do we depend on?". See
+	// internal/extractor/external_service.go.
+	RelationshipKindDependsOnService RelationshipKind = "DEPENDS_ON_SERVICE"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1078,6 +1117,7 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #3628 error-flow: THROWS / CATCHES exception-type edges:
 		RelationshipKindThrows,
 		RelationshipKindCatches,
+		RelationshipKindDependsOnService,
 	}
 }
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -65,7 +65,7 @@ categories:
   databases:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
-    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling]
+    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection]
   protocol:

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -41,6 +41,37 @@ records:
         issues_implemented: ["3640"]
         verified_at: "2026-06-02"
 
+  analysis.integration.third-party-sdk:
+    capabilities:
+      external_service_dependency:
+        # #3628 area: SDK-LEVEL named third-party integration detection,
+        # distinct from raw HTTP-client CONSUMES_API (path-level). Each
+        # language extractor emits a DEPENDS_ON_SERVICE edge from the calling
+        # function/method to a synthetic SCOPE.ExternalService node
+        # (Name "service:<name>") so every call site of a service converges on
+        # ONE node — answering "what third-party services does this codebase
+        # integrate with, and where?". Shared dictionary + node/edge builders
+        # in internal/extractor/external_service.go. PARTIAL: python +
+        # javascript/typescript lanes only; precision-first import-gated
+        # detection (dynamic boto3 -> aws-generic; non-SDK receiver -> no edge).
+        status: partial
+        symbols:
+          - file: internal/extractor/external_service.go
+            functions: [ServiceForImportSource, AWSServiceFromArg, ExternalServiceEntity, ExternalServiceTargetID, ExternalServiceName, EmitServiceDependencyEdges, IsAWSImportSentinel]
+          - file: internal/extractors/python/external_service.go
+            functions: [emitServiceDependencyEdges, pyServiceCall, pyAttributeRootAndTail, pyAWSServiceFromCall]
+          - file: internal/extractors/javascript/external_service.go
+            functions: [emitServiceDependencyEdges, jsNewExpressionService, jsCallService, jsMemberRootAndTail, awsServiceFromCtorName]
+        tests:
+          - file: internal/extractor/external_service_test.go
+            functions: [TestServiceForImportSource, TestAWSServiceFromArg, TestEmitServiceDependencyEdges_Converge, TestEmitServiceDependencyEdges_DropsSentinelAndEmpty]
+          - file: internal/extractors/python/external_service_test.go
+            functions: [TestPyService_Stripe, TestPyService_AWSS3FromLiteral, TestPyService_AWSDynamoResource, TestPyService_Convergence, TestPyService_TwilioConstructor, TestPyService_DynamicAWSArg_Generic, TestPyService_NonSDKReceiver_NoEdge, TestPyService_NoImport_NoEdge]
+          - file: internal/extractors/javascript/external_service_test.go
+            functions: [TestJSService_StripeConstructThenCall, TestJSService_SendGrid, TestJSService_AWSS3Client, TestJSService_SentryNamespaceInit, TestJSService_Convergence, TestJSService_NonSDKReceiver_NoEdge, TestTSService_Stripe]
+        issues_implemented: ["3628"]
+        verified_at: "2026-06-02"
+
   lang.cobol.runtime.ibm-enterprise:
     capabilities:
       core_extraction:


### PR DESCRIPTION
Closes #3788 (child of #3628).

## What
SDK-level detection of third-party-service integrations. Each language extractor emits a `DEPENDS_ON_SERVICE` edge from the calling function/method to a synthetic `SCOPE.ExternalService:<name>` node, so the graph answers **"what third-party services does this codebase integrate with, and where?"** — distinct from raw HTTP-client `CONSUMES_API` (path-level).

## Node + edge model
Mirrors the `SCOPE.ExceptionType` / `SCOPE.Config` convergence trick:
- **`SCOPE.ExternalService`** entity kind (subtype `external_service`), file-agnostic synthetic node (constant `SourceFile`, `QualifiedName == edge ToID`) so the resolver's `byQualifiedName` tier binds the edge with no new linker code, and the same service across files/languages converges on ONE node. Name `service:<name>`.
- **`DEPENDS_ON_SERVICE`** relationship kind (fn/method → service node), optional `operation` edge property (e.g. `charges.create`, `put_object`).
- Shared dictionary + builders: `internal/extractor/external_service.go`.

## Service dictionary
`stripe`, `twilio`, `sendgrid`, `openai`, `slack`, `sentry`, `firebase`, `algolia`, and the AWS family `aws-s3 / aws-ses / aws-sns / aws-sqs / aws-dynamodb / aws-lambda / ...` — resolved from the boto3 `client`/`resource` literal arg, or the `@aws-sdk` v3 client-class name.

## Lanes
- **python** (`internal/extractors/python/external_service.go`): import-gated attribute-chain (`stripe.Charge.create`) + from-import constructor (`from twilio.rest import Client`); AWS service from the `boto3.client("s3")` literal.
- **javascript / typescript** (`internal/extractors/javascript/external_service.go`): import-gated `new Stripe()` + local-var back-reference (`stripe.charges.create()`), default-import receiver (`sgMail.send()`), namespace `Sentry.init()`, `@aws-sdk` client class → `aws-<svc>`.

## Precision-first / honest-partial
- dynamic `boto3.client(svc_var)` → `aws-generic` (never a fabricated concrete service)
- unrecognised SDK or a bare `.create()` / `.send()` on a non-imported object → **no edge**
- import-gated: a bare `stripe.Charge.create` with no `stripe` import → no edge
- **PARTIAL**: only python + js/ts lanes implemented; java/go/ruby/php and the long tail of SDKs are future lanes.

## Service deps asserted by tests (value-asserting — service node id + edge, not len>0)
- `stripe.Charge.create()` in `pay()` → `DEPENDS_ON_SERVICE(pay → SCOPE.ExternalService:stripe)`, op `Charge.create`
- `boto3.client("s3").put_object()` → `aws-s3` (service from the literal; not aws-generic)
- `boto3.resource("dynamodb")` → `aws-dynamodb`
- two functions using Stripe → exactly ONE `service:stripe` node (convergence)
- `from twilio.rest import Client; Client()` → `twilio`
- JS `new Stripe(); stripe.charges.create()` → `stripe`; `sgMail.send()` → `sendgrid`; `new S3Client()` → `aws-s3`; `Sentry.init()` → `sentry`; TS variant of Stripe
- negatives: dynamic boto3 arg → `aws-generic` (no concrete); `.create()` on a non-SDK object → no edge; no-import → no edge
- shared-helper unit tests for `ServiceForImportSource`, `AWSServiceFromArg`, convergence, sentinel/empty drop

## Validation
- `go test ./internal/types/ ./internal/extractor/ ./internal/extractors/python/ ./internal/extractors/javascript/ ./internal/engine/ ./internal/custom/... ./tools/coverage/` — green
- `go test ./internal/types/` (kind-registry gate) — green
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical; `gofmt -l` empty; `go vet` clean
- Coverage record `analysis.integration.third-party-sdk` added (registry.json + capability-map.yaml + dictionary), docs regenerated.

## DEPLOY-DEFERRED
Extractor + kinds land here; live-daemon rebuild + reindex is a separate coordinated step (does not disturb the running rewrite daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)