### PR TITLE
feat(i18n): translation-key usage extraction (USES_TRANSLATION)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -1,47 +1,48 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # platform
 
-**Total**: 38 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 32 · **python**: 1 · **ruby**: 1
+**Total**: 39 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 33 · **python**: 1 · **ruby**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Dependency attribution | Env resolution | External service dependency | File parsing | Resource extraction | Shared data coupling | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | — | — | ✅ | — | — | ✅ | |
-| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | — | ✅ | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | — | — | 🟢 | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | — | 🟢 | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | — | — | ✅ | — | ✅ | |
-| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
+| Language | Name | Dependency attribution | Env resolution | External service dependency | File parsing | Resource extraction | Shared data coupling | Translation key usage | Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | — | — | ✅ | — | — | — | ✅ | |
+| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | — | — | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | — | ✅ | — | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | — | — | 🟢 | — | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | — | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | — | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | — | 🟢 | — | — | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | — | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [i18n translation-key usage (USES_TRANSLATION)](../detail/analysis.localization.i18n-keys.md) | — | — | — | — | — | — | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |

--- a/docs/coverage/detail/analysis.localization.i18n-keys.md
+++ b/docs/coverage/detail/analysis.localization.i18n-keys.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `analysis.localization.i18n-keys` — i18n translation-key usage (USES_TRANSLATION)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [platform](../by-category/platform.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Translation key usage | 🟢 `partial` | `2026-06-02` | 3628 | `internal/extractor/translation_key.go`<br>`internal/extractor/translation_key_test.go`<br>`internal/extractors/javascript/translation_key.go`<br>`internal/extractors/javascript/translation_key_test.go`<br>`internal/extractors/php/translation_key.go`<br>`internal/extractors/php/translation_key_test.go`<br>`internal/extractors/python/translation_key.go`<br>`internal/extractors/python/translation_key_test.go`<br>`internal/extractors/ruby/translation_key.go`<br>`internal/extractors/ruby/translation_key_test.go`<br>`internal/types/kinds.go` | #3628 area: i18n / localization KEY-USAGE detection. Each language extractor emits a USES_TRANSLATION edge from the enclosing function/component to a synthetic SCOPE.TranslationKey node (Name "i18n:<key>") so every reference site of a literal key converges on ONE node and the graph answers "where is the 'errors.notFound' string used?" and supports untranslated-key analysis (a key node with no backing catalog entry). Shared node/edge builders live in internal/extractor/translation_key.go (TranslationKeyEntity, TranslationKeyTargetID, EmitTranslationKeyEdges) with the JS/TS i18n import dictionary (IsI18nImportSource) and the static-key guard (IsStaticTranslationKey). JS/TS pass: react-i18next/i18next t('k')/i18n.t('k')/<Trans i18nKey> and vue-i18n $t('k') (bare t requires an i18n import in the file). Python pass: Django/gettext _('m')/gettext('x')/gettext_lazy('x') import-gated to django.utils.translation / gettext. Ruby pass: Rails I18n.t('k') and relative t('.k'). PHP pass: Laravel __('k')/trans('k'). PRECISION-FIRST / REQUIRE-I18N-CONTEXT honest-partial: a dynamic key (t(keyVar), interpolated) or a non-i18n _('x') (lodash) / unrelated t(...) without i18n context emits NO node/edge; an ambiguous bare Rails t('plain') (no receiver, no leading dot) is dropped. PARTIAL because jsts/python/ruby/php lanes are implemented (java/go and the Blade @lang directive in *.blade.php template text are future lanes) and recall is deliberately bounded to static literal keys. DEPLOY-DEFERRED: extractor + kinds land here; live-daemon reindex is a separate coordinated step. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update analysis.localization.i18n-keys ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -59,6 +59,21 @@
       }
     },
     {
+      "id": "analysis.localization.i18n-keys",
+      "category": "platform",
+      "language": "multi",
+      "label": "i18n translation-key usage (USES_TRANSLATION)",
+      "capabilities": {
+        "translation_key_usage": {
+          "status": "partial",
+          "cites": ["internal/extractor/translation_key.go","internal/extractor/translation_key_test.go","internal/extractors/javascript/translation_key.go","internal/extractors/javascript/translation_key_test.go","internal/extractors/php/translation_key.go","internal/extractors/php/translation_key_test.go","internal/extractors/python/translation_key.go","internal/extractors/python/translation_key_test.go","internal/extractors/ruby/translation_key.go","internal/extractors/ruby/translation_key_test.go","internal/types/kinds.go"],
+          "issue": "3628",
+          "notes": "#3628 area: i18n / localization KEY-USAGE detection. Each language extractor emits a USES_TRANSLATION edge from the enclosing function/component to a synthetic SCOPE.TranslationKey node (Name \"i18n:\u003ckey\u003e\") so every reference site of a literal key converges on ONE node and the graph answers \"where is the 'errors.notFound' string used?\" and supports untranslated-key analysis (a key node with no backing catalog entry). Shared node/edge builders live in internal/extractor/translation_key.go (TranslationKeyEntity, TranslationKeyTargetID, EmitTranslationKeyEdges) with the JS/TS i18n import dictionary (IsI18nImportSource) and the static-key guard (IsStaticTranslationKey). JS/TS pass: react-i18next/i18next t('k')/i18n.t('k')/\u003cTrans i18nKey\u003e and vue-i18n $t('k') (bare t requires an i18n import in the file). Python pass: Django/gettext _('m')/gettext('x')/gettext_lazy('x') import-gated to django.utils.translation / gettext. Ruby pass: Rails I18n.t('k') and relative t('.k'). PHP pass: Laravel __('k')/trans('k'). PRECISION-FIRST / REQUIRE-I18N-CONTEXT honest-partial: a dynamic key (t(keyVar), interpolated) or a non-i18n _('x') (lodash) / unrelated t(...) without i18n context emits NO node/edge; an ambiguous bare Rails t('plain') (no receiver, no leading dot) is dropped. PARTIAL because jsts/python/ruby/php lanes are implemented (java/go and the Blade @lang directive in *.blade.php template text are future lanes) and recall is deliberately bounded to static literal keys. DEPLOY-DEFERRED: extractor + kinds land here; live-daemon reindex is a separate coordinated step.",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "api-spec.openapi-ingestion",
       "category": "protocol",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 154
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 155
 
 ## Coverage by language
 
@@ -33,14 +33,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 12 | 0 | 8 | 4 |
-| [Platform / k8s](by-category/platform.md) | 32 | 20 | 12 | 0 |
+| [Platform / k8s](by-category/platform.md) | 33 | 20 | 13 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 21 | 9 | 10 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 12 | 5 | 4 | 3 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 112 | 42 | 43 | 27 |
+| **Total** | 113 | 42 | 44 | 27 |
 
 ## Languages with extractor support, no records yet
 
@@ -68,4 +68,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 224 frameworks · 111 tools · 155 ORMs · 154 other
+Total: 224 frameworks · 111 tools · 155 ORMs · 155 other

--- a/internal/extractor/translation_key.go
+++ b/internal/extractor/translation_key.go
@@ -1,0 +1,237 @@
+// translation_key.go — shared, cross-language helpers for the i18n /
+// localization key-usage topology (child of epic #3628). It mirrors the
+// external-service model in external_service.go and the template-render model
+// in template_render.go.
+//
+// The capability answers one question a rewrite (or an i18n / localization
+// audit) needs: "where is the 'errors.notFound' string used, and which keys
+// are referenced at all?" — so a graph consumer can drive untranslated-key
+// analysis (a key node with no backing catalog entry) and impact analysis
+// (rename a key → every USES_TRANSLATION caller).
+//
+// To make every reference site of a key converge on ONE graph node, each
+// language extractor emits:
+//
+//   - one SCOPE.TranslationKey / subtype="translation_key" entity per distinct
+//     literal key, with a SYNTHETIC constant SourceFile (TranslationKeySourceFile)
+//     so EntityRecord.ComputeID(SourceFile+Kind+Name) collapses the same key
+//     across files AND languages/frameworks into a single node. An
+//     `errors.notFound` referenced in Login.tsx and again in Signup.tsx
+//     therefore share one "i18n:errors.notFound" node, and that node's inbound
+//     USES_TRANSLATION set is the codebase's full footprint for that key.
+//
+//   - one USES_TRANSLATION edge (enclosing function / component → key node)
+//     carried as a structural-ref ToID (TranslationKeyTargetID) that the
+//     resolver binds via the byQualifiedName exact-match tier (the entity's
+//     QualifiedName is set equal to that ToID).
+//
+// Precision-first / honest-partial: the REQUIRE-I18N-CONTEXT boundary. An edge
+// is emitted only when the call is rooted at a recognised i18n function context
+// (a t/$t/i18n.t/Trans i18next binding, a gettext family symbol, Rails I18n.t /
+// relative t('.x'), Laravel __ / trans) AND the key is a STATIC string literal.
+// A dynamic key (`t(keyVar)`, interpolated template) is skipped; a bare
+// `_('x')` that is NOT the gettext underscore (e.g. lodash `_`) or an unrelated
+// `t(...)` that is not an i18n binding emits NO node/edge — a fabricated key
+// would poison untranslated-key analysis. The detection of these shapes lives
+// in each language extractor; this file owns the node/edge construction so the
+// convergence invariant is identical everywhere.
+
+package extractor
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TranslationKeySourceFile is the synthetic, constant SourceFile assigned to
+// every translation-key entity so identical keys converge to a single graph
+// node under EntityRecord.ComputeID (SourceFile+Kind+Name).
+const TranslationKeySourceFile = "<translation-key>"
+
+// translationKeyName is the "i18n:" namespace prefix for a key node's Name so
+// it never collides with a same-named code symbol, e.g. "i18n:errors.notFound".
+const translationKeyName = "i18n:"
+
+// TranslationKeyName returns the canonical entity Name for a translation key.
+func TranslationKeyName(key string) string {
+	return translationKeyName + key
+}
+
+// TranslationKeyTargetID returns the structural-ref ToID for a USES_TRANSLATION
+// edge pointing at a key entity. Shape:
+//
+//	scope:translationkey:<key>
+//
+// This value is ALSO stored as the key entity's QualifiedName, so the
+// resolver's byQualifiedName exact-match tier (internal/resolve/refs.go) binds
+// the edge to that entity without any new linker code. Constant across
+// languages so a react-i18next `t('errors.notFound')` and a hypothetical
+// gettext `_('errors.notFound')` resolve to the same node.
+func TranslationKeyTargetID(key string) string {
+	return "scope:translationkey:" + key
+}
+
+// TranslationKeyEntity builds the SCOPE.TranslationKey / translation_key entity
+// for a single literal key. The entity is deliberately file-agnostic (synthetic
+// SourceFile) so it is the shared localization convergence node, and its
+// QualifiedName equals the edge ToID so USES_TRANSLATION edges resolve via
+// byQualifiedName.
+func TranslationKeyEntity(key, lang string) types.EntityRecord {
+	e := types.EntityRecord{
+		Name:          TranslationKeyName(key),
+		QualifiedName: TranslationKeyTargetID(key),
+		Kind:          string(types.EntityKindTranslationKey),
+		Subtype:       "translation_key",
+		Language:      lang,
+		SourceFile:    TranslationKeySourceFile,
+		StartLine:     1,
+		EndLine:       1,
+		Signature:     TranslationKeyName(key),
+		Properties: map[string]string{
+			"key": key,
+		},
+	}
+	if rel := relativeKeyRoot(key); rel {
+		e.Properties["relative"] = "true"
+	}
+	e.ID = e.ComputeID()
+	return e
+}
+
+// relativeKeyRoot reports whether key is a Rails "relative" key (leading dot,
+// e.g. `t('.title')`), which resolves against the current view/controller
+// scope at runtime. We keep it as-written (the literal IS the key) but flag it
+// so consumers know the resolution is scope-dependent.
+func relativeKeyRoot(key string) bool {
+	return strings.HasPrefix(key, ".")
+}
+
+// TranslationUse is one resolved i18n key reference detected by a language
+// extractor: the literal key, the Name of the enclosing function / component,
+// and the optional framework tag (e.g. "react-i18next", "vue-i18n", "gettext",
+// "rails-i18n", "laravel") captured for the edge property.
+type TranslationUse struct {
+	Key      string // literal translation key (errors.notFound, messages.welcome)
+	FromName string // enclosing function/component Name; "" => file entity
+	Tag      string // i18n framework tag for the edge property
+}
+
+// EmitTranslationKeyEdges appends, to *entities, the translation-key entities
+// and USES_TRANSLATION edges for the given detections.
+//
+// entities[0] MUST be the file entity (every language extractor appends it
+// first). Edges whose FromName is "" — or whose FromName has no matching host
+// entity — attach to the file entity (index 0) as a conservative fallback so
+// the edge is never silently dropped. Identical keys converge to one key entity
+// (deduped by key) and one edge per (FromName, key) tuple (the first tag seen
+// for that tuple wins).
+//
+// Returns the number of USES_TRANSLATION edges emitted. Safe with nil/empty
+// input. Detections whose Key is empty (or that look dynamic — caller's
+// responsibility to pre-filter) are skipped — precision over recall.
+func EmitTranslationKeyEdges(entities *[]types.EntityRecord, lang string, uses []TranslationUse) int {
+	if entities == nil || len(*entities) == 0 || len(uses) == 0 {
+		return 0
+	}
+
+	hostByName := map[string]int{}
+	for i := range *entities {
+		hostByName[(*entities)[i].Name] = i
+	}
+
+	seenEdge := map[string]bool{}
+	seenKey := map[string]bool{}
+	var newEntities []types.EntityRecord
+	emitted := 0
+
+	for _, u := range uses {
+		key := strings.TrimSpace(u.Key)
+		if key == "" {
+			continue
+		}
+
+		hostIdx := 0 // file entity by default
+		if u.FromName != "" {
+			if idx, ok := hostByName[u.FromName]; ok {
+				hostIdx = idx
+			}
+		}
+
+		edgeKey := u.FromName + "\x00" + key
+		if !seenEdge[edgeKey] {
+			seenEdge[edgeKey] = true
+			props := map[string]string{"key": key}
+			if u.Tag != "" {
+				props["framework"] = u.Tag
+			}
+			(*entities)[hostIdx].Relationships = append((*entities)[hostIdx].Relationships,
+				types.RelationshipRecord{
+					ToID:       TranslationKeyTargetID(key),
+					Kind:       string(types.RelationshipKindUsesTranslation),
+					Properties: props,
+				})
+			emitted++
+		}
+
+		if !seenKey[key] {
+			seenKey[key] = true
+			newEntities = append(newEntities, TranslationKeyEntity(key, lang))
+		}
+	}
+
+	*entities = append(*entities, newEntities...)
+	return emitted
+}
+
+// IsI18nImportSource reports whether a JS/TS import module / package name
+// establishes an i18n CONTEXT for a file (react-i18next, i18next, vue-i18n, …).
+// A file that imports one of these is allowed to resolve a bare i18n-function
+// call (t/$t/useTranslation/useI18n) into a key reference; a file with NO such
+// import does not (so a local helper named `t` or a lodash `_` never fabricates
+// a key). Matched by leading scoped/path segment. Python gettext context is
+// gated separately by the Python extractor's isI18nPythonSource.
+func IsI18nImportSource(source string) bool {
+	s := strings.ToLower(strings.TrimSpace(source))
+	s = strings.Trim(s, "'\"`")
+	s = strings.ReplaceAll(s, "\\", "/")
+	if s == "" {
+		return false
+	}
+	// Leading scoped or path segment.
+	head := s
+	if strings.HasPrefix(s, "@") {
+		parts := strings.SplitN(s, "/", 3)
+		if len(parts) >= 2 {
+			head = parts[0] + "/" + parts[1]
+		}
+	} else if i := strings.IndexAny(s, "/."); i >= 0 {
+		head = s[:i]
+	}
+	// JS/TS i18n packages only — Python gettext / django.utils.translation
+	// context is gated by the Python extractor's own isI18nPythonSource, not
+	// this leading-segment dictionary (which would misfire on a `django.*`
+	// import that is unrelated to translation).
+	switch head {
+	case "react-i18next", "i18next", "next-i18next",
+		"vue-i18n", "@nuxtjs/i18n", "i18n-js",
+		"@lingui/react", "@lingui/macro":
+		return true
+	}
+	return false
+}
+
+// IsStaticTranslationKey reports whether s is a usable static translation key:
+// non-empty, and free of interpolation markers that signal a dynamic value
+// (`${`, `#{`, `{{`, a bare `+` concatenation is handled by the caller seeing a
+// non-literal node). This is the literal-payload guard; the CONTEXT guard
+// (is this actually an i18n function?) is the language extractor's job.
+func IsStaticTranslationKey(s string) bool {
+	if strings.TrimSpace(s) == "" {
+		return false
+	}
+	if strings.Contains(s, "${") || strings.Contains(s, "#{") || strings.Contains(s, "{{") {
+		return false
+	}
+	return true
+}

--- a/internal/extractor/translation_key_test.go
+++ b/internal/extractor/translation_key_test.go
@@ -1,0 +1,108 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestIsI18nImportSource(t *testing.T) {
+	cases := map[string]bool{
+		"react-i18next":            true,
+		"i18next":                  true,
+		"next-i18next":             true,
+		"vue-i18n":                 true,
+		"@nuxtjs/i18n":             true,
+		"@lingui/react":            true,
+		"gettext":                  false, // python gettext gated by python extractor, not this JS dict
+		"django.utils.translation": false, // module form handled by python extractor, not this dict
+		"express":                  false,
+		"lodash":                   false,
+		"./local/util":             false,
+		"":                         false,
+	}
+	for in, want := range cases {
+		if got := IsI18nImportSource(in); got != want {
+			t.Errorf("IsI18nImportSource(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestIsStaticTranslationKey(t *testing.T) {
+	cases := map[string]bool{
+		"errors.notFound": true,
+		".relative":       true,
+		"Welcome":         true,
+		"":                false,
+		"  ":              false,
+		"a.${x}":          false, // JS interpolation
+		"a.#{x}":          false, // Ruby interpolation
+		"a.{{x}}":         false, // mustache/handlebars interpolation
+	}
+	for in, want := range cases {
+		if got := IsStaticTranslationKey(in); got != want {
+			t.Errorf("IsStaticTranslationKey(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// Convergence at the construction layer: the same key emitted from two callers
+// produces ONE entity (deduped) and one edge per (caller, key) tuple — and the
+// key node id is stable regardless of caller / language.
+func TestEmitTranslationKeyEdges_Convergence(t *testing.T) {
+	file := types.EntityRecord{Name: "file", Kind: "SCOPE.Component", Subtype: "file"}
+	a := types.EntityRecord{Name: "A", Kind: string(types.EntityKindFunction)}
+	b := types.EntityRecord{Name: "B", Kind: string(types.EntityKindFunction)}
+	ents := []types.EntityRecord{file, a, b}
+
+	n := EmitTranslationKeyEdges(&ents, "jsts", []TranslationUse{
+		{Key: "errors.notFound", FromName: "A", Tag: "react-i18next"},
+		{Key: "errors.notFound", FromName: "B", Tag: "react-i18next"},
+		{Key: "errors.notFound", FromName: "A", Tag: "react-i18next"}, // dup edge
+	})
+	if n != 2 {
+		t.Fatalf("expected 2 edges (A,B), got %d", n)
+	}
+
+	// Exactly one key node.
+	keyNodes := 0
+	var keyID string
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindTranslationKey) &&
+			ents[i].Name == TranslationKeyName("errors.notFound") {
+			keyNodes++
+			keyID = ents[i].ID
+		}
+	}
+	if keyNodes != 1 {
+		t.Fatalf("expected exactly 1 translation-key node, got %d", keyNodes)
+	}
+	if keyID == "" {
+		t.Fatalf("key node has empty ID")
+	}
+
+	// Each caller has exactly one USES_TRANSLATION edge to the key target.
+	want := TranslationKeyTargetID("errors.notFound")
+	for _, name := range []string{"A", "B"} {
+		count := 0
+		for i := range ents {
+			if ents[i].Name != name {
+				continue
+			}
+			for _, r := range ents[i].Relationships {
+				if r.Kind == string(types.RelationshipKindUsesTranslation) && r.ToID == want {
+					count++
+				}
+			}
+		}
+		if count != 1 {
+			t.Errorf("caller %s: expected 1 USES_TRANSLATION edge, got %d", name, count)
+		}
+	}
+
+	// Cross-language stability: a python-emitted key converges to the SAME ID.
+	pyEnt := TranslationKeyEntity("errors.notFound", "python")
+	if pyEnt.ID != keyID {
+		t.Errorf("cross-language key ID mismatch: python=%q jsts=%q", pyEnt.ID, keyID)
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -361,6 +361,16 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		x.emitTemplateRenderEdges(root)
 	}()
 
+	// Localization topology (child of epic #3628) — USES_TRANSLATION edges from
+	// functions / components to a shared SCOPE.TranslationKey node for
+	// react-i18next / i18next `t('k')` / `i18n.t('k')` / `<Trans i18nKey>` and
+	// vue-i18n `$t('k')` shapes (dynamic keys dropped; bare `t` requires an i18n
+	// import in the file). Runs after walk so enclosing entities exist.
+	func() {
+		defer func() { _ = recover() }()
+		x.emitTranslationKeyEdges(root)
+	}()
+
 	// Third pass (#713): platform-variant and test-file relationship emission.
 	// Detects React Native platform-specific file naming (.ios.tsx,
 	// .android.tsx, .tablet.tsx, …) and emits PLATFORM_VARIANT_OF edges.

--- a/internal/extractors/javascript/translation_key.go
+++ b/internal/extractors/javascript/translation_key.go
@@ -1,0 +1,264 @@
+// translation_key.go — supplemental pass that emits USES_TRANSLATION edges
+// from JS/TS functions / components to a shared SCOPE.TranslationKey node
+// (localization capability, child of epic #3628). It lets the graph answer
+// "where is the 'errors.notFound' string used?" and supports untranslated-key
+// analysis. Covers react-i18next / i18next and vue-i18n.
+//
+// Detected shapes (REQUIRE-I18N-CONTEXT — honest-partial, precision-first):
+//
+//	import { useTranslation } from "react-i18next";
+//	const { t } = useTranslation(); t("errors.notFound")        → errors.notFound
+//	import i18n from "i18next"; i18n.t("x")                      → x
+//	i18next.t("x")                                               → x
+//	<Trans i18nKey="x">…</Trans>                                 → x
+//	vue-i18n: $t("x") / this.$t("x") / t("x") from useI18n()     → x
+//
+// The i18n CONTEXT gate: a file must either import a recognised i18n module
+// (react-i18next / i18next / vue-i18n / …) OR the call must be on an
+// unambiguous i18n receiver (`i18n.t` / `i18next.t` / `$t` / `this.$t`). A bare
+// `t("x")` is honored ONLY when an i18n import is present in the file — so a
+// local helper named `t` or a lodash `_` never fabricates a key.
+//
+// Intentionally DROPPED: a dynamic key (`t(keyVar)`, `t(`a${x}`)`); a bare
+// `t("x")` with NO i18n import in the file; any call whose receiver is not a
+// recognised i18n binding.
+//
+// Node/edge construction (convergence on one node per key via a synthetic
+// SourceFile) lives in extractor.EmitTranslationKeyEdges.
+
+package javascript
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// emitTranslationKeyEdges scans the AST for i18n key references rooted at a
+// recognised i18n context and appends translation-key entities +
+// USES_TRANSLATION edges to x.entities. x.entities[0] MUST be the file entity.
+func (x *extractor) emitTranslationKeyEdges(root *sitter.Node) {
+	if root == nil || len(x.entities) == 0 {
+		return
+	}
+	hasI18nImport := x.fileHasI18nImport()
+
+	var uses []extreg.TranslationUse
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "function_declaration", "generator_function_declaration":
+			enclosing = x.nodeText(n.ChildByFieldName("name"))
+		case "method_definition":
+			enclosing = x.nodeText(n.ChildByFieldName("name"))
+		case "variable_declarator":
+			// const Login = () => {...} / const Login = function() {...}
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				if v := n.ChildByFieldName("value"); v != nil {
+					switch v.Type() {
+					case "arrow_function", "function", "function_expression":
+						enclosing = x.nodeText(nn)
+					}
+				}
+			}
+		case "call_expression":
+			if key, tag, ok := x.jsTranslationCall(n, hasI18nImport); ok {
+				uses = append(uses, extreg.TranslationUse{Key: key, FromName: enclosing, Tag: tag})
+			}
+		case "jsx_self_closing_element", "jsx_opening_element":
+			if key, ok := x.jsxTransKey(n); ok {
+				uses = append(uses, extreg.TranslationUse{Key: key, FromName: enclosing, Tag: "react-i18next"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extreg.EmitTranslationKeyEdges(&x.entities, x.language, uses)
+}
+
+// fileHasI18nImport reports whether the file imports a recognised i18n module
+// (react-i18next / i18next / vue-i18n / …). Establishes the CONTEXT that makes
+// a bare `t("x")` trustworthy.
+func (x *extractor) fileHasI18nImport() bool {
+	for _, b := range x.importByLocal {
+		if b != nil && extreg.IsI18nImportSource(b.importPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// jsTranslationCall resolves a call_expression to an i18n key when the call is
+// a recognised translation invocation AND its first argument is a static
+// string literal. Returns (key, framework-tag, true) or ("","",false).
+func (x *extractor) jsTranslationCall(call *sitter.Node, hasI18nImport bool) (string, string, bool) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return "", "", false
+	}
+
+	tag := ""
+	switch fn.Type() {
+	case "identifier":
+		name := x.nodeText(fn)
+		switch name {
+		case "t":
+			// Bare t("x") — trustworthy only with an i18n import in the file.
+			if !hasI18nImport {
+				return "", "", false
+			}
+			tag = "react-i18next"
+		case "$t":
+			tag = "vue-i18n"
+		default:
+			return "", "", false
+		}
+	case "member_expression":
+		root, tail := x.i18nMemberRootTail(fn)
+		switch {
+		case tail == "t" && (root == "i18n" || root == "i18next"):
+			tag = "i18next"
+		case tail == "t" && root == "this":
+			// this.t(...) — only with an i18n import (vue Options API rarely).
+			if !hasI18nImport {
+				return "", "", false
+			}
+			tag = "react-i18next"
+		case tail == "$t" && root == "this":
+			tag = "vue-i18n"
+		default:
+			return "", "", false
+		}
+	default:
+		return "", "", false
+	}
+
+	key, ok := x.jsFirstStringArg(call)
+	if !ok {
+		return "", "", false
+	}
+	return key, tag, true
+}
+
+// jsFirstStringArg returns the first argument of a call when it is a plain
+// static string literal (single/double quote, or a backtick template with NO
+// substitutions). Returns ok=false for a dynamic key (identifier, interpolated
+// template, member access, concatenation) — the honest-partial boundary.
+func (x *extractor) jsFirstStringArg(call *sitter.Node) (string, bool) {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", false
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "string":
+			lit := stringLiteralValue(x.nodeText(a))
+			if extreg.IsStaticTranslationKey(lit) {
+				return lit, true
+			}
+			return "", false
+		case "template_string", "template_literal":
+			// Static only when there is no `${...}` substitution child.
+			if jsTemplateHasSubstitution(a) {
+				return "", false
+			}
+			lit := stringLiteralValue(x.nodeText(a))
+			if extreg.IsStaticTranslationKey(lit) {
+				return lit, true
+			}
+			return "", false
+		default:
+			// First positional arg is dynamic (variable / member / concat).
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// jsTemplateHasSubstitution reports whether a template_string node contains a
+// `${...}` interpolation (template_substitution child).
+func jsTemplateHasSubstitution(n *sitter.Node) bool {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if c := n.Child(i); c != nil && c.Type() == "template_substitution" {
+			return true
+		}
+	}
+	return false
+}
+
+// jsxTransKey extracts the static `i18nKey="..."` attribute value from a
+// `<Trans i18nKey="x">` element. Returns ("", false) when the element is not a
+// Trans element, has no i18nKey, or the attribute value is dynamic ({expr}).
+func (x *extractor) jsxTransKey(el *sitter.Node) (string, bool) {
+	nameNode := el.ChildByFieldName("name")
+	if nameNode == nil {
+		return "", false
+	}
+	if x.nodeText(nameNode) != "Trans" {
+		return "", false
+	}
+	for i := 0; i < int(el.ChildCount()); i++ {
+		attr := el.Child(i)
+		if attr == nil || attr.Type() != "jsx_attribute" {
+			continue
+		}
+		// jsx_attribute children: property_identifier "=" (string | jsx_expression)
+		if attr.NamedChildCount() < 1 {
+			continue
+		}
+		an := attr.NamedChild(0)
+		if an == nil || x.nodeText(an) != "i18nKey" {
+			continue
+		}
+		// Find the value node (string => static; jsx_expression => dynamic).
+		for j := 0; j < int(attr.NamedChildCount()); j++ {
+			v := attr.NamedChild(j)
+			if v == nil {
+				continue
+			}
+			if v.Type() == "string" {
+				lit := stringLiteralValue(x.nodeText(v))
+				if extreg.IsStaticTranslationKey(lit) {
+					return lit, true
+				}
+				return "", false
+			}
+		}
+		return "", false // i18nKey present but value dynamic
+	}
+	return "", false
+}
+
+// i18nMemberRootTail returns the ROOT and LAST property of a member_expression.
+// For `i18n.t` it returns ("i18n", "t"); for `this.$t` it returns ("this",
+// "$t"). Returns ("", "") when the receiver is neither a plain identifier nor
+// `this`. (Distinct from external_service.go's jsMemberRootAndTail, which
+// flattens a deep dotted tail and rejects a `this` root.)
+func (x *extractor) i18nMemberRootTail(member *sitter.Node) (string, string) {
+	prop := member.ChildByFieldName("property")
+	obj := member.ChildByFieldName("object")
+	if prop == nil || obj == nil {
+		return "", ""
+	}
+	tail := strings.TrimSpace(x.nodeText(prop))
+	switch obj.Type() {
+	case "identifier":
+		return strings.TrimSpace(x.nodeText(obj)), tail
+	case "this":
+		return "this", tail
+	}
+	return "", tail
+}

--- a/internal/extractors/javascript/translation_key_test.go
+++ b/internal/extractors/javascript/translation_key_test.go
@@ -1,0 +1,164 @@
+package javascript_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func jsTransEdge(recs []types.EntityRecord, fromName, key string) bool {
+	want := extreg.TranslationKeyTargetID(key)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindUsesTranslation) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jsTransNode(recs []types.EntityRecord, key string) (string, int) {
+	want := extreg.TranslationKeyName(key)
+	id, count := "", 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) && recs[i].Name == want {
+			id = recs[i].ID
+			count++
+		}
+	}
+	return id, count
+}
+
+func jsAnyTransNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// react-i18next: `const { t } = useTranslation(); t('errors.notFound')` →
+// USES_TRANSLATION(Login -> i18n:errors.notFound). Asserts node id + edge.
+func TestJSTrans_ReactI18next(t *testing.T) {
+	src := []byte(`import { useTranslation } from "react-i18next";
+
+function Login() {
+  const { t } = useTranslation();
+  return t("errors.notFound");
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTransEdge(recs, "Login", "errors.notFound") {
+		t.Fatalf("missing USES_TRANSLATION(Login -> errors.notFound)")
+	}
+	if id, n := jsTransNode(recs, "errors.notFound"); id == "" || n != 1 {
+		t.Errorf("expected exactly 1 errors.notFound node, got id=%q n=%d", id, n)
+	}
+}
+
+// i18next: `i18n.t('x')` — explicit receiver is the context (no import needed).
+func TestJSTrans_I18nReceiver(t *testing.T) {
+	src := []byte(`function greet() {
+  return i18n.t("home.greeting");
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTransEdge(recs, "greet", "home.greeting") {
+		t.Fatalf("missing USES_TRANSLATION(greet -> home.greeting)")
+	}
+}
+
+// <Trans i18nKey="x"> JSX attribute.
+func TestJSTrans_TransComponent(t *testing.T) {
+	src := []byte(`import { Trans } from "react-i18next";
+
+function Banner() {
+  return <Trans i18nKey="banner.title">Hello</Trans>;
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTransEdge(recs, "Banner", "banner.title") {
+		t.Fatalf("missing USES_TRANSLATION(Banner -> banner.title)")
+	}
+}
+
+// vue-i18n: `$t('x')`.
+func TestJSTrans_VueI18n(t *testing.T) {
+	src := []byte(`function render() {
+  return $t("nav.home");
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if !jsTransEdge(recs, "render", "nav.home") {
+		t.Fatalf("missing USES_TRANSLATION(render -> nav.home)")
+	}
+}
+
+// Convergence: the SAME key referenced in two components collapses to ONE node,
+// with an edge from each caller.
+func TestJSTrans_Convergence(t *testing.T) {
+	src := []byte(`import { useTranslation } from "react-i18next";
+
+function A() {
+  const { t } = useTranslation();
+  return t("shared.label");
+}
+function B() {
+  const { t } = useTranslation();
+  return t("shared.label");
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if id, n := jsTransNode(recs, "shared.label"); id == "" || n != 1 {
+		t.Fatalf("expected exactly 1 shared.label node, got id=%q n=%d", id, n)
+	}
+	if !jsTransEdge(recs, "A", "shared.label") {
+		t.Errorf("missing USES_TRANSLATION(A -> shared.label)")
+	}
+	if !jsTransEdge(recs, "B", "shared.label") {
+		t.Errorf("missing USES_TRANSLATION(B -> shared.label)")
+	}
+}
+
+// Negative: bare `t('x')` with NO i18n import in the file → no node/edge (could
+// be a local helper named t).
+func TestJSTrans_BareTNoImport_Skipped(t *testing.T) {
+	src := []byte(`function doThing() {
+  return t("not.i18n");
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if jsAnyTransNode(recs) {
+		t.Fatalf("bare t() with no i18n import should NOT create a translation node")
+	}
+}
+
+// Negative: dynamic key `t(keyVar)` → no node/edge.
+func TestJSTrans_DynamicKey_Skipped(t *testing.T) {
+	src := []byte(`import { useTranslation } from "react-i18next";
+
+function Dyn(keyVar) {
+  const { t } = useTranslation();
+  return t(keyVar);
+}
+`)
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if jsAnyTransNode(recs) {
+		t.Fatalf("dynamic key t(keyVar) should NOT create a translation node")
+	}
+}
+
+// Negative: interpolated template `t(`a.${x}`)` → no node/edge.
+func TestJSTrans_InterpolatedKey_Skipped(t *testing.T) {
+	src := []byte("import { useTranslation } from \"react-i18next\";\n\nfunction Dyn(x) {\n  const { t } = useTranslation();\n  return t(`a.${x}`);\n}\n")
+	recs := extract(t, src, "javascript", parseJS(t, src))
+	if jsAnyTransNode(recs) {
+		t.Fatalf("interpolated key should NOT create a translation node")
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -74,6 +74,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// controller actions to a shared SCOPE.Template node for view('name') /
 	// View::make('name') shapes (dynamic / interpolated names are dropped).
 	emitTemplateRenderEdges(root, file, &entities)
+	// Localization topology (child of epic #3628) — USES_TRANSLATION edges from
+	// functions / methods to a shared SCOPE.TranslationKey node for Laravel
+	// `__('k')` / `trans('k')` shapes (dynamic / interpolated keys dropped).
+	emitTranslationKeyEdges(root, file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")

--- a/internal/extractors/php/translation_key.go
+++ b/internal/extractors/php/translation_key.go
@@ -1,0 +1,113 @@
+// translation_key.go — supplemental pass that emits USES_TRANSLATION edges
+// from PHP functions / methods to a shared SCOPE.TranslationKey node
+// (localization capability, child of epic #3628). It lets the graph answer
+// "where is the 'messages.welcome' string used?" and supports untranslated-key
+// analysis. Covers Laravel.
+//
+// Detected shapes (REQUIRE-I18N-CONTEXT — honest-partial, precision-first):
+//
+//	__('messages.welcome')         → messages.welcome   (Laravel translate helper)
+//	trans('users.title')           → users.title        (Laravel trans helper)
+//	trans_choice('apples', $n)     → apples             (pluralization helper)
+//
+// The i18n CONTEXT gate is the helper NAME: `__`, `trans`, and `trans_choice`
+// are Laravel's global translation helpers — recognised directly (they are not
+// general-purpose PHP functions). A static literal first argument is required.
+//
+// Intentionally DROPPED: a dynamic key (`__($key)`, interpolated `"users.$id"`);
+// the Blade `@lang('x')` directive (it lives in *.blade.php template text, not
+// the PHP AST — honest-skip here).
+//
+// Node/edge construction (convergence on one node per key) lives in
+// extractor.EmitTranslationKeyEdges.
+
+package php
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// laravelTransHelpers are the recognised Laravel translation helper names.
+var laravelTransHelpers = map[string]bool{
+	"__": true, "trans": true, "trans_choice": true,
+}
+
+// emitTranslationKeyEdges scans every function / method body (and file scope)
+// for Laravel translation-helper calls and appends translation-key entities +
+// USES_TRANSLATION edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var uses []extractor.TranslationUse
+
+	var walk func(n *sitter.Node, enclosingClass, enclosing string)
+	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration", "interface_declaration", "trait_declaration":
+			cls := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), cls, enclosing)
+			}
+			return
+		case "method_declaration":
+			leaf := childFieldText(n, "name", src)
+			name := leaf
+			if enclosingClass != "" && leaf != "" {
+				name = enclosingClass + "." + leaf
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, name)
+			}
+			return
+		case "function_definition":
+			leaf := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, leaf)
+			}
+			return
+		case "function_call_expression":
+			if key, ok := phpTranslationCall(n, src); ok {
+				uses = append(uses, extractor.TranslationUse{Key: key, FromName: enclosing, Tag: "laravel"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingClass, enclosing)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitTranslationKeyEdges(entities, "php", uses)
+}
+
+// phpTranslationCall returns the literal key when the call is a recognised
+// Laravel translation helper (`__`, `trans`, `trans_choice`) with a static
+// first string argument, or ("", false).
+func phpTranslationCall(call *sitter.Node, src []byte) (string, bool) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "name" {
+		return "", false
+	}
+	name := strings.TrimSpace(string(src[fn.StartByte():fn.EndByte()]))
+	if !laravelTransHelpers[name] {
+		return "", false
+	}
+	key := phpFirstStringArg(call.ChildByFieldName("arguments"), src)
+	if !extractor.IsStaticTranslationKey(key) {
+		return "", false
+	}
+	return key, true
+}

--- a/internal/extractors/php/translation_key_test.go
+++ b/internal/extractors/php/translation_key_test.go
@@ -1,0 +1,106 @@
+package php_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func phpTransEdge(recs []types.EntityRecord, fromName, key string) bool {
+	want := extractor.TranslationKeyTargetID(key)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindUsesTranslation) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func phpTransNode(recs []types.EntityRecord, key string) (string, int) {
+	want := extractor.TranslationKeyName(key)
+	id, count := "", 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) && recs[i].Name == want {
+			id = recs[i].ID
+			count++
+		}
+	}
+	return id, count
+}
+
+func phpAnyTransNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// Laravel: `__('messages.welcome')` in greet →
+// USES_TRANSLATION(Ctrl.greet -> i18n:messages.welcome). Asserts node id + edge.
+func TestPHPTrans_LaravelDoubleUnderscore(t *testing.T) {
+	src := `<?php
+class Ctrl {
+    public function greet() {
+        return __('messages.welcome');
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTransEdge(recs, "Ctrl.greet", "messages.welcome") {
+		t.Fatalf("missing USES_TRANSLATION(Ctrl.greet -> messages.welcome)")
+	}
+	if id, n := phpTransNode(recs, "messages.welcome"); id == "" || n != 1 {
+		t.Errorf("expected exactly 1 messages.welcome node, got id=%q n=%d", id, n)
+	}
+}
+
+// trans('users.title') helper.
+func TestPHPTrans_TransHelper(t *testing.T) {
+	src := `<?php
+function show() {
+    return trans('users.title');
+}
+`
+	recs := extractPHPRecords(t, src)
+	if !phpTransEdge(recs, "show", "users.title") {
+		t.Fatalf("missing USES_TRANSLATION(show -> users.title)")
+	}
+}
+
+// Convergence: same key in two methods → one node, two edges.
+func TestPHPTrans_Convergence(t *testing.T) {
+	src := `<?php
+class C {
+    public function a() { return __('shared.k'); }
+    public function b() { return __('shared.k'); }
+}
+`
+	recs := extractPHPRecords(t, src)
+	if id, n := phpTransNode(recs, "shared.k"); id == "" || n != 1 {
+		t.Fatalf("expected exactly 1 shared.k node, got id=%q n=%d", id, n)
+	}
+	if !phpTransEdge(recs, "C.a", "shared.k") || !phpTransEdge(recs, "C.b", "shared.k") {
+		t.Errorf("expected USES_TRANSLATION from both C.a and C.b")
+	}
+}
+
+// Negative: dynamic key `__($key)` → no node/edge.
+func TestPHPTrans_DynamicKey_Skipped(t *testing.T) {
+	src := `<?php
+function dyn($key) {
+    return __($key);
+}
+`
+	recs := extractPHPRecords(t, src)
+	if phpAnyTransNode(recs) {
+		t.Fatalf("dynamic key __($key) should NOT create a translation node")
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -355,6 +355,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitTemplateRenderEdges(root, file, &entities)
 	}()
 
+	// Localization topology (child of #3628) — supplemental pass that links
+	// functions / methods to a shared SCOPE.TranslationKey node via
+	// USES_TRANSLATION for Django / gettext `_('msg')` / `gettext('x')` shapes
+	// (import-gated to a recognised gettext source; dynamic keys dropped).
+	func() {
+		defer func() { _ = recover() }()
+		emitTranslationKeyEdges(root, file, &entities)
+	}()
+
 	// Issue #1884 — supplemental package-module pass (Wave 1).
 	// Emits one Module entity per Python package boundary (__init__.py or
 	// plain .py module) so docgen can seed per-package pages and flow

--- a/internal/extractors/python/translation_key.go
+++ b/internal/extractors/python/translation_key.go
@@ -1,0 +1,228 @@
+// translation_key.go — supplemental pass that emits USES_TRANSLATION edges
+// from Python functions / methods to a shared SCOPE.TranslationKey node
+// (localization capability, child of epic #3628). It lets the graph answer
+// "where is the 'Welcome' string used?" and supports untranslated-key
+// analysis. Covers Django / gettext.
+//
+// Detected shapes (REQUIRE-I18N-CONTEXT — honest-partial, precision-first):
+//
+//	from django.utils.translation import gettext as _
+//	_("Welcome")                                              → Welcome
+//	from django.utils.translation import gettext_lazy
+//	gettext_lazy("Sign in")                                   → Sign in
+//	from gettext import gettext, ngettext
+//	gettext("Hello")                                          → Hello
+//
+// The i18n CONTEXT gate is the IMPORT: the called name (`_`, `gettext`,
+// `gettext_lazy`, `ngettext`, `pgettext`, `ugettext`, …) must be bound by a
+// `from django.utils.translation import …` / `from gettext import …` (alias
+// honored). A bare `_("x")` whose `_` was NOT imported from a gettext source
+// emits NO edge — so a throwaway `_` placeholder variable never fabricates a
+// key.
+//
+// Intentionally DROPPED: a dynamic key (`_(msg_var)`); a `_("x")` whose `_` is
+// not a recognised gettext import; module-scope keys attach to the file entity.
+//
+// Node/edge construction (convergence on one node per key via a synthetic
+// SourceFile) lives in extractor.EmitTranslationKeyEdges.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// gettextFunctions are the recognised gettext-family callable names. The import
+// source still has to be a recognised i18n module (gettext context gate).
+var gettextFunctions = map[string]bool{
+	"_": true, "gettext": true, "gettext_lazy": true,
+	"ngettext": true, "ngettext_lazy": true,
+	"pgettext": true, "pgettext_lazy": true,
+	"npgettext": true, "ugettext": true, "ugettext_lazy": true,
+}
+
+// i18nPythonSources are the import modules that establish a gettext context.
+func isI18nPythonSource(module string) bool {
+	m := strings.TrimSpace(module)
+	return m == "gettext" ||
+		m == "django.utils.translation" ||
+		strings.HasSuffix(m, ".utils.translation") ||
+		m == "flask_babel" || m == "flask_babelex" ||
+		m == "babel" || m == "gettext.gettext"
+}
+
+// emitTranslationKeyEdges scans every function / method body for gettext-family
+// key references rooted at a recognised i18n import and appends translation-key
+// entities + USES_TRANSLATION edges.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input. Keys at module scope attach to the file entity.
+func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	imports := buildPythonImportMap(root, file)
+	if len(imports) == 0 {
+		return // no imports → no gettext context can exist
+	}
+	src := file.Content
+
+	// i18nLocal maps a local callable name to true when it was imported from a
+	// recognised i18n module AND is a gettext-family function.
+	i18nLocal := map[string]bool{}
+	for local, b := range imports {
+		if b.plainModule {
+			continue // `import gettext` → calls are `gettext.gettext(...)`, handled below
+		}
+		if isI18nPythonSource(b.sourceModule) && gettextFunctions[b.importedName] {
+			i18nLocal[local] = true
+		}
+	}
+	// `import gettext` style — calls look like `gettext.gettext("x")`.
+	gettextModuleAliases := map[string]bool{}
+	for local, b := range imports {
+		if b.plainModule && (b.sourceModule == "gettext" || b.sourceModule == "django.utils.translation") {
+			gettextModuleAliases[local] = true
+		}
+	}
+
+	if len(i18nLocal) == 0 && len(gettextModuleAliases) == 0 {
+		return
+	}
+
+	var uses []extractor.TranslationUse
+
+	var stack []string
+	current := func() string {
+		if len(stack) == 0 {
+			return ""
+		}
+		return stack[len(stack)-1]
+	}
+
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			cls := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				cls = nodeText(nn, src)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			stack = append(stack, childCls)
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "function_definition":
+			leaf := ""
+			if nn := n.ChildByFieldName("name"); nn != nil {
+				leaf = nodeText(nn, src)
+			}
+			emitted := leaf
+			if parentClass != "" && leaf != "" {
+				emitted = parentClass + "." + leaf
+			}
+			stack = append(stack, emitted)
+			if body := n.ChildByFieldName("body"); body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), parentClass)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "decorated_definition":
+			if inner := n.ChildByFieldName("definition"); inner != nil {
+				walk(inner, parentClass)
+			}
+			return
+		case "call":
+			if key, ok := pyTranslationCall(n, src, i18nLocal, gettextModuleAliases); ok {
+				uses = append(uses, extractor.TranslationUse{Key: key, FromName: current(), Tag: "gettext"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitTranslationKeyEdges(entities, "python", uses)
+}
+
+// pyTranslationCall inspects a `call` node and returns the literal key when it
+// is a recognised gettext-family call with a static first string argument.
+//
+// Two recognition paths:
+//  1. bare `_("x")` / `gettext("x")` where the callee name is in i18nLocal.
+//  2. `gettext.gettext("x")` where the root module is a gettext module alias
+//     and the tail is a gettext-family function.
+//
+// Returns ok=false for an unrecognised callee or a dynamic first argument.
+func pyTranslationCall(call *sitter.Node, src []byte, i18nLocal, gettextModuleAliases map[string]bool) (string, bool) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return "", false
+	}
+	switch fn.Type() {
+	case "identifier":
+		name := strings.TrimSpace(nodeText(fn, src))
+		if !i18nLocal[name] {
+			return "", false
+		}
+	case "attribute":
+		root, tail := pyAttributeRootAndTail(fn, src)
+		if root == "" || !gettextModuleAliases[root] || !gettextFunctions[tail] {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+	return pyTransFirstStringArg(call, src)
+}
+
+// pyTransFirstStringArg returns the first positional argument of a call when it
+// is a static string literal. Returns ok=false for a dynamic first argument
+// (variable, f-string, concatenation) — the honest-partial boundary. Uses
+// pyStringLiteralValue so an f-string with an interpolation yields "" (drop).
+func pyTransFirstStringArg(call *sitter.Node, src []byte) (string, bool) {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", false
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "string":
+			lit := pyStringLiteralValue(a, src)
+			if extractor.IsStaticTranslationKey(lit) {
+				return lit, true
+			}
+			return "", false
+		case "keyword_argument", "comment":
+			// e.g. message="x" — not the positional key; keep scanning.
+			continue
+		default:
+			// First positional is dynamic (identifier, f-string, binary op).
+			return "", false
+		}
+	}
+	return "", false
+}

--- a/internal/extractors/python/translation_key_test.go
+++ b/internal/extractors/python/translation_key_test.go
@@ -1,0 +1,132 @@
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func transEdge(recs []types.EntityRecord, fromName, key string) bool {
+	want := extractor.TranslationKeyTargetID(key)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindUsesTranslation) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func transNode(recs []types.EntityRecord, key string) (string, int) {
+	want := extractor.TranslationKeyName(key)
+	id, count := "", 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) && recs[i].Name == want {
+			id = recs[i].ID
+			count++
+		}
+	}
+	return id, count
+}
+
+func anyTransNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// Django/gettext: `_('Welcome')` (gettext aliased to _) in `home` →
+// USES_TRANSLATION(home -> i18n:Welcome). Asserts node id + edge.
+func TestPyTrans_DjangoGettextUnderscore(t *testing.T) {
+	src := `from django.utils.translation import gettext as _
+
+def home(request):
+    return _('Welcome')
+`
+	recs := extractPy(t, src, "views.py")
+	if !transEdge(recs, "home", "Welcome") {
+		t.Fatalf("missing USES_TRANSLATION(home -> Welcome)")
+	}
+	if id, n := transNode(recs, "Welcome"); id == "" || n != 1 {
+		t.Errorf("expected exactly 1 Welcome node, got id=%q n=%d", id, n)
+	}
+}
+
+// gettext_lazy('Sign in').
+func TestPyTrans_GettextLazy(t *testing.T) {
+	src := `from django.utils.translation import gettext_lazy
+
+LABEL = gettext_lazy('Sign in')
+`
+	recs := extractPy(t, src, "forms.py")
+	// Module-scope key attaches to the file entity; assert the node exists.
+	if id, n := transNode(recs, "Sign in"); id == "" || n != 1 {
+		t.Fatalf("expected exactly 1 'Sign in' node, got id=%q n=%d", id, n)
+	}
+}
+
+// `import gettext; gettext.gettext('Hello')`.
+func TestPyTrans_GettextModuleAttr(t *testing.T) {
+	src := `import gettext
+
+def greet():
+    return gettext.gettext('Hello')
+`
+	recs := extractPy(t, src, "g.py")
+	if !transEdge(recs, "greet", "Hello") {
+		t.Fatalf("missing USES_TRANSLATION(greet -> Hello)")
+	}
+}
+
+// Convergence: same key in two functions → one node, two edges.
+func TestPyTrans_Convergence(t *testing.T) {
+	src := `from django.utils.translation import gettext as _
+
+def a():
+    return _('shared')
+
+def b():
+    return _('shared')
+`
+	recs := extractPy(t, src, "v.py")
+	if id, n := transNode(recs, "shared"); id == "" || n != 1 {
+		t.Fatalf("expected exactly 1 'shared' node, got id=%q n=%d", id, n)
+	}
+	if !transEdge(recs, "a", "shared") || !transEdge(recs, "b", "shared") {
+		t.Errorf("expected USES_TRANSLATION from both a and b")
+	}
+}
+
+// Negative: a non-i18n `_('x')` — `_` is NOT imported from a gettext source
+// (e.g. a local placeholder / lodash-style underscore) → no node/edge.
+func TestPyTrans_NonI18nUnderscore_Skipped(t *testing.T) {
+	src := `def handler():
+    _ = compute()
+    return _('not.i18n')
+`
+	recs := extractPy(t, src, "h.py")
+	if anyTransNode(recs) {
+		t.Fatalf("bare _('x') with no gettext import should NOT create a translation node")
+	}
+}
+
+// Negative: dynamic key `_(msg)` → no node/edge.
+func TestPyTrans_DynamicKey_Skipped(t *testing.T) {
+	src := `from django.utils.translation import gettext as _
+
+def dyn(msg):
+    return _(msg)
+`
+	recs := extractPy(t, src, "d.py")
+	if anyTransNode(recs) {
+		t.Fatalf("dynamic key _(msg) should NOT create a translation node")
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -54,6 +54,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// `render template:/partial:` shapes (symbol / implicit-convention renders
 	// and dynamic names are dropped).
 	emitTemplateRenderEdges(root, file.Content, &entities)
+	// Localization topology (child of epic #3628) — USES_TRANSLATION edges from
+	// methods to a shared SCOPE.TranslationKey node for Rails `I18n.t('k')` /
+	// relative `t('.k')` shapes (dynamic keys + ambiguous bare `t('plain')`
+	// dropped).
+	emitTranslationKeyEdges(root, file.Content, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")

--- a/internal/extractors/ruby/translation_key.go
+++ b/internal/extractors/ruby/translation_key.go
@@ -1,0 +1,145 @@
+// translation_key.go — supplemental pass that emits USES_TRANSLATION edges
+// from Ruby methods to a shared SCOPE.TranslationKey node (localization
+// capability, child of epic #3628). It lets the graph answer "where is the
+// 'users.title' string used?" and supports untranslated-key analysis. Covers
+// Rails I18n.
+//
+// Detected shapes (REQUIRE-I18N-CONTEXT — honest-partial, precision-first):
+//
+//	I18n.t('users.title')          → users.title    (explicit I18n receiver)
+//	I18n.translate('a.b')          → a.b
+//	t('.title')                    → .title         (Rails relative key — the
+//	                                 leading dot makes it unambiguously i18n)
+//
+// The i18n CONTEXT gate:
+//   - `I18n.t` / `I18n.translate` — the explicit receiver IS the context.
+//   - bare `t('x')` — honored ONLY when the key is a Rails relative key
+//     (leading `.`), an unambiguous i18n shape. A bare `t('plain')` with no
+//     receiver and no leading dot is ambiguous (could be a local method) and
+//     is DROPPED — precision over recall.
+//
+// Intentionally DROPPED: a dynamic key (`t(key_var)`, interpolated); a bare
+// `t('plain')` (ambiguous); symbol args.
+//
+// Node/edge construction (convergence on one node per key) lives in
+// extractor.EmitTranslationKeyEdges.
+
+package ruby
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitTranslationKeyEdges scans every method body for Rails I18n key references
+// and appends translation-key entities + USES_TRANSLATION edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitTranslationKeyEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var uses []extractor.TranslationUse
+
+	var walk func(n *sitter.Node, enclosing string)
+	walk = func(n *sitter.Node, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "method", "singleton_method":
+			name := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), name)
+			}
+			return
+		case "call":
+			if key, ok := rubyTranslationCall(n, src); ok {
+				uses = append(uses, extractor.TranslationUse{Key: key, FromName: enclosing, Tag: "rails-i18n"})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosing)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitTranslationKeyEdges(entities, "ruby", uses)
+}
+
+// rubyTranslationCall returns the literal key for a recognised Rails I18n call
+// with a static first string argument, or ("", false).
+//
+//	I18n.t('x') / I18n.translate('x')  → explicit-receiver i18n
+//	t('.relative')                     → relative-key i18n (leading dot)
+func rubyTranslationCall(call *sitter.Node, src []byte) (string, bool) {
+	method := call.ChildByFieldName("method")
+	if method == nil {
+		return "", false
+	}
+	mname := strings.TrimSpace(rubyNodeText(method, src))
+
+	recv := call.ChildByFieldName("receiver")
+	requireRelative := false
+	switch {
+	case recv != nil:
+		// Explicit receiver — must be I18n with t/translate.
+		if strings.TrimSpace(rubyNodeText(recv, src)) != "I18n" {
+			return "", false
+		}
+		if mname != "t" && mname != "translate" {
+			return "", false
+		}
+	default:
+		// Receiver-less — only `t` / `translate`, and only the relative form.
+		if mname != "t" && mname != "translate" {
+			return "", false
+		}
+		requireRelative = true
+	}
+
+	key, ok := rubyFirstStringArg(call, src)
+	if !ok {
+		return "", false
+	}
+	if requireRelative && !strings.HasPrefix(key, ".") {
+		return "", false // bare t('plain') is ambiguous — drop
+	}
+	return key, true
+}
+
+// rubyFirstStringArg returns the first positional argument when it is a static
+// string literal, or ("", false) for a dynamic / symbol / interpolated arg.
+func rubyFirstStringArg(call *sitter.Node, src []byte) (string, bool) {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", false
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "string":
+			s := rubyStringContent(a, src)
+			if extractor.IsStaticTranslationKey(s) {
+				return s, true
+			}
+			return "", false
+		case "pair":
+			// keyword arg (scope:, default:) — not the positional key.
+			continue
+		default:
+			// First positional is a symbol / variable / interpolation — dynamic.
+			return "", false
+		}
+	}
+	return "", false
+}

--- a/internal/extractors/ruby/translation_key_test.go
+++ b/internal/extractors/ruby/translation_key_test.go
@@ -1,0 +1,123 @@
+package ruby_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func rbTransEdge(recs []types.EntityRecord, fromName, key string) bool {
+	want := extractor.TranslationKeyTargetID(key)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindUsesTranslation) && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rbTransNode(recs []types.EntityRecord, key string) (string, int) {
+	want := extractor.TranslationKeyName(key)
+	id, count := "", 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) && recs[i].Name == want {
+			id = recs[i].ID
+			count++
+		}
+	}
+	return id, count
+}
+
+func rbAnyTransNode(recs []types.EntityRecord) bool {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTranslationKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// Rails: `I18n.t('users.title')` in `title` →
+// USES_TRANSLATION(title -> i18n:users.title). Asserts node id + edge.
+func TestRubyTrans_I18nT(t *testing.T) {
+	src := `class UsersController
+  def title
+    I18n.t('users.title')
+  end
+end
+`
+	recs := extractRubyRecords(t, src)
+	if !rbTransEdge(recs, "title", "users.title") {
+		t.Fatalf("missing USES_TRANSLATION(title -> users.title)")
+	}
+	if id, n := rbTransNode(recs, "users.title"); id == "" || n != 1 {
+		t.Errorf("expected exactly 1 users.title node, got id=%q n=%d", id, n)
+	}
+}
+
+// I18n.translate alias.
+func TestRubyTrans_I18nTranslate(t *testing.T) {
+	src := `class A
+  def show
+    I18n.translate('a.b.c')
+  end
+end
+`
+	recs := extractRubyRecords(t, src)
+	if !rbTransEdge(recs, "show", "a.b.c") {
+		t.Fatalf("missing USES_TRANSLATION(show -> a.b.c)")
+	}
+}
+
+// Relative key: `t('.title')` (leading dot is the unambiguous Rails i18n form).
+func TestRubyTrans_RelativeKey(t *testing.T) {
+	src := `class B
+  def edit
+    t('.title')
+  end
+end
+`
+	recs := extractRubyRecords(t, src)
+	if !rbTransEdge(recs, "edit", ".title") {
+		t.Fatalf("missing USES_TRANSLATION(edit -> .title)")
+	}
+	id, _ := rbTransNode(recs, ".title")
+	if id == "" {
+		t.Errorf("expected a .title node")
+	}
+}
+
+// Negative: bare `t('plain')` with NO receiver and NO leading dot is ambiguous
+// (could be a local method) → no node/edge.
+func TestRubyTrans_BarePlain_Skipped(t *testing.T) {
+	src := `class C
+  def index
+    t('plain')
+  end
+end
+`
+	recs := extractRubyRecords(t, src)
+	if rbAnyTransNode(recs) {
+		t.Fatalf("ambiguous bare t('plain') should NOT create a translation node")
+	}
+}
+
+// Negative: dynamic key `I18n.t(key)` → no node/edge.
+func TestRubyTrans_DynamicKey_Skipped(t *testing.T) {
+	src := `class D
+  def show(key)
+    I18n.t(key)
+  end
+end
+`
+	recs := extractRubyRecords(t, src)
+	if rbAnyTransNode(recs) {
+		t.Fatalf("dynamic key I18n.t(key) should NOT create a translation node")
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -254,6 +254,26 @@ const (
 	//                    "rails_enum", "csharp_enum").
 	// See internal/extractor/enum_valueset.go.
 	EntityKindEnum EntityKind = "SCOPE.Enum"
+	// EntityKindTranslationKey is a synthetic, file-agnostic node representing a
+	// single i18n / localization translation KEY by its literal value — e.g.
+	// "errors.notFound", "messages.welcome", "users.title", "Welcome". It is the
+	// convergence point for the localization capability (child of #3628): every
+	// function / component that references the SAME key via a recognised i18n
+	// function gets a USES_TRANSLATION edge to the SAME key node, so the graph
+	// answers "where is the 'errors.notFound' string used?" (a key's inbound
+	// USES_TRANSLATION edges are its reference sites) and supports
+	// untranslated-key analysis (keys with no catalog backing). Like
+	// SCOPE.ExternalService it carries a constant synthetic SourceFile
+	// (TranslationKeySourceFile) so EntityRecord.ComputeID(SourceFile+Kind+Name)
+	// collapses the same key across files/languages/frameworks (react-i18next /
+	// i18next t('k') / <Trans i18nKey>, vue-i18n $t('k'), Django/gettext _('m') /
+	// {% trans %}, Rails I18n.t('k') / t('.k'), Laravel __('k') / trans('k'))
+	// into one node. Name = "i18n:<key>". Precision-first / honest-partial: an
+	// edge is emitted only when the i18n function CONTEXT is recognised (import
+	// or unambiguous framework symbol) and the key is a STATIC literal; a dynamic
+	// key (`t(keyVar)`, interpolated) or a non-i18n `_('x')` (lodash) /
+	// unrelated `t(...)` emits NO node/edge. See internal/extractor/translation_key.go.
+	EntityKindTranslationKey EntityKind = "SCOPE.TranslationKey"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -334,6 +354,7 @@ func AllEntityKinds() []EntityKind {
 		EntityKindChannel,
 		// #3628 data-model: enum / value-set node.
 		EntityKindEnum,
+		EntityKindTranslationKey,
 	}
 }
 
@@ -1072,6 +1093,24 @@ const (
 	// integration edge would mislead "what services do we depend on?". See
 	// internal/extractor/external_service.go.
 	RelationshipKindDependsOnService RelationshipKind = "DEPENDS_ON_SERVICE"
+	// RelationshipKindUsesTranslation points an enclosing function / component at
+	// a synthetic SCOPE.TranslationKey node for each STATIC i18n key it
+	// references via a recognised translation function (localization capability,
+	// child of #3628). Direction: caller → key. Two callers that reference the
+	// same key converge on ONE key node, so the node's inbound USES_TRANSLATION
+	// set is the key's full reference footprint ("where is 'errors.notFound'
+	// used?") and the absence of a backing catalog flags an untranslated key.
+	// Recognised shapes:
+	//   JS/TS   react-i18next/i18next `t('errors.notFound')`, `i18n.t('x')`,
+	//           `<Trans i18nKey="x">`; vue-i18n `$t('x')` / `t('x')` (useI18n).
+	//   Python  Django/gettext `_('Welcome')`, `gettext('x')`, `gettext_lazy('x')`.
+	//   Ruby    Rails `I18n.t('users.title')`, relative `t('.title')`.
+	//   PHP     Laravel `__('messages.welcome')`, `trans('x')`.
+	// Precision-first / honest-partial: emitted ONLY when the i18n CONTEXT is
+	// recognised (import or unambiguous framework symbol) and the key is a static
+	// literal — a dynamic key (`t(keyVar)`) or a non-i18n `_('x')` (lodash) /
+	// unrelated `t(...)` emits NO edge. See internal/extractor/translation_key.go.
+	RelationshipKindUsesTranslation RelationshipKind = "USES_TRANSLATION"
 	// [realtime] WS room/channel grouping (child of #3628). Both edges point a
 	// callable (function / method) at a synthetic SCOPE.Channel node
 	// (Name "channel:<room>") so a join and a broadcast on the SAME room
@@ -1254,6 +1293,7 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindThrows,
 		RelationshipKindCatches,
 		RelationshipKindDependsOnService,
+		RelationshipKindUsesTranslation,
 		// [realtime] WS room/channel grouping: JOINS_CHANNEL / BROADCASTS_TO.
 		RelationshipKindJoinsChannel,
 		RelationshipKindBroadcastsTo,

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -65,7 +65,7 @@ categories:
   databases:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
-    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency]
+    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency, translation_key_usage]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection]
   protocol:

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -72,6 +72,47 @@ records:
         issues_implemented: ["3628"]
         verified_at: "2026-06-02"
 
+  analysis.localization.i18n-keys:
+    capabilities:
+      translation_key_usage:
+        # #3628 area: i18n / localization KEY-USAGE detection. Each language
+        # extractor emits a USES_TRANSLATION edge from the enclosing function /
+        # component to a synthetic SCOPE.TranslationKey node (Name
+        # "i18n:<key>") so every reference site of a key converges on ONE node
+        # — answering "where is the 'errors.notFound' string used?" and
+        # supporting untranslated-key analysis. Shared node/edge builders +
+        # JS/TS i18n import dictionary in internal/extractor/translation_key.go.
+        # PARTIAL: jsts (react-i18next / i18next / vue-i18n / <Trans>), python
+        # (Django/gettext), ruby (Rails I18n), php (Laravel) lanes.
+        # Precision-first / REQUIRE-I18N-CONTEXT: a bare `t('x')` needs an i18n
+        # import; a dynamic key (`t(keyVar)`, interpolated) or a non-i18n
+        # `_('x')` (lodash) emits NO node/edge.
+        status: partial
+        symbols:
+          - file: internal/extractor/translation_key.go
+            functions: [TranslationKeyName, TranslationKeyTargetID, TranslationKeyEntity, EmitTranslationKeyEdges, IsI18nImportSource, IsStaticTranslationKey]
+          - file: internal/extractors/javascript/translation_key.go
+            functions: [emitTranslationKeyEdges, fileHasI18nImport, jsTranslationCall, jsFirstStringArg, jsxTransKey, i18nMemberRootTail]
+          - file: internal/extractors/python/translation_key.go
+            functions: [emitTranslationKeyEdges, pyTranslationCall, pyTransFirstStringArg, isI18nPythonSource]
+          - file: internal/extractors/ruby/translation_key.go
+            functions: [emitTranslationKeyEdges, rubyTranslationCall, rubyFirstStringArg]
+          - file: internal/extractors/php/translation_key.go
+            functions: [emitTranslationKeyEdges, phpTranslationCall]
+        tests:
+          - file: internal/extractor/translation_key_test.go
+            functions: [TestIsI18nImportSource, TestIsStaticTranslationKey, TestEmitTranslationKeyEdges_Convergence]
+          - file: internal/extractors/javascript/translation_key_test.go
+            functions: [TestJSTrans_ReactI18next, TestJSTrans_I18nReceiver, TestJSTrans_TransComponent, TestJSTrans_VueI18n, TestJSTrans_Convergence, TestJSTrans_BareTNoImport_Skipped, TestJSTrans_DynamicKey_Skipped, TestJSTrans_InterpolatedKey_Skipped]
+          - file: internal/extractors/python/translation_key_test.go
+            functions: [TestPyTrans_DjangoGettextUnderscore, TestPyTrans_GettextLazy, TestPyTrans_GettextModuleAttr, TestPyTrans_Convergence, TestPyTrans_NonI18nUnderscore_Skipped, TestPyTrans_DynamicKey_Skipped]
+          - file: internal/extractors/ruby/translation_key_test.go
+            functions: [TestRubyTrans_I18nT, TestRubyTrans_I18nTranslate, TestRubyTrans_RelativeKey, TestRubyTrans_BarePlain_Skipped, TestRubyTrans_DynamicKey_Skipped]
+          - file: internal/extractors/php/translation_key_test.go
+            functions: [TestPHPTrans_LaravelDoubleUnderscore, TestPHPTrans_TransHelper, TestPHPTrans_Convergence, TestPHPTrans_DynamicKey_Skipped]
+        issues_implemented: ["3628"]
+        verified_at: "2026-06-02"
+
   lang.cobol.runtime.ibm-enterprise:
     capabilities:
       core_extraction:


### PR DESCRIPTION
Closes #3816 (child of epic #3628).

## Node model
Models i18n / localization **translation-key usage** so the graph answers "where is the 'errors.notFound' string used?" and supports untranslated-key analysis.

Mirrors the `SCOPE.ExternalService` convergence model:
- **`SCOPE.TranslationKey`** entity — Name `i18n:<key>`, synthetic constant `SourceFile` (`<translation-key>`) so `EntityRecord.ComputeID(SourceFile+Kind+Name)` collapses the SAME literal key across files/languages/frameworks into **one node**.
- **`USES_TRANSLATION`** edge (enclosing fn/component → key) — carried as a structural-ref `ToID` (`scope:translationkey:<key>`) that equals the key entity's `QualifiedName`, so it resolves via the existing `byQualifiedName` tier with **no new linker code**.
- A key referenced in N places converges on one node; its inbound `USES_TRANSLATION` set is the key's full reference footprint. A key node with no backing catalog entry is the untranslated-key signal.

## Frameworks (per-language AST detectors)
| Lane | Shapes |
|---|---|
| jsts | react-i18next/i18next `t('k')`, `i18n.t('k')`, `i18next.t('k')`, `<Trans i18nKey="k">`; vue-i18n `$t('k')` / `this.$t('k')` |
| python | Django/gettext `_('m')`, `gettext('x')`, `gettext_lazy('x')`, `gettext.gettext('x')` |
| ruby | Rails `I18n.t('k')` / `I18n.translate('k')`, relative `t('.k')` |
| php | Laravel `__('k')`, `trans('k')`, `trans_choice('k')` |

## REQUIRE-I18N-CONTEXT honesty boundary (precision-first)
A node/edge is emitted ONLY when the i18n CONTEXT is recognised AND the key is a static literal:
- bare `t('x')` (JS) requires an i18n import in the file; `i18n.t`/`$t` receivers are self-contextualizing.
- Python `_`/`gettext` must be imported from `django.utils.translation` / `gettext` (alias honored — `gettext as _` works).
- Ruby bare `t('plain')` (no receiver, no leading dot) is ambiguous → **dropped**; `I18n.t` and relative `t('.x')` are kept.
- Dynamic keys (`t(keyVar)`, interpolated `` t(`a.${x}`) ``, f-strings) → **dropped**.
- A non-i18n `_('x')` (lodash) / unrelated `t(...)` without i18n context → **no node/edge**.

## Tests (value-asserting — assert key node id + edge, not len>0)
- Core: `IsI18nImportSource`, `IsStaticTranslationKey`, construction-layer convergence + cross-language ID stability.
- Per-lane: react-i18next `t('errors.notFound')` in Login → `USES_TRANSLATION(Login → i18n:errors.notFound)`; Django `_('Welcome')`; Rails `I18n.t('users.title')`; Laravel `__('messages.welcome')`; same-key-two-places → one node.
- Negatives: dynamic key, interpolated key, bare-`t`-no-import, non-i18n `_('x')`, ambiguous bare Rails `t('plain')` → no node/edge.

## Coverage
New registry record `analysis.localization.i18n-keys` / capability `translation_key_usage` (status partial) citing the extractor + tests; capability-map + dictionary updated; `coverage validate` 0 errors, `fmt --check` canonical, docs regenerated.

## Scope / deploy
PARTIAL lanes: jsts/python/ruby/php. Future: java/go, the Blade `@lang(...)` directive in `*.blade.php` template text (not in the PHP AST).

**DEPLOY-DEFERRED**: extractor + kinds land here; live-daemon reindex is a separate coordinated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)