### PR TITLE
feat(graphql): code-first schema type→type graph (completes #3804)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -29,10 +29,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/5 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/5 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/5 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/3 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/5 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
@@ -59,7 +59,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/5 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/5 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 6/11 | |
@@ -72,10 +72,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/12 | |
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [JS/TS](../by-language/jsts.md) | [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [JS/TS](../by-language/jsts.md) | [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
-| [JS/TS](../by-language/jsts.md) | [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [JS/TS](../by-language/jsts.md) | [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [lua](../by-language/lua.md) | [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/5 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
 | [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/5 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/5 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
@@ -86,7 +86,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 10/11 | |
-| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
@@ -94,8 +94,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/11 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
-| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/14 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | 🟡 4/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
@@ -103,7 +103,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 5/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
-| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
@@ -111,7 +111,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
@@ -122,7 +122,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/4 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
-| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
@@ -133,10 +133,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
 | [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/13 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/5 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 
 
 ## JVM Backend

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/5 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/5 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/5 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/3 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/5 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -41,7 +41,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/5 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/5 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/5 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -36,10 +36,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [NestJS](../detail/lang.jsts.framework.nestjs.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 10/12 | |
 | [Polka](../detail/lang.jsts.framework.polka.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [Pothos (GraphQL)](../detail/lang.jsts.framework.pothos.md) | 🟡 2/4 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [Restify](../detail/lang.jsts.framework.restify.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Sails](../detail/lang.jsts.framework.sails.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
-| [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [TypeGraphQL (GraphQL)](../detail/lang.jsts.framework.type-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -32,7 +32,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 10/11 | |
-| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
@@ -40,7 +40,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/5 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 8/11 | |
 | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/5 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/12 | |
+| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/14 | |
 | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Django](../detail/lang.python.framework.django.md) | 🟡 4/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
@@ -34,7 +34,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 5/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
-| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
 | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
@@ -42,7 +42,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -34,7 +34,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 3/5 | ✅ 1/1 | — | ✅ 1/1 | 🟡 23/25 | 🟡 8/12 | |
 | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/5 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/12 | |
 | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/4 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 5/10 | |
-| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/12 | |
+| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/5 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -36,7 +36,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
 | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/5 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/13 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/5 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/5 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
 

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/5 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | low-level network/event library; no HTTP middleware pipeline |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/restinio_middleware.go` | non_matched_request_handler, make_chain<H1,H2,...>, request_handler chaining detected; regex/partial |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-28` | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | app.UseMiddleware<T> typed registrations, inline app.Use() lambda middleware, IMiddleware class + InvokeAsync detection, [ServiceFilter]/[TypeFilter]/IActionFilter-based MVC filter coverage. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | Carter app.MapCarter()/AddCarter() pipeline wiring detected; ICarterModule.AddRoutes already covers route registration. Middleware wiring is the AddCarter/MapCarter registration surface. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | FastEndpoints AddFastEndpoints()/UseFastEndpoints() pipeline wiring and IGlobalPreProcessor/IGlobalPostProcessor/IPreProcessor/IPostProcessor class declarations detected. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
+++ b/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | NancyFX DefaultNancyBootstrapper subclass, RequestStartup/ApplicationStartup overrides, and this.Before += / this.After += module pipeline hook registrations detected. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/csharp/middleware_extra.go`<br>`internal/custom/csharp/middleware_extra_test.go` | ServiceStack AppHostBase subclass, Plugins.Add<T>(), GlobalRequestFilters.Add, and Pre/PostResponseFilters pipeline registration patterns detected. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/substrate/taint_sites_elixir.go` | Absinthe.Middleware.* module uses detected via engine YAML; plug pipeline middleware tracked via taint substrate |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | Ash is a resource/action framework without HTTP middleware; middleware layer handled by Plug/Phoenix integration |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | Bandit is a raw HTTP/2 server with no middleware pipeline; pipeline is Plug-layer concern |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/substrate/taint_sites_elixir.go` | Cowboy middleware defined via stream_handlers; taint substrate tracks conn access patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.finch.md
+++ b/docs/coverage/detail/lang.elixir.framework.finch.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.guardian.md
+++ b/docs/coverage/detail/lang.elixir.framework.guardian.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/elixir/phoenix.go` | phoenixExtractor parses pipeline :name do...end blocks into ordered plug chains (plug_chain, plug_order per step) and binds scopes to pipelines via pipe_through [:a,:b]; module + function plugs captured. Tests assert exact :browser chain order + protect_from_forgery index + pipe_through 'api -> auth' binding. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/elixir/plug.go` | plugExtractor captures the ordered Plug.Builder/Plug.Router plug chain with plug_order per step (plug :name and plug Module). Test asserts Plug.Logger order 0 within builder chain. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.req.md
+++ b/docs/coverage/detail/lang.elixir.framework.req.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.tesla.md
+++ b/docs/coverage/detail/lang.elixir.framework.tesla.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | 3511 | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | BaseUrl/JSON Tesla plug middleware parsed for base-url only; full middleware-chain modeling pending (#3511) |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-06-02` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/route_middleware.go`<br>`internal/custom/golang/route_middleware_test.go` | balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -> group .Group args/.Use -> inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger<CORS<RateLimit; group AuthRequired<Logger; echo trailing handler dropped; chi engine Logger<Recoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order). |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-06-02` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/route_middleware.go`<br>`internal/custom/golang/route_middleware_test.go` | balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -> group .Group args/.Use -> inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger<CORS<RateLimit; group AuthRequired<Logger; echo trailing handler dropped; chi engine Logger<Recoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order). |
 | Rate limit stamping | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/custom/golang/echo.go`<br>`internal/custom/golang/gin.go`<br>`internal/custom/golang/rate_limit_route.go`<br>`internal/custom/golang/rate_limit_route_test.go` | tollbooth / ulule-limiter / golang.org/x/time/rate: a limiter applied as route/group/engine middleware stamps rate_limited/rate_limit_scope(route|group|engine)/rate_limit_source on the route op; a rate.NewLimiter(rate.Limit(N),burst) or tollbooth NewLimiter/SetMax(N) literal resolves rate="N/s". Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter constructed but never applied to a route is not stamped. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | balanced .Use(...) chain parser with paren-depth tracking; one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...); string-literal mount prefix skipped; fixture-driven tests per framework |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.fx.md
+++ b/docs/coverage/detail/lang.go.framework.fx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3628 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-06-02` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/route_middleware.go`<br>`internal/custom/golang/route_middleware_test.go` | balanced .Use(...) chain parser with paren-depth tracking emits one SCOPE.Pattern per middleware in registration order (mw_order 0,1,2,...). #3628 child: route_middleware.go ALSO binds the ORDERED chain to each route op (SCOPE.Operation/endpoint) via middleware_chain (JSON [{name,expr,scope,order,auth_kind?}], outermost-first: engine .Use -> group .Group args/.Use -> inline route mw), plus middleware_count/middleware_names (chain order)/middleware_scope (engine|group|route, +-joined). Answers 'what middleware runs before this route, in order' at endpoint granularity, at parity with the JS/TS http_endpoint_jsts_middleware pass (#2853). Auth middleware appears IN the chain (auth_kind set) not double-modeled; it remains separately stamped by route_auth.go (#3734). Value-asserting tests assert middleware identity AND relative order index (Logger<CORS<RateLimit; group AuthRequired<Logger; echo trailing handler dropped; chi engine Logger<Recoverer). Honest-partial: dynamically/spread-built chains and chi closure-subrouter group .Use are skipped (no fabricated order). |
 | Rate limit stamping | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/custom/golang/echo.go`<br>`internal/custom/golang/gin.go`<br>`internal/custom/golang/rate_limit_route.go`<br>`internal/custom/golang/rate_limit_route_test.go` | tollbooth / ulule-limiter / golang.org/x/time/rate: a limiter applied as route/group/engine middleware stamps rate_limited/rate_limit_scope(route|group|engine)/rate_limit_source on the route op; a rate.NewLimiter(rate.Limit(N),burst) or tollbooth NewLimiter/SetMax(N) literal resolves rate="N/s". Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter constructed but never applied to a route is not stamped. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/go_zero.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | gorilla-mux .Use() chain scanned via shared middleware_auth_extend pass; one SCOPE.Pattern per middleware in registration order (mw_order); TestGorillaMuxMiddlewareAuthExtend proves ordering + auth classification |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3613 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/extractors/graphql/graphql.go`<br>`internal/extractors/graphql/type_graph.go` | gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphql files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) already emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/huma.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/kratos.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.wire.md
+++ b/docs/coverage/detail/lang.go.framework.wire.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3628 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/adonisjs_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/express_middleware.ts` | — |
 | Rate limit stamping | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/engine/http_endpoint_jsts_ratelimit.go`<br>`internal/engine/http_endpoint_jsts_ratelimit_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | express-rate-limit / express-slow-down: resolves windowMs+max to a human rate and stamps rate_limited/rate_limit/rate_limit_scope (route|app)/rate_limit_source on the endpoint op. Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter defined but never applied to a route is not stamped. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/fastify_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/feathers_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/hapi_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/hono_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/koa_middleware.ts` | — |
 | Rate limit stamping | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/engine/http_endpoint_jsts_ratelimit.go`<br>`internal/engine/http_endpoint_jsts_ratelimit_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | express-rate-limit / express-slow-down: resolves windowMs+max to a human rate and stamps rate_limited/rate_limit/rate_limit_scope (route|app)/rate_limit_source on the endpoint op. Imported/config-driven limiters → rate_limited=true with rate omitted (honest-partial). Negative: a limiter defined but never applied to a route is not stamped. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/marblejs_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/nestjs_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/polka_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.pothos.md
+++ b/docs/coverage/detail/lang.jsts.framework.pothos.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3619 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/graphql_codefirst_typegraph.go`<br>`internal/custom/javascript/graphql_codefirst_typegraph_test.go` | Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef("graphql",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. TypeGraphQL @Field(() => [Order]) thunk + Nexus t.list.field({type}) + Pothos t.field({type:[...]}) resolved. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/restify_middleware.ts` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 49
+- **Capability cells:** 50
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | Sails does not attach middleware to individual endpoints; its global middleware pipeline is the declarative `order` array under `middleware` in config/http.js. Covered by the framework_specific Middleware Pipeline / middleware_order_recognition cell (ParseSailsMiddlewareOrder). |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.type-graphql.md
+++ b/docs/coverage/detail/lang.jsts.framework.type-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3619 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/graphql_codefirst_typegraph.go`<br>`internal/custom/javascript/graphql_codefirst_typegraph_test.go` | Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef("graphql",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. TypeGraphQL @Field(() => [Order]) thunk + Nexus t.list.field({type}) + Pothos t.field({type:[...]}) resolved. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.lua.framework.apisix.md
+++ b/docs/coverage/detail/lang.lua.framework.apisix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.lua.framework.kong.md
+++ b/docs/coverage/detail/lang.lua.framework.kong.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/lua/middleware.go` | Lapis middleware chain: before_filter/app:before (phase=before) + app:after filters with chain_index ordering, error_handler/on_error, lapis.flow pipeline. value-asserting tests in extractors_test.go. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/lua/middleware.go` | OpenResty middleware chain: nginx phase directives (init/init_worker/rewrite/access/content/header_filter/body_filter/log _by_lua) emitted with chain_index (textual order) + phase_order (canonical request-lifecycle rank) so the ordered chain is reconstructable; Kong plugin handler phases. value-asserting test TestLuaMiddlewareOrdering asserts specific phase_order ranks. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.api-platform.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route ->middleware() attachment and ->withoutMiddleware() exclusion |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.lighthouse.md
+++ b/docs/coverage/detail/lang.php.framework.lighthouse.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/php/symfony.go` | EventSubscriberInterface implementors with getSubscribedEvents() event name extraction; addListener/addSubscriber kernel event registration; kernel event names emitted as SCOPE.Pattern |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.ariadne.md
+++ b/docs/coverage/detail/lang.python.framework.ariadne.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 53
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-06-02` | — | `internal/engine/django_imports_rewrite.go`<br>`internal/engine/http_endpoint_python_middleware.go` | Django import rewriting covers stock middleware by class-name. #3628: applyPythonMiddlewareCoverage now BINDS DRF view permission_classes/authentication_classes/throttle_classes as the view-scope middleware_chain on the ViewSet's router-registered endpoints (same-file ViewSet, bound by router.register prefix), per the cross-stack {name,expr,scope,order,auth_kind?} contract; permission/authentication classes carry auth_kind=auth. Still partial: cross-file ViewSet (views.py separate from urls.py) is not joined; settings-level DEFAULT_*_CLASSES not parsed (honest-partial). Test: TestMiddleware_DRFView. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-06-02` | — | `internal/custom/python/django.go`<br>`internal/engine/http_endpoint_python_middleware.go` | django.go extracts *Middleware class definitions + process_* hooks. #3628: applyPythonMiddlewareCoverage now BINDS the ordered settings.MIDDLEWARE list (static list literal, declaration order) as the global-scope middleware_chain on every same-file Django route op, matching the Go (#3777) / JS-TS (#2853) endpoint contract {name,expr,scope,order,auth_kind?} (auth middleware tagged auth_kind, not double-modeled). Still partial: cross-file settings.py MIDDLEWARE (routes in urls.py, list in settings.py) is not joined; dynamically-assembled MIDDLEWARE lists are skipped (honest-partial). Tests: TestMiddleware_DjangoGlobal, TestMiddleware_DjangoDynamicSkipped. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-06-02` | — | `internal/custom/python/fastapi.go`<br>`internal/custom/python/http_middleware.go`<br>`internal/engine/http_endpoint_python_middleware.go` | @app.middleware('http') + app.add_middleware(Cls) extracted by fastapi.go/http_middleware.go. #3628: applyPythonMiddlewareCoverage now BINDS the ordered chain to ENDPOINTS — app.add_middleware as global-scope entries (outermost) + per-route dependencies=[Depends(...)] as route-scope entries (innermost) — stamping middleware_chain/count/names/scope per the cross-stack {name,expr,scope,order,auth_kind?} contract shared with Go (#3777)/JS-TS (#2853). The FastAPI route-decorator regex was hardened to tolerate nested-paren kwargs so dependencies-bearing routes synthesise. Test: TestMiddleware_FastAPIGlobalAndRoute. |
 | Rate limit stamping | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/custom/python/fastapi.go`<br>`internal/custom/python/rate_limit_endpoint.go`<br>`internal/custom/python/rate_limit_endpoint_test.go` | slowapi @limiter.limit("5/minute") stamps rate_limited/rate_limit/rate_limit_source on the route op. DRF @throttle_classes resolver (rate from a co-located custom throttle's rate attr; settings-driven built-ins → honest-partial) shared via resolvePyEndpointRateLimit. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/python/flask.go` | flask.go extracts @app.before_request / @app.after_request / @app.teardown_request / @bp.before_app_request decorators as request_hook pattern entities — these ARE Flask's middleware mechanism (no traditional middleware class in Flask; hooks are the canonical approach). Test: TestFlask_RequestHook proves before_request hook extraction with hook_type property. |
 | Rate limit stamping | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3778) | `internal/custom/python/flask.go`<br>`internal/custom/python/rate_limit_endpoint.go`<br>`internal/custom/python/rate_limit_endpoint_test.go` | flask-limiter @limiter.limit("100/hour") and django-ratelimit @ratelimit(key='ip', rate='5/m') stamp rate_limited/rate_limit/rate_limit_scope/rate_limit_source on the route op. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.graphene.md
+++ b/docs/coverage/detail/lang.python.framework.graphene.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/custom/python/graphql_codefirst_typegraph.go`<br>`internal/custom/python/graphql_codefirst_typegraph_test.go` | Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef("graphql",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. Strawberry orders: list["Order"] / graphene List(lambda: Order) + Field(Account) resolved; graphene Query/Mutation roots excluded as owners. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/custom/python/graphql_codefirst_typegraph.go`<br>`internal/custom/python/graphql_codefirst_typegraph_test.go` | Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef("graphql",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. Strawberry orders: list["Order"] / graphene List(lambda: Order) + Field(Account) resolved; graphene Query/Mutation roots excluded as owners. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Rack use and Cuba before/after blocks. Part of #3282. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | — `not_applicable` | — | — | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Rack use, Rails before/after_action, Grape before/after hooks, Sinatra before/after blocks, Roda plugins, Cuba before/after. Part of #3282. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
+++ b/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | 3621 | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Rack use via Hanami::Application, config.middleware.use. Part of #3282. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Rack use, config.middleware.use, Padrino before/after blocks. Part of #3282. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/ruby/middleware.go`<br>`internal/custom/ruby/middleware_test.go` | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Roda plugin :name declarations and Rack use. Part of #3282. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 48
+- **Capability cells:** 49
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/middleware.go`<br>`internal/custom/ruby/middleware_test.go`<br>`internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go` | Covers: use Rack::X Rack middleware, before do / after do filters, before '/path' do scoped filters, helpers do blocks, custom Rack middleware class detection (initialize(app)+call(env)). Full idiomatic Sinatra middleware surface. Closes #3344. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | custom Transform<S,ServiceRequest> impls + .wrap() registrations captured with middleware_name/middleware_trait |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.async-graphql.md
+++ b/docs/coverage/detail/lang.rust.framework.async-graphql.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/axum.go` | .layer/.route_layer + tower ServiceBuilder ordered layer chains enumerated in source order (layer_order + layer_order_list) |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but gotham layer chains are not ordered/enumerated like tower |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | hyper services compose via tower ServiceBuilder::new().layer() chains, enumerated in order (layer_order + layer_chain) by the shared tower matcher |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but poem layer chains are not ordered/enumerated like tower |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/rocket.go` | impl Fairing for X middleware captured with middleware_name + middleware_trait=Fairing; .attach() registration captured |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but salvo layer chains are not ordered/enumerated like tower |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.tonic.md
+++ b/docs/coverage/detail/lang.rust.framework.tonic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | ServiceBuilder::new().layer(..).layer(..) chains enumerated in source order: per-layer layer_order plus a layer_chain entity with layer_count + layer_order_list |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.utoipa.md
+++ b/docs/coverage/detail/lang.rust.framework.utoipa.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but warp layer chains are not ordered/enumerated like tower |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [swift](../by-language/swift.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 47
+- **Capability cells:** 48
 
 ## Capabilities
 
@@ -46,6 +46,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/swift/vapor.go`<br>`internal/custom/swift/vapor_extended.go` | vapor.go extracts Middleware protocol conformances (struct/class conforming to Middleware); vapor_extended.go extracts .grouped(XMiddleware, YMiddleware) middleware chains from route group definitions; proven by TestVaporRouteCollection and TestVaporExtendedMiddleware. |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2445,6 +2445,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -2707,6 +2713,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -2967,6 +2979,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -3240,6 +3258,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -3511,6 +3535,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -3780,6 +3810,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -4201,6 +4237,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -4461,6 +4503,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -4749,6 +4797,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -5098,6 +5152,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -5369,6 +5429,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -5638,6 +5704,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -6268,6 +6340,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -6537,6 +6615,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -8031,6 +8115,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -8301,6 +8391,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -9191,6 +9287,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -9463,6 +9565,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -9904,6 +10012,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -10143,6 +10258,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -10631,6 +10752,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -12413,6 +12540,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "partial",
@@ -12688,6 +12822,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "partial",
@@ -12954,6 +13094,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -13254,6 +13400,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "partial",
@@ -13521,6 +13673,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -13911,6 +14069,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -14130,6 +14294,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -14393,6 +14563,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -14670,6 +14846,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -15168,6 +15350,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "partial",
@@ -15437,6 +15625,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -15668,6 +15862,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -16569,6 +16769,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -16838,6 +17044,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -17113,6 +17325,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -17395,6 +17613,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -17664,6 +17888,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -17951,6 +18181,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -18213,6 +18449,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -18564,6 +18806,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -18835,6 +19083,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -19333,6 +19587,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -19607,6 +19867,14 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/graphql/graphql.go","internal/extractors/graphql/type_graph.go"],
+            "notes": "gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphql files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) already emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph.",
+            "verified_at": "2026-06-02"
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -19843,6 +20111,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -20117,6 +20391,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -20386,6 +20666,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -20658,6 +20944,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -20927,6 +21219,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -21214,6 +21512,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -21473,6 +21777,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -30401,6 +30711,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -31632,6 +31948,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -31940,6 +32262,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -32244,6 +32572,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -32996,6 +33330,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -33295,6 +33635,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -33832,6 +34178,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -34175,6 +34527,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -34699,6 +35057,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -35541,6 +35905,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -35825,6 +36195,14 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/graphql_codefirst_typegraph.go","internal/custom/javascript/graphql_codefirst_typegraph_test.go"],
+            "notes": "Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef(\"graphql\",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. TypeGraphQL @Field(() =\u003e [Order]) thunk + Nexus t.list.field({type}) + Pothos t.field({type:[...]}) resolved. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -36931,6 +37309,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -37220,6 +37604,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -38260,6 +38650,14 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/graphql_codefirst_typegraph.go","internal/custom/javascript/graphql_codefirst_typegraph_test.go"],
+            "notes": "Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef(\"graphql\",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. TypeGraphQL @Field(() =\u003e [Order]) thunk + Nexus t.list.field({type}) + Pothos t.field({type:[...]}) resolved. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence.",
+            "verified_at": "2026-06-02"
           }
         },
         "Type System": {
@@ -44167,6 +44565,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -44399,6 +44803,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -44628,6 +45038,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -44900,6 +45316,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -45716,6 +46138,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -45950,6 +46378,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -46227,6 +46661,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -46502,6 +46942,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -46771,6 +47217,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -47005,6 +47458,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -47281,6 +47740,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -47560,6 +48025,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -47794,6 +48266,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -48071,6 +48549,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -48344,6 +48828,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -48621,6 +49111,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -48896,6 +49392,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -49179,6 +49681,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -49452,6 +49960,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -50638,6 +51152,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -50927,6 +51447,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -51176,6 +51703,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -51699,6 +52232,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -51993,6 +52532,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -52296,6 +52841,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -52846,6 +53397,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -53141,6 +53698,12 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "slowapi @limiter.limit(\"5/minute\") stamps rate_limited/rate_limit/rate_limit_source on the route op. DRF @throttle_classes resolver (rate from a co-located custom throttle's rate attr; settings-driven built-ins → honest-partial) shared via resolvePyEndpointRateLimit.",
             "verified_at": "2026-06-02"
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -53452,6 +54015,12 @@
             "verified_at": "2026-06-02"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -53757,6 +54326,14 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/graphql_codefirst_typegraph.go","internal/custom/python/graphql_codefirst_typegraph_test.go"],
+            "notes": "Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef(\"graphql\",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. Strawberry orders: list[\"Order\"] / graphene List(lambda: Order) + Field(Account) resolved; graphene Query/Mutation roots excluded as owners. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence.",
+            "verified_at": "2026-06-02"
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -53998,6 +54575,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -54331,6 +54914,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -54623,6 +55212,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -54921,6 +55516,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -55212,6 +55813,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -55720,6 +56327,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -56011,6 +56624,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -56309,6 +56928,14 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/graphql_codefirst_typegraph.go","internal/custom/python/graphql_codefirst_typegraph_test.go"],
+            "notes": "Code-first GraphQL object-type→type graph: an object-typed field emits a GRAPH_RELATES edge between the SCOPE.Schema type nodes (addressed via BuildOperationStructuralRef(\"graphql\",...) — same identity contract as the SDL pass #3805, node reuse/no duplicate), carrying {list, nullable, item_nullable, cardinality:to_one|to_many, field_name, self_ref, graphql_field, framework}. Strawberry orders: list[\"Order\"] / graphene List(lambda: Order) + Field(Account) resolved; graphene Query/Mutation roots excluded as owners. Scalar/unresolved targets make NO edge. Value-asserting tests assert exact FromID+ToID+cardinality + node convergence.",
+            "verified_at": "2026-06-02"
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -56600,6 +57227,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -58244,6 +58877,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -58501,6 +59140,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -58767,6 +59412,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -59031,6 +59682,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -59265,6 +59923,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -59530,6 +60194,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -59798,6 +60468,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -60082,6 +60758,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "not_applicable",
@@ -60348,6 +61030,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -61518,6 +62206,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -61783,6 +62477,13 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804",
+            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -62026,6 +62727,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -62299,6 +63006,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -62569,6 +63282,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -62871,6 +63590,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -63169,6 +63894,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -63438,6 +64169,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -63872,6 +64609,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "full",
@@ -64137,6 +64880,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -64385,6 +65134,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -64652,6 +65407,12 @@
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
+          }
+        },
         "Type System": {
           "enum_extraction": {
             "status": "missing",
@@ -64893,6 +65654,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type→type graph (object-typed field -\u003e referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph."
           }
         },
         "Type System": {
@@ -70430,6 +71197,12 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/3778",
             "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+          }
+        },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804"
           }
         },
         "Type System": {

--- a/internal/custom/javascript/graphql_codefirst_typegraph.go
+++ b/internal/custom/javascript/graphql_codefirst_typegraph.go
@@ -1,0 +1,458 @@
+package javascript
+
+// graphql_codefirst_typegraph.go — code-first GraphQL schema type→type graph
+// for the JS/TS code-first servers (epic #3628, child of #3804 / completes the
+// SDL pass shipped in #3805).
+//
+// Background
+// ----------
+// The SDL extractor (internal/extractors/graphql) models the GraphQL schema's
+// entity-relationship graph for *.graphql files: an object-typed field
+// (`type User { orders: [Order!]! }`) becomes a GRAPH_RELATES edge between the
+// owning type node and the referenced type node, carrying list/nullable
+// cardinality (#3805). Code-first servers build the schema from TS code instead
+// of an SDL string, so the SDL regexes never fire on them and the #3607-family
+// synthesizers only emit the root Query/Mutation/Subscription *operation*
+// endpoints — never the data object-type nodes (User, Order) nor the
+// relationships between them.
+//
+// This extractor closes that gap for the three TS code-first builders:
+//
+//	TypeGraphQL  @ObjectType() class User { @Field(() => [Order]) orders: Order[] }
+//	Nexus        objectType({ name:'User', definition(t){ t.list.field('orders',{type:'Order'}) }})
+//	Pothos       builder.objectType('User', { fields: t => ({ orders: t.field({ type: ['Order'] }) }) })
+//
+// For each object type it emits a SCOPE.Schema/subtype="type" node addressed
+// with the SAME canonical structural ref the SDL pass uses
+// (BuildOperationStructuralRef("graphql", file, TypeName)) so the two passes
+// converge on one identity per type, and a GRAPH_RELATES edge per
+// object-typed field carrying the identical cardinality property contract:
+//
+//	{field_name, list, nullable, item_nullable, cardinality:to_one|to_many,
+//	 self_ref, graphql_field, framework}
+//
+// Honest-partial: a field whose referenced type is a built-in scalar, or is not
+// a known object type declared *in the same file*, produces NO edge. Cross-file
+// targets and unresolved thunks are skipped — never guessed.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_graphql_codefirst_typegraph", &graphqlCodeFirstTypeGraphExtractor{})
+}
+
+type graphqlCodeFirstTypeGraphExtractor struct{}
+
+func (e *graphqlCodeFirstTypeGraphExtractor) Language() string {
+	return "custom_js_graphql_codefirst_typegraph"
+}
+
+// gqlcfBuiltinScalars mirrors the SDL pass: these never make a type→type edge.
+// "Date"/"DateTime"/"JSON" are common custom scalars in code-first servers and
+// are excluded too (they are not object types).
+var gqlcfBuiltinScalars = map[string]bool{
+	"String": true, "Int": true, "Float": true, "Boolean": true, "ID": true,
+	"Date": true, "DateTime": true, "JSON": true, "number": true, "string": true,
+	"boolean": true,
+}
+
+var (
+	// reTGObjectType matches a TypeGraphQL `@ObjectType()` decorator (optionally
+	// `@ObjectType("Name")` / `@ObjectType({ ... })`) immediately preceding a
+	// class declaration. Group 1 = the class name; an explicit string name
+	// argument (group capturing not used — TypeGraphQL's GraphQL type name
+	// defaults to the class name, and the relationship graph is keyed on the
+	// class identifier which is what other TS data also reference).
+	reTGObjectType = regexp.MustCompile(
+		`(?m)^[ \t]*@ObjectType\b[^\n]*\)?[ \t]*\r?\n(?:[ \t]*@[A-Za-z][^\n]*\r?\n)*[ \t]*(?:export\s+)?(?:abstract\s+)?class\s+([A-Za-z_]\w*)`,
+	)
+
+	// reTGField matches a TypeGraphQL `@Field(() => Type)` / `@Field(() => [Type])`
+	// decorator and the property it annotates. The decorator and the property may
+	// share a line (`@Field(() => [Order]) orders: Order[];`) or be split across
+	// lines; the optional separator `[ \t\r\n]*` tolerates both. The explicit
+	// thunk return type is authoritative (TS arrays erase to `Type[]` which we
+	// also parse as a list fallback). Group 1 = thunk type expression (may
+	// include []/!?), group 2 = property name, group 3 = the TS declared type
+	// (fallback when no thunk).
+	reTGField = regexp.MustCompile(
+		`@Field\s*\(\s*(?:\(\s*\)\s*=>\s*([^,)\n]+))?[^\n]*?\)[ \t]*(?:\r?\n[ \t]*)?([A-Za-z_]\w*)\s*[!?]?\s*:\s*([^;\n=]+)`,
+	)
+
+	// reNexusObjectType matches a Nexus `objectType({ name: 'User', ... })`
+	// declaration. Group 1 = the type name string literal.
+	reNexusObjectType = regexp.MustCompile(
+		`objectType\s*\(\s*\{\s*name\s*:\s*['"]([A-Za-z_]\w*)['"]`,
+	)
+
+	// reNexusField matches a Nexus field registration inside a definition block:
+	//	t.field('orders', { type: 'Order' })
+	//	t.list.field('orders', { type: 'Order' })
+	//	t.nonNull.field('owner', { type: 'User' })
+	//	t.list.nonNull.field('tags', { type: 'Tag' })
+	// Group 1 = the chain between `t.` and `.field` (list/nonNull/null modifiers),
+	// group 2 = field name, group 3 = the type name (string-literal form).
+	reNexusField = regexp.MustCompile(
+		`\bt\.((?:list|nonNull|nullable)(?:\.(?:list|nonNull|nullable))*\.)?field\s*\(\s*['"]([A-Za-z_]\w*)['"]\s*,\s*\{[^}]*?\btype\s*:\s*['"]([A-Za-z_]\w*)['"]`,
+	)
+
+	// rePothosObjectType matches a Pothos `builder.objectType('User', { ... })`
+	// (or `builder.objectType(UserRef, ...)` — only the string-literal form is
+	// resolvable to a name). Group 1 = the type name string literal.
+	rePothosObjectType = regexp.MustCompile(
+		`\bbuilder\.objectType\s*\(\s*['"]([A-Za-z_]\w*)['"]`,
+	)
+
+	// rePothosField matches a Pothos field registration:
+	//	orders: t.field({ type: ['Order'] })   → list
+	//	owner:  t.field({ type: 'User' })       → singular
+	//	tags:   t.field({ type: ['Tag'], nullable: true })
+	// Group 1 = field name, group 2 = `[` when list, group 3 = type name.
+	rePothosField = regexp.MustCompile(
+		`([A-Za-z_]\w*)\s*:\s*t\.field\s*\(\s*\{[^}]*?\btype\s*:\s*(\[)?\s*['"]([A-Za-z_]\w*)['"]`,
+	)
+)
+
+func (e *graphqlCodeFirstTypeGraphExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.js_graphql_codefirst_typegraph")
+	_, span := tracer.Start(ctx, "custom.js_graphql_codefirst_typegraph")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Fast-path gate: bail unless one of the three code-first markers is present.
+	hasTG := strings.Contains(src, "@ObjectType")
+	hasNexus := strings.Contains(src, "objectType(")
+	hasPothos := strings.Contains(src, "builder.objectType")
+	if !hasTG && !hasNexus && !hasPothos {
+		return nil, nil
+	}
+
+	// Pass 1: collect all object-type names declared in this file (per framework
+	// the names co-resolve so a field can target any sibling type).
+	known := map[string]bool{}
+	if hasTG {
+		for _, m := range reTGObjectType.FindAllStringSubmatch(src, -1) {
+			known[m[1]] = true
+		}
+	}
+	if hasNexus {
+		for _, m := range reNexusObjectType.FindAllStringSubmatch(src, -1) {
+			known[m[1]] = true
+		}
+	}
+	if hasPothos {
+		for _, m := range rePothosObjectType.FindAllStringSubmatch(src, -1) {
+			known[m[1]] = true
+		}
+	}
+	if len(known) == 0 {
+		return nil, nil
+	}
+
+	// nodeFor lazily creates (once) the SCOPE.Schema type node for a known
+	// object type, addressed with the SDL-canonical structural ref so the SDL
+	// and code-first passes converge on a single identity per type.
+	nodes := map[string]int{} // type name → index into entities
+	var entities []types.EntityRecord
+	nodeFor := func(name, framework string, line int) int {
+		if idx, ok := nodes[name]; ok {
+			return idx
+		}
+		ent := makeEntity(name, "SCOPE.Schema", "type", file.Path, file.Language, line)
+		setProps(&ent,
+			"graphql_type", name,
+			"framework", framework,
+			"code_first", "true",
+			"structural_ref", extreg.BuildOperationStructuralRef("graphql", file.Path, name),
+			"provenance", "INFERRED_FROM_CODEFIRST_GRAPHQL_OBJECTTYPE",
+		)
+		entities = append(entities, ent)
+		nodes[name] = len(entities) - 1
+		return nodes[name]
+	}
+
+	addEdge := func(owner, target, framework, fieldName string, tc gqlcfCardinality) {
+		if target == owner {
+			// self-ref is permitted (mirrors SDL self_ref); still emit.
+		}
+		ownerRef := extreg.BuildOperationStructuralRef("graphql", file.Path, owner)
+		targetRef := extreg.BuildOperationStructuralRef("graphql", file.Path, target)
+		props := map[string]string{
+			"field_name":    fieldName,
+			"list":          gqlcfBool(tc.list),
+			"nullable":      gqlcfBool(tc.nullable),
+			"cardinality":   gqlcfCardLabel(tc),
+			"self_ref":      gqlcfBool(target == owner),
+			"graphql_field": owner + "." + fieldName,
+			"framework":     framework,
+			"provenance":    "INFERRED_FROM_CODEFIRST_GRAPHQL_FIELD",
+		}
+		if tc.list {
+			props["item_nullable"] = gqlcfBool(tc.itemNullable)
+		}
+		idx := nodes[owner]
+		entities[idx].Relationships = append(entities[idx].Relationships,
+			types.RelationshipRecord{
+				FromID:     ownerRef,
+				ToID:       targetRef,
+				Kind:       string(types.RelationshipKindGraphRelates),
+				Properties: props,
+			})
+	}
+
+	// resolve a captured field target+modifiers into an edge if the base type is
+	// a known sibling object type (not a scalar). Dedup per (owner,field,target).
+	seen := map[string]bool{}
+	emit := func(owner, framework, fieldName, target string, tc gqlcfCardinality) {
+		if !known[target] || gqlcfBuiltinScalars[target] {
+			return
+		}
+		key := owner + "|" + fieldName + "|" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		addEdge(owner, target, framework, fieldName, tc)
+	}
+
+	// Pass 2 (TypeGraphQL): walk each @ObjectType class body and its @Field
+	// decorators. We slice the source per class so a field is attributed to the
+	// class that owns it.
+	if hasTG {
+		for _, cls := range tgClassBodies(src) {
+			nodeFor(cls.name, "typegraphql", cls.line)
+			for _, fm := range reTGField.FindAllStringSubmatch(cls.body, -1) {
+				thunk := strings.TrimSpace(fm[1])
+				fieldName := fm[2]
+				tsType := strings.TrimSpace(fm[3])
+				base, tc := tgResolveFieldType(thunk, tsType)
+				if base == "" {
+					continue
+				}
+				emit(cls.name, "typegraphql", fieldName, base, tc)
+			}
+		}
+	}
+
+	// Pass 2 (Nexus): each objectType definition block; fields are t.*.field(...)
+	// calls. We attribute by the nearest preceding objectType name.
+	if hasNexus {
+		for _, blk := range nexusObjectBodies(src) {
+			nodeFor(blk.name, "nexus", blk.line)
+			for _, fm := range reNexusField.FindAllStringSubmatch(blk.body, -1) {
+				chain := fm[1]
+				fieldName := fm[2]
+				target := fm[3]
+				tc := nexusCardinality(chain)
+				emit(blk.name, "nexus", fieldName, target, tc)
+			}
+		}
+	}
+
+	// Pass 2 (Pothos): each builder.objectType('Name', { ... }) block.
+	if hasPothos {
+		for _, blk := range pothosObjectBodies(src) {
+			nodeFor(blk.name, "pothos", blk.line)
+			for _, fm := range rePothosField.FindAllStringSubmatch(blk.body, -1) {
+				fieldName := fm[1]
+				isList := fm[2] == "["
+				target := fm[3]
+				tc := gqlcfCardinality{list: isList, nullable: true, itemNullable: true}
+				emit(blk.name, "pothos", fieldName, target, tc)
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// --- cardinality model (mirrors internal/extractors/graphql/type_graph.go) ---
+
+type gqlcfCardinality struct {
+	list         bool
+	nullable     bool
+	itemNullable bool
+}
+
+func gqlcfBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func gqlcfCardLabel(tc gqlcfCardinality) string {
+	if tc.list {
+		return "to_many"
+	}
+	return "to_one"
+}
+
+// --- TypeGraphQL field-type resolution ---
+
+// tgResolveFieldType resolves a TypeGraphQL field to its base GraphQL type and
+// cardinality, preferring the explicit `@Field(() => …)` thunk (authoritative
+// for nullability via list markers) and falling back to the TS declared type
+// (`Order[]` / `Order`). Returns base="" when no object identifier is found.
+func tgResolveFieldType(thunk, tsType string) (string, gqlcfCardinality) {
+	// Prefer the thunk return type when present.
+	if thunk != "" {
+		base, tc, ok := tgParseTypeExpr(thunk)
+		if ok {
+			return base, tc
+		}
+	}
+	base, tc, ok := tgParseTypeExpr(tsType)
+	if !ok {
+		return "", gqlcfCardinality{}
+	}
+	return base, tc
+}
+
+var tgIdentRe = regexp.MustCompile(`[A-Za-z_]\w*`)
+
+// tgParseTypeExpr parses a TS/TypeGraphQL type expression into base + list.
+//
+//	[Order]   / Order[]   → list=true,  base=Order
+//	Order               → list=false, base=Order
+//	Order | null        → nullable handled by caller's default; base=Order
+//
+// TS code-first nullability is conventionally driven by `{ nullable: true }`
+// option which we do not parse here; we default nullable=true (GraphQL default)
+// and itemNullable=true, matching the SDL pass's behaviour for an un-annotated
+// `[Order]`. Returns ok=false when no identifier base can be recovered.
+func tgParseTypeExpr(expr string) (string, gqlcfCardinality, bool) {
+	expr = strings.TrimSpace(expr)
+	tc := gqlcfCardinality{nullable: true, itemNullable: true}
+	if strings.HasPrefix(expr, "[") || strings.Contains(expr, "[]") {
+		tc.list = true
+	}
+	// strip array/union/null noise and take the first type identifier.
+	id := tgIdentRe.FindString(strings.TrimLeft(expr, "[ "))
+	if id == "" || id == "null" || id == "undefined" {
+		return "", tc, false
+	}
+	return id, tc, true
+}
+
+// nexusCardinality maps a Nexus `t.<chain>.field(...)` modifier chain to a
+// cardinality. `list` ⇒ to_many; `nonNull` ⇒ non-nullable; absence ⇒ nullable.
+func nexusCardinality(chain string) gqlcfCardinality {
+	tc := gqlcfCardinality{nullable: true, itemNullable: true}
+	if strings.Contains(chain, "list") {
+		tc.list = true
+	}
+	if strings.Contains(chain, "nonNull") {
+		tc.nullable = false
+		tc.itemNullable = false
+	}
+	return tc
+}
+
+// --- block slicing helpers ---
+
+type gqlcfBlock struct {
+	name string
+	line int
+	body string
+}
+
+// tgClassBodies slices the source into one block per @ObjectType class, the
+// block body running from the class declaration to the matching closing brace
+// (brace-balanced). Fields are attributed to the class whose body contains them.
+func tgClassBodies(src string) []gqlcfBlock {
+	var out []gqlcfBlock
+	for _, m := range reTGObjectType.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// find the class body's opening brace after the decorator match.
+		open := strings.IndexByte(src[m[1]:], '{')
+		if open < 0 {
+			continue
+		}
+		start := m[1] + open
+		end := gqlcfMatchBrace(src, start)
+		if end <= start {
+			continue
+		}
+		out = append(out, gqlcfBlock{name: name, line: lineOf(src, m[0]), body: src[start:end]})
+	}
+	return out
+}
+
+// nexusObjectBodies slices one block per `objectType({ name:'X', ... })`.
+func nexusObjectBodies(src string) []gqlcfBlock {
+	var out []gqlcfBlock
+	for _, m := range reNexusObjectType.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// m[0] starts at the `objectType(` keyword; the arg object's opening
+		// brace is the first `{` after it.
+		open := strings.IndexByte(src[m[0]:], '{')
+		if open < 0 {
+			continue
+		}
+		start := m[0] + open
+		end := gqlcfMatchBrace(src, start)
+		if end <= start {
+			continue
+		}
+		out = append(out, gqlcfBlock{name: name, line: lineOf(src, m[0]), body: src[start:end]})
+	}
+	return out
+}
+
+// pothosObjectBodies slices one block per `builder.objectType('X', { ... })`.
+func pothosObjectBodies(src string) []gqlcfBlock {
+	var out []gqlcfBlock
+	for _, m := range rePothosObjectType.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		open := strings.IndexByte(src[m[1]:], '{')
+		if open < 0 {
+			continue
+		}
+		start := m[1] + open
+		end := gqlcfMatchBrace(src, start)
+		if end <= start {
+			continue
+		}
+		out = append(out, gqlcfBlock{name: name, line: lineOf(src, m[0]), body: src[start:end]})
+	}
+	return out
+}
+
+// gqlcfMatchBrace returns the index just past the brace matching the one at
+// `open` (which must be '{'), or -1 if unbalanced. String/template literals are
+// not unescaped — adequate for the structural slicing this extractor needs.
+func gqlcfMatchBrace(src string, open int) int {
+	if open >= len(src) || src[open] != '{' {
+		return -1
+	}
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}

--- a/internal/custom/javascript/graphql_codefirst_typegraph_test.go
+++ b/internal/custom/javascript/graphql_codefirst_typegraph_test.go
@@ -1,0 +1,248 @@
+package javascript_test
+
+// graphql_codefirst_typegraph_test.go — value-asserting tests for the
+// custom_js_graphql_codefirst_typegraph extractor (epic #3628, completes #3804).
+//
+// Asserts the GRAPH_RELATES object-type→type edges for the three TS code-first
+// GraphQL builders (TypeGraphQL / Nexus / Pothos) carry the exact FromID/ToID
+// structural refs + cardinality the SDL pass (#3805) emits, that the owning type
+// node is reused (no duplicate), and that scalar / unresolved fields make NO edge.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runGqlCF(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_graphql_codefirst_typegraph")
+	if !ok {
+		t.Fatal("custom_js_graphql_codefirst_typegraph not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "typescript", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findGraphRelates returns the GRAPH_RELATES edge with the given FromID/ToID, or nil.
+func findGraphRelates(ents []types.EntityRecord, fromID, toID string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) &&
+				r.FromID == fromID && r.ToID == toID {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func ref(path, name string) string {
+	return "scope:operation:method:graphql:" + path + ":" + name
+}
+
+func countTypeNodes(ents []types.EntityRecord, name string) int {
+	n := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "type" && e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// --- TypeGraphQL ---
+
+func TestGqlCF_TypeGraphQL_ListAndToOne(t *testing.T) {
+	path := "user.ts"
+	src := `
+import { ObjectType, Field, ID } from "type-graphql";
+
+@ObjectType()
+class Order {
+  @Field(() => ID) id: string;
+}
+
+@ObjectType()
+class User {
+  @Field() name: string;
+  @Field(() => [Order]) orders: Order[];
+  @Field(() => Order) latest: Order;
+}
+`
+	ents := runGqlCF(t, path, src)
+
+	// User → Order list edge.
+	e := findGraphRelates(ents, ref(path, "User"), ref(path, "Order"))
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User→Order")
+	}
+	if e.Properties["list"] != "true" || e.Properties["cardinality"] != "to_many" {
+		t.Errorf("orders edge: want list=true to_many, got %v", e.Properties)
+	}
+	if e.Properties["field_name"] != "orders" {
+		t.Errorf("want field_name=orders, got %q", e.Properties["field_name"])
+	}
+
+	// There are two User→Order edges (orders=list, latest=to_one); confirm a
+	// to_one one exists too.
+	var sawToOne bool
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.FromID == ref(path, "User") && r.ToID == ref(path, "Order") &&
+				r.Properties["field_name"] == "latest" {
+				sawToOne = true
+				if r.Properties["list"] != "false" || r.Properties["cardinality"] != "to_one" {
+					t.Errorf("latest edge: want to_one, got %v", r.Properties)
+				}
+			}
+		}
+	}
+	if !sawToOne {
+		t.Error("expected to_one User→Order edge for `latest`")
+	}
+
+	// Scalar field `name` → NO edge (no self/scalar target).
+	if findGraphRelates(ents, ref(path, "User"), ref(path, "string")) != nil {
+		t.Error("scalar field name must not produce an edge")
+	}
+
+	// Convergence: exactly one User node, one Order node (node reuse).
+	if c := countTypeNodes(ents, "User"); c != 1 {
+		t.Errorf("expected 1 User type node, got %d", c)
+	}
+	if c := countTypeNodes(ents, "Order"); c != 1 {
+		t.Errorf("expected 1 Order type node, got %d", c)
+	}
+}
+
+func TestGqlCF_TypeGraphQL_UnresolvedTargetNoEdge(t *testing.T) {
+	path := "u.ts"
+	src := `
+import { ObjectType, Field } from "type-graphql";
+@ObjectType()
+class User {
+  @Field(() => Address) home: Address;  // Address declared in another file
+}
+`
+	ents := runGqlCF(t, path, src)
+	if findGraphRelates(ents, ref(path, "User"), ref(path, "Address")) != nil {
+		t.Error("cross-file unresolved target must not produce an edge")
+	}
+}
+
+// --- Nexus ---
+
+func TestGqlCF_Nexus_ListField(t *testing.T) {
+	path := "schema.ts"
+	src := `
+import { objectType } from "nexus";
+
+export const Order = objectType({
+  name: "Order",
+  definition(t) { t.id("id"); },
+});
+
+export const User = objectType({
+  name: "User",
+  definition(t) {
+    t.string("name");
+    t.list.field("orders", { type: "Order" });
+    t.nonNull.field("primary", { type: "Order" });
+  },
+});
+`
+	ents := runGqlCF(t, path, src)
+
+	e := findGraphRelates(ents, ref(path, "User"), ref(path, "Order"))
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User→Order (nexus)")
+	}
+	// the list field
+	var list, nonNull *types.RelationshipRecord
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.FromID == ref(path, "User") && r.ToID == ref(path, "Order") {
+				switch r.Properties["field_name"] {
+				case "orders":
+					list = r
+				case "primary":
+					nonNull = r
+				}
+			}
+		}
+	}
+	if list == nil || list.Properties["list"] != "true" || list.Properties["cardinality"] != "to_many" {
+		t.Errorf("nexus orders: want list=true to_many, got %v", list)
+	}
+	if nonNull == nil || nonNull.Properties["nullable"] != "false" || nonNull.Properties["cardinality"] != "to_one" {
+		t.Errorf("nexus primary: want nullable=false to_one, got %v", nonNull)
+	}
+	// scalar t.string("name") → no edge
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			if ents[i].Relationships[j].Properties["field_name"] == "name" {
+				t.Error("nexus scalar `name` must not produce an edge")
+			}
+		}
+	}
+}
+
+// --- Pothos ---
+
+func TestGqlCF_Pothos_ListField(t *testing.T) {
+	path := "builder.ts"
+	src := `
+builder.objectType("Order", {
+  fields: (t) => ({ id: t.exposeID("id") }),
+});
+
+builder.objectType("User", {
+  fields: (t) => ({
+    name: t.exposeString("name"),
+    orders: t.field({ type: ["Order"] }),
+    primary: t.field({ type: "Order" }),
+  }),
+});
+`
+	ents := runGqlCF(t, path, src)
+
+	var list, single *types.RelationshipRecord
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.FromID == ref(path, "User") && r.ToID == ref(path, "Order") {
+				switch r.Properties["field_name"] {
+				case "orders":
+					list = r
+				case "primary":
+					single = r
+				}
+			}
+		}
+	}
+	if list == nil || list.Properties["list"] != "true" || list.Properties["cardinality"] != "to_many" {
+		t.Errorf("pothos orders: want list=true to_many, got %v", list)
+	}
+	if single == nil || single.Properties["cardinality"] != "to_one" {
+		t.Errorf("pothos primary: want to_one, got %v", single)
+	}
+}
+
+// Negative: a file with no code-first GraphQL markers yields nothing.
+func TestGqlCF_NoMarkers_NoOp(t *testing.T) {
+	ents := runGqlCF(t, "plain.ts", `export const x = 1; class Foo { bar: number; }`)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-graphql file, got %d", len(ents))
+	}
+}

