### PR TITLE
feat(authz): capture endpoint required permission/scope/role (PreAuthorize/DRF/Nest/Express/Pundit)

### DIFF
--- a/internal/custom/python/auth_endpoint.go
+++ b/internal/custom/python/auth_endpoint.go
@@ -48,14 +48,15 @@ import (
 
 // pyEndpointAuth is the resolved auth posture for one route endpoint.
 type pyEndpointAuth struct {
-	Required   bool
-	Method     string // "dependency" | "decorator" | "permission_classes"
-	Guard      string // primary guard symbol (evidence)
-	Scopes     []string
-	Roles      []string
-	Confidence string // "high" | "medium" | "low"
-	found      bool   // an explicit auth signal was recognised
-	publicSet  bool   // an explicit public marker was recognised (AllowAny)
+	Required    bool
+	Method      string // "dependency" | "decorator" | "permission_classes"
+	Guard       string // primary guard symbol (evidence)
+	Scopes      []string
+	Roles       []string
+	Permissions []string // fine-grained permission strings (DRF/Flask args)
+	Confidence  string   // "high" | "medium" | "low"
+	found       bool     // an explicit auth signal was recognised
+	publicSet   bool     // an explicit public marker was recognised (AllowAny)
 }
 
 // stamp writes the resolved posture onto an endpoint Properties map, mirroring
@@ -85,6 +86,11 @@ func (a pyEndpointAuth) stamp(props map[string]string) {
 			r := append([]string(nil), a.Roles...)
 			sort.Strings(r)
 			props["auth_roles"] = strings.Join(r, ",")
+		}
+		if len(a.Permissions) > 0 {
+			p := append([]string(nil), a.Permissions...)
+			sort.Strings(p)
+			props["auth_permissions"] = strings.Join(p, ",")
 		}
 		return
 	}
