### PR TITLE
feat(view): handler → template RENDERS (Flask/Django/Express/Koa/Spring-MVC/Laravel/Rails)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,179 +11,179 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/10 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/4 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/8 | |
-| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/11 | |
-| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/11 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/5 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/11 | |
-| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/10 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/10 | |
-| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/10 | |
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/11 | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/11 | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/11 | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/12 | |
-| [JS/TS](../by-language/jsts.md) | [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [lua](../by-language/lua.md) | [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/11 | |
-| [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/11 | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/10 | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/10 | |
-| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/10 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
-| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/16 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
-| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/3 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/9 | |
-| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/4 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
+| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
+| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/12 | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
+| [JS/TS](../by-language/jsts.md) | [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [lua](../by-language/lua.md) | [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
+| [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 10/11 | |
+| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/11 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/17 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
+| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/3 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 
 
 ## JVM Backend
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/14 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 2/17 | |
-| [java](../by-language/java.md) | [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🟡 3/17 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/14 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/17 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/17 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/17 | |
-| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/17 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 4/4 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 24/24 | 🟡 16/19 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 13/17 | |
-| [java](../by-language/java.md) | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/17 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/4 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/7 | |
-| [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/17 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/13 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/16 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/16 | |
-| [kotlin](../by-language/kotlin.md) | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/23 | 🔴 0/17 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/16 | |
-| [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/17 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/17 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/4 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/23 | 🟡 6/17 | |
-| [scala](../by-language/scala.md) | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/23 | 🟡 1/17 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [scala](../by-language/scala.md) | [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [scala](../by-language/scala.md) | [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/23 | 🟡 5/17 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/15 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 2/18 | |
+| [java](../by-language/java.md) | [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🟡 3/18 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/15 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/18 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/18 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/18 | |
+| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/18 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 4/4 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 24/24 | 🟡 17/20 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 13/18 | |
+| [java](../by-language/java.md) | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/18 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/4 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/8 | |
+| [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/18 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/14 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/17 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/17 | |
+| [kotlin](../by-language/kotlin.md) | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/23 | 🔴 0/18 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/17 | |
+| [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/18 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/18 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/4 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/23 | 🟡 6/18 | |
+| [scala](../by-language/scala.md) | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/23 | 🟡 1/18 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [scala](../by-language/scala.md) | [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [scala](../by-language/scala.md) | [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/23 | 🟡 5/18 | |
 
 
 ## UI Frontend

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -26,20 +26,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/1 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -26,13 +26,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/10 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,18 +26,18 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/4 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/7 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/8 | |
-| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/11 | |
-| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/11 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/5 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/11 | |
-| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/4 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
+| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/12 | |
+| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/12 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/4 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/12 | |
+| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
 
 
 ### Meta Framework

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -26,24 +26,24 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/10 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Iris](../detail/lang.go.framework.iris.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Revel](../detail/lang.go.framework.revel.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [chi](../detail/lang.go.framework.chi.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/10 | |
-| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/10 | |
+| [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Iris](../detail/lang.go.framework.iris.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Revel](../detail/lang.go.framework.revel.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [chi](../detail/lang.go.framework.chi.md) | 🟡 3/4 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/4 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
+| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/4 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -26,22 +26,22 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/14 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 2/17 | |
-| [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🟡 3/17 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/14 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/17 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/17 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/17 | |
-| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/17 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 4/4 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 24/24 | 🟡 16/19 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 13/17 | |
-| [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/8 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/15 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 2/18 | |
+| [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🟡 3/18 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 1/15 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/18 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/18 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 14/18 | |
+| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 4/18 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 4/4 | ✅ 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 24/24 | 🟡 17/20 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 13/18 | |
+| [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/4 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 22/23 | 🟡 3/9 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -26,20 +26,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 6/10 | |
-| [Express](../detail/lang.jsts.framework.express.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/11 | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/11 | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/11 | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/12 | |
-| [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 6/11 | |
+| [Express](../detail/lang.jsts.framework.express.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/12 | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
+| [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -26,19 +26,19 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/17 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/4 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/7 | |
-| [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/17 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/13 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/16 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/16 | |
-| [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/23 | 🔴 0/17 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/16 | |
-| [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/17 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/17 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/18 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/4 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/8 | |
+| [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/18 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/14 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/17 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/17 | |
+| [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/23 | 🔴 0/18 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/17 | |
+| [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/18 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 1/18 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/11 | |
-| [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/11 | |
-| [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/10 | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/10 | |
+| [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
+| [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/4 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
+| [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/10 | |
-| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/10 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/11 | |
+| [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 10/11 | |
+| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/11 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/4 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -26,25 +26,25 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
-| [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Django](../detail/lang.python.framework.django.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/11 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/16 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
-| [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 9/12 | |
-| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
-| [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/11 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/11 | |
+| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Django](../detail/lang.python.framework.django.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/17 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 4/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
+| [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
+| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 
 
 ### AI Integration

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -26,15 +26,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 7/11 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/3 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/9 | |
-| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/11 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/4 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/4 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/3 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,19 +26,19 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/10 | |
-| [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/11 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/4 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -26,18 +26,18 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/4 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/23 | 🟡 6/17 | |
-| [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/23 | 🟡 1/17 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/4 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/10 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/7 | |
-| [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/17 | |
-| [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/23 | 🟡 5/17 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/4 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/23 | 🟡 6/18 | |
+| [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/4 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/23 | 🟡 1/18 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/2 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/5 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/4 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 9/11 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/8 | |
+| [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/23 | 🔴 0/18 | |
+| [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/4 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/23 | 🟡 5/18 | |
 
 
 ### Meta Framework

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/10 | |
+| [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/4 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | ace is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | ace is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | ace is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | boost-asio is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | boost-asio is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | boost-asio is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | boost is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | boost is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | boost is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/cpprestsdk_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/cpprestsdk_routes.go` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/cpprestsdk_routes.go` | Path strings extracted from http_listener init + support() calls; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/crow_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/crow_routes.go` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/crow_routes.go` | Path strings extracted from CROW_ROUTE/CROW_BP_ROUTE macros; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/drogon_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/drogon_routes.go` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/drogon_routes.go` | Path strings extracted from ADD_METHOD_TO/METHOD_ADD/registerHandler; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | libev is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | libev is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | libev is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | libevent is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | libevent is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | libevent is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | libuv is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Handler attribution | — `not_applicable` | — | — | — | libuv is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
 | Route extraction | — `not_applicable` | — | — | — | libuv is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/custom/cpp/oatpp_routes.go` | SCOPE.Operation entities emitted from ENDPOINT/ENDPOINT_ASYNC macros; partial = regex |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/cpp/oatpp_routes.go` | Handler names extracted from ENDPOINT macro third arg; partial = regex heuristic |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/oatpp_routes.go` | Path strings from ENDPOINT/ENDPOINT_ASYNC macros; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/pistache_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/pistache_routes.go` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/pistache_routes.go` | Path strings extracted from Routes::Get/Post/etc and router.get; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/custom/cpp/poco_routes.go` | SCOPE.Operation entities from POCO handler registration; partial = regex |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/cpp/poco_routes.go` | Handler class names extracted from addHandler<T> and server.addHandler; partial = regex |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/poco_routes.go` | Paths from addHandler<T>/router.add/server.addHandler; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/custom/cpp/restbed_routes.go` | SCOPE.Operation entities from Restbed Resource registration; partial = regex |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/cpp/restbed_routes.go` | Handler names from set_method_handler third arg; partial = regex |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/restbed_routes.go` | Paths from Resource set_path/set_method_handler; partial = regex + same-file var correlation |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/custom/cpp/restinio_routes.go` | SCOPE.Operation entities from RESTinio router method calls; partial = regex |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/cpp/restinio_routes.go` | Handler names extracted from RESTinio router calls; partial = regex |
 | Route extraction | ✅ `full` | — | — | `internal/custom/cpp/restinio_routes.go` | Paths from router->http_get/post/etc and add_handler; partial = regex heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_core.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/aspnet_core_routes.go` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/csharp/aspnet_core.go`<br>`internal/engine/aspnet_core_routes.go` | Minimal-API app.MapGet/Post/Put/Delete route path strings extracted via reAspNetMinimalAPI; attribute routes via reAspNetHTTPMethod; route_path property set on each emitted entity. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
 | Route extraction | ✅ `full` | — | — | `internal/custom/csharp/aspnet_core.go`<br>`internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | MVC controller [Route] + [HttpGet/Post/Put/Delete/Patch] attribute routes extracted; route path strings captured by asp_net_mvc.yaml source_patterns and aspnet_core.go reAspNetHTTPMethod/reAspNetMinimalAPI. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter route endpoint_synthesis via regex extractor; heuristic |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter module/endpoint class declarations detected via regex; heuristic |
 | Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter route path strings extracted via regex; heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints route endpoint_synthesis via regex extractor; heuristic |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints module/endpoint class declarations detected via regex; heuristic |
 | Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints route path strings extracted via regex; heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
+++ b/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | synthesizeHotChocolate emits http:GRAPHQL:/graphql/<Query|Mutation|Subscription>/<field> per public resolver method — EXACT canonical shape as gqlgen (Go) / Strawberry (Python) / Apollo (JS) / Absinthe so client links (#3667) + cross-repo linker join. Field name = HotChocolate default: leading Get stripped + first letter lower-cased (GetUser->user, GetUsersByTeam->usersByTeam, CreateUser->createUser). Recognises [QueryType]/[MutationType]/[SubscriptionType] markers, [ExtendObjectType(typeof(Query))] extensions, and same-file fluent .AddQueryType<T>() registrations. Value-asserting tests assert the EXACT endpoint ids. |
 | Handler attribution | ✅ `full` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | Each endpoint carries source_handler=SCOPE.Operation:<Class>.<Method> (same naming as the C# extractor buildOperation), which ResolveHTTPEndpointHandlers rebinds to the resolver method — HANDLES edge endpoint->method. Value-asserting tests assert source_handler=SCOPE.Operation:Query.GetUser / Mutation.CreateUser / UserQueries.GetUserByEmail. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | 3617 | `internal/engine/http_endpoint_hotchocolate.go`<br>`internal/engine/http_endpoint_hotchocolate_test.go` | Root-type registration recovered from marker attributes, [ExtendObjectType] extensions, or SAME-FILE fluent .AddQueryType<T>(). PARTIAL (honest): a resolver class registered fluently in a DIFFERENT file than its declaration, descriptor.Field() runtime fluent field definitions, and SDL schema-first .graphqls binding are not resolved. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx route endpoint_synthesis via regex extractor; heuristic |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx module/endpoint class declarations detected via regex; heuristic |
 | Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx route path strings extracted via regex; heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack route endpoint_synthesis via regex extractor; heuristic |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack module/endpoint class declarations detected via regex; heuristic |
 | Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack route path strings extracted via regex; heuristic |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizeAbsinthe maps each top-level 'field :name' under an Absinthe query/mutation/subscription block to http:GRAPHQL:/graphql/<Root>/<field> (Strawberry/Apollo convention, #3066), tracking do/end depth so nested object-type fields are excluded. Value-asserting test (TestAbsinthe_Schema proves Query/users, Query/user, Mutation/create_user and excludes nested object fields). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | Ash resources + AshPhoenix router integration detected via engine YAML; resource actions serve as route equivalents |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | Bandit has no endpoint/route concept; it is a transport adapter |
 | Handler attribution | 🟢 `partial` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/substrate/entry_points_elixir.go` | Bandit delegates to Plug-compatible handlers; Plug.call/2 attribution tracked via entry-point sniffer |
 | Route extraction | — `not_applicable` | — | — | — | Bandit is a low-level HTTP server (replaces Cowboy); routing belongs to Phoenix/Plug layer above it |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/substrate/entry_points_elixir.go` | Cowboy handler init/handle callbacks recognised as framework_lifecycle entry-points |
 | Handler attribution | 🟢 `partial` | — | — | `internal/substrate/entry_points_elixir.go` | init/2 and handle/2 callbacks recognised as framework_lifecycle; cowboy_handler behaviour tracked via @behaviour |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizeCowboy parses :cowboy_router.compile dispatch tables, emitting an ANY http_endpoint per {"/path", Handler, _} route (:id->{id}), attributed to the handler module; the :_ host wildcard rule is skipped and the gate requires a cowboy_router/cowboy_handler signal. Value-asserting test (TestCowboy_Dispatch proves ANY /, ANY /users/{id}, ANY /ws with handler attribution). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.finch.md
+++ b/docs/coverage/detail/lang.elixir.framework.finch.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Finch.build(:verb,url) literal + interpolated-variable -> outbound http_endpoint_call (#1483/#3511) |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.guardian.md
+++ b/docs/coverage/detail/lang.elixir.framework.guardian.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/nerves.yaml` | — |
 | Route extraction | — `not_applicable` | — | — | — | Nerves is an embedded/IoT firmware framework; no HTTP routing concept. NervesHub is separate. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/oban.yaml` | — |
 | Route extraction | — `not_applicable` | — | — | — | Oban is a background job processor; no HTTP routing. Jobs are enqueued via Oban.insert/2. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/phoenix_routes.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/phoenix_routes.go`<br>`internal/engine/phoenix_routes_test.go` | synthesizePhoenix emits canonical http_endpoint per get/post/put/patch/delete/head/options verb + resources CRUD expansion (only:/except: filters) with nested scope-prefix composition and :id->{id} normalisation; controller#action attributed via handler_file hint. Value-asserting engine tests (TestPhoenix_VerbInScope/Resources/NestedScope/ControllerHandlerRef) prove exact (verb,path,controller#action). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go` | use Plug.Router module extracted; match routes synthesised as SCOPE.Operation/endpoint per verb+path |
 | Handler attribution | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go` | def call(conn, opts) implementation captured as SCOPE.Operation/plug_impl per module |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/plug.go`<br>`internal/custom/elixir/plug_test.go`<br>`internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizePlugRouter emits canonical http_endpoint per Plug.Router get/post/put/patch/delete/options/head verb route (:id->{id}) + forward/2 as ANY mount, attributed to the router module; catch-all 'match _' correctly excluded. plugExtractor additionally emits SCOPE.Operation route + middleware/call entities. Value-asserting tests (TestPlugRouter_Verbs proves GET /health, GET /users/{id}, POST /users, DELETE /users/{id}, ANY /admin; TestPlugRouter_NotPlug guards false positives). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.req.md
+++ b/docs/coverage/detail/lang.elixir.framework.req.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Req.get!/Req.<verb> literal + interpolated + concat + url: keyword -> outbound http_endpoint_call (#3511) |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.tesla.md
+++ b/docs/coverage/detail/lang.elixir.framework.tesla.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Tesla use-module + BaseUrl middleware + Tesla.<verb>/bare-verb client calls -> outbound http_endpoint_call with verb+canonical path (#3511) |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/beego.go`<br>`internal/engine/rules/go/frameworks/beego.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/beego.go`<br>`internal/engine/rules/go/frameworks/beego.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/beego.go`<br>`internal/engine/rules/go/frameworks/beego.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/buffalo.go`<br>`internal/engine/rules/go/frameworks/buffalo.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/buffalo.go`<br>`internal/engine/rules/go/frameworks/buffalo.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/buffalo.go`<br>`internal/engine/rules/go/frameworks/buffalo.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/chi.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/chi.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/chi.go`<br>`internal/custom/golang/extractors_test.go` | regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/echo.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/echo.go`<br>`internal/custom/golang/extractors_test.go` | regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/fasthttp.go`<br>`internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/fasthttp.go`<br>`internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/fasthttp.go`<br>`internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/fiber.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/extractors_test.go`<br>`internal/custom/golang/fiber.go` | regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.fx.md
+++ b/docs/coverage/detail/lang.go.framework.fx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | 3628 | — | — |
 | Handler attribution | 🔴 `missing` | — | 3628 | — | — |
 | Route extraction | 🔴 `missing` | — | 3628 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gin.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/extractors_test.go`<br>`internal/custom/golang/gin.go` | regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/gorilla_mux.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/gorilla_mux.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/extractors_test.go`<br>`internal/custom/golang/gorilla_mux.go` | regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml` | Resolver method on generated *queryResolver/*mutationResolver/*subscriptionResolver -> http:GRAPHQL:/graphql/<Root>/<field>; source_handler=SCOPE.Operation:<receiver>.<Method> rebinds to a HANDLES edge. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | 3613 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_gqlgen_3613_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/gqlgen_go.yaml`<br>`internal/extractors/graphql/graphql.go` | Operation endpoints synthesised from Go resolver receivers; SDL schema types parsed by the shared graphql extractor. Field-name mapping is gqlgen default lowerCamel and does not yet read gqlgen.yml overrides or @goField directives. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz.go`<br>`internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/testdata/hertz_routes.go` | Regex AST extractor: server.Default/New engine, h.GET/POST/... verb routes, nested h.Group prefix resolution, Static mounts; fixture-proven. |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz.go`<br>`internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/testdata/hertz_routes.go` | Trailing-arg handler attribution on each verb route (skips inline middleware); fixture-proven. |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/hertz.go`<br>`internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/testdata/hertz_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_routes.go`<br>`internal/engine/http_endpoint_go_trio.go` | huma.Register(api, huma.Operation{Method,Path}, handler) -> endpoint. Engine synthesis (go_trio) + dedicated SCOPE-entity extractor; fixture-proven. |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_routes.go`<br>`internal/engine/http_endpoint_go_trio.go` | Final huma.Register argument attributed as handler; fixture-proven. |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_routes.go`<br>`internal/engine/http_endpoint_go_trio.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/iris.go`<br>`internal/engine/rules/go/frameworks/iris.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/iris.go`<br>`internal/engine/rules/go/frameworks/iris.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/iris.go`<br>`internal/engine/rules/go/frameworks/iris.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/nethttp.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/nethttp.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/extractors_test.go`<br>`internal/custom/golang/nethttp.go` | regex-based: http.HandleFunc + http.Handle on DefaultServeMux + http.NewServeMux() + Go 1.22+ method-prefixed patterns (GET /path) tested; misses cross-file route splits and dynamic path construction |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/revel.go`<br>`internal/engine/rules/go/frameworks/revel.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/revel.go`<br>`internal/engine/rules/go/frameworks/revel.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/golang/revel.go`<br>`internal/engine/rules/go/frameworks/revel.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.go.framework.wire.md
+++ b/docs/coverage/detail/lang.go.framework.wire.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | 3628 | — | — |
 | Handler attribution | 🔴 `missing` | — | 3628 | — | — |
 | Route extraction | 🔴 `missing` | — | 3628 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | 3092 | `internal/engine/http_endpoint_synthesis.go` | — |
 | Handler attribution | ✅ `full` | `2026-06-01` | — | `internal/custom/java/akka_http_routes.go` | — |
 | Route extraction | 🟢 `partial` | — | 3092 | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.dgs.md
+++ b/docs/coverage/detail/lang.java.framework.dgs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | — | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | @DgsQuery/@DgsMutation/@DgsSubscription + @DgsData(parentType=Query|Mutation|Subscription, field=) data-fetcher methods to canonical GRAPHQL endpoint /graphql/<Operation>/<field> (verb GRAPHQL), identical shape to gqlgen/HotChocolate/JS so client links join. Value-asserted user/addUser/events/allUsers/search in TestDGS_*. |
 | Handler attribution | ✅ `full` | `2026-06-02` | — | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | Each endpoint emits handler_name=<Fetcher>.<method> + resolver_method and a HANDLES edge endpoint to resolver SCOPE.Operation, preserved under field= rename (field=allUsers, resolver_method=users). Asserted in TestDGS_ShorthandOperations/_FieldOverrideAndDgsData. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | backfill:dictionary-completeness | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | Operation paths derived from @Dgs* annotations; @DgsData(parentType=non-root) field resolvers correctly skipped. PARTIAL: file-local annotation-driven; SDL-only fields and custom DGS servlet mapping not read. Asserted _FieldResolverSkipped. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | Dropwizard uses Jersey (JAX-RS); @Path/@GET/@POST annotations covered by java_annotation_routes.go |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.guice.md
+++ b/docs/coverage/detail/lang.java.framework.guice.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | 3699 | — | — |
 | Handler attribution | 🔴 `missing` | — | 3699 | — | — |
 | Route extraction | 🔴 `missing` | — | 3699 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-29` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/microprofile.yaml` | MicroProfile JAX-RS @Path + verb annotations covered by java_annotation_routes.go; partial (no class-level @Path composition with vert.x-style mounts) |
 | Handler attribution | 🟢 `partial` | `2026-05-29` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/microprofile.yaml` | JAX-RS method-level handler attribution via SCOPE.Operation entity; same pass as Quarkus/Jakarta EE |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/microprofile.yaml` | JAX-RS @Path annotation route extraction; class+method composition; MicroProfile flavor same as Quarkus |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | 3085 | `internal/engine/http_endpoint_synthesis.go` | — |
 | Handler attribution | ✅ `full` | `2026-06-01` | — | `internal/custom/java/javalin_routes.go` | — |
 | Route extraction | 🟢 `partial` | — | 3085 | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 53
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | Annotation-driven route composition scanned (@RequestMapping/@GetMapping/etc.); path-variable expression resolution not implemented |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/java/template_render.go`<br>`internal/extractors/java/template_render_test.go` | @Controller method String/ModelAndView view name -> RENDERS SCOPE.Template; @RestController/@ResponseBody skipped (REST not MVC); dynamic names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.spring-graphql.md
+++ b/docs/coverage/detail/lang.java.framework.spring-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | — | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | @QueryMapping/@MutationMapping/@SubscriptionMapping + @SchemaMapping(typeName=Query|Mutation|Subscription) controller methods to canonical GRAPHQL endpoint /graphql/<Operation>/<field> (verb GRAPHQL), identical shape to gqlgen/HotChocolate/graphql-kotlin/JS so GraphQL client links (#3667) join. Value-asserted users/createUser/events/allUsers/node in TestSpringGraphQL_*. |
 | Handler attribution | ✅ `full` | `2026-06-02` | — | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | Each endpoint emits handler_name=<Controller>.<method> + resolver_method and a HANDLES edge endpoint to resolver SCOPE.Operation, preserved under name=/field= rename (field=allUsers, resolver_method=usersAlias). Asserted in TestSpringGraphQL_QueryMapping/_NameOverride. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | backfill:dictionary-completeness | `internal/custom/java/patterns_dispatch.go`<br>`internal/custom/java/spring_graphql.go` | Operation paths /graphql/<Operation>/<field> derived from annotation; @SchemaMapping(typeName=non-root) field resolvers correctly skipped. PARTIAL: file-local annotation-driven; SDL-only fields and custom spring.graphql.path mount not read. Asserted _SchemaMappingExplicitRoot. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3080 | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | Route extraction | ✅ `full` | `2026-06-01` | — | `internal/custom/java/struts_routes.go` | Extracts @Action(value=...) annotations and struts.xml <action> elements; @Namespace prefix composition; HANDLED_BY relationships to action classes |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_group_prefix.ts`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3062 | `internal/custom/javascript/express.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go`<br>`internal/engine/http_endpoint_synthesis_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/javascript/template_render.go`<br>`internal/extractors/javascript/template_render_test.go` | res.render('view') -> RENDERS SCOPE.Template; response-receiver heuristic; dynamic/template-literal names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3062 | `internal/custom/javascript/fastify.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go`<br>`internal/engine/http_endpoint_synthesis_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/feathers.yaml`<br>`testdata/fixtures/typescript/feathers_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/feathers.yaml`<br>`testdata/fixtures/typescript/feathers_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/hapi.yaml`<br>`testdata/fixtures/typescript/hapi_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/hapi.yaml`<br>`testdata/fixtures/typescript/hapi_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/javascript/template_render.go`<br>`internal/extractors/javascript/template_render_test.go` | ctx.render('view') -> RENDERS SCOPE.Template; dynamic names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/marblejs.yaml`<br>`testdata/fixtures/typescript/marblejs_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/marblejs.yaml`<br>`testdata/fixtures/typescript/marblejs_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | 2932 | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | 2932 | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/polka.yaml`<br>`testdata/fixtures/typescript/polka_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/polka.yaml`<br>`testdata/fixtures/typescript/polka_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.pothos.md
+++ b/docs/coverage/detail/lang.jsts.framework.pothos.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | — |
 | Handler attribution | — `not_applicable` | — | — | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | Pothos root fields are inline-arrow resolvers (builder.queryField('users', t => ...)) with no addressable handler symbol; the operation endpoint is emitted with NO source_handler (NoHandlerProp keep-path), matching the Apollo resolver-map convention. There is no method symbol to bind a HANDLES edge to. |
 | Route extraction | 🟢 `partial` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/pothos_jsts.yaml` | builder.queryField/mutationField/subscriptionField + the builder.queryType/mutationType/subscriptionType fields:(t)=>({...}) maps -> http:GRAPHQL:/graphql/<Root>/<field> (EXACT canonical shape as gqlgen/Apollo/Strawberry so client links #3667 join). Honest-partial: a non-literal (variable/computed) field name is not recovered. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/restify.yaml`<br>`testdata/fixtures/typescript/restify_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/restify.yaml`<br>`testdata/fixtures/typescript/restify_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/sails.yaml`<br>`testdata/fixtures/typescript/sails_routes.ts` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/sails.yaml`<br>`testdata/fixtures/typescript/sails_routes.ts` | — |
 | Route extraction | 🟢 `partial` | `2026-05-29` | 3062 | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.jsts.framework.type-graphql.md
+++ b/docs/coverage/detail/lang.jsts.framework.type-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | — |
 | Handler attribution | ✅ `full` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | @Query/@Mutation/@Subscription method in an @Resolver class -> http:GRAPHQL:/graphql/<Root>/<field>; source_handler=SCOPE.Operation:<method> rebinds to a HANDLES (IMPLEMENTS) edge against the extracted method symbol (proven end-to-end in TestResolve_TypeGraphQL_HandlesEdge). |
 | Route extraction | 🟢 `partial` | — | 3619 | `internal/engine/http_endpoint_graphql_jsts_codefirst.go`<br>`internal/engine/http_endpoint_resolve.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go`<br>`internal/engine/httproutes/canonicalize.go`<br>`internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml` | Root @Query/@Mutation/@Subscription methods only; @FieldResolver (non-root) methods are skipped, matching gqlgen/spring-graphql. Field name = method name or the { name: '...' } decorator option. Honest-partial: a dynamic/computed name option is not recovered. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` | — |
 | Route extraction | — `not_applicable` | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` | — |
 | Route extraction | — `not_applicable` | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.dagger-hilt.md
+++ b/docs/coverage/detail/lang.kotlin.framework.dagger-hilt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.graphql-kotlin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.graphql-kotlin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/graphql_kotlin.go` | class : Query/Mutation/Subscription marker-interface roots → each public member fun is a GraphQL field synthesised as a GRAPHQL endpoint /graphql/<Operation>/<field>. Value-asserted (user, users, createUser) in TestGraphQLKotlin_ResolverFields/_NameRename. File-local: cross-file root composition via SchemaGeneratorConfig not chased. |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/graphql_kotlin.go` | Each synthesised GraphQL field carries handler_name=<Class>.<fun> and resolver_fun, binding the field to its Kotlin resolver function even under @GraphQLName rename (field=createUser, resolver_fun=addUser). Asserted in TestGraphQLKotlin_NameRename. |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/graphql_kotlin.go` | GraphQL operation paths /graphql/<Operation>/<field> derived from the Query/Mutation/Subscription supertype; @GraphQLName renames the field segment, @GraphQLIgnore and private/protected/internal funs excluded. Asserted in TestGraphQLKotlin_ResolverFields/_IgnoreAndPrivate. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; Kotlin trailing-lambda route DSL proven by TestKotlinJavalin_Routes_Issue3274 |
 | Handler attribution | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; handler attribution proven by TestKotlinJavalin_Routes_Issue3274 |
 | Route extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274 |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.koin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.koin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.kotlinx-serialization.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kotlinx-serialization.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/ktor_routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.retrofit.md
+++ b/docs/coverage/detail/lang.kotlin.framework.retrofit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Retrofit interface verb annotations (@GET/@POST/@PUT/@DELETE/@PATCH/@HEAD/@OPTIONS) → one outbound http_endpoint (consumer) per annotated method + FETCHES from the method; Retrofit.Builder().baseUrl() composed; {param} paths normalized. Value-asserted in http_endpoint_kotlin_client_test.go. |
 | Handler attribution | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | FETCHES edge attributes each outbound call to the enclosing Retrofit interface method. Value-asserted in http_endpoint_kotlin_client_test.go. |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes_kotlin.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.lua.framework.apisix.md
+++ b/docs/coverage/detail/lang.lua.framework.apisix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.lua.framework.kong.md
+++ b/docs/coverage/detail/lang.lua.framework.kong.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/engine/lua_routes.go` | Lapis routes synthesized to canonical http_endpoint via synthesizeLapis (app:get/post/put/patch/delete/options/head verb routes, named + unnamed app:match, respond_to verb tables) with :id->{id} normalization (httproutes.FrameworkLapis) and app/route-name handler attribution; value-asserting tests in lua_routes_test.go. Custom extractor also stamps canonical_path. |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/lua/routing.go`<br>`internal/engine/lua_routes.go` | Lapis routes synthesized to canonical http_endpoint via synthesizeLapis (app:get/post/put/patch/delete/options/head verb routes, named + unnamed app:match, respond_to verb tables) with :id->{id} normalization (httproutes.FrameworkLapis) and app/route-name handler attribution; value-asserting tests in lua_routes_test.go. Custom extractor also stamps canonical_path. |
 | Route extraction | ✅ `full` | — | — | `internal/custom/lua/routing.go`<br>`internal/engine/lua_routes.go` | Lapis routes synthesized to canonical http_endpoint via synthesizeLapis (app:get/post/put/patch/delete/options/head verb routes, named + unnamed app:match, respond_to verb tables) with :id->{id} normalization (httproutes.FrameworkLapis) and app/route-name handler attribution; value-asserting tests in lua_routes_test.go. Custom extractor also stamps canonical_path. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | — | — | `internal/engine/lua_routes.go` | OpenResty routes synthesized to canonical http_endpoint via synthesizeOpenResty: nginx location stanzas (content_by_lua-gated, ANY verb) + lua-resty-router r:get/post/... DSL with :id->{id} normalization (httproutes.FrameworkOpenResty); value-asserting tests in lua_routes_test.go. Pure nginx.conf location blocks (non-lua-classified) covered by custom extractor internal/custom/lua/routing.go which stamps canonical_path. |
 | Handler attribution | ✅ `full` | — | — | `internal/custom/lua/routing.go`<br>`internal/engine/lua_routes.go` | OpenResty routes synthesized to canonical http_endpoint via synthesizeOpenResty: nginx location stanzas (content_by_lua-gated, ANY verb) + lua-resty-router r:get/post/... DSL with :id->{id} normalization (httproutes.FrameworkOpenResty); value-asserting tests in lua_routes_test.go. Pure nginx.conf location blocks (non-lua-classified) covered by custom extractor internal/custom/lua/routing.go which stamps canonical_path. |
 | Route extraction | ✅ `full` | — | — | `internal/custom/lua/routing.go`<br>`internal/engine/lua_routes.go` | OpenResty routes synthesized to canonical http_endpoint via synthesizeOpenResty: nginx location stanzas (content_by_lua-gated, ANY verb) + lua-resty-router r:get/post/... DSL with :id->{id} normalization (httproutes.FrameworkOpenResty); value-asserting tests in lua_routes_test.go. Pure nginx.conf location blocks (non-lua-classified) covered by custom extractor internal/custom/lua/routing.go which stamps canonical_path. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.api-platform.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-31` | — | `internal/custom/php/apiplatform.go`<br>`internal/custom/php/apiplatform_test.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-31` | — | `internal/custom/php/apiplatform.go`<br>`internal/custom/php/apiplatform_test.go` | — |
 | Route extraction | ✅ `full` | `2026-05-31` | — | `internal/custom/php/apiplatform.go`<br>`internal/custom/php/apiplatform_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/laravel.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_php_producer.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/http_endpoint_php_producer_lrroute_test.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/php/template_render.go`<br>`internal/extractors/php/template_render_test.go` | view('users.list') / View::make() -> RENDERS SCOPE.Template; dot-notation normalized to slash; dynamic names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.lighthouse.md
+++ b/docs/coverage/detail/lang.php.framework.lighthouse.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-31` | — | `internal/custom/php/lighthouse.go`<br>`internal/custom/php/lighthouse_test.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-31` | — | `internal/custom/php/lighthouse.go`<br>`internal/custom/php/lighthouse_test.go` | — |
 | Route extraction | ✅ `full` | `2026-05-31` | — | `internal/custom/php/lighthouse.go`<br>`internal/custom/php/lighthouse_test.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Lumen app->get/post/router->method routes extracted; endpoint synthesis via regex route parsing |
 | Handler attribution | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Lumen controller string patterns (Controller@method) extracted alongside routes |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Phalcon app->get/post/router->method routes and group prefixes extracted |
 | Handler attribution | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Phalcon controller class detection alongside route definitions |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/symfony.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_php_producer.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/php/symfony.go` | PHP8 attribute routes with methods/name, @Route annotations, YAML routes (config/routes.yaml) with path+method extraction; class-level prefix support |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
 | Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.ariadne.md
+++ b/docs/coverage/detail/lang.python.framework.ariadne.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | schema-first Ariadne: QueryType()/MutationType()/SubscriptionType()/ObjectType("Query") binders + @<binder>.field("<name>") decorator resolvers -> http:GRAPHQL:/graphql/<Root>/<field>, identical shape to Strawberry. synthesizeAriadne. |
 | Handler attribution | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | decorated resolver function is the handler; source_handler=SCOPE.Operation:<funcName> rebinds to a HANDLES edge. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | Binder var -> root type resolved from QueryType/MutationType/SubscriptionType ctor or ObjectType("<Type>") arg; field name is the literal decorator string. Dynamically-named fields and set_field()/schema-directive bindings not resolved (honest-partial). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/bottle.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/bottle.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/cherrypy.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/cherrypy.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/cherrypy.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 51
+- **Capability cells:** 52
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/python_relational_bundle_test.go`<br>`internal/extractors/python/router_register.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/python/template_render.go`<br>`internal/extractors/python/template_render_test.go` | render(request,'x.html') + TemplateView.template_name -> RENDERS SCOPE.Template; dynamic names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/falcon.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/falcon.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/falcon.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/fastapi.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/fastapi.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/flask.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/python/template_render.go`<br>`internal/extractors/python/template_render_test.go` | render_template('x.html') -> RENDERS SCOPE.Template; dynamic/f-string names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.graphene.md
+++ b/docs/coverage/detail/lang.python.framework.graphene.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | graphene.ObjectType Query/Mutation/Subscription root classes; resolve_<field> methods and graphene.<X>(...) class-attribute fields -> http:GRAPHQL:/graphql/<Root>/<field>, identical shape to Strawberry/gqlgen. synthesizeGraphene. |
 | Handler attribution | ✅ `full` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | resolve_<field> method is the handler; source_handler=SCOPE.Operation:<Root>.resolve_<field> rebinds to a HANDLES edge. Default-resolver fields (no method) emitted honest-partial with the conventional resolver name. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | 3620 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_graphene_ariadne_3620_test.go`<br>`internal/engine/httproutes/canonicalize.go` | Operation endpoints synthesised from root-class fields; field name is the snake_case attribute (no name mangling). Dynamic/programmatically-named fields not resolved (honest-partial). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/hug.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/hug.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/hug.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/litestar.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/litestar.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/pyramid.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/pyramid.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/quart.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/quart.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3065 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_py_routing_3065_test.go`<br>`internal/engine/rules/python/frameworks/quart.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/robyn.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/robyn.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/sanic.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/sanic.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/starlette.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/starlette.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/tornado.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/tornado.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/custom/ruby/cuba_routing.go` | Cuba on 'path' string segments and :param parametric routing tree synthesis. Part of #3282. |
 | Handler attribution | 🟢 `partial` | — | — | `internal/custom/ruby/cuba_routing.go` | Cuba on get/post/put/patch/delete verb handler attribution. Part of #3282. |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/dry_rb.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/grape_deep.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
+++ b/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-06-02` | 3621 | `internal/engine/http_endpoint_graphql_ruby.go`<br>`internal/engine/http_endpoint_graphql_ruby_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | synthesizeGraphQLRuby emits http:GRAPHQL:/graphql/<Query|Mutation|Subscription>/<field> per `field :name` on a root operation type class (QueryType/MutationType/SubscriptionType, subclasses of *BaseObject or GraphQL::Schema::Object) — EXACT canonical shape as gqlgen (Go) / Strawberry (Python) / HotChocolate (C#) / Apollo (JS) / Absinthe so client links + cross-repo linker join. Field name = the Ruby `field :name` snake_case symbol verbatim (graphql-ruby keeps snake_case on the wire). Value-asserting tests assert the EXACT endpoint ids for Query/users, Query/user, Mutation/create_user, Mutation/delete_user, Subscription/user_added. |
 | Handler attribution | ✅ `full` | `2026-06-02` | 3621 | `internal/engine/http_endpoint_graphql_ruby.go`<br>`internal/engine/http_endpoint_graphql_ruby_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Each `field :name` is attributed to its same-name resolver method `def name` on the type class via source_handler=SCOPE.Operation:<field> plus a same-file handler_file hint; the resolver post-pass rebinds it to a HANDLES edge against the extracted Ruby method entity. Value-asserted in the tests. |
 | Route extraction | 🟢 `partial` | `2026-06-02` | 3621 | `internal/engine/http_endpoint_graphql_ruby.go`<br>`internal/engine/http_endpoint_graphql_ruby_test.go`<br>`internal/engine/httproutes/canonicalize.go` | Operation endpoints synthesised from `field :name` declarations on the convention-named root type classes. Honest-partial: keys on the conventional QueryType/MutationType/SubscriptionType class names rather than the schema's query(...)/mutation(...) registration, and resolves the default same-name `def` resolver — does not yet follow `resolver: SomeResolver` / `method:` field overrides or dynamically generated fields. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/rails_routes.go`<br>`internal/custom/ruby/rails_routes_test.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` | Deep config/routes.rb DSL extractor (custom_ruby_rails_routes): resources->7 RESTful routes + resource->6 singular, nested resources path composition (/photos/:photo_id/comments), namespace + scope + scope module: prefixing, member/collection (+inline on:), only:/except: filters, root, get/post/put/patch/delete to:'c#a', match via:, mount engines, concern/concerns: expansion. Each route emits resolved full path + HTTP method + controller#action handler with CALLS structural-ref to the action method. Value-asserting tests in rails_routes_test.go assert exact path+method+handler sets (TestRailsRoutes_ResourcesSevenRESTful, _NestedResources, _Namespace, _ScopePath/_ScopeModule, _MemberCollection, _OnlyFilter/_ExceptFilter, _Root, _MatchVia, _Mount, _Concerns, _RealisticCombined). Honest remainder: constraints blocks recorded but not expanded; direct/resolve URL helpers not modelled. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🟢 `partial` | `2026-06-02` | 3628 | `internal/extractor/template_render.go`<br>`internal/extractors/ruby/template_render.go`<br>`internal/extractors/ruby/template_render_test.go` | explicit render 'path' / template:/partial: -> RENDERS SCOPE.Template; symbol (render :index) + implicit-convention renders honest-skipped; dynamic names dropped (#3628) |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 46
+- **Capability cells:** 47
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/routes.go`<br>`internal/custom/ruby/routes_test.go`<br>`internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go` | Extracts all Sinatra verb blocks (get/post/put/patch/delete/head/options) with exact route path and HTTP method. Covers class-based Sinatra::Base/Sinatra::Application and standalone apps (require 'sinatra'). Named params /:id, splat /*path, regex routes all emitted. Full parity with TS/JS Express route_extraction. Closes #3344. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/extractors_test.go`<br>`internal/custom/rust/helpers.go` | Extracts attribute-macro and manual web::get().to() routes; normalises path params; composes web::scope() prefix onto manual routes |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.async-graphql.md
+++ b/docs/coverage/detail/lang.rust.framework.async-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/async_graphql.go`<br>`internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go` | Synthesizes verb GRAPHQL endpoints from resolver impl blocks; Schema::build root captured as SCOPE.Service |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/async_graphql.go`<br>`internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go` | handler_name=<Root>.<field> attributed per resolver method |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/async_graphql.go`<br>`internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go` | Each #[Object] impl Query/Mutation/Subscription resolver method becomes a GRAPHQL endpoint at /graphql/<Root>/<field>; operation kind derived from impl root |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_axum.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/axum.go`<br>`internal/custom/rust/extractors_test.go`<br>`internal/custom/rust/helpers.go` | Extracts verb+path; normalises :id/<id>/{id} to canonical {id}; composes .nest() prefix; expands chained method routers get(h).post(h) |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | route.verb(path).to(h); :id params normalised to {id}; verb+path+handler asserted |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Extracts (&Method::VERB, "/path") match-arm routes; raw hyper paths are literal string matches with no param syntax, so param normalisation is N/A and dynamic-segment routes (manual path splitting) are not recovered |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Route::new().at(path, verb(h)); #[handler] attribution; :id params normalised to {id} |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rocket_routes.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/extractors_test.go`<br>`internal/custom/rust/helpers.go`<br>`internal/custom/rust/rocket.go` | Extracts #[verb(path, data=..)] macros; normalises <id> to {id}; composes .mount(prefix, routes![]) onto handler paths |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Router with_path/.path().verb(h); <id> path params normalised to {id} |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | app.at(path).verb(h); :id params normalised to {id}; verb+path+handler asserted |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.tonic.md
+++ b/docs/coverage/detail/lang.rust.framework.tonic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go`<br>`internal/custom/rust/tonic.go` | RPC endpoints synthesized per async method; .add_service(<Svc>Server::new) captured as SCOPE.Service registration |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go`<br>`internal/custom/rust/tonic.go` | handler_name=<ImplType>.<method> attributed per RPC method |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/graphql_grpc_test.go`<br>`internal/custom/rust/helpers.go`<br>`internal/custom/rust/tonic.go` | #[tonic::async_trait] impl <Service> for <Type> RPC methods become RPC endpoints at /<Service>/<Method>; verb=RPC, rpc_protocol=grpc |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | ServiceBuilder::new/.layer/.service patterns detected; tower does not have URL routing natively |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | tower is a middleware/service-composition layer, not a router: ServiceBuilder.layer()/.service() are extracted but tower defines no verb+path routes, so route_extraction is structurally partial |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.utoipa.md
+++ b/docs/coverage/detail/lang.rust.framework.utoipa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | each #[utoipa::path] attribute -> SCOPE.Operation endpoint (verb + canonical path) |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | handler fn name captured from the fn following each #[utoipa::path] attribute |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | utoipa::path(verb, path=...) yields canonical verb+path (normalises {id}/:id/<id>); captures handler fn; enriches bare axum/actix routes with documented contract |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | warp::path! filter chains; typed segments (u32) normalised to {param}; verb+path+handler attribution |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.caliban.md
+++ b/docs/coverage/detail/lang.scala.framework.caliban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/caliban.go`<br>`internal/custom/scala/caliban_test.go` | graphQL(RootResolver(...)) synthesises one GRAPHQL endpoint per resolver case-class field, path /graphql/<Root>/<field>, positional Query/Mutation/Subscription root. TestCalibanResolverFields. |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/caliban.go`<br>`internal/custom/scala/caliban_test.go` | handler_name = <Root>.<field> bound from resolver case-class field. TestCalibanResolverFields. |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/caliban.go`<br>`internal/custom/scala/caliban_test.go` | GraphQL field path /graphql/<Root>/<field> recorded as route_path. TestCalibanResolverFields. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Cask @cask.get/@cask.post routes synthesized into SCOPE.Operation/http_route entities with method+path. |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Cask route annotation detected in context of the enclosing object/class — handler method attributed to route. |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: @cask.get/@cask.post annotation routes with path extraction. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | — `not_applicable` | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` | — |
 | Route extraction | — `not_applicable` | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.pekko-http.md
+++ b/docs/coverage/detail/lang.scala.framework.pekko-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: pekko-http routes synthesized as http_route entities; cross-file route-tree composition not resolved. |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: pekko-http route directives detected; complete(...) handler binding is file-local and not resolved to a named handler cross-file. |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks: pekko-http detected as its own framework (org.apache.pekko import) and routed through the shared akka-http branch (case akka-http,pekko-http). path("users"/LongNumber)/pathPrefix + method directives combined via nearest-path positional context, canonicalScalaPathExpr ({id} from LongNumber). Value-asserting test TestPekkoHttpRoute pins GET:/api/users/{id} + POST + framework=pekko-http. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.sttp.md
+++ b/docs/coverage/detail/lang.scala.framework.sttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-31` | — | `internal/engine/http_endpoint_scala_client.go`<br>`internal/engine/http_endpoint_scala_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | sttp basicRequest/quickRequest/emptyRequest verb combinators (.get/.post/.put/.patch/.delete/.head/.options) with uri"..." literals -> one outbound http_endpoint_call (consumer) per call site + FETCHES from the enclosing def; host stripped, $id/${...} interpolation -> {param}. Value-asserted (GET/POST /v1/users, PUT /v1/users/{param}). |
 | Handler attribution | ✅ `full` | `2026-05-31` | — | `internal/engine/http_endpoint_scala_client.go`<br>`internal/engine/http_endpoint_scala_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | FETCHES edge attributes each outbound sttp call to the enclosing def (nearest preceding def <name>). Value-asserted via requireFetches in http_endpoint_scala_client_test.go. |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.tapir.md
+++ b/docs/coverage/detail/lang.scala.framework.tapir.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir endpoint values synthesized into http_route entities backend-agnostically (akka/pekko/http4s/netty). method+path+DTO refs+handler in one entity. File-local. |
 | Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir .serverLogic/.serverLogicSuccess/Pure(handler) bound to the endpoint, stamped as handler + handler_attribution prop. Value-asserting test asserts handler=handleGetUser/createUserHandler. File-local (handler def may live cross-file). |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir endpoint-DSL. Each endpoint(.get/.post/.method(Method.X)).in("seg" / path[T]("name")).in(query[T]) chain parsed into one http_route with http_method + canonical http_path ({name} from path[T], query params separate). Value-asserting tests TestTapirEndpointRouteAndDTOs/PostRequestBodyDTO/MethodExplicitForm/NamedPathParam pin verb+path. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** JVM Backend
-- **Capability cells:** 50
+- **Capability cells:** 51
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [swift](../by-language/swift.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 45
+- **Capability cells:** 46
 
 ## Capabilities
 
@@ -19,6 +19,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/swift/vapor.go` | vapor.go emits SCOPE.Operation entities with http_method and route_path properties from Vapor route registrations; the cross-repo http_pass.go can match these endpoints for cross-link synthesis; proven by TestVaporRoute. |
 | Handler attribution | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/swift/vapor.go` | vapor.go emits RouteCollection controller entities (SCOPE.Component/controller) and links routes to file context; full handler-to-function attribution requires resolving trailing closures back to named handler functions which is not yet implemented. |
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/swift/vapor.go` | vapor.go custom extractor handles app.get/post/put/delete/patch/options route registrations, RouteCollection conformances, and .grouped prefix declarations; emits SCOPE.Operation/endpoint with http_method and route_path properties; proven by TestVaporRoute and TestVaporRouteCollection. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2350,6 +2350,12 @@
             "notes": "ace is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -2599,6 +2605,12 @@
             "notes": "boost is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -2846,6 +2858,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "boost-asio is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -3098,6 +3116,12 @@
             "status": "full",
             "cites": ["internal/custom/cpp/cpprestsdk_routes.go"],
             "notes": "Path strings extracted from http_listener init + support() calls; partial = regex heuristic"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -3358,6 +3382,12 @@
             "notes": "Path strings extracted from CROW_ROUTE/CROW_BP_ROUTE macros; partial = regex heuristic"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -3614,6 +3644,12 @@
             "status": "full",
             "cites": ["internal/custom/cpp/drogon_routes.go"],
             "notes": "Path strings extracted from ADD_METHOD_TO/METHOD_ADD/registerHandler; partial = regex heuristic"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -4023,6 +4059,12 @@
             "notes": "libev is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -4270,6 +4312,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "libevent is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -4545,6 +4593,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "libuv is a low-level async I/O library; no HTTP route-registration DSL exists — routing is app-level, not framework-provided"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -4876,6 +4930,12 @@
             "notes": "Path strings from ENDPOINT/ENDPOINT_ASYNC macros; partial = regex heuristic"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -5131,6 +5191,12 @@
             "status": "full",
             "cites": ["internal/custom/cpp/pistache_routes.go"],
             "notes": "Path strings extracted from Routes::Get/Post/etc and router.get; partial = regex heuristic"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -5389,6 +5455,12 @@
             "status": "full",
             "cites": ["internal/custom/cpp/poco_routes.go"],
             "notes": "Paths from addHandler\u003cT\u003e/router.add/server.addHandler; partial = regex heuristic"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -6001,6 +6073,12 @@
             "notes": "Paths from Resource set_path/set_method_handler; partial = regex + same-file var correlation"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -6257,6 +6335,12 @@
             "status": "full",
             "cites": ["internal/custom/cpp/restinio_routes.go"],
             "notes": "Paths from router-\u003ehttp_get/post/etc and add_handler; partial = regex heuristic"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -7691,6 +7775,12 @@
             "notes": "Minimal-API app.MapGet/Post/Put/Delete route path strings extracted via reAspNetMinimalAPI; attribute routes via reAspNetHTTPMethod; route_path property set on each emitted entity."
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -7948,6 +8038,12 @@
             "status": "full",
             "cites": ["internal/custom/csharp/aspnet_core.go","internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
             "notes": "MVC controller [Route] + [HttpGet/Post/Put/Delete/Patch] attribute routes extracted; route path strings captured by asp_net_mvc.yaml source_patterns and aspnet_core.go reAspNetHTTPMethod/reAspNetMinimalAPI."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -8823,6 +8919,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -9082,6 +9184,12 @@
             "issue": "3263",
             "notes": "fastendpoints route path strings extracted via regex; heuristic",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -9511,6 +9619,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -9731,6 +9845,12 @@
             "issue": "3263",
             "notes": "nancyfx route path strings extracted via regex; heuristic",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -10206,6 +10326,12 @@
             "issue": "3263",
             "notes": "servicestack route path strings extracted via regex; heuristic",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -11923,6 +12049,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -12187,6 +12319,12 @@
             "notes": "Ash resources + AshPhoenix router integration detected via engine YAML; resource actions serve as route equivalents"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -12444,6 +12582,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "Bandit is a low-level HTTP server (replaces Cowboy); routing belongs to Phoenix/Plug layer above it"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -12730,6 +12874,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -12985,6 +13135,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -13355,6 +13511,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -13565,6 +13727,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "Nerves is an embedded/IoT firmware framework; no HTTP routing concept. NervesHub is separate."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -13811,6 +13979,12 @@
           "route_extraction": {
             "status": "not_applicable",
             "notes": "Oban is a background job processor; no HTTP routing. Jobs are enqueued via Oban.insert/2."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -14071,6 +14245,12 @@
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/phoenix_routes.go","internal/engine/phoenix_routes_test.go"],
             "notes": "synthesizePhoenix emits canonical http_endpoint per get/post/put/patch/delete/head/options verb + resources CRUD expansion (only:/except: filters) with nested scope-prefix composition and :id-\u003e{id} normalisation; controller#action attributed via handler_file hint. Value-asserting engine tests (TestPhoenix_VerbInScope/Resources/NestedScope/ControllerHandlerRef) prove exact (verb,path,controller#action).",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -14556,6 +14736,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -14818,6 +15004,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -15033,6 +15225,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -15878,6 +16076,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -16134,6 +16338,12 @@
             "cites": ["internal/custom/golang/buffalo.go","internal/engine/rules/go/frameworks/buffalo.yaml"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -16393,6 +16603,12 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "regex-based: direct .GET/.POST/.DELETE/.PATCH etc + .Group()/.Route() prefix resolution tested; misses cross-file route splits, dynamic path construction, indirect router variable aliasing, and conditional registration",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -16660,6 +16876,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -16922,6 +17144,12 @@
             "cites": ["internal/custom/golang/fasthttp.go","internal/engine/rules/go/frameworks/fasthttp.yaml"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -17190,6 +17418,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -17448,6 +17682,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "3628"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -17775,6 +18015,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -18037,6 +18283,12 @@
             "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -18518,6 +18770,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -18788,6 +19046,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -19005,6 +19269,12 @@
             "cites": ["internal/custom/golang/hertz.go","internal/custom/golang/hertz_huma_test.go","internal/custom/golang/testdata/hertz_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -19267,6 +19537,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -19522,6 +19798,12 @@
             "cites": ["internal/custom/golang/iris.go","internal/engine/rules/go/frameworks/iris.yaml"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -19782,6 +20064,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -20038,6 +20326,12 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "regex-based: http.HandleFunc + http.Handle on DefaultServeMux + http.NewServeMux() + Go 1.22+ method-prefixed patterns (GET /path) tested; misses cross-file route splits and dynamic path construction",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -20312,6 +20606,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -20563,6 +20863,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "3628"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -21429,6 +21735,12 @@
             "issue": "3092"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -22171,6 +22483,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -22410,6 +22728,12 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "Dropwizard uses Jersey (JAX-RS); @Path/@GET/@POST annotations covered by java_annotation_routes.go",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -22709,6 +23033,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "3699"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -23172,6 +23502,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -23484,6 +23820,12 @@
             "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -23802,6 +24144,12 @@
             "issue": "3085"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -24103,6 +24451,12 @@
             "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -24470,6 +24824,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -24787,6 +25147,12 @@
             "cites": ["internal/engine/java_annotation_routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -25359,6 +25725,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -25676,6 +26048,15 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "Annotation-driven route composition scanned (@RequestMapping/@GetMapping/etc.); path-variable expression resolution not implemented",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/java/template_render.go","internal/extractors/java/template_render_test.go"],
+            "issue": "3628",
+            "notes": "@Controller method String/ModelAndView view name -\u003e RENDERS SCOPE.Template; @RestController/@ResponseBody skipped (REST not MVC); dynamic names dropped (#3628)",
+            "verified_at": "2026-06-02"
           }
         },
         "Auth": {
@@ -26014,6 +26395,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -26252,6 +26639,12 @@
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "3080",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -26581,6 +26974,12 @@
             "cites": ["internal/custom/java/struts_routes.go"],
             "notes": "Extracts @Action(value=...) annotations and struts.xml \u003caction\u003e elements; @Namespace prefix composition; HANDLED_BY relationships to action classes",
             "verified_at": "2026-06-01"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -27097,6 +27496,12 @@
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3086",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -29057,6 +29462,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -30268,6 +30679,15 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/javascript/template_render.go","internal/extractors/javascript/template_render_test.go"],
+            "issue": "3628",
+            "notes": "res.render('view') -\u003e RENDERS SCOPE.Template; response-receiver heuristic; dynamic/template-literal names dropped (#3628)",
+            "verified_at": "2026-06-02"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -30567,6 +30987,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -30858,6 +31284,12 @@
             "cites": ["internal/engine/http_endpoint_jsts_backend.go","internal/engine/http_endpoint_jsts_backend_test.go","internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go"],
             "issue": "3062",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -31590,6 +32022,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -31876,6 +32314,12 @@
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go"],
             "issue": "3062",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -32395,6 +32839,15 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/javascript/template_render.go","internal/extractors/javascript/template_render_test.go"],
+            "issue": "3628",
+            "notes": "ctx.render('view') -\u003e RENDERS SCOPE.Template; dynamic names dropped (#3628)",
+            "verified_at": "2026-06-02"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -32727,6 +33180,12 @@
             "cites": ["internal/engine/http_endpoint_jsts_backend.go","internal/engine/http_endpoint_jsts_backend_test.go","internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go"],
             "issue": "3062",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -33235,6 +33694,12 @@
             "cites": ["internal/custom/javascript/nestjs.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_test.go"],
             "issue": "3062",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -34067,6 +34532,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -34341,6 +34812,12 @@
             "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/pothos_jsts.yaml"],
             "issue": "3619",
             "notes": "builder.queryField/mutationField/subscriptionField + the builder.queryType/mutationType/subscriptionType fields:(t)=\u003e({...}) maps -\u003e http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e (EXACT canonical shape as gqlgen/Apollo/Strawberry so client links #3667 join). Honest-partial: a non-literal (variable/computed) field name is not recovered."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -35431,6 +35908,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -35706,6 +36189,12 @@
             "cites": ["internal/engine/http_endpoint_jsts_backend.go","internal/engine/http_endpoint_jsts_backend_test.go","internal/engine/http_endpoint_synthesis_jsts_route_3062_test.go"],
             "issue": "3062",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -36732,6 +37221,12 @@
             "cites": ["internal/engine/http_endpoint_graphql_jsts_codefirst.go","internal/engine/http_endpoint_resolve.go","internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_graphql_jsts_codefirst_3619_test.go","internal/engine/httproutes/canonicalize.go","internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml"],
             "issue": "3619",
             "notes": "Root @Query/@Mutation/@Subscription methods only; @FieldResolver (non-root) methods are skipped, matching gqlgen/spring-graphql. Field name = method name or the { name: '...' } decorator option. Honest-partial: a dynamic/computed name option is not recovered."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -37806,6 +38301,12 @@
             "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -38460,6 +38961,12 @@
             "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -38728,6 +39235,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -38970,6 +39483,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -39206,6 +39725,12 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -39487,6 +40012,12 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/3586",
             "notes": "java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -39976,6 +40507,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -40210,6 +40747,12 @@
           "route_extraction": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -40447,6 +40990,12 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/ktor_routes.go"],
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -40734,6 +41283,12 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -41037,6 +41592,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -41337,6 +41898,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -41575,6 +42142,12 @@
             "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -42333,6 +42906,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -42552,6 +43131,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -42769,6 +43354,12 @@
             "status": "full",
             "cites": ["internal/custom/lua/routing.go","internal/engine/lua_routes.go"],
             "notes": "Lapis routes synthesized to canonical http_endpoint via synthesizeLapis (app:get/post/put/patch/delete/options/head verb routes, named + unnamed app:match, respond_to verb tables) with :id-\u003e{id} normalization (httproutes.FrameworkLapis) and app/route-name handler attribution; value-asserting tests in lua_routes_test.go. Custom extractor also stamps canonical_path."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -43027,6 +43618,12 @@
             "status": "full",
             "cites": ["internal/custom/lua/routing.go","internal/engine/lua_routes.go"],
             "notes": "OpenResty routes synthesized to canonical http_endpoint via synthesizeOpenResty: nginx location stanzas (content_by_lua-gated, ANY verb) + lua-resty-router r:get/post/... DSL with :id-\u003e{id} normalization (httproutes.FrameworkOpenResty); value-asserting tests in lua_routes_test.go. Pure nginx.conf location blocks (non-lua-classified) covered by custom extractor internal/custom/lua/routing.go which stamps canonical_path."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -43799,6 +44396,12 @@
             "verified_at": "2026-05-31"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -44015,6 +44618,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -44279,6 +44888,12 @@
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -44539,6 +45154,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -44802,6 +45423,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -45018,6 +45645,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -45280,6 +45913,15 @@
             "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/http_endpoint_php_producer_lrroute_test.go"],
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/php/template_render.go","internal/extractors/php/template_render_test.go"],
+            "issue": "3628",
+            "notes": "view('users.list') / View::make() -\u003e RENDERS SCOPE.Template; dot-notation normalized to slash; dynamic names dropped (#3628)",
+            "verified_at": "2026-06-02"
           }
         },
         "Auth": {
@@ -45549,6 +46191,12 @@
             "verified_at": "2026-05-31"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -45765,6 +46413,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -46029,6 +46683,12 @@
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -46289,6 +46949,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -46553,6 +47219,12 @@
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -46813,6 +47485,12 @@
             "cites": ["internal/custom/php/symfony.go"],
             "notes": "PHP8 attribute routes with methods/name, @Route annotations, YAML routes (config/routes.yaml) with path+method extraction; class-level prefix support",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -47085,6 +47763,12 @@
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -47345,6 +48029,12 @@
             "cites": ["internal/custom/php/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
             "notes": "Regex-based per-framework route extraction covering HTTP method routes, resource routes, URL rules"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -48457,6 +49147,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -48744,6 +49440,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -48969,6 +49671,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -49479,6 +50187,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -49758,6 +50472,15 @@
             "status": "full",
             "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/python/template_render.go","internal/extractors/python/template_render_test.go"],
+            "issue": "3628",
+            "notes": "render(request,'x.html') + TemplateView.template_name -\u003e RENDERS SCOPE.Template; dynamic names dropped (#3628)",
+            "verified_at": "2026-06-02"
           }
         },
         "Auth": {
@@ -50047,6 +50770,12 @@
             "status": "full",
             "cites": ["internal/extractors/python/python_relational_bundle_test.go","internal/extractors/python/router_register.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -50583,6 +51312,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -50865,6 +51600,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -51157,6 +51898,15 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/python/template_render.go","internal/extractors/python/template_render_test.go"],
+            "issue": "3628",
+            "notes": "render_template('x.html') -\u003e RENDERS SCOPE.Template; dynamic/f-string names dropped (#3628)",
+            "verified_at": "2026-06-02"
           }
         },
         "Auth": {
@@ -51463,6 +52213,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -51680,6 +52436,12 @@
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_py_routing_3065_test.go","internal/engine/rules/python/frameworks/hug.yaml"],
             "issue": "3065",
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -52000,6 +52762,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -52279,6 +53047,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -52564,6 +53338,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -52842,6 +53622,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -53337,6 +54123,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -53615,6 +54407,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -53900,6 +54698,12 @@
             "verified_at": "2026-05-29"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -54178,6 +54982,12 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_synthesis.go"],
             "verified_at": "2026-05-29"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -55738,6 +56548,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -55988,6 +56804,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
@@ -56235,6 +57057,12 @@
             "status": "full",
             "cites": ["internal/custom/ruby/grape_deep.go"],
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -56492,6 +57320,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -56707,6 +57541,12 @@
             "cites": ["internal/custom/ruby/routes.go"],
             "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -56961,6 +57801,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -57211,6 +58057,15 @@
             "cites": ["internal/custom/ruby/rails_routes.go","internal/custom/ruby/rails_routes_test.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
             "notes": "Deep config/routes.rb DSL extractor (custom_ruby_rails_routes): resources-\u003e7 RESTful routes + resource-\u003e6 singular, nested resources path composition (/photos/:photo_id/comments), namespace + scope + scope module: prefixing, member/collection (+inline on:), only:/except: filters, root, get/post/put/patch/delete to:'c#a', match via:, mount engines, concern/concerns: expansion. Each route emits resolved full path + HTTP method + controller#action handler with CALLS structural-ref to the action method. Value-asserting tests in rails_routes_test.go assert exact path+method+handler sets (TestRailsRoutes_ResourcesSevenRESTful, _NestedResources, _Namespace, _ScopePath/_ScopeModule, _MemberCollection, _OnlyFilter/_ExceptFilter, _Root, _MatchVia, _Mount, _Concerns, _RealisticCombined). Honest remainder: constraints blocks recorded but not expanded; direct/resolve URL helpers not modelled.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "partial",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/ruby/template_render.go","internal/extractors/ruby/template_render_test.go"],
+            "issue": "3628",
+            "notes": "explicit render 'path' / template:/partial: -\u003e RENDERS SCOPE.Template; symbol (render :index) + implicit-convention renders honest-skipped; dynamic names dropped (#3628)",
+            "verified_at": "2026-06-02"
           }
         },
         "Auth": {
@@ -57482,6 +58337,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -57732,6 +58593,12 @@
             "cites": ["internal/custom/ruby/routes.go","internal/custom/ruby/routes_test.go","internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go"],
             "notes": "Extracts all Sinatra verb blocks (get/post/put/patch/delete/head/options) with exact route path and HTTP method. Covers class-based Sinatra::Base/Sinatra::Application and standalone apps (require 'sinatra'). Named params /:id, splat /*path, regex routes all emitted. Full parity with TS/JS Express route_extraction. Closes #3344.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -58832,6 +59699,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -59090,6 +59963,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -59314,6 +60193,12 @@
             "cites": ["internal/custom/rust/axum.go","internal/custom/rust/extractors_test.go","internal/custom/rust/helpers.go"],
             "notes": "Extracts verb+path; normalises :id/\u003cid\u003e/{id} to canonical {id}; composes .nest() prefix; expands chained method routers get(h).post(h)",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -59570,6 +60455,12 @@
             "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
             "notes": "route.verb(path).to(h); :id params normalised to {id}; verb+path+handler asserted",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -59829,6 +60720,12 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "Extracts (\u0026Method::VERB, \"/path\") match-arm routes; raw hyper paths are literal string matches with no param syntax, so param normalisation is N/A and dynamic-segment routes (manual path splitting) are not recovered",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -60118,6 +61015,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -60405,6 +61308,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -60659,6 +61568,12 @@
             "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
             "notes": "Router with_path/.path().verb(h); \u003cid\u003e path params normalised to {id}",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -61076,6 +61991,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -61336,6 +62257,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -61563,6 +62490,12 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "tower is a middleware/service-composition layer, not a router: ServiceBuilder.layer()/.service() are extracted but tower defines no verb+path routes, so route_extraction is structurally partial",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -61825,6 +62758,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -62045,6 +62984,12 @@
             "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
             "notes": "warp::path! filter chains; typed segments (u32) normalised to {param}; verb+path+handler attribution",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -62672,6 +63617,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -62966,6 +63917,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -63218,6 +64175,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
             "notes": "custom_scala_frameworks extractor: @cask.get/@cask.post annotation routes with path extraction. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -63510,6 +64473,12 @@
             "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "not_applicable",
@@ -63792,6 +64761,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
             "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -64093,6 +65068,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "full",
@@ -64383,6 +65364,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
             "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -64686,6 +65673,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
             "notes": "custom_scala_frameworks: pekko-http detected as its own framework (org.apache.pekko import) and routed through the shared akka-http branch (case akka-http,pekko-http). path(\"users\"/LongNumber)/pathPrefix + method directives combined via nearest-path positional context, canonicalScalaPathExpr ({id} from LongNumber). Value-asserting test TestPekkoHttpRoute pins GET:/api/users/{id} + POST + framework=pekko-http. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -65327,6 +66320,12 @@
             "verified_at": "2026-05-30"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
@@ -65620,6 +66619,12 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
+          }
+        },
         "Auth": {
           "auth_coverage": {
             "status": "missing",
@@ -65859,6 +66864,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go"],
             "notes": "custom_scala_frameworks: tapir endpoint-DSL. Each endpoint(.get/.post/.method(Method.X)).in(\"seg\" / path[T](\"name\")).in(query[T]) chain parsed into one http_route with http_method + canonical http_path ({name} from path[T], query params separate). Value-asserting tests TestTapirEndpointRouteAndDTOs/PostRequestBodyDTO/MethodExplicitForm/NamedPathParam pin verb+path. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -66115,6 +67126,12 @@
             "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
             "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {
@@ -67318,6 +68335,12 @@
             "cites": ["internal/custom/swift/vapor.go"],
             "notes": "vapor.go custom extractor handles app.get/post/put/delete/patch/options route registrations, RouteCollection conformances, and .grouped prefix declarations; emits SCOPE.Operation/endpoint with http_method and route_path properties; proven by TestVaporRoute and TestVaporRouteCollection.",
             "verified_at": "2026-05-30"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "view_rendering:#3628-not-yet-extracted"
           }
         },
         "Auth": {

--- a/internal/extractor/template_render.go
+++ b/internal/extractor/template_render.go
@@ -1,0 +1,236 @@
+package extractor
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// template_render.go — shared cross-language helpers for the server-side
+// view-layer topology (epic #3628). It mirrors the error-flow model in
+// exception_flow.go.
+//
+// The view-layer capability answers two questions a rewrite needs to keep the
+// presentation contract intact:
+//
+//   - "what template does this handler render?"   → a handler's outbound
+//     RENDERS edge.
+//   - "who renders users/list.html?"               → a template's inbound
+//     RENDERS edges.
+//
+// To make a template rendered by two different handlers converge on ONE graph
+// node, every language extractor emits:
+//
+//   - one SCOPE.Template / subtype="template" entity per distinct (normalized)
+//     template name, with a SYNTHETIC constant SourceFile (TemplateSourceFile)
+//     so EntityRecord.ComputeID(SourceFile+Kind+Name) collapses identical
+//     template names — even across files, languages and frameworks — into a
+//     single node. A 'users/list.html' rendered by a Flask view and an Express
+//     route therefore share one node, and that node's inbound-RENDERS set is
+//     the list of handlers that present it.
+//
+//   - one RENDERS edge (handler function/method → template node), carried as a
+//     structural-ref ToID (TemplateTargetID) that the resolver binds via the
+//     byQualifiedName exact-match tier (the entity's QualifiedName equals that
+//     ToID).
+//
+// Precision-first / honest-partial: only STATIC template names are recorded.
+// Dynamic-or-computed template names (a variable passed to render_template /
+// res.render / view(), a Spring method returning a computed view name) emit NO
+// edge — a single wrong RENDERS edge would mislead view-layer analysis. The
+// detection of those shapes lives in each language extractor; this file owns
+// only the node/edge construction so the convergence invariant is identical
+// everywhere.
+
+// TemplateSourceFile is the synthetic, constant SourceFile assigned to every
+// template entity so identical template names converge to a single graph node
+// under EntityRecord.ComputeID (which hashes SourceFile+Kind+Name).
+const TemplateSourceFile = "<template>"
+
+// TemplateName returns the canonical entity Name for a template. The
+// "template:" prefix namespaces the node (so it never collides with a
+// same-named code symbol) and keeps the human-readable logical name verbatim,
+// e.g. "template:users/list.html", "template:dashboard", "template:welcome".
+func TemplateName(name string) string {
+	return "template:" + name
+}
+
+// TemplateTargetID returns the structural-ref ToID for a RENDERS edge pointing
+// at a template entity. Shape:
+//
+//	scope:template:<name>
+//
+// This value is ALSO stored as the template entity's QualifiedName, so the
+// resolver's byQualifiedName exact-match tier (internal/resolve/refs.go) binds
+// the edge to that entity without any new linker code. Constant across
+// languages so a Flask render_template('x.html') and an Express res.render('x')
+// resolve to the same node when the normalized names match.
+func TemplateTargetID(name string) string {
+	return "scope:template:" + name
+}
+
+// NormalizeTemplateName canonicalizes a raw template-name token (already
+// stripped of surrounding quotes by the caller) into the convergence key, or
+// returns "" if the token is not a usable static name (empty, or containing
+// characters that signal a dynamic / computed / interpolated name the caller
+// must drop).
+//
+//	"users/list.html"  -> "users/list.html"   (Flask / Django / Express)
+//	"users.list"       -> "users/list"        (Laravel dot-notation → slash)
+//	"users/show"       -> "users/show"        (Rails / Express, no ext)
+//	"./partials/nav"   -> "partials/nav"      (leading ./ stripped)
+//
+// Returns "" for tokens that contain interpolation / concatenation / operators
+// (spaces, ${...}, "+", "#{...}", backticks, parentheses, etc.) so dynamic
+// renders like render_template(name_var) or res.render(`p/${id}`) never
+// fabricate a node. Laravel dot-notation is converted to slash form so
+// view('users.list') and an explicit 'users/list' path converge.
+func NormalizeTemplateName(raw string) string {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return ""
+	}
+	// Reject anything that signals a dynamic / interpolated / concatenated name.
+	// A static template literal is a plain path of identifier / path chars.
+	for i := 0; i < len(t); i++ {
+		c := t[i]
+		isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		isDigit := c >= '0' && c <= '9'
+		switch {
+		case isLetter || isDigit:
+		case c == '/' || c == '.' || c == '_' || c == '-':
+		default:
+			return "" // space, +, $, {, #, `, (, etc. → dynamic, drop
+		}
+	}
+	// Strip a leading "./" (relative-path noise) — but not ".." which would be
+	// an unusual escape we leave to drop below.
+	t = strings.TrimPrefix(t, "./")
+	// Laravel / Blade dot-notation: convert dots to slashes UNLESS the token
+	// looks like a path-with-extension (contains a slash already, or ends in a
+	// known template extension). "users.list" -> "users/list"; "x.html" stays.
+	if !strings.Contains(t, "/") && !hasTemplateExt(t) {
+		t = strings.ReplaceAll(t, ".", "/")
+	}
+	t = strings.Trim(t, "/")
+	if t == "" || strings.Contains(t, "..") {
+		return ""
+	}
+	return t
+}
+
+// hasTemplateExt reports whether name ends in a recognized view-template file
+// extension, in which case its dots are part of a path+extension and must not
+// be rewritten to slashes.
+func hasTemplateExt(name string) bool {
+	for _, ext := range []string{
+		".html", ".htm", ".jinja", ".jinja2", ".j2", ".twig", ".ejs",
+		".pug", ".jade", ".hbs", ".handlebars", ".mustache", ".erb",
+		".haml", ".slim", ".blade.php", ".php", ".jsp", ".thymeleaf",
+		".vm", ".ftl", ".njk", ".liquid",
+	} {
+		if strings.HasSuffix(name, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// TemplateEntity builds the SCOPE.Template / template entity for a single
+// normalized template name in the given language. The entity is deliberately
+// file-agnostic (synthetic SourceFile) so it is the shared view-layer
+// convergence node, and its QualifiedName equals the edge ToID so RENDERS edges
+// resolve via byQualifiedName.
+func TemplateEntity(name, lang string) types.EntityRecord {
+	e := types.EntityRecord{
+		Name:          TemplateName(name),
+		QualifiedName: TemplateTargetID(name),
+		Kind:          string(types.EntityKindTemplate),
+		Subtype:       "template",
+		Language:      lang,
+		SourceFile:    TemplateSourceFile,
+		StartLine:     1,
+		EndLine:       1,
+		Signature:     TemplateName(name),
+		Properties: map[string]string{
+			"template": name,
+		},
+	}
+	e.ID = e.ComputeID()
+	return e
+}
+
+// TemplateEdge is one resolved static render detected by a language extractor:
+// the raw template-name token (already unquoted), the Name of the enclosing
+// handler function / method, and the detector label.
+type TemplateEdge struct {
+	Name     string // raw template-name token (normalized internally)
+	FromName string // enclosing handler/method Name; "" => file entity
+	Pattern  string // detector label, e.g. "render_template", "res_render", "spring_view"
+}
+
+// EmitTemplateEdges appends, to *entities, the template entities and RENDERS
+// edges for the given static render detections.
+//
+// entities[0] MUST be the file entity (every language extractor appends it
+// first). Edges whose FromName is "" — or whose FromName has no matching host
+// entity — attach to the file entity (index 0) as a conservative fallback so
+// the edge is never silently dropped. Identical template names converge to one
+// template entity (deduped by name) and one edge per (FromName, name) tuple.
+//
+// Returns the number of RENDERS edges emitted. Safe with nil/empty input.
+// Tokens that NormalizeTemplateName rejects (dynamic / computed names) are
+// skipped — precision over recall.
+func EmitTemplateEdges(entities *[]types.EntityRecord, lang string, edges []TemplateEdge) int {
+	if entities == nil || len(*entities) == 0 || len(edges) == 0 {
+		return 0
+	}
+
+	hostByName := map[string]int{}
+	for i := range *entities {
+		hostByName[(*entities)[i].Name] = i
+	}
+
+	seenEdge := map[string]bool{}
+	seenTpl := map[string]bool{}
+	var newEntities []types.EntityRecord
+	emitted := 0
+
+	for _, ed := range edges {
+		name := NormalizeTemplateName(ed.Name)
+		if name == "" {
+			continue // dynamic / computed / unusable name — drop
+		}
+
+		hostIdx := 0 // file entity by default
+		if ed.FromName != "" {
+			if idx, ok := hostByName[ed.FromName]; ok {
+				hostIdx = idx
+			}
+		}
+
+		edgeKey := ed.FromName + "\x00" + name
+		if !seenEdge[edgeKey] {
+			seenEdge[edgeKey] = true
+			props := map[string]string{"template": name}
+			if ed.Pattern != "" {
+				props["pattern"] = ed.Pattern
+			}
+			(*entities)[hostIdx].Relationships = append((*entities)[hostIdx].Relationships,
+				types.RelationshipRecord{
+					ToID:       TemplateTargetID(name),
+					Kind:       string(types.RelationshipKindRenders),
+					Properties: props,
+				})
+			emitted++
+		}
+
+		if !seenTpl[name] {
+			seenTpl[name] = true
+			newEntities = append(newEntities, TemplateEntity(name, lang))
+		}
+	}
+
+	*entities = append(*entities, newEntities...)
+	return emitted
+}

--- a/internal/extractor/template_render_test.go
+++ b/internal/extractor/template_render_test.go
@@ -1,0 +1,116 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func tplEntityID(recs []types.EntityRecord, name string) string {
+	want := TemplateName(name)
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			return recs[i].ID
+		}
+	}
+	return ""
+}
+
+func tplCount(recs []types.EntityRecord, name string) int {
+	want := TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+// TestTemplateRender_Convergence is the value-asserting test: two distinct
+// handlers rendering the SAME template must produce two RENDERS edges that both
+// point at ONE template node (deduped). That convergence IS the capability.
+func TestTemplateRender_Convergence(t *testing.T) {
+	recs := newRecords("views.py", "python", "list_view", "search_view")
+	n := EmitTemplateEdges(&recs, "python", []TemplateEdge{
+		{Name: "users/list.html", FromName: "list_view", Pattern: "render_template"},
+		{Name: "users/list.html", FromName: "search_view", Pattern: "render_template"},
+	})
+	if n != 2 {
+		t.Fatalf("expected 2 RENDERS edges, got %d", n)
+	}
+	if got := tplCount(recs, "users/list.html"); got != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", got)
+	}
+	id := tplEntityID(recs, "users/list.html")
+	if id == "" {
+		t.Fatal("template node users/list.html not found")
+	}
+	toID := TemplateTargetID("users/list.html")
+	if !edgeTo(recs, "list_view", "RENDERS", toID) {
+		t.Error("missing RENDERS(list_view -> users/list.html)")
+	}
+	if !edgeTo(recs, "search_view", "RENDERS", toID) {
+		t.Error("missing RENDERS(search_view -> users/list.html)")
+	}
+}
+
+func TestTemplateRender_Dedup(t *testing.T) {
+	recs := newRecords("v.py", "python", "h")
+	n := EmitTemplateEdges(&recs, "python", []TemplateEdge{
+		{Name: "home.html", FromName: "h"},
+		{Name: "home.html", FromName: "h"},
+	})
+	if n != 1 {
+		t.Fatalf("expected 1 deduped edge, got %d", n)
+	}
+}
+
+func TestNormalizeTemplateName(t *testing.T) {
+	cases := map[string]string{
+		"users/list.html":    "users/list.html",
+		"users.list":         "users/list",   // Laravel dot-notation → slash
+		"users/show":         "users/show",   // no extension, has slash → verbatim
+		"./partials/nav":     "partials/nav", // leading ./ stripped
+		"dashboard":          "dashboard",
+		"x.html":             "x.html", // has ext → dots preserved
+		"name_var + '.html'": "",       // concatenation → dynamic, drop
+		"`p/${id}`":          "",       // template literal interpolation → drop
+		"":                   "",
+		"a b":                "", // space → drop
+		"../etc/passwd":      "", // traversal → drop
+	}
+	for in, want := range cases {
+		if got := NormalizeTemplateName(in); got != want {
+			t.Errorf("NormalizeTemplateName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestTemplateRender_DynamicDropped: a dynamic template name yields no edge and
+// no node — honest-partial, precision over recall.
+func TestTemplateRender_DynamicDropped(t *testing.T) {
+	recs := newRecords("v.py", "python", "h")
+	n := EmitTemplateEdges(&recs, "python", []TemplateEdge{
+		{Name: "tpl_var + suffix", FromName: "h"},
+	})
+	if n != 0 {
+		t.Fatalf("expected 0 edges for dynamic name, got %d", n)
+	}
+	if tplEntityID(recs, "tpl_var + suffix") != "" {
+		t.Error("dynamic template must not create a node")
+	}
+}
+
+func TestTemplateEntity_Synthetic(t *testing.T) {
+	e := TemplateEntity("dashboard", "python")
+	if e.SourceFile != TemplateSourceFile {
+		t.Errorf("SourceFile = %q, want synthetic %q", e.SourceFile, TemplateSourceFile)
+	}
+	if e.QualifiedName != TemplateTargetID("dashboard") {
+		t.Errorf("QualifiedName = %q, want %q", e.QualifiedName, TemplateTargetID("dashboard"))
+	}
+	if e.Kind != string(types.EntityKindTemplate) {
+		t.Errorf("Kind = %q, want %q", e.Kind, types.EntityKindTemplate)
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -231,6 +231,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitExceptionFlowEdges(root, file, &entities)
 	}()
 
+	// View-layer topology (epic #3628) — RENDERS edges from Spring MVC
+	// controller methods that return a static view name to a shared
+	// SCOPE.Template node. Honest REST-vs-MVC boundary: @RestController /
+	// @ResponseBody methods are skipped (String return is a body, not a view),
+	// and dynamic view names are dropped.
+	func() {
+		defer func() { _ = recover() }()
+		emitTemplateRenderEdges(root, file, &entities)
+	}()
+
 	// Track B (analog of #642/#650 for Java) — IMPORTS ToID rewrite.
 	// Rewrites IMPORTS edges whose source_module's longest dotted
 	// prefix matches a known external JVM package to an

--- a/internal/extractors/java/template_render.go
+++ b/internal/extractors/java/template_render.go
@@ -1,0 +1,218 @@
+// template_render.go — supplemental pass that emits RENDERS edges from Spring
+// MVC controller methods to a shared SCOPE.Template node (epic #3628). It lets
+// the graph answer "what view does this handler render?" (outbound RENDERS) and
+// "who renders users/list?" (inbound RENDERS).
+//
+// Detected shapes (static only — honest-partial, precision-first):
+//
+//	@Controller class X {
+//	  @GetMapping("/users") public String list() { return "users/list"; }   → RENDERS users/list
+//	  @GetMapping("/u")     public ModelAndView u() { return new ModelAndView("users/show"); }  → RENDERS users/show
+//	}
+//
+// REST-vs-MVC honesty boundary (the crux of precision here): a String return
+// value is a Spring *view name* ONLY in an MVC controller. It is NOT a view
+// when the class is @RestController, or when the class/method carries
+// @ResponseBody — in those cases the String is a serialized HTTP response body
+// (REST), not a template. We therefore emit NO template edge for:
+//
+//	- @RestController classes
+//	- methods (or whole classes) annotated @ResponseBody
+//	- methods returning a computed/variable String (dynamic view name)
+//	- methods with no Spring request-mapping annotation (not a handler)
+//
+// All node/edge construction (convergence on one node per view name) lives in
+// extractor.EmitTemplateEdges.
+
+package java
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// springMappingAnnotations are the Spring MVC request-mapping annotations whose
+// presence marks a method as an HTTP handler whose String return is a view name.
+var springMappingAnnotations = map[string]bool{
+	"RequestMapping": true,
+	"GetMapping":     true,
+	"PostMapping":    true,
+	"PutMapping":     true,
+	"DeleteMapping":  true,
+	"PatchMapping":   true,
+}
+
+// emitTemplateRenderEdges scans Spring MVC controllers for handler methods that
+// return a static view name and appends template entities + RENDERS edges.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var edges []extractor.TemplateEdge
+
+	var walk func(n *sitter.Node, enclosingClass string)
+	walk = func(n *sitter.Node, enclosingClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration":
+			cls := childFieldText(n, "name", src)
+			childCls := cls
+			if enclosingClass != "" && cls != "" {
+				childCls = enclosingClass + "." + cls
+			}
+			anns := annotationNames(n, src)
+			// @RestController, or a class-level @ResponseBody, makes EVERY method
+			// a REST endpoint — String returns are response bodies, not views.
+			classIsRest := anns["RestController"] || anns["ResponseBody"]
+			classIsMVC := anns["Controller"] && !classIsRest
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					ch := body.Child(i)
+					if ch != nil && ch.Type() == "method_declaration" {
+						if classIsMVC {
+							if name, pat := javaSpringViewName(ch, childCls, src); name != "" {
+								edges = append(edges, extractor.TemplateEdge{
+									Name: name, FromName: childCls + "." + childFieldText(ch, "name", src), Pattern: pat,
+								})
+							}
+						}
+					}
+					// Recurse for nested classes.
+					walk(ch, childCls)
+				}
+			}
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingClass)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitTemplateEdges(entities, "java", edges)
+}
+
+// javaSpringViewName returns the static view name a Spring MVC handler method
+// renders, plus the detector pattern, or "", "" if the method is not a
+// view-returning handler. Honesty guards:
+//   - the method MUST carry a Spring request-mapping annotation (it is a handler)
+//   - the method MUST NOT carry @ResponseBody (else String is a REST body)
+//   - the returned value MUST be a String literal, or `new ModelAndView("...")`
+//     with a literal first argument; anything else (variable, computed) → drop.
+func javaSpringViewName(method *sitter.Node, enclosingClass string, src []byte) (string, string) {
+	anns := annotationNames(method, src)
+	if anns["ResponseBody"] {
+		return "", "" // REST response body, not a view name
+	}
+	mapped := false
+	for a := range anns {
+		if springMappingAnnotations[a] {
+			mapped = true
+			break
+		}
+	}
+	if !mapped {
+		return "", "" // not an HTTP handler — no view inference
+	}
+
+	body := method.ChildByFieldName("body")
+	if body == nil {
+		return "", ""
+	}
+	// Find a `return <expr>;` whose expr is a String literal or ModelAndView(...).
+	var found, pat string
+	var scan func(n *sitter.Node)
+	scan = func(n *sitter.Node) {
+		if n == nil || found != "" {
+			return
+		}
+		// Do not descend into nested type/lambda bodies that could carry their
+		// own returns; Spring handler bodies are flat enough that a shallow scan
+		// over return_statement nodes is correct, and nested lambdas returning
+		// strings are not the handler's view. We still recurse generally but the
+		// first matching literal return wins.
+		if n.Type() == "return_statement" {
+			if name, p := javaReturnViewName(n, src); name != "" {
+				found, pat = name, p
+				return
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			scan(n.Child(i))
+		}
+	}
+	scan(body)
+	if found == "" {
+		return "", ""
+	}
+	_ = enclosingClass
+	return found, pat
+}
+
+// javaReturnViewName extracts a static view name from a return_statement:
+//
+//	return "users/list";                 → "users/list", "spring_view"
+//	return new ModelAndView("users/x");  → "users/x",     "model_and_view"
+//
+// Returns "", "" for a non-literal return (variable / concatenation / computed),
+// so dynamic view names never fabricate a node.
+func javaReturnViewName(ret *sitter.Node, src []byte) (string, string) {
+	var expr *sitter.Node
+	for i := 0; i < int(ret.NamedChildCount()); i++ {
+		c := ret.NamedChild(i)
+		if c != nil {
+			expr = c
+			break
+		}
+	}
+	if expr == nil {
+		return "", ""
+	}
+	switch expr.Type() {
+	case "string_literal":
+		return javaStripString(nodeText(expr, src)), "spring_view"
+	case "object_creation_expression":
+		typeNode := expr.ChildByFieldName("type")
+		if typeNode == nil || lastIdent(strings.TrimSpace(nodeText(typeNode, src))) != "ModelAndView" {
+			return "", ""
+		}
+		args := expr.ChildByFieldName("arguments")
+		if args == nil {
+			return "", ""
+		}
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			a := args.NamedChild(i)
+			if a == nil {
+				continue
+			}
+			if a.Type() == "string_literal" {
+				return javaStripString(nodeText(a, src)), "model_and_view"
+			}
+			return "", "" // first ctor arg is dynamic → drop
+		}
+	}
+	return "", ""
+}
+
+// annotationNames returns the set of simple annotation names on a declaration's
+// immediate modifiers (e.g. {"Controller": true, "GetMapping": true}).
+func annotationNames(decl *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	for _, a := range findAnnotations(decl, src) {
+		if a.name != "" {
+			out[a.name] = true
+		}
+	}
+	return out
+}

--- a/internal/extractors/java/template_render_test.go
+++ b/internal/extractors/java/template_render_test.go
@@ -1,0 +1,166 @@
+package java_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func javaTplEdge(recs []types.EntityRecord, fromName, name string) bool {
+	want := extractor.TemplateTargetID(name)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func javaTplNode(recs []types.EntityRecord, name string) int {
+	want := extractor.TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+func javaAnyTplNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestJavaTemplate_SpringMVCViewName: a @Controller @GetMapping method returning
+// a String literal yields RENDERS to that view template.
+func TestJavaTemplate_SpringMVCViewName(t *testing.T) {
+	src := `package demo;
+
+@Controller
+public class UserController {
+    @GetMapping("/users")
+    public String list() {
+        return "users/list";
+    }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if !javaTplEdge(recs, "UserController.list", "users/list") {
+		t.Error("missing RENDERS(UserController.list -> users/list)")
+	}
+	if javaTplNode(recs, "users/list") != 1 {
+		t.Error("expected one SCOPE.Template node users/list")
+	}
+}
+
+// TestJavaTemplate_ModelAndView: `new ModelAndView("users/show")` yields RENDERS.
+func TestJavaTemplate_ModelAndView(t *testing.T) {
+	src := `package demo;
+
+@Controller
+public class UserController {
+    @RequestMapping("/show")
+    public ModelAndView show() {
+        return new ModelAndView("users/show");
+    }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if !javaTplEdge(recs, "UserController.show", "users/show") {
+		t.Error("missing RENDERS(UserController.show -> users/show)")
+	}
+}
+
+// TestJavaTemplate_RestControllerNoView: a @RestController method returning a
+// String is a REST response BODY, not a view — NO template edge (the honesty
+// boundary).
+func TestJavaTemplate_RestControllerNoView(t *testing.T) {
+	src := `package demo;
+
+@RestController
+public class ApiController {
+    @GetMapping("/ping")
+    public String ping() {
+        return "pong";
+    }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if javaTplEdge(recs, "ApiController.ping", "pong") {
+		t.Error("@RestController String return must NOT be a template (REST, not MVC)")
+	}
+	if javaAnyTplNode(recs) {
+		t.Error("@RestController must not produce any template node")
+	}
+}
+
+// TestJavaTemplate_ResponseBodyNoView: a @ResponseBody method inside a
+// @Controller is also REST — NO template edge.
+func TestJavaTemplate_ResponseBodyNoView(t *testing.T) {
+	src := `package demo;
+
+@Controller
+public class MixedController {
+    @GetMapping("/data")
+    @ResponseBody
+    public String data() {
+        return "raw-json";
+    }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if javaTplEdge(recs, "MixedController.data", "raw-json") {
+		t.Error("@ResponseBody String return must NOT be a template")
+	}
+}
+
+// TestJavaTemplate_DynamicViewDropped: a computed/variable view name is dropped.
+func TestJavaTemplate_DynamicViewDropped(t *testing.T) {
+	src := `package demo;
+
+@Controller
+public class DynController {
+    @GetMapping("/x")
+    public String x(String which) {
+        return which;
+    }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if javaAnyTplNode(recs) {
+		t.Error("dynamic (variable) view name must not produce a template node")
+	}
+}
+
+// TestJavaTemplate_Convergence: two MVC handlers returning the same view → one node.
+func TestJavaTemplate_Convergence(t *testing.T) {
+	src := `package demo;
+
+@Controller
+public class C {
+    @GetMapping("/a")
+    public String a() { return "shared/page"; }
+
+    @GetMapping("/b")
+    public String b() { return "shared/page"; }
+}
+`
+	recs := extractJavaRaw(t, src)
+	if !javaTplEdge(recs, "C.a", "shared/page") || !javaTplEdge(recs, "C.b", "shared/page") {
+		t.Fatal("both handlers must RENDERS shared/page")
+	}
+	if n := javaTplNode(recs, "shared/page"); n != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", n)
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -341,6 +341,15 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		x.emitExceptionFlowEdges(root)
 	}()
 
+	// View-layer topology (epic #3628) — RENDERS edges from Express/Koa
+	// handlers to a shared SCOPE.Template node for `<res>.render('view')`
+	// shapes (dynamic / template-literal names are dropped). Runs after walk
+	// so enclosing handler entities exist.
+	func() {
+		defer func() { _ = recover() }()
+		x.emitTemplateRenderEdges(root)
+	}()
+
 	// Third pass (#713): platform-variant and test-file relationship emission.
 	// Detects React Native platform-specific file naming (.ios.tsx,
 	// .android.tsx, .tablet.tsx, …) and emits PLATFORM_VARIANT_OF edges.

--- a/internal/extractors/javascript/template_render.go
+++ b/internal/extractors/javascript/template_render.go
@@ -1,0 +1,137 @@
+// template_render.go — supplemental pass that emits RENDERS edges from
+// JS/TS request handlers to a shared SCOPE.Template node (epic #3628). It lets
+// the graph answer "what view does this route render?" (outbound RENDERS) and
+// "who renders profile?" (inbound RENDERS).
+//
+// Detected shapes (static only — honest-partial, precision-first):
+//
+//	res.render('profile', {...})   → RENDERS profile        (Express)
+//	res.render("users/list")        → RENDERS users/list      (Express)
+//	ctx.render('home')              → RENDERS home            (Koa, koa-views)
+//
+// Intentionally DROPPED (would mislead view-layer analysis):
+//
+//	res.render(viewName)            (variable / dynamic name)
+//	res.render(`p/${id}`)           (template-literal interpolation)
+//	res.json(...) / res.send(...)   (not a view render — REST, not MVC)
+//
+// The receiver heuristic requires the method to be `render` on a `res` / `ctx`
+// /-suffixed response object (res, ctx, response) so component-composition or
+// unrelated `.render()` calls don't false-positive. All node/edge construction
+// (convergence on one node per template name) lives in
+// extractor.EmitTemplateEdges.
+
+package javascript
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// emitTemplateRenderEdges scans the AST for Express/Koa `<res>.render('view')`
+// calls and appends template entities + RENDERS edges to x.entities.
+// x.entities[0] MUST be the file entity. Safe with an empty tree.
+func (x *extractor) emitTemplateRenderEdges(root *sitter.Node) {
+	if root == nil || len(x.entities) == 0 {
+		return
+	}
+
+	var edges []extreg.TemplateEdge
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "function_declaration", "generator_function_declaration":
+			name := x.nodeText(n.ChildByFieldName("name"))
+			if body := n.ChildByFieldName("body"); body != nil {
+				walk(body, name)
+			}
+			return
+		case "method_definition":
+			name := x.nodeText(n.ChildByFieldName("name"))
+			if body := n.ChildByFieldName("body"); body != nil {
+				walk(body, name)
+			}
+			return
+		case "variable_declarator":
+			nameNode := n.ChildByFieldName("name")
+			valNode := n.ChildByFieldName("value")
+			if nameNode != nil && valNode != nil {
+				switch valNode.Type() {
+				case "arrow_function", "function", "function_expression":
+					name := x.nodeText(nameNode)
+					if body := valNode.ChildByFieldName("body"); body != nil {
+						walk(body, name)
+						return
+					}
+				}
+			}
+		case "call_expression":
+			if tpl := x.jsRenderCallTemplate(n); tpl != "" {
+				edges = append(edges, extreg.TemplateEdge{
+					Name: tpl, FromName: enclosing, Pattern: "res_render",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extreg.EmitTemplateEdges(&x.entities, x.language, edges)
+}
+
+// jsRenderCallTemplate returns the raw (unquoted) template name from a
+// `<res>.render('view', ...)` call where the receiver is a response-like object
+// (res / ctx / response, case-insensitive) and the first argument is a plain
+// string literal. Returns "" otherwise (non-render method, non-response
+// receiver, or dynamic first argument → drop).
+func (x *extractor) jsRenderCallTemplate(call *sitter.Node) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return ""
+	}
+	prop := fn.ChildByFieldName("property")
+	if prop == nil || x.nodeText(prop) != "render" {
+		return ""
+	}
+	obj := fn.ChildByFieldName("object")
+	if obj == nil || !isResponseReceiver(x.nodeText(obj)) {
+		return ""
+	}
+
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	// First positional argument must be a plain string literal.
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil || a.Type() == "comment" {
+			continue
+		}
+		if a.Type() == "string" {
+			return jsStripString(x.nodeText(a))
+		}
+		return "" // first arg is dynamic / template-literal → drop
+	}
+	return ""
+}
+
+// isResponseReceiver reports whether an object expression text names a typical
+// HTTP-response object: exactly "res", "ctx", "response", or "reply" (Fastify),
+// case-insensitive. Conservative on purpose — a random `widget.render('x')`
+// must not be mistaken for a server-side view render.
+func isResponseReceiver(obj string) bool {
+	switch obj {
+	case "res", "ctx", "response", "reply",
+		"Res", "Ctx", "Response", "Reply":
+		return true
+	}
+	return false
+}

--- a/internal/extractors/javascript/template_render_test.go
+++ b/internal/extractors/javascript/template_render_test.go
@@ -1,0 +1,106 @@
+package javascript_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func jsTplEdge(recs []types.EntityRecord, fromName, name string) bool {
+	want := extreg.TemplateTargetID(name)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jsTplNode(recs []types.EntityRecord, name string) int {
+	want := extreg.TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+// TestJSTemplate_ExpressResRender: res.render('profile') in a named handler.
+func TestJSTemplate_ExpressResRender(t *testing.T) {
+	src := []byte(`function profile(req, res) {
+  res.render('profile', { user: req.user });
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTplEdge(recs, "profile", "profile") {
+		t.Error("missing RENDERS(profile -> profile)")
+	}
+	if jsTplNode(recs, "profile") != 1 {
+		t.Error("expected one SCOPE.Template node profile")
+	}
+}
+
+// TestJSTemplate_PathArrow: arrow handler rendering a nested view path.
+func TestJSTemplate_PathArrow(t *testing.T) {
+	src := []byte(`const listUsers = (req, res) => {
+  res.render("users/list");
+};
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTplEdge(recs, "listUsers", "users/list") {
+		t.Error("missing RENDERS(listUsers -> users/list)")
+	}
+}
+
+// TestJSTemplate_Convergence: two handlers render the same view → one node.
+func TestJSTemplate_Convergence(t *testing.T) {
+	src := []byte(`function a(req, res) { res.render('home'); }
+function b(req, res) { res.render('home'); }
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTplEdge(recs, "a", "home") || !jsTplEdge(recs, "b", "home") {
+		t.Fatal("both handlers must RENDERS home")
+	}
+	if n := jsTplNode(recs, "home"); n != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", n)
+	}
+}
+
+// TestJSTemplate_DynamicDropped: variable view name yields no edge/node.
+func TestJSTemplate_DynamicDropped(t *testing.T) {
+	src := []byte("function show(req, res) {\n  const view = req.params.view;\n  res.render(view);\n  res.render(`p/${req.id}`);\n}\n")
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			t.Fatalf("dynamic render must not create a template node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" {
+				t.Fatal("dynamic view name must not yield a RENDERS edge")
+			}
+		}
+	}
+}
+
+// TestJSTemplate_NonResponseReceiver: a non-response receiver `.render()` is not
+// a server-side view render (avoid false positives on component .render()).
+func TestJSTemplate_NonResponseReceiver(t *testing.T) {
+	src := []byte(`function draw(widget) {
+  widget.render('whatever');
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			t.Fatalf("widget.render must not create a template node, got %q", recs[i].Name)
+		}
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -70,6 +70,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// Issue #3641 (epic #3625) — config-key consumption edges
 	// (getenv / $_ENV / Laravel env() / config()) → shared SCOPE.Config nodes.
 	emitConfigConsumerEdges(root, file, &entities)
+	// View-layer topology (epic #3628) — RENDERS edges from Laravel
+	// controller actions to a shared SCOPE.Template node for view('name') /
+	// View::make('name') shapes (dynamic / interpolated names are dropped).
+	emitTemplateRenderEdges(root, file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")

--- a/internal/extractors/php/template_render.go
+++ b/internal/extractors/php/template_render.go
@@ -1,0 +1,140 @@
+// template_render.go — supplemental pass that emits RENDERS edges from Laravel
+// controller actions / routes to a shared SCOPE.Template node (epic #3628). It
+// lets the graph answer "what Blade view does this action render?" (outbound
+// RENDERS) and "who renders welcome?" (inbound RENDERS).
+//
+// Detected shapes (static only — honest-partial, precision-first):
+//
+//	return view('welcome');            → RENDERS welcome           (Laravel helper)
+//	view('users.list', $data);         → RENDERS users/list        (dot → slash)
+//	return View::make('dashboard');    → RENDERS dashboard         (View facade)
+//
+// Intentionally DROPPED (would mislead view-layer analysis):
+//
+//	view($name)                        (variable / dynamic view name)
+//	view("users.$id")                  (interpolated string → dynamic)
+//
+// Laravel uses dot-notation for Blade view paths (`users.list` == the file
+// resources/views/users/list.blade.php). NormalizeTemplateName converts the
+// dots to slashes so a `view('users.list')` and an explicit 'users/list'
+// converge to one node. All node/edge construction lives in
+// extractor.EmitTemplateEdges.
+
+package php
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitTemplateRenderEdges scans every function / method body (and file scope)
+// for Laravel view() / View::make() render shapes and appends template entities
+// + RENDERS edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var edges []extractor.TemplateEdge
+
+	var walk func(n *sitter.Node, enclosingClass, enclosing string)
+	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration", "interface_declaration", "trait_declaration":
+			cls := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), cls, enclosing)
+			}
+			return
+		case "method_declaration":
+			leaf := childFieldText(n, "name", src)
+			name := leaf
+			if enclosingClass != "" && leaf != "" {
+				name = enclosingClass + "." + leaf
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, name)
+			}
+			return
+		case "function_definition":
+			leaf := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, leaf)
+			}
+			return
+		case "function_call_expression":
+			if name, pat := phpViewCallTemplate(n, src); name != "" {
+				edges = append(edges, extractor.TemplateEdge{Name: name, FromName: enclosing, Pattern: pat})
+			}
+		case "scoped_call_expression":
+			if name, pat := phpViewMakeTemplate(n, src); name != "" {
+				edges = append(edges, extractor.TemplateEdge{Name: name, FromName: enclosing, Pattern: pat})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingClass, enclosing)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitTemplateEdges(entities, "php", edges)
+}
+
+// phpViewCallTemplate returns the literal Blade view name + detector label when
+// the call is the Laravel `view('name')` global helper with a literal first
+// string argument, or ("","") otherwise (including dynamic names → drop).
+func phpViewCallTemplate(call *sitter.Node, src []byte) (string, string) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "name" {
+		return "", ""
+	}
+	if strings.TrimSpace(string(src[fn.StartByte():fn.EndByte()])) != "view" {
+		return "", ""
+	}
+	name := phpFirstStringArg(call.ChildByFieldName("arguments"), src)
+	if name == "" {
+		return "", ""
+	}
+	return name, "laravel_view"
+}
+
+// phpViewMakeTemplate returns the literal Blade view name + detector label when
+// the call is the Laravel `View::make('name')` facade with a literal first
+// string argument, or ("","") otherwise.
+func phpViewMakeTemplate(call *sitter.Node, src []byte) (string, string) {
+	nameNode := call.ChildByFieldName("name")
+	if nameNode == nil || nameNode.Type() != "name" {
+		return "", ""
+	}
+	if strings.TrimSpace(string(src[nameNode.StartByte():nameNode.EndByte()])) != "make" {
+		return "", ""
+	}
+	scope := call.ChildByFieldName("scope")
+	if scope == nil {
+		return "", ""
+	}
+	raw := strings.TrimSpace(string(src[scope.StartByte():scope.EndByte()]))
+	leaf := raw
+	if i := strings.LastIndex(raw, "\\"); i >= 0 {
+		leaf = raw[i+1:]
+	}
+	if leaf != "View" {
+		return "", ""
+	}
+	name := phpFirstStringArg(call.ChildByFieldName("arguments"), src)
+	if name == "" {
+		return "", ""
+	}
+	return name, "view_make"
+}

--- a/internal/extractors/php/template_render_test.go
+++ b/internal/extractors/php/template_render_test.go
@@ -1,0 +1,128 @@
+package php_test
+
+// template_render_test.go — value-asserting tests for the PHP/Laravel
+// view-layer pass (epic #3628). Asserts the SPECIFIC template node + RENDERS
+// edge, not len>0.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func phpTplEdge(recs []types.EntityRecord, fromName, name string) bool {
+	want := extractor.TemplateTargetID(name)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func phpTplNode(recs []types.EntityRecord, name string) int {
+	want := extractor.TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+func phpAnyTplNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPHPTemplate_LaravelViewHelper: return view('welcome') in a controller
+// action → RENDERS welcome.
+func TestPHPTemplate_LaravelViewHelper(t *testing.T) {
+	src := `<?php
+class HomeController {
+    public function index() {
+        return view('welcome');
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTplEdge(recs, "HomeController.index", "welcome") {
+		t.Error("missing RENDERS(HomeController.index -> welcome)")
+	}
+	if phpTplNode(recs, "welcome") != 1 {
+		t.Error("expected one SCOPE.Template node welcome")
+	}
+}
+
+// TestPHPTemplate_DotNotation: view('users.list') → users/list (dot → slash).
+func TestPHPTemplate_DotNotation(t *testing.T) {
+	src := `<?php
+class UserController {
+    public function list() {
+        return view('users.list', $data);
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTplEdge(recs, "UserController.list", "users/list") {
+		t.Error("missing RENDERS(UserController.list -> users/list) — dot-notation must normalize to slash")
+	}
+}
+
+// TestPHPTemplate_ViewMakeFacade: return View::make('dashboard') → RENDERS.
+func TestPHPTemplate_ViewMakeFacade(t *testing.T) {
+	src := `<?php
+class DashController {
+    public function show() {
+        return View::make('dashboard');
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTplEdge(recs, "DashController.show", "dashboard") {
+		t.Error("missing RENDERS(DashController.show -> dashboard)")
+	}
+}
+
+// TestPHPTemplate_DynamicDropped: a variable view name is dropped.
+func TestPHPTemplate_DynamicDropped(t *testing.T) {
+	src := `<?php
+class C {
+    public function show($name) {
+        return view($name);
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if phpAnyTplNode(recs) {
+		t.Error("dynamic view($name) must not produce a template node")
+	}
+}
+
+// TestPHPTemplate_Convergence: two actions rendering the same view → one node.
+func TestPHPTemplate_Convergence(t *testing.T) {
+	src := `<?php
+class C {
+    public function a() { return view('users.list'); }
+    public function b() { return view('users.list'); }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTplEdge(recs, "C.a", "users/list") || !phpTplEdge(recs, "C.b", "users/list") {
+		t.Fatal("both actions must RENDERS users/list")
+	}
+	if n := phpTplNode(recs, "users/list"); n != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", n)
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -334,6 +334,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitExceptionFlowEdges(root, file, &entities)
 	}()
 
+	// #3628 view-layer — supplemental pass that links Flask render_template /
+	// Django render / TemplateView.template_name handlers to a shared
+	// SCOPE.Template node via RENDERS (dynamic / f-string names are dropped).
+	// Runs after primary entity emission so the enclosing function/method/class
+	// entities exist to attach edges to.
+	func() {
+		defer func() { _ = recover() }()
+		emitTemplateRenderEdges(root, file, &entities)
+	}()
+
 	// Issue #1884 — supplemental package-module pass (Wave 1).
 	// Emits one Module entity per Python package boundary (__init__.py or
 	// plain .py module) so docgen can seed per-package pages and flow

--- a/internal/extractors/python/template_render.go
+++ b/internal/extractors/python/template_render.go
@@ -1,0 +1,226 @@
+// template_render.go — supplemental pass that emits RENDERS edges from Python
+// request handlers / views to a shared SCOPE.Template node (epic #3628). It
+// lets the graph answer "what does this view render?" (outbound RENDERS) and
+// "who renders users/list.html?" (inbound RENDERS).
+//
+// Detected shapes (static only — honest-partial, precision-first):
+//
+//	render_template('users/list.html', ...)   → RENDERS users/list.html   (Flask)
+//	render(request, 'home.html', ...)          → RENDERS home.html          (Django)
+//	class X(TemplateView): template_name = 'd.html'  → RENDERS d.html       (Django CBV)
+//
+// Intentionally DROPPED (would mislead view-layer analysis):
+//
+//	render_template(name_var)                  (dynamic / variable name)
+//	render_template(f"{x}.html")               (f-string interpolation)
+//	render(request, build_name())              (computed name)
+//
+// All node/edge construction (convergence on one node per template name via a
+// synthetic SourceFile) lives in extractor.EmitTemplateEdges.
+
+package python
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitTemplateRenderEdges scans every function / method body for Flask
+// render_template / Django render call shapes and class bodies for the Django
+// TemplateView.template_name attribute, appending template entities + RENDERS
+// edges.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input. Renders at module scope attach to the file entity.
+func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var edges []extractor.TemplateEdge
+
+	var stack []string // enclosing entity-Name stack; top = current scope
+	current := func() string {
+		if len(stack) == 0 {
+			return ""
+		}
+		return stack[len(stack)-1]
+	}
+
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			cls := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				cls = nodeText(nn, src)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			stack = append(stack, childCls)
+			if body := n.ChildByFieldName("body"); body != nil {
+				// Django CBV: template_name = 'x.html' at class scope binds the
+				// template to the class entity itself.
+				if tpl := pyTemplateNameAttr(body, src); tpl != "" {
+					edges = append(edges, extractor.TemplateEdge{
+						Name: tpl, FromName: childCls, Pattern: "template_name",
+					})
+				}
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "function_definition":
+			leaf := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				leaf = nodeText(nn, src)
+			}
+			emitted := leaf
+			if parentClass != "" && leaf != "" {
+				emitted = parentClass + "." + leaf
+			}
+			stack = append(stack, emitted)
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), parentClass)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "decorated_definition":
+			if inner := n.ChildByFieldName("definition"); inner != nil {
+				walk(inner, parentClass)
+			}
+			return
+		case "call":
+			if name, pat := pyRenderCallTemplate(n, src); name != "" {
+				edges = append(edges, extractor.TemplateEdge{
+					Name: name, FromName: current(), Pattern: pat,
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitTemplateEdges(entities, "python", edges)
+}
+
+// pyRenderCallTemplate inspects a call node and, if it is a Flask
+// render_template(...) or Django render(request, '...') call whose template
+// argument is a plain string literal, returns the (raw) template name and the
+// detector pattern label. Returns "", "" otherwise (including dynamic names —
+// a non-string template argument yields nothing, so EmitTemplateEdges drops it).
+func pyRenderCallTemplate(call *sitter.Node, src []byte) (string, string) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return "", ""
+	}
+	callee := ""
+	switch fn.Type() {
+	case "identifier":
+		callee = nodeText(fn, src)
+	case "attribute":
+		// flask.render_template / shortcuts.render → trailing attribute leaf.
+		if a := fn.ChildByFieldName("attribute"); a != nil {
+			callee = nodeText(a, src)
+		}
+	}
+
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", ""
+	}
+
+	switch callee {
+	case "render_template":
+		// Flask: first positional arg is the template name.
+		if s := pyFirstStringArg(args, src); s != "" {
+			return s, "render_template"
+		}
+	case "render":
+		// Django shortcut: render(request, 'template.html', context). The
+		// template name is the SECOND positional argument. We require the first
+		// positional arg to be present (request) and read the second string.
+		if s := pyNthStringArg(args, src, 1); s != "" {
+			return s, "django_render"
+		}
+	}
+	return "", ""
+}
+
+// pyFirstStringArg returns the unquoted value of the first positional string
+// literal argument in an argument_list, or "" if the first positional argument
+// is not a plain string literal (dynamic name → drop).
+func pyFirstStringArg(args *sitter.Node, src []byte) string {
+	return pyNthStringArg(args, src, 0)
+}
+
+// pyNthStringArg returns the unquoted value of the n-th positional argument if
+// it is a plain string literal; "" otherwise. Keyword arguments are skipped
+// when counting positionals. A non-string positional at index n yields "" so
+// dynamic template names never fabricate an edge.
+func pyNthStringArg(args *sitter.Node, src []byte, n int) string {
+	pos := -1
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		c := args.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "keyword_argument", "comment":
+			continue // not positional
+		}
+		pos++
+		if pos == n {
+			if c.Type() == "string" {
+				return stripQuotes(nodeText(c, src))
+			}
+			return "" // n-th positional is not a plain string literal → dynamic
+		}
+	}
+	return ""
+}
+
+// pyTemplateNameAttr scans a class body for a `template_name = '...'`
+// assignment (Django class-based views) and returns the unquoted literal, or ""
+// if absent / dynamic.
+func pyTemplateNameAttr(body *sitter.Node, src []byte) string {
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil {
+			continue
+		}
+		// expression_statement → assignment
+		var assign *sitter.Node
+		if stmt.Type() == "expression_statement" && stmt.NamedChildCount() > 0 {
+			assign = stmt.NamedChild(0)
+		} else if stmt.Type() == "assignment" {
+			assign = stmt
+		}
+		if assign == nil || assign.Type() != "assignment" {
+			continue
+		}
+		left := assign.ChildByFieldName("left")
+		right := assign.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		if left.Type() == "identifier" && nodeText(left, src) == "template_name" && right.Type() == "string" {
+			return stripQuotes(nodeText(right, src))
+		}
+	}
+	return ""
+}

--- a/internal/extractors/python/template_render_test.go
+++ b/internal/extractors/python/template_render_test.go
@@ -1,0 +1,123 @@
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func tplEdge(recs []types.EntityRecord, fromName, name string) bool {
+	want := extractor.TemplateTargetID(name)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func tplNode(recs []types.EntityRecord, name string) int {
+	want := extractor.TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+func TestPyTemplate_FlaskRenderTemplate(t *testing.T) {
+	src := `from flask import render_template
+
+@app.route("/dashboard")
+def dashboard():
+    return render_template("dashboard.html", user=u)
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "dashboard", "dashboard.html") {
+		t.Error("missing RENDERS(dashboard -> dashboard.html)")
+	}
+	if tplNode(recs, "dashboard.html") != 1 {
+		t.Error("expected one SCOPE.Template node dashboard.html")
+	}
+}
+
+func TestPyTemplate_DjangoRender(t *testing.T) {
+	src := `from django.shortcuts import render
+
+def home(request):
+    return render(request, "home.html", {"x": 1})
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "home", "home.html") {
+		t.Error("missing RENDERS(home -> home.html)")
+	}
+	if tplNode(recs, "home.html") != 1 {
+		t.Error("expected one SCOPE.Template node home.html")
+	}
+}
+
+func TestPyTemplate_DjangoTemplateView(t *testing.T) {
+	src := `from django.views.generic import TemplateView
+
+class AboutView(TemplateView):
+    template_name = "about.html"
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "AboutView", "about.html") {
+		t.Error("missing RENDERS(AboutView -> about.html)")
+	}
+	if tplNode(recs, "about.html") != 1 {
+		t.Error("expected one SCOPE.Template node about.html")
+	}
+}
+
+// Convergence: two views rendering the same template → one node.
+func TestPyTemplate_Convergence(t *testing.T) {
+	src := `from flask import render_template
+
+def list_users():
+    return render_template("users/list.html")
+
+def search_users():
+    return render_template("users/list.html")
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "list_users", "users/list.html") {
+		t.Error("missing RENDERS(list_users -> users/list.html)")
+	}
+	if !tplEdge(recs, "search_users", "users/list.html") {
+		t.Error("missing RENDERS(search_users -> users/list.html)")
+	}
+	if n := tplNode(recs, "users/list.html"); n != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", n)
+	}
+}
+
+// Negative: a dynamic (variable / computed) template name yields no node/edge.
+func TestPyTemplate_DynamicDropped(t *testing.T) {
+	src := `from flask import render_template
+
+def show(name):
+    page = name + ".html"
+    return render_template(page)
+`
+	recs := extractPy(t, src, "views.py")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			t.Fatalf("dynamic render_template must not create a template node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" {
+				t.Fatalf("dynamic template name must not yield a RENDERS edge")
+			}
+		}
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -49,6 +49,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// Issue #3641 (epic #3625) — config-key consumption edges
 	// (ENV['X'] / ENV.fetch('X')) → shared SCOPE.Config config_key nodes.
 	emitConfigConsumerEdges(root, file.Content, &entities)
+	// View-layer topology (epic #3628) — RENDERS edges from Rails controller
+	// actions to a shared SCOPE.Template node for explicit `render 'path'` /
+	// `render template:/partial:` shapes (symbol / implicit-convention renders
+	// and dynamic names are dropped).
+	emitTemplateRenderEdges(root, file.Content, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")

--- a/internal/extractors/ruby/template_render.go
+++ b/internal/extractors/ruby/template_render.go
@@ -1,0 +1,150 @@
+// template_render.go — supplemental pass that emits RENDERS edges from Rails
+// controller actions to a shared SCOPE.Template node (epic #3628). It lets the
+// graph answer "what view does this action render?" (outbound RENDERS) and
+// "who renders users/show?" (inbound RENDERS).
+//
+// Detected EXPLICIT render shapes (static only — honest-partial, precision-first):
+//
+//	render 'users/show'           → RENDERS users/show       (explicit template path)
+//	render template: 'x/y'        → RENDERS x/y              (explicit :template)
+//	render partial: 'list'        → RENDERS list             (explicit :partial)
+//
+// Intentionally DROPPED / honest-skip:
+//
+//	render @user / render(view)    (variable / object arg — dynamic)
+//	render :index                  (SYMBOL → implicit-convention action view; the
+//	                                target file action.html.erb is resolved by
+//	                                Rails at runtime from the *controller+action*,
+//	                                NOT a literal template path. Recording it as a
+//	                                template-NAME node would fabricate a path, so
+//	                                we skip the bare symbol form.)
+//	(no render call → implicit render of action view)  — convention-only,
+//	                                no literal path in source → honest-skip.
+//
+// All node/edge construction (convergence on one node per template name) lives
+// in extractor.EmitTemplateEdges.
+
+package ruby
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitTemplateRenderEdges scans every method body for explicit Rails `render`
+// calls with a literal template path and appends template entities + RENDERS
+// edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitTemplateRenderEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var edges []extractor.TemplateEdge
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "method", "singleton_method":
+			name := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), name)
+			}
+			return
+		case "call":
+			if name, pat := rubyRenderTemplate(n, src); name != "" {
+				edges = append(edges, extractor.TemplateEdge{Name: name, FromName: enclosing, Pattern: pat})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitTemplateEdges(entities, "ruby", edges)
+}
+
+// rubyRenderTemplate returns the literal template path + detector label for an
+// explicit Rails `render` call, or ("","") otherwise. Accepted forms:
+//
+//	render 'users/show'        → ("users/show", "render_string")
+//	render template: 'x/y'     → ("x/y", "render_template")
+//	render partial: 'list'     → ("list", "render_partial")
+//
+// A bare receiver (`obj.render`) is NOT a Rails controller render and is
+// rejected. Symbol args (render :index) and variable/object args are dropped.
+func rubyRenderTemplate(call *sitter.Node, src []byte) (string, string) {
+	// Must be a receiver-less `render ...` call (Rails controller DSL).
+	if recv := call.ChildByFieldName("receiver"); recv != nil {
+		return "", ""
+	}
+	method := call.ChildByFieldName("method")
+	if method == nil || strings.TrimSpace(rubyNodeText(method, src)) != "render" {
+		return "", ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", ""
+	}
+
+	// Inspect the first argument: a bare string (explicit path) or a pair with
+	// a :template / :partial key.
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "string":
+			if s := rubyStringContent(a, src); s != "" {
+				return s, "render_string"
+			}
+			return "", "" // interpolated → dynamic
+		case "pair":
+			key, val := rubyPairParts(a, src)
+			switch key {
+			case "template":
+				if val != "" {
+					return val, "render_template"
+				}
+			case "partial":
+				if val != "" {
+					return val, "render_partial"
+				}
+			}
+			// keep scanning later pairs (e.g. render layout:..., template:...)
+			continue
+		default:
+			// First positional arg is a symbol (render :index), a variable, or an
+			// object (render @user) — dynamic / convention-only, drop.
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+// rubyPairParts returns the hash_key_symbol name and, if the value is a literal
+// string, its content — for a `key: 'value'` pair. A non-string value yields
+// ("key", "").
+func rubyPairParts(pair *sitter.Node, src []byte) (string, string) {
+	var key, val string
+	if k := pair.ChildByFieldName("key"); k != nil {
+		key = strings.TrimSpace(rubyNodeText(k, src))
+		key = strings.TrimSuffix(key, ":")
+		key = strings.TrimPrefix(key, ":")
+	}
+	if v := pair.ChildByFieldName("value"); v != nil && v.Type() == "string" {
+		val = rubyStringContent(v, src)
+	}
+	return key, val
+}

--- a/internal/extractors/ruby/template_render_test.go
+++ b/internal/extractors/ruby/template_render_test.go
@@ -1,0 +1,135 @@
+package ruby_test
+
+// template_render_test.go — value-asserting tests for the Rails view-layer pass
+// (epic #3628). Asserts the SPECIFIC template node + RENDERS edge, not len>0.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func rubyTplEdge(recs []types.EntityRecord, fromName, name string) bool {
+	want := extractor.TemplateTargetID(name)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rubyTplNode(recs []types.EntityRecord, name string) int {
+	want := extractor.TemplateName(name)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+func rubyAnyTplNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRubyTemplate_ExplicitString: render 'users/show' → RENDERS users/show.
+func TestRubyTemplate_ExplicitString(t *testing.T) {
+	src := `class UsersController < ApplicationController
+  def show
+    render 'users/show'
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if !rubyTplEdge(recs, "show", "users/show") {
+		t.Error("missing RENDERS(show -> users/show)")
+	}
+	if rubyTplNode(recs, "users/show") != 1 {
+		t.Error("expected one SCOPE.Template node users/show")
+	}
+}
+
+// TestRubyTemplate_TemplateKeyword: render template: 'admin/edit'.
+func TestRubyTemplate_TemplateKeyword(t *testing.T) {
+	src := `class AdminController < ApplicationController
+  def edit
+    render template: 'admin/edit'
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if !rubyTplEdge(recs, "edit", "admin/edit") {
+		t.Error("missing RENDERS(edit -> admin/edit)")
+	}
+}
+
+// TestRubyTemplate_PartialKeyword: render partial: 'shared/list'.
+func TestRubyTemplate_PartialKeyword(t *testing.T) {
+	src := `class ListController < ApplicationController
+  def index
+    render partial: 'shared/list', locals: {x: 1}
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if !rubyTplEdge(recs, "index", "shared/list") {
+		t.Error("missing RENDERS(index -> shared/list)")
+	}
+}
+
+// TestRubyTemplate_SymbolDropped: render :index is an implicit-convention action
+// view (no literal path) — NO template node fabricated.
+func TestRubyTemplate_SymbolDropped(t *testing.T) {
+	src := `class C < ApplicationController
+  def show
+    render :index
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if rubyAnyTplNode(recs) {
+		t.Error("render :index (symbol) must not fabricate a template node")
+	}
+}
+
+// TestRubyTemplate_DynamicDropped: render(view) variable arg is dropped.
+func TestRubyTemplate_DynamicDropped(t *testing.T) {
+	src := `class C < ApplicationController
+  def show
+    view = params[:v]
+    render view
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if rubyAnyTplNode(recs) {
+		t.Error("render(variable) must not fabricate a template node")
+	}
+}
+
+// TestRubyTemplate_Convergence: two actions rendering the same view → one node.
+func TestRubyTemplate_Convergence(t *testing.T) {
+	src := `class C < ApplicationController
+  def a
+    render 'shared/page'
+  end
+  def b
+    render 'shared/page'
+  end
+end`
+	recs := extractRubyRecords(t, src)
+	if !rubyTplEdge(recs, "a", "shared/page") || !rubyTplEdge(recs, "b", "shared/page") {
+		t.Fatal("both actions must RENDERS shared/page")
+	}
+	if n := rubyTplNode(recs, "shared/page"); n != 1 {
+		t.Fatalf("expected ONE converged template node, got %d", n)
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -176,6 +176,20 @@ const (
 	// names across files/languages into one node. See
 	// internal/extractor/exception_flow.go.
 	EntityKindExceptionType EntityKind = "SCOPE.ExceptionType"
+	// EntityKindTemplate is a synthetic, file-agnostic node representing a
+	// server-side view template by its normalized logical name/path — e.g.
+	// "users/list.html", "dashboard", "welcome". It is the convergence point
+	// for the view-layer capability (epic #3628): a request handler / controller
+	// method renders a template, and two handlers that render the SAME template
+	// resolve to ONE node, so the graph answers "what renders users/list.html?"
+	// (inbound RENDERS) and "what does this handler render?" (outbound RENDERS).
+	// Like SCOPE.ExceptionType it carries a constant synthetic SourceFile
+	// (TemplateSourceFile) so EntityRecord.ComputeID(SourceFile+Kind+Name)
+	// collapses identical template names across files/languages/frameworks
+	// (Flask render_template, Django render/TemplateView, Express res.render,
+	// Rails render, Spring MVC view names, Laravel view()) into one node. See
+	// internal/extractor/template_render.go.
+	EntityKindTemplate EntityKind = "SCOPE.Template"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -245,6 +259,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindModelEvent,
 		// #3628 error-flow: synthetic exception-type convergence node.
 		EntityKindExceptionType,
+		// #3628 view-layer: synthetic template convergence node.
+		EntityKindTemplate,
 	}
 }
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -141,9 +141,12 @@ subcategories:
       - drf_default_auth_throttle_settings
       - validate_on_submit_detection
       - tests_edges_via_delay_apply
+      - view_rendering
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction, endpoint_deprecation_versioning]
+      - name: View
+        keys: [view_rendering]
       - name: Auth
         keys: [auth_coverage]
       - name: Validation
@@ -217,9 +220,12 @@ subcategories:
       - trace_extraction
       - log_extraction
       - metric_extraction
+      - view_rendering
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction, endpoint_deprecation_versioning]
+      - name: View
+        keys: [view_rendering]
       - name: Auth
         keys: [auth_coverage]
       - name: Validation

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -921,6 +921,19 @@ records:
 
   lang.python.framework.flask:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/python/template_render.go
+              functions: [emitTemplateRenderEdges, pyRenderCallTemplate, pyNthStringArg, pyTemplateNameAttr]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/python/template_render_test.go
+              functions: [TestPyTemplate_FlaskRenderTemplate, TestPyTemplate_Convergence, TestPyTemplate_DynamicDropped]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Type System:
         interface_extraction:
           status: partial
@@ -1583,6 +1596,19 @@ records:
 
   lang.jsts.framework.express:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/template_render.go
+              functions: [emitTemplateRenderEdges, jsRenderCallTemplate, isResponseReceiver]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/javascript/template_render_test.go
+              functions: [TestJSTemplate_ExpressResRender, TestJSTemplate_Convergence, TestJSTemplate_DynamicDropped, TestJSTemplate_NonResponseReceiver]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Data:
         db_effect:
           status: full
@@ -1770,6 +1796,19 @@ records:
 
   lang.jsts.framework.koa:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/template_render.go
+              functions: [emitTemplateRenderEdges, jsRenderCallTemplate, isResponseReceiver]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/javascript/template_render_test.go
+              functions: [TestJSTemplate_PathArrow, TestJSTemplate_DynamicDropped]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Data:
         db_effect:
           status: full
@@ -2461,6 +2500,19 @@ records:
 
   lang.java.framework.spring-boot:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/java/template_render.go
+              functions: [emitTemplateRenderEdges, javaSpringViewName, javaReturnViewName, annotationNames]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/java/template_render_test.go
+              functions: [TestJavaTemplate_SpringMVCViewName, TestJavaTemplate_ModelAndView, TestJavaTemplate_RestControllerNoView, TestJavaTemplate_ResponseBodyNoView, TestJavaTemplate_Convergence]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Observability:
         log_extraction:
           status: full
@@ -7044,6 +7096,19 @@ records:
 
   lang.ruby.framework.rails:
     capabilities:
+      View:
+        view_rendering:
+          status: partial
+          symbols:
+            - file: internal/extractors/ruby/template_render.go
+              functions: [emitTemplateRenderEdges, rubyRenderTemplate, rubyPairParts]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/ruby/template_render_test.go
+              functions: [TestRubyTemplate_ExplicitString, TestRubyTemplate_TemplateKeyword, TestRubyTemplate_PartialKeyword, TestRubyTemplate_SymbolDropped, TestRubyTemplate_Convergence]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Substrate:
         feature_flag_gating:
           status: full
@@ -7227,6 +7292,19 @@ records:
 
   lang.php.framework.laravel:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/php/template_render.go
+              functions: [emitTemplateRenderEdges, phpViewCallTemplate, phpViewMakeTemplate]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/php/template_render_test.go
+              functions: [TestPHPTemplate_LaravelViewHelper, TestPHPTemplate_DotNotation, TestPHPTemplate_ViewMakeFacade, TestPHPTemplate_DynamicDropped, TestPHPTemplate_Convergence]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Substrate:
         constant_propagation:
           status: full
@@ -14939,6 +15017,19 @@ records:
           verified_at: "2026-05-29"
   lang.python.framework.django:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/python/template_render.go
+              functions: [emitTemplateRenderEdges, pyRenderCallTemplate, pyNthStringArg, pyTemplateNameAttr]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/python/template_render_test.go
+              functions: [TestPyTemplate_DjangoRender, TestPyTemplate_DjangoTemplateView]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-02"
       Testing:
         tests_linkage:
           status: full

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
@@ -18,6 +18,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint synthesis | ✅ `full` | `2026-05-27` | — | `internal/engine/http_endpoint_synthesis.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-27` | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |


### PR DESCRIPTION
Closes #3799 (child of #3628).

## What
Models the **server-side view layer**: links a request handler / controller method to the template it renders, so the graph answers `what does this handler render?` (outbound) and `who renders users/list.html?` (inbound).

## Node model
- New entity kind **`SCOPE.Template`** (subtype `template`), file-agnostic synthetic SourceFile `<template>` → identical template names converge to **one node** across files / languages / frameworks (mirrors `SCOPE.ExceptionType`).
- Reuses the existing **`RENDERS`** relationship: `RENDERS(handler fn → SCOPE.Template:<name>)`.
- Shared builder `internal/extractor/template_render.go`: `NormalizeTemplateName` / `TemplateEntity` / `TemplateTargetID` / `EmitTemplateEdges` (dedup + convergence + dynamic-name rejection). `NormalizeTemplateName` converts Laravel dot-notation (`users.list` → `users/list`) so dot- and slash-forms converge.

## Per-language detection (static names only)
| Lang | Shapes | Status |
|---|---|---|
| Python | Flask `render_template('x.html')`; Django `render(request,'x.html')` + `TemplateView.template_name` | full |
| JS/TS | Express/Koa `res.render('view')` / `ctx.render(...)` (response-receiver heuristic) | full |
| Java | Spring MVC `@Controller` method returning `String` view name / `ModelAndView('x')` | full |
| PHP | Laravel `view('users.list')` / `View::make('x')` | full |
| Ruby | Rails explicit `render 'path'` / `render template:/partial:` | partial |

## Spring REST-vs-MVC honesty boundary
A `String` return is a *view name* **only** in an MVC controller. `@RestController` classes and `@ResponseBody` methods are **skipped** — there the `String` is a serialized HTTP response body (REST), not a template. Asserted by `TestJavaTemplate_RestControllerNoView` / `TestJavaTemplate_ResponseBodyNoView`.

## Honest-partial
Variable / interpolated / computed template names (`render_template(name_var)`, `res.render(\`p/${id}\`)`, Spring `return which;`) emit **no node, no edge** — precision over recall. Ruby is `partial`: symbol (`render :index`) and implicit-convention renders are honest-skipped (no literal path in source).

## Tests (value-asserting)
Each language asserts the exact template node id + handler RENDERS edge, a two-handlers-→-one-node convergence test, and a dynamic-name negative. Shared-builder tests cover normalization + dedup. `go test` targeted green (incl. `internal/engine`, `internal/types`); `coverage validate` 0 errors; `fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## Coverage
`view_rendering` capability added to the dictionary (http_backend + jvm_backend, new **View** group), 7 framework cells (6 full + rails partial) citing the extractors, lane completeness backfilled, capability-map mappings added, docs regenerated.

**DEPLOY-DEFERRED**: extractor + coverage only; live-daemon rebuild / reindex deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)