### PR TITLE
feat(engine): per-migration schema-operation MODIFIES_TABLE edges

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -64,13 +64,14 @@ const (
 	PassSharedDB      = "shared-db"      // Pass 8.8: shared-database cross-service coupling (#3628 area #13)
 	PassLibBoundary   = "lib-boundary"   // Pass 8.9: first_party/third_party boundary on DEPENDS_ON edges (#3638)
 	PassMigrationSeq  = "migration-seq"  // Pass 8.10: DB-migration ordering metadata + Alembic PRECEDES (#3639)
+	PassMigrationOps  = "migration-ops"  // Pass 8.11: per-migration schema-op MODIFIES_TABLE edges (#3628 [schema])
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassLibBoundary, PassMigrationSeq, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassLibBoundary, PassMigrationSeq, PassMigrationOps, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1632,6 +1633,27 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			fmt.Fprintf(os.Stderr,
 				"archigraph: migration-seq files=%d entities_annotated=%d precedes_edges=%d\n",
 				msStats.FilesMatched, msStats.EntitiesAnnotated, msStats.PrecedesEdges)
+		}
+	}
+
+	// Pass 8.11 — per-migration schema operations (#3628 [schema], epic #3625).
+	// Complements migration-seq (apply-ORDER / PRECEDES) with the actual
+	// OPERATIONS: for every migration schema-op entity the language extractors
+	// already emit (Alembic SCOPE.Schema, Rails/JS SCOPE.Evolution, Django
+	// Migration operations JSON, Flyway/Liquibase SQL CREATE TABLE), derive
+	// (op, table[, column]) and emit a MODIFIES_TABLE edge to a synthetic
+	// SCOPE.Table convergence node keyed by the SAME normalised table key the
+	// query→table (ACCESSES_TABLE) axis uses — then rewire matching
+	// SCOPE.DataAccess accessors onto that node so "what touches table X"
+	// unifies schema evolution + data access on one node. Honest: dynamic
+	// table names are skipped. Skippable via --skip-pass=migration-ops.
+	if !i.skipPasses[PassMigrationOps] {
+		moStats := engine.ApplyMigrationSchemaOps(doc)
+		if verbose() || moStats.ModifiesEdges > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: migration-ops considered=%d tables=%d modifies_edges=%d access_converged=%d\n",
+				moStats.OpsConsidered, moStats.TablesConverged,
+				moStats.ModifiesEdges, moStats.AccessConvergedEdges)
 		}
 	}
 

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -11,158 +11,158 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟡 3/4 | |
-| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟡 7/8 | |
-| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟡 3/4 | |
-| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟡 3/4 | |
-| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟡 3/4 | |
-| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟡 1/2 | |
-| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟡 3/4 | |
-| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/3 | |
-| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/3 | |
-| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/4 | |
-| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/9 | |
-| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/8 | |
-| [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/7 | |
-| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/2 | |
-| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 1/3 | |
-| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/2 | |
-| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | 🟡 1/3 | |
-| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | 🟡 7/8 | |
-| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | 🔴 0/2 | |
-| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | 🔴 0/2 | |
-| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | 🟡 1/2 | |
-| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | 🟡 7/8 | |
-| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | 🟡 3/4 | |
-| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | 🟡 7/8 | |
-| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🔴 0/2 | |
-| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🔴 0/2 | |
-| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/4 | |
-| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/9 | |
-| [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | 🟢 9/9 | |
-| [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/9 | |
-| [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/4 | |
-| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 4/5 | |
-| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟡 2/3 | |
-| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 2/3 | |
-| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 2/3 | |
-| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/2 | |
-| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/5 | |
-| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/4 | |
-| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/4 | |
-| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/5 | |
-| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/5 | |
-| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 6/6 | |
-| [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/7 | |
-| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/4 | |
-| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [MongoDB Java Driver](../detail/lang.java.driver.mongodb.md) | 🟡 1/2 | |
-| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟡 4/6 | |
-| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/4 | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/4 | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/8 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/4 | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/4 | |
-| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/7 | |
-| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/8 | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/9 | |
-| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/6 | |
-| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/9 | |
-| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 9/9 | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 9/9 | |
-| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/5 | |
-| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | 🟡 1/2 | |
-| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | 🟡 1/2 | |
-| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 7/8 | |
-| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/9 | |
-| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 7/8 | |
-| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 7/8 | |
-| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/8 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/9 | |
-| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/2 | |
-| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/9 | |
-| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/9 | |
-| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/9 | |
-| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/3 | |
-| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/3 | |
-| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/3 | |
-| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/9 | |
-| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/6 | |
-| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/2 | |
-| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/2 | |
-| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/2 | |
-| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/4 | |
-| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/3 | |
-| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/7 | |
-| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 9/9 | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/7 | |
-| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/3 | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/7 | |
-| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/7 | |
-| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 9/9 | |
-| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/9 | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/8 | |
-| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [neo4j (Python driver) / neomodel OGM](../detail/lang.python.driver.neo4j.md) | 🟡 3/5 | |
-| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 2/3 | |
-| [python](../by-language/python.md) | [pymongo / motor](../detail/lang.python.driver.mongodb.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | 🟡 1/2 | |
-| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 2/3 | |
-| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/2 | |
-| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 9/9 | |
-| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/9 | |
-| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/7 | |
-| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/9 | |
-| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/9 | |
-| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/2 | |
-| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/3 | |
-| [ruby](../by-language/ruby.md) | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/2 | |
-| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/2 | |
-| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/5 | |
-| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/2 | |
-| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/2 | |
-| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/2 | |
-| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 7/8 | |
-| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/5 | |
-| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 8/9 | |
-| [rust](../by-language/rust.md) | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/9 | |
-| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🔴 0/2 | |
-| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/2 | |
-| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🔴 0/2 | |
-| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | 🟡 1/2 | |
-| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | 🔴 0/2 | |
-| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | 🟡 3/4 | |
-| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/2 | |
-| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 1/2 | |
-| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🔴 0/2 | |
-| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 4/5 | |
-| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🔴 0/2 | |
-| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 3/4 | |
-| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/4 | |
-| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/6 | |
-| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/7 | |
-| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/4 | |
-| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/8 | |
+| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟡 3/5 | |
+| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟡 7/9 | |
+| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟡 3/5 | |
+| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟡 3/5 | |
+| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟡 3/5 | |
+| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟡 1/3 | |
+| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟡 3/5 | |
+| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/4 | |
+| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/4 | |
+| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/5 | |
+| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/10 | |
+| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/9 | |
+| [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/8 | |
+| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/3 | |
+| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 1/4 | |
+| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/3 | |
+| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | 🟡 1/4 | |
+| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | 🟡 7/9 | |
+| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | 🔴 0/3 | |
+| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | 🔴 0/3 | |
+| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | 🟡 1/3 | |
+| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | 🟡 7/9 | |
+| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | 🟡 3/5 | |
+| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | 🟡 7/9 | |
+| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🔴 0/3 | |
+| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🔴 0/3 | |
+| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/5 | |
+| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/10 | |
+| [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | 🟡 9/10 | |
+| [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/10 | |
+| [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/5 | |
+| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 4/6 | |
+| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟡 2/4 | |
+| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 2/4 | |
+| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 2/4 | |
+| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/3 | |
+| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/6 | |
+| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/5 | |
+| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/5 | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/6 | |
+| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/6 | |
+| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/7 | |
+| [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/8 | |
+| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/5 | |
+| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/9 | |
+| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/9 | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/9 | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 8/9 | |
+| [java](../by-language/java.md) | [MongoDB Java Driver](../detail/lang.java.driver.mongodb.md) | 🟡 1/3 | |
+| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 7/9 | |
+| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟡 4/7 | |
+| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 7/9 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/5 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/5 | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/9 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/5 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/5 | |
+| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/8 | |
+| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/9 | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/10 | |
+| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/7 | |
+| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/10 | |
+| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/9 | |
+| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 10/10 | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 10/10 | |
+| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/6 | |
+| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | 🟡 1/3 | |
+| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 7/9 | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/10 | |
+| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 7/9 | |
+| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/4 | |
+| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 7/9 | |
+| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/9 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/10 | |
+| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/3 | |
+| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/10 | |
+| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/10 | |
+| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/10 | |
+| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/4 | |
+| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/4 | |
+| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/4 | |
+| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/10 | |
+| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/7 | |
+| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/3 | |
+| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/3 | |
+| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/3 | |
+| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/5 | |
+| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/4 | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/8 | |
+| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 10/10 | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/8 | |
+| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/4 | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/8 | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/8 | |
+| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 10/10 | |
+| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/10 | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/9 | |
+| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [neo4j (Python driver) / neomodel OGM](../detail/lang.python.driver.neo4j.md) | 🟡 3/6 | |
+| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 2/4 | |
+| [python](../by-language/python.md) | [pymongo / motor](../detail/lang.python.driver.mongodb.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | 🟡 1/3 | |
+| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 2/4 | |
+| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/3 | |
+| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 10/10 | |
+| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/10 | |
+| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/8 | |
+| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/10 | |
+| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/10 | |
+| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/3 | |
+| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/4 | |
+| [ruby](../by-language/ruby.md) | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/3 | |
+| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/3 | |
+| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/3 | |
+| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/3 | |
+| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 7/9 | |
+| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 8/10 | |
+| [rust](../by-language/rust.md) | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/10 | |
+| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/3 | |
+| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | 🟡 1/3 | |
+| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | 🟡 3/5 | |
+| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/3 | |
+| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 1/3 | |
+| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🔴 0/3 | |
+| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 3/5 | |
+| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/5 | |
+| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/7 | |
+| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/8 | |
+| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/5 | |
+| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/9 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -93,13 +93,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟡 3/4 | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟡 7/8 | |
-| [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟡 3/4 | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟡 3/4 | |
-| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟡 3/4 | |
-| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟡 1/2 | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟡 3/4 | |
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟡 3/5 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟡 7/9 | |
+| [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟡 3/5 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟡 3/5 | |
+| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟡 3/5 | |
+| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟡 1/3 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟡 3/5 | |
 
 
 ## Other

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -87,20 +87,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/3 | |
-| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/3 | |
-| [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/4 | |
-| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/9 | |
-| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/8 | |
-| [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/7 | |
-| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/2 | |
-| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 1/3 | |
-| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/2 | |
-| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | 🟡 1/3 | |
-| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | 🟡 7/8 | |
-| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | 🔴 0/2 | |
-| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | 🔴 0/2 | |
-| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | 🟡 1/2 | |
+| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/4 | |
+| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/4 | |
+| [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/5 | |
+| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/10 | |
+| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/9 | |
+| [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/8 | |
+| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/3 | |
+| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 1/4 | |
+| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/3 | |
+| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | 🟡 1/4 | |
+| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | 🟡 7/9 | |
+| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | 🔴 0/3 | |
+| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | 🔴 0/3 | |
+| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | 🟡 1/3 | |
 
 
 ## Other

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -71,16 +71,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Ecto](../detail/lang.elixir.orm.ecto.md) | 🟡 7/8 | |
-| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | 🔴 0/2 | |
-| [MyXQL](../detail/lang.elixir.driver.myxql.md) | 🔴 0/2 | |
-| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | 🔴 0/2 | |
-| [Redix](../detail/lang.elixir.driver.redix.md) | 🔴 0/2 | |
-| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | 🔴 0/2 | |
-| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | 🟡 3/4 | |
-| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | 🟡 7/8 | |
-| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🔴 0/2 | |
-| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🔴 0/2 | |
+| [Ecto](../detail/lang.elixir.orm.ecto.md) | 🟡 7/9 | |
+| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | 🔴 0/3 | |
+| [MyXQL](../detail/lang.elixir.driver.myxql.md) | 🔴 0/3 | |
+| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | 🔴 0/3 | |
+| [Redix](../detail/lang.elixir.driver.redix.md) | 🔴 0/3 | |
+| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | 🔴 0/3 | |
+| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | 🟡 3/5 | |
+| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | 🟡 7/9 | |
+| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🔴 0/3 | |
+| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🔴 0/3 | |
 
 
 ## Other

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -80,20 +80,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/4 | |
-| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/9 | |
-| [GORM](../detail/lang.go.orm.gorm.md) | 🟢 9/9 | |
-| [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/9 | |
-| [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/4 | |
-| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 4/5 | |
-| [go-redis](../detail/lang.go.driver.redis.md) | 🟡 2/3 | |
-| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 2/3 | |
-| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 2/3 | |
-| [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/2 | |
-| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/5 | |
-| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/4 | |
-| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/4 | |
-| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/5 | |
-| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/5 | |
-| [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 6/6 | |
-| [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/7 | |
+| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/5 | |
+| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/10 | |
+| [GORM](../detail/lang.go.orm.gorm.md) | 🟡 9/10 | |
+| [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/10 | |
+| [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/5 | |
+| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 4/6 | |
+| [go-redis](../detail/lang.go.driver.redis.md) | 🟡 2/4 | |
+| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 2/4 | |
+| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 2/4 | |
+| [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/3 | |
+| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/6 | |
+| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/5 | |
+| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/5 | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/6 | |
+| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/6 | |
+| [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/7 | |
+| [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/8 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -96,21 +96,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/4 | |
-| [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/8 | |
-| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/8 | |
-| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/8 | |
-| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 7/8 | |
-| [MongoDB Java Driver](../detail/lang.java.driver.mongodb.md) | 🟡 1/2 | |
-| [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 7/8 | |
-| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟡 4/6 | |
-| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 7/8 | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/4 | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/4 | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/8 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/4 | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/4 | |
-| [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/7 | |
+| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/5 | |
+| [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/9 | |
+| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/9 | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/9 | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 8/9 | |
+| [MongoDB Java Driver](../detail/lang.java.driver.mongodb.md) | 🟡 1/3 | |
+| [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 7/9 | |
+| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟡 4/7 | |
+| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 7/9 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/5 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/5 | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/9 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/5 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/5 | |
+| [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/8 | |
 
 
 ## Other

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -129,24 +129,24 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | 🟡 1/2 | |
-| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/2 | |
-| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/8 | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 7/7 | |
-| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/9 | |
-| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/2 | |
-| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/6 | |
-| [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/9 | |
-| [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ 8/8 | |
-| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 9/9 | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 9/9 | |
-| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/2 | |
-| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/2 | |
-| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/2 | |
-| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/2 | |
-| [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/5 | |
-| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | 🟡 1/2 | |
-| [supabase-js](../detail/lang.jsts.driver.supabase.md) | 🟡 1/2 | |
+| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | 🟡 1/3 | |
+| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/3 | |
+| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/9 | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 8/8 | |
+| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/10 | |
+| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/3 | |
+| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/7 | |
+| [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/10 | |
+| [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/9 | |
+| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 10/10 | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 10/10 | |
+| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/3 | |
+| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/3 | |
+| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/3 | |
+| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/3 | |
+| [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/6 | |
+| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | 🟡 1/3 | |
+| [supabase-js](../detail/lang.jsts.driver.supabase.md) | 🟡 1/3 | |
 
 
 ## Other

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -64,10 +64,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 7/8 | |
-| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/9 | |
-| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 7/8 | |
-| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/3 | |
-| [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 7/8 | |
-| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/8 | |
-| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/9 | |
+| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 7/9 | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 7/10 | |
+| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 7/9 | |
+| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/4 | |
+| [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 7/9 | |
+| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/9 | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 7/10 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -61,17 +61,17 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/2 | |
-| [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/9 | |
-| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/9 | |
-| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/9 | |
-| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/3 | |
-| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/3 | |
-| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/3 | |
-| [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/9 | |
-| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/6 | |
-| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/2 | |
-| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/2 | |
-| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/2 | |
-| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/4 | |
-| [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/2 | |
+| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/3 | |
+| [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/10 | |
+| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/10 | |
+| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/10 | |
+| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/4 | |
+| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/4 | |
+| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/4 | |
+| [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/10 | |
+| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/7 | |
+| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/3 | |
+| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/3 | |
+| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/3 | |
+| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/5 | |
+| [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/3 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -90,24 +90,24 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/3 | |
-| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/7 | |
-| [Django ORM](../detail/lang.python.orm.django.md) | ✅ 9/9 | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/7 | |
-| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/3 | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/7 | |
-| [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/7 | |
-| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 9/9 | |
-| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/9 | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/8 | |
-| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/2 | |
-| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟡 1/2 | |
-| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟡 1/2 | |
-| [neo4j (Python driver) / neomodel OGM](../detail/lang.python.driver.neo4j.md) | 🟡 3/5 | |
-| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 2/3 | |
-| [pymongo / motor](../detail/lang.python.driver.mongodb.md) | 🟡 1/2 | |
-| [redis-py](../detail/lang.python.driver.redis.md) | 🟡 1/2 | |
-| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 2/3 | |
+| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/4 | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/8 | |
+| [Django ORM](../detail/lang.python.orm.django.md) | ✅ 10/10 | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/8 | |
+| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/4 | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/8 | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/8 | |
+| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 10/10 | |
+| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/10 | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/9 | |
+| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/3 | |
+| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟡 1/3 | |
+| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟡 1/3 | |
+| [neo4j (Python driver) / neomodel OGM](../detail/lang.python.driver.neo4j.md) | 🟡 3/6 | |
+| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 2/4 | |
+| [pymongo / motor](../detail/lang.python.driver.mongodb.md) | 🟡 1/3 | |
+| [redis-py](../detail/lang.python.driver.redis.md) | 🟡 1/3 | |
+| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 2/4 | |
 
 
 ## Other

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -55,20 +55,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/2 | |
-| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 9/9 | |
-| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/9 | |
-| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/7 | |
-| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/9 | |
-| [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/9 | |
-| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/2 | |
-| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/3 | |
-| [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/2 | |
-| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/2 | |
-| [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/5 | |
-| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/2 | |
-| [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/2 | |
-| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/2 | |
+| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/3 | |
+| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 10/10 | |
+| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/10 | |
+| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/8 | |
+| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/10 | |
+| [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/10 | |
+| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/3 | |
+| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/4 | |
+| [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/3 | |
+| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/3 | |
+| [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/6 | |
+| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/3 | |
+| [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/3 | |
+| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/3 | |
 
 
 ## Other

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -66,21 +66,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 7/8 | |
-| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/5 | |
-| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 8/9 | |
-| [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/9 | |
-| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🔴 0/2 | |
-| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/2 | |
-| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🔴 0/2 | |
-| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | 🟡 1/2 | |
-| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | 🔴 0/2 | |
-| [neo4rs](../detail/lang.rust.driver.neo4j.md) | 🟡 3/4 | |
-| [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/2 | |
-| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 1/2 | |
-| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🔴 0/2 | |
-| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 4/5 | |
-| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🔴 0/2 | |
+| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 7/9 | |
+| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/6 | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 8/10 | |
+| [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/10 | |
+| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🔴 0/3 | |
+| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/3 | |
+| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🔴 0/3 | |
+| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | 🟡 1/3 | |
+| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | 🔴 0/3 | |
+| [neo4rs](../detail/lang.rust.driver.neo4j.md) | 🟡 3/5 | |
+| [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/3 | |
+| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 1/3 | |
+| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🔴 0/3 | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 4/6 | |
+| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🔴 0/3 | |
 
 
 ## Other

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -69,9 +69,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 3/4 | |
-| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/4 | |
-| [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/6 | |
-| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/7 | |
-| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/4 | |
-| [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/8 | |
+| [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 3/5 | |
+| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/5 | |
+| [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/7 | |
+| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/8 | |
+| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/5 | |
+| [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/9 | |

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | raw driver — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | raw driver — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | raw driver — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | raw driver — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.orm.odb.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.odb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-30` | — | — | ODB has no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.orm.soci.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.soci.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-30` | — | — | SOCI has no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 has no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.orm.dapper.md
+++ b/docs/coverage/detail/lang.csharp.orm.dapper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | micro-ORM/query-lib — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-29` | 3262 | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
+++ b/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | micro-ORM/query-lib — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.orm.linqtodb.md
+++ b/docs/coverage/detail/lang.csharp.orm.linqtodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | micro-ORM/query-lib — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.csharp.orm.nhibernate.md
+++ b/docs/coverage/detail/lang.csharp.orm.nhibernate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | micro-ORM/query-lib — no built-in migration system |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/ecto.go` | create table(:name) migration macros extracted as SCOPE.Schema/migration; add/remove column not yet tracked |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/ecto.go` | create table(:name) migration macros extracted as SCOPE.Schema/migration; add/remove column not yet tracked |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/elasticsearch.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.bun.md
+++ b/docs/coverage/detail/lang.go.orm.bun.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-29` | 3255 | `internal/custom/golang/bun.go`<br>`internal/custom/golang/bun_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.ent.md
+++ b/docs/coverage/detail/lang.go.orm.ent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-29` | 3255 | `internal/custom/golang/ent.go`<br>`internal/custom/golang/ent_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.gen.md
+++ b/docs/coverage/detail/lang.go.orm.gen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | gen generates query code, not migrations (gorm.go) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.gorm.md
+++ b/docs/coverage/detail/lang.go.orm.gorm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/gorm.go`<br>`internal/custom/golang/gorm_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.migrate.md
+++ b/docs/coverage/detail/lang.go.orm.migrate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/golang_migrate.yaml` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.sqlc.md
+++ b/docs/coverage/detail/lang.go.orm.sqlc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/sqlc.go`<br>`internal/custom/golang/sqlc_test.go` | file-based NNN_slug.up/down.sql migration file recognition; sqlc.yaml config has_schema/has_queries properties extracted; TestSqlcConfig + TestSqlcMigrationFile prove both |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.sqlx.md
+++ b/docs/coverage/detail/lang.go.orm.sqlx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | file-based NNN_slug.up/down.sql migrations recognised by filename; no migration runner integration; ALTER TABLE in migration content not parsed for schema delta |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.go.orm.xo.md
+++ b/docs/coverage/detail/lang.go.orm.xo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | xo introspects existing schema; no migration management |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.driver.mongodb.md
+++ b/docs/coverage/detail/lang.java.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.ebean.md
+++ b/docs/coverage/detail/lang.java.orm.ebean.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.eclipselink.md
+++ b/docs/coverage/detail/lang.java.orm.eclipselink.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.jooq.md
+++ b/docs/coverage/detail/lang.java.orm.jooq.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | 3098 | `internal/custom/java/jooq.go` | jOOQ is a query DSL, not schema-migration tooling; migration_parsing is not applicable |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🟢 `partial` | `2026-06-02` | 3628 | `internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go`<br>`internal/extractors/sql/sql.go` | Flyway/Liquibase versioned SQL (Vn__*.sql) CREATE TABLE parsed by the SQL DDL extractor (SCOPE.Datastore subtype=table, migration_file set) converges via MODIFIES_TABLE op=create_table (#3628). Asserted by TestFlywaySQLCreateTable. Partial: ALTER TABLE ADD/DROP COLUMN inside migrations not yet mapped to add_column/drop_column ops. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | MyBatis is an SQL mapper; database migration files are owned by Flyway/Liquibase, not MyBatis. Same rationale as T1 ORM sweep (#3180). |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | 3098 | `internal/custom/java/neo4j.go` | Neo4j graph database has no SQL migration files; migration_parsing is not applicable |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.panache.md
+++ b/docs/coverage/detail/lang.java.orm.panache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | Panache is a JPA wrapper (Quarkus-backed); database migration files are owned by Flyway/Liquibase. Same rationale as T1 ORM sweep (#3180). |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.cassandra.md
+++ b/docs/coverage/detail/lang.jsts.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.elastic.md
+++ b/docs/coverage/detail/lang.jsts.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.mongodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.mysql.md
+++ b/docs/coverage/detail/lang.jsts.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.neo4j.md
+++ b/docs/coverage/detail/lang.jsts.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.postgres.md
+++ b/docs/coverage/detail/lang.jsts.driver.postgres.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.redis.md
+++ b/docs/coverage/detail/lang.jsts.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.sqlite.md
+++ b/docs/coverage/detail/lang.jsts.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.driver.supabase.md
+++ b/docs/coverage/detail/lang.jsts.driver.supabase.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.drizzle.md
+++ b/docs/coverage/detail/lang.jsts.orm.drizzle.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/drizzle.go`<br>`internal/custom/javascript/extractors_coverage_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/knex.go` | — |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/knex.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | knex schema-builder ops (createTable/table/dropTable) SCOPE.Evolution entities converge via MODIFIES_TABLE (#3628). Asserted by TestKnexCreateTable. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 10
+- **Capability cells:** 11
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.prisma.md
+++ b/docs/coverage/detail/lang.jsts.orm.prisma.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/prisma.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/sequelize.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | Sequelize queryInterface.createTable/addColumn migration ops converge via MODIFIES_TABLE (#3628). Same engine pass as knex/typeorm. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/typeorm.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | TypeORM queryRunner.createTable/addColumn migration ops converge via MODIFIES_TABLE (#3628). Asserted by TestTypeORMAddColumn. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.exposed.md
+++ b/docs/coverage/detail/lang.kotlin.orm.exposed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/kotlin/jpa_compose_ext.go` | New extractor: kotlinJPAMigrationExtractor emits migration entities from Flyway versioned/repeatable class declarations (V2__...), BaseJavaMigration extends, Liquibase @ChangeSet annotations, flyway.migrate() calls, and config bean detection. Partial because SQL migration files (V1__init.sql) are handled by internal/extractors/sql/sql.go. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.ktorm.md
+++ b/docs/coverage/detail/lang.kotlin.orm.ktorm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | Ktorm has no built-in migration layer; migrations are handled externally (Flyway, Liquibase, etc.) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.room.md
+++ b/docs/coverage/detail/lang.kotlin.orm.room.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/kotlin/jpa_compose_ext.go` | New extractor: kotlinJPAMigrationExtractor covers Flyway/Liquibase migration declarations in Kotlin — same patterns apply to Spring Data JPA projects (both use Flyway/Liquibase for schema migration). SpringLiquibase bean detection is explicit. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
+++ b/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/php/orm_data.go` | AbstractMigration subclasses + up/down methods scanned. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | — | — | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | RedBeanPHP is zero-config — schema is created/altered automatically at runtime; no migration files to parse. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.mongodb.md
+++ b/docs/coverage/detail/lang.python.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-06-02` | 3639 | `internal/custom/python/alembic_schema.go`<br>`internal/engine/migration_sequence.go`<br>`internal/engine/rules/python/orms/alembic.yaml`<br>`internal/enrichers/migration_sequence_enricher.go` | Previously FALSE-full (#3630): the cited migration_sequence_enricher.go was orphaned (imported by zero production code) so no sequence/ordering metadata was ever emitted. #3639 wires it as live Pass 8.9 (engine.ApplyMigrationSequence, cmd/archigraph/index.go): each Alembic versions/*.py entity is stamped sequence_number/migration_name/migration_pattern from the filename, and the pass reads the file body (enrichers.ParseAlembicRevisions) to emit a PRECEDES edge along the down_revision to revision DAG, making the migration chain traversable. Separately alembic_schema.go parses upgrade() op content. Partial: op.alter_column type changes, dropped columns, and server_default/constraint metadata are still not modeled. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-06-02` | 3639 | `internal/engine/migration_sequence.go`<br>`internal/extractors/python/django_migration.go` | django_migration.go parses NNNN_name.py into op_count/operations/dependencies. #3639 additionally stamps sequence_number (the NNNN ordinal) + migration_name + migration_pattern=django on each migration entity via live Pass 8.9 (engine.ApplyMigrationSequence). |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go`<br>`internal/extractors/python/django_migration.go` | Django CreateModel/AddField/RemoveField operations (from the Migration entity operations JSON) emit MODIFIES_TABLE edges keyed by model name (#3628). Asserted by TestDjangoCreateModelAndAddField. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | Peewee-migrate is a separate optional library; core peewee has no built-in migration concept (#3184) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | Pony ORM has no built-in migration support; schema changes require manual intervention (#3184) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-29` | 3060 | `internal/engine/rules/python/orms/alembic.yaml` | — |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/custom/python/alembic_schema.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | Alembic op.create_table/add_column/create_index SCOPE.Schema entities converge onto a synthetic SCOPE.Table via MODIFIES_TABLE edges (engine pass, #3628). Asserted by TestAlembicCreateTableAndAddColumn. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.sqlmodel.md
+++ b/docs/coverage/detail/lang.python.orm.sqlmodel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-29` | 3056 | `internal/engine/rules/python/orms/alembic.yaml` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | Aerich handles migrations separately; core tortoise-orm has no built-in migration support (#3184) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.mongodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | — | 3639 | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go`<br>`internal/engine/migration_sequence.go` | db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. #3639 additionally stamps sequence_number (the YYYYMMDDHHMMSS timestamp) + migration_name + migration_pattern=rails on each db/migrate entity via live Pass 8.9 (engine.ApplyMigrationSequence). |
+| Migration schema ops | ✅ `full` | `2026-06-02` | — | `internal/custom/ruby/activerecord_deep.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | Rails create_table/add_column/drop_column/add_index SCOPE.Evolution ops converge via MODIFIES_TABLE (#3628). Asserted by TestRailsAddColumn. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.orm.datamapper.md
+++ b/docs/coverage/detail/lang.ruby.orm.datamapper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/ruby/activerecord.go` | DataMapper::Migration / migration(n, :name) blocks, create_table/add_column via dm-migrations. Part of #3282. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.orm.rom-rb.md
+++ b/docs/coverage/detail/lang.ruby.orm.rom-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/ruby/activerecord.go` | ROM-rb uses Sequel.migration underneath; migration block detection covers this. Part of #3282. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.ruby.orm.sequel.md
+++ b/docs/coverage/detail/lang.ruby.orm.sequel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | — | — | `internal/custom/ruby/activerecord.go` | Sequel.migration, DB.create_table/alter_table, add_column inside Sequel migration blocks. Part of #3282. |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.framework.sea-query.md
+++ b/docs/coverage/detail/lang.rust.framework.sea-query.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/diesel_seaorm_test.go`<br>`internal/custom/rust/orm_props_test.go`<br>`internal/custom/rust/testdata/diesel_up.sql` | Detects embed_migrations!(), run_pending_migrations(), impl MigrationHarness patterns |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Detects table_meta! and rbatis::table_sync! migration macros |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_migration.rs` | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | sqlx::migrate! path + migration file refs detected; parsing the referenced migrations/*.sql DDL is out of scope (sqlx resolves them at compile time, not in the .rs source). |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.doobie.md
+++ b/docs/coverage/detail/lang.scala.orm.doobie.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | `internal/custom/scala/orm_extractors.go` | Doobie does not manage migrations; use Flyway or Liquibase alongside doobie |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.quill.md
+++ b/docs/coverage/detail/lang.scala.orm.quill.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | `internal/custom/scala/orm_extractors.go` | Quill does not manage schema migrations; use Flyway/Liquibase/scala-migrations alongside Quill |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
+++ b/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | — | — | `internal/custom/scala/orm_extractors.go` | scalikejdbcDBMigrationRe captures DB autoCommit/localTx blocks which can contain DDL; scalikejdbc-play-support includes DB evolution integration |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.scala.orm.slick.md
+++ b/docs/coverage/detail/lang.scala.orm.slick.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 9
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -38,6 +38,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | — | — | `internal/custom/scala/orm_extractors.go` | slickMigrationRe captures schema.create / schema.createIfNotExists / DBIO.seq DDL patterns; full SQL migration file parsing not applicable (use Flyway) |
+| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
 
 ### Transactions
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2135,6 +2135,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "raw driver — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -2197,6 +2201,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "raw driver — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -2258,6 +2266,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "raw driver — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -2315,6 +2327,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "raw driver — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -6755,6 +6771,10 @@
             "status": "not_applicable",
             "notes": "ODB has no built-in migration system",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -6822,6 +6842,10 @@
             "status": "not_applicable",
             "notes": "SOCI has no built-in migration system",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -6888,6 +6912,10 @@
             "status": "not_applicable",
             "notes": "sqlpp11 has no built-in migration system",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7206,6 +7234,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7263,6 +7295,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7320,6 +7356,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7377,6 +7417,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7432,6 +7476,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7487,6 +7535,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7542,6 +7594,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7598,6 +7654,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -7653,6 +7713,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -10988,6 +11052,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "micro-ORM/query-lib — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11051,6 +11119,10 @@
             "status": "full",
             "issue": "3262",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11122,6 +11194,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "micro-ORM/query-lib — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11191,6 +11267,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "micro-ORM/query-lib — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11264,6 +11344,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "micro-ORM/query-lib — no built-in migration system"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11494,6 +11578,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11549,6 +11637,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11604,6 +11696,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11659,6 +11755,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11719,6 +11819,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11774,6 +11878,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11829,6 +11937,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -11884,6 +11996,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15304,6 +15420,10 @@
             "cites": ["internal/custom/elixir/ecto.go"],
             "notes": "create table(:name) migration macros extracted as SCOPE.Schema/migration; add/remove column not yet tracked",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15371,6 +15491,10 @@
             "cites": ["internal/custom/elixir/ecto.go"],
             "notes": "create table(:name) migration macros extracted as SCOPE.Schema/migration; add/remove column not yet tracked",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15428,6 +15552,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15488,6 +15616,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15551,6 +15683,10 @@
             "cites": ["internal/custom/golang/elasticsearch.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/elasticsearch_go.yaml"],
             "issue": "3214",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15607,6 +15743,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15668,6 +15808,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15727,6 +15871,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15780,6 +15928,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -15839,6 +15991,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -20823,6 +20979,10 @@
             "cites": ["internal/custom/golang/bun.go","internal/custom/golang/bun_test.go"],
             "issue": "3255",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -20894,6 +21054,10 @@
             "cites": ["internal/custom/golang/ent.go","internal/custom/golang/ent_test.go"],
             "issue": "3255",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -20953,6 +21117,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "gen generates query code, not migrations (gorm.go)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21018,6 +21186,10 @@
             "status": "full",
             "cites": ["internal/custom/golang/gorm.go","internal/custom/golang/gorm_test.go"],
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21075,6 +21247,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21137,6 +21313,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21201,6 +21381,10 @@
             "cites": ["internal/custom/golang/sqlc.go","internal/custom/golang/sqlc_test.go"],
             "notes": "file-based NNN_slug.up/down.sql migration file recognition; sqlc.yaml config has_schema/has_queries properties extracted; TestSqlcConfig + TestSqlcMigrationFile prove both",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21267,6 +21451,10 @@
             "issue": "3214",
             "notes": "file-based NNN_slug.up/down.sql migrations recognised by filename; no migration runner integration; ALTER TABLE in migration content not parsed for schema delta",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21334,6 +21522,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "xo introspects existing schema; no migration management"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -21391,6 +21583,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27433,6 +27629,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27505,6 +27705,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27576,6 +27780,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27647,6 +27855,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27717,6 +27929,10 @@
             "cites": ["internal/custom/java/jooq.go"],
             "issue": "3098",
             "notes": "jOOQ is a query DSL, not schema-migration tooling; migration_parsing is not applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27790,6 +28006,13 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "partial",
+            "cites": ["internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go","internal/extractors/sql/sql.go"],
+            "issue": "3628",
+            "notes": "Flyway/Liquibase versioned SQL (Vn__*.sql) CREATE TABLE parsed by the SQL DDL extractor (SCOPE.Datastore subtype=table, migration_file set) converges via MODIFIES_TABLE op=create_table (#3628). Asserted by TestFlywaySQLCreateTable. Partial: ALTER TABLE ADD/DROP COLUMN inside migrations not yet mapped to add_column/drop_column ops.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -27865,6 +28088,10 @@
             "status": "not_applicable",
             "notes": "MyBatis is an SQL mapper; database migration files are owned by Flyway/Liquibase, not MyBatis. Same rationale as T1 ORM sweep (#3180).",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -27935,6 +28162,10 @@
             "cites": ["internal/custom/java/neo4j.go"],
             "issue": "3098",
             "notes": "Neo4j graph database has no SQL migration files; migration_parsing is not applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28011,6 +28242,10 @@
             "status": "not_applicable",
             "notes": "Panache is a JPA wrapper (Quarkus-backed); database migration files are owned by Flyway/Liquibase. Same rationale as T1 ORM sweep (#3180).",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28077,6 +28312,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28143,6 +28382,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28214,6 +28457,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28280,6 +28527,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28346,6 +28597,10 @@
             "status": "not_applicable",
             "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28481,6 +28736,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28540,6 +28799,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28599,6 +28862,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28658,6 +28925,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28717,6 +28988,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28780,6 +29055,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28839,6 +29118,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28898,6 +29181,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -28957,6 +29244,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -29016,6 +29307,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37287,6 +37582,10 @@
             "status": "full",
             "cites": ["internal/custom/javascript/drizzle.go","internal/custom/javascript/extractors_coverage_test.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37358,6 +37657,12 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/knex.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/knex.go","internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go"],
+            "notes": "knex schema-builder ops (createTable/table/dropTable) SCOPE.Evolution entities converge via MODIFIES_TABLE (#3628). Asserted by TestKnexCreateTable.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -37428,6 +37733,10 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37491,6 +37800,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37554,6 +37867,10 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37630,6 +37947,10 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/prisma.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -37700,6 +38021,12 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/sequelize.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/sequelize.go","internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go"],
+            "notes": "Sequelize queryInterface.createTable/addColumn migration ops converge via MODIFIES_TABLE (#3628). Same engine pass as knex/typeorm.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -37768,6 +38095,12 @@
             "status": "full",
             "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/typeorm.go"],
             "verified_at": "2026-05-28"
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/typeorm.go","internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go"],
+            "notes": "TypeORM queryRunner.createTable/addColumn migration ops converge via MODIFIES_TABLE (#3628). Asserted by TestTypeORMAddColumn.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -41906,6 +42239,10 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/orm_schema.go","internal/custom/kotlin/orm_schema_test.go"],
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -41977,6 +42314,10 @@
             "status": "partial",
             "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
             "notes": "New extractor: kotlinJPAMigrationExtractor emits migration entities from Flyway versioned/repeatable class declarations (V2__...), BaseJavaMigration extends, Liquibase @ChangeSet annotations, flyway.migrate() calls, and config bean detection. Partial because SQL migration files (V1__init.sql) are handled by internal/extractors/sql/sql.go."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -42041,6 +42382,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "Ktorm has no built-in migration layer; migrations are handled externally (Flyway, Liquibase, etc.)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -42098,6 +42443,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -42160,6 +42509,10 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/orm_schema.go","internal/custom/kotlin/orm_schema_test.go"],
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -42231,6 +42584,10 @@
             "status": "partial",
             "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
             "notes": "New extractor: kotlinJPAMigrationExtractor covers Flyway/Liquibase migration declarations in Kotlin — same patterns apply to Spring Data JPA projects (both use Flyway/Liquibase for schema migration). SpringLiquibase bean detection is explicit."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -42294,6 +42651,10 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/orm_schema.go","internal/custom/kotlin/orm_schema_test.go"],
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43306,6 +43667,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43362,6 +43727,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43418,6 +43787,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43474,6 +43847,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43531,6 +43908,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43591,6 +43972,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43648,6 +44033,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43704,6 +44093,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -43761,6 +44154,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47638,6 +48035,10 @@
             "status": "partial",
             "cites": ["internal/custom/php/orm_data.go"],
             "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47707,6 +48108,10 @@
             "cites": ["internal/custom/php/orm_data.go"],
             "notes": "AbstractMigration subclasses + up/down methods scanned.",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47770,6 +48175,10 @@
             "status": "full",
             "cites": ["internal/custom/php/orm_data.go"],
             "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47838,6 +48247,10 @@
             "status": "partial",
             "cites": ["internal/custom/php/orm_data.go"],
             "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47901,6 +48314,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "RedBeanPHP is zero-config — schema is created/altered automatically at runtime; no migration files to parse."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -47957,6 +48374,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48013,6 +48434,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48069,6 +48494,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48126,6 +48555,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48184,6 +48617,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48247,6 +48684,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48305,6 +48746,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48361,6 +48806,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -48419,6 +48868,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54481,6 +54934,10 @@
             "issue": "3639",
             "notes": "Previously FALSE-full (#3630): the cited migration_sequence_enricher.go was orphaned (imported by zero production code) so no sequence/ordering metadata was ever emitted. #3639 wires it as live Pass 8.9 (engine.ApplyMigrationSequence, cmd/archigraph/index.go): each Alembic versions/*.py entity is stamped sequence_number/migration_name/migration_pattern from the filename, and the pass reads the file body (enrichers.ParseAlembicRevisions) to emit a PRECEDES edge along the down_revision to revision DAG, making the migration chain traversable. Separately alembic_schema.go parses upgrade() op content. Partial: op.alter_column type changes, dropped columns, and server_default/constraint metadata are still not modeled.",
             "verified_at": "2026-06-02"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54547,6 +55004,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54617,6 +55078,12 @@
             "issue": "3639",
             "notes": "django_migration.go parses NNNN_name.py into op_count/operations/dependencies. #3639 additionally stamps sequence_number (the NNNN ordinal) + migration_name + migration_pattern=django on each migration entity via live Pass 8.9 (engine.ApplyMigrationSequence).",
             "verified_at": "2026-06-02"
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go","internal/extractors/python/django_migration.go"],
+            "notes": "Django CreateModel/AddField/RemoveField operations (from the Migration entity operations JSON) emit MODIFIES_TABLE edges keyed by model name (#3628). Asserted by TestDjangoCreateModelAndAddField.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -54685,6 +55152,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54749,6 +55220,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "Peewee-migrate is a separate optional library; core peewee has no built-in migration concept (#3184)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54813,6 +55288,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "Pony ORM has no built-in migration support; schema changes require manual intervention (#3184)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -54883,6 +55362,12 @@
             "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
             "issue": "3060",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/custom/python/alembic_schema.go","internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go"],
+            "notes": "Alembic op.create_table/add_column/create_index SCOPE.Schema entities converge onto a synthetic SCOPE.Table via MODIFIES_TABLE edges (engine pass, #3628). Asserted by TestAlembicCreateTableAndAddColumn.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -54956,6 +55441,10 @@
             "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
             "issue": "3056",
             "verified_at": "2026-05-29"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55022,6 +55511,10 @@
           "migration_parsing": {
             "status": "not_applicable",
             "notes": "Aerich handles migrations separately; core tortoise-orm has no built-in migration support (#3184)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55245,6 +55738,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55301,6 +55798,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55358,6 +55859,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55415,6 +55920,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55470,6 +55979,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55533,6 +56046,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55588,6 +56105,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55644,6 +56165,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -55699,6 +56224,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58028,6 +58557,12 @@
             "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go","internal/engine/migration_sequence.go"],
             "issue": "3639",
             "notes": "db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. #3639 additionally stamps sequence_number (the YYYYMMDDHHMMSS timestamp) + migration_name + migration_pattern=rails on each db/migrate entity via live Pass 8.9 (engine.ApplyMigrationSequence)."
+          },
+          "migration_schema_ops": {
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord_deep.go","internal/engine/migration_schema_ops.go","internal/engine/migration_schema_ops_test.go"],
+            "notes": "Rails create_table/add_column/drop_column/add_index SCOPE.Evolution ops converge via MODIFIES_TABLE (#3628). Asserted by TestRailsAddColumn.",
+            "verified_at": "2026-06-02"
           }
         },
         "Transactions": {
@@ -58095,6 +58630,10 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/activerecord.go"],
             "notes": "DataMapper::Migration / migration(n, :name) blocks, create_table/add_column via dm-migrations. Part of #3282."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58160,6 +58699,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58225,6 +58768,10 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/activerecord.go"],
             "notes": "ROM-rb uses Sequel.migration underneath; migration block detection covers this. Part of #3282."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58290,6 +58837,10 @@
             "status": "partial",
             "cites": ["internal/custom/ruby/activerecord.go"],
             "notes": "Sequel.migration, DB.create_table/alter_table, add_column inside Sequel migration blocks. Part of #3282."
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58346,6 +58897,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58401,6 +58956,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58456,6 +59015,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58512,6 +59075,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58567,6 +59134,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58627,6 +59198,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58682,6 +59257,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58738,6 +59317,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -58793,6 +59376,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -60944,6 +61531,10 @@
           "migration_parsing": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -62335,6 +62926,10 @@
             "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/diesel_seaorm_test.go","internal/custom/rust/orm_props_test.go","internal/custom/rust/testdata/diesel_up.sql"],
             "notes": "Detects embed_migrations!(), run_pending_migrations(), impl MigrationHarness patterns",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -62399,6 +62994,10 @@
             "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
             "notes": "Detects table_meta! and rbatis::table_sync! migration macros",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -62453,6 +63052,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -62523,6 +63126,10 @@
             "status": "partial",
             "cites": ["internal/custom/rust/seaorm.go","internal/custom/rust/testdata/seaorm_migration.rs"],
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -62584,6 +63191,10 @@
             "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
             "notes": "sqlx::migrate! path + migration file refs detected; parsing the referenced migrations/*.sql DDL is out of scope (sqlx resolves them at compile time, not in the .rs source).",
             "verified_at": "2026-05-30"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66439,6 +67050,10 @@
             "status": "not_applicable",
             "cites": ["internal/custom/scala/orm_extractors.go"],
             "notes": "Doobie does not manage migrations; use Flyway or Liquibase alongside doobie"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66500,6 +67115,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66564,6 +67183,10 @@
             "status": "not_applicable",
             "cites": ["internal/custom/scala/orm_extractors.go"],
             "notes": "Quill does not manage schema migrations; use Flyway/Liquibase/scala-migrations alongside Quill"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66627,6 +67250,10 @@
             "status": "full",
             "cites": ["internal/custom/scala/orm_extractors.go"],
             "notes": "scalikejdbcDBMigrationRe captures DB autoCommit/localTx blocks which can contain DDL; scalikejdbc-play-support includes DB evolution integration"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66688,6 +67315,10 @@
         "Migrations": {
           "migration_parsing": {
             "status": "not_applicable"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {
@@ -66753,6 +67384,10 @@
             "status": "full",
             "cites": ["internal/custom/scala/orm_extractors.go"],
             "notes": "slickMigrationRe captures schema.create / schema.createIfNotExists / DBIO.seq DDL patterns; full SQL migration file parsing not applicable (use Flyway)"
+          },
+          "migration_schema_ops": {
+            "status": "missing",
+            "issue": "3628"
           }
         },
         "Transactions": {

--- a/internal/engine/migration_schema_ops.go
+++ b/internal/engine/migration_schema_ops.go
@@ -1,0 +1,403 @@
+package engine
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// migration_schema_ops.go — the per-migration schema-OPERATION pass (#3628,
+// epic #3625).
+//
+// WHY. A separate pass (migration_sequence.go) already restores migration
+// APPLY-ORDER (the PRECEDES edge). The language extractors already detect the
+// individual schema mutations a migration performs and emit them as entities:
+//
+//   - Alembic       SCOPE.Schema  framework=alembic   (table / column / index)
+//   - Rails / AR    SCOPE.Evolution framework=activerecord (ddl_operation)
+//   - TypeORM/knex/  SCOPE.Evolution (migration_op + table[/column])
+//     Sequelize/objection
+//   - Django        Migration (subtype=django) with an `operations` JSON array
+//   - Flyway/Liqui   SCOPE.Datastore subtype=table carrying migration_file
+//     (SQL DDL CREATE TABLE inside a versioned migration)
+//
+// But NONE of those entities was connected to the table it mutates by an edge
+// that converges with the QUERY→table access axis (ACCESSES_TABLE → a
+// SCOPE.DataAccess node carrying a `table` property). So "what touches table
+// users" could see queries OR migration entities, but never on ONE node, and
+// the shared-DB-coupling pass (which groups by normalised table key) ignored
+// migrations entirely.
+//
+// WHAT THIS PASS DOES. For every migration schema-op entity it:
+//
+//  1. derives (op, table[, column]) from the entity's kind/framework/props;
+//  2. gets-or-creates ONE synthetic SCOPE.Table convergence node per
+//     (repo, normalised-table) — id = EntityID(repo,"SCOPE.Table",table,"");
+//  3. emits a MODIFIES_TABLE edge migration-op-entity → SCOPE.Table carrying
+//     {op, table, column}; and
+//  4. so the convergence is real (not just same-key-in-properties), rewires
+//     the QUERY side too: for every SCOPE.DataAccess on that same normalised
+//     table it emits an ACCESSES_TABLE edge SCOPE.DataAccess → the SAME
+//     SCOPE.Table node.
+//
+// The synthetic node's `table` property uses the SAME normTable() key the
+// shared-DB-coupling pass and ACCESSES_TABLE attribution already use, so the
+// migration→table and query→table axes now genuinely meet on one logical
+// table.
+//
+// HONEST / IDEMPOTENT. Dynamic table names (variable, "", UNKNOWN) are
+// skipped — no edge, no node. A re-run recomputes identical node ids and
+// stable RelationshipIDs, so no duplicates are produced.
+
+// MigrationSchemaOpsStats summarises an ApplyMigrationSchemaOps run.
+type MigrationSchemaOpsStats struct {
+	Skipped bool
+	// OpsConsidered is the number of migration schema-op entities inspected.
+	OpsConsidered int
+	// TablesConverged is the number of distinct synthetic SCOPE.Table nodes
+	// created.
+	TablesConverged int
+	// ModifiesEdges is the number of MODIFIES_TABLE edges emitted.
+	ModifiesEdges int
+	// AccessConvergedEdges is the number of ACCESSES_TABLE edges emitted that
+	// rewire a SCOPE.DataAccess onto a converged SCOPE.Table node.
+	AccessConvergedEdges int
+}
+
+// migrationSchemaOp is the normalised result of recognising one migration
+// schema-op entity.
+type migrationSchemaOp struct {
+	op     string // create_table | add_column | drop_column | create_index | ...
+	table  string // RAW table name (normalisation happens at convergence)
+	column string // optional column name ("" when not column-scoped)
+}
+
+// ApplyMigrationSchemaOps emits MODIFIES_TABLE edges (and converging
+// ACCESSES_TABLE edges) for every recognised migration schema-op entity in
+// doc. Returns stats; sets Skipped when no migration schema-op entity exists.
+func ApplyMigrationSchemaOps(doc *graph.Document) MigrationSchemaOpsStats {
+	if doc == nil || len(doc.Entities) == 0 {
+		return MigrationSchemaOpsStats{Skipped: true}
+	}
+
+	var stats MigrationSchemaOpsStats
+
+	// tableNode caches the synthetic SCOPE.Table id per (repo, normalised-table)
+	// so repeated ops on the same table converge on ONE node.
+	type tk struct{ repo, table string }
+	tableNodeID := make(map[tk]string)
+	// existingEdge dedupes both MODIFIES_TABLE and ACCESSES_TABLE edges this
+	// pass emits, keyed by their stable RelationshipID, so a re-run (or two
+	// ops with the same from/to/kind) never duplicates an edge.
+	existingEdge := make(map[string]struct{})
+	for i := range doc.Relationships {
+		existingEdge[doc.Relationships[i].ID] = struct{}{}
+	}
+
+	var newTables []graph.Entity
+	var newEdges []graph.Relationship
+
+	getTableNode := func(repo, normName string) string {
+		key := tk{repo: repo, table: normName}
+		if id, ok := tableNodeID[key]; ok {
+			return id
+		}
+		id := graph.EntityID(repo, string(types.EntityKindTable), normName, "")
+		tableNodeID[key] = id
+		newTables = append(newTables, graph.Entity{
+			ID:         id,
+			Name:       normName,
+			Kind:       string(types.EntityKindTable),
+			Subtype:    "table",
+			SourceFile: "",
+			Language:   "",
+			Properties: map[string]string{
+				"table":      normName,
+				"repo":       repo,
+				"provenance": "SYNTHESIZED_TABLE_CONVERGENCE",
+			},
+		})
+		stats.TablesConverged++
+		return id
+	}
+
+	// addEdge emits an edge, deduped by a stable id. `idSalt` disambiguates
+	// edges that share (from,to,kind) but differ semantically — e.g. several
+	// distinct ops (create_table + add_column + drop_column) a single Django
+	// migration performs on the SAME table converge on one table node yet must
+	// remain distinct edges. The salt is folded into the kind for ID hashing
+	// only (the stored Kind is unchanged).
+	addEdge := func(fromID, toID, kind, idSalt string, props map[string]string) bool {
+		id := graph.RelationshipID(fromID, toID, kind+"\x00"+idSalt)
+		if _, dup := existingEdge[id]; dup {
+			return false
+		}
+		existingEdge[id] = struct{}{}
+		newEdges = append(newEdges, graph.Relationship{
+			ID:         id,
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       kind,
+			Properties: props,
+		})
+		return true
+	}
+
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		ops := recognizeMigrationSchemaOps(e)
+		if len(ops) == 0 {
+			continue
+		}
+		repo := entityRepo(doc, e)
+		for _, op := range ops {
+			norm := normTable(op.table)
+			if norm == "" {
+				continue // honest-partial: dynamic / unknown table
+			}
+			stats.OpsConsidered++
+			tableID := getTableNode(repo, norm)
+
+			props := map[string]string{
+				"op":    op.op,
+				"table": norm,
+			}
+			if op.column != "" {
+				props["column"] = op.column
+			}
+			if addEdge(e.ID, tableID, string(types.RelationshipKindModifiesTable),
+				op.op+":"+op.column, props) {
+				stats.ModifiesEdges++
+			}
+		}
+	}
+
+	if stats.ModifiesEdges == 0 {
+		return MigrationSchemaOpsStats{Skipped: true}
+	}
+
+	// Convergence step: rewire query-side accessors onto the same SCOPE.Table.
+	// For every SCOPE.DataAccess on a table a migration touched, emit an
+	// ACCESSES_TABLE edge to the converged node. This is what makes
+	// "what touches table X" unify migrations + queries on ONE node.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != sharedKindDataAccess {
+			continue
+		}
+		norm := normTable(e.Properties["table"])
+		if norm == "" {
+			continue
+		}
+		repo := entityRepo(doc, e)
+		key := tk{repo: repo, table: norm}
+		tableID, ok := tableNodeID[key]
+		if !ok {
+			continue // no migration touched this table — leave it untouched
+		}
+		if addEdge(e.ID, tableID, sharedRelAccessTable, "", map[string]string{
+			"table":      norm,
+			"provenance": "CONVERGED_ONTO_MIGRATION_TABLE",
+		}) {
+			stats.AccessConvergedEdges++
+		}
+	}
+
+	// Deterministic append order (stable across runs) for reproducible output.
+	sort.Slice(newTables, func(a, b int) bool { return newTables[a].ID < newTables[b].ID })
+	sort.Slice(newEdges, func(a, b int) bool {
+		if newEdges[a].Kind != newEdges[b].Kind {
+			return newEdges[a].Kind < newEdges[b].Kind
+		}
+		return newEdges[a].ID < newEdges[b].ID
+	})
+
+	doc.Entities = append(doc.Entities, newTables...)
+	doc.Relationships = append(doc.Relationships, newEdges...)
+
+	return stats
+}
+
+// recognizeMigrationSchemaOps inspects one entity and returns the schema
+// operation(s) it represents, or nil when the entity is not a recognised
+// migration schema-op. It is deliberately conservative: an op is only
+// recognised when the entity's framework/provenance proves it came from a
+// MIGRATION context (so a non-migration create_table-looking call is ignored).
+func recognizeMigrationSchemaOps(e *graph.Entity) []migrationSchemaOp {
+	if e == nil {
+		return nil
+	}
+	p := e.Properties
+
+	switch e.Kind {
+	// --- Django: one Migration entity, operations in a JSON array -----------
+	case "Migration":
+		if e.Subtype != "django" {
+			return nil
+		}
+		return djangoOps(p["operations"])
+
+	// --- Rails / ActiveRecord: SCOPE.Evolution with ddl_operation -----------
+	// --- JS knex/typeorm/sequelize/objection: SCOPE.Evolution with table ----
+	case string(types.EntityKindEvolution):
+		return evolutionOp(e, p)
+
+	// --- Alembic: SCOPE.Schema framework=alembic ----------------------------
+	case string(types.EntityKindSchema):
+		if p == nil || p["framework"] != "alembic" {
+			return nil
+		}
+		return alembicSchemaOp(e, p)
+
+	// --- Flyway/Liquibase SQL DDL: SCOPE.Datastore table in a migration -----
+	case string(types.EntityKindDatastore):
+		if p == nil || p["migration_file"] == "" || e.Subtype != "table" {
+			return nil
+		}
+		// CREATE TABLE inside a versioned SQL migration.
+		return []migrationSchemaOp{{op: "create_table", table: e.Name}}
+	}
+	return nil
+}
+
+// evolutionOp recognises Rails-AR + JS-ORM SCOPE.Evolution schema ops.
+func evolutionOp(e *graph.Entity, p map[string]string) []migrationSchemaOp {
+	if p == nil {
+		return nil
+	}
+	// Rails/ActiveRecord migration op (activerecord_deep.go).
+	if p["framework"] == "activerecord" {
+		op := p["ddl_operation"]
+		if op == "" {
+			op = e.Subtype
+		}
+		if op == "" {
+			return nil
+		}
+		table := firstNonEmpty(p["table_name"], p["from_table"])
+		if table == "" {
+			return nil
+		}
+		return []migrationSchemaOp{{op: op, table: table, column: p["column_name"]}}
+	}
+	// JS query-builder / ORM migration op (knex, typeorm, sequelize,
+	// objection). These carry `framework` + a `table` property and an op
+	// subtype; `migration_op` is the raw method name.
+	switch p["framework"] {
+	case "knex", "typeorm", "sequelize", "objection", "mikroorm":
+		op := e.Subtype
+		if op == "" {
+			op = p["migration_op"]
+		}
+		table := p["table"]
+		if op == "" || table == "" {
+			return nil
+		}
+		return []migrationSchemaOp{{op: op, table: table, column: p["column"]}}
+	}
+	return nil
+}
+
+// alembicSchemaOp maps an Alembic SCOPE.Schema entity (table/column/index) to
+// its schema operation. The alembic extractor records pattern_type +
+// table_name/parent_table.
+func alembicSchemaOp(e *graph.Entity, p map[string]string) []migrationSchemaOp {
+	switch p["pattern_type"] {
+	case "table":
+		if t := p["table_name"]; t != "" {
+			return []migrationSchemaOp{{op: "create_table", table: t}}
+		}
+	case "column":
+		// add_column: the column is attributed to its parent table. The
+		// alembic extractor emits column entities both for create_table bodies
+		// and for op.add_column; we model both as add_column on the parent
+		// table. parent_table is always set; the bare column is the suffix of
+		// the entity Name ("<table>.<col>").
+		if t := p["parent_table"]; t != "" {
+			col := p["column_name"]
+			if col == "" {
+				if idx := strings.LastIndex(e.Name, "."); idx >= 0 && idx+1 < len(e.Name) {
+					col = e.Name[idx+1:]
+				}
+			}
+			return []migrationSchemaOp{{op: "add_column", table: t, column: col}}
+		}
+	case "index":
+		if t := p["parent_table"]; t != "" {
+			return []migrationSchemaOp{{op: "create_index", table: t}}
+		}
+	}
+	return nil
+}
+
+// djangoOpOperation is one element of the Django migration `operations` JSON
+// array emitted by django_migration.go.
+type djangoOpOperation struct {
+	Type  string `json:"type"`
+	Model string `json:"model"`
+	Field string `json:"field"`
+}
+
+// djangoOps decodes the Django `operations` JSON property into schema ops.
+// Django addresses tables by MODEL name (the ORM derives the table name from
+// it); we use the model name as the convergence key. Dynamic/unknown models
+// (empty) are skipped.
+func djangoOps(raw string) []migrationSchemaOp {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var ops []djangoOpOperation
+	if err := json.Unmarshal([]byte(raw), &ops); err != nil {
+		return nil
+	}
+	var out []migrationSchemaOp
+	for _, o := range ops {
+		op := djangoOpType(o.Type)
+		if op == "" {
+			continue
+		}
+		table := firstNonEmpty(o.Model, "")
+		if table == "" {
+			continue
+		}
+		out = append(out, migrationSchemaOp{op: op, table: table, column: o.Field})
+	}
+	return out
+}
+
+// djangoOpType maps a Django operation class name to the shared op taxonomy.
+func djangoOpType(t string) string {
+	switch t {
+	case "CreateModel":
+		return "create_table"
+	case "DeleteModel":
+		return "drop_table"
+	case "AddField":
+		return "add_column"
+	case "RemoveField":
+		return "drop_column"
+	case "AlterField":
+		return "alter_column"
+	case "RenameField":
+		return "rename_column"
+	case "RenameModel":
+		return "rename_table"
+	case "AddIndex":
+		return "create_index"
+	case "RemoveIndex":
+		return "drop_index"
+	}
+	return ""
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/engine/migration_schema_ops_test.go
+++ b/internal/engine/migration_schema_ops_test.go
@@ -1,0 +1,290 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// helper: build a doc from entities (no pre-existing edges).
+func docOf(repo string, ents ...graph.Entity) *graph.Document {
+	return &graph.Document{Repo: repo, Entities: ents}
+}
+
+// helper: find the synthetic SCOPE.Table node id for a normalised table.
+func tableNodeFor(t *testing.T, doc *graph.Document, repo, norm string) string {
+	t.Helper()
+	want := graph.EntityID(repo, string(types.EntityKindTable), norm, "")
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == want {
+			if doc.Entities[i].Kind != string(types.EntityKindTable) {
+				t.Fatalf("node %s has kind %q, want SCOPE.Table", want, doc.Entities[i].Kind)
+			}
+			if got := doc.Entities[i].Properties["table"]; got != norm {
+				t.Fatalf("SCOPE.Table.table=%q, want %q", got, norm)
+			}
+			return want
+		}
+	}
+	t.Fatalf("no SCOPE.Table node for (%s,%s) [id %s]", repo, norm, want)
+	return ""
+}
+
+// helper: assert a MODIFIES_TABLE edge fromID→tableNode(norm) with op[/column].
+func assertModifies(t *testing.T, doc *graph.Document, fromID, repo, norm, op, col string) {
+	t.Helper()
+	tableID := tableNodeFor(t, doc, repo, norm)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != string(types.RelationshipKindModifiesTable) {
+			continue
+		}
+		if r.FromID != fromID || r.ToID != tableID {
+			continue
+		}
+		if r.Properties["op"] != op {
+			continue // same from/to, different op — keep looking
+		}
+		if r.Properties["table"] != norm {
+			t.Fatalf("MODIFIES_TABLE table=%q, want %q", r.Properties["table"], norm)
+		}
+		if col != "" && r.Properties["column"] != col {
+			t.Fatalf("MODIFIES_TABLE op=%s column=%q, want %q", op, r.Properties["column"], col)
+		}
+		return
+	}
+	t.Fatalf("no MODIFIES_TABLE edge %s -> Table:%s op=%s", fromID, norm, op)
+}
+
+// ---- Alembic ---------------------------------------------------------------
+
+func TestAlembicCreateTableAndAddColumn(t *testing.T) {
+	createTbl := graph.Entity{
+		ID: "a1", Name: "orders", Kind: string(types.EntityKindSchema),
+		Properties: map[string]string{
+			"framework": "alembic", "pattern_type": "table", "table_name": "orders",
+		},
+	}
+	addCol := graph.Entity{
+		ID: "a2", Name: "orders.total", Kind: string(types.EntityKindSchema),
+		Properties: map[string]string{
+			"framework": "alembic", "pattern_type": "column", "parent_table": "orders",
+		},
+	}
+	doc := docOf("svc", createTbl, addCol)
+
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("pass skipped, want edges")
+	}
+	assertModifies(t, doc, "a1", "svc", "orders", "create_table", "")
+	assertModifies(t, doc, "a2", "svc", "orders", "add_column", "total")
+
+	// Convergence: both ops point at the SAME table node.
+	id1 := graph.EntityID("svc", string(types.EntityKindTable), "orders", "")
+	tableCount := 0
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == string(types.EntityKindTable) {
+			tableCount++
+		}
+	}
+	if tableCount != 1 {
+		t.Fatalf("expected 1 SCOPE.Table node (orders), got %d", tableCount)
+	}
+	_ = id1
+}
+
+// ---- Django ----------------------------------------------------------------
+
+func TestDjangoCreateModelAndAddField(t *testing.T) {
+	mig := graph.Entity{
+		ID: "d1", Name: "0001_initial", Kind: "Migration", Subtype: "django",
+		Properties: map[string]string{
+			"operations": `[{"type":"CreateModel","model":"order"},` +
+				`{"type":"AddField","model":"order","field":"total"},` +
+				`{"type":"RemoveField","model":"order","field":"legacy"}]`,
+		},
+	}
+	doc := docOf("svc", mig)
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("pass skipped")
+	}
+	assertModifies(t, doc, "d1", "svc", "order", "create_table", "")
+	assertModifies(t, doc, "d1", "svc", "order", "add_column", "total")
+	assertModifies(t, doc, "d1", "svc", "order", "drop_column", "legacy")
+}
+
+// ---- Rails / ActiveRecord --------------------------------------------------
+
+func TestRailsAddColumn(t *testing.T) {
+	op := graph.Entity{
+		ID: "r1", Name: "add_column:orders.total", Kind: string(types.EntityKindEvolution),
+		Subtype: "add_column",
+		Properties: map[string]string{
+			"framework": "activerecord", "ddl_operation": "add_column",
+			"table_name": "orders", "column_name": "total",
+		},
+	}
+	doc := docOf("svc", op)
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("skipped")
+	}
+	assertModifies(t, doc, "r1", "svc", "orders", "add_column", "total")
+}
+
+// ---- JS (knex / typeorm) ---------------------------------------------------
+
+func TestKnexCreateTable(t *testing.T) {
+	op := graph.Entity{
+		ID: "k1", Name: "create_table:users", Kind: string(types.EntityKindEvolution),
+		Subtype: "create_table",
+		Properties: map[string]string{
+			"framework": "knex", "migration_op": "createTable", "table": "users",
+		},
+	}
+	doc := docOf("svc", op)
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("skipped")
+	}
+	assertModifies(t, doc, "k1", "svc", "users", "create_table", "")
+}
+
+func TestTypeORMAddColumn(t *testing.T) {
+	op := graph.Entity{
+		ID: "t1", Name: "add_column:users", Kind: string(types.EntityKindEvolution),
+		Subtype: "add_column",
+		Properties: map[string]string{
+			"framework": "typeorm", "migration_op": "addColumn",
+			"table": "users", "column": "email",
+		},
+	}
+	doc := docOf("svc", op)
+	ApplyMigrationSchemaOps(doc)
+	assertModifies(t, doc, "t1", "svc", "users", "add_column", "email")
+}
+
+// ---- Flyway / Liquibase SQL ------------------------------------------------
+
+func TestFlywaySQLCreateTable(t *testing.T) {
+	tbl := graph.Entity{
+		ID: "f1", Name: "accounts", Kind: string(types.EntityKindDatastore),
+		Subtype: "table",
+		Properties: map[string]string{
+			"migration_file": "V1__init.sql", "migration_order": "1",
+		},
+	}
+	doc := docOf("svc", tbl)
+	ApplyMigrationSchemaOps(doc)
+	assertModifies(t, doc, "f1", "svc", "accounts", "create_table", "")
+}
+
+// ---- Convergence with query→table (ACCESSES_TABLE) -------------------------
+
+func TestConvergenceMigrationAndQuerySameTableNode(t *testing.T) {
+	// A migration add_column on `orders` ...
+	mig := graph.Entity{
+		ID: "m1", Name: "add_column:orders.total", Kind: string(types.EntityKindEvolution),
+		Subtype: "add_column",
+		Properties: map[string]string{
+			"framework": "activerecord", "ddl_operation": "add_column",
+			"table_name": "orders", "column_name": "total",
+		},
+	}
+	// ... and a query SELECT on the SAME table (a SCOPE.DataAccess node).
+	query := graph.Entity{
+		ID: "q1", Name: "SELECT orders", Kind: "SCOPE.DataAccess",
+		Properties: map[string]string{"table": "orders", "operation": "SELECT"},
+	}
+	doc := docOf("svc", mig, query)
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("skipped")
+	}
+	tableID := tableNodeFor(t, doc, "svc", "orders")
+
+	// MODIFIES_TABLE points at the converged node.
+	assertModifies(t, doc, "m1", "svc", "orders", "add_column", "total")
+
+	// ACCESSES_TABLE from the query points at the SAME converged node.
+	foundAccess := false
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind == sharedRelAccessTable && r.FromID == "q1" && r.ToID == tableID {
+			foundAccess = true
+		}
+	}
+	if !foundAccess {
+		t.Fatalf("query SCOPE.DataAccess q1 not converged onto Table node %s", tableID)
+	}
+	if st.AccessConvergedEdges != 1 {
+		t.Fatalf("AccessConvergedEdges=%d, want 1", st.AccessConvergedEdges)
+	}
+}
+
+// ---- Negatives -------------------------------------------------------------
+
+func TestDynamicTableSkipped(t *testing.T) {
+	// Rails op whose table_name is dynamic/unknown → normTable("") → no edge.
+	op := graph.Entity{
+		ID: "n1", Name: "add_column", Kind: string(types.EntityKindEvolution),
+		Subtype: "add_column",
+		Properties: map[string]string{
+			"framework": "activerecord", "ddl_operation": "add_column",
+			"table_name": "UNKNOWN", "column_name": "x",
+		},
+	}
+	doc := docOf("svc", op)
+	st := ApplyMigrationSchemaOps(doc)
+	if !st.Skipped {
+		t.Fatalf("expected Skipped (no resolvable table), got edges=%d", st.ModifiesEdges)
+	}
+	for i := range doc.Relationships {
+		if doc.Relationships[i].Kind == string(types.RelationshipKindModifiesTable) {
+			t.Fatal("emitted MODIFIES_TABLE for a dynamic table")
+		}
+	}
+}
+
+func TestNonMigrationCreateTableLookalikeIgnored(t *testing.T) {
+	// A SCOPE.Datastore table WITHOUT migration_file (e.g. a plain schema.sql
+	// CREATE TABLE) must NOT be treated as a migration op.
+	tbl := graph.Entity{
+		ID: "x1", Name: "users", Kind: string(types.EntityKindDatastore),
+		Subtype:    "table",
+		Properties: map[string]string{}, // no migration_file
+	}
+	// And a SCOPE.Schema column NOT from alembic.
+	col := graph.Entity{
+		ID: "x2", Name: "users.id", Kind: string(types.EntityKindSchema),
+		Properties: map[string]string{"framework": "sqlalchemy", "pattern_type": "column"},
+	}
+	doc := docOf("svc", tbl, col)
+	st := ApplyMigrationSchemaOps(doc)
+	if !st.Skipped {
+		t.Fatalf("non-migration lookalikes produced %d edges, want 0", st.ModifiesEdges)
+	}
+}
+
+// ---- Idempotency -----------------------------------------------------------
+
+func TestIdempotentReRun(t *testing.T) {
+	op := graph.Entity{
+		ID: "i1", Name: "create_table:users", Kind: string(types.EntityKindEvolution),
+		Subtype: "create_table",
+		Properties: map[string]string{
+			"framework": "knex", "migration_op": "createTable", "table": "users",
+		},
+	}
+	doc := docOf("svc", op)
+	ApplyMigrationSchemaOps(doc)
+	ents1, rels1 := len(doc.Entities), len(doc.Relationships)
+	ApplyMigrationSchemaOps(doc)
+	if len(doc.Entities) != ents1 || len(doc.Relationships) != rels1 {
+		t.Fatalf("re-run not idempotent: entities %d->%d rels %d->%d",
+			ents1, len(doc.Entities), rels1, len(doc.Relationships))
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -10,26 +10,32 @@ package types
 type EntityKind string
 
 const (
-	EntityKindOperation     EntityKind = "SCOPE.Operation"
-	EntityKindComponent     EntityKind = "SCOPE.Component"
-	EntityKindClass         EntityKind = "SCOPE.Class"
-	EntityKindFunction      EntityKind = "SCOPE.Function"
-	EntityKindSchema        EntityKind = "SCOPE.Schema"
-	EntityKindVariable      EntityKind = "SCOPE.Variable"
-	EntityKindReference     EntityKind = "SCOPE.Reference"
-	EntityKindPattern       EntityKind = "SCOPE.Pattern"
-	EntityKindEvolution     EntityKind = "SCOPE.Evolution"
-	EntityKindEndpoint      EntityKind = "SCOPE.Endpoint"
-	EntityKindRoute         EntityKind = "SCOPE.Route"
-	EntityKindService       EntityKind = "SCOPE.Service"
-	EntityKindView          EntityKind = "SCOPE.View"
-	EntityKindUIComponent   EntityKind = "SCOPE.UIComponent"
-	EntityKindJSX           EntityKind = "SCOPE.JSX"
-	EntityKindStylesheet    EntityKind = "SCOPE.Stylesheet"
-	EntityKindQueue         EntityKind = "SCOPE.Queue"
-	EntityKindEvent         EntityKind = "SCOPE.Event"
-	EntityKindDatastore     EntityKind = "SCOPE.Datastore"
-	EntityKindDataAccess    EntityKind = "SCOPE.DataAccess"
+	EntityKindOperation   EntityKind = "SCOPE.Operation"
+	EntityKindComponent   EntityKind = "SCOPE.Component"
+	EntityKindClass       EntityKind = "SCOPE.Class"
+	EntityKindFunction    EntityKind = "SCOPE.Function"
+	EntityKindSchema      EntityKind = "SCOPE.Schema"
+	EntityKindVariable    EntityKind = "SCOPE.Variable"
+	EntityKindReference   EntityKind = "SCOPE.Reference"
+	EntityKindPattern     EntityKind = "SCOPE.Pattern"
+	EntityKindEvolution   EntityKind = "SCOPE.Evolution"
+	EntityKindEndpoint    EntityKind = "SCOPE.Endpoint"
+	EntityKindRoute       EntityKind = "SCOPE.Route"
+	EntityKindService     EntityKind = "SCOPE.Service"
+	EntityKindView        EntityKind = "SCOPE.View"
+	EntityKindUIComponent EntityKind = "SCOPE.UIComponent"
+	EntityKindJSX         EntityKind = "SCOPE.JSX"
+	EntityKindStylesheet  EntityKind = "SCOPE.Stylesheet"
+	EntityKindQueue       EntityKind = "SCOPE.Queue"
+	EntityKindEvent       EntityKind = "SCOPE.Event"
+	EntityKindDatastore   EntityKind = "SCOPE.Datastore"
+	EntityKindDataAccess  EntityKind = "SCOPE.DataAccess"
+	// #3628 [schema]: synthetic per-(repo,table) convergence node. The
+	// migration-schema-ops engine pass creates one SCOPE.Table per logical
+	// table and points both migration MODIFIES_TABLE edges and (existing)
+	// query ACCESSES_TABLE accessors at it, so "what touches table X" unifies
+	// schema evolution (migrations) with data access (queries) on one node.
+	EntityKindTable         EntityKind = "SCOPE.Table"
 	EntityKindExternalAPI   EntityKind = "SCOPE.ExternalAPI"
 	EntityKindInfraResource EntityKind = "SCOPE.InfraResource"
 	EntityKindCodeBlock     EntityKind = "SCOPE.CodeBlock"
@@ -203,6 +209,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindEvent,
 		EntityKindDatastore,
 		EntityKindDataAccess,
+		// #3628 [schema] migration↔query table convergence node:
+		EntityKindTable,
 		EntityKindExternalAPI,
 		EntityKindInfraResource,
 		EntityKindCodeBlock,
@@ -334,6 +342,19 @@ const (
 	// FromID migration PRECEDES the ToID migration. Lets expand/traces walk the
 	// migration chain in apply order rather than re-deriving it from filenames.
 	RelationshipKindPrecedes RelationshipKind = "PRECEDES"
+
+	// #3628 [schema]: per-migration schema-operation edge. Emitted by the
+	// migration-schema-ops engine pass from a migration schema-change entity
+	// (Alembic op.create_table / Rails create_table / Django CreateModel /
+	// TypeORM-knex-Sequelize schema ops / Flyway-Liquibase DDL) to the table
+	// it mutates. The edge carries `op` (create_table|add_column|drop_column|
+	// create_index|drop_table|alter_column|…), `table`, and (when known)
+	// `column`. The edge's `table` property uses the SAME normalised table
+	// key that ACCESSES_TABLE uses, so the shared-DB coupling pass and
+	// "what touches table X" queries converge query→table access with
+	// migration→table evolution on one logical table. Complements PRECEDES
+	// (apply-order) with the actual operations a migration performs.
+	RelationshipKindModifiesTable RelationshipKind = "MODIFIES_TABLE"
 
 	// ADR-0018: Agent-learned pattern edge kinds (append-only additions).
 	// Outgoing from Pattern entities:
@@ -1075,6 +1096,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindFederates,
 		// #3639 (epic #3625) DB-migration apply-order edge (Alembic chain):
 		RelationshipKindPrecedes,
+		// #3628 [schema] per-migration schema-operation edge (migration→table):
+		RelationshipKindModifiesTable,
 		// #3628 error-flow: THROWS / CATCHES exception-type edges:
 		RelationshipKindThrows,
 		RelationshipKindCatches,

--- a/tools/coverage/buckets_test.go
+++ b/tools/coverage/buckets_test.go
@@ -42,7 +42,7 @@ func TestBucketCapabilityKeys(t *testing.T) {
 
 	// ORMs: only `orm` category populated today.
 	got = bucketCapabilityKeys(BucketORMs)
-	want = []string{"migration_parsing", "model_extraction", "query_attribution"}
+	want = []string{"migration_parsing", "migration_schema_ops", "model_extraction", "query_attribution"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ORMs keys = %v, want %v", got, want)
 	}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -52,7 +52,7 @@ categories:
     capabilities: [endpoint_synthesis, handler_attribution, auth_coverage, middleware_coverage]
     subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration, task_queue]
   orm:
-    capabilities: [model_extraction, query_attribution, migration_parsing]
+    capabilities: [model_extraction, query_attribution, migration_parsing, migration_schema_ops]
     subcategory_order: [orm_mapper]
   message_broker:
     capabilities: [producer_extraction, consumer_extraction, topic_attribution]
@@ -582,6 +582,7 @@ subcategories:
       - lazy_loading_recognition
       - query_attribution
       - migration_parsing
+      - migration_schema_ops
       - transaction_function_stamping
     groups:
       - name: Models
@@ -591,7 +592,7 @@ subcategories:
       - name: Queries
         keys: [query_attribution]
       - name: Migrations
-        keys: [migration_parsing]
+        keys: [migration_parsing, migration_schema_ops]
       - name: Transactions
         keys: [transaction_function_stamping]
 


### PR DESCRIPTION
Closes #3798 (child of #3628).

## What
A new engine pass — `ApplyMigrationSchemaOps` (Pass 8.11, `internal/engine/migration_schema_ops.go`) — models the actual schema OPERATIONS each DB migration performs, complementing the existing migration-sequence pass (which only models apply-ORDER via `PRECEDES`).

## Op model + table-node convergence
The language extractors already emit the per-migration schema mutations as entities. This pass:
1. derives `(op, table[, column])` from each — op taxonomy: `create_table`, `add_column`, `drop_column`, `create_index`, `drop_table`, `alter_column`, `rename_column`, `rename_table`, `drop_index`;
2. gets-or-creates ONE synthetic `SCOPE.Table` node per `(repo, normTable)` — **keyed by the SAME `normTable()` the query→table `ACCESSES_TABLE` axis uses**;
3. emits `MODIFIES_TABLE` (migration-op → `SCOPE.Table`) carrying `{op, table, column}`;
4. **rewires query-side `SCOPE.DataAccess` accessors onto the SAME node** via `ACCESSES_TABLE`.

Result: "what touches table X" unifies schema evolution (migrations) and data access (queries) on one logical table node, and shared-DB coupling now sees migrations.

## Dialects
| Dialect | Source entity | Example op edge |
|---|---|---|
| Alembic (Python) | `SCOPE.Schema` framework=alembic | `op.create_table('orders')` → MODIFIES_TABLE(→Table:orders, op=create_table); `op.add_column('orders', sa.Column('total'))` → op=add_column column=total |
| Django | `Migration` operations JSON | `AddField(model_name='order', name='total')` → Table:order add_column total |
| Rails/ActiveRecord | `SCOPE.Evolution` ddl_operation | `add_column :orders, :total` → op=add_column |
| TypeORM / knex / Sequelize / objection | `SCOPE.Evolution` (migration_op + table) | `queryRunner.createTable`, `knex.schema.createTable` |
| Flyway / Liquibase | `SCOPE.Datastore` table w/ migration_file (SQL DDL) | versioned `CREATE TABLE` → op=create_table |

## Schema-op edges asserted (value-asserting tests, not len>0)
- Alembic `create_table('orders')` → MODIFIES_TABLE(→Table:orders, op=create_table); `add_column` → op=add_column column=total
- Django `CreateModel/AddField/RemoveField('order')` → Table:order create_table / add_column total / drop_column legacy
- Rails `add_column :orders, :total` → op=add_column column=total
- knex `createTable('users')` → op=create_table; TypeORM `addColumn` → op=add_column column=email
- Flyway SQL `CREATE TABLE accounts` (V1__init.sql) → op=create_table
- **Convergence**: a migration add_column AND a query SELECT on `orders` resolve to the SAME `SCOPE.Table` node (MODIFIES_TABLE + ACCESSES_TABLE both → it)
- **Negatives**: dynamic/UNKNOWN table → no edge (pass Skipped); non-migration create_table-lookalike (no migration_file / non-alembic framework) → ignored
- **Idempotent**: re-run adds no entities/edges

## New kinds
`RelationshipKindModifiesTable` (`MODIFIES_TABLE`), `EntityKindTable` (`SCOPE.Table`). Registered; `go test ./internal/types/` green.

## Quality gates
- targeted `go test` green (engine, custom/python·ruby·javascript, extractors/…, types, tools/coverage)
- `go test ./internal/types/` green; `gofmt -l` empty; `go vet` clean
- `coverage validate` 0 errors; `coverage fmt --check` canonical; docs regenerated
- coverage: `migration_schema_ops` lane — full (python alembic/sqlalchemy, django; ruby activerecord; jsts knex/typeorm/sequelize), partial (java flyway/liquibase SQL); backfilled across orm_mapper

## DEPLOY-DEFERRED
No live daemon rebuild / reindex in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)