@@ -220,8 +226,19 @@ func resolveFlaskDecoratorAuth(decoratorBlock string) pyEndpointAuth {
 	a.Confidence = "high"
 	a.Guard = m[1]
 	if len(m) > 2 && m[2] != "" {
+		// `@roles_required('admin')` / `@roles_accepted(...)` name roles;
+		// `@permission_required('app.delete_order')` names a fine-grained
+		// permission. Route each decorator's quoted args to the right bucket so
+		// the captured value answers "what permission does this route require?".
+		toPermissions := m[1] == "permission_required"
 		for _, q := range faQuotedRe.FindAllStringSubmatch(m[2], -1) {
-			if tok := strings.TrimSpace(q[1]); tok != "" {
+			tok := strings.TrimSpace(q[1])
+			if tok == "" {
+				continue
+			}
+			if toPermissions {
+				a.Permissions = append(a.Permissions, tok)
+			} else {
 				a.Roles = append(a.Roles, tok)
 			}
 		}
@@ -286,7 +303,78 @@ func resolveDRFDecoratorAuth(decoratorBlock string) pyEndpointAuth {
 	// Role-bearing permission classes (IsAdminUser → ADMIN) are surfaced as a
 	// guard only; DRF permission classes are opaque policies, not named roles,
 	// so we do not synthesise speculative role strings.
+	//
+	// BUT a parameterised permission/scope class carries the SPECIFIC required
+	// grant as a literal arg — `HasPermission('orders.delete')`,
+	// `HasScope('read')` — so capture those into permissions/scopes.
+	a.Permissions = append(a.Permissions, drfPermissionArgs(raw)...)
+	a.Scopes = append(a.Scopes, drfScopeArgs(decoratorBlock, raw)...)
 	return a
+}
+
+// drfScopeClassRe matches an OAuth2 scope permission class in a
+// permission_classes list (django-oauth-toolkit `TokenHasScope` /
+// `TokenHasReadWriteScope`, DRF-style `HasScope`). Group 1 = the class name,
+// group 2 = its optional call args (`HasScope('read')`).
+var drfScopeClassRe = regexp.MustCompile(`\b(TokenHas\w*Scope\w*|HasScope|HasAnyScope)\b\s*(?:\(([^)]*)\))?`)
+
+// drfPermClassCallRe matches a permission-class entry that carries explicit
+// literal args, e.g. `HasPermission('orders.delete')` /
+// `RequiresPermission("app.edit")`. Group 1 = class name, group 2 = raw args.
+var drfPermClassCallRe = regexp.MustCompile(`\b(\w*Permission\w*)\s*\(([^)]*)\)`)
+
+// drfRequiredScopesRe matches a `required_scopes = ['read', 'write']` attribute
+// that django-oauth-toolkit's TokenHasScope reads. Group 1 = the raw list. The
+// attribute may sit alongside the view in the same decorator block region.
+var drfRequiredScopesRe = regexp.MustCompile(`required_scopes\s*=\s*\[([^\]]*)\]`)
+
+// drfPermissionArgs extracts the literal permission strings carried as call
+// args by a parameterised permission class (`HasPermission('orders.delete')`).
+// A scope class (TokenHasScope/HasScope) is handled by drfScopeArgs instead, so
+// it is skipped here to avoid double-classifying a scope as a permission.
+func drfPermissionArgs(raw string) []string {
+	var out []string
+	for _, m := range drfPermClassCallRe.FindAllStringSubmatch(raw, -1) {
+		if drfScopeClassRe.MatchString(m[1]) {
+			continue
+		}
+		for _, q := range faQuotedRe.FindAllStringSubmatch(m[2], -1) {
+			if tok := strings.TrimSpace(q[1]); tok != "" {
+				out = append(out, tok)
+			}
+		}
+	}
+	return out
+}
+
+// drfScopeArgs extracts the OAuth2 scopes an endpoint requires. Two sources:
+// an inline scope-class call arg (`HasScope('read')`) and a `required_scopes`
+// attribute that the TokenHasScope permission class consults. The
+// `required_scopes` attribute is captured only when a scope permission class is
+// actually present (otherwise the kwarg is unrelated noise).
+func drfScopeArgs(decoratorBlock, raw string) []string {
+	var out []string
+	scopeClassPresent := false
+	for _, m := range drfScopeClassRe.FindAllStringSubmatch(raw, -1) {
+		scopeClassPresent = true
+		if len(m) > 2 && m[2] != "" {
+			for _, q := range faQuotedRe.FindAllStringSubmatch(m[2], -1) {
+				if tok := strings.TrimSpace(q[1]); tok != "" {
+					out = append(out, tok)
+				}
+			}
+		}
+	}
+	if scopeClassPresent {
+		if rm := drfRequiredScopesRe.FindStringSubmatch(decoratorBlock); rm != nil {
+			for _, q := range faQuotedRe.FindAllStringSubmatch(rm[1], -1) {
+				if tok := strings.TrimSpace(q[1]); tok != "" {
+					out = append(out, tok)
+				}
+			}
+		}
+	}
+	return out
 }
 
 // drfPermClassList parses a permission-class list literal into leaf class

--- a/internal/custom/python/auth_endpoint_authz_test.go
+++ b/internal/custom/python/auth_endpoint_authz_test.go
@@ -1,0 +1,92 @@
+// Internal tests for the fine-grained authz (permission / scope) capture added
+// to the Python endpoint-protection resolvers. These assert the SPECIFIC
+// permission / scope value lands on the right bucket, not merely len>0.
+package python
+
+import (
+	"strings"
+	"testing"
+)
+
+// DRF custom permission class carrying an explicit permission literal —
+// `HasPermission('orders.delete')` — must surface that string on Permissions.
+func TestDRFAuth_CustomPermissionArg(t *testing.T) {
+	block := "@permission_classes([IsAuthenticated, HasPermission('orders.delete')])"
+	a := resolveDRFDecoratorAuth(block)
+	if !a.found {
+		t.Fatal("expected found=true for a non-public permission class")
+	}
+	if strings.Join(a.Permissions, ",") != "orders.delete" {
+		t.Errorf("expected permissions=[orders.delete], got %v", a.Permissions)
+	}
+}
+
+// django-oauth-toolkit `TokenHasScope` + `required_scopes = ['read']` must
+// surface the scope on Scopes.
+func TestDRFAuth_TokenHasScope(t *testing.T) {
+	block := "required_scopes = ['read', 'write']\n@permission_classes([TokenHasScope])"
+	a := resolveDRFDecoratorAuth(block)
+	if !a.found {
+		t.Fatal("expected found=true for TokenHasScope")
+	}
+	got := append([]string(nil), a.Scopes...)
+	if strings.Join(sortedForTest(got), ",") != "read,write" {
+		t.Errorf("expected scopes=[read,write], got %v", a.Scopes)
+	}
+}
+
+// `HasScope('read')` inline arg must be captured as a scope, not a permission.
+func TestDRFAuth_InlineScopeArg(t *testing.T) {
+	block := "@permission_classes([HasScope('reports:read')])"
+	a := resolveDRFDecoratorAuth(block)
+	if strings.Join(a.Scopes, ",") != "reports:read" {
+		t.Errorf("expected scopes=[reports:read], got %v", a.Scopes)
+	}
+	if len(a.Permissions) != 0 {
+		t.Errorf("a scope class must not become a permission, got %v", a.Permissions)
+	}
+}
+
+// Negative: a generic IsAuthenticated (authn, not authz) must add no
+// permission/scope/role — it is auth_required only.
+func TestDRFAuth_IsAuthenticatedNoPermission(t *testing.T) {
+	a := resolveDRFDecoratorAuth("@permission_classes([IsAuthenticated])")
+	if !a.found {
+		t.Fatal("expected found=true (protected)")
+	}
+	if len(a.Permissions) != 0 || len(a.Scopes) != 0 || len(a.Roles) != 0 {
+		t.Errorf("IsAuthenticated must not yield authz tokens, got perms=%v scopes=%v roles=%v",
+			a.Permissions, a.Scopes, a.Roles)
+	}
+}
+
+// Flask `@permission_required('app.delete_order')` routes the literal to
+// Permissions, while `@roles_required('admin')` routes to Roles.
+func TestFlaskAuth_PermissionRequiredArg(t *testing.T) {
+	a := resolveFlaskDecoratorAuth("@permission_required('app.delete_order')")
+	if strings.Join(a.Permissions, ",") != "app.delete_order" {
+		t.Errorf("expected permissions=[app.delete_order], got %v", a.Permissions)
+	}
+	if len(a.Roles) != 0 {
+		t.Errorf("permission_required must not yield roles, got %v", a.Roles)
+	}
+
+	r := resolveFlaskDecoratorAuth("@roles_required('admin')")
+	if strings.Join(r.Roles, ",") != "admin" {
+		t.Errorf("expected roles=[admin], got %v", r.Roles)
+	}
+	if len(r.Permissions) != 0 {
+		t.Errorf("roles_required must not yield permissions, got %v", r.Permissions)
+	}
+}
+
+func sortedForTest(s []string) []string {
+	for i := 0; i < len(s); i++ {
+		for j := i + 1; j < len(s); j++ {
+			if s[j] < s[i] {
+				s[i], s[j] = s[j], s[i]
+			}
+		}
+	}
+	return s
+}

--- a/internal/custom/python/auth_endpoint_test.go
+++ b/internal/custom/python/auth_endpoint_test.go
@@ -168,6 +168,35 @@ def admin_panel():
 	}
 }
 
+// Django `@permission_required('orders.delete_order')` on a function view must
+// stamp the specific required permission on auth_permissions (cross-language
+// flat contract), answering "what permission does this route require?".
+func TestDjangoAuth_PermissionRequiredView(t *testing.T) {
+	src := `
+from django.contrib.auth.decorators import permission_required
+
+@permission_required('orders.delete_order')
+def delete_order(request, pk):
+    return None
+`
+	ents := extract(t, "python_django", src)
+	var found bool
+	for _, e := range ents {
+		if e.Props["decorator"] == "permission_required" {
+			found = true
+			if e.Props["auth_permissions"] != "orders.delete_order" {
+				t.Fatalf("auth_permissions = %q, want orders.delete_order", e.Props["auth_permissions"])
+			}
+			if e.Props["auth_required"] != "true" {
+				t.Fatalf("auth_required = %q, want true", e.Props["auth_required"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no permission_required view emitted (got %d entities)", len(ents))
+	}
+}
+
 // Negative: an unguarded Flask route is unprotected.
 func TestFlaskAuth_NoDecoratorUnprotected(t *testing.T) {
 	src := `

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -416,7 +416,19 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		funcName := source[idx[4]:idx[5]]
 		line := lineOf(source, idx[0])
 		out = append(out, entity(funcName, "SCOPE.Operation", "function", file.Path, line,
-			map[string]string{"framework": "django", "pattern_type": "view_decorator", "decorator": "permission_required", "permission": permission, "auth_required": "true"}))
+			map[string]string{
+				"framework":    "django",
+				"pattern_type": "view_decorator",
+				"decorator":    "permission_required",
+				"permission":   permission,
+				// #authz — the specific required permission on the cross-language
+				// flat contract so archigraph_auth_coverage answers
+				// "what permission does this route require?" uniformly.
+				"auth_permissions": permission,
+				"auth_method":      "decorator",
+				"auth_confidence":  "high",
+				"auth_required":    "true",
+			}))
 	}
 
 	// 12. Form / ModelForm per-field type introspection (issue #3346).

--- a/internal/custom/ruby/controller_auth.go
+++ b/internal/custom/ruby/controller_auth.go
@@ -93,6 +93,14 @@ var (
 	// per-action Pundit authorize call inside a method body: authorize @post
 	caPunditAuthorizeRe = regexp.MustCompile(`(?m)^\s*authorize\s+[@a-z_]`)
 
+	// Pundit `authorize @post, :destroy?` — the trailing symbol is the explicit
+	// policy method. Group 1 = the policy-method name (without the `?`).
+	caPunditActionRe = regexp.MustCompile(`(?m)^\s*authorize\s+[@A-Za-z_][\w.]*\s*,\s*:([a-z_]+)\??`)
+
+	// CanCanCan `authorize! :destroy, @post` — the leading symbol is the ability.
+	// Group 1 = the ability name.
+	caCanCanActionRe = regexp.MustCompile(`(?m)^\s*authorize!\s+:([a-z_]+)`)
+
 	// only:/except: option lists, reused from the routes parser shape.
 	caOnlyRe   = regexp.MustCompile(`\bonly:\s*(?:\[([^\]]*)\]|:(\w+))`)
 	caExceptRe = regexp.MustCompile(`\bexcept:\s*(?:\[([^\]]*)\]|:(\w+))`)
@@ -128,7 +136,8 @@ func (e *railsControllerAuthExtractor) Extract(ctx context.Context, file extract
 		!(strings.Contains(src, "before_action") ||
 			strings.Contains(src, "load_and_authorize_resource") ||
 			strings.Contains(src, "authorize_resource") ||
-			strings.Contains(src, "authorize ")) {
+			strings.Contains(src, "authorize ") ||
+			strings.Contains(src, "authorize!")) {
 		return nil, nil
 	}
 
@@ -184,6 +193,10 @@ type caActionPosture struct {
 	guard      string
 	method     string
 	confidence string
+	// permission is the specific Pundit policy method / CanCanCan ability the
+	// action checks (`authorize @post, :destroy?` → "destroy"). Empty when the
+	// guard is a coarse authenticate before_action (authn, not authz).
+	permission string
 }
 
 func (p caActionPosture) stamp(props map[string]string) {
@@ -195,6 +208,11 @@ func (p caActionPosture) stamp(props map[string]string) {
 	props["auth_confidence"] = p.confidence
 	if p.guard != "" {
 		props["auth_guard"] = p.guard
+	}
+	// #authz — the specific authorization action required, so
+	// archigraph_auth_coverage answers "what permission does this route require?".
+	if p.permission != "" {
+		props["auth_permissions"] = p.permission
 	}
 }
 
@@ -292,12 +310,28 @@ func caResolveAction(level caControllerLevelAuth, body, action string) caActionP
 		}
 	}
 
-	// Per-action Pundit authorize inside the action body (medium — the guard is
-	// body-local, not a declarative before_action).
-	if caActionBodyHasAuthorize(body, action) {
-		return caActionPosture{
-			required: true, guard: "authorize",
-			method: "pundit", confidence: "medium",
+	// Per-action Pundit / CanCanCan authorize inside the action body (medium —
+	// the guard is body-local, not a declarative before_action). When the call
+	// names an explicit action symbol (`authorize @post, :destroy?` /
+	// `authorize! :destroy, @post`) capture it as the required permission.
+	if actionBody, ok := caActionBody(body, action); ok {
+		if caPunditAuthorizeRe.MatchString(actionBody) {
+			perm := ""
+			if m := caPunditActionRe.FindStringSubmatch(actionBody); m != nil {
+				perm = m[1]
+			}
+			return caActionPosture{
+				required: true, guard: "authorize",
+				method: "pundit", confidence: "medium",
+				permission: perm,
+			}
+		}
+		if m := caCanCanActionRe.FindStringSubmatch(actionBody); m != nil {
+			return caActionPosture{
+				required: true, guard: "authorize!",
+				method: "cancancan", confidence: "medium",
+				permission: m[1],
+			}
 		}
 	}
 
@@ -335,20 +369,20 @@ func caPrivateOffset(body string) int {
 	return -1
 }
 
-// caActionBodyHasAuthorize reports whether the named action's method body
-// contains a Pundit `authorize` call. Scans from the action's `def` to its
-// matching `end` (heuristic: the next top-level `def` or the body end).
-func caActionBodyHasAuthorize(body, action string) bool {
+// caActionBody returns the source span of the named action's method body (from
+// the action's `def` to the next top-level `def` or the body end). The bool is
+// false when the action is not found.
+func caActionBody(body, action string) (string, bool) {
 	defRe := regexp.MustCompile(`(?m)^\s*def\s+` + regexp.QuoteMeta(action) + `\b`)
 	loc := defRe.FindStringIndex(body)
 	if loc == nil {
-		return false
+		return "", false
 	}
 	rest := body[loc[1]:]
 	if nxt := caActionDefRe.FindStringIndex(rest); nxt != nil {
 		rest = rest[:nxt[0]]
 	}
-	return caPunditAuthorizeRe.MatchString(rest)
+	return rest, true
 }
 
 // caClassBody returns the source of a controller class body starting at offset

--- a/internal/custom/ruby/controller_auth_test.go
+++ b/internal/custom/ruby/controller_auth_test.go
@@ -211,6 +211,71 @@ end
 	}
 }
 
+// TestControllerAuthPunditExplicitAction — `authorize @post, :destroy?` must
+// capture the specific policy action on auth_permissions (#authz).
+func TestControllerAuthPunditExplicitAction(t *testing.T) {
+	src := `class PostsController < ApplicationController
+  def destroy
+    @post = Post.find(params[:id])
+    authorize @post, :destroy?
+    @post.destroy
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["posts#destroy"]
+	if !ok {
+		t.Fatalf("posts#destroy should be protected (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_permissions"] != "destroy" {
+		t.Errorf("posts#destroy: auth_permissions=%q, want destroy (props: %v)", e.Properties["auth_permissions"], e.Properties)
+	}
+	if e.Properties["auth_method"] != "pundit" {
+		t.Errorf("posts#destroy: auth_method=%q, want pundit", e.Properties["auth_method"])
+	}
+}
+
+// TestControllerAuthCanCanCanBang — `authorize! :destroy, @post` captures the
+// CanCanCan ability on auth_permissions.
+func TestControllerAuthCanCanCanBang(t *testing.T) {
+	src := `class ArticlesController < ApplicationController
+  def destroy
+    @article = Article.find(params[:id])
+    authorize! :destroy, @article
+    @article.destroy
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["articles#destroy"]
+	if !ok {
+		t.Fatalf("articles#destroy should be protected (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_permissions"] != "destroy" {
+		t.Errorf("articles#destroy: auth_permissions=%q, want destroy (props: %v)", e.Properties["auth_permissions"], e.Properties)
+	}
+	if e.Properties["auth_method"] != "cancancan" {
+		t.Errorf("articles#destroy: auth_method=%q, want cancancan", e.Properties["auth_method"])
+	}
+}
+
+// Negative: a coarse `authorize @report` with no explicit action symbol must
+// NOT fabricate a permission (it is protected but the action is implicit).
+func TestControllerAuthPunditNoExplicitActionNoPermission(t *testing.T) {
+	src := `class ReportsController < ApplicationController
+  def show
+    @report = Report.find(params[:id])
+    authorize @report
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e := eps["reports#show"]
+	if v := e.Properties["auth_permissions"]; v != "" {
+		t.Errorf("reports#show: expected no auth_permissions for implicit authorize, got %q", v)
+	}
+}
+
 // TestControllerAuthNamespaced — Admin::UsersController → admin/users handler.
 func TestControllerAuthNamespaced(t *testing.T) {
 	src := `class Admin::UsersController < ApplicationController

--- a/internal/engine/http_endpoint_jsts_auth.go
+++ b/internal/engine/http_endpoint_jsts_auth.go
@@ -44,6 +44,7 @@ package engine
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
@@ -110,6 +111,17 @@ var jsAuthGuardArgRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?:\([^)]*\))?`)
 // jsRolesDecoratorRe captures NestJS `@Roles('admin', 'user')` /
 // `@Roles(Role.Admin)` role declarations. Group 1 = the raw argument list.
 var jsRolesDecoratorRe = regexp.MustCompile(`@Roles\s*\(([^)]*)\)`)
+
+// jsPermissionsDecoratorRe captures NestJS fine-grained permission decorators —
+// `@RequirePermissions('user:delete')` (nest-access-control / casl convention),
+// `@Permissions('orders.read')`, `@CheckPermissions(...)`. Group 1 = the raw
+// argument list. The leading word boundary keeps it from matching a longer
+// identifier suffix.
+var jsPermissionsDecoratorRe = regexp.MustCompile(`@(?:RequirePermissions|Permissions|CheckPermissions|RequirePermission)\s*\(([^)]*)\)`)
+
+// jsScopesDecoratorRe captures NestJS OAuth scope decorators —
+// `@Scopes('write:users')` / `@RequireScopes('read')`. Group 1 = the raw args.
+var jsScopesDecoratorRe = regexp.MustCompile(`@(?:Scopes|RequireScopes|RequireScope)\s*\(([^)]*)\)`)
 
 // jsQuotedTokenRe pulls single- or double-quoted tokens out of an argument
 // list (the Java extractQuotedTokens helper is double-quote only; JS/TS role
@@ -263,9 +275,19 @@ func resolveJSTSFileAuth(content, file string) jsAuthContext {
 		if gm == nil || len(parseGuardArgs(gm[1])) == 0 {
 			continue
 		}
+		ctext := "class @UseGuards(" + strings.TrimSpace(gm[1]) + ")"
+		if rm := jsRolesDecoratorRe.FindStringSubmatch(block); rm != nil {
+			ctext += " @Roles(" + strings.TrimSpace(rm[1]) + ")"
+		}
+		if pm := jsPermissionsDecoratorRe.FindStringSubmatch(block); pm != nil {
+			ctext += " @RequirePermissions(" + strings.TrimSpace(pm[1]) + ")"
+		}
+		if sm := jsScopesDecoratorRe.FindStringSubmatch(block); sm != nil {
+			ctext += " @Scopes(" + strings.TrimSpace(sm[1]) + ")"
+		}
 		ctx.classGuards = append(ctx.classGuards, AuthSignal{
 			Kind: "guard",
-			Text: "class @UseGuards(" + strings.TrimSpace(gm[1]) + ")",
+			Text: ctext,
 			File: file,
 			Line: lineAtOffset(content, m[0]),
 		})
@@ -373,6 +395,8 @@ func resolveEndpointAuth(
 	if sigs, ok := routeAuth[key]; ok && len(sigs) > 0 {
 		return AuthPolicy{
 			Required: true, Method: "middleware", Confidence: "high",
+			Permissions: permsFromSignals(sigs),
+			Scopes:      scopesFromSignals(sigs),
 			SourceChain: sigs,
 		}
 	}
@@ -382,6 +406,8 @@ func resolveEndpointAuth(
 			return AuthPolicy{
 				Required: true, Method: "guard", Confidence: "high",
 				Roles:       rolesFromSignals(sigs),
+				Permissions: permsFromSignals(sigs),
+				Scopes:      scopesFromSignals(sigs),
 				SourceChain: sigs,
 			}
 		}
@@ -427,6 +453,8 @@ func resolveEndpointAuth(
 		return AuthPolicy{
 			Required: true, Method: "guard", Confidence: "medium",
 			Roles:       rolesFromSignals(ctx.classGuards),
+			Permissions: permsFromSignals(ctx.classGuards),
+			Scopes:      scopesFromSignals(ctx.classGuards),
 			SourceChain: ctx.classGuards,
 		}
 	}
@@ -464,21 +492,41 @@ func nestHandlerName(ref string) string {
 // rolesFromSignals scans @Roles decorators captured alongside guard signals.
 // (Roles are merged into the guard source chain text by the indexers.)
 func rolesFromSignals(sigs []AuthSignal) []string {
-	var roles []string
+	return jsTokensFromSignals(sigs, "@Roles(")
+}
+
+// permsFromSignals scans @RequirePermissions decorators merged into a guard
+// signal's source-chain text and returns the specific required permissions.
+func permsFromSignals(sigs []AuthSignal) []string {
+	return jsTokensFromSignals(sigs, "@RequirePermissions(")
+}
+
+// scopesFromSignals scans @Scopes decorators merged into a guard signal's
+// source-chain text and returns the specific required OAuth scopes.
+func scopesFromSignals(sigs []AuthSignal) []string {
+	return jsTokensFromSignals(sigs, "@Scopes(")
+}
+
+// jsTokensFromSignals extracts the quoted string tokens from a `marker(...)`
+// decorator embedded in any signal's Text. Returns nil when the marker is
+// absent or carries only non-literal args (e.g. `@Roles(roleEnumVar)`), so a
+// dynamic decorator never fabricates a token.
+func jsTokensFromSignals(sigs []AuthSignal, marker string) []string {
+	var out []string
 	for _, s := range sigs {
-		if i := strings.Index(s.Text, "@Roles("); i >= 0 {
-			inner := s.Text[i+len("@Roles("):]
+		if i := strings.Index(s.Text, marker); i >= 0 {
+			inner := s.Text[i+len(marker):]
 			if j := strings.IndexByte(inner, ')'); j >= 0 {
 				inner = inner[:j]
 			}
 			for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(inner, -1) {
 				if tok := strings.TrimSpace(q[1]); tok != "" {
-					roles = append(roles, tok)
+					out = append(out, tok)
 				}
 			}
 		}
 	}
-	return roles
+	return out
 }
 
 // stampAuthPolicy writes the resolved policy onto an endpoint Properties map
@@ -496,6 +544,19 @@ func stampAuthPolicy(props map[string]string, policy AuthPolicy) {
 	}
 	if len(policy.Roles) > 0 {
 		props["auth_roles"] = strings.Join(policy.Roles, ",")
+	}
+	// #authz — the specific fine-grained permission / scope required by the
+	// endpoint (Nest @RequirePermissions / @Scopes), so archigraph_auth_coverage
+	// answers "what permission does this route require?".
+	if len(policy.Permissions) > 0 {
+		perms := append([]string(nil), policy.Permissions...)
+		sort.Strings(perms)
+		props["auth_permissions"] = strings.Join(perms, ",")
+	}
+	if len(policy.Scopes) > 0 {
+		scs := append([]string(nil), policy.Scopes...)
+		sort.Strings(scs)
+		props["auth_scopes"] = strings.Join(scs, ",")
 	}
 	// MCP signal-1 keys (auth_coverage.go): a single recognised middleware /
 	// guard symbol so the tool's cheap property check fires without parsing
@@ -550,12 +611,75 @@ func indexRouteLevelAuth(content, _ string) map[string][]AuthSignal {
 			continue
 		}
 		key := verb + " " + canonical
+		text := "route-level: " + sym
+		// Capture a parameterised authz middleware's literal grant —
+		// `requireScope('write:users')` → scope, `checkPermission('x')` →
+		// permission — by appending a marker the stamp step parses.
+		if perms, scopes := jsMiddlewareGrants(rest); len(perms) > 0 || len(scopes) > 0 {
+			if len(perms) > 0 {
+				text += " @RequirePermissions(" + strings.Join(jsQuoteAll(perms), ",") + ")"
+			}
+			if len(scopes) > 0 {
+				text += " @Scopes(" + strings.Join(jsQuoteAll(scopes), ",") + ")"
+			}
+		}
 		out[key] = append(out[key], AuthSignal{
 			Kind: "middleware",
-			Text: "route-level: " + sym,
+			Text: text,
 			File: "",
 			Line: lineAtOffset(content, m[0]),
 		})
+	}
+	return out
+}
+
+// jsScopeMiddlewareRe matches a scope-gating middleware call carrying a literal
+// scope, e.g. `requireScope('write:users')` / `hasScope("read")` /
+// `checkScope('admin')`. Group 1 = the raw argument list.
+var jsScopeMiddlewareRe = regexp.MustCompile(`(?i)\b(?:require|has|check|need|assert)scopes?\s*\(([^)]*)\)`)
+
+// jsPermMiddlewareRe matches a permission-gating middleware call carrying a
+// literal permission, e.g. `checkPermission('users:delete')` /
+// `requirePermission("edit")` / `can('delete','User')` (casl). Group 1 = args.
+var jsPermMiddlewareRe = regexp.MustCompile(`(?i)\b(?:check|require|has|need|assert)permissions?\s*\(([^)]*)\)`)
+
+// jsCaslCanRe matches a casl ability check `can('delete', 'User')`. Group 1 =
+// the action (the permission verb). The subject (group-2-ish) is left out — the
+// permission is the action.
+var jsCaslCanRe = regexp.MustCompile(`\bcan\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`)
+
+// jsMiddlewareGrants scans an Express route middleware chain for parameterised
+// authz middlewares and returns the literal permissions and scopes they
+// require. Dynamic args (no string literal) yield nothing — never fabricated.
+func jsMiddlewareGrants(rest string) (perms, scopes []string) {
+	for _, m := range jsScopeMiddlewareRe.FindAllStringSubmatch(rest, -1) {
+		for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(m[1], -1) {
+			if tok := strings.TrimSpace(q[1]); tok != "" {
+				scopes = append(scopes, tok)
+			}
+		}
+	}
+	for _, m := range jsPermMiddlewareRe.FindAllStringSubmatch(rest, -1) {
+		for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(m[1], -1) {
+			if tok := strings.TrimSpace(q[1]); tok != "" {
+				perms = append(perms, tok)
+			}
+		}
+	}
+	for _, m := range jsCaslCanRe.FindAllStringSubmatch(rest, -1) {
+		if tok := strings.TrimSpace(m[1]); tok != "" {
+			perms = append(perms, tok)
+		}
+	}
+	return perms, scopes
+}
+
+// jsQuoteAll wraps each token in single quotes so the merged decorator-marker
+// text is parsed back by jsTokensFromSignals (which expects quoted literals).
+func jsQuoteAll(toks []string) []string {
+	out := make([]string, len(toks))
+	for i, t := range toks {
+		out[i] = "'" + t + "'"
 	}
 	return out
 }
@@ -622,6 +746,12 @@ func indexNestMethodGuards(content, _ string) map[string][]AuthSignal {
 		text := "@UseGuards(" + strings.TrimSpace(gm[1]) + ")"
 		if rm := jsRolesDecoratorRe.FindStringSubmatch(block); rm != nil {
 			text += " @Roles(" + strings.TrimSpace(rm[1]) + ")"
+		}
+		if pm := jsPermissionsDecoratorRe.FindStringSubmatch(block); pm != nil {
+			text += " @RequirePermissions(" + strings.TrimSpace(pm[1]) + ")"
+		}
+		if sm := jsScopesDecoratorRe.FindStringSubmatch(block); sm != nil {
+			text += " @Scopes(" + strings.TrimSpace(sm[1]) + ")"
 		}
 		out[method] = append(out[method], AuthSignal{
 			Kind: "guard",

--- a/internal/engine/http_endpoint_jsts_auth_test.go
+++ b/internal/engine/http_endpoint_jsts_auth_test.go
@@ -289,3 +289,107 @@ func TestAuth_SailsCrossFileAttribution(t *testing.T) {
 	// Action-level override: AuthController.logout is gated.
 	requireProtected(t, eps, "POST /logout", "config")
 }
+
+// ---------------------------------------------------------------------------
+// Fine-grained authz capture: required permission / scope per endpoint (#authz)
+// ---------------------------------------------------------------------------
+
+// NestJS method-level @RequirePermissions('user:delete') alongside the guard
+// must surface the SPECIFIC permission on auth_permissions for that endpoint.
+func TestAuthz_NestRequirePermissions(t *testing.T) {
+	src := `
+import { Controller, Delete, UseGuards } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Delete(':id')
+  @UseGuards(PermissionsGuard)
+  @RequirePermissions('user:delete')
+  remove() {}
+}
+`
+	eps := authProps(t, "typescript", "users.controller.ts", src)
+	e, ok := eps["DELETE /users/{id}"]
+	if !ok {
+		t.Fatalf("DELETE /users/{id} not synthesised (got: %v)", keysOf(eps))
+	}
+	if e.Properties["auth_permissions"] != "user:delete" {
+		t.Errorf("auth_permissions=%q, want user:delete (props: %v)", e.Properties["auth_permissions"], e.Properties)
+	}
+}
+
+// NestJS @Scopes('write:users') must surface the scope on auth_scopes.
+func TestAuthz_NestScopes(t *testing.T) {
+	src := `
+import { Controller, Post, UseGuards } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Post()
+  @UseGuards(ScopesGuard)
+  @Scopes('write:users')
+  create() {}
+}
+`
+	eps := authProps(t, "typescript", "users.controller.ts", src)
+	e := eps["POST /users"]
+	if e.Properties["auth_scopes"] != "write:users" {
+		t.Errorf("auth_scopes=%q, want write:users (props: %v)", e.Properties["auth_scopes"], e.Properties)
+	}
+}
+
+// Express route-level requireScope('write:users') middleware must surface the
+// scope on auth_scopes for that route.
+func TestAuthz_ExpressRequireScope(t *testing.T) {
+	src := `
+const express = require('express');
+const app = express();
+app.put('/users/:id', requireAuth, requireScope('write:users'), (req, res) => res.send('ok'));
+`
+	eps := authProps(t, "javascript", "app.js", src)
+	e, ok := eps["PUT /users/{id}"]
+	if !ok {
+		t.Fatalf("PUT /users/{id} not synthesised (got: %v)", keysOf(eps))
+	}
+	if e.Properties["auth_scopes"] != "write:users" {
+		t.Errorf("auth_scopes=%q, want write:users (props: %v)", e.Properties["auth_scopes"], e.Properties)
+	}
+}
+
+// Express checkPermission('users:delete') middleware → auth_permissions.
+func TestAuthz_ExpressCheckPermission(t *testing.T) {
+	src := `
+const express = require('express');
+const app = express();
+app.delete('/users/:id', requireAuth, checkPermission('users:delete'), (req, res) => res.send('ok'));
+`
+	eps := authProps(t, "javascript", "app.js", src)
+	e, ok := eps["DELETE /users/{id}"]
+	if !ok {
+		t.Fatalf("DELETE /users/{id} not synthesised (got: %v)", keysOf(eps))
+	}
+	if e.Properties["auth_permissions"] != "users:delete" {
+		t.Errorf("auth_permissions=%q, want users:delete (props: %v)", e.Properties["auth_permissions"], e.Properties)
+	}
+}
+
+// Negative: a dynamic @Roles(roleVar) / requireScope(scopeVar) with no string
+// literal must not fabricate a permission/scope/role.
+func TestAuthz_DynamicNoFabrication(t *testing.T) {
+	src := `
+const express = require('express');
+const app = express();
+app.get('/x', requireAuth, requireScope(scopeVar), (req, res) => res.send('ok'));
+`
+	eps := authProps(t, "javascript", "app.js", src)
+	e, ok := eps["GET /x"]
+	if !ok {
+		t.Fatalf("GET /x not synthesised (got: %v)", keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "true" {
+		t.Errorf("GET /x: expected auth_required=true (requireAuth present)")
+	}
+	if v := e.Properties["auth_scopes"]; v != "" {
+		t.Errorf("GET /x: expected no auth_scopes for dynamic scope, got %q", v)
+	}
+}

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -58,6 +58,7 @@ package engine
 import (
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
@@ -794,6 +795,19 @@ func buildMethodEndpointsWithAuth(
 		}
 		if len(policy.Roles) > 0 {
 			props["auth_roles"] = strings.Join(policy.Roles, ",")
+		}
+		// #authz — the specific fine-grained permission / scope required by the
+		// endpoint (Spring hasAuthority / hasPermission), sorted for a
+		// deterministic flat companion field.
+		if len(policy.Permissions) > 0 {
+			perms := append([]string(nil), policy.Permissions...)
+			sort.Strings(perms)
+			props["auth_permissions"] = strings.Join(perms, ",")
+		}
+		if len(policy.Scopes) > 0 {
+			scs := append([]string(nil), policy.Scopes...)
+			sort.Strings(scs)
+			props["auth_scopes"] = strings.Join(scs, ",")
 		}
 		if methodConsumes != "" {
 			props["consumes"] = methodConsumes

--- a/internal/engine/java_auth_policy.go
+++ b/internal/engine/java_auth_policy.go
@@ -49,9 +49,15 @@ import (
 //   - medium = config-driven policy matching the endpoint path.
 //   - low    = framework default (no explicit signal).
 type AuthPolicy struct {
-	Required    bool         `json:"required"`
-	Method      string       `json:"method"` // "annotation" | "middleware" | "config" | "framework_default" | "unknown"
-	Roles       []string     `json:"roles,omitempty"`
+	Required bool     `json:"required"`
+	Method   string   `json:"method"` // "annotation" | "middleware" | "config" | "framework_default" | "unknown"
+	Roles    []string `json:"roles,omitempty"`
+	// Permissions are fine-grained authorization grants required by the
+	// endpoint (e.g. `user:delete`, `orders.read`) — distinct from coarse
+	// roles. Populated from Spring hasAuthority/hasPermission, DRF custom
+	// permission classes, NestJS @RequirePermissions, Express checkPermission
+	// and Rails Pundit action policies.
+	Permissions []string     `json:"permissions,omitempty"`
 	Scopes      []string     `json:"scopes,omitempty"`
 	Confidence  string       `json:"confidence"` // "high" | "medium" | "low"
 	SourceChain []AuthSignal `json:"source_chain,omitempty"`
@@ -115,12 +121,28 @@ var (
 // across frameworks.
 var authRoleArgRe = regexp.MustCompile(`"([^"]+)"`)
 
-// preAuthRoleRe extracts role names from a Spring SpEL expression such as
-// `hasRole('ADMIN')`, `hasAnyRole('ADMIN','USER')`, or `hasAuthority('SCOPE_x')`.
-var preAuthRoleRe = regexp.MustCompile(`(?:hasRole|hasAnyRole|hasAuthority|hasAnyAuthority)\s*\(\s*([^)]+)\)`)
+// preAuthRoleRe extracts the role names declared via the role-specific SpEL
+// helpers `hasRole('ADMIN')` / `hasAnyRole('ADMIN','USER')`. These always name
+// roles (Spring prepends the `ROLE_` authority prefix internally), so they map
+// to auth_roles.
+var preAuthRoleRe = regexp.MustCompile(`(?:hasRole|hasAnyRole)\s*\(\s*([^)]+)\)`)
+
+// preAuthAuthorityRe extracts the authority strings declared via
+// `hasAuthority('user:delete')` / `hasAnyAuthority('SCOPE_read','x')`. An
+// authority is a free-form granted-authority string: it is a fine-grained
+// PERMISSION (e.g. `user:delete`) unless it carries Spring's role/scope
+// prefix, in which case it is classified as a role or a scope respectively.
+var preAuthAuthorityRe = regexp.MustCompile(`(?:hasAuthority|hasAnyAuthority)\s*\(\s*([^)]+)\)`)
+
+// preAuthPermissionRe extracts the arguments from a Spring
+// `hasPermission(#id, 'Order', 'delete')` / `hasPermission(target, 'read')`
+// ACL check. The LAST quoted argument is the permission name (`delete`,
+// `read`). We only capture quoted (literal) permission strings and never
+// fabricate one from a non-literal target.
+var preAuthPermissionRe = regexp.MustCompile(`hasPermission\s*\(([^)]*)\)`)
 
 // preAuthQuotedRe pulls quoted args (single or double quoted) out of the SpEL
-// expression captured by preAuthRoleRe.
+// expression captured by the helpers above.
 var preAuthQuotedRe = regexp.MustCompile(`['"]([^'"]+)['"]`)
 
 // ResolveJavaAuthPolicy combines per-method, per-class, and project-level
@@ -275,14 +297,20 @@ func matchAnnotationPolicy(annoText string, line int, file, _ string) (AuthPolic
 		}, true
 	}
 
-	// @PreAuthorize("...") — Spring SpEL.
+	// @PreAuthorize("...") — Spring SpEL. The SpEL expression can declare roles
+	// (hasRole), fine-grained permissions (hasAuthority('user:delete'),
+	// hasPermission(...,'delete')) and OAuth scopes (hasAuthority('SCOPE_read')),
+	// so we split the captured authority tokens across roles/permissions/scopes
+	// rather than dumping everything into roles.
 	if m := javaPreAuthorizeRe.FindStringSubmatch(annoText); m != nil {
-		roles := parsePreAuthorizeRoles(m[1])
+		roles, perms, scopes := parsePreAuthorizeExpr(m[1])
 		return AuthPolicy{
-			Required:   true,
-			Method:     "annotation",
-			Roles:      roles,
-			Confidence: "high",
+			Required:    true,
+			Method:      "annotation",
+			Roles:       roles,
+			Permissions: perms,
+			Scopes:      scopes,
+			Confidence:  "high",
 			SourceChain: []AuthSignal{{
 				Kind: "annotation",
 				Text: "@PreAuthorize(\"" + m[1] + "\")",
@@ -319,20 +347,58 @@ func stripRolePrefix(roles []string) []string {
 	return out
 }
 
-// parsePreAuthorizeRoles parses a Spring SpEL expression such as
-// `hasRole('ADMIN')` or `hasAnyRole('ADMIN','USER')` and returns the
-// captured role names. Returns nil when no role helper is recognised.
-func parsePreAuthorizeRoles(spel string) []string {
-	var roles []string
+// parsePreAuthorizeExpr parses a Spring SpEL `@PreAuthorize` expression and
+// splits the authorization tokens it declares into roles, permissions and
+// scopes:
+//
+//   - hasRole('ADMIN') / hasAnyRole(...)            → roles
+//   - hasAuthority('user:delete')                   → permissions
+//   - hasAuthority('SCOPE_read') / 'scope:read'     → scopes (prefix stripped)
+//   - hasAuthority('ROLE_ADMIN')                    → roles (prefix stripped)
+//   - hasPermission(#id, 'Order', 'delete')         → permissions (last literal)
+//
+// Dynamic / non-literal arguments (e.g. `hasRole(roleVar)`, a hasPermission
+// target that is a variable) yield no token — we never fabricate a value.
+func parsePreAuthorizeExpr(spel string) (roles, perms, scopes []string) {
+	// hasRole / hasAnyRole — always roles.
 	for _, m := range preAuthRoleRe.FindAllStringSubmatch(spel, -1) {
 		for _, q := range preAuthQuotedRe.FindAllStringSubmatch(m[1], -1) {
-			r := strings.TrimPrefix(strings.TrimSpace(q[1]), "ROLE_")
-			if r != "" {
+			if r := strings.TrimPrefix(strings.TrimSpace(q[1]), "ROLE_"); r != "" {
 				roles = append(roles, r)
 			}
 		}
 	}
-	return roles
+	// hasAuthority / hasAnyAuthority — classify each authority string.
+	for _, m := range preAuthAuthorityRe.FindAllStringSubmatch(spel, -1) {
+		for _, q := range preAuthQuotedRe.FindAllStringSubmatch(m[1], -1) {
+			tok := strings.TrimSpace(q[1])
+			if tok == "" {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(tok, "ROLE_"):
+				roles = append(roles, strings.TrimPrefix(tok, "ROLE_"))
+			case strings.HasPrefix(tok, "SCOPE_"):
+				scopes = append(scopes, strings.TrimPrefix(tok, "SCOPE_"))
+			case strings.HasPrefix(tok, "scope:"):
+				scopes = append(scopes, strings.TrimPrefix(tok, "scope:"))
+			default:
+				perms = append(perms, tok)
+			}
+		}
+	}
+	// hasPermission(target, [domainObjectType,] 'permission') — the last quoted
+	// literal is the permission name.
+	for _, m := range preAuthPermissionRe.FindAllStringSubmatch(spel, -1) {
+		quoted := preAuthQuotedRe.FindAllStringSubmatch(m[1], -1)
+		if len(quoted) == 0 {
+			continue
+		}
+		if last := strings.TrimSpace(quoted[len(quoted)-1][1]); last != "" {
+			perms = append(perms, last)
+		}
+	}
+	return roles, perms, scopes
 }
 
 // quarkusPermMatches reports whether any of the permission's path patterns
@@ -394,6 +460,9 @@ func EncodeAuthPolicy(p AuthPolicy) string {
 	cp := p
 	if len(cp.Roles) > 1 {
 		sort.Strings(cp.Roles)
+	}
+	if len(cp.Permissions) > 1 {
+		sort.Strings(cp.Permissions)
 	}
 	if len(cp.Scopes) > 1 {
 		sort.Strings(cp.Scopes)

--- a/internal/engine/java_auth_policy_test.go
+++ b/internal/engine/java_auth_policy_test.go
@@ -200,6 +200,87 @@ func TestResolveJavaAuthPolicy_PreAuthorize(t *testing.T) {
 	}
 }
 
+// @PreAuthorize("hasAuthority('user:delete')") must capture the fine-grained
+// permission on auth_permissions, NOT conflate it into auth_roles.
+func TestResolveJavaAuthPolicy_PreAuthorizeAuthorityPermission(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@DeleteMapping("/users/{id}")
+@PreAuthorize("hasAuthority('user:delete')")`,
+		51,
+		"", "UserController", 9,
+		"client-fixture-x/UserController.java",
+		"/users/{id}",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Fatal("expected required=true for @PreAuthorize hasAuthority")
+	}
+	if strings.Join(policy.Permissions, ",") != "user:delete" {
+		t.Errorf("expected permissions=[user:delete], got %v", policy.Permissions)
+	}
+	if len(policy.Roles) != 0 {
+		t.Errorf("expected no roles for a hasAuthority permission, got %v", policy.Roles)
+	}
+}
+
+// @PreAuthorize("hasAuthority('SCOPE_read')") is an OAuth scope, not a role or
+// a bare permission — the SCOPE_ prefix must route it to auth_scopes.
+func TestResolveJavaAuthPolicy_PreAuthorizeScope(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@GetMapping("/reports")
+@PreAuthorize("hasAuthority('SCOPE_reports:read')")`,
+		60,
+		"", "ReportController", 9,
+		"client-fixture-x/ReportController.java",
+		"/reports",
+		JavaAuthContext{},
+	)
+	if strings.Join(policy.Scopes, ",") != "reports:read" {
+		t.Errorf("expected scopes=[reports:read], got %v", policy.Scopes)
+	}
+	if len(policy.Roles) != 0 || len(policy.Permissions) != 0 {
+		t.Errorf("expected no roles/permissions for a SCOPE_ authority, got roles=%v perms=%v", policy.Roles, policy.Permissions)
+	}
+}
+
+// @PreAuthorize("hasPermission(#id, 'Order', 'delete')") — the trailing literal
+// is the permission name; the dynamic target #id must not become a permission.
+func TestResolveJavaAuthPolicy_PreAuthorizeHasPermission(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@DeleteMapping("/orders/{id}")
+@PreAuthorize("hasPermission(#id, 'Order', 'delete')")`,
+		70,
+		"", "OrderController", 9,
+		"client-fixture-x/OrderController.java",
+		"/orders/{id}",
+		JavaAuthContext{},
+	)
+	if strings.Join(policy.Permissions, ",") != "delete" {
+		t.Errorf("expected permissions=[delete], got %v", policy.Permissions)
+	}
+}
+
+// Negative: @PreAuthorize("hasRole(roleVar)") with a non-literal role argument
+// must NOT fabricate a role/permission.
+func TestResolveJavaAuthPolicy_PreAuthorizeDynamicRoleNoFabrication(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@GetMapping("/x")
+@PreAuthorize("hasRole(roleVar)")`,
+		80,
+		"", "DynController", 9,
+		"client-fixture-x/DynController.java",
+		"/x",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Fatal("expected required=true (the annotation is present)")
+	}
+	if len(policy.Roles) != 0 || len(policy.Permissions) != 0 || len(policy.Scopes) != 0 {
+		t.Errorf("expected no fabricated tokens for a dynamic role, got roles=%v perms=%v scopes=%v",
+			policy.Roles, policy.Permissions, policy.Scopes)
+	}
+}
+
 func TestResolveJavaAuthPolicy_DenyAll(t *testing.T) {
 	policy := ResolveJavaAuthPolicy(
 		"@GET\n@DenyAll",

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -987,11 +987,21 @@ records:
       Auth:
         auth_coverage:
           status: partial
+          # resolveFlaskDecoratorAuth (auth_endpoint.go) stamps auth_required/
+          # auth_guard plus the SPECIFIC authz: @roles_required('admin') →
+          # auth_roles, @permission_required('app.delete_order') →
+          # auth_permissions. DRF permission/scope classes are split likewise.
           symbols:
             - file: internal/custom/python/flask.go
               functions: [Extract]
-          issues_implemented: ["2977"]
-          verified_at: "2026-05-29"
+            - file: internal/custom/python/auth_endpoint.go
+              functions:
+                - resolveFlaskDecoratorAuth
+                - resolveDRFDecoratorAuth
+                - drfPermissionArgs
+                - drfScopeArgs
+          issues_implemented: ["2977", "3628"]
+          verified_at: "2026-06-02"
       Middleware:
         middleware_coverage:
           status: partial
@@ -1648,6 +1658,27 @@ records:
             - file: internal/engine/rules/javascript_typescript/frameworks/express.yaml
           issues_implemented: []
           verified_at: "2026-05-28"
+      Auth:
+        auth_coverage:
+          # http_endpoint_jsts_auth.go resolves the per-endpoint auth posture
+          # from the route middleware chain (requireAuth/passport) AND the
+          # SPECIFIC required authz from parameterised middleware:
+          # requireScope('write:users') → auth_scopes,
+          # checkPermission('users:delete') → auth_permissions, casl can(...).
+          status: partial
+          symbols:
+            - file: internal/engine/http_endpoint_jsts_auth.go
+              functions:
+                - indexRouteLevelAuth
+                - jsMiddlewareGrants
+                - permsFromSignals
+                - scopesFromSignals
+            - file: internal/engine/http_endpoint_jsts_auth_test.go
+              functions:
+                - TestAuthz_ExpressRequireScope
+                - TestAuthz_ExpressCheckPermission
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Validation:
         request_validation:
           status: full
@@ -1700,11 +1731,25 @@ records:
           verified_at: "2026-05-28"
       Auth:
         auth_coverage:
+          # http_endpoint_jsts_auth.go resolves the per-endpoint auth posture
+          # (@UseGuards method/class) AND the SPECIFIC required authz:
+          # @Roles('admin') → auth_roles, @RequirePermissions('user:delete') →
+          # auth_permissions, @Scopes('write:users') → auth_scopes.
           status: partial
           symbols:
             - file: internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml
-          issues_implemented: []
-          verified_at: "2026-05-28"
+            - file: internal/engine/http_endpoint_jsts_auth.go
+              functions:
+                - resolveEndpointAuth
+                - indexNestMethodGuards
+                - permsFromSignals
+                - scopesFromSignals
+            - file: internal/engine/http_endpoint_jsts_auth_test.go
+              functions:
+                - TestAuthz_NestRequirePermissions
+                - TestAuthz_NestScopes
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Middleware:
         middleware_coverage:
           status: partial
@@ -2644,18 +2689,24 @@ records:
           verified_at: "2026-06-02"
       Auth:
         auth_coverage:
+          # Endpoint auth posture (auth_required/method/confidence) PLUS the
+          # specific required authorization: roles (@RolesAllowed/@Secured/
+          # hasRole), fine-grained permissions (hasAuthority('user:delete'),
+          # hasPermission(...,'delete')) and OAuth scopes (hasAuthority('SCOPE_x'))
+          # split across auth_roles/auth_permissions/auth_scopes by
+          # parsePreAuthorizeExpr.
           status: full
           symbols:
             - file: internal/engine/java_auth_policy.go
               functions:
                 - ResolveJavaAuthPolicy
                 - matchAnnotationPolicy
-                - parsePreAuthorizeRoles
+                - parsePreAuthorizeExpr
                 - EncodeAuthPolicy
                 - DecodeAuthPolicy
                 - BuildJavaAuthContext
-          issues_implemented: ["2680"]
-          verified_at: "2026-05-28"
+          issues_implemented: ["2680", "3628"]
+          verified_at: "2026-06-02"
       Middleware:
         middleware_coverage:
           # java_annotation_params.go surfaces @PathVariable/@RequestHeader etc. param
@@ -7172,6 +7223,27 @@ records:
               functions: [runTaintFlowPass, computeFindings]
           issues_implemented: ["2773"]
           verified_at: "2026-05-28"
+      Auth:
+        auth_coverage:
+          # controller_auth.go resolves per-action auth posture from Devise
+          # before_action :authenticate_user! (+ only:/except:/skip) and per-
+          # action Pundit/CanCanCan guards, AND captures the SPECIFIC required
+          # authorization action: `authorize @post, :destroy?` /
+          # `authorize! :destroy, @post` → auth_permissions=destroy.
+          status: partial
+          symbols:
+            - file: internal/custom/ruby/controller_auth.go
+              functions:
+                - Extract
+                - caResolveAction
+                - resolveControllerLevelAuth
+          tests:
+            - file: internal/custom/ruby/controller_auth_test.go
+              functions:
+                - TestControllerAuthPunditExplicitAction
+                - TestControllerAuthCanCanCanBang
+          issues_implemented: ["3734", "3628"]
+          verified_at: "2026-06-02"
       Middleware:
         middleware_coverage:
           status: partial


### PR DESCRIPTION
Closes #3792 (child of #3628 area #6, authz).

## Summary
Extends the endpoint auth-protection passes (#3696 / #3735 / #3734 / #1942) beyond authentication (`auth_required` / `auth_guard`) to the **specific required authorization** — fine-grained permission, OAuth scope, or role — per endpoint. The graph can now answer "what permission does `DELETE /users/{id}` require?".

## What changed, by lane

**Java / Spring** (`internal/engine/java_auth_policy.go`, `java_annotation_routes.go`)
- `parsePreAuthorizeRoles` → `parsePreAuthorizeExpr`, which splits SpEL authority tokens instead of dumping everything into `auth_roles`:
  - `hasRole('ADMIN')` / `hasAnyRole(...)` → `auth_roles`
  - `hasAuthority('user:delete')` → `auth_permissions`
  - `hasAuthority('SCOPE_read')` / `'scope:read'` → `auth_scopes`
  - `hasAuthority('ROLE_x')` → `auth_roles` (prefix stripped)
  - `hasPermission(#id, 'Order', 'delete')` → permission `delete` (trailing literal; dynamic target ignored)
- New `AuthPolicy.Permissions` field; `auth_permissions` / `auth_scopes` stamped on the synthetic endpoint.

**Python** (`internal/custom/python/auth_endpoint.go`, `django.go`)
- DRF parameterised permission classes `HasPermission('orders.delete')` → `auth_permissions`; `HasScope('read')` / `TokenHasScope` + `required_scopes=[...]` → `auth_scopes`.
- Flask `@permission_required('app.delete_order')` → `auth_permissions` (vs `@roles_required` → roles).
- Django function-view `@permission_required(...)` now also stamps the cross-language `auth_permissions` flat field.

**JS/TS** (`internal/engine/http_endpoint_jsts_auth.go`)
- NestJS `@RequirePermissions('user:delete')` → `auth_permissions`, `@Scopes('write:users')` → `auth_scopes` (method + class level).
- Express parameterised middleware `requireScope('write:users')` → `auth_scopes`; `checkPermission('users:delete')` / casl `can('delete', ...)` → `auth_permissions`.

**Rails** (`internal/custom/ruby/controller_auth.go`)
- Pundit `authorize @post, :destroy?` and CanCanCan `authorize! :destroy, @post` → `auth_permissions=destroy`.

## Discipline (quality-first)
- **No fabrication**: dynamic / non-literal tokens (`hasRole(roleVar)`, `requireScope(scopeVar)`, implicit `authorize @x`) capture nothing.
- Generic authn (`IsAuthenticated`) stays `auth_required` only — no permission synthesised.
- Value-asserting tests assert the **specific** scope/role/permission value on the **specific** endpoint, plus negative no-fabrication tests, in every lane.

## Verification
- `go test` targeted green: `./internal/engine/ ./internal/custom/python/ ./internal/custom/ruby/ ./internal/custom/java/ ./internal/types/ ./tools/coverage/`
- `go vet` clean; `gofmt -l` empty.
- `coverage validate` → 0 errors (pre-existing warnings only); `coverage fmt --check` canonical; `coverage gen` → no doc drift.
- Coverage cite-map (`tools/coverage/capability-map.yaml`) enriched for the java/python/jsts/ruby Auth cells (renamed `parsePreAuthorizeExpr`, backfilled express + rails Auth cells citing the real resolvers + new tests).

DEPLOY-DEFERRED — no daemon rebuild / reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)