### PR TITLE
feat(engine): frontend route → component graph (React-Router/Vue/Angular)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # platform
 
-**Total**: 38 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 32 · **python**: 1 · **ruby**: 1
+**Total**: 39 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 33 · **python**: 1 · **ruby**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -26,6 +26,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | — | ✅ | — | ✅ | |
 | [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
 | [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Frontend route → component graph (SPA client routing)](../detail/frontend.routing.spa-route-component.md) | 🟢 | — | — | — | 🟢 | — | 🟢 | |
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | — | ✅ | — | ✅ | |
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | — | ✅ | — | ✅ | |
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | — | ✅ | — | ✅ | |

--- a/docs/coverage/detail/frontend.routing.spa-route-component.md
+++ b/docs/coverage/detail/frontend.routing.spa-route-component.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `frontend.routing.spa-route-component` — Frontend route → component graph (SPA client routing)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [platform](../by-category/platform.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/frontend_route_edges.go`<br>`internal/engine/frontend_route_edges_test.go`<br>`internal/resolve/refs.go` | epic #3628: emits a ROUTES_TO edge SCOPE.Route(frontend) → component. The edge ToID is the BARE component identifier (e.g. "Users"), exactly as the JSX RENDERS edge does; the cross-file resolver (internal/resolve byName index) rewrites it to the declaring component entity (SCOPE.Function / SCOPE.Class) at pass 2. No new Kind introduced (reuses SCOPE.Route + ROUTES_TO). Value-asserting tests assert each specific route node id + route→component edge (feroute:App.tsx:/users ROUTES_TO Users; feroute:router.ts:/u/:id ROUTES_TO UserDetail; feroute:app.routes.ts:users ROUTES_TO UsersComponent; feroute:routes.tsx:/dash ROUTES_TO Dashboard). Honest-partial: dynamic template-literal paths (${…}) mint no node; a <Route> with no resolvable element/component mints no edge; non-PascalCase component refs are dropped. |
+| Resource extraction | 🟢 `partial` | `2026-06-02` | — | `internal/engine/detector.go`<br>`internal/engine/frontend_route_edges.go`<br>`internal/engine/frontend_route_edges_test.go` | epic #3628: client-side routing graph for JS/TS SPAs — the previously-invisible table a router consults to decide WHICH COMPONENT renders for a URL path. New LIVE engine pass applyFrontendRouteEdges (registered in detector.go after applyAPIGatewayRoutingEdges; JS/TS only, gated, append-only). Mints a SCOPE.Route node keyed `feroute:<file>:<path>` with props synthesis=frontend_routing, scope=client, framework, route. This is a DISTINCT node from a backend SCOPE.Endpoint or an api-gateway SCOPE.Route (`route:<tool>:…`, synthesis=api_gateway_routing) even when the path string coincides — a frontend `/users` view and a backend `GET /users` API are different runtime concerns. Recognises React Router (`<Route path="/users" element={<Users/>}/>` + v5 `component={Users}`; `createBrowserRouter([{path,element}])`), Vue Router (`routes:[{path:'/u/:id', component:UserDetail}]`), Angular (`RouterModule.forRoot([{path:'users', component:UsersComponent}])`). Partial: covers the declarative config-table + JSX-element route forms only — Next.js/Remix file-based routing and fully programmatic/computed route configs are not yet modelled (follow-up). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update frontend.routing.spa-route-component ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1310,6 +1310,26 @@
       }
     },
     {
+      "id": "frontend.routing.spa-route-component",
+      "category": "platform",
+      "language": "multi",
+      "label": "Frontend route → component graph (SPA client routing)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/frontend_route_edges.go","internal/engine/frontend_route_edges_test.go","internal/resolve/refs.go"],
+          "notes": "epic #3628: emits a ROUTES_TO edge SCOPE.Route(frontend) → component. The edge ToID is the BARE component identifier (e.g. \"Users\"), exactly as the JSX RENDERS edge does; the cross-file resolver (internal/resolve byName index) rewrites it to the declaring component entity (SCOPE.Function / SCOPE.Class) at pass 2. No new Kind introduced (reuses SCOPE.Route + ROUTES_TO). Value-asserting tests assert each specific route node id + route→component edge (feroute:App.tsx:/users ROUTES_TO Users; feroute:router.ts:/u/:id ROUTES_TO UserDetail; feroute:app.routes.ts:users ROUTES_TO UsersComponent; feroute:routes.tsx:/dash ROUTES_TO Dashboard). Honest-partial: dynamic template-literal paths (${…}) mint no node; a \u003cRoute\u003e with no resolvable element/component mints no edge; non-PascalCase component refs are dropped.",
+          "verified_at": "2026-06-02"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/detector.go","internal/engine/frontend_route_edges.go","internal/engine/frontend_route_edges_test.go"],
+          "notes": "epic #3628: client-side routing graph for JS/TS SPAs — the previously-invisible table a router consults to decide WHICH COMPONENT renders for a URL path. New LIVE engine pass applyFrontendRouteEdges (registered in detector.go after applyAPIGatewayRoutingEdges; JS/TS only, gated, append-only). Mints a SCOPE.Route node keyed `feroute:\u003cfile\u003e:\u003cpath\u003e` with props synthesis=frontend_routing, scope=client, framework, route. This is a DISTINCT node from a backend SCOPE.Endpoint or an api-gateway SCOPE.Route (`route:\u003ctool\u003e:…`, synthesis=api_gateway_routing) even when the path string coincides — a frontend `/users` view and a backend `GET /users` API are different runtime concerns. Recognises React Router (`\u003cRoute path=\"/users\" element={\u003cUsers/\u003e}/\u003e` + v5 `component={Users}`; `createBrowserRouter([{path,element}])`), Vue Router (`routes:[{path:'/u/:id', component:UserDetail}]`), Angular (`RouterModule.forRoot([{path:'users', component:UsersComponent}])`). Partial: covers the declarative config-table + JSX-element route forms only — Next.js/Remix file-based routing and fully programmatic/computed route configs are not yet modelled (follow-up).",
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "infra.container.docker-compose",
       "category": "platform",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 154
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 155
 
 ## Coverage by language
 
@@ -33,14 +33,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 12 | 0 | 8 | 4 |
-| [Platform / k8s](by-category/platform.md) | 32 | 20 | 12 | 0 |
+| [Platform / k8s](by-category/platform.md) | 33 | 20 | 13 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 21 | 9 | 10 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 12 | 5 | 4 | 3 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 112 | 42 | 43 | 27 |
+| **Total** | 113 | 42 | 44 | 27 |
 
 ## Languages with extractor support, no records yet
 
@@ -68,4 +68,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 224 frameworks · 111 tools · 155 ORMs · 154 other
+Total: 224 frameworks · 111 tools · 155 ORMs · 155 other

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -847,6 +847,16 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// dynamic/templated upstreams (${...}) are omitted, not guessed. Append-only
 	// — cannot regress surrounding passes.
 	applyPass(applyAPIGatewayRoutingEdges)
+	// Frontend route -> component graph (epic #3628). Complements the BACKEND
+	// routing passes above by modelling the CLIENT-SIDE routing table: which
+	// component a single-page-app router (React Router, Vue Router, Angular)
+	// renders for a URL path. Mints a SCOPE.Route node keyed `feroute:<file>:
+	// <path>` (synthesis="frontend_routing", scope="client") — DISTINCT from a
+	// backend SCOPE.Endpoint or api-gateway SCOPE.Route even when the path
+	// coincides — and a ROUTES_TO edge to the rendered component (bare name,
+	// bound by the cross-file resolver). Honest-partial: dynamic paths and
+	// unresolvable component refs are dropped. JS/TS only; gated; append-only.
+	applyPass(applyFrontendRouteEdges)
 	// Workflow orchestration edges (#934). Emits SCOPE.Workflow, SCOPE.Activity,
 	// and SCOPE.StateMachine entities plus STARTS_WORKFLOW, EXECUTES_ACTIVITY,
 	// and STEPFUNCTION_STEP_INVOKES edges for Temporal (Python, Go, Java, Node),

--- a/internal/engine/frontend_route_edges.go
+++ b/internal/engine/frontend_route_edges.go
@@ -1,0 +1,285 @@
+// Frontend route → component graph synthesis — epic #3628.
+//
+// Backend routing is already modelled: HTTP endpoints (SCOPE.Endpoint), API-
+// gateway routes (api_gateway_routing_edges.go: SCOPE.Route -ROUTES_TO-> backend
+// SCOPE.Service), and k8s/ingress topology. The CLIENT-SIDE routing graph — the
+// table a single-page-app router consults to decide WHICH COMPONENT renders for
+// a given URL path — was previously invisible. The only client-side routing
+// signal in the graph was NAVIGATES_TO, which models a *navigation call site* or
+// link directive (caller-op -> route stub); it does NOT model the route
+// *definition* nor the component a route renders. Notably the Angular route-table
+// scan (angular_nav_lifecycle.go) parsed `path:` but DROPPED the paired
+// `component:`, so no route -> component edge existed for any framework.
+//
+// This pass mints the missing definitional half:
+//
+//	SCOPE.Route(frontend)  -- ROUTES_TO -->  component (SCOPE.Function / SCOPE.Class)
+//
+// It recognises the declarative route tables of the three config-driven SPA
+// routers plus React's element-prop JSX form:
+//
+//   - React Router: <Route path="/users" element={<Users/>} />  and the
+//     component={Users} form; createBrowserRouter([{path:'/users',
+//     element:<Users/>}]) object form.
+//   - Vue Router:   const routes = [{ path: '/users', component: Users }]
+//   - Angular:      RouterModule.forRoot([{ path: 'users', component: UsersComponent }])
+//
+// # Node model + distinction from backend endpoints
+//
+// The route node is keyed `feroute:<file>:<path>` and stamped
+// Properties["synthesis"]="frontend_routing" + ["scope"]="client". This keeps it
+// a DISTINCT node from a backend SCOPE.Endpoint or an api-gateway SCOPE.Route
+// (keyed `route:<tool>:…`, synthesis="api_gateway_routing") even when the path
+// string coincides — a frontend `/users` view and a backend `GET /users` API are
+// different graph entities, as they are different runtime concerns.
+//
+// The ROUTES_TO edge's ToID is the BARE component identifier (e.g. "Users"),
+// exactly as the JSX RENDERS edge does (extractor.go) — the cross-file resolver
+// (internal/resolve, byName index) rewrites it to the declaring component entity
+// at pass 2. Self-contained: no new Kind is introduced (SCOPE.Route + ROUTES_TO
+// already exist).
+//
+// # Honest-partial
+//
+// Only statically-resolvable path+component pairs emit. A dynamic path (`path:
+// pathVar`, a template literal with `${…}`) or a non-PascalCase / unresolvable
+// component reference is skipped rather than emitting a garbage node/edge.
+//
+// # Scope guard
+//
+// Append-only and gated: fires only for JS/TS files whose content contains a
+// recognised router marker; every other file is a fast no-op. It never modifies
+// or removes existing entities/edges, so it cannot regress the pipeline.
+//
+// Epic #3628. DEPLOY-DEFERRED.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+const (
+	feRouteKind     = string(types.EntityKindRoute)
+	feRouteRoutesTo = string(types.RelationshipKindRoutesTo)
+)
+
+// feRouteID keys a frontend route node distinctly from backend / api-gateway
+// SCOPE.Route nodes (which are keyed "route:<tool>:…"). The "feroute:" prefix +
+// file scoping guarantees no collision with a backend route of the same path.
+func feRouteID(file, path string) string {
+	return "feroute:" + file + ":" + path
+}
+
+// reFEReactRouteElement matches a React Router <Route … /> JSX element and
+// captures the path attribute (group 1). The element/component attribute is
+// resolved separately from the same element text so attribute order is
+// irrelevant.
+var reFEReactRouteElement = regexp.MustCompile(`(?s)<Route\b([^>]*?)/?>`)
+
+// reFEPathAttr matches a path="…" JSX attribute (string literal form).
+var reFEPathAttr = regexp.MustCompile(`\bpath\s*=\s*["']([^"']*)["']`)
+
+// reFEElementJSX matches element={<Comp …/>} and captures the component tag.
+var reFEElementJSX = regexp.MustCompile(`\belement\s*=\s*\{\s*<\s*([A-Za-z_$][\w$]*)`)
+
+// reFEComponentAttr matches component={Comp} (React Router v5) and the object-
+// form `component: Comp` (Vue / Angular / createBrowserRouter). Capture group 1
+// is the component identifier.
+var reFEComponentAttr = regexp.MustCompile(`\bcomponent\s*[=:]\s*\{?\s*([A-Za-z_$][\w$]*)`)
+
+// reFEObjectRoute matches a single `{ … path: '…' … }` route-config object and
+// captures the path literal (group 1). Used for createBrowserRouter / Vue
+// `routes:[…]` / Angular `RouterModule.forRoot([…])` object-form tables.
+var reFEObjectRoute = regexp.MustCompile(`path\s*:\s*["'` + "`" + `]([^"'` + "`" + `]*)["'` + "`" + `]`)
+
+// reFEElementObj matches the object-form `element: <Comp …/>` (createBrowserRouter).
+var reFEElementObj = regexp.MustCompile(`element\s*:\s*<\s*([A-Za-z_$][\w$]*)`)
+
+// feRouterMarkers gate the pass: the file must mention at least one to do any work.
+var feRouterMarkers = []string{
+	"<Route",              // react-router JSX
+	"createBrowserRouter", // react-router data-router
+	"createHashRouter",
+	"createRoutesFromElements",
+	"vue-router",   // vue
+	"createRouter", // vue
+	"RouterModule", // angular
+	"@angular/router",
+	"routes", // generic object table (cheap pre-filter; refined below)
+}
+
+// isFEComponentName reports whether s is a PascalCase component identifier — the
+// React/Vue/Angular convention. Mirrors isComponentName in the JS extractor.
+func isFEComponentName(s string) bool {
+	if s == "" {
+		return false
+	}
+	r := rune(s[0])
+	return r >= 'A' && r <= 'Z'
+}
+
+// feDynamicPath reports whether a captured path string is statically
+// unresolvable (contains a template-literal interpolation). Parametric segments
+// like ":id" or "[id]" are legitimate STATIC route declarations and are kept.
+func feDynamicPath(p string) bool {
+	return strings.Contains(p, "${")
+}
+
+// feNormalizePath gives an empty path a stable display label so the index/
+// default child route is still a navigable node.
+func feNormalizePath(p string) string {
+	if p == "" {
+		return "<index>"
+	}
+	return p
+}
+
+// applyFrontendRouteEdges is the per-file engine pass. Append-only.
+func applyFrontendRouteEdges(args DetectorPassArgs) DetectorPassResult {
+	entities := args.Entities
+	relationships := args.Relationships
+
+	if args.Lang != "javascript" && args.Lang != "typescript" {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	if len(args.Content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	src := string(args.Content)
+
+	gated := false
+	for _, m := range feRouterMarkers {
+		if strings.Contains(src, m) {
+			gated = true
+			break
+		}
+	}
+	if !gated {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	// emit mints (route node, ROUTES_TO edge) for one resolved path+component
+	// pair. Dynamic paths and non-component refs are dropped by the callers.
+	emit := func(path, component, framework, via string) {
+		path = feNormalizePath(strings.TrimSpace(path))
+		component = strings.TrimSpace(component)
+		if !isFEComponentName(component) {
+			return
+		}
+		id := feRouteID(args.Path, path)
+		if !seenEnt[id] {
+			seenEnt[id] = true
+			entities = append(entities, types.EntityRecord{
+				ID:            id,
+				Name:          path,
+				QualifiedName: id,
+				Kind:          feRouteKind,
+				SourceFile:    args.Path,
+				Language:      args.Lang,
+				Properties: map[string]string{
+					"synthesis": "frontend_routing",
+					"scope":     "client",
+					"framework": framework,
+					"route":     path,
+				},
+				EnrichmentStatus: types.StatusPending,
+				QualityScore:     0.8,
+			})
+		}
+		edgeKey := id + "|" + component
+		if seenEdge[edgeKey] {
+			return
+		}
+		seenEdge[edgeKey] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: id,
+			ToID:   component, // bare name; cross-file resolver binds to the component entity
+			Kind:   feRouteRoutesTo,
+			Properties: map[string]string{
+				"synthesis": "frontend_routing",
+				"scope":     "client",
+				"framework": framework,
+				"via":       via,
+				"route":     path,
+			},
+		})
+	}
+
+	// 1. React Router JSX <Route path=… element={<Comp/>} | component={Comp} />.
+	for _, m := range reFEReactRouteElement.FindAllStringSubmatch(src, -1) {
+		attrs := m[1]
+		pm := reFEPathAttr.FindStringSubmatch(attrs)
+		if pm == nil || feDynamicPath(pm[1]) {
+			continue
+		}
+		comp := ""
+		if em := reFEElementJSX.FindStringSubmatch(attrs); em != nil {
+			comp = em[1]
+		} else if cm := reFEComponentAttr.FindStringSubmatch(attrs); cm != nil {
+			comp = cm[1]
+		}
+		if comp != "" {
+			emit(pm[1], comp, "react_router", "jsx_route_element")
+		}
+	}
+
+	// 2. Object-form route tables: createBrowserRouter([{path, element|component}]),
+	//    Vue `routes:[{path, component}]`, Angular RouterModule.forRoot([{path,
+	//    component}]). Split the source on `path:` occurrences so each route
+	//    object's path is paired with the NEAREST following component/element ref
+	//    within the same object literal window.
+	framework := feFramework(src)
+	for _, loc := range reFEObjectRoute.FindAllStringSubmatchIndex(src, -1) {
+		path := src[loc[2]:loc[3]]
+		if feDynamicPath(path) {
+			continue
+		}
+		// Window: from the end of the path match to the next `path:` (or +400
+		// chars), so a route's component is matched within its own object and
+		// does not leak from a sibling route.
+		winStart := loc[1]
+		winEnd := winStart + 400
+		if winEnd > len(src) {
+			winEnd = len(src)
+		}
+		if next := reFEObjectRoute.FindStringIndex(src[winStart:]); next != nil {
+			if cand := winStart + next[0]; cand < winEnd {
+				winEnd = cand
+			}
+		}
+		window := src[winStart:winEnd]
+		comp := ""
+		if em := reFEElementObj.FindStringSubmatch(window); em != nil {
+			comp = em[1]
+		} else if cm := reFEComponentAttr.FindStringSubmatch(window); cm != nil {
+			comp = cm[1]
+		}
+		if comp != "" {
+			emit(path, comp, framework, "route_table_object")
+		}
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// feFramework infers the SPA router framework from import / API markers in the
+// file, for the object-form table whose syntax is shared across routers.
+func feFramework(src string) string {
+	switch {
+	case strings.Contains(src, "@angular/router") || strings.Contains(src, "RouterModule"):
+		return "angular"
+	case strings.Contains(src, "vue-router") || strings.Contains(src, "createRouter"):
+		return "vue_router"
+	case strings.Contains(src, "react-router") || strings.Contains(src, "createBrowserRouter") ||
+		strings.Contains(src, "createHashRouter"):
+		return "react_router"
+	default:
+		return "spa_router"
+	}
+}

--- a/internal/engine/frontend_route_edges_test.go
+++ b/internal/engine/frontend_route_edges_test.go
@@ -1,0 +1,226 @@
+// Tests for the frontend route -> component graph pass (epic #3628).
+//
+// Value-asserting: every positive test asserts a SPECIFIC SCOPE.Route node
+// (id `feroute:<file>:<path>`, synthesis="frontend_routing", scope="client")
+// AND a SPECIFIC ROUTES_TO edge from it to the named component — never len>0.
+//
+//   - React Router JSX   <Route path="/users" element={<Users/>} />
+//     → feroute:App.tsx:/users  ROUTES_TO  Users
+//   - React Router v5    <Route path="/about" component={About} />
+//     → feroute:App.tsx:/about  ROUTES_TO  About
+//   - Vue Router         { path: '/u/:id', component: UserDetail }
+//     → feroute:router.ts:/u/:id  ROUTES_TO  UserDetail
+//   - Angular            { path: 'users', component: UsersComponent }
+//     → feroute:app.routes.ts:users  ROUTES_TO  UsersComponent
+//   - createBrowserRouter { path: '/dash', element: <Dashboard/> }
+//     → feroute:routes.tsx:/dash  ROUTES_TO  Dashboard
+//
+// Negatives: a dynamic path `{ path: pathVar }` mints no node; a <Route> with
+// no resolvable element/component mints no edge; a non-JS/TS file no-ops.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runFERouteDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	res := applyFrontendRouteEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
+}
+
+// feRouteNode returns the SCOPE.Route entity with the given id, or nil.
+func feRouteNode(ents []types.EntityRecord, id string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].ID == id && ents[i].Kind == feRouteKind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// feRoutesToEdge returns the ROUTES_TO edge fromID->toComponent, or nil.
+func feRoutesToEdge(rels []types.RelationshipRecord, fromID, toComponent string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].Kind == feRouteRoutesTo && rels[i].FromID == fromID && rels[i].ToID == toComponent {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+func assertFERoute(t *testing.T, ents []types.EntityRecord, rels []types.RelationshipRecord, routeID, component, framework string) {
+	t.Helper()
+	node := feRouteNode(ents, routeID)
+	if node == nil {
+		t.Fatalf("expected SCOPE.Route node %q, got entities: %+v", routeID, ents)
+	}
+	if got := node.Properties["synthesis"]; got != "frontend_routing" {
+		t.Errorf("node %s synthesis=%q, want frontend_routing", routeID, got)
+	}
+	if got := node.Properties["scope"]; got != "client" {
+		t.Errorf("node %s scope=%q, want client", routeID, got)
+	}
+	if framework != "" {
+		if got := node.Properties["framework"]; got != framework {
+			t.Errorf("node %s framework=%q, want %q", routeID, got, framework)
+		}
+	}
+	edge := feRoutesToEdge(rels, routeID, component)
+	if edge == nil {
+		t.Fatalf("expected ROUTES_TO %s -> %s, got rels: %+v", routeID, component, rels)
+	}
+	if got := edge.Properties["synthesis"]; got != "frontend_routing" {
+		t.Errorf("edge %s->%s synthesis=%q, want frontend_routing", routeID, component, got)
+	}
+}
+
+func TestFERoute_ReactRouter_JSXElement(t *testing.T) {
+	src := `
+import { Routes, Route } from "react-router-dom";
+import Users from "./Users";
+export function App() {
+  return (
+    <Routes>
+      <Route path="/users" element={<Users/>} />
+    </Routes>
+  );
+}`
+	ents, rels := runFERouteDetect(t, "typescript", "App.tsx", src)
+	assertFERoute(t, ents, rels, "feroute:App.tsx:/users", "Users", "react_router")
+}
+
+func TestFERoute_ReactRouter_V5ComponentProp(t *testing.T) {
+	src := `
+import { Route } from "react-router-dom";
+import About from "./About";
+const r = <Route path="/about" component={About} />;`
+	ents, rels := runFERouteDetect(t, "typescript", "App.tsx", src)
+	assertFERoute(t, ents, rels, "feroute:App.tsx:/about", "About", "react_router")
+}
+
+func TestFERoute_VueRouter_ObjectTable(t *testing.T) {
+	src := `
+import { createRouter, createWebHistory } from "vue-router";
+import UserDetail from "./UserDetail.vue";
+const routes = [
+  { path: '/u/:id', component: UserDetail },
+];
+export default createRouter({ history: createWebHistory(), routes });`
+	ents, rels := runFERouteDetect(t, "typescript", "router.ts", src)
+	assertFERoute(t, ents, rels, "feroute:router.ts:/u/:id", "UserDetail", "vue_router")
+}
+
+func TestFERoute_Angular_RouterModule(t *testing.T) {
+	src := `
+import { RouterModule } from "@angular/router";
+import { UsersComponent } from "./users.component";
+const routes = [{ path: 'users', component: UsersComponent }];
+@NgModule({ imports: [RouterModule.forRoot(routes)] })
+export class AppRoutingModule {}`
+	ents, rels := runFERouteDetect(t, "typescript", "app.routes.ts", src)
+	assertFERoute(t, ents, rels, "feroute:app.routes.ts:users", "UsersComponent", "angular")
+}
+
+func TestFERoute_CreateBrowserRouter_ElementObject(t *testing.T) {
+	src := `
+import { createBrowserRouter } from "react-router-dom";
+import Dashboard from "./Dashboard";
+const router = createBrowserRouter([
+  { path: '/dash', element: <Dashboard/> },
+]);`
+	ents, rels := runFERouteDetect(t, "typescript", "routes.tsx", src)
+	assertFERoute(t, ents, rels, "feroute:routes.tsx:/dash", "Dashboard", "react_router")
+}
+
+// Distinct-from-backend: the frontend route node id never collides with a
+// backend/api-gateway SCOPE.Route id, even on the same path string.
+func TestFERoute_DistinctFromBackendRouteID(t *testing.T) {
+	src := `
+import { Route } from "react-router-dom";
+import Users from "./Users";
+const r = <Route path="/users" element={<Users/>} />;`
+	ents, _ := runFERouteDetect(t, "typescript", "App.tsx", src)
+	node := feRouteNode(ents, "feroute:App.tsx:/users")
+	if node == nil {
+		t.Fatal("expected frontend route node")
+	}
+	// Backend api-gateway nodes are keyed "route:<tool>:…"; assert no overlap.
+	if got := node.ID; got == "route:/users" || got == "route:react_router:App.tsx:/users" {
+		t.Errorf("frontend route id %q collides with a backend route key shape", got)
+	}
+	if node.Properties["synthesis"] == "api_gateway_routing" {
+		t.Error("frontend route incorrectly tagged as api_gateway_routing")
+	}
+}
+
+// NEGATIVE: a dynamic (template-literal interpolated) path mints no node.
+func TestFERoute_DynamicPath_NoNode(t *testing.T) {
+	src := "import { Route } from \"react-router-dom\";\n" +
+		"const p = base + '/x';\n" +
+		"const r = <Route path={`${base}/users`} element={<Users/>} />;"
+	ents, rels := runFERouteDetect(t, "typescript", "App.tsx", src)
+	for _, e := range ents {
+		if e.Kind == feRouteKind {
+			t.Errorf("dynamic path should mint no SCOPE.Route node, got %q", e.ID)
+		}
+	}
+	for _, r := range rels {
+		if r.Kind == feRouteRoutesTo {
+			t.Errorf("dynamic path should mint no ROUTES_TO edge, got %s->%s", r.FromID, r.ToID)
+		}
+	}
+}
+
+// NEGATIVE: a <Route> with no resolvable element/component mints no edge
+// (a layout/index route with only children).
+func TestFERoute_NoComponent_NoEdge(t *testing.T) {
+	src := `
+import { Route } from "react-router-dom";
+const r = <Route path="/layout"></Route>;`
+	ents, rels := runFERouteDetect(t, "typescript", "App.tsx", src)
+	if n := feRouteNode(ents, "feroute:App.tsx:/layout"); n != nil {
+		t.Errorf("route with no component should mint no node, got %q", n.ID)
+	}
+	for _, r := range rels {
+		if r.Kind == feRouteRoutesTo {
+			t.Errorf("route with no component should mint no edge, got %s->%s", r.FromID, r.ToID)
+		}
+	}
+}
+
+// NEGATIVE: a non-JS/TS file is a fast no-op even if it mentions "routes".
+func TestFERoute_NonJSFile_NoOp(t *testing.T) {
+	src := `routes:
+  - path: /users
+    component: Users`
+	ents, rels := runFERouteDetect(t, "yaml", "routes.yaml", src)
+	for _, e := range ents {
+		if e.Kind == feRouteKind {
+			t.Errorf("non-JS file should no-op, got node %q", e.ID)
+		}
+	}
+	if len(rels) != 0 {
+		t.Errorf("non-JS file should emit no edges, got %d", len(rels))
+	}
+}
+
+// Append-only: the pass returns pre-existing entities/edges untouched.
+func TestFERoute_AppendOnly(t *testing.T) {
+	pre := []types.EntityRecord{{ID: "pre:1", Kind: "SCOPE.Function"}}
+	preRel := []types.RelationshipRecord{{FromID: "a", ToID: "b", Kind: "CALLS"}}
+	res := applyFrontendRouteEdges(DetectorPassArgs{
+		Lang: "typescript", Path: "App.tsx",
+		Content:       []byte(`<Route path="/x" element={<X/>} />`),
+		Entities:      pre,
+		Relationships: preRel,
+	})
+	if len(res.Entities) < 1 || res.Entities[0].ID != "pre:1" {
+		t.Error("pre-existing entity was modified or dropped")
+	}
+	if len(res.Relationships) < 1 || res.Relationships[0].Kind != "CALLS" {
+		t.Error("pre-existing relationship was modified or dropped")
+	}
+}


### PR DESCRIPTION
Closes #3819. Epic #3628.

## Problem
The **client-side routing graph** was invisible. The only client-side routing signal in the graph was `NAVIGATES_TO`, which models a *navigation call site / link directive* (caller-op → route stub) — it models **neither the route definition nor the component a route renders**. The Angular route-table scan (`angular_nav_lifecycle.go`) even parsed `path:` but DROPPED the paired `component:`, so no route→component edge existed for any framework.

## Node model
New LIVE engine pass `applyFrontendRouteEdges` (`internal/engine/frontend_route_edges.go`, registered in `detector.go` after `applyAPIGatewayRoutingEdges`; JS/TS only, gated, append-only):

```
SCOPE.Route(frontend)  -- ROUTES_TO -->  component (SCOPE.Function / SCOPE.Class)
```

- **Route node** keyed `feroute:<file>:<path>`, props `synthesis=frontend_routing`, `scope=client`, `framework`, `route`.
- **ROUTES_TO edge** ToID is the **bare component name** (exactly as JSX `RENDERS`); the cross-file resolver (`internal/resolve` byName index) rewrites it to the declaring component entity at pass 2.
- **No new Kind** — reuses the existing `SCOPE.Route` + `ROUTES_TO`.

### Distinction from backend endpoints
The frontend route node is a **DISTINCT graph entity** from a backend `SCOPE.Endpoint` or an api-gateway `SCOPE.Route` (`route:<tool>:…`, `synthesis=api_gateway_routing`) **even when the path string coincides** — a frontend `/users` view and a backend `GET /users` API are different runtime concerns. The `feroute:` prefix + file scoping + `synthesis=frontend_routing`/`scope=client` props guarantee no collision; a dedicated test asserts this.

## Frameworks
- **React Router:** `<Route path="/users" element={<Users/>}/>` + v5 `component={Users}`; `createBrowserRouter([{path:'/dash', element:<Dashboard/>}])`.
- **Vue Router:** `routes:[{path:'/u/:id', component:UserDetail}]`.
- **Angular:** `RouterModule.forRoot([{path:'users', component:UsersComponent}])`.

## Honest-partial
Dynamic template-literal paths (`${…}`) mint no node; a `<Route>` with no resolvable element/component mints no edge; non-PascalCase component refs are dropped.

## Route→component edges asserted (value-asserting tests)
| Route node | edge |
|---|---|
| `feroute:App.tsx:/users` | ROUTES_TO `Users` (react_router, jsx element) |
| `feroute:App.tsx:/about` | ROUTES_TO `About` (react_router, v5 component prop) |
| `feroute:router.ts:/u/:id` | ROUTES_TO `UserDetail` (vue_router) |
| `feroute:app.routes.ts:users` | ROUTES_TO `UsersComponent` (angular) |
| `feroute:routes.tsx:/dash` | ROUTES_TO `Dashboard` (createBrowserRouter element obj) |

Plus negatives (dynamic path → no node; no-component `<Route>` → no edge; non-JS file → no-op) and an append-only guard.

## Follow-up (not in this PR)
Next.js / Remix **file-based** routing (`app/users/page.tsx` → `/users`; `pages/users/[id].tsx` → `/users/:id`, component = default export) and lazy `loadChildren` / programmatic route configs.

## Verification
- `go test ./internal/engine/ ./internal/custom/... ./internal/extractors/... ./internal/types/ ./tools/coverage/` green
- `go test ./internal/types/` green; `gofmt -l` empty; `go vet ./internal/engine/` clean
- `coverage validate` 0 errors (645 records, +1); `coverage fmt --check` canonical; docs regenerated (no drift)
- Coverage record `frontend.routing.spa-route-component` added (resource_extraction + dependency_attribution, both partial, citing the extractor)

**DEPLOY-DEFERRED** — the live daemon serves the rewrite agent; reindex separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)