--- a/internal/custom/python/graphql_codefirst_typegraph.go
+++ b/internal/custom/python/graphql_codefirst_typegraph.go
@@ -1,0 +1,380 @@
+package python
+
+// graphql_codefirst_typegraph.go — code-first GraphQL schema type→type graph
+// for the Python code-first servers (epic #3628, child of #3804 / completes the
+// SDL pass shipped in #3805).
+//
+// The SDL extractor (internal/extractors/graphql) models the object-type→type
+// relationship graph for *.graphql files (`type User { orders: [Order!]! }` →
+// GRAPH_RELATES User→Order with list/nullable cardinality, #3805). Python
+// code-first servers declare the schema in Python classes, so the SDL regexes
+// never fire and the #3607-family synthesizers only emit the root
+// Query/Mutation/Subscription operation endpoints — never the data object-type
+// nodes (User, Order) nor the relationships between them.
+//
+// This extractor closes that gap for the two Python code-first frameworks:
+//
+//	Strawberry  @strawberry.type
+//	            class User:
+//	                orders: list["Order"]
+//	                owner: "Account"
+//
+//	Graphene    class User(graphene.ObjectType):
+//	                orders = graphene.List(lambda: Order)   # or List(Order)
+//	                owner  = graphene.Field(Account)
+//
+// For each object type it emits a SCOPE.Schema/subtype="type" node addressed
+// with the SAME canonical structural ref the SDL pass uses
+// (BuildOperationStructuralRef("graphql", file, TypeName)) so both passes
+// converge on one identity per type, plus a GRAPH_RELATES edge per
+// object-typed field carrying the identical cardinality property contract:
+//
+//	{field_name, list, nullable, item_nullable, cardinality:to_one|to_many,
+//	 self_ref, graphql_field, framework}
+//
+// Honest-partial: a field whose referenced type is a scalar, or is not a known
+// object type declared in the same file, produces NO edge. The graphene root
+// types (Query/Mutation/Subscription) carry resolver fields not data relations
+// and are excluded as owners — they are operation roots already modelled by the
+// #3620 synthesizer.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_graphql_codefirst_typegraph", &GraphQLCodeFirstTypeGraphExtractor{})
+}
+
+// GraphQLCodeFirstTypeGraphExtractor builds the object-type→type relationship
+// graph for Strawberry and Graphene code-first schemas.
+type GraphQLCodeFirstTypeGraphExtractor struct{}
+
+func (e *GraphQLCodeFirstTypeGraphExtractor) Language() string {
+	return "python_graphql_codefirst_typegraph"
+}
+
+// gqlcfPyBuiltinScalars never make a type→type edge. Includes the GraphQL
+// built-ins plus the python primitives and the strawberry/graphene scalar shims
+// commonly used as field types.
+var gqlcfPyBuiltinScalars = map[string]bool{
+	"str": true, "int": true, "float": true, "bool": true, "bytes": true,
+	"ID": true, "String": true, "Int": true, "Float": true, "Boolean": true,
+	"datetime": true, "date": true, "time": true, "Decimal": true, "UUID": true,
+	"JSON": true, "Any": true,
+}
+
+var (
+	// reStrawType matches a `@strawberry.type` (or @strawberry.input is
+	// excluded — inputs are not part of the object relationship graph) decorator
+	// preceding a class. Group 1 = class name. Strawberry's @strawberry.federation
+	// .type is also matched via the optional `.federation` segment.
+	reStrawType = regexp.MustCompile(
+		`(?m)^[ \t]*@strawberry(?:\.federation)?\.type\b[^\n]*\r?\n(?:[ \t]*@[^\n]*\r?\n)*[ \t]*class\s+([A-Za-z_]\w*)`,
+	)
+
+	// reGrapheneType matches a class whose base list contains ObjectType:
+	//	class User(graphene.ObjectType):
+	//	class User(ObjectType):
+	// Group 1 = class name, group 2 = the base list.
+	reGrapheneType = regexp.MustCompile(
+		`(?m)^class\s+([A-Za-z_]\w*)\s*\(([^)]*ObjectType[^)]*)\)\s*:`,
+	)
+
+	// reStrawField matches a Strawberry annotated field:
+	//	orders: list["Order"]
+	//	owner: "Account"
+	//	tags: List[Tag]
+	//	maybe: Optional["Profile"]
+	// Group 1 = field name, group 2 = the type annotation expression. Excludes
+	// lines that are method defs.
+	reStrawField = regexp.MustCompile(
+		`(?m)^[ \t]+([A-Za-z_]\w*)\s*:\s*([^\n=]+?)\s*(?:=\s*[^\n]*)?$`,
+	)
+
+	// reGrapheneField matches a graphene class attribute bound to a type:
+	//	orders = graphene.List(lambda: Order)
+	//	orders = List(Order)
+	//	owner  = graphene.Field(lambda: Account)
+	//	owner  = Field("Account")
+	// Group 1 = field name, group 2 = wrapper (List|Field), group 3 = the
+	// argument body up to the first comma/paren close.
+	reGrapheneField = regexp.MustCompile(
+		`(?m)^[ \t]+([A-Za-z_]\w*)\s*=\s*(?:graphene\.)?(List|Field|NonNull)\s*\(\s*([^,)\n]+)`,
+	)
+
+	// reGrapheneIdent extracts the referenced type name from a graphene field
+	// argument, tolerating `lambda: Order`, `"Order"`, `Order`, `NonNull(Order)`.
+	reGrapheneIdent = regexp.MustCompile(`(?:lambda\s*:\s*)?["']?([A-Za-z_]\w*)["']?`)
+)
+
+func (e *GraphQLCodeFirstTypeGraphExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_graphql_codefirst_typegraph")
+	_, span := tracer.Start(ctx, "custom.python_graphql_codefirst_typegraph")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasStraw := strings.Contains(src, "@strawberry") && strings.Contains(src, ".type")
+	hasGraphene := strings.Contains(src, "ObjectType")
+	if !hasStraw && !hasGraphene {
+		return nil, nil
+	}
+
+	// Pass 1: collect declared object-type names + their (line, body) blocks.
+	type clsBlock struct {
+		name      string
+		framework string
+		line      int
+		body      string
+		isRoot    bool // graphene Query/Mutation/Subscription — owner-excluded
+	}
+	var blocks []clsBlock
+	known := map[string]bool{}
+
+	if hasStraw {
+		for _, m := range reStrawType.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			body := pyClassBody(src, m[3])
+			blocks = append(blocks, clsBlock{name: name, framework: "strawberry", line: lineOf(src, m[0]), body: body})
+			known[name] = true
+		}
+	}
+	if hasGraphene {
+		for _, m := range reGrapheneType.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			body := pyClassBody(src, m[3])
+			isRoot := name == "Query" || name == "Mutation" || name == "Subscription"
+			blocks = append(blocks, clsBlock{name: name, framework: "graphene", line: lineOf(src, m[0]), body: body, isRoot: isRoot})
+			if !isRoot {
+				known[name] = true
+			}
+		}
+	}
+	if len(known) == 0 {
+		return nil, nil
+	}
+
+	nodes := map[string]int{}
+	var out []types.EntityRecord
+	nodeFor := func(name, framework string, line int) int {
+		if idx, ok := nodes[name]; ok {
+			return idx
+		}
+		props := map[string]string{
+			"graphql_type":   name,
+			"framework":      framework,
+			"code_first":     "true",
+			"structural_ref": extractor.BuildOperationStructuralRef("graphql", file.Path, name),
+			"provenance":     "INFERRED_FROM_CODEFIRST_GRAPHQL_OBJECTTYPE",
+		}
+		out = append(out, entity(name, "SCOPE.Schema", "type", file.Path, line, props))
+		nodes[name] = len(out) - 1
+		return nodes[name]
+	}
+
+	seen := map[string]bool{}
+	emit := func(owner, framework, fieldName, target string, tc gqlcfPyCard) {
+		if !known[target] || gqlcfPyBuiltinScalars[target] {
+			return
+		}
+		key := owner + "|" + fieldName + "|" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ownerRef := extractor.BuildOperationStructuralRef("graphql", file.Path, owner)
+		targetRef := extractor.BuildOperationStructuralRef("graphql", file.Path, target)
+		props := map[string]string{
+			"field_name":    fieldName,
+			"list":          gqlcfPyBool(tc.list),
+			"nullable":      gqlcfPyBool(tc.nullable),
+			"cardinality":   gqlcfPyCardLabel(tc),
+			"self_ref":      gqlcfPyBool(target == owner),
+			"graphql_field": owner + "." + fieldName,
+			"framework":     framework,
+			"provenance":    "INFERRED_FROM_CODEFIRST_GRAPHQL_FIELD",
+		}
+		if tc.list {
+			props["item_nullable"] = gqlcfPyBool(tc.itemNullable)
+		}
+		idx := nodes[owner]
+		out[idx].Relationships = append(out[idx].Relationships,
+			types.RelationshipRecord{
+				FromID:     ownerRef,
+				ToID:       targetRef,
+				Kind:       string(types.RelationshipKindGraphRelates),
+				Properties: props,
+			})
+	}
+
+	for _, blk := range blocks {
+		if blk.isRoot {
+			continue // graphene operation root — not a data owner.
+		}
+		nodeFor(blk.name, blk.framework, blk.line)
+		switch blk.framework {
+		case "strawberry":
+			for _, fm := range reStrawField.FindAllStringSubmatch(blk.body, -1) {
+				fieldName := fm[1]
+				ann := strings.TrimSpace(fm[2])
+				if strings.HasPrefix(ann, "Callable") || ann == "" {
+					continue
+				}
+				base, tc := strawParseAnnotation(ann)
+				if base == "" {
+					continue
+				}
+				emit(blk.name, "strawberry", fieldName, base, tc)
+			}
+		case "graphene":
+			for _, fm := range reGrapheneField.FindAllStringSubmatch(blk.body, -1) {
+				fieldName := fm[1]
+				wrapper := fm[2]
+				arg := fm[3]
+				base := grapheneTypeArg(arg)
+				if base == "" {
+					continue
+				}
+				tc := gqlcfPyCard{nullable: true, itemNullable: true}
+				if wrapper == "List" {
+					tc.list = true
+				}
+				if wrapper == "NonNull" {
+					tc.nullable = false
+				}
+				emit(blk.name, "graphene", fieldName, base, tc)
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// --- cardinality model (mirrors internal/extractors/graphql/type_graph.go) ---
+
+type gqlcfPyCard struct {
+	list         bool
+	nullable     bool
+	itemNullable bool
+}
+
+func gqlcfPyBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func gqlcfPyCardLabel(tc gqlcfPyCard) string {
+	if tc.list {
+		return "to_many"
+	}
+	return "to_one"
+}
+
+var gqlcfPyIdentRe = regexp.MustCompile(`[A-Za-z_]\w*`)
+
+// strawParseAnnotation resolves a Strawberry field annotation into its base
+// object type and cardinality.
+//
+//	list["Order"] / List[Order] / Sequence[Order] → list=true,  base=Order
+//	Optional["Profile"]                            → list=false, nullable=true
+//	"Account"                                      → list=false
+//
+// Returns base="" when no identifier base can be recovered. Forward-ref string
+// quotes are stripped. `Optional[...]` flags nullable; a bare annotation is
+// non-null in Strawberry (we record nullable=false to match its semantics).
+func strawParseAnnotation(ann string) (string, gqlcfPyCard) {
+	tc := gqlcfPyCard{itemNullable: false}
+	lower := ann
+	isList := strings.Contains(lower, "list[") || strings.Contains(lower, "List[") ||
+		strings.Contains(lower, "Sequence[") || strings.Contains(lower, "tuple[")
+	tc.list = isList
+	if strings.Contains(ann, "Optional[") || strings.HasSuffix(strings.TrimSpace(ann), "| None") ||
+		strings.Contains(ann, "Optional ") {
+		tc.nullable = true
+		tc.itemNullable = isList
+	}
+	// Strip wrappers and quotes, take the LAST identifier inside the innermost
+	// brackets (the actual element type), falling back to the first ident.
+	inner := ann
+	if i := strings.LastIndex(inner, "["); i >= 0 {
+		if j := strings.Index(inner[i:], "]"); j >= 0 {
+			inner = inner[i+1 : i+j]
+		} else {
+			inner = inner[i+1:]
+		}
+	}
+	inner = strings.Trim(strings.TrimSpace(inner), `"'`)
+	id := gqlcfPyIdentRe.FindString(inner)
+	if id == "" || id == "None" {
+		// fall back to the whole annotation's first identifier
+		id = gqlcfPyIdentRe.FindString(strings.Trim(ann, `"'`))
+	}
+	if id == "" || id == "None" || id == "Optional" || id == "list" || id == "List" {
+		return "", tc
+	}
+	return id, tc
+}
+
+// grapheneTypeArg extracts the referenced type name from a graphene field
+// argument expression (`lambda: Order`, `"Order"`, `Order`, `NonNull(Account)`).
+func grapheneTypeArg(arg string) string {
+	arg = strings.TrimSpace(arg)
+	// Unwrap a NonNull(...) inner.
+	if strings.HasPrefix(arg, "NonNull(") {
+		arg = strings.TrimPrefix(arg, "NonNull(")
+	}
+	m := reGrapheneIdent.FindStringSubmatch(arg)
+	if m == nil {
+		return ""
+	}
+	id := m[1]
+	if id == "lambda" || id == "NonNull" || id == "List" || id == "Field" {
+		return ""
+	}
+	return id
+}
+
+// pyClassBody returns the indented body of a class whose header ends at byte
+// offset `headerEnd` (the offset just past the class name). It collects the
+// contiguous run of lines more-indented than the `class` keyword line, which is
+// the conventional Python class body. Adequate for attribute-level field
+// scanning without a full parser.
+func pyClassBody(src string, headerEnd int) string {
+	// Find the `:` ending the class header, then start at the next line.
+	nl := strings.IndexByte(src[headerEnd:], '\n')
+	if nl < 0 {
+		return ""
+	}
+	start := headerEnd + nl + 1
+	lines := strings.Split(src[start:], "\n")
+	var body []string
+	for _, ln := range lines {
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			body = append(body, ln)
+			continue
+		}
+		// stop at the first non-indented line (dedent to module/class level).
+		if ln[0] != ' ' && ln[0] != '\t' {
+			break
+		}
+		body = append(body, ln)
+	}
+	return strings.Join(body, "\n")
+}

--- a/internal/custom/python/graphql_codefirst_typegraph_test.go
+++ b/internal/custom/python/graphql_codefirst_typegraph_test.go
@@ -1,0 +1,204 @@
+package python_test
+
+// graphql_codefirst_typegraph_test.go — value-asserting tests for the
+// python_graphql_codefirst_typegraph extractor (epic #3628, completes #3804).
+//
+// Asserts the GRAPH_RELATES object-type→type edges for the two Python code-first
+// GraphQL frameworks (Strawberry / Graphene) carry the exact FromID/ToID
+// structural refs + cardinality the SDL pass (#3805) emits, that the owning type
+// node is reused (no duplicate), and that scalar / unresolved fields make NO edge.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runGqlCFPy(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("python_graphql_codefirst_typegraph")
+	if !ok {
+		t.Fatal("python_graphql_codefirst_typegraph not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extractor.FileInput{Path: path, Language: "python", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func refPy(path, name string) string {
+	return "scope:operation:method:graphql:" + path + ":" + name
+}
+
+func findGR(ents []types.EntityRecord, fromID, toID, field string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) &&
+				r.FromID == fromID && r.ToID == toID && r.Properties["field_name"] == field {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func countTypeNodesPy(ents []types.EntityRecord, name string) int {
+	n := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "type" && e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// --- Strawberry ---
+
+func TestGqlCFPy_Strawberry_ListAndToOne(t *testing.T) {
+	path := "schema.py"
+	src := `
+import strawberry
+
+@strawberry.type
+class Order:
+    id: int
+
+@strawberry.type
+class User:
+    name: str
+    orders: list["Order"]
+    account: "Account"
+`
+	src += "\n@strawberry.type\nclass Account:\n    id: int\n"
+	ents := runGqlCFPy(t, path, src)
+
+	// User → Order list edge.
+	e := findGR(ents, refPy(path, "User"), refPy(path, "Order"), "orders")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User→Order for orders")
+	}
+	if e.Properties["list"] != "true" || e.Properties["cardinality"] != "to_many" {
+		t.Errorf("orders edge: want list=true to_many, got %v", e.Properties)
+	}
+
+	// User → Account to_one edge (forward ref).
+	a := findGR(ents, refPy(path, "User"), refPy(path, "Account"), "account")
+	if a == nil {
+		t.Fatal("expected GRAPH_RELATES User→Account for account")
+	}
+	if a.Properties["cardinality"] != "to_one" || a.Properties["list"] != "false" {
+		t.Errorf("account edge: want to_one list=false, got %v", a.Properties)
+	}
+
+	// scalar field name: str → NO edge.
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			if ents[i].Relationships[j].Properties["field_name"] == "name" {
+				t.Error("scalar `name` must not produce an edge")
+			}
+		}
+	}
+
+	// Convergence: one User node, one Order node.
+	if c := countTypeNodesPy(ents, "User"); c != 1 {
+		t.Errorf("expected 1 User node, got %d", c)
+	}
+	if c := countTypeNodesPy(ents, "Order"); c != 1 {
+		t.Errorf("expected 1 Order node, got %d", c)
+	}
+}
+
+func TestGqlCFPy_Strawberry_UnresolvedNoEdge(t *testing.T) {
+	path := "s.py"
+	src := `
+import strawberry
+@strawberry.type
+class User:
+    home: "Address"   # Address declared elsewhere
+`
+	ents := runGqlCFPy(t, path, src)
+	if findGR(ents, refPy(path, "User"), refPy(path, "Address"), "home") != nil {
+		t.Error("unresolved cross-file target must not produce an edge")
+	}
+}
+
+// --- Graphene ---
+
+func TestGqlCFPy_Graphene_ListLambdaAndField(t *testing.T) {
+	path := "g.py"
+	src := `
+import graphene
+
+class Order(graphene.ObjectType):
+    id = graphene.ID()
+
+class User(graphene.ObjectType):
+    name = graphene.String()
+    orders = graphene.List(lambda: Order)
+    account = graphene.Field(Account)
+
+class Account(graphene.ObjectType):
+    id = graphene.ID()
+`
+	ents := runGqlCFPy(t, path, src)
+
+	e := findGR(ents, refPy(path, "User"), refPy(path, "Order"), "orders")
+	if e == nil {
+		t.Fatal("expected GRAPH_RELATES User→Order for orders (graphene List(lambda: Order))")
+	}
+	if e.Properties["list"] != "true" || e.Properties["cardinality"] != "to_many" {
+		t.Errorf("orders edge: want list=true to_many, got %v", e.Properties)
+	}
+
+	a := findGR(ents, refPy(path, "User"), refPy(path, "Account"), "account")
+	if a == nil {
+		t.Fatal("expected GRAPH_RELATES User→Account for account (graphene Field)")
+	}
+	if a.Properties["cardinality"] != "to_one" {
+		t.Errorf("account edge: want to_one, got %v", a.Properties)
+	}
+
+	// scalar graphene.String() → no edge
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			if ents[i].Relationships[j].Properties["field_name"] == "name" {
+				t.Error("graphene scalar `name` must not produce an edge")
+			}
+		}
+	}
+}
+
+// Graphene root Query/Mutation are NOT owners (operation roots, not data types).
+func TestGqlCFPy_Graphene_RootTypeNotOwner(t *testing.T) {
+	path := "q.py"
+	src := `
+import graphene
+
+class User(graphene.ObjectType):
+    id = graphene.ID()
+
+class Query(graphene.ObjectType):
+    user = graphene.Field(User)
+`
+	ents := runGqlCFPy(t, path, src)
+	// Query is excluded as a type node and as an edge owner.
+	if countTypeNodesPy(ents, "Query") != 0 {
+		t.Error("Query root must not be emitted as a data type node")
+	}
+	if findGR(ents, refPy(path, "Query"), refPy(path, "User"), "user") != nil {
+		t.Error("Query root must not own a GRAPH_RELATES data edge")
+	}
+}
+
+func TestGqlCFPy_NoMarkers_NoOp(t *testing.T) {
+	ents := runGqlCFPy(t, "plain.py", "class Foo:\n    bar: int\n")
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -143,6 +143,7 @@ subcategories:
       - validate_on_submit_detection
       - tests_edges_via_delay_apply
       - view_rendering
+      - type_graph_extraction
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction, endpoint_deprecation_versioning, endpoint_pagination_posture]
@@ -154,6 +155,8 @@ subcategories:
         keys: [request_validation, dto_extraction]
       - name: Middleware
         keys: [middleware_coverage, rate_limit_stamping]
