### PR TITLE
feat(data-model): enum value-sets for TS/Java/Go/Rails (completes #3806)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -48,7 +48,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 8/12 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/5 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
@@ -119,7 +119,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/4 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
 | [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Echo](../detail/lang.go.framework.echo.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 8/12 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [Gin](../detail/lang.go.framework.gin.md) | 🟡 3/5 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 3/5 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -31,7 +31,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
 | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
 | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/4 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
 | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | — `not_applicable` | `2026-05-29` | — | — | Go has no first-class enum keyword; the idiom is const(...iota). The Go extractor extracts no const/iota enum constructs, so this capability is not applicable. |
+| Enum extraction | 🟢 `partial` | `2026-06-02` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/golang/enum_valueset.go` | Go has no enum keyword; the idiom is a named int/string type + a const(...) block typed by it. extractGoEnums emits a value-carrying SCOPE.Enum value-set node per such block (kind_hint=go_iota): members in declaration order, explicit literal members capture their value (Color: Red=red; Level: Low=1), iota members recorded value-less (honest-partial, no fabricated ordinals). Const blocks typed only by a builtin / untyped are skipped. |
 | Interface extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/golang/extractor.go`<br>`internal/extractors/golang/extractor_test.go` | — |
 | Type alias extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/golang/extractor.go` | type X = Y alias declarations via tree-sitter base extractor; framework-specific type aliases (e.g. gin.HandlerFunc, echo.HandlerFunc) captured but not distinguished from user-defined aliases; no value-asserting framework-specific tests |
 | Type extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/golang/extractor.go`<br>`internal/extractors/golang/extractor_test.go` | — |

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -57,7 +57,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
+| Enum extraction | ✅ `full` | `2026-06-02` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/java/enum_valueset.go`<br>`internal/extractors/java/java.go` | enum_declaration -> SCOPE.Component/enum AND a value-carrying SCOPE.Enum value-set node (buildJavaEnumValueSet, kind_hint=java_enum): bare constants recorded as members (Status: ACTIVE, INACTIVE), constructor-arg enums capture the first literal argument as the member value (Color: RED=#f00; Planet: MERCURY=1). Non-literal constructor args recorded value-less (honest-partial). |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ✅ `full` | `2026-05-29` | 3160 | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue1343_ts_type_extraction_test.go` | — |
+| Enum extraction | ✅ `full` | `2026-06-02` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/javascript/enum_valueset.go`<br>`internal/extractors/javascript/extractor.go` | TS enum_declaration -> SCOPE.Schema/enum AND a value-carrying SCOPE.Enum value-set node (emitTSEnumValueSet, kind_hint=ts_enum): string/numeric explicit members capture values (Status: Active=active; Level: Low=1), implicit/numeric-positional enums recorded value-less (honest-partial). String-literal union aliases type Role = 'admin'|'user' -> SCOPE.Enum (kind_hint=ts_literal_union) values admin,user; unions with any non-literal arm (string|Foo) emit no node. |
 | Interface extraction | ✅ `full` | `2026-05-29` | 3160 | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue1343_ts_type_extraction_test.go` | — |
 | Type alias extraction | ✅ `full` | `2026-05-29` | 3160 | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue1343_ts_type_extraction_test.go` | — |
 | Type extraction | ✅ `full` | `2026-05-29` | 3160 | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue1343_ts_type_extraction_test.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | — `not_applicable` | — | — | — | Ruby is dynamically typed — no enum keyword (duck typing idiom) |
+| Enum extraction | 🟢 `partial` | `2026-06-02` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/ruby/enum_valueset.go` | Ruby is dynamically typed (no enum keyword), but Rails ActiveRecord declares value-sets via the enum DSL. buildRailsEnumValueSet emits a value-carrying SCOPE.Enum node per declaration (kind_hint=rails_enum): enum status: { active: 0, archived: 1 } -> values active=0, archived=1; array form enum priority: [:low, :high] -> members value-less; Rails 7 positional enum :state, {...} form supported. Non-literal/dynamic args skipped (honest-partial). |
 | Interface extraction | — `not_applicable` | — | — | — | Ruby is dynamically typed — no interface keyword (duck typing idiom) |
 | Type alias extraction | — `not_applicable` | — | — | — | Ruby is dynamically typed — no type keyword (duck typing idiom) |
 | Type extraction | — `not_applicable` | — | — | — | Ruby dynamically typed; framework exposes no static type DSL |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18566,9 +18566,10 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "not_applicable",
-            "notes": "Go has no first-class enum keyword; the idiom is const(...iota). The Go extractor extracts no const/iota enum constructs, so this capability is not applicable.",
-            "verified_at": "2026-05-29"
+            "status": "partial",
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/golang/enum_valueset.go"],
+            "notes": "Go has no enum keyword; the idiom is a named int/string type + a const(...) block typed by it. extractGoEnums emits a value-carrying SCOPE.Enum value-set node per such block (kind_hint=go_iota): members in declaration order, explicit literal members capture their value (Color: Red=red; Level: Low=1), iota members recorded value-less (honest-partial, no fabricated ordinals). Const blocks typed only by a builtin / untyped are skipped.",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "full",
@@ -26852,8 +26853,9 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/java/java.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/java/enum_valueset.go","internal/extractors/java/java.go"],
+            "notes": "enum_declaration -\u003e SCOPE.Component/enum AND a value-carrying SCOPE.Enum value-set node (buildJavaEnumValueSet, kind_hint=java_enum): bare constants recorded as members (Status: ACTIVE, INACTIVE), constructor-arg enums capture the first literal argument as the member value (Color: RED=#f00; Planet: MERCURY=1). Non-literal constructor args recorded value-less (honest-partial).",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "full",
@@ -34704,9 +34706,9 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue1343_ts_type_extraction_test.go"],
-            "issue": "3160",
-            "verified_at": "2026-05-29"
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/javascript/enum_valueset.go","internal/extractors/javascript/extractor.go"],
+            "notes": "TS enum_declaration -\u003e SCOPE.Schema/enum AND a value-carrying SCOPE.Enum value-set node (emitTSEnumValueSet, kind_hint=ts_enum): string/numeric explicit members capture values (Status: Active=active; Level: Low=1), implicit/numeric-positional enums recorded value-less (honest-partial). String-literal union aliases type Role = 'admin'|'user' -\u003e SCOPE.Enum (kind_hint=ts_literal_union) values admin,user; unions with any non-literal arm (string|Foo) emit no node.",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "full",
@@ -59802,8 +59804,10 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "not_applicable",
-            "notes": "Ruby is dynamically typed — no enum keyword (duck typing idiom)"
+            "status": "partial",
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/ruby/enum_valueset.go"],
+            "notes": "Ruby is dynamically typed (no enum keyword), but Rails ActiveRecord declares value-sets via the enum DSL. buildRailsEnumValueSet emits a value-carrying SCOPE.Enum node per declaration (kind_hint=rails_enum): enum status: { active: 0, archived: 1 } -\u003e values active=0, archived=1; array form enum priority: [:low, :high] -\u003e members value-less; Rails 7 positional enum :state, {...} form supported. Non-literal/dynamic args skipped (honest-partial).",
+            "verified_at": "2026-06-02"
           },
           "interface_extraction": {
             "status": "not_applicable",

--- a/internal/extractors/golang/enum_valueset.go
+++ b/internal/extractors/golang/enum_valueset.go
@@ -1,0 +1,188 @@
+package golang
+
+// enum_valueset.go — value-carrying SCOPE.Enum value-set nodes for Go
+// (data-model, epic #3628 / completes #3806). Go has no `enum` keyword; the
+// idiom is a named integer/string type plus a parenthesised const block typed
+// by it:
+//
+//	type Status int
+//	const (
+//	    Active Status = iota
+//	    Inactive
+//	    Pending
+//	)
+//
+// This reuses the shared cross-language builder in internal/extractor
+// (EnumEntity / EnumMember / StripLiteralQuotes) so Go const-group enums
+// converge on the same node model as Python, C#, TS, Java and Rails.
+//
+// Detection (precision-first):
+//   - The const block's FIRST const_spec must name a type (the second
+//     identifier in `Name Type = ...`), AND that type must be declared in the
+//     same file as a named type (`type Status int`). A const block typed by a
+//     builtin only (or untyped) is NOT treated as an enum value-set.
+//   - The named type carries implicitly to subsequent specs (Go repetition),
+//     so every const_spec in the block is a member of the enum.
+//
+// Values:
+//   - iota-based members are recorded value-less (member name only) — the
+//     extractor does not materialise the synthetic ordinal (honest-partial).
+//   - explicit literal members (`Red Color = "red"`, `Mask Flag = 1`) capture
+//     the literal value.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractGoEnums scans the file for const blocks typed by a same-file named
+// type and emits one SCOPE.Enum value-set node per such block.
+func extractGoEnums(root *sitter.Node, src []byte, filePath string) []types.EntityRecord {
+	if root == nil {
+		return nil
+	}
+	named := collectNamedTypes(root, src)
+	if len(named) == 0 {
+		return nil
+	}
+	var out []types.EntityRecord
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "const_declaration" {
+			if rec, ok := buildGoEnumValueSet(n, src, filePath, named); ok {
+				out = append(out, rec)
+			}
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return out
+}
+
+// collectNamedTypes returns the set of type names declared in the file whose
+// underlying type is a primitive (int/string family) — the Go enum idiom. A
+// struct/interface/func type is excluded (those are never enum bases).
+func collectNamedTypes(root *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "type_spec" {
+			name := nodeText(firstChildOfType(n, "type_identifier"), src)
+			// The underlying type is the second named child.
+			if name != "" {
+				if under := typeSpecUnderlying(n); under != nil && isEnumBaseType(under) {
+					out[name] = true
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return out
+}
+
+// typeSpecUnderlying returns the underlying-type node of a type_spec (the node
+// after the type name), or nil.
+func typeSpecUnderlying(spec *sitter.Node) *sitter.Node {
+	seenName := false
+	for i := 0; i < int(spec.ChildCount()); i++ {
+		ch := spec.Child(i)
+		if ch == nil || !ch.IsNamed() {
+			continue
+		}
+		if !seenName {
+			seenName = true
+			continue
+		}
+		return ch
+	}
+	return nil
+}
+
+// isEnumBaseType reports whether an underlying-type node is a primitive base a
+// Go enum is built on (a bare type_identifier naming an int/string/numeric
+// builtin). Struct/interface/map/func/etc. underlying types are not enum bases.
+func isEnumBaseType(under *sitter.Node) bool {
+	return under.Type() == "type_identifier"
+}
+
+// buildGoEnumValueSet builds the SCOPE.Enum node for one const block, when the
+// block is typed by a same-file named type. enumName is taken from the first
+// const_spec's type. Returns ok=false otherwise.
+func buildGoEnumValueSet(constDecl *sitter.Node, src []byte, filePath string, named map[string]bool) (types.EntityRecord, bool) {
+	// Find the enum type from the first const_spec carrying a type identifier.
+	var enumType string
+	for i := 0; i < int(constDecl.ChildCount()); i++ {
+		spec := constDecl.Child(i)
+		if spec == nil || spec.Type() != "const_spec" {
+			continue
+		}
+		if tn := firstChildOfType(spec, "type_identifier"); tn != nil {
+			enumType = nodeText(tn, src)
+			break
+		}
+	}
+	if enumType == "" || !named[enumType] {
+		return types.EntityRecord{}, false
+	}
+
+	var members []extractor.EnumMember
+	for i := 0; i < int(constDecl.ChildCount()); i++ {
+		spec := constDecl.Child(i)
+		if spec == nil || spec.Type() != "const_spec" {
+			continue
+		}
+		// Member name(s): the leading identifier(s) before the type/`=`.
+		name := nodeText(firstChildOfType(spec, "identifier"), src)
+		if name == "" || name == "_" {
+			continue
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  name,
+			Value: goConstSpecLiteral(spec, src),
+		})
+	}
+
+	return extractor.EnumEntity(
+		enumType, "go", "go_iota", filePath,
+		int(constDecl.StartPoint().Row)+1, int(constDecl.EndPoint().Row)+1, members,
+	)
+}
+
+// goConstSpecLiteral returns the statically-known literal value of a const_spec
+// RHS, or "" for iota / non-literal / absent values (honest-partial).
+func goConstSpecLiteral(spec *sitter.Node, src []byte) string {
+	el := firstChildOfType(spec, "expression_list")
+	if el == nil {
+		return ""
+	}
+	for i := 0; i < int(el.ChildCount()); i++ {
+		ch := el.Child(i)
+		if ch == nil || !ch.IsNamed() {
+			continue
+		}
+		switch ch.Type() {
+		case "interpreted_string_literal", "raw_string_literal":
+			return extractor.StripLiteralQuotes(nodeText(ch, src))
+		case "int_literal", "float_literal":
+			return nodeText(ch, src)
+		default:
+			// iota, binary_expression, call, etc. → not a captured literal.
+			return ""
+		}
+	}
+	return ""
+}

--- a/internal/extractors/golang/enum_valueset_test.go
+++ b/internal/extractors/golang/enum_valueset_test.go
@@ -1,0 +1,124 @@
+package golang_test
+
+// enum_valueset_test.go — value-asserting tests for the Go SCOPE.Enum
+// value-set node (data-model, epic #3628 / completes #3806).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func goEnumRecords(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	out, err := extractFromPath(src, "enums.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	recs := make([]types.EntityRecord, 0, len(out))
+	for _, r := range out {
+		recs = append(recs, r.(types.EntityRecord))
+	}
+	return recs
+}
+
+func findGoEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestGoEnumValueSet_IotaMembersInOrder(t *testing.T) {
+	recs := goEnumRecords(t, `package p
+type Status int
+const (
+	Active Status = iota
+	Inactive
+	Pending
+)
+`)
+	en := findGoEnum(recs, "Status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Status value-set node not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "go_iota" {
+		t.Fatalf("kind_hint = %q, want go_iota", got)
+	}
+	if got := en.Properties["members"]; got != "Active, Inactive, Pending" {
+		t.Fatalf("members = %q, want %q (order matters)", got, "Active, Inactive, Pending")
+	}
+	// iota members are recorded value-less (no fabricated ordinals).
+	if got, ok := en.Properties["values"]; ok {
+		t.Fatalf("values should be absent for iota members, got %q", got)
+	}
+}
+
+func TestGoEnumValueSet_ExplicitStringValues(t *testing.T) {
+	recs := goEnumRecords(t, `package p
+type Color string
+const (
+	Red   Color = "red"
+	Green Color = "green"
+	Blue  Color = "blue"
+)
+`)
+	en := findGoEnum(recs, "Color")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Color value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "Red=red, Green=green, Blue=blue" {
+		t.Fatalf("values = %q, want %q", got, "Red=red, Green=green, Blue=blue")
+	}
+	wantQN := "scope:enum:enums.go:Color"
+	if en.QualifiedName != wantQN {
+		t.Fatalf("QualifiedName = %q, want %q", en.QualifiedName, wantQN)
+	}
+}
+
+func TestGoEnumValueSet_ExplicitIntValues(t *testing.T) {
+	recs := goEnumRecords(t, `package p
+type Level int
+const (
+	Low  Level = 1
+	High Level = 2
+)
+`)
+	en := findGoEnum(recs, "Level")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Level value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "Low=1, High=2" {
+		t.Fatalf("values = %q, want %q", got, "Low=1, High=2")
+	}
+}
+
+// Negative: an untyped const block (no named type) is not an enum value-set.
+func TestGoEnumValueSet_UntypedConst_NoEnum(t *testing.T) {
+	recs := goEnumRecords(t, `package p
+const (
+	A = 1
+	B = 2
+)
+`)
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" {
+			t.Fatalf("untyped const block should NOT produce a SCOPE.Enum node, got %q", recs[i].Name)
+		}
+	}
+}
+
+// Negative: a const block typed by a builtin-only (no same-file named type)
+// is not an enum value-set.
+func TestGoEnumValueSet_BuiltinTyped_NoEnum(t *testing.T) {
+	recs := goEnumRecords(t, `package p
+const (
+	Pi float64 = 3.14
+)
+`)
+	if en := findGoEnum(recs, "float64"); en != nil {
+		t.Fatal("builtin-typed const should NOT produce a SCOPE.Enum node")
+	}
+}

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -127,6 +127,10 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	records = append(records, typeEntities...)
 	structs = sCount
 
+	// Value-carrying SCOPE.Enum value-set nodes for const-group enums typed by
+	// a same-file named type (data-model, epic #3628).
+	records = append(records, extractGoEnums(root, file.Content, file.Path)...)
+
 	// ----------------------------------------------------------------
 	// 3. Import relationships — emitted as standalone SCOPE.Component
 	//    EntityRecord entries (one per import path). Not fanned out to

--- a/internal/extractors/java/enum_valueset.go
+++ b/internal/extractors/java/enum_valueset.go
@@ -1,0 +1,100 @@
+package java
+
+// enum_valueset.go — value-carrying SCOPE.Enum value-set nodes for Java
+// (data-model, epic #3628 / completes #3806). Reuses the shared cross-language
+// builder in internal/extractor (EnumEntity / EnumMember / StripLiteralQuotes)
+// so Java enums converge on the same model as Python, C#, TS, Go and Rails.
+//
+//   - `enum Status { ACTIVE, INACTIVE }` → members ACTIVE, INACTIVE (no values).
+//   - `enum Color { RED("#f00"), GREEN("#0f0") }` → constructor-arg enums:
+//     the FIRST literal constructor argument is captured as the member value,
+//     so Color.RED carries value "#f00" (kind_hint="java_enum").
+//
+// Honest-partial: a constant whose first constructor argument is not a literal
+// (a method call, a reference to another constant, a complex expression) is
+// recorded value-less — the member name is kept, no fabricated value.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildJavaEnumValueSet builds the SCOPE.Enum node for a Java `enum_declaration`.
+func buildJavaEnumValueSet(node *sitter.Node, file extractor.FileInput) (recOut types.EntityRecord, ok bool) {
+	name := childFieldText(node, "name", file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch == nil || ch.Type() != "enum_constant" {
+			continue
+		}
+		mname := childFieldText(ch, "name", file.Content)
+		if mname == "" {
+			// Fall back to the first identifier child.
+			if idn := firstChildOfType(ch, "identifier"); idn != nil {
+				mname = nodeText(idn, file.Content)
+			}
+		}
+		if mname == "" {
+			continue
+		}
+		mval := javaEnumConstantValue(ch, file.Content)
+		members = append(members, extractor.EnumMember{Name: mname, Value: mval})
+	}
+	return extractor.EnumEntity(
+		name, "java", "java_enum", file.Path,
+		int(node.StartPoint().Row)+1, int(node.EndPoint().Row)+1, members,
+	)
+}
+
+// javaEnumConstantValue returns the statically-known literal value of an
+// enum_constant's first constructor argument, or "" when the constant has no
+// argument list or the first argument is not a literal.
+func javaEnumConstantValue(constNode *sitter.Node, src []byte) string {
+	args := childByType(constNode, "argument_list")
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil || !a.IsNamed() {
+			continue
+		}
+		// First named argument is the value we capture.
+		switch a.Type() {
+		case "string_literal", "decimal_integer_literal", "decimal_floating_point_literal",
+			"hex_integer_literal", "character_literal", "true", "false":
+			return extractor.StripLiteralQuotes(nodeText(a, src))
+		default:
+			// Non-literal first argument → honest-partial, no value.
+			return ""
+		}
+	}
+	return ""
+}
+
+// firstChildOfType returns the first direct child of n with the given type.
+func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch != nil && ch.Type() == typ {
+			return ch
+		}
+	}
+	return nil
+}
+
+// childByType is an alias kept local to this file to avoid coupling to other
+// helpers' naming; identical semantics to firstChildOfType.
+func childByType(n *sitter.Node, typ string) *sitter.Node {
+	return firstChildOfType(n, typ)
+}

