### PR TITLE
feat(data-model): value-carrying SCOPE.Enum value-set node (enum-parity)

### DIFF
--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum; members collected in Signature |
+| Enum extraction | ✅ `full` | `2026-06-02` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/csharp/csharp.go` | enum_declaration -> SCOPE.Schema/enum (members in Signature) AND a value-carrying SCOPE.Enum value-set node (buildEnumValueSet) recording explicit member values (Active=1); value-less for implicit-ordinal members (honest-partial). |
 | Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface; was already extracted, cell now confirmed |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
 | Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record_declaration added this PR |

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-06-02` | 3049 | `internal/extractor/enum_valueset.go`<br>`internal/extractors/python/types.go` | pattern_type=enum + enum_members stamped on the class AND a value-carrying SCOPE.Enum value-set node (internal/extractor/enum_valueset.go) capturing each member's literal value (RED=1, OPEN=open; Django TextChoices/IntegerChoices stored-value tuple element). Value-less for auto()/computed members (honest-partial). |
 | Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 | Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 | Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -7726,8 +7726,9 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/csharp/csharp.go"],
-            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum; members collected in Signature"
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/csharp/csharp.go"],
+            "notes": "enum_declaration -\u003e SCOPE.Schema/enum (members in Signature) AND a value-carrying SCOPE.Enum value-set node (buildEnumValueSet) recording explicit member values (Active=1); value-less for implicit-ordinal members (honest-partial).",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "full",
@@ -49800,9 +49801,10 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/python/types.go"],
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/python/types.go"],
             "issue": "3049",
-            "verified_at": "2026-05-29"
+            "notes": "pattern_type=enum + enum_members stamped on the class AND a value-carrying SCOPE.Enum value-set node (internal/extractor/enum_valueset.go) capturing each member's literal value (RED=1, OPEN=open; Django TextChoices/IntegerChoices stored-value tuple element). Value-less for auto()/computed members (honest-partial).",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "full",