+      - name: Schema
+        keys: [type_graph_extraction]
       - name: Type System
         keys: [interface_extraction, type_alias_extraction, enum_extraction, type_extraction]
       - name: DI

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -11,7 +11,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | 🟢 1/1 | ✅ 1/1 | 🟡 1/3 | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | 🟢 1/1 | ✅ 1/1 | 🟡 1/4 | |
 
 
 ## Other

--- a/tools/coverage/testdata/fixture-out/by-language/jsts.md
+++ b/tools/coverage/testdata/fixture-out/by-language/jsts.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | 🟢 1/1 | ✅ 1/1 | 🟡 1/3 | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | 🟢 1/1 | ✅ 1/1 | 🟡 1/4 | |
 
 
 ### Other

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 8
 
 ## Capabilities
 
@@ -39,6 +39,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | — |
 
 ### Type System
 

--- a/tools/coverage/testdata/fixture.json
+++ b/tools/coverage/testdata/fixture.json
@@ -46,6 +46,12 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/2940"
           }
         },
+        "Schema": {
+          "type_graph_extraction": {
+            "status": "missing",
+            "issue": "3804"
+          }
+        },
         "Substrate": {
           "import_resolution_quality": {
             "status": "full",


### PR DESCRIPTION
Completes the GraphQL schema **type→type** graph that wave-11 (#3805) shipped for SDL (`.graphql`) only — code-first frameworks were flagged as follow-up.

## What
Code-first GraphQL servers declare the schema in host-language code, so the SDL regexes in `internal/extractors/graphql` never fire, and the #3607-family synthesizers only emit the root Query/Mutation/Subscription **operation** endpoints — never the data object-type nodes (User, Order) nor the relationships between them. This adds two custom extractors that emit those object-type nodes **and** the object-type→type `GRAPH_RELATES` edges, reusing the SDL contract from #3805.

## Frameworks
| Framework | Lang | Example resolved |
|---|---|---|
| TypeGraphQL | TS | `@ObjectType() class User { @Field(() => [Order]) orders }` → User→Order list |
| Nexus | TS | `objectType({ name:'User', definition(t){ t.list.field('orders',{type:'Order'}) }})` |
| Pothos | TS | `builder.objectType('User', { fields: t => ({ orders: t.field({ type:['Order'] }) }) })` |
| Strawberry | Python | `@strawberry.type class User: orders: list["Order"]` |
| graphene | Python | `class User(graphene.ObjectType): orders = List(lambda: Order)` / `Field(Account)` |
| gqlgen | Go | SDL-driven — already covered by the SDL pass (#3805); no code-first Go extractor needed |

## Contract (mirrors `internal/extractors/graphql/type_graph.go`, #3805)
- **Node reuse, no duplicates**: type nodes addressed via `BuildOperationStructuralRef("graphql", file, TypeName)` — the same identity the SDL pass uses, so both passes converge on one node per type.
- **Edge props**: `{field_name, list, nullable, item_nullable, cardinality:to_one|to_many, self_ref, graphql_field, framework}` (+ `provenance`).
- **Honest-partial**: scalar fields → no edge; unresolved / cross-file target types → no edge; graphene `Query`/`Mutation`/`Subscription` roots excluded as owners (they're operation roots, already modelled by #3620).

## Files
- `internal/custom/javascript/graphql_codefirst_typegraph.go` (+ test) — registered `custom_js_graphql_codefirst_typegraph` (TS/JS dispatch).
- `internal/custom/python/graphql_codefirst_typegraph.go` (+ test) — registered `python_graphql_codefirst_typegraph`.

## Tests (value-asserting, not `len>0`)
- TypeGraphQL `@Field(() => [Order]) orders` → `GRAPH_RELATES(User→Order, list=true, to_many)`; `latest: Order` → to_one.
- Nexus `t.list.field` → to_many; `t.nonNull.field` → nullable=false.
- Pothos `type:['Order']` → list; `type:'Order'` → to_one.
- Strawberry `orders: list["Order"]` → to_many; forward-ref `account: "Account"` → to_one.
- graphene `List(lambda: Order)` → to_many; `Field(Account)` → to_one.
- Each asserts exact **FromID + ToID** structural-refs + cardinality + **node convergence** (exactly one node per type).
- Negative: scalar (`name: str` / `@Field() name: string` / `t.string`) → no edge; unresolved cross-file target → no edge; graphene root → not an owner; no-marker file → no-op.

## Coverage
`type_graph_extraction` declared on the `http_backend` Schema group; flipped **typegraphql / pothos / strawberry / graphene / gqlgen → full** citing the extractors. The 7 other-language GraphQL frameworks (hotchocolate, absinthe, ariadne, graphql-ruby, async-graphql, graphql-php, lighthouse) stay `missing` as honest #3804 backfill; the ~114 non-GraphQL HTTP frameworks set `not_applicable` (type→type graph is a GraphQL-only concept, mirroring how #3805 marked grpc/protobuf/trpc). Registry canonical, `validate` 0 errors, docs regenerated, golden fixture updated.

## Quality gate
`go test` targeted (custom/javascript, custom/python, extractors/…, engine, types, tools/coverage) green; `internal/types/` green; `coverage validate` 0 errors; `fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

DEPLOY-DEFERRED (no daemon rebuild / reindex in this PR).

Closes #3812

🤖 Generated with [Claude Code](https://claude.com/claude-code)