--- a/internal/extractors/java/enum_valueset_test.go
+++ b/internal/extractors/java/enum_valueset_test.go
@@ -1,0 +1,108 @@
+package java_test
+
+// enum_valueset_test.go — value-asserting tests for the Java SCOPE.Enum
+// value-set node (data-model, epic #3628 / completes #3806).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractJavaForEnum(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "java", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func findJavaEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestJavaEnumValueSet_BareMembers(t *testing.T) {
+	recs := extractJavaForEnum(t, "Status.java", `
+public enum Status { ACTIVE, INACTIVE, PENDING }
+`)
+	en := findJavaEnum(recs, "Status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Status value-set node not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "java_enum" {
+		t.Fatalf("kind_hint = %q, want java_enum", got)
+	}
+	if got := en.Properties["members"]; got != "ACTIVE, INACTIVE, PENDING" {
+		t.Fatalf("members = %q, want %q", got, "ACTIVE, INACTIVE, PENDING")
+	}
+	// Bare constants have no constructor args → no fabricated values.
+	if got, ok := en.Properties["values"]; ok {
+		t.Fatalf("values should be absent for bare members, got %q", got)
+	}
+}
+
+func TestJavaEnumValueSet_ConstructorValues(t *testing.T) {
+	recs := extractJavaForEnum(t, "Color.java", `
+public enum Color {
+    RED("#f00"),
+    GREEN("#0f0"),
+    BLUE("#00f");
+
+    private final String hex;
+    Color(String hex) { this.hex = hex; }
+}
+`)
+	en := findJavaEnum(recs, "Color")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Color value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "RED=#f00, GREEN=#0f0, BLUE=#00f" {
+		t.Fatalf("values = %q, want %q", got, "RED=#f00, GREEN=#0f0, BLUE=#00f")
+	}
+	wantQN := "scope:enum:Color.java:Color"
+	if en.QualifiedName != wantQN {
+		t.Fatalf("QualifiedName = %q, want %q", en.QualifiedName, wantQN)
+	}
+}
+
+func TestJavaEnumValueSet_NumericConstructorValue(t *testing.T) {
+	recs := extractJavaForEnum(t, "Planet.java", `
+public enum Planet {
+    MERCURY(1),
+    VENUS(2);
+    Planet(int order) {}
+}
+`)
+	en := findJavaEnum(recs, "Planet")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Planet value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "MERCURY=1, VENUS=2" {
+		t.Fatalf("values = %q, want %q", got, "MERCURY=1, VENUS=2")
+	}
+}
+
+// Negative: a plain class is not an enum value-set.
+func TestJavaEnumValueSet_NonEnumClass(t *testing.T) {
+	recs := extractJavaForEnum(t, "Foo.java", `
+public class Foo { private int x; }
+`)
+	if en := findJavaEnum(recs, "Foo"); en != nil {
+		t.Fatal("non-enum class Foo should NOT produce a SCOPE.Enum node")
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -336,6 +336,12 @@ func walk(
 			// them as CONTAINS children with type metadata.
 			subtype = "record"
 		}
+		if node.Type() == "enum_declaration" {
+			// Value-carrying SCOPE.Enum value-set node (data-model #3628).
+			if vs, vok := buildJavaEnumValueSet(node, file); vok {
+				*out = append(*out, vs)
+			}
+		}
 		rec, ok := buildComponent(node, file, subtype, pkgName)
 		if ok {
 			// Issue #1996 — emit EXTENDS / IMPLEMENTS edges so the docgen

--- a/internal/extractors/javascript/enum_valueset.go
+++ b/internal/extractors/javascript/enum_valueset.go
@@ -1,0 +1,155 @@
+package javascript
+
+// enum_valueset.go — value-carrying SCOPE.Enum value-set nodes for TypeScript
+// (data-model, epic #3628 / completes #3806). Reuses the shared cross-language
+// builder in internal/extractor (EnumEntity / EnumMember / StripLiteralQuotes)
+// so TS enums and string-literal unions converge on the same node model as
+// Python, C#, Java, Go and Rails.
+//
+// Two TS constructs map to a value-set:
+//
+//   - `enum Status { Active = 'active', Inactive = 'inactive' }` →
+//     kind_hint="ts_enum", values=[Active=active, Inactive=inactive].
+//     Numeric/implicit enums (`enum Dir { Up, Down }`) record members only —
+//     no fabricated ordinals (honest-partial).
+//   - `type Role = 'admin' | 'user'` → kind_hint="ts_literal_union",
+//     members/values are the literal arms. ONLY when EVERY arm of the union is
+//     a string/number literal; a union with any type reference
+//     (`string | Foo`) is NOT an enumerated value-set → no node.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// emitTSEnumValueSet builds the value-carrying SCOPE.Enum node for a TS
+// `enum_declaration`, capturing each member's explicit literal value when the
+// member is an `enum_assignment` with a string/number RHS.
+func (x *extractor) emitTSEnumValueSet(n *sitter.Node, name string) {
+	body := n.ChildByFieldName("body")
+	if body == nil {
+		return
+	}
+	var members []extreg.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "property_identifier", "identifier":
+			// Bare member, no explicit value (numeric/implicit enum).
+			members = append(members, extreg.EnumMember{Name: x.nodeText(ch)})
+		case "enum_assignment":
+			mn := ch.ChildByFieldName("name")
+			mname := x.nodeText(mn)
+			if mname == "" {
+				if first := ch.Child(0); first != nil {
+					mname = x.nodeText(first)
+				}
+			}
+			if mname == "" {
+				continue
+			}
+			mval := ""
+			if v := ch.ChildByFieldName("value"); v != nil {
+				if lit := tsLiteralValue(v, x); lit != "" {
+					mval = lit
+				}
+			} else {
+				// Fall back to the last named child after the `=`.
+				for j := int(ch.ChildCount()) - 1; j >= 0; j-- {
+					c := ch.Child(j)
+					if c != nil && c.IsNamed() && c.Type() != "property_identifier" {
+						if lit := tsLiteralValue(c, x); lit != "" {
+							mval = lit
+						}
+						break
+					}
+				}
+			}
+			members = append(members, extreg.EnumMember{Name: mname, Value: mval})
+		}
+	}
+	start, end := lines(n)
+	if ent, ok := extreg.EnumEntity(name, x.language, "ts_enum", x.filePath, start, end, members); ok {
+		x.entities = append(x.entities, ent)
+	}
+}
+
+// emitTSLiteralUnionValueSet builds a SCOPE.Enum node for a string/number
+// literal union type alias (`type Role = 'admin' | 'user'`). It emits a node
+// ONLY when the RHS is a union_type whose EVERY arm is a literal_type wrapping
+// a string/number literal. Any non-literal arm (type reference, predefined
+// type, object type) disqualifies the alias — it is not an enumerated value-set.
+func (x *extractor) emitTSLiteralUnionValueSet(n *sitter.Node, name string) {
+	valueNode := n.ChildByFieldName("value")
+	if valueNode == nil || valueNode.Type() != "union_type" {
+		return
+	}
+	// A multi-arm union is left-nested by the grammar:
+	//   `a | b | c` → union_type(union_type(a, b), c). Flatten recursively;
+	// any non-literal arm disqualifies the whole alias (ok=false).
+	var members []extreg.EnumMember
+	if !collectUnionLiterals(valueNode, x, &members) || len(members) < 1 {
+		return
+	}
+	start, end := lines(n)
+	if ent, ok := extreg.EnumEntity(name, x.language, "ts_literal_union", x.filePath, start, end, members); ok {
+		x.entities = append(x.entities, ent)
+	}
+}
+
+// collectUnionLiterals flattens a (possibly left-nested) union_type, appending
+// one EnumMember per literal arm. It returns false the moment it encounters a
+// non-literal arm (type reference, predefined type, object type) so the caller
+// emits no value-set node for a non-enumerated union.
+func collectUnionLiterals(u *sitter.Node, x *extractor, out *[]extreg.EnumMember) bool {
+	for i := 0; i < int(u.ChildCount()); i++ {
+		arm := u.Child(i)
+		if arm == nil || !arm.IsNamed() {
+			continue
+		}
+		switch arm.Type() {
+		case "union_type":
+			if !collectUnionLiterals(arm, x, out) {
+				return false
+			}
+		case "literal_type":
+			lit := tsLiteralValue(arm, x)
+			if lit == "" {
+				return false
+			}
+			*out = append(*out, extreg.EnumMember{Name: lit, Value: lit})
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// tsLiteralValue returns the statically-known literal text of a TS value node
+// (string / number / unary minus number), with surrounding quotes stripped.
+// Returns "" for non-literal nodes so callers can treat that as "not a literal".
+func tsLiteralValue(n *sitter.Node, x *extractor) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "literal_type":
+		// Unwrap to the inner literal node.
+		if c := n.NamedChild(0); c != nil {
+			return tsLiteralValue(c, x)
+		}
+		return ""
+	case "string":
+		return extreg.StripLiteralQuotes(x.nodeText(n))
+	case "number":
+		return x.nodeText(n)
+	case "unary_expression":
+		// e.g. -1
+		return x.nodeText(n)
+	}
+	return ""
+}

--- a/internal/extractors/javascript/enum_valueset_test.go
+++ b/internal/extractors/javascript/enum_valueset_test.go
@@ -1,0 +1,115 @@
+package javascript_test
+
+// enum_valueset_test.go — value-asserting tests for the TypeScript SCOPE.Enum
+// value-set node (data-model, epic #3628 / completes #3806). Asserts the enum
+// node id + specific member values, not merely a non-empty member list.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func findTSEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestTSEnumValueSet_StringValues(t *testing.T) {
+	src := []byte(`enum Status { Active = 'active', Inactive = 'inactive' }`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	en := findTSEnum(recs, "Status")
+	if en == nil {
+		t.Fatalf("SCOPE.Enum:Status value-set node not found; names: %v", entityNames(recs))
+	}
+	if got := en.Properties["kind_hint"]; got != "ts_enum" {
+		t.Fatalf("kind_hint = %q, want ts_enum", got)
+	}
+	if got := en.Properties["values"]; got != "Active=active, Inactive=inactive" {
+		t.Fatalf("values = %q, want %q", got, "Active=active, Inactive=inactive")
+	}
+	wantQN := "scope:enum:" + en.SourceFile + ":Status"
+	if en.QualifiedName != wantQN {
+		t.Fatalf("QualifiedName = %q, want %q", en.QualifiedName, wantQN)
+	}
+}
+
+func TestTSEnumValueSet_ImplicitMembers(t *testing.T) {
+	src := []byte(`enum Dir { Up, Down, Left, Right }`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	en := findTSEnum(recs, "Dir")
+	if en == nil {
+		t.Fatalf("SCOPE.Enum:Dir value-set node not found")
+	}
+	if got := en.Properties["members"]; got != "Up, Down, Left, Right" {
+		t.Fatalf("members = %q, want %q", got, "Up, Down, Left, Right")
+	}
+	// Implicit numeric enum → no fabricated ordinals.
+	if got, ok := en.Properties["values"]; ok {
+		t.Fatalf("values should be absent for implicit members, got %q", got)
+	}
+}
+
+func TestTSEnumValueSet_NumericExplicit(t *testing.T) {
+	src := []byte(`enum Level { Low = 1, High = 2 }`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	en := findTSEnum(recs, "Level")
+	if en == nil {
+		t.Fatalf("SCOPE.Enum:Level value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "Low=1, High=2" {
+		t.Fatalf("values = %q, want %q", got, "Low=1, High=2")
+	}
+}
+
+func TestTSLiteralUnionValueSet(t *testing.T) {
+	src := []byte(`type Role = 'admin' | 'user' | 'guest';`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	en := findTSEnum(recs, "Role")
+	if en == nil {
+		t.Fatalf("SCOPE.Enum:Role value-set node not found; names: %v", entityNames(recs))
+	}
+	if got := en.Properties["kind_hint"]; got != "ts_literal_union" {
+		t.Fatalf("kind_hint = %q, want ts_literal_union", got)
+	}
+	if got := en.Properties["members"]; got != "admin, user, guest" {
+		t.Fatalf("members = %q, want %q", got, "admin, user, guest")
+	}
+	if got := en.Properties["values"]; got != "admin=admin, user=user, guest=guest" {
+		t.Fatalf("values = %q, want %q", got, "admin=admin, user=user, guest=guest")
+	}
+}
+
+// Negative: a union with any type reference is not an enumerated value-set.
+func TestTSMixedUnion_NoEnum(t *testing.T) {
+	src := []byte(`type Mixed = string | Foo;`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	if en := findTSEnum(recs, "Mixed"); en != nil {
+		t.Fatalf("Mixed should NOT produce a SCOPE.Enum value-set node")
+	}
+}
+
+// Negative: a plain non-enum type alias produces no value-set node.
+func TestTSPlainAlias_NoEnum(t *testing.T) {
+	src := []byte(`type ID = string;`)
+	tree := parseTS(t, src)
+	recs := extract(t, src, "typescript", tree)
+
+	if en := findTSEnum(recs, "ID"); en != nil {
+		t.Fatalf("plain alias ID should NOT produce a SCOPE.Enum value-set node")
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1392,6 +1392,10 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 	}
 	e.ID = e.ComputeID()
 	x.entities = append(x.entities, e)
+
+	// A string/number literal-union alias (`type Role = 'admin' | 'user'`) is an
+	// enumerated value-set; emit a SCOPE.Enum node alongside (data-model #3628).
+	x.emitTSLiteralUnionValueSet(n, name)
 }
 
 // handleEnumDeclaration handles TypeScript enum declarations: enum Direction { Up, Down }
@@ -1437,6 +1441,9 @@ func (x *extractor) handleEnumDeclaration(n *sitter.Node) {
 	}
 
 	x.emitWithProps(name, "SCOPE.Schema", n, "enum", fmt.Sprintf("enum %s", name), props, nil)
+
+	// Value-carrying SCOPE.Enum value-set node (data-model, epic #3628).
+	x.emitTSEnumValueSet(n, name)
 }
 
 // handleVariableDeclaration handles: const/let foo = (...) => {...} or = function(...) {...}

--- a/internal/extractors/ruby/enum_valueset.go
+++ b/internal/extractors/ruby/enum_valueset.go
@@ -1,0 +1,215 @@
+package ruby
+
+// enum_valueset.go — value-carrying SCOPE.Enum value-set nodes for Rails
+// ActiveRecord `enum` declarations (data-model, epic #3628 / completes #3806).
+// Reuses the shared cross-language builder in internal/extractor (EnumEntity /
+// EnumMember / StripLiteralQuotes) so Rails enums converge on the same node
+// model as Python, C#, TS, Java and Go.
+//
+// Recognised forms (class-body `call` nodes whose method identifier is `enum`):
+//
+//	enum status: { active: 0, archived: 1 }   # hash → members WITH values
+//	enum status: [:active, :archived]         # array → members, value-less
+//	enum :status, { active: 0 }               # Rails 7 positional name form
+//
+// The enum's NAME is the attribute (`status`); its MEMBERS are the hash keys /
+// array symbols, and member values are the hash values when statically known.
+// Honest-partial: a dynamic argument (a method call, a constant reference) is
+// skipped — only literal hash/array forms produce a node.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildRailsEnumValueSet inspects a `call` node and, when it is a Rails
+// `enum <name>: {...}` / `enum <name>: [...]` / `enum :<name>, {...}`
+// declaration, returns the SCOPE.Enum value-set node for it.
+func buildRailsEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	if node == nil || node.Type() != "call" {
+		return types.EntityRecord{}, false
+	}
+	if !rubyCallIsNamed(node, file.Content, "enum") {
+		return types.EntityRecord{}, false
+	}
+	args := node.ChildByFieldName("arguments")
+	if args == nil {
+		args = firstChildOfType(node, "argument_list")
+	}
+	if args == nil {
+		return types.EntityRecord{}, false
+	}
+
+	enumName, valueNode := railsEnumNameAndValues(args, file.Content)
+	if enumName == "" || valueNode == nil {
+		return types.EntityRecord{}, false
+	}
+
+	members := railsEnumMembers(valueNode, file.Content)
+	return extractor.EnumEntity(
+		enumName, "ruby", "rails_enum", file.Path,
+		int(node.StartPoint().Row)+1, int(node.EndPoint().Row)+1, members,
+	)
+}
+
+// railsEnumNameAndValues extracts the enum attribute name and the node holding
+// its members from a `enum` call's argument_list. Handles both the
+// `status: {...}` pair form and the `:status, {...}` positional form.
+func railsEnumNameAndValues(args *sitter.Node, src []byte) (string, *sitter.Node) {
+	// Pair form: `enum status: { ... }` → a single `pair` argument.
+	if pair := firstChildOfType(args, "pair"); pair != nil {
+		key := pairKeyName(pair, src)
+		val := pairValueNode(pair)
+		if key != "" && (nodeIsHashOrArray(val)) {
+			return key, val
+		}
+	}
+	// Positional form: `enum :status, { ... }` → simple_symbol then hash/array.
+	var name string
+	var values *sitter.Node
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil || !ch.IsNamed() {
+			continue
+		}
+		switch ch.Type() {
+		case "simple_symbol":
+			if name == "" {
+				name = trimLeadingColon(nodeText(ch, src))
+			}
+		case "hash", "array":
+			if values == nil {
+				values = ch
+			}
+		}
+	}
+	if name != "" && values != nil {
+		return name, values
+	}
+	return "", nil
+}
+
+// railsEnumMembers builds EnumMembers from a hash (`{ active: 0 }`) or array
+// (`[:active, :archived]`) value node.
+func railsEnumMembers(val *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	switch val.Type() {
+	case "hash":
+		for i := 0; i < int(val.ChildCount()); i++ {
+			pair := val.Child(i)
+			if pair == nil || pair.Type() != "pair" {
+				continue
+			}
+			key := pairKeyName(pair, src)
+			if key == "" {
+				continue
+			}
+			mval := ""
+			if v := pairValueNode(pair); v != nil {
+				mval = railsLiteral(v, src)
+			}
+			members = append(members, extractor.EnumMember{Name: key, Value: mval})
+		}
+	case "array":
+		for i := 0; i < int(val.ChildCount()); i++ {
+			el := val.Child(i)
+			if el == nil || !el.IsNamed() {
+				continue
+			}
+			switch el.Type() {
+			case "simple_symbol":
+				members = append(members, extractor.EnumMember{Name: trimLeadingColon(nodeText(el, src))})
+			case "string":
+				members = append(members, extractor.EnumMember{Name: extractor.StripLiteralQuotes(nodeText(el, src))})
+			}
+		}
+	}
+	return members
+}
+
+// railsLiteral returns the statically-known literal value of a hash value node,
+// or "" for non-literal values (honest-partial).
+func railsLiteral(n *sitter.Node, src []byte) string {
+	switch n.Type() {
+	case "integer", "float":
+		return nodeText(n, src)
+	case "string":
+		return extractor.StripLiteralQuotes(nodeText(n, src))
+	case "simple_symbol":
+		return trimLeadingColon(nodeText(n, src))
+	}
+	return ""
+}
+
+// --- small node helpers (local to this file) ---------------------------------
+
+func rubyCallIsNamed(call *sitter.Node, src []byte, name string) bool {
+	if m := call.ChildByFieldName("method"); m != nil {
+		return nodeText(m, src) == name
+	}
+	// Command form: first identifier child is the method name.
+	if id := firstChildOfType(call, "identifier"); id != nil {
+		return nodeText(id, src) == name
+	}
+	return false
+}
+
+func pairKeyName(pair *sitter.Node, src []byte) string {
+	if k := pair.ChildByFieldName("key"); k != nil {
+		return trimLeadingColon(nodeText(k, src))
+	}
+	if k := firstChildOfType(pair, "hash_key_symbol"); k != nil {
+		return nodeText(k, src)
+	}
+	if k := firstChildOfType(pair, "simple_symbol"); k != nil {
+		return trimLeadingColon(nodeText(k, src))
+	}
+	return ""
+}
+
+func pairValueNode(pair *sitter.Node) *sitter.Node {
+	if v := pair.ChildByFieldName("value"); v != nil {
+		return v
+	}
+	// Fall back to the last named child (after the key).
+	for i := int(pair.ChildCount()) - 1; i >= 0; i-- {
+		ch := pair.Child(i)
+		if ch != nil && ch.IsNamed() && ch.Type() != "hash_key_symbol" {
+			return ch
+		}
+	}
+	return nil
+}
+
+func nodeIsHashOrArray(n *sitter.Node) bool {
+	return n != nil && (n.Type() == "hash" || n.Type() == "array")
+}
+
+func trimLeadingColon(s string) string {
+	if len(s) > 0 && s[0] == ':' {
+		return s[1:]
+	}
+	return s
+}
+
+func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch != nil && ch.Type() == typ {
+			return ch
+		}
+	}
+	return nil
+}
+
+func nodeText(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	return string(src[n.StartByte():n.EndByte()])
+}

--- a/internal/extractors/ruby/enum_valueset_test.go
+++ b/internal/extractors/ruby/enum_valueset_test.go
@@ -1,0 +1,99 @@
+package ruby_test
+
+// enum_valueset_test.go — value-asserting tests for the Rails SCOPE.Enum
+// value-set node (data-model, epic #3628 / completes #3806).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractRubyForEnum(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("ruby")
+	if !ok {
+		t.Fatal("ruby extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "ruby", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func findRubyEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestRailsEnumValueSet_HashValues(t *testing.T) {
+	recs := extractRubyForEnum(t, "order.rb", `class Order < ApplicationRecord
+  enum status: { active: 0, archived: 1 }
+end`)
+	en := findRubyEnum(recs, "status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:status value-set node not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "rails_enum" {
+		t.Fatalf("kind_hint = %q, want rails_enum", got)
+	}
+	if got := en.Properties["values"]; got != "active=0, archived=1" {
+		t.Fatalf("values = %q, want %q", got, "active=0, archived=1")
+	}
+	wantQN := "scope:enum:order.rb:status"
+	if en.QualifiedName != wantQN {
+		t.Fatalf("QualifiedName = %q, want %q", en.QualifiedName, wantQN)
+	}
+}
+
+func TestRailsEnumValueSet_ArraySymbols(t *testing.T) {
+	recs := extractRubyForEnum(t, "task.rb", `class Task < ApplicationRecord
+  enum priority: [:low, :medium, :high]
+end`)
+	en := findRubyEnum(recs, "priority")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:priority value-set node not found")
+	}
+	if got := en.Properties["members"]; got != "low, medium, high" {
+		t.Fatalf("members = %q, want %q", got, "low, medium, high")
+	}
+	// Array form has no explicit values.
+	if got, ok := en.Properties["values"]; ok {
+		t.Fatalf("values should be absent for array symbols, got %q", got)
+	}
+}
+
+func TestRailsEnumValueSet_PositionalName(t *testing.T) {
+	recs := extractRubyForEnum(t, "post.rb", `class Post < ApplicationRecord
+  enum :state, { draft: 0, published: 1 }
+end`)
+	en := findRubyEnum(recs, "state")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:state value-set node not found")
+	}
+	if got := en.Properties["values"]; got != "draft=0, published=1" {
+		t.Fatalf("values = %q, want %q", got, "draft=0, published=1")
+	}
+}
+
+// Negative: a non-enum DSL call produces no value-set node.
+func TestRailsEnumValueSet_NonEnumCall_NoNode(t *testing.T) {
+	recs := extractRubyForEnum(t, "user.rb", `class User < ApplicationRecord
+  validates :email, presence: true
+end`)
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" {
+			t.Fatalf("non-enum call should NOT produce a SCOPE.Enum node, got %q", recs[i].Name)
+		}
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -97,6 +97,13 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 			}
 		}
 		if body != nil {
+			// Rails ActiveRecord `enum status: {...}` declarations → value-set
+			// SCOPE.Enum nodes (data-model, epic #3628).
+			for i := range body.ChildCount() {
+				if vs, vok := buildRailsEnumValueSet(body.Child(int(i)), file); vok {
+					*out = append(*out, vs)
+				}
+			}
 			before := len(*out)
 			for i := range body.ChildCount() {
 				walk(body.Child(int(i)), file, out)


### PR DESCRIPTION
Closes #3810. Child of epic #3628 (data-model). Completes the enum/value-set follow-up that wave-11 PR #3807 left open.

## What
PR #3807 built the shared cross-language enum value-set builder (`internal/extractor/enum_valueset.go` — `EnumEntity`/`EnumMember`/`EnumQualifiedName`/`StripLiteralQuotes`, `SCOPE.Enum` kind, `TYPED_AS` rel) and wired Python + C#. This PR reuses that builder verbatim for four more languages so every language emits the identical node shape: `values` = "Name=Literal" pairs, `members`, `member_count`, `kind_hint`, `QualifiedName = scope:enum:<file>:<Name>`.

| Lang | File | Construct | kind_hint |
|---|---|---|---|
| TS | `internal/extractors/javascript/enum_valueset.go` | `enum` + string-literal union `type Role='admin'\|'user'` | `ts_enum` / `ts_literal_union` |
| Java | `internal/extractors/java/enum_valueset.go` | `enum {A,B}` + ctor-arg `RED("#f00")` | `java_enum` |
| Go | `internal/extractors/golang/enum_valueset.go` | const block typed by same-file named type (`type Status int; const(...iota)`) | `go_iota` |
| Rails | `internal/extractors/ruby/enum_valueset.go` | AR `enum status: {active:0}` / `[:active]` / positional `enum :status,{...}` | `rails_enum` |

## Honest-partial
- TS unions with any non-literal arm (`string\|Foo`) emit NO node.
- Go iota members are value-less (no fabricated ordinals); const blocks typed only by a builtin / untyped are skipped.
- Java non-literal constructor args, Rails dynamic args -> member kept, value omitted.

## Asserted enum nodes + values (value-asserting tests, not len>0)
- TS `enum Status{Active='active',Inactive='inactive'}` -> `SCOPE.Enum:Status` values `Active=active, Inactive=inactive`; `enum Level{Low=1,High=2}` -> `Low=1, High=2`; `type Role='admin'|'user'|'guest'` -> `SCOPE.Enum:Role` (ts_literal_union) values `admin=admin, user=user, guest=guest`; negatives `type Mixed=string|Foo`, `type ID=string` -> no node.
- Java `enum Status{ACTIVE,INACTIVE,PENDING}` -> members in order; `enum Color{RED("#f00"),GREEN("#0f0"),BLUE("#00f")}` -> `RED=#f00, GREEN=#0f0, BLUE=#00f`; `Planet{MERCURY(1),VENUS(2)}` -> `MERCURY=1, VENUS=2`; negative non-enum class -> no node.
- Go `type Status int; const(Active=iota;Inactive;Pending)` -> members `Active, Inactive, Pending` value-less; `type Color string; const(Red="red";...)` -> `Red=red, Green=green, Blue=blue`; `type Level int; const(Low=1;High=2)` -> `Low=1, High=2`; negatives untyped/builtin-typed const -> no node.
- Rails `enum status:{active:0,archived:1}` -> `SCOPE.Enum:status` values `active=0, archived=1`; `enum priority:[:low,:medium,:high]` -> members value-less; `enum :state,{draft:0,published:1}` -> `draft=0, published=1`; negative `validates ...` -> no node.

## Coverage
- go (`lang.go.framework.gin`), ruby (`lang.ruby.framework.rails`): `not_applicable` -> `partial` (the prior "Go/Ruby extracts no enum constructs" claim is now false).
- java (`lang.java.framework.spring-boot`), jsts (`lang.jsts.framework.nestjs`): cites + notes refreshed to the value-set node; status stays `full`.
- `coverage validate` exit 0 (warnings only, pre-existing), `coverage fmt --check` canonical, docs regenerated via `coverage gen`.

## Verification
`go test` green for javascript/java/golang/ruby/extractor/python/csharp/types; `gofmt -l` empty; `go vet` clean.

DEPLOY-DEFERRED — requires a coordinated live-daemon rebuild + reindex before the new SCOPE.Enum nodes appear in served graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)