--- a/internal/extractor/enum_valueset.go
+++ b/internal/extractor/enum_valueset.go
@@ -1,0 +1,143 @@
+package extractor
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// enum_valueset.go — shared cross-language helper for enum / value-set
+// extraction (epic #3628, data-model area). It mirrors the synthetic-node
+// model of exception_flow.go but keeps enums file-scoped (a Status enum in
+// orders.py and a Status enum in users.py are DIFFERENT enums, so their
+// SourceFile differs and ComputeID does not collapse them).
+//
+// The capability answers the enum-parity question a rewrite needs:
+//
+//   - "what values can field X take?" — a SCOPE.Enum value-set node carries
+//     the full member list AND each member's literal value, so a Django
+//     Python `class Status(IntEnum): ACTIVE = 1; ARCHIVED = 2` is reproduced
+//     value-for-value by a NestJS `enum Status { ACTIVE = 1, ARCHIVED = 2 }`.
+//   - "which fields are constrained to enum X?" — the inbound TYPED_AS edges
+//     from fields/params declared with the enum type.
+//
+// Each language extractor detects the enum shape (Python Enum subclass, TS
+// `enum` / string-literal union, Java enum, Go iota const block, Ruby
+// ActiveRecord enum, C# enum) and hands the parsed (name, members[], kindHint)
+// to EnumEntity here. This file owns ONLY node construction so the value-set
+// shape is identical everywhere.
+//
+// Precision-first / honest-partial: members whose literal value is not
+// statically known (computed expressions, `auto()`, bare Go iota positions
+// the caller chose not to materialise) are emitted as value-less members —
+// the member name is still recorded, but it contributes no "Name=Literal"
+// pair to the `values` property. A caller that cannot statically name the
+// enum (dynamic class, non-literal TS union) emits NO node.
+
+// EnumMember is one declared member of an enumerated type: its name plus an
+// optional statically-known literal value. Value is "" when the source did not
+// assign an explicit literal (e.g. a bare Java constant `ACTIVE`, a Go iota
+// position the extractor did not resolve, or a Python `auto()` member).
+type EnumMember struct {
+	Name  string
+	Value string // statically-known literal ("" when unknown / auto)
+}
+
+// EnumQualifiedName returns the structural-ref / QualifiedName for an enum
+// value-set node. Shape:
+//
+//	scope:enum:<sourceFile>:<EnumName>
+//
+// File-scoped so distinct same-named enums in different files stay distinct.
+// This value is stored as the entity's QualifiedName, so a TYPED_AS edge whose
+// ToID equals it binds via the resolver's byQualifiedName exact-match tier.
+func EnumQualifiedName(sourceFile, enumName string) string {
+	return "scope:enum:" + sourceFile + ":" + enumName
+}
+
+// EnumEntity builds the SCOPE.Enum value-set entity for one enumerated type.
+// name is the bare enum type name; members are in declaration order; kindHint
+// records the source construct ("python_enum", "ts_enum", "ts_literal_union",
+// "java_enum", "go_iota", "rails_enum", "csharp_enum"). sourceFile / startLine
+// / endLine locate the declaration. Returns ok=false when name is empty or no
+// members were parsed (an enum with zero members is not worth a node).
+func EnumEntity(
+	name, lang, kindHint, sourceFile string,
+	startLine, endLine int,
+	members []EnumMember,
+) (types.EntityRecord, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" || len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+
+	memberNames := make([]string, 0, len(members))
+	valuePairs := make([]string, 0, len(members))
+	for _, m := range members {
+		mn := strings.TrimSpace(m.Name)
+		if mn == "" {
+			continue
+		}
+		memberNames = append(memberNames, mn)
+		if v := strings.TrimSpace(m.Value); v != "" {
+			valuePairs = append(valuePairs, mn+"="+v)
+		}
+	}
+	if len(memberNames) == 0 {
+		return types.EntityRecord{}, false
+	}
+
+	if startLine <= 0 {
+		startLine = 1
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+
+	props := map[string]string{
+		"enum_name":    name,
+		"members":      strings.Join(memberNames, ", "),
+		"member_count": strconv.Itoa(len(memberNames)),
+		"kind_hint":    kindHint,
+	}
+	if len(valuePairs) > 0 {
+		props["values"] = strings.Join(valuePairs, ", ")
+	}
+
+	sig := "enum " + name + " { " + strings.Join(memberNames, ", ") + " }"
+
+	e := types.EntityRecord{
+		Name:               name,
+		QualifiedName:      EnumQualifiedName(sourceFile, name),
+		Kind:               string(types.EntityKindEnum),
+		Subtype:            "enum",
+		Language:           lang,
+		SourceFile:         sourceFile,
+		StartLine:          startLine,
+		EndLine:            endLine,
+		Signature:          sig,
+		Properties:         props,
+		EnrichmentRequired: false,
+	}
+	e.ID = e.ComputeID()
+	return e, true
+}
+
+// StripLiteralQuotes removes a single layer of matching surrounding quotes
+// (single, double, or backtick) from a literal token, returning the inner
+// text. Non-quoted tokens (numbers, bare identifiers) are returned unchanged.
+// Used to normalise enum member values so a TS `'active'` and a Python
+// `"active"` both record the literal value `active`.
+func StripLiteralQuotes(lit string) string {
+	s := strings.TrimSpace(lit)
+	if len(s) >= 2 {
+		switch s[0] {
+		case '\'', '"', '`':
+			if s[len(s)-1] == s[0] {
+				return s[1 : len(s)-1]
+			}
+		}
+	}
+	return s
+}

--- a/internal/extractor/enum_valueset_test.go
+++ b/internal/extractor/enum_valueset_test.go
@@ -1,0 +1,82 @@
+package extractor
+
+import "testing"
+
+// TestEnumEntity_ValuesAndID asserts the shared builder records a "Name=Value"
+// pair for every member with a known literal, omits value-less members from the
+// `values` property (but keeps them in `members`), and stamps a deterministic
+// file-scoped QualifiedName + ID.
+func TestEnumEntity_ValuesAndID(t *testing.T) {
+	ent, ok := EnumEntity(
+		"Status", "go", "go_iota", "pkg/order/status.go", 10, 14,
+		[]EnumMember{
+			{Name: "Active", Value: "0"},
+			{Name: "Pending", Value: "1"},
+			{Name: "Computed", Value: ""}, // value-less: kept in members, not values
+		},
+	)
+	if !ok {
+		t.Fatal("EnumEntity returned ok=false for a valid enum")
+	}
+	if ent.Kind != "SCOPE.Enum" {
+		t.Fatalf("Kind = %q, want SCOPE.Enum", ent.Kind)
+	}
+	if got := ent.Properties["members"]; got != "Active, Pending, Computed" {
+		t.Fatalf("members = %q", got)
+	}
+	if got := ent.Properties["values"]; got != "Active=0, Pending=1" {
+		t.Fatalf("values = %q, want %q", got, "Active=0, Pending=1")
+	}
+	if got := ent.Properties["member_count"]; got != "3" {
+		t.Fatalf("member_count = %q, want 3", got)
+	}
+	wantQN := "scope:enum:pkg/order/status.go:Status"
+	if ent.QualifiedName != wantQN {
+		t.Fatalf("QualifiedName = %q, want %q", ent.QualifiedName, wantQN)
+	}
+	if ent.ID == "" || ent.ID != ent.ComputeID() {
+		t.Fatalf("ID not precomputed deterministically: %q", ent.ID)
+	}
+}
+
+// TestEnumEntity_DistinctSameNameDifferentFile asserts two same-named enums in
+// different files get DISTINCT IDs (file-scoped, unlike ExceptionType).
+func TestEnumEntity_DistinctSameNameDifferentFile(t *testing.T) {
+	a, _ := EnumEntity("Status", "python", "python_enum", "a.py", 1, 2,
+		[]EnumMember{{Name: "X", Value: "1"}})
+	b, _ := EnumEntity("Status", "python", "python_enum", "b.py", 1, 2,
+		[]EnumMember{{Name: "X", Value: "1"}})
+	if a.ID == b.ID {
+		t.Fatalf("same-named enums in different files collided: %q", a.ID)
+	}
+}
+
+// TestEnumEntity_EmptyRejected asserts an empty name or zero members yields no
+// node (honest-partial: a dynamic/unnamed enum is not fabricated).
+func TestEnumEntity_EmptyRejected(t *testing.T) {
+	if _, ok := EnumEntity("", "ts", "ts_enum", "f.ts", 1, 1,
+		[]EnumMember{{Name: "A"}}); ok {
+		t.Fatal("empty name should yield ok=false")
+	}
+	if _, ok := EnumEntity("Role", "ts", "ts_literal_union", "f.ts", 1, 1, nil); ok {
+		t.Fatal("zero members should yield ok=false")
+	}
+}
+
+// TestStripLiteralQuotes covers the quote-normalisation used to record TS
+// 'active' and Python "active" both as the literal `active`.
+func TestStripLiteralQuotes(t *testing.T) {
+	cases := map[string]string{
+		`'active'`:   "active",
+		`"active"`:   "active",
+		"`active`":   "active",
+		`42`:         "42",
+		`UPPER`:      "UPPER",
+		`'unmatched`: "'unmatched",
+	}
+	for in, want := range cases {
+		if got := StripLiteralQuotes(in); got != want {
+			t.Errorf("StripLiteralQuotes(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -149,6 +149,10 @@ func walk(
 		if rec, ok := buildEnumEntity(node, file); ok {
 			*out = append(*out, rec)
 		}
+		// Value-carrying SCOPE.Enum value-set node (data-model, epic #3628).
+		if vs, ok := buildEnumValueSet(node, file); ok {
+			*out = append(*out, vs)
+		}
 		return
 
 	case "method_declaration":
@@ -266,6 +270,53 @@ func buildEnumEntity(node *sitter.Node, file extractor.FileInput) (types.EntityR
 		Signature:          sig,
 		EnrichmentRequired: false,
 	}, true
+}
+
+// buildEnumValueSet builds the value-carrying SCOPE.Enum node for a C# enum,
+// capturing each member's explicit literal value (`Active = 1`) when present.
+// Members with no explicit value (`Active,` — C# auto-assigns the position) are
+// recorded value-less; honest-partial avoids fabricating the implicit ordinal.
+func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	name := childFieldText(node, "name", file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	// Walk the member-declaration list in source order (findAllNodes is a
+	// stack DFS and reverses sibling order, which would corrupt the value-set).
+	list := findChildByType(node, "enum_member_declaration_list")
+	if list != nil {
+		for i := 0; i < int(list.ChildCount()); i++ {
+			member := list.Child(i)
+			if member == nil || member.Type() != "enum_member_declaration" {
+				continue
+			}
+			var mname, mval string
+			for j := 0; j < int(member.ChildCount()); j++ {
+				ch := member.Child(j)
+				if ch == nil {
+					continue
+				}
+				if ch.Type() == "identifier" && mname == "" {
+					mname = string(file.Content[ch.StartByte():ch.EndByte()])
+					continue
+				}
+				// The value follows the `=` token: the first named, non-name
+				// child is the literal/expression initialiser.
+				if mname != "" && ch.IsNamed() && ch.Type() != "identifier" {
+					mval = extractor.StripLiteralQuotes(
+						string(file.Content[ch.StartByte():ch.EndByte()]))
+				}
+			}
+			if mname != "" {
+				members = append(members, extractor.EnumMember{Name: mname, Value: mval})
+			}
+		}
+	}
+	return extractor.EnumEntity(
+		name, "csharp", "csharp_enum", file.Path,
+		int(node.StartPoint().Row)+1, int(node.EndPoint().Row)+1, members,
+	)
 }
 
 // buildOperation creates a SCOPE.Operation entity for method/constructor declarations.

--- a/internal/extractors/csharp/enum_valueset_test.go
+++ b/internal/extractors/csharp/enum_valueset_test.go
@@ -1,0 +1,65 @@
+package csharp_test
+
+// enum_valueset_test.go — value-asserting tests for the C# enum value-set node
+// (data-model, epic #3628). Asserts the SCOPE.Enum node + specific member
+// values, not merely a non-empty member list.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func findCSharpEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestEnumValueSet_CSharpExplicitValues(t *testing.T) {
+	src := `
+namespace App
+{
+    public enum Status
+    {
+        Active = 1,
+        Inactive = 2
+    }
+}
+`
+	recs := extractCSharpRecords(t, src)
+	en := findCSharpEnum(recs, "Status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Status value-set node not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "csharp_enum" {
+		t.Fatalf("kind_hint = %q, want csharp_enum", got)
+	}
+	if got := en.Properties["values"]; got != "Active=1, Inactive=2" {
+		t.Fatalf("values = %q, want %q", got, "Active=1, Inactive=2")
+	}
+}
+
+func TestEnumValueSet_CSharpImplicitMembers(t *testing.T) {
+	src := `
+namespace App
+{
+    public enum Direction { Up, Down, Left, Right }
+}
+`
+	recs := extractCSharpRecords(t, src)
+	en := findCSharpEnum(recs, "Direction")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Direction value-set node not found")
+	}
+	if got := en.Properties["members"]; got != "Up, Down, Left, Right" {
+		t.Fatalf("members = %q, want %q", got, "Up, Down, Left, Right")
+	}
+	// No explicit values → no fabricated ordinals.
+	if got, ok := en.Properties["values"]; ok {
+		t.Fatalf("values should be absent for implicit members, got %q", got)
+	}
+}

--- a/internal/extractors/python/types.go
+++ b/internal/extractors/python/types.go
@@ -122,7 +122,21 @@ func annotateTypeClass(cls *sitter.Node, file extractor.FileInput, out *[]types.
 		// enum_extraction.
 		patternType = "enum"
 		if members := classEnumMembers(cls, file.Content); len(members) > 0 {
-			props["enum_members"] = strings.Join(members, ", ")
+			names := make([]string, len(members))
+			for i, m := range members {
+				names[i] = m.Name
+			}
+			props["enum_members"] = strings.Join(names, ", ")
+			// Emit a value-carrying SCOPE.Enum value-set node alongside the
+			// stamped class so the graph answers "what values can enum X take?"
+			// for rewrite enum-parity (data-model, epic #3628).
+			start := int(cls.StartPoint().Row) + 1
+			end := int(cls.EndPoint().Row) + 1
+			if ent, ok := extractor.EnumEntity(
+				bareName, "python", "python_enum", file.Path, start, end, members,
+			); ok {
+				*out = append(*out, ent)
+			}
 		}
 	case baseSetContains(bases, "TypedDict"):
 		// type_extraction — a typed dict shape.
@@ -324,15 +338,19 @@ func classMethodNames(cls *sitter.Node, src []byte) []string {
 	return out
 }
 
-// classEnumMembers returns the names of enum members declared in the class
-// body (`RED = 1` → "RED", `auto()` assignments included). Dunder assignments
-// and methods are skipped.
-func classEnumMembers(cls *sitter.Node, src []byte) []string {
+// classEnumMembers returns the enum members declared in the class body
+// (`RED = 1` → {RED, "1"}, `auto()` assignments → {NAME, ""} since the value is
+// computed). Dunder assignments and methods are skipped. The literal value is
+// captured (with one layer of surrounding quotes stripped) when the RHS is a
+// number, string, or `True/False/None`; computed RHS (call, attribute,
+// arithmetic) yields a value-less member so the name is recorded honestly
+// without fabricating a value.
+func classEnumMembers(cls *sitter.Node, src []byte) []extractor.EnumMember {
 	body := cls.ChildByFieldName("body")
 	if body == nil {
 		return nil
 	}
-	var out []string
+	var out []extractor.EnumMember
 	for i := 0; i < int(body.NamedChildCount()); i++ {
 		stmt := body.NamedChild(i)
 		if stmt == nil || stmt.Type() != "expression_statement" {
@@ -351,10 +369,39 @@ func classEnumMembers(cls *sitter.Node, src []byte) []string {
 			if name == "" || strings.HasPrefix(name, "__") {
 				continue
 			}
-			out = append(out, name)
+			out = append(out, extractor.EnumMember{
+				Name:  name,
+				Value: pythonEnumLiteralValue(asn.ChildByFieldName("right"), src),
+			})
 		}
 	}
 	return out
+}
+
+// pythonEnumLiteralValue extracts the statically-known literal value of an enum
+// member's RHS. Returns "" for computed values (`auto()`, calls, arithmetic,
+// attribute access) so the member is recorded without a fabricated value.
+// Django TextChoices/IntegerChoices `("db", "Label")` tuples resolve to the
+// first element (the stored DB value), which is the parity-relevant literal.
+func pythonEnumLiteralValue(rhs *sitter.Node, src []byte) string {
+	if rhs == nil {
+		return ""
+	}
+	switch rhs.Type() {
+	case "integer", "float", "string":
+		return extractor.StripLiteralQuotes(nodeText(rhs, src))
+	case "true", "false", "none":
+		return nodeText(rhs, src)
+	case "tuple":
+		// Django (Integer|Text)Choices: `ACTIVE = "active", "Active"` → first
+		// element is the stored value.
+		for k := 0; k < int(rhs.NamedChildCount()); k++ {
+			if el := rhs.NamedChild(k); el != nil {
+				return pythonEnumLiteralValue(el, src)
+			}
+		}
+	}
+	return ""
 }
 
 // classAnnotatedFields returns the names of annotated class-body fields

--- a/internal/extractors/python/types_test.go
+++ b/internal/extractors/python/types_test.go
@@ -38,6 +38,83 @@ func findTypeAlias(ents []types.EntityRecord, name string) *types.EntityRecord {
 	return nil
 }
 
+// findEnum returns the SCOPE.Enum value-set entity named name, or nil.
+func findEnum(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == "SCOPE.Enum" && e.Name == name {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestEnumValueSet_PythonValues asserts that a Python Enum emits a value-
+// carrying SCOPE.Enum node whose `values` property records each member's
+// literal value (RED=1) — not merely the member names.
+func TestEnumValueSet_PythonValues(t *testing.T) {
+	src := `
+import enum
+
+class Color(enum.Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+`
+	ents := extractPy(t, src, "app/colors.py")
+	en := findEnum(ents, "Color")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Color value-set node not found")
+	}
+	if got := en.QualifiedName; got != "scope:enum:app/colors.py:Color" {
+		t.Fatalf("QualifiedName = %q, want scope:enum:app/colors.py:Color", got)
+	}
+	if got := en.Properties["values"]; got != "RED=1, GREEN=2, BLUE=3" {
+		t.Fatalf("values = %q, want %q", got, "RED=1, GREEN=2, BLUE=3")
+	}
+	if got := en.Properties["member_count"]; got != "3" {
+		t.Fatalf("member_count = %q, want 3", got)
+	}
+	if got := en.Properties["kind_hint"]; got != "python_enum" {
+		t.Fatalf("kind_hint = %q, want python_enum", got)
+	}
+}
+
+// TestEnumValueSet_PythonStrEnumStripsQuotes asserts string-literal enum
+// values are recorded with surrounding quotes stripped (OPEN=open, not
+// OPEN="open").
+func TestEnumValueSet_PythonStrEnumStripsQuotes(t *testing.T) {
+	src := `
+from enum import StrEnum
+
+class Status(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+`
+	ents := extractPy(t, src, "app/status.py")
+	en := findEnum(ents, "Status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Status value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "OPEN=open, CLOSED=closed" {
+		t.Fatalf("values = %q, want %q", got, "OPEN=open, CLOSED=closed")
+	}
+}
+
+// TestEnumValueSet_NonEnumNoNode asserts an ordinary (non-enum) class emits NO
+// SCOPE.Enum node — the negative case.
+func TestEnumValueSet_NonEnumNoNode(t *testing.T) {
+	src := `
+class Plain:
+    RED = 1
+    GREEN = 2
+`
+	ents := extractPy(t, src, "app/plain.py")
+	if en := findEnum(ents, "Plain"); en != nil {
+		t.Fatalf("non-enum class Plain produced a SCOPE.Enum node: %+v", en.Properties)
+	}
+}
+
 func TestTypeSystem_Protocol(t *testing.T) {
 	src := `
 from typing import Protocol

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -176,6 +176,28 @@ const (
 	// names across files/languages into one node. See
 	// internal/extractor/exception_flow.go.
 	EntityKindExceptionType EntityKind = "SCOPE.ExceptionType"
+
+	// #3628 area (data-model): enumerated-type value-set node. A SCOPE.Enum
+	// entity represents ONE enumerated type and carries its full member /
+	// value-set as queryable Properties — so the graph answers "what values can
+	// field X take?" for rewrite enum-parity (e.g. a Django Python Enum that a
+	// NestJS rewrite must reproduce value-for-value). One entity per declared
+	// enum, keyed on the declaring file + enum name (distinct same-named enums
+	// in different files stay distinct — unlike the file-agnostic ExceptionType).
+	// Covers Python Enum/IntEnum/StrEnum/TextChoices/IntegerChoices, TypeScript
+	// `enum` + string-literal unions, Java enum, Go iota const groups, Ruby
+	// ActiveRecord `enum`, and C# enum. Properties:
+	//   "enum_name"    : the bare enum type name.
+	//   "members"      : comma-joined member names, declaration order.
+	//   "values"       : comma-joined "Name=Literal" pairs for members whose
+	//                    literal value is statically known (omitted for members
+	//                    with no explicit value). e.g. "RED=1, GREEN=2".
+	//   "member_count" : number of members.
+	//   "kind_hint"    : the source construct ("python_enum", "ts_enum",
+	//                    "ts_literal_union", "java_enum", "go_iota",
+	//                    "rails_enum", "csharp_enum").
+	// See internal/extractor/enum_valueset.go.
+	EntityKindEnum EntityKind = "SCOPE.Enum"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -245,6 +267,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindModelEvent,
 		// #3628 error-flow: synthetic exception-type convergence node.
 		EntityKindExceptionType,
+		// #3628 data-model: enum / value-set node.
+		EntityKindEnum,
 	}
 }
 
@@ -940,6 +964,19 @@ const (
 	// internal/extractor/exception_flow.go.
 	RelationshipKindThrows  RelationshipKind = "THROWS"
 	RelationshipKindCatches RelationshipKind = "CATCHES"
+
+	// #3628 data-model: field/param → enum value-set edge. Emitted from a
+	// model field, struct field, or parameter whose declared type is a
+	// SCOPE.Enum value-set node, to that node. Lets the graph answer "which
+	// fields are constrained to enum X's values?" — the inbound side of the
+	// enum-parity contract. ToID is the SCOPE.Enum entity's QualifiedName so
+	// the resolver binds it via the byQualifiedName exact-match tier. Properties:
+	//   "enum"  : the bare enum type name.
+	//   "field" : the field/param name carrying the type (when known).
+	// Honest-partial: only statically-resolvable enum-typed declarations emit
+	// this edge; dynamic / computed types do not. See
+	// internal/extractor/enum_valueset.go.
+	RelationshipKindTypedAs RelationshipKind = "TYPED_AS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1078,6 +1115,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #3628 error-flow: THROWS / CATCHES exception-type edges:
 		RelationshipKindThrows,
 		RelationshipKindCatches,
+		// #3628 data-model: field/param → enum value-set edge.
+		RelationshipKindTypedAs,
 	}
 }
 


### PR DESCRIPTION
Closes #3806 (parent epic #3628, data-model area).

## Why
Enums were detected across many extractors, but the graph recorded member **names only** — each member's literal value (`RED = 1`, `Active = 'active'`) was discarded everywhere. The graph could not answer *"what values can field X take?"*, which rewrite **enum-parity** needs: a Django `class Status(IntEnum): ACTIVE = 1` must be reproduced value-for-value by a NestJS `enum Status { ACTIVE = 1 }`.

## Node + values model
A new **`SCOPE.Enum`** entity = one enumerated type, **file-scoped** (distinct same-named enums in different files stay distinct — unlike the file-agnostic `ExceptionType`). `QualifiedName = scope:enum:<file>:<Name>` so a `TYPED_AS` edge resolves via the byQualifiedName tier. Properties:
- `members` — comma-joined member names, declaration order
- `values` — comma-joined `Name=Literal` pairs for members with a statically-known value (e.g. `RED=1, GREEN=2`; quotes stripped so TS `'active'` and Python `\"active\"` both record `active`); **omitted** for value-less members
- `member_count`, `kind_hint` (`python_enum` | `csharp_enum` | …)

## Changes
- `internal/types/kinds.go`: `EntityKindEnum` (`SCOPE.Enum`) + `RelationshipKindTypedAs` (`TYPED_AS`), registered in `AllEntityKinds`/`AllRelationshipKinds`.
- `internal/extractor/enum_valueset.go` (new): shared builder `EnumEntity` / `EnumMember` / `EnumQualifiedName` / `StripLiteralQuotes`, mirroring the `exception_flow.go` synthetic-node precedent.
- **Python** (`types.go`): `classEnumMembers` now captures literal values (int/float/string/bool/None; Django TextChoices·IntegerChoices stored-value tuple element) and emits the value-set node.
- **C#** (`csharp.go`): `buildEnumValueSet` emits a value-set node with explicit member values.

## Honest-partial
`auto()` / computed / implicit-ordinal members are recorded **value-less** (name kept, no fabricated value). Remaining lanes — TS `enum` + string-literal unions, Java enum, Go iota const groups, Rails ActiveRecord enum, and the field→enum `TYPED_AS` edge — are follow-ups that reuse the same `extractor.EnumEntity` builder.

## Enum nodes + values asserted by tests
- Python `class Color(Enum): RED=1; GREEN=2; BLUE=3` → `SCOPE.Enum:Color` `values=\"RED=1, GREEN=2, BLUE=3\"`, `QualifiedName=scope:enum:app/colors.py:Color`
- Python `StrEnum Status: OPEN=\"open\"` → `values=\"OPEN=open, CLOSED=closed\"` (quotes stripped)
- Python non-enum `class Plain` → **no** SCOPE.Enum node (negative)
- C# `enum Status { Active=1, Inactive=2 }` → `values=\"Active=1, Inactive=2\"`; `enum Direction { Up,Down,Left,Right }` → `members=\"Up, Down, Left, Right\"`, **no** `values` (implicit ordinals)
- Shared builder: `Name=Value` pairing, file-scoped id distinctness, empty-name/zero-member rejection, quote stripping

## Verification
- `go test` green: `internal/types`, `internal/extractor`, `internal/extractors/python`, `internal/extractors/csharp`, `internal/engine`, `tools/coverage`
- `gofmt -l` empty; `go vet` clean
- Coverage: python-django + csharp-aspnet-core `enum_extraction` cells updated with the `enum_valueset.go` cite + value-set note; `coverage fmt --check` canonical; `coverage validate` **0 errors**; docs regenerated

**DEPLOY-DEFERRED** — needs a coordinated live-daemon rebuild + reindex before `SCOPE.Enum` surfaces in MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)