### PR TITLE
feat(graphql): SDL schema type→type graph (object-field type edges + cardinality)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -262,7 +262,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/24 | 🟢 4/4 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟡 22/24 | 🟢 4/4 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/24 | 🟡 3/4 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 5/5 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 23/24 | ✅ 4/4 | |
 | [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🟡 2/24 | 🟢 4/4 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -85,7 +85,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 5/5 | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 6/6 | |
 | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 23/24 | ✅ 4/4 | |
 
 

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | each overridden Status RPC method -> SCOPE.Operation endpoint |
 | Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | req/resp messages emitted as SCOPE.Schema DTO refs (names only) |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | each .proto rpc -> SCOPE.Operation endpoint /<Service>/<Method> |
 | Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | .proto messages+fields fully parsed (name/type/number/label); generated .pb.h message classes recovered by name |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | — | — | `internal/custom/csharp/grpc_net.go`<br>`internal/custom/csharp/grpc_net_test.go` | [ProtoContract] annotated C# classes, [ProtoMember] field annotations, and proto file service/rpc declarations emitted as SCOPE.Schema/procedure_extraction. |
 | Schema extraction | 🟢 `partial` | — | — | `internal/custom/csharp/grpc_net.go`<br>`internal/custom/csharp/grpc_net_test.go` | Proto message declarations, [DataContract] C# classes, and XxxService:XxxServiceBase generated implementation classes emitted as SCOPE.Schema/schema_extraction. |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc :Method, Req, Resp declarations in use GRPC.Service modules emitted as SCOPE.GrpcMethod (grpc:<service>/<method>) with method + request/response message names. |
 | Schema extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | Request/response protobuf message names captured per rpc; stream() wrappers stripped and classified into streaming mode. |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 31
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | 🟢 `partial` | `2026-06-02` | 3623 | `internal/extractors/graphql/federation_test.go`<br>`internal/extractors/graphql/graphql.go`<br>`internal/types/kinds.go` | Apollo Federation SDL: type Foo @key(fields:"id") -> entity Properties {federated:true, federation:apollo, key_fields:id} (+shareable:true on @shareable); extend type Foo @key(...) { f @external/@requires/@provides } -> FEDERATES edge to owning entity Foo carrying key_fields + external_fields/requires_fields/provides_fields buckets (legacy IMPORTS edge preserved). Value-asserting tests assert exact key_fields and FEDERATES ToID=owning type. PARTIAL: regex SDL only — no @link/@composeDirective import resolution, no interfaceObject, no cross-file/cross-repo subgraph entity merge (gateway-level concern for the downstream linker). |
 | Procedure extraction | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
 | Schema extraction | ✅ `full` | `2026-05-28` | 2932 | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
+| Type graph extraction | ✅ `full` | `2026-06-02` | 3804 | `internal/extractors/graphql/graphql.go`<br>`internal/extractors/graphql/type_graph.go`<br>`internal/extractors/graphql/type_graph_test.go`<br>`internal/types/kinds.go` | SDL schema type→type graph: an object-typed field (type User { orders: [Order!]! }) emits a GRAPH_RELATES edge between the EXISTING SCOPE.Schema type nodes (User node -> Order node, addressed via BuildOperationStructuralRef — node reuse, no duplicate), carrying cardinality props {list, nullable, item_nullable, cardinality: to_one|to_many, field_name, self_ref}. Object + interface targets only; scalar/enum/input/custom-scalar and unresolved type names make NO edge. Union-typed fields expand to one edge per concrete member declared in-file (via_union prop). Value-asserting tests assert exact FromID+ToID+cardinality. Reuses the ORM GRAPH_RELATES vocabulary (#3611/#3747). Code-first lanes (TypeGraphQL/Nexus/Strawberry/graphene/Pothos/gqlgen) tracked separately for type-graph backfill. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` | — |
 | Schema extraction | ✅ `full` | `2026-05-28` | 2865 | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/http_endpoint_trpc_schema.go`<br>`internal/engine/http_endpoint_trpc_schema_test.go`<br>`testdata/fixtures/typescript/trpc_input_schema.ts` | — |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
+++ b/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 29
+- **Capability cells:** 30
 
 ## Capabilities
 
@@ -18,6 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Federation extraction | — `not_applicable` | — | 3623 | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
 | Procedure extraction | ✅ `full` | `2026-05-31` | — | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | custom_scala_grpc: each def <rpc>(request: ReqT): Eff[RespT] of a ScalaPB AbstractService / zio-grpc ZGeneratedService / fs2-grpc *Fs2Grpc service trait -> SCOPE.Operation endpoint at /<Service>/<rpc>, verb=RPC, rpc_protocol=grpc, grpc_service+grpc_method+handler_name stamped. Value-asserting tests pin sayHello/listUsers + service Greeter (Z/Fs2Grpc decorations stripped). File-local. |
 | Schema extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | custom_scala_grpc: request/response message types recovered from the method signature (Request<T> param + last effect type-arg of ZIO/Future/F[_]) and emitted as SCOPE.Schema DTO refs with grpc_message_role request/response. PARTIAL: message FIELD shapes live in ScalaPB-generated case-class companions; names only. Value-asserted (HelloRequest/HelloReply/UserList). |
+| Type graph extraction | — `not_applicable` | — | 3804 | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph. |
 
 ### Codegen
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3872,6 +3872,11 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "req/resp messages emitted as SCOPE.Schema DTO refs (names only)",
             "verified_at": "2026-05-30"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {
@@ -5646,6 +5651,11 @@
             "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
             "notes": ".proto messages+fields fully parsed (name/type/number/label); generated .pb.h message classes recovered by name",
             "verified_at": "2026-05-30"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {
@@ -9333,6 +9343,11 @@
             "status": "partial",
             "cites": ["internal/custom/csharp/grpc_net.go","internal/custom/csharp/grpc_net_test.go"],
             "notes": "Proto message declarations, [DataContract] C# classes, and XxxService:XxxServiceBase generated implementation classes emitted as SCOPE.Schema/schema_extraction."
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {
@@ -13204,6 +13219,11 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "Request/response protobuf message names captured per rpc; stream() wrappers stripped and classified into streaming mode.",
             "verified_at": "2026-05-31"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {
@@ -31382,6 +31402,13 @@
             "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml","internal/extractors/graphql/graphql.go"],
             "issue": "2932",
             "verified_at": "2026-05-28"
+          },
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/graphql/graphql.go","internal/extractors/graphql/type_graph.go","internal/extractors/graphql/type_graph_test.go","internal/types/kinds.go"],
+            "issue": "3804",
+            "notes": "SDL schema type→type graph: an object-typed field (type User { orders: [Order!]! }) emits a GRAPH_RELATES edge between the EXISTING SCOPE.Schema type nodes (User node -\u003e Order node, addressed via BuildOperationStructuralRef — node reuse, no duplicate), carrying cardinality props {list, nullable, item_nullable, cardinality: to_one|to_many, field_name, self_ref}. Object + interface targets only; scalar/enum/input/custom-scalar and unresolved type names make NO edge. Union-typed fields expand to one edge per concrete member declared in-file (via_union prop). Value-asserting tests assert exact FromID+ToID+cardinality. Reuses the ORM GRAPH_RELATES vocabulary (#3611/#3747). Code-first lanes (TypeGraphQL/Nexus/Strawberry/graphene/Pothos/gqlgen) tracked separately for type-graph backfill.",
+            "verified_at": "2026-06-02"
           }
         },
         "Codegen": {
@@ -36534,6 +36561,11 @@
             "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/http_endpoint_trpc_schema.go","internal/engine/http_endpoint_trpc_schema_test.go","testdata/fixtures/typescript/trpc_input_schema.ts"],
             "issue": "2865",
             "verified_at": "2026-05-28"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {
@@ -65173,6 +65205,11 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "custom_scala_grpc: request/response message types recovered from the method signature (Request\u003cT\u003e param + last effect type-arg of ZIO/Future/F[_]) and emitted as SCOPE.Schema DTO refs with grpc_message_role request/response. PARTIAL: message FIELD shapes live in ScalaPB-generated case-class companions; names only. Value-asserted (HelloRequest/HelloReply/UserList).",
             "verified_at": "2026-05-31"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "issue": "3804",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-SDL concept; gRPC/protobuf/tRPC message schemas are modelled separately and have no GraphQL object-type relationship graph."
           }
         },
         "Codegen": {

--- a/internal/extractors/graphql/graphql.go
+++ b/internal/extractors/graphql/graphql.go
@@ -136,6 +136,11 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 	var entities []types.EntityRecord
 	seen := make(map[string]bool)
 
+	// First pass: index every named definition so the type-graph pass can
+	// resolve a field's base type to a real object-type node (and exclude
+	// scalars/enums). #3628 — schema type→type graph.
+	schema := collectSchemaTypes(src)
+
 	// File-level container entity. Inserted at index 0 so subsequent CONTAINS
 	// edges for top-level definitions can be appended to entities[0].
 	entities = append(entities, types.EntityRecord{
@@ -205,6 +210,18 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 			bodyStart >= 0 && bodyEnd > bodyStart {
 			body := src[bodyStart:bodyEnd]
 			fields := collectFields(body)
+
+			// #3628 — schema type→type graph: object-typed fields become
+			// GRAPH_RELATES edges between the existing type nodes (this node
+			// and the referenced type node), carrying list/nullable
+			// cardinality. Only object/interface targets; scalars/enums skip.
+			// Interface targets are valid; input objects are not relationship
+			// roots in the entity-graph sense, so we skip them as owners.
+			if subtype == "type" || subtype == "interface" {
+				ent.Relationships = append(ent.Relationships,
+					typeGraphEdges(name, filePath, fields, schema)...)
+			}
+
 			fieldSeen := make(map[string]bool)
 			for _, f := range fields {
 				if fieldSeen[f.name] {
@@ -439,11 +456,25 @@ func scanFederation(headerLine, src string, bodyStart, bodyEnd int) fedInfo {
 // fieldHit is one captured field declaration inside a type/interface/input body.
 type fieldHit struct {
 	name       string
-	lineOffset int // 0-based line offset within the body
+	typeExpr   string // the raw GraphQL type expression, e.g. "[Order!]!"
+	lineOffset int    // 0-based line offset within the body
 }
+
+// fieldDeclRE re-parses a field line to split the leading name from the type
+// expression after the colon (and any args). collectFields uses the index form
+// of fieldRE for offsets; this captures the type expression for the type-graph.
+//
+//	name: [Order!]!   → name="name", typeExpr="[Order!]!"
+//	posts(first: Int): [Post!]!   → name="posts", typeExpr="[Post!]!"
+var fieldDeclRE = regexp.MustCompile(
+	`^[ \t]*([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:\s*([^\n#@]+)`,
+)
 
 // collectFields scans a type/interface/input body for field declarations.
 // Field names are returned in declaration order; deduping is the caller's job.
+// The field's type expression (everything after the colon, before any trailing
+// directive/comment) is captured so the type-graph pass can resolve object-type
+// references and their list/nullable cardinality.
 func collectFields(body string) []fieldHit {
 	var out []fieldHit
 	for _, m := range fieldRE.FindAllStringSubmatchIndex(body, -1) {
@@ -453,7 +484,13 @@ func collectFields(body string) []fieldHit {
 			continue
 		}
 		offset := strings.Count(body[:m[0]], "\n")
-		out = append(out, fieldHit{name: name, lineOffset: offset})
+		// Re-parse the matched line to recover the type expression. The full
+		// match span [m[0],m[1]) is the field line.
+		var typeExpr string
+		if mm := fieldDeclRE.FindStringSubmatch(body[m[0]:m[1]]); mm != nil {
+			typeExpr = strings.TrimSpace(mm[2])
+		}
+		out = append(out, fieldHit{name: name, typeExpr: typeExpr, lineOffset: offset})
 	}
 	return out
 }

--- a/internal/extractors/graphql/type_graph.go
+++ b/internal/extractors/graphql/type_graph.go
@@ -1,0 +1,263 @@
+// type_graph.go — SDL schema type→type graph (epic #3628, child of #3607 family).
+//
+// The base SDL extraction (graphql.go) emits one SCOPE.Schema node per object
+// type / interface / input / enum / union and CONTAINS edges to each field. It
+// does NOT model the *typed relationships between object types*: a field whose
+// type is another object type (`orders: [Order!]!`) is a structural edge from
+// the owning type to the referenced type — the schema's entity-relationship
+// graph. That is a distinct gap from the resolver/endpoint work (#3607).
+//
+// This file adds GRAPH_RELATES edges (the same kind the ORM relational
+// extractors use, #3611/#3747) between the *existing* type nodes graphql.go
+// already emits — no parallel node is created. The edge is hung off the owning
+// type node and points at the referenced type node, both addressed with the
+// canonical structural ref BuildOperationStructuralRef("graphql", file, Name).
+//
+// Cardinality is captured from the field's GraphQL type expression:
+//
+//	[Order!]!   → list=true,  nullable=false (the list), item_nullable=false
+//	[Order]     → list=true,  nullable=true,           item_nullable=true
+//	Order!      → list=false, nullable=false
+//	Order       → list=false, nullable=true
+//
+// Scalar fields (String/Int/Float/Boolean/ID and any non-object custom scalar)
+// do NOT produce a type→type edge. enum/union/input target types: a field whose
+// base type names a declared union is linked to the union's concrete members
+// when those members are object types declared in the same file (honest-partial
+// interface/union handling); an unresolved type name is skipped.
+package graphql
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Built-in GraphQL scalars never make a type→type edge.
+var builtinScalars = map[string]bool{
+	"String": true, "Int": true, "Float": true, "Boolean": true, "ID": true,
+}
+
+// schemaTypes is the set of named definitions collected in a first pass over the
+// source, used to resolve a field's base type to a real type node and to know
+// its kind (object/interface/union/enum/input/scalar) so scalars and enums are
+// correctly excluded from the type-graph.
+type schemaTypes struct {
+	kind          map[string]string   // type name → subtype (type/interface/union/enum/input/scalar)
+	unionMembers  map[string][]string // union name → concrete member type names
+	customScalars map[string]bool     // names declared via `scalar Foo`
+}
+
+// unionDefRE captures a union definition and its member list:
+//
+//	union SearchResult = User | Post | Comment
+var unionDefRE = regexp.MustCompile(
+	`(?m)^union\s+(\w+)\s*=\s*([^\n]+)`,
+)
+
+// collectSchemaTypes scans the whole source for every top-level named
+// definition so the field-type resolver knows which names are object types
+// (edge targets) vs scalars/enums (no edge). It is intentionally a cheap,
+// single-pass regex scan mirroring typeDefRE in graphql.go.
+func collectSchemaTypes(src string) schemaTypes {
+	st := schemaTypes{
+		kind:          make(map[string]string),
+		unionMembers:  make(map[string][]string),
+		customScalars: make(map[string]bool),
+	}
+	for _, m := range typeDefRE.FindAllStringSubmatchIndex(src, -1) {
+		subtype := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		if _, ok := st.kind[name]; !ok {
+			st.kind[name] = subtype
+		}
+		if subtype == "scalar" {
+			st.customScalars[name] = true
+		}
+	}
+	for _, m := range unionDefRE.FindAllStringSubmatch(src, -1) {
+		name := m[1]
+		var members []string
+		for _, part := range strings.Split(m[2], "|") {
+			mm := strings.TrimSpace(part)
+			// stop a member list at a trailing directive / comment
+			if i := strings.IndexAny(mm, " \t@#"); i >= 0 {
+				mm = mm[:i]
+			}
+			if mm != "" {
+				members = append(members, mm)
+			}
+		}
+		st.unionMembers[name] = members
+	}
+	return st
+}
+
+// typeCardinality is the parsed shape of a GraphQL field type expression.
+type typeCardinality struct {
+	base         string // the named base type, e.g. "Order"
+	list         bool   // wrapped in [...]
+	nullable     bool   // the outermost value is nullable (no trailing !)
+	itemNullable bool   // for lists, whether the inner item is nullable
+}
+
+// parseTypeExpr decomposes a GraphQL field type expression into its base type
+// and list/nullable cardinality.
+//
+//	[Order!]!  → base=Order list=true  nullable=false itemNullable=false
+//	[Order]    → base=Order list=true  nullable=true  itemNullable=true
+//	Order!     → base=Order list=false nullable=false
+//	Order      → base=Order list=false nullable=true
+//
+// Returns ok=false when no identifier base type can be recovered.
+func parseTypeExpr(expr string) (typeCardinality, bool) {
+	expr = strings.TrimSpace(expr)
+	// Drop a trailing default-value / directive tail if any survived.
+	if i := strings.IndexAny(expr, " \t="); i >= 0 {
+		expr = expr[:i]
+	}
+	var tc typeCardinality
+	if strings.HasPrefix(expr, "[") {
+		tc.list = true
+		// outer list nullability: trailing ! after the closing bracket
+		closing := strings.LastIndex(expr, "]")
+		if closing < 0 {
+			return tc, false
+		}
+		outer := expr[closing+1:]
+		tc.nullable = !strings.Contains(outer, "!")
+		inner := strings.TrimSpace(expr[1:closing])
+		tc.itemNullable = !strings.HasSuffix(inner, "!")
+		inner = strings.TrimRight(inner, "!")
+		tc.base = inner
+	} else {
+		tc.nullable = !strings.HasSuffix(expr, "!")
+		tc.base = strings.TrimRight(expr, "!")
+	}
+	tc.base = strings.TrimSpace(tc.base)
+	if !isTypeIdent(tc.base) {
+		return tc, false
+	}
+	return tc, true
+}
+
+// isTypeIdent reports whether s is a bare GraphQL type identifier (letters /
+// digits / underscore, leading non-digit). Rejects empty / wrapped remnants.
+func isTypeIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := c == '_' ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9' && i > 0)
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// isObjectTarget reports whether a base type name is a valid type→type edge
+// target: a declared object type or interface. Scalars (built-in or custom),
+// enums and input objects are not edge targets in the entity-relationship
+// graph. Unions are handled separately (expanded to members).
+func (st schemaTypes) isObjectTarget(name string) bool {
+	if builtinScalars[name] || st.customScalars[name] {
+		return false
+	}
+	switch st.kind[name] {
+	case "type", "interface":
+		return true
+	default:
+		return false
+	}
+}
+
+// typeGraphEdges returns the GRAPH_RELATES type→type edges for one object-type
+// (or interface) definition named `owner`, given its parsed fields. The edges
+// hang off the owner's type node (FromID = owner ref) and point at the
+// referenced type node (ToID = target ref). Union-typed fields expand to one
+// edge per concrete member resolvable in this file. Scalar / enum / input /
+// unresolved targets are skipped.
+func typeGraphEdges(owner, filePath string, fields []fieldHit, st schemaTypes) []types.RelationshipRecord {
+	ownerRef := extractor.BuildOperationStructuralRef("graphql", filePath, owner)
+	var out []types.RelationshipRecord
+	seen := make(map[string]bool) // dedupe (field,target) pairs
+
+	emit := func(target string, tc typeCardinality, fieldName string, viaUnion string) {
+		key := fieldName + "→" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		props := map[string]string{
+			"field_name":    fieldName,
+			"list":          boolToString(tc.list),
+			"nullable":      boolToString(tc.nullable),
+			"cardinality":   cardinalityLabel(tc),
+			"self_ref":      boolToString(target == owner),
+			"graphql_field": owner + "." + fieldName,
+		}
+		if tc.list {
+			props["item_nullable"] = boolToString(tc.itemNullable)
+		}
+		if viaUnion != "" {
+			props["via_union"] = viaUnion
+		}
+		out = append(out, types.RelationshipRecord{
+			FromID:     ownerRef,
+			ToID:       extractor.BuildOperationStructuralRef("graphql", filePath, target),
+			Kind:       string(types.RelationshipKindGraphRelates),
+			Properties: props,
+		})
+	}
+
+	for _, f := range fields {
+		if f.typeExpr == "" {
+			continue
+		}
+		tc, ok := parseTypeExpr(f.typeExpr)
+		if !ok {
+			continue
+		}
+		switch {
+		case st.isObjectTarget(tc.base):
+			emit(tc.base, tc, f.name, "")
+		case st.kind[tc.base] == "union":
+			// honest-partial: expand to concrete object members declared here.
+			for _, member := range st.unionMembers[tc.base] {
+				if st.isObjectTarget(member) {
+					emit(member, tc, f.name, tc.base)
+				}
+			}
+			// unresolved members are skipped (no edge).
+		default:
+			// scalar / enum / input / unresolved custom type → no edge.
+		}
+	}
+	return out
+}
+
+// boolToString formats a bool as "true" / "false" for Properties storage,
+// which is map[string]string.
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// cardinalityLabel maps a parsed cardinality to a short human label mirroring
+// the ORM GRAPH_RELATES vocabulary so cross-language graph queries read
+// uniformly. A list field is "to_many"; a singular object field is "to_one".
+func cardinalityLabel(tc typeCardinality) string {
+	if tc.list {
+		return "to_many"
+	}
+	return "to_one"
+}

--- a/internal/extractors/graphql/type_graph_test.go
+++ b/internal/extractors/graphql/type_graph_test.go
@@ -1,0 +1,270 @@
+package graphql_test
+
+// type_graph_test.go — value-asserting tests for the SDL schema type→type graph
+// (#3628, child of the #3607 GraphQL family). The extractor emits GRAPH_RELATES
+// edges between the *existing* SCOPE.Schema type nodes for object-typed fields,
+// carrying list/nullable cardinality. Scalar fields make no edge.
+//
+// These tests assert FROM type id + TO type id + cardinality props — not len>0.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findGraphRelates returns the first GRAPH_RELATES edge from `owner` whose ToID
+// resolves to type `target` in `file`, plus its field_name match.
+func findGraphRelates(entities []types.EntityRecord, file, owner, target, field string) *types.RelationshipRecord {
+	fromRef := extractor.BuildOperationStructuralRef("graphql", file, owner)
+	toRef := extractor.BuildOperationStructuralRef("graphql", file, target)
+	for _, e := range entities {
+		for i := range e.Relationships {
+			r := e.Relationships[i]
+			if r.Kind != string(types.RelationshipKindGraphRelates) {
+				continue
+			}
+			if r.FromID == fromRef && r.ToID == toRef &&
+				(field == "" || r.Properties["field_name"] == field) {
+				return &e.Relationships[i]
+			}
+		}
+	}
+	return nil
+}
+
+func graphRelatesCount(entities []types.EntityRecord) int {
+	n := 0
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// type User { orders: [Order!]! } → User→Order, list=true, non-null.
+func TestTypeGraph_ListNonNull(t *testing.T) {
+	const file = "schema.graphql"
+	src := `type User {
+  id: ID!
+  name: String!
+  orders: [Order!]!
+}
+type Order {
+  id: ID!
+}
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "User", "Order", "orders")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User → Order on field orders")
+	}
+	// Convergence: the FromID is the SAME structural ref the base extractor
+	// uses for the User type node (BuildOperationStructuralRef), proving we
+	// reuse the existing node rather than minting a duplicate.
+	wantFrom := extractor.BuildOperationStructuralRef("graphql", file, "User")
+	if e.FromID != wantFrom {
+		t.Errorf("FromID = %q, want canonical type node ref %q", e.FromID, wantFrom)
+	}
+	if e.Properties["list"] != "true" {
+		t.Errorf("list = %q, want true", e.Properties["list"])
+	}
+	if e.Properties["nullable"] != "false" {
+		t.Errorf("nullable = %q, want false ([Order!]! list is non-null)", e.Properties["nullable"])
+	}
+	if e.Properties["item_nullable"] != "false" {
+		t.Errorf("item_nullable = %q, want false (Order! items non-null)", e.Properties["item_nullable"])
+	}
+	if e.Properties["cardinality"] != "to_many" {
+		t.Errorf("cardinality = %q, want to_many", e.Properties["cardinality"])
+	}
+}
+
+// type Order { user: User! } → Order→User, non-null singular (to_one).
+func TestTypeGraph_SingularNonNull(t *testing.T) {
+	const file = "schema.graphql"
+	src := `type Order {
+  user: User!
+}
+type User {
+  id: ID!
+}
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "Order", "User", "user")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES Order → User on field user")
+	}
+	if e.Properties["list"] != "false" {
+		t.Errorf("list = %q, want false", e.Properties["list"])
+	}
+	if e.Properties["nullable"] != "false" {
+		t.Errorf("nullable = %q, want false (User!)", e.Properties["nullable"])
+	}
+	if e.Properties["cardinality"] != "to_one" {
+		t.Errorf("cardinality = %q, want to_one", e.Properties["cardinality"])
+	}
+}
+
+// Nullable singular: type A { b: B } → list=false, nullable=true.
+func TestTypeGraph_SingularNullable(t *testing.T) {
+	const file = "s.graphql"
+	src := `type A { b: B }
+type B { id: ID! }
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "A", "B", "b")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES A → B")
+	}
+	if e.Properties["nullable"] != "true" {
+		t.Errorf("nullable = %q, want true (B has no !)", e.Properties["nullable"])
+	}
+}
+
+// Nullable list items: type A { bs: [B] } → list=true, nullable=true, item_nullable=true.
+func TestTypeGraph_ListNullable(t *testing.T) {
+	const file = "s.graphql"
+	src := `type A { bs: [B] }
+type B { id: ID! }
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "A", "B", "bs")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES A → B (list)")
+	}
+	if e.Properties["list"] != "true" || e.Properties["nullable"] != "true" || e.Properties["item_nullable"] != "true" {
+		t.Errorf("cardinality props = %+v, want list=true nullable=true item_nullable=true", e.Properties)
+	}
+}
+
+// NEGATIVE: a type whose fields are all scalars makes NO type→type edge.
+func TestTypeGraph_ScalarOnly_NoEdge(t *testing.T) {
+	const file = "s.graphql"
+	src := `type User {
+  id: ID!
+  name: String!
+  age: Int
+  active: Boolean
+  score: Float!
+}
+`
+	ents := extractGQL(t, file, src)
+	if n := graphRelatesCount(ents); n != 0 {
+		t.Errorf("scalar-only type produced %d GRAPH_RELATES edges, want 0", n)
+	}
+}
+
+// NEGATIVE: a field referencing an undeclared custom type → no edge (unresolved).
+func TestTypeGraph_UnresolvedType_NoEdge(t *testing.T) {
+	const file = "s.graphql"
+	src := `type User {
+  widget: Widget
+}
+`
+	ents := extractGQL(t, file, src)
+	if n := graphRelatesCount(ents); n != 0 {
+		t.Errorf("unresolved custom type produced %d edges, want 0", n)
+	}
+}
+
+// NEGATIVE: enum-typed field makes no type→type edge (enum is not an object).
+func TestTypeGraph_EnumTarget_NoEdge(t *testing.T) {
+	const file = "s.graphql"
+	src := `enum Role { ADMIN USER }
+type User { role: Role! }
+`
+	ents := extractGQL(t, file, src)
+	if e := findGraphRelates(ents, file, "User", "Role", "role"); e != nil {
+		t.Errorf("enum-typed field must not produce a type→type edge, got %+v", e)
+	}
+}
+
+// Interface target: a field typed as an interface is a valid edge target.
+func TestTypeGraph_InterfaceTarget(t *testing.T) {
+	const file = "s.graphql"
+	src := `interface Node { id: ID! }
+type User { node: Node! }
+`
+	ents := extractGQL(t, file, src)
+	if e := findGraphRelates(ents, file, "User", "Node", "node"); e == nil {
+		t.Error("expected GRAPH_RELATES User → Node (interface target)")
+	}
+}
+
+// Self-reference: type Employee { manager: Employee } → self_ref=true.
+func TestTypeGraph_SelfRef(t *testing.T) {
+	const file = "s.graphql"
+	src := `type Employee {
+  manager: Employee
+  reports: [Employee!]
+}
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "Employee", "Employee", "manager")
+	if e == nil {
+		t.Fatal("expected self-referential GRAPH_RELATES Employee → Employee")
+	}
+	if e.Properties["self_ref"] != "true" {
+		t.Errorf("self_ref = %q, want true", e.Properties["self_ref"])
+	}
+}
+
+// Union expansion (honest-partial): a union-typed field links to each concrete
+// member declared in the same file.
+func TestTypeGraph_UnionExpansion(t *testing.T) {
+	const file = "s.graphql"
+	src := `union SearchResult = User | Post
+type User { id: ID! }
+type Post { id: ID! }
+type Query2 { results: [SearchResult!]! }
+`
+	ents := extractGQL(t, file, src)
+	toUser := findGraphRelates(ents, file, "Query2", "User", "results")
+	toPost := findGraphRelates(ents, file, "Query2", "Post", "results")
+	if toUser == nil || toPost == nil {
+		t.Fatalf("expected union expansion Query2 → {User, Post}, got user=%v post=%v", toUser, toPost)
+	}
+	if toUser.Properties["via_union"] != "SearchResult" {
+		t.Errorf("via_union = %q, want SearchResult", toUser.Properties["via_union"])
+	}
+	if toUser.Properties["list"] != "true" {
+		t.Errorf("union member edge should carry the field's list cardinality, got %+v", toUser.Properties)
+	}
+}
+
+// Field with arguments: posts(first: Int): [Post!]! still resolves the return
+// type, not an argument type.
+func TestTypeGraph_FieldWithArgs(t *testing.T) {
+	const file = "s.graphql"
+	src := `type User {
+  posts(first: Int, after: String): [Post!]!
+}
+type Post { id: ID! }
+`
+	ents := extractGQL(t, file, src)
+	e := findGraphRelates(ents, file, "User", "Post", "posts")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User → Post for field with args")
+	}
+	if e.Properties["list"] != "true" {
+		t.Errorf("list = %q, want true", e.Properties["list"])
+	}
+}
+
+// input objects are not edge roots: an input type's object-typed field does not
+// create a GRAPH_RELATES edge (inputs are argument shapes, not entity nodes).
+func TestTypeGraph_InputNotRoot(t *testing.T) {
+	const file = "s.graphql"
+	src := `input CreateOrder { user: User! }
+type User { id: ID! }
+`
+	ents := extractGQL(t, file, src)
+	if n := graphRelatesCount(ents); n != 0 {
+		t.Errorf("input object produced %d edges, want 0", n)
+	}
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -458,6 +458,7 @@ subcategories:
       - procedure_extraction
       - schema_extraction
       - federation_extraction
+      - type_graph_extraction
       - client_codegen
       - transport_binding
       - constant_propagation
@@ -486,7 +487,7 @@ subcategories:
       - template_pattern_catalog
     groups:
       - name: Schema
-        keys: [schema_extraction, procedure_extraction, federation_extraction]
+        keys: [schema_extraction, procedure_extraction, federation_extraction, type_graph_extraction]
       - name: Codegen
         keys: [client_codegen]
       - name: Transport


### PR DESCRIPTION
Closes #3804 (epic #3628; #3607 GraphQL family).

## Problem
The SDL GraphQL extractor emitted `SCOPE.Schema` type nodes and `CONTAINS` edges to fields, and the #3607 family synthesizes resolver/HTTP-endpoint records — but the schema's **entity-relationship graph** was never modelled. A field whose type is another object type (`type User { orders: [Order!]! }`) is a typed `type→type` relationship (`User` → `Order`) that had no edge. That is the schema TYPE DATA MODEL, distinct from the resolver/endpoint surface.

## Edge model + node reuse
For each object-typed (or interface-typed) field on a `type`/`interface` definition, emit a `GRAPH_RELATES` edge between the **existing** type nodes the base extractor already emits — addressed via `BuildOperationStructuralRef("graphql", file, Name)`, so the `User` node is the **same** one the rest of the GraphQL extraction uses (no duplicate node). Reuses the ORM relational `GRAPH_RELATES` vocabulary (#3611/#3747).

```
type User { orders: [Order!]! }
  → User --GRAPH_RELATES(field_name=orders, list=true, nullable=false,
    item_nullable=false, cardinality=to_many)--> Order
type Order { user: User! }
  → Order --GRAPH_RELATES(user, to_one, nullable=false)--> User
```

Cardinality is parsed from the field type expression (`[Order!]!` → list, non-null list, non-null items).

### Rules
- scalar fields (`String/Int/Float/Boolean/ID` + custom scalars) → **no edge**
- enum / input-object / unresolved custom-type targets → **no edge**
- interface targets → edge; input objects are **not** edge roots
- union-typed fields → one edge per concrete in-file member (`via_union` prop); honest-partial — unresolved members skipped
- self-reference (`manager: Employee`) → `self_ref=true`

## Files
- `internal/extractors/graphql/type_graph.go` — type index (first pass), type-expression cardinality parser, `typeGraphEdges`
- `internal/extractors/graphql/graphql.go` — `collectFields` now captures the type expression; `typeGraphEdges` wired into the type/interface field loop
- `internal/extractors/graphql/type_graph_test.go` — value-asserting tests: exact FromID + ToID + cardinality (not len>0); negatives (scalar-only, unresolved, enum, input-not-root); union expansion; self-ref; field-with-args; node-reuse convergence
- Coverage: new `type_graph_extraction` lane on the rpc_framework `Schema` group — `full` for `graphql-resolvers` citing the extractor, `not_applicable` for gRPC/protobuf/tRPC; dictionary + registry + generated docs updated

## Validation
- `go test ./internal/extractors/graphql/ ./internal/types/ ./tools/coverage/` green
- `go vet` clean, `gofmt -l` empty
- `coverage validate` 0 errors, registry canonical (`fmt --check` ok), docs regenerated

## Follow-up
Code-first lanes (TypeGraphQL/Nexus/Strawberry/graphene/Pothos/gqlgen) type-graph backfill tracked under #3804.

**DEPLOY-DEFERRED**: extractor change only; no live-daemon rebuild/reindex in this wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)