### PR TITLE
feat(data-model): lifecycle traits TS/Python — TypeORM/Sequelize/Django/SQLAlchemy

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -83,8 +83,8 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/8 | |
 | [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/11 | |
 | [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/10 | |
-| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟡 10/11 | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟡 10/11 | |
+| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 11/11 | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 11/11 | |
 | [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/4 | |
@@ -115,12 +115,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/4 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/5 | |
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/9 | |
-| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | 🟡 10/11 | |
+| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 11/11 | |
 | [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/9 | |
 | [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/5 | |
 | [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/9 | |
 | [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/9 | |
-| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | 🟡 10/11 | |
+| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 11/11 | |
 | [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/11 | |
 | [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/10 | |
 | [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -138,8 +138,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/8 | |
 | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/11 | |
 | [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/10 | |
-| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟡 10/11 | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟡 10/11 | |
+| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 11/11 | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 11/11 | |
 | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/4 | |
 | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/4 | |
 | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -92,12 +92,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|
 | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/5 | |
 | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 5/9 | |
-| [Django ORM](../detail/lang.python.orm.django.md) | 🟡 10/11 | |
+| [Django ORM](../detail/lang.python.orm.django.md) | ✅ 11/11 | |
 | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟡 5/9 | |
 | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 2/5 | |
 | [Peewee](../detail/lang.python.orm.peewee.md) | 🟡 6/9 | |
 | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟡 6/9 | |
-| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | 🟡 10/11 | |
+| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 11/11 | |
 | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | 🟡 8/11 | |
 | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | 🟡 7/10 | |
 | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | 🟡 1/4 | |

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` | — |
-| Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
+| Model lifecycle extraction | ✅ `full` | `2026-06-02` | 3628 | `internal/custom/javascript/lifecycle_traits_test.go`<br>`internal/custom/javascript/sequelize.go`<br>`internal/lifecycle/lifecycle.go`<br>`internal/lifecycle/lifecycle_test.go` | soft_delete + soft_delete_column (paranoid:true -> deletedAt, or deletedAt:'col' override), timestamps (default-on for Sequelize models unless timestamps:false; paranoid forces them on), audit_columns (createdBy/created_by/... attribute keys). Honesty: no paranoid -> no soft_delete; timestamps:false omits timestamps. Reads attributes + options objects of define()/init(). |
 | Schema extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
 
 ### Relationships

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` | — |
-| Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
+| Model lifecycle extraction | ✅ `full` | `2026-06-02` | 3628 | `internal/custom/javascript/lifecycle_traits_test.go`<br>`internal/custom/javascript/typeorm.go`<br>`internal/lifecycle/lifecycle.go`<br>`internal/lifecycle/lifecycle_test.go` | soft_delete + soft_delete_column (@DeleteDateColumn() -> its property name), timestamps (@CreateDateColumn() + @UpdateDateColumn() both present), audit_columns (@Column() createdBy/created_by/...). Honesty: a plain @Column() 'deleted' boolean with no @DeleteDateColumn is NOT soft_delete; @CreateDateColumn alone does not assert timestamps. Per-@Entity body isolation. |
 | Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/javascript/typeorm.go` | reTypeORMEntity+reTypeORMColumn+reTypeORMViewEntity extract entity/column/view decorators (#3183) |
 
 ### Relationships

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` | — |
-| Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
+| Model lifecycle extraction | ✅ `full` | `2026-06-02` | 3628 | `internal/custom/python/django.go`<br>`internal/custom/python/lifecycle_traits_test.go`<br>`internal/lifecycle/lifecycle.go`<br>`internal/lifecycle/lifecycle_test.go` | soft_delete + soft_delete_column (deleted_at DateTimeField -> deleted_at, is_deleted BooleanField -> is_deleted, or a django-safedelete base -> deleted_at), timestamps (auto_now_add + auto_now, or created_at + updated_at fields), audit_columns (created_by/updated_by FK). Honesty: a plain 'deleted' boolean with no deleted_at/is_deleted/safedelete is NOT soft_delete. Emits a SCOPE.Schema/model node per class X(models.Model). |
 | Schema extraction | ✅ `full` | `2026-05-29` | 3060 | `internal/extractors/python/django_relational.go` | field_type and all keyword arguments (max_length, null, blank, on_delete, related_name, etc.) are stamped on each SCOPE.Schema/field entity by stampDjangoFieldProperties(); structured JSON Schema or OpenAPI emission not yet implemented |
 
 ### Relationships

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` | — |
-| Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
+| Model lifecycle extraction | ✅ `full` | `2026-06-02` | 3628 | `internal/custom/python/lifecycle_traits_test.go`<br>`internal/custom/python/sqlalchemy.go`<br>`internal/lifecycle/lifecycle.go`<br>`internal/lifecycle/lifecycle_test.go` | soft_delete + soft_delete_column (deleted_at Column/mapped_column, or a SoftDeleteMixin base -> deleted_at), timestamps (created_at + updated_at columns WITH a server_default/onupdate/default=func|datetime signal), audit_columns (created_by/updated_by). Honesty: a plain 'deleted' boolean Column is NOT soft_delete; a pair of plain DateTime columns without a timestamp-default signal does NOT assert timestamps. |
 | Schema extraction | ✅ `full` | `2026-05-29` | 3060 | `internal/custom/python/sqlalchemy.go`<br>`internal/engine/orm_field_edges.go` | __tablename__, Mapped[] columns, relationship attributes, and ForeignKey targets are extracted as SCOPE.Schema entities; structured JSON Schema or OpenAPI emission not yet implemented |
 
 ### Relationships

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -39501,8 +39501,11 @@
             "verified_at": "2026-05-28"
           },
           "model_lifecycle_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/javascript/lifecycle_traits_test.go","internal/custom/javascript/sequelize.go","internal/lifecycle/lifecycle.go","internal/lifecycle/lifecycle_test.go"],
+            "issue": "3628",
+            "notes": "soft_delete + soft_delete_column (paranoid:true -\u003e deletedAt, or deletedAt:'col' override), timestamps (default-on for Sequelize models unless timestamps:false; paranoid forces them on), audit_columns (createdBy/created_by/... attribute keys). Honesty: no paranoid -\u003e no soft_delete; timestamps:false omits timestamps. Reads attributes + options objects of define()/init().",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "full",
@@ -39581,8 +39584,11 @@
             "verified_at": "2026-05-28"
           },
           "model_lifecycle_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/javascript/lifecycle_traits_test.go","internal/custom/javascript/typeorm.go","internal/lifecycle/lifecycle.go","internal/lifecycle/lifecycle_test.go"],
+            "issue": "3628",
+            "notes": "soft_delete + soft_delete_column (@DeleteDateColumn() -\u003e its property name), timestamps (@CreateDateColumn() + @UpdateDateColumn() both present), audit_columns (@Column() createdBy/created_by/...). Honesty: a plain @Column() 'deleted' boolean with no @DeleteDateColumn is NOT soft_delete; @CreateDateColumn alone does not assert timestamps. Per-@Entity body isolation.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "partial",
@@ -57417,8 +57423,11 @@
             "verified_at": "2026-05-28"
           },
           "model_lifecycle_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/python/django.go","internal/custom/python/lifecycle_traits_test.go","internal/lifecycle/lifecycle.go","internal/lifecycle/lifecycle_test.go"],
+            "issue": "3628",
+            "notes": "soft_delete + soft_delete_column (deleted_at DateTimeField -\u003e deleted_at, is_deleted BooleanField -\u003e is_deleted, or a django-safedelete base -\u003e deleted_at), timestamps (auto_now_add + auto_now, or created_at + updated_at fields), audit_columns (created_by/updated_by FK). Honesty: a plain 'deleted' boolean with no deleted_at/is_deleted/safedelete is NOT soft_delete. Emits a SCOPE.Schema/model node per class X(models.Model).",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "full",
@@ -57717,8 +57726,11 @@
             "verified_at": "2026-05-28"
           },
           "model_lifecycle_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/python/lifecycle_traits_test.go","internal/custom/python/sqlalchemy.go","internal/lifecycle/lifecycle.go","internal/lifecycle/lifecycle_test.go"],
+            "issue": "3628",
+            "notes": "soft_delete + soft_delete_column (deleted_at Column/mapped_column, or a SoftDeleteMixin base -\u003e deleted_at), timestamps (created_at + updated_at columns WITH a server_default/onupdate/default=func|datetime signal), audit_columns (created_by/updated_by). Honesty: a plain 'deleted' boolean Column is NOT soft_delete; a pair of plain DateTime columns without a timestamp-default signal does NOT assert timestamps.",
+            "verified_at": "2026-06-02"
           },
           "schema_extraction": {
             "status": "full",

--- a/internal/custom/javascript/lifecycle_traits_test.go
+++ b/internal/custom/javascript/lifecycle_traits_test.go
@@ -1,0 +1,187 @@
+// lifecycle_traits_test.go — value-asserting tests for ORM model
+// data-lifecycle traits (#3628 child) stamped onto TypeORM @Entity and
+// Sequelize model nodes: soft_delete / soft_delete_column / timestamps /
+// audit_columns. Asserts the trait + column on the specific model entity,
+// not just len>0.
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+func extractRaw(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func findModel(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == "SCOPE.Schema" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// --- TypeORM ---------------------------------------------------------------
+
+func TestTypeORMLifecycle_SoftDeleteAndTimestamps(t *testing.T) {
+	src := `
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn() id: number;
+  @Column() createdBy: string;
+  @CreateDateColumn() createdAt: Date;
+  @UpdateDateColumn() updatedAt: Date;
+  @DeleteDateColumn() deletedAt: Date;
+}
+`
+	ents := extractRaw(t, "custom_js_typeorm", fi("user.ts", "typescript", src))
+	user := findModel(ents, "User")
+	if user == nil {
+		t.Fatal("User @Entity model node not emitted")
+	}
+	if user.Properties["soft_delete"] != "true" {
+		t.Errorf("User.soft_delete: want true, got %q", user.Properties["soft_delete"])
+	}
+	if user.Properties["soft_delete_column"] != "deletedAt" {
+		t.Errorf("User.soft_delete_column: want deletedAt, got %q", user.Properties["soft_delete_column"])
+	}
+	if user.Properties["timestamps"] != "true" {
+		t.Errorf("User.timestamps: want true, got %q", user.Properties["timestamps"])
+	}
+	if user.Properties["audit_columns"] != "created_by" {
+		t.Errorf("User.audit_columns: want created_by, got %q", user.Properties["audit_columns"])
+	}
+}
+
+func TestTypeORMLifecycle_PlainEntity_NoTraits(t *testing.T) {
+	src := `
+@Entity()
+export class Tag {
+  @Column() deleted: boolean;
+  @Column() name: string;
+}
+`
+	ents := extractRaw(t, "custom_js_typeorm", fi("tag.ts", "typescript", src))
+	tag := findModel(ents, "Tag")
+	if tag == nil {
+		t.Fatal("Tag @Entity model node not emitted")
+	}
+	if _, ok := tag.Properties["soft_delete"]; ok {
+		t.Error("plain @Column() deleted boolean must NOT stamp soft_delete")
+	}
+	if _, ok := tag.Properties["timestamps"]; ok {
+		t.Error("no date columns → timestamps must be absent")
+	}
+}
+
+func TestTypeORMLifecycle_PerEntityBodyIsolation(t *testing.T) {
+	src := `
+@Entity()
+export class Soft {
+  @DeleteDateColumn() deletedAt: Date;
+}
+@Entity()
+export class Hard {
+  @Column() name: string;
+}
+`
+	ents := extractRaw(t, "custom_js_typeorm", fi("two.ts", "typescript", src))
+	soft := findModel(ents, "Soft")
+	hard := findModel(ents, "Hard")
+	if soft == nil || hard == nil {
+		t.Fatal("both @Entity nodes must be emitted")
+	}
+	if soft.Properties["soft_delete"] != "true" {
+		t.Error("Soft must be soft_delete")
+	}
+	if _, ok := hard.Properties["soft_delete"]; ok {
+		t.Error("Hard must NOT inherit Soft's soft_delete (body isolation)")
+	}
+}
+
+// --- Sequelize -------------------------------------------------------------
+
+func TestSequelizeLifecycle_DefineParanoid(t *testing.T) {
+	src := `
+const User = sequelize.define("User", {
+  name: DataTypes.STRING,
+  createdBy: DataTypes.STRING,
+}, {
+  paranoid: true,
+});
+`
+	ents := extractRaw(t, "custom_js_sequelize", fi("user.js", "javascript", src))
+	user := findModel(ents, "User")
+	if user == nil {
+		t.Fatal("User define model node not emitted")
+	}
+	if user.Properties["soft_delete"] != "true" {
+		t.Errorf("User.soft_delete: want true, got %q", user.Properties["soft_delete"])
+	}
+	if user.Properties["soft_delete_column"] != "deletedAt" {
+		t.Errorf("User.soft_delete_column: want deletedAt, got %q", user.Properties["soft_delete_column"])
+	}
+	if user.Properties["timestamps"] != "true" {
+		t.Errorf("User.timestamps: want true (paranoid forces it), got %q", user.Properties["timestamps"])
+	}
+	if user.Properties["audit_columns"] != "created_by" {
+		t.Errorf("User.audit_columns: want created_by, got %q", user.Properties["audit_columns"])
+	}
+}
+
+func TestSequelizeLifecycle_TimestampsDisabled(t *testing.T) {
+	src := `
+const Log = sequelize.define("Log", {
+  message: DataTypes.STRING,
+}, {
+  timestamps: false,
+});
+`
+	ents := extractRaw(t, "custom_js_sequelize", fi("log.js", "javascript", src))
+	log := findModel(ents, "Log")
+	if log == nil {
+		t.Fatal("Log define model node not emitted")
+	}
+	if _, ok := log.Properties["timestamps"]; ok {
+		t.Error("timestamps:false must omit timestamps")
+	}
+	if _, ok := log.Properties["soft_delete"]; ok {
+		t.Error("no paranoid → no soft_delete")
+	}
+}
+
+func TestSequelizeLifecycle_ClassInitParanoid(t *testing.T) {
+	src := `
+class Account extends Model {}
+Account.init({
+  email: DataTypes.STRING,
+}, {
+  sequelize,
+  paranoid: true,
+});
+`
+	ents := extractRaw(t, "custom_js_sequelize", fi("account.js", "javascript", src))
+	acct := findModel(ents, "Account")
+	if acct == nil {
+		t.Fatal("Account class model node not emitted")
+	}
+	if acct.Properties["soft_delete"] != "true" {
+		t.Errorf("Account.soft_delete: want true, got %q", acct.Properties["soft_delete"])
+	}
+}

--- a/internal/custom/javascript/sequelize.go
+++ b/internal/custom/javascript/sequelize.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/lifecycle"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -138,6 +139,51 @@ func sequelizeMigrationOpSubtype(method string) string {
 	}
 }
 
+// reSequelizeAttrKey matches a top-level attribute key inside the attributes
+// object of a define()/init() model spec (`fieldName: {` or `fieldName: DataTypes...`).
+var reSequelizeAttrKey = regexp.MustCompile(`(?m)^\s{2,}([a-zA-Z_][A-Za-z0-9_]*)\s*:`)
+
+// sequelizeBracedSpan returns the substring spanning the brace-balanced object
+// that begins at the first '{' at or after start, and the index just past its
+// closing '}'. Returns ("", start) when no balanced object is found.
+func sequelizeBracedSpan(src string, start int) (string, int) {
+	open := strings.IndexByte(src[start:], '{')
+	if open < 0 {
+		return "", start
+	}
+	open += start
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open : i+1], i + 1
+			}
+		}
+	}
+	return "", start
+}
+
+// sequelizeModelLifecycle resolves lifecycle traits for a Sequelize model whose
+// declaration ends at declEnd (just past the `define(`/`.init(` opener). It reads
+// the attributes object (column names) and the following options object
+// (paranoid/timestamps flags) and returns the resolved traits.
+func sequelizeModelLifecycle(src string, declEnd int) lifecycle.Traits {
+	attrs, after := sequelizeBracedSpan(src, declEnd)
+	if attrs == "" {
+		return lifecycle.Traits{}
+	}
+	var cols []string
+	for _, m := range reSequelizeAttrKey.FindAllStringSubmatch(attrs, -1) {
+		cols = append(cols, m[1])
+	}
+	options, _ := sequelizeBracedSpan(src, after)
+	return lifecycle.Sequelize(lifecycle.SequelizeInput{OptionsBlob: options, Columns: cols})
+}
+
 func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
 	_, span := tracer.Start(ctx, "indexer.sequelize_extractor.extract",
@@ -176,29 +222,47 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		addEntity(ent)
 	}
 
-	// sequelize.define models
+	// sequelize.define models. The model node carries data-lifecycle traits
+	// (#3628 child) resolved from the attributes + options objects that follow
+	// the define( opener: paranoid → soft-delete, timestamps default-on, audit
+	// columns from the attribute keys.
 	for _, m := range reSequelizeDefine.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "provenance", "INFERRED_FROM_SEQUELIZE_DEFINE")
+		sequelizeModelLifecycle(src, m[1]).
+			Stamp(func(kv ...string) { setProps(&ent, kv...) })
 		addEntity(ent)
 	}
 
-	// Class extends Model
+	// Class extends Model. The lifecycle traits live in the X.init({...}, {...})
+	// call, so we record the model-node index and stamp them once the matching
+	// init() is found below.
 	classNames := make(map[string]bool)
+	classModelIdx := make(map[string]int)
 	for _, m := range reSequelizeClassExtends.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		classNames[name] = true
 		ent := makeEntity(name, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "provenance", "INFERRED_FROM_SEQUELIZE_CLASS_MODEL")
+		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+			classModelIdx[name] = len(entities)
+		}
 		addEntity(ent)
 	}
 
-	// Model.init() calls (only for known class models)
+	// Model.init() calls (only for known class models). Resolve lifecycle traits
+	// from the init spec and stamp them back onto the class model node.
 	for _, m := range reSequelizeModelInit.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		if !classNames[name] {
 			continue
+		}
+		if idx, ok := classModelIdx[name]; ok {
+			// reSequelizeModelInit consumes the attributes object's opening '{',
+			// so back up one byte to let sequelizeBracedSpan see it.
+			sequelizeModelLifecycle(src, m[1]-1).
+				Stamp(func(kv ...string) { setProps(&entities[idx], kv...) })
 		}
 		ent := makeEntity(name+".init", "SCOPE.Operation", "model_init", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "model_name", name,

--- a/internal/custom/javascript/typeorm.go
+++ b/internal/custom/javascript/typeorm.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/lifecycle"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -217,10 +218,21 @@ func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 	}
 	var owners []ownerInfo
 	knownEntities := make(map[string]bool)
-	for _, m := range reTypeORMEntity.FindAllStringSubmatchIndex(src, -1) {
+	entityMatches := reTypeORMEntity.FindAllStringSubmatchIndex(src, -1)
+	for i, m := range entityMatches {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "entity", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "typeorm", "provenance", "INFERRED_FROM_TYPEORM_ENTITY")
+		// Data-lifecycle traits (#3628 child): scan this entity's class body —
+		// from its @Entity decorator to the next @Entity (or EOF) — for the
+		// TypeORM soft-delete/timestamp/audit decorators and stamp the resolved
+		// traits onto the model node before it is emitted.
+		bodyEnd := len(src)
+		if i+1 < len(entityMatches) {
+			bodyEnd = entityMatches[i+1][0]
+		}
+		lifecycle.TypeORM(src[m[0]:bodyEnd]).
+			Stamp(func(kv ...string) { setProps(&ent, kv...) })
 		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
 			owners = append(owners, ownerInfo{name: name, offset: m[0], idx: len(entities)})
 			knownEntities[name] = true

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/lifecycle"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -53,6 +54,11 @@ var (
 	djangoMgmtHandleRe        = regexp.MustCompile(`(?m)^\s{4,}def\s+handle\s*\(\s*self`)
 	djangoManagerClassRe      = regexp.MustCompile(
 		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*(?:(?:models\.)?(?:Manager|QuerySet)|BaseManager)[^)]*\)\s*:`)
+	// Django model class: class Foo(models.Model) / a SafeDeleteModel subclass.
+	// Group 1 = class name, group 2 = base-class list.
+	djangoModelClassRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*(?:models\.Model|SafeDeleteModel|SafeDeleteMPTTModel)[^)]*)\)\s*:`)
+
 	djangoLoginRequiredRe = regexp.MustCompile(`(?m)@login_required\s*(?:\([^)]*\))?\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	djangoPermRequiredRe  = regexp.MustCompile(`(?m)@permission_required\s*\(\s*["']?([^)"']+)["']?[^)]*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 
@@ -402,6 +408,32 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		line := lineOf(source, idx[0])
 		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, line,
 			map[string]string{"framework": "django", "pattern_type": "model_manager"}))
+	}
+
+	// 10b. Model classes with data-lifecycle traits (#3628 child).
+	//      Each `class X(models.Model)` (or django-safedelete subclass) is
+	//      emitted as a SCOPE.Schema model node stamped with soft-delete /
+	//      timestamps / audit-column traits resolved from its class body, so the
+	//      graph can answer "which Django models soft-delete / track timestamps?".
+	//      Detection is convention-driven (deleted_at/is_deleted field, a
+	//      safedelete base, auto_now/auto_now_add or created_at+updated_at) — a
+	//      plain `deleted` boolean is NOT reported as soft-delete.
+	for _, idx := range allMatchesIndex(djangoModelClassRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+		props := map[string]string{
+			"framework":    "django",
+			"pattern_type": "model",
+			"provenance":   "INFERRED_FROM_DJANGO_MODEL",
+		}
+		lifecycle.Django(bases, body).Stamp(func(kv ...string) {
+			for i := 0; i+1 < len(kv); i += 2 {
+				props[kv[i]] = kv[i+1]
+			}
+		})
+		out = append(out, entity(className, "SCOPE.Schema", "model", file.Path, classLine, props))
 	}
 
 	// 11. View decorators

--- a/internal/custom/python/lifecycle_traits_test.go
+++ b/internal/custom/python/lifecycle_traits_test.go
@@ -1,0 +1,171 @@
+// lifecycle_traits_test.go — value-asserting tests for ORM model
+// data-lifecycle traits (#3628 child) stamped onto Django and SQLAlchemy model
+// nodes: soft_delete / soft_delete_column / timestamps / audit_columns. Asserts
+// the trait + column on the specific model entity, not just len>0.
+package python_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+)
+
+func pyExtract(t *testing.T, name, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), extractor.FileInput{
+		Path: "models.py", Language: "python", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func pyModel(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == "SCOPE.Schema" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// --- Django ----------------------------------------------------------------
+
+func TestDjangoLifecycle_DeletedAtAndTimestamps(t *testing.T) {
+	src := `
+class Order(models.Model):
+    name = models.CharField(max_length=20)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+`
+	ents := pyExtract(t, "python_django", src)
+	order := pyModel(ents, "Order")
+	if order == nil {
+		t.Fatal("Order Django model node not emitted")
+	}
+	if order.Properties["soft_delete"] != "true" {
+		t.Errorf("Order.soft_delete: want true, got %q", order.Properties["soft_delete"])
+	}
+	if order.Properties["soft_delete_column"] != "deleted_at" {
+		t.Errorf("Order.soft_delete_column: want deleted_at, got %q", order.Properties["soft_delete_column"])
+	}
+	if order.Properties["timestamps"] != "true" {
+		t.Errorf("Order.timestamps: want true, got %q", order.Properties["timestamps"])
+	}
+	if order.Properties["audit_columns"] != "created_by" {
+		t.Errorf("Order.audit_columns: want created_by, got %q", order.Properties["audit_columns"])
+	}
+}
+
+func TestDjangoLifecycle_SafeDeleteBase(t *testing.T) {
+	src := `
+class Account(SafeDeleteModel):
+    name = models.CharField(max_length=10)
+`
+	ents := pyExtract(t, "python_django", src)
+	acct := pyModel(ents, "Account")
+	if acct == nil {
+		t.Fatal("Account SafeDeleteModel node not emitted")
+	}
+	if acct.Properties["soft_delete"] != "true" || acct.Properties["soft_delete_column"] != "deleted_at" {
+		t.Errorf("Account soft-delete traits: want true/deleted_at, got %q/%q",
+			acct.Properties["soft_delete"], acct.Properties["soft_delete_column"])
+	}
+}
+
+func TestDjangoLifecycle_PlainDeletedBool_NoSoftDelete(t *testing.T) {
+	src := `
+class Item(models.Model):
+    deleted = models.BooleanField(default=False)
+    name = models.CharField(max_length=10)
+`
+	ents := pyExtract(t, "python_django", src)
+	item := pyModel(ents, "Item")
+	if item == nil {
+		t.Fatal("Item model node not emitted")
+	}
+	if _, ok := item.Properties["soft_delete"]; ok {
+		t.Error("plain `deleted` boolean must NOT stamp soft_delete")
+	}
+	if _, ok := item.Properties["timestamps"]; ok {
+		t.Error("no timestamp fields → timestamps absent")
+	}
+}
+
+// --- SQLAlchemy ------------------------------------------------------------
+
+func TestSQLAlchemyLifecycle_SoftDeleteMixin(t *testing.T) {
+	src := `
+class User(Base, SoftDeleteMixin):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    created_by = Column(String)
+`
+	ents := pyExtract(t, "python_sqlalchemy", src)
+	user := pyModel(ents, "User")
+	if user == nil {
+		t.Fatal("User SQLAlchemy model node not emitted")
+	}
+	if user.Properties["soft_delete"] != "true" || user.Properties["soft_delete_column"] != "deleted_at" {
+		t.Errorf("User soft-delete: want true/deleted_at, got %q/%q",
+			user.Properties["soft_delete"], user.Properties["soft_delete_column"])
+	}
+	if user.Properties["audit_columns"] != "created_by" {
+		t.Errorf("User.audit_columns: want created_by, got %q", user.Properties["audit_columns"])
+	}
+}
+
+func TestSQLAlchemyLifecycle_TimestampsAndDeletedAt(t *testing.T) {
+	src := `
+class Post(Base):
+    __tablename__ = "posts"
+    id = Column(Integer, primary_key=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, onupdate=func.now())
+    deleted_at = Column(DateTime, nullable=True)
+`
+	ents := pyExtract(t, "python_sqlalchemy", src)
+	post := pyModel(ents, "Post")
+	if post == nil {
+		t.Fatal("Post SQLAlchemy model node not emitted")
+	}
+	if post.Properties["soft_delete"] != "true" || post.Properties["soft_delete_column"] != "deleted_at" {
+		t.Errorf("Post soft-delete: want true/deleted_at, got %q/%q",
+			post.Properties["soft_delete"], post.Properties["soft_delete_column"])
+	}
+	if post.Properties["timestamps"] != "true" {
+		t.Errorf("Post.timestamps: want true, got %q", post.Properties["timestamps"])
+	}
+}
+
+func TestSQLAlchemyLifecycle_PlainTimestamps_NotAsserted(t *testing.T) {
+	src := `
+class Plain(Base):
+    __tablename__ = "plain"
+    id = Column(Integer, primary_key=True)
+    created_at = Column(DateTime)
+    updated_at = Column(DateTime)
+`
+	ents := pyExtract(t, "python_sqlalchemy", src)
+	plain := pyModel(ents, "Plain")
+	if plain == nil {
+		t.Fatal("Plain model node not emitted")
+	}
+	if _, ok := plain.Properties["timestamps"]; ok {
+		t.Error("plain DateTime columns without default/onupdate must NOT assert timestamps")
+	}
+	if _, ok := plain.Properties["soft_delete"]; ok {
+		t.Error("no deleted_at/mixin → soft_delete absent")
+	}
+}

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/lifecycle"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -143,6 +144,15 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 		if tm := saTablenameRe.FindStringSubmatch(body); tm != nil {
 			props["tablename"] = tm[1]
 		}
+		// Data-lifecycle traits (#3628 child): soft-delete (deleted_at Column /
+		// SoftDeleteMixin), timestamps (created_at+updated_at with a
+		// server_default/onupdate signal), audit columns — stamped onto the model
+		// node. A plain `deleted` boolean is NOT reported as soft-delete.
+		lifecycle.SQLAlchemy(bases, body).Stamp(func(kv ...string) {
+			for i := 0; i+1 < len(kv); i += 2 {
+				props[kv[i]] = kv[i+1]
+			}
+		})
 		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, line, props))
 		modelIdx := len(out) - 1 // index of this model node, for GRAPH_RELATES edges
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -13,7 +13,10 @@
 // partial) rather than asserted.
 package lifecycle
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // Traits is the resolved data-lifecycle trait set for one ORM model. Zero
 // value means "no recognised lifecycle traits" — every field is then omitted
@@ -154,4 +157,262 @@ func railsSoftDeleteScope(body string) bool {
 	return strings.Contains(body, "deleted_at: nil") ||
 		strings.Contains(body, "deleted_at IS NULL") ||
 		strings.Contains(body, "deleted_at is null")
+}
+
+// --- TypeORM (TypeScript) --------------------------------------------------
+
+// reTypeORMDeleteDateColumn captures the property name of a @DeleteDateColumn()
+// decorated field — TypeORM's first-class soft-delete marker. The column name
+// is the property identifier (TypeORM defaults the DB column to it).
+var reTypeORMDeleteDateColumn = regexp.MustCompile(
+	`@DeleteDateColumn\s*\([^)]*\)\s+(\w+)`,
+)
+
+// reTypeORMColumnProp captures the property name of a plain @Column()/@Column(...)
+// decorated field, used to surface conventional audit columns declared on the
+// entity body.
+var reTypeORMColumnProp = regexp.MustCompile(
+	`@Column\s*\([^)]*\)\s+(\w+)`,
+)
+
+// TypeORM resolves lifecycle traits from the body of a single TypeORM @Entity
+// class. Detection is decorator-driven (honest):
+//
+//   - @DeleteDateColumn() deletedAt → soft-delete, column = the property name.
+//   - @CreateDateColumn() AND @UpdateDateColumn() both present → timestamps.
+//   - conventional @Column() audit fields (created_by/createdBy/…) → audit_columns.
+//
+// A plain `deleted` boolean @Column with no @DeleteDateColumn is NOT soft-delete.
+func TypeORM(body string) Traits {
+	var t Traits
+	if m := reTypeORMDeleteDateColumn.FindStringSubmatch(body); m != nil {
+		t.SoftDelete = true
+		t.SoftDeleteColumn = m[1]
+	}
+	if strings.Contains(body, "@CreateDateColumn") && strings.Contains(body, "@UpdateDateColumn") {
+		t.Timestamps = true
+	}
+	var cols []string
+	for _, m := range reTypeORMColumnProp.FindAllStringSubmatch(body, -1) {
+		cols = append(cols, m[1])
+	}
+	t.AuditColumns = collectAuditColumns(normalizeCamelColumns(cols))
+	return t
+}
+
+// --- Sequelize (TypeScript / JavaScript) -----------------------------------
+
+// reSequelizeBoolOption matches a `<key>: true|false` entry inside a Sequelize
+// model options object (the second arg of define()/init()). Group 1 = key,
+// group 2 = boolean literal.
+var reSequelizeBoolOption = regexp.MustCompile(
+	`(?m)\b(paranoid|timestamps)\s*:\s*(true|false)\b`,
+)
+
+// SequelizeInput carries the Sequelize model-options facts an extractor parsed:
+// the options-object source blob (for paranoid/timestamps flags) and the
+// resolved column names declared in the model attributes object.
+type SequelizeInput struct {
+	OptionsBlob string   // the model-options object source (second define/init arg)
+	Columns     []string // attribute/column names declared on the model
+}
+
+// Sequelize resolves lifecycle traits for a Sequelize model.
+//
+//   - `paranoid: true` → soft-delete (column deletedAt unless overridden).
+//   - timestamps are ON by default; only `timestamps: false` disables them.
+//   - conventional audit columns among the attributes → audit_columns.
+//
+// paranoid:true with no explicit timestamps:false also implies timestamps
+// (Sequelize requires timestamps for paranoid mode).
+func Sequelize(in SequelizeInput) Traits {
+	var t Traits
+	paranoid := false
+	timestampsDisabled := false
+	for _, m := range reSequelizeBoolOption.FindAllStringSubmatch(in.OptionsBlob, -1) {
+		switch m[1] {
+		case "paranoid":
+			paranoid = m[2] == "true"
+		case "timestamps":
+			if m[2] == "false" {
+				timestampsDisabled = true
+			}
+		}
+	}
+	if paranoid {
+		t.SoftDelete = true
+		t.SoftDeleteColumn = sequelizeDeletedAtOverride(in.OptionsBlob)
+	}
+	// Timestamps default ON; disabled only by an explicit timestamps:false.
+	// paranoid mode forces timestamps on regardless.
+	if !timestampsDisabled || paranoid {
+		t.Timestamps = true
+	}
+	t.AuditColumns = collectAuditColumns(normalizeCamelColumns(in.Columns))
+	return t
+}
+
+// reSequelizeDeletedAtOpt captures a `deletedAt: 'column_name'` override in the
+// Sequelize options object, which renames the soft-delete marker column.
+var reSequelizeDeletedAtOpt = regexp.MustCompile(
+	`deletedAt\s*:\s*['"]([A-Za-z0-9_]+)['"]`,
+)
+
+// sequelizeDeletedAtOverride returns the soft-delete column for a paranoid
+// model: the `deletedAt: 'x'` override when present, else the Sequelize default
+// `deletedAt`.
+func sequelizeDeletedAtOverride(optionsBlob string) string {
+	if m := reSequelizeDeletedAtOpt.FindStringSubmatch(optionsBlob); m != nil {
+		return m[1]
+	}
+	return "deletedAt"
+}
+
+// --- Django (Python) -------------------------------------------------------
+
+// reDjangoField matches a model field assignment line: `name = models.XxxField(`,
+// `name = SomethingField(`, or a relation field (`models.ForeignKey(`). Group 1 =
+// field name, group 2 = field type.
+var reDjangoField = regexp.MustCompile(
+	`(?m)^\s+(\w+)\s*=\s*(?:models\.)?(\w*Field|ForeignKey)\s*\(`,
+)
+
+// reDjangoSoftDeleteBase matches a django-safedelete base class in the model's
+// base list, the conventional library marker for soft-delete.
+var reDjangoSoftDeleteBase = regexp.MustCompile(
+	`\bSafeDelete(?:Model|MPTTModel|NewManager)?\b`,
+)
+
+// Django resolves lifecycle traits from a single Django model class. `bases` is
+// the base-class list (between the parens of `class X(...)`), `body` the class
+// body. Detection requires a recognised soft-delete convention (honest):
+//
+//   - a SafeDeleteModel / django-safedelete base → soft-delete.
+//   - a `deleted_at` DateTimeField or an `is_deleted` BooleanField → soft-delete.
+//   - auto_now_add + auto_now, OR created_at + updated_at DateTimeFields → timestamps.
+//   - created_by / updated_by FK fields → audit_columns.
+//
+// A plain `deleted` boolean with no deleted_at/is_deleted/library is NOT
+// soft-delete.
+func Django(bases, body string) Traits {
+	var t Traits
+
+	fields := map[string]bool{}
+	for _, m := range reDjangoField.FindAllStringSubmatch(body, -1) {
+		fields[strings.ToLower(m[1])] = true
+	}
+
+	switch {
+	case reDjangoSoftDeleteBase.MatchString(bases):
+		t.SoftDelete = true
+		t.SoftDeleteColumn = "deleted_at"
+	case fields["deleted_at"]:
+		t.SoftDelete = true
+		t.SoftDeleteColumn = "deleted_at"
+	case fields["is_deleted"]:
+		t.SoftDelete = true
+		t.SoftDeleteColumn = "is_deleted"
+	}
+
+	if (strings.Contains(body, "auto_now_add=True") && strings.Contains(body, "auto_now=True")) ||
+		(fields["created_at"] && fields["updated_at"]) {
+		t.Timestamps = true
+	}
+
+	cols := make([]string, 0, len(fields))
+	for f := range fields {
+		cols = append(cols, f)
+	}
+	t.AuditColumns = collectAuditColumns(cols)
+	return t
+}
+
+// --- SQLAlchemy (Python) ---------------------------------------------------
+
+// reSQLAColumn matches an attribute assigned a Column(...)/mapped_column(...),
+// optionally via a Mapped[...] annotation. Group 1 = attribute name. Captures
+// both `x = Column(...)` and `x: Mapped[...] = mapped_column(...)`.
+var reSQLAColumn = regexp.MustCompile(
+	`(?m)^\s+(\w+)\s*(?::\s*Mapped\[[^\]]*\])?\s*=\s*(?:Column|mapped_column)\s*\(`,
+)
+
+// reSQLASoftDeleteMixin matches a conventional soft-delete mixin in the base
+// list (SoftDeleteMixin / SoftDeleteable / etc.).
+var reSQLASoftDeleteMixin = regexp.MustCompile(
+	`\bSoftDelete(?:Mixin|able|Model)?\b`,
+)
+
+// SQLAlchemy resolves lifecycle traits from a single SQLAlchemy declarative
+// model. `bases` is the base-class list, `body` the class body. Detection is
+// convention-driven (honest):
+//
+//   - a SoftDeleteMixin base → soft-delete, column deleted_at.
+//   - a `deleted_at` Column/mapped_column → soft-delete with that column.
+//   - created_at + updated_at columns whose definitions carry server_default /
+//     onupdate (timestamp semantics) → timestamps.
+//   - created_by / updated_by columns → audit_columns.
+//
+// A plain `deleted` boolean Column with no mixin/deleted_at is NOT soft-delete.
+func SQLAlchemy(bases, body string) Traits {
+	var t Traits
+
+	cols := map[string]bool{}
+	for _, m := range reSQLAColumn.FindAllStringSubmatch(body, -1) {
+		cols[strings.ToLower(m[1])] = true
+	}
+
+	switch {
+	case reSQLASoftDeleteMixin.MatchString(bases):
+		t.SoftDelete = true
+		t.SoftDeleteColumn = "deleted_at"
+	case cols["deleted_at"]:
+		t.SoftDelete = true
+		t.SoftDeleteColumn = "deleted_at"
+	}
+
+	// Timestamps require created_at + updated_at columns AND a timestamp-default
+	// signal (server_default / default / onupdate) so a pair of plain nullable
+	// DateTime columns is not over-claimed.
+	if cols["created_at"] && cols["updated_at"] &&
+		(strings.Contains(body, "server_default") ||
+			strings.Contains(body, "onupdate") ||
+			strings.Contains(body, "default=func") ||
+			strings.Contains(body, "default=datetime")) {
+		t.Timestamps = true
+	}
+
+	names := make([]string, 0, len(cols))
+	for c := range cols {
+		names = append(names, c)
+	}
+	t.AuditColumns = collectAuditColumns(names)
+	return t
+}
+
+// normalizeCamelColumns maps camelCase identifiers (createdBy) to the snake_case
+// audit-convention names (created_by) so the shared collectAuditColumns set
+// matches JS/TS property identifiers as well as snake_case columns.
+func normalizeCamelColumns(cols []string) []string {
+	out := make([]string, 0, len(cols)*2)
+	for _, c := range cols {
+		out = append(out, c, camelToSnake(c))
+	}
+	return out
+}
+
+// camelToSnake converts a camelCase identifier to snake_case (createdById →
+// created_by_id). ASCII-only, sufficient for the closed audit-convention set.
+func camelToSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r - 'A' + 'a')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -87,6 +87,233 @@ func TestRails_OrderingScope_NotSoftDelete(t *testing.T) {
 	}
 }
 
+// --- TypeORM ---------------------------------------------------------------
+
+func TestTypeORM_DeleteDateColumn(t *testing.T) {
+	body := `@Entity() class User {
+	@PrimaryGeneratedColumn() id: number;
+	@DeleteDateColumn() deletedAt: Date;
+}`
+	got := TypeORM(body)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deletedAt" {
+		t.Errorf("want soft_delete deletedAt, got %+v", got)
+	}
+	if got.Timestamps {
+		t.Error("no create/update date columns → timestamps must be absent")
+	}
+}
+
+func TestTypeORM_CreateUpdateDateColumns_Timestamps(t *testing.T) {
+	body := `@Entity() class Post {
+	@CreateDateColumn() createdAt: Date;
+	@UpdateDateColumn() updatedAt: Date;
+}`
+	got := TypeORM(body)
+	if !got.Timestamps {
+		t.Error("@CreateDateColumn + @UpdateDateColumn → timestamps")
+	}
+	if got.SoftDelete {
+		t.Error("no @DeleteDateColumn → soft_delete must be absent")
+	}
+}
+
+func TestTypeORM_CreateOnly_NoTimestamps(t *testing.T) {
+	body := `@Entity() class Log { @CreateDateColumn() createdAt: Date; }`
+	if TypeORM(body).Timestamps {
+		t.Error("@CreateDateColumn alone must NOT assert timestamps")
+	}
+}
+
+func TestTypeORM_AuditColumns(t *testing.T) {
+	body := `@Entity() class Doc {
+	@Column() createdBy: string;
+	@Column() title: string;
+}`
+	got := TypeORM(body)
+	if len(got.AuditColumns) != 1 || got.AuditColumns[0] != "created_by" {
+		t.Errorf("want [created_by], got %v", got.AuditColumns)
+	}
+}
+
+func TestTypeORM_PlainDeletedBool_NotSoftDelete(t *testing.T) {
+	body := `@Entity() class Item { @Column() deleted: boolean; }`
+	if TypeORM(body).SoftDelete {
+		t.Error("plain @Column() deleted boolean must NOT be soft_delete")
+	}
+}
+
+func TestTypeORM_NoTraits_Absent(t *testing.T) {
+	got := TypeORM(`@Entity() class Plain { @Column() name: string; }`)
+	if got.SoftDelete || got.Timestamps || len(got.AuditColumns) != 0 {
+		t.Errorf("entity with no lifecycle conventions must have no traits, got %+v", got)
+	}
+}
+
+// --- Sequelize -------------------------------------------------------------
+
+func TestSequelize_Paranoid(t *testing.T) {
+	got := Sequelize(SequelizeInput{OptionsBlob: `{ paranoid: true }`})
+	if !got.SoftDelete || got.SoftDeleteColumn != "deletedAt" {
+		t.Errorf("paranoid:true → soft_delete deletedAt, got %+v", got)
+	}
+	if !got.Timestamps {
+		t.Error("paranoid mode forces timestamps on")
+	}
+}
+
+func TestSequelize_ParanoidDeletedAtOverride(t *testing.T) {
+	got := Sequelize(SequelizeInput{OptionsBlob: `{ paranoid: true, deletedAt: 'destroyed_on' }`})
+	if got.SoftDeleteColumn != "destroyed_on" {
+		t.Errorf("want override column destroyed_on, got %q", got.SoftDeleteColumn)
+	}
+}
+
+func TestSequelize_TimestampsDefaultOn(t *testing.T) {
+	got := Sequelize(SequelizeInput{OptionsBlob: `{ tableName: 'users' }`})
+	if !got.Timestamps {
+		t.Error("timestamps default ON unless timestamps:false")
+	}
+	if got.SoftDelete {
+		t.Error("no paranoid → no soft_delete")
+	}
+}
+
+func TestSequelize_TimestampsDisabled(t *testing.T) {
+	got := Sequelize(SequelizeInput{OptionsBlob: `{ timestamps: false }`})
+	if got.Timestamps {
+		t.Error("timestamps:false must disable timestamps")
+	}
+}
+
+func TestSequelize_AuditColumns(t *testing.T) {
+	got := Sequelize(SequelizeInput{Columns: []string{"id", "createdBy", "name"}, OptionsBlob: `{ timestamps: false }`})
+	if len(got.AuditColumns) != 1 || got.AuditColumns[0] != "created_by" {
+		t.Errorf("want [created_by], got %v", got.AuditColumns)
+	}
+}
+
+// --- Django ----------------------------------------------------------------
+
+func TestDjango_DeletedAtField(t *testing.T) {
+	body := `class Order(models.Model):
+    name = models.CharField(max_length=20)
+    deleted_at = models.DateTimeField(null=True)`
+	got := Django("models.Model", body)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deleted_at" {
+		t.Errorf("deleted_at field → soft_delete deleted_at, got %+v", got)
+	}
+}
+
+func TestDjango_SafeDeleteBase(t *testing.T) {
+	got := Django("SafeDeleteModel", `class A(SafeDeleteModel):
+    pass`)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deleted_at" {
+		t.Errorf("SafeDeleteModel base → soft_delete, got %+v", got)
+	}
+}
+
+func TestDjango_IsDeletedField(t *testing.T) {
+	body := `class B(models.Model):
+    is_deleted = models.BooleanField(default=False)`
+	got := Django("models.Model", body)
+	if !got.SoftDelete || got.SoftDeleteColumn != "is_deleted" {
+		t.Errorf("is_deleted field → soft_delete is_deleted, got %+v", got)
+	}
+}
+
+func TestDjango_AutoNowTimestamps(t *testing.T) {
+	body := `class C(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)`
+	got := Django("models.Model", body)
+	if !got.Timestamps {
+		t.Error("auto_now_add + auto_now → timestamps")
+	}
+}
+
+func TestDjango_AuditColumns(t *testing.T) {
+	body := `class D(models.Model):
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+    title = models.CharField(max_length=10)`
+	got := Django("models.Model", body)
+	if len(got.AuditColumns) != 1 || got.AuditColumns[0] != "created_by" {
+		t.Errorf("want [created_by], got %v", got.AuditColumns)
+	}
+}
+
+func TestDjango_PlainDeletedBool_NotSoftDelete(t *testing.T) {
+	body := `class E(models.Model):
+    deleted = models.BooleanField(default=False)`
+	got := Django("models.Model", body)
+	if got.SoftDelete {
+		t.Error("plain `deleted` boolean must NOT be soft_delete")
+	}
+}
+
+func TestDjango_NoTraits_Absent(t *testing.T) {
+	got := Django("models.Model", `class F(models.Model):
+    name = models.CharField(max_length=5)`)
+	if got.SoftDelete || got.Timestamps || len(got.AuditColumns) != 0 {
+		t.Errorf("plain model must have no traits, got %+v", got)
+	}
+}
+
+// --- SQLAlchemy ------------------------------------------------------------
+
+func TestSQLAlchemy_SoftDeleteMixin(t *testing.T) {
+	got := SQLAlchemy("Base, SoftDeleteMixin", `class User(Base, SoftDeleteMixin):
+    __tablename__ = "users"`)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deleted_at" {
+		t.Errorf("SoftDeleteMixin → soft_delete deleted_at, got %+v", got)
+	}
+}
+
+func TestSQLAlchemy_DeletedAtColumn(t *testing.T) {
+	body := `class Doc(Base):
+    deleted_at = Column(DateTime, nullable=True)`
+	got := SQLAlchemy("Base", body)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deleted_at" {
+		t.Errorf("deleted_at Column → soft_delete, got %+v", got)
+	}
+}
+
+func TestSQLAlchemy_Timestamps(t *testing.T) {
+	body := `class Post(Base):
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, onupdate=func.now())`
+	got := SQLAlchemy("Base", body)
+	if !got.Timestamps {
+		t.Error("created_at/updated_at with server_default/onupdate → timestamps")
+	}
+}
+
+func TestSQLAlchemy_PlainTimestampCols_NotAsserted(t *testing.T) {
+	body := `class Plain(Base):
+    created_at = Column(DateTime)
+    updated_at = Column(DateTime)`
+	got := SQLAlchemy("Base", body)
+	if got.Timestamps {
+		t.Error("plain DateTime columns without default/onupdate must NOT assert timestamps")
+	}
+}
+
+func TestSQLAlchemy_PlainDeletedBool_NotSoftDelete(t *testing.T) {
+	body := `class Item(Base):
+    deleted = Column(Boolean, default=False)`
+	if SQLAlchemy("Base", body).SoftDelete {
+		t.Error("plain `deleted` boolean Column must NOT be soft_delete")
+	}
+}
+
+func TestSQLAlchemy_MappedColumn(t *testing.T) {
+	body := `class M(Base):
+    deleted_at: Mapped[datetime] = mapped_column(nullable=True)`
+	got := SQLAlchemy("Base", body)
+	if !got.SoftDelete || got.SoftDeleteColumn != "deleted_at" {
+		t.Errorf("mapped_column deleted_at → soft_delete, got %+v", got)
+	}
+}
+
 func TestStamp_OmitsAbsent(t *testing.T) {
 	props := stamped(Traits{})
 	if len(props) != 0 {


### PR DESCRIPTION
Closes #3814. Completes #3808; child of epic #3628.

**Stacked on #3809** (wave-12 GORM + ActiveRecord). Base is the `model-lifecycle-traits` branch so the diff is just this commit; once #3809 merges, retarget to `main`.

## What
Reuses the wave-12 `internal/lifecycle` package to stamp the same flat props — `soft_delete` / `soft_delete_column` / `timestamps` / `audit_columns` — onto TypeScript and Python ORM model entities. Four new pure detectors (`TypeORM`, `Sequelize`, `Django`, `SQLAlchemy`) wired into the existing extractors.

| ORM | soft_delete | timestamps | audit_columns |
|---|---|---|---|
| **TypeORM** | `@DeleteDateColumn()` -> column = property name | `@CreateDateColumn()` + `@UpdateDateColumn()` | `@Column()` createdBy/... |
| **Sequelize** | `paranoid:true` -> deletedAt (or `deletedAt:'col'`) | default-on unless `timestamps:false` (paranoid forces on) | attribute keys |
| **Django** | `deleted_at`/`is_deleted` field or safedelete base | `auto_now_add`+`auto_now` or `created_at`+`updated_at` | `created_by`/`updated_by` FK |
| **SQLAlchemy** | `deleted_at` Column/mapped_column or SoftDeleteMixin | `created_at`+`updated_at` WITH server_default/onupdate | `created_by`/`updated_by` |

TypeORM scans each `@Entity` body in isolation; Sequelize reads the attributes + options objects of `define()`/`init()`; Django emits a `SCOPE.Schema`/model node per `class X(models.Model)`; SQLAlchemy stamps the existing declarative-model node.

## Honesty boundary (matched to #3809)
A plain `deleted` boolean with no library/scope/`deleted_at` convention is NOT soft_delete. SQLAlchemy timestamps require a `server_default`/`onupdate`/`default=func|datetime` signal; `@CreateDateColumn` alone does not assert timestamps; Sequelize `timestamps:false` omits timestamps.

## Tests (value-asserting, not len>0)
- `internal/lifecycle/lifecycle_test.go`: per-detector trait+column assertions + negatives.
- `internal/custom/javascript/lifecycle_traits_test.go`: TypeORM `@DeleteDateColumn() deletedAt` on `@Entity() User` -> soft_delete=true column=deletedAt + timestamps + audit_columns; per-entity body isolation; Sequelize paranoid; timestamps:false negative; class+init.
- `internal/custom/python/lifecycle_traits_test.go`: Django deleted_at/safedelete/auto_now + plain-bool negative; SQLAlchemy SoftDeleteMixin/deleted_at/timestamps + plain-timestamp negative.

## Coverage
Flips the typeorm/sequelize/django/sqlalchemy `model_lifecycle_extraction` cells missing -> **full** with honest cites + notes; `coverage validate` 0 errors, `fmt --check` canonical, docs regenerated via `coverage gen`.

`go test` (lifecycle, custom/js, custom/python, types, tools/coverage) green; `gofmt -l` empty; `go vet` clean.

DEPLOY-DEFERRED — no live daemon rebuild/reindex in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)