### PR TITLE
feat(security): CORS policy extraction — origins/credentials/wildcard

### DIFF
--- a/docs/coverage/by-category/security.md
+++ b/docs/coverage/by-category/security.md
@@ -1,21 +1,22 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # security
 
-**Total**: 12 records · **elixir**: 1 · **java**: 1 · **multi**: 10
+**Total**: 13 records · **elixir**: 1 · **java**: 1 · **multi**: 11
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Auth policy | Secret detection | SQL injection | Status | Notes |
-|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Ueberauth (Elixir OAuth)](../detail/lang.elixir.framework.ueberauth.md) | 🟢 | 🔴 | — | 🔴 | |
-| [java](../by-language/java.md) | [Auth policy resolver (Java/Kotlin — Phase 1 of #1942)](../detail/security.auth-java.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)](../detail/security.auth-other.md) | 🔴 | — | — | 🔴 | |
-| [multi](../by-language/multi.md) | [CSRF heuristic detector](../detail/security.csrf.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [HTTP Basic Auth](../detail/security.auth.basic.md) | 🟢 | 🔴 | — | 🔴 | |
-| [multi](../by-language/multi.md) | [JWT](../detail/security.auth.jwt.md) | 🟢 | 🔴 | — | 🔴 | |
-| [multi](../by-language/multi.md) | [OAuth2](../detail/security.auth.oauth2.md) | 🟢 | 🔴 | — | 🔴 | |
-| [multi](../by-language/multi.md) | [OIDC (OpenID Connect)](../detail/security.auth.oidc.md) | 🟢 | 🔴 | — | 🔴 | |
-| [multi](../by-language/multi.md) | [SAML](../detail/security.auth.saml.md) | 🔴 | 🔴 | — | 🔴 | |
-| [multi](../by-language/multi.md) | [SQL injection heuristic (f-string / .format() / % interpolation into SQL)](../detail/security.sql-injection.md) | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Secret material extraction (Phase 1 security audit)](../detail/security.secrets.md) | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Session cookies](../detail/security.auth.session.md) | 🟢 | 🔴 | — | 🔴 | |
+| Language | Name | Auth policy | Cors policy | Secret detection | SQL injection | Status | Notes |
+|---|---|---|---|---|---|---|---|
+| [elixir](../by-language/elixir.md) | [Ueberauth (Elixir OAuth)](../detail/lang.elixir.framework.ueberauth.md) | 🟢 | — | 🔴 | — | 🔴 | |
+| [java](../by-language/java.md) | [Auth policy resolver (Java/Kotlin — Phase 1 of #1942)](../detail/security.auth-java.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)](../detail/security.auth-other.md) | 🔴 | — | — | — | 🔴 | |
+| [multi](../by-language/multi.md) | [CORS policy extraction (origins/credentials/wildcard) — Express, FastAPI/Starlette, django-cors-headers, Spring @CrossOrigin/CorsRegistry, ASP.NET, Rails rack-cors](../detail/security.cors-policy.md) | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [CSRF heuristic detector](../detail/security.csrf.md) | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [HTTP Basic Auth](../detail/security.auth.basic.md) | 🟢 | — | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [JWT](../detail/security.auth.jwt.md) | 🟢 | — | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [OAuth2](../detail/security.auth.oauth2.md) | 🟢 | — | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [OIDC (OpenID Connect)](../detail/security.auth.oidc.md) | 🟢 | — | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [SAML](../detail/security.auth.saml.md) | 🔴 | — | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [SQL injection heuristic (f-string / .format() / % interpolation into SQL)](../detail/security.sql-injection.md) | — | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Secret material extraction (Phase 1 security audit)](../detail/security.secrets.md) | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Session cookies](../detail/security.auth.session.md) | 🟢 | — | 🔴 | — | 🔴 | |

--- a/docs/coverage/detail/security.cors-policy.md
+++ b/docs/coverage/detail/security.cors-policy.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.cors-policy` — CORS policy extraction (origins/credentials/wildcard) — Express, FastAPI/Starlette, django-cors-headers, Spring @CrossOrigin/CorsRegistry, ASP.NET, Rails rack-cors
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Cors policy | ✅ `full` | `2026-06-02` | — | `internal/patterns/cors_extractor.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.cors-policy ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -72107,6 +72107,19 @@
       }
     },
     {
+      "id": "security.cors-policy",
+      "category": "security",
+      "language": "multi",
+      "label": "CORS policy extraction (origins/credentials/wildcard) — Express, FastAPI/Starlette, django-cors-headers, Spring @CrossOrigin/CorsRegistry, ASP.NET, Rails rack-cors",
+      "capabilities": {
+        "cors_policy": {
+          "status": "full",
+          "cites": ["internal/patterns/cors_extractor.go"],
+          "verified_at": "2026-06-02"
+        }
+      }
+    },
+    {
       "id": "security.csrf",
       "category": "security",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 154
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 155
 
 ## Coverage by language
 
@@ -36,11 +36,11 @@
 | [Platform / k8s](by-category/platform.md) | 32 | 20 | 12 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 21 | 9 | 10 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
-| [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
+| [Security](by-category/security.md) | 11 | 4 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 12 | 5 | 4 | 3 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 112 | 42 | 43 | 27 |
+| **Total** | 113 | 43 | 43 | 27 |
 
 ## Languages with extractor support, no records yet
 
@@ -68,4 +68,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 224 frameworks · 111 tools · 155 ORMs · 154 other
+Total: 224 frameworks · 111 tools · 155 ORMs · 155 other

--- a/internal/patterns/cors_extractor.go
+++ b/internal/patterns/cors_extractor.go
@@ -8,27 +8,55 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// corsExtractor detects CORS middleware configuration across frameworks.
-// Matches Python cors_extractor.py.
+// corsExtractor detects CORS middleware configuration across frameworks and
+// stamps a security-relevant policy node (SCOPE.Config / cors_policy) carrying
+// the allowed origins, methods, credentials flag, and a wildcard flag. The
+// dangerous posture — a wildcard origin ("*") combined with credentials — is
+// captured explicitly so the graph can answer "what origins can call this API?"
+// and flag the permissive `*` + credentials combination.
+//
+// CORS configuration is usually GLOBAL (app/middleware level), in which case
+// the policy applies to every endpoint in that app; per-route configuration
+// (Spring @CrossOrigin, ASP.NET [EnableCors]) is stamped on just that route's
+// scope. We emit one cors_policy node per configuration site (matching the
+// auth_policy posture model) rather than mutating every endpoint op.
 type corsExtractor struct{}
 
 var (
-	corsExpressRE          = regexp.MustCompile(`(?:app|router)\s*\.\s*use\s*\(\s*cors\s*\(\s*(\{[^}]*\})?\s*\)`)
-	corsExpressOriginRE    = regexp.MustCompile(`origin\s*:\s*["']([^"']+)["']`)
-	corsExpressMethodsRE   = regexp.MustCompile(`methods\s*:\s*["']([^"']+)["']`)
-	corsExpressHeadersRE   = regexp.MustCompile(`allowedHeaders\s*:\s*["']([^"']+)["']`)
-	corsSpringCrossOriRE   = regexp.MustCompile(`@CrossOrigin\s*(?:\([^)]*\))?`)
-	corsSpringOriginsRE    = regexp.MustCompile(`origins\s*=\s*["']([^"']+)["']`)
-	corsSpringMethodsRE    = regexp.MustCompile(`allowedMethods\s*=\s*["']([^"']+)["']`)
-	corsSpringRegistryRE   = regexp.MustCompile(`addMapping\s*\(\s*["']([^"']+)["']\s*\)`)
-	corsSpringAllowedRE    = regexp.MustCompile(`allowedOrigins\s*\(\s*["']([^"']+)["']`)
+	corsExpressRE        = regexp.MustCompile(`(?:app|router)\s*\.\s*use\s*\(\s*cors\s*\(\s*(\{[^}]*\})?\s*\)`)
+	corsExpressOriginRE  = regexp.MustCompile(`origin\s*:\s*["']([^"']+)["']`)
+	corsExpressMethodsRE = regexp.MustCompile(`methods\s*:\s*["']([^"']+)["']`)
+	corsExpressHeadersRE = regexp.MustCompile(`allowedHeaders\s*:\s*["']([^"']+)["']`)
+	corsExpressOriginTRE = regexp.MustCompile(`origin\s*:\s*true\b`)
+
+	corsSpringCrossOriRE = regexp.MustCompile(`@CrossOrigin\s*(?:\([^)]*\))?`)
+	corsSpringOriginsRE  = regexp.MustCompile(`origins\s*=\s*["']([^"']+)["']`)
+	corsSpringMethodsRE  = regexp.MustCompile(`allowedMethods\s*=\s*["']([^"']+)["']`)
+	corsSpringRegistryRE = regexp.MustCompile(`addMapping\s*\(\s*["']([^"']+)["']\s*\)`)
+	corsSpringAllowedRE  = regexp.MustCompile(`allowedOrigins(?:Patterns)?\s*\(\s*["']([^"']+)["']`)
+	corsSpringCredRE     = regexp.MustCompile(`allowCredentials\s*(?:\(\s*true\s*\)|=\s*["']?true)`)
+
 	corsASPNetAddCorsRE    = regexp.MustCompile(`(?:services|builder\s*\.\s*Services)\s*\.\s*AddCors\s*\(`)
 	corsASPNetPolicyNameRE = regexp.MustCompile(`AddPolicy\s*\(\s*["']([^"']+)["']`)
 	corsASPNetEnableCorsRE = regexp.MustCompile(`\[EnableCors\s*\(\s*["']([^"']+)["']\s*\)\]`)
-	corsFastAPIRE          = regexp.MustCompile(`(?s)add_middleware\s*\(\s*CORSMiddleware\s*,([^)]+)\)`)
-	corsFastAPIOriginsRE   = regexp.MustCompile(`(?s)allow_origins\s*=\s*\[([^\]]*)\]`)
-	corsFastAPIMethodsRE   = regexp.MustCompile(`(?s)allow_methods\s*=\s*\[([^\]]*)\]`)
-	corsStringLiteralRE    = regexp.MustCompile(`["']([^"']+)["']`)
+
+	corsFastAPIRE        = regexp.MustCompile(`(?s)add_middleware\s*\(\s*CORSMiddleware\s*,([^)]+)\)`)
+	corsFastAPIOriginsRE = regexp.MustCompile(`(?s)allow_origins\s*=\s*\[([^\]]*)\]`)
+	corsFastAPIMethodsRE = regexp.MustCompile(`(?s)allow_methods\s*=\s*\[([^\]]*)\]`)
+	corsFastAPICredRE    = regexp.MustCompile(`allow_credentials\s*=\s*True\b`)
+
+	// django-cors-headers settings.
+	corsDjangoAllowAllRE = regexp.MustCompile(`CORS_ALLOW_ALL_ORIGINS\s*=\s*True\b`)
+	corsDjangoOriginsRE  = regexp.MustCompile(`(?s)CORS_ALLOWED_ORIGINS\s*=\s*\[([^\]]*)\]`)
+	corsDjangoCredRE     = regexp.MustCompile(`CORS_ALLOW_CREDENTIALS\s*=\s*True\b`)
+
+	// Rails rack-cors: `origins '*'` / `origins 'example.com'` inside a
+	// Rack::Cors block. credentials true sets the credentials flag.
+	corsRackBlockRE   = regexp.MustCompile(`Rack::Cors`)
+	corsRackOriginsRE = regexp.MustCompile(`origins\s+([^\n]+)`)
+	corsRackCredRE    = regexp.MustCompile(`credentials\s+true\b`)
+
+	corsStringLiteralRE = regexp.MustCompile(`["']([^"']+)["']`)
 )
 
 var corsImportTokens = []string{
@@ -36,11 +64,14 @@ var corsImportTokens = []string{
 	"AddCors", "EnableCors", "CorsPolicy",
 	"CORSMiddleware", "starlette.middleware.cors", "fastapi.middleware.cors",
 	"require('cors')", `require("cors")`, "import cors",
+	"CORS_ALLOWED_ORIGINS", "CORS_ALLOW_ALL_ORIGINS", "corsheaders",
+	"Rack::Cors", "rack-cors",
 }
 
 var corsSourceTokens = []string{
 	"cors(", "cors({", "CORSMiddleware", "@CrossOrigin",
 	"AddCors(", "EnableCors(", "addMapping(", "allowedOrigins(",
+	"CORS_ALLOW_ALL_ORIGINS", "CORS_ALLOWED_ORIGINS", "Rack::Cors",
 }
 
 func (c *corsExtractor) Category() string { return "cors" }
@@ -59,20 +90,54 @@ func (c *corsExtractor) AppliesTo(src string) bool {
 	return false
 }
 
+// isWildcardOrigin reports whether a resolved origin pattern is permissive
+// (reflects/allows any origin). Express `cors()` with no options defaults to
+// reflecting the request origin, which is treated as wildcard for posture.
+func isWildcardOrigin(origin string) bool {
+	return origin == "*" || strings.Contains(origin, "*")
+}
+
+// corsPolicyProps builds the property bag for a cors_policy node, always
+// stamping cors_enabled and deriving cors_wildcard from the origin. credentials
+// is stamped only when explicitly enabled. Origins are omitted (not fabricated)
+// when dynamic.
+func corsPolicyProps(framework, origin string, credentials bool) map[string]string {
+	props := map[string]string{
+		"kind":           "cors_policy",
+		"framework":      framework,
+		"cors_enabled":   "true",
+		"origin_pattern": origin,
+	}
+	if origin != "dynamic" {
+		props["cors_origins"] = origin
+	}
+	if isWildcardOrigin(origin) {
+		props["cors_wildcard"] = "true"
+	}
+	if credentials {
+		props["cors_credentials"] = "true"
+	}
+	return props
+}
+
 func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRecord {
 	var results []types.EntityRecord
 	seen := map[string]bool{}
 
-	// Express: app.use(cors({...}))
+	// Express: app.use(cors({...})) — global middleware.
 	for idx, m := range corsExpressRE.FindAllStringSubmatchIndex(src, -1) {
 		opts := ""
 		if m[2] >= 0 {
 			opts = src[m[2]:m[3]]
 		}
+		// Default cors() with no options reflects any origin → wildcard.
 		origin := "*"
 		if opts != "" {
 			if om := corsExpressOriginRE.FindStringSubmatch(opts); om != nil {
 				origin = om[1]
+			} else if corsExpressOriginTRE.MatchString(opts) {
+				// origin: true reflects the request origin → wildcard posture.
+				origin = "*"
 			} else {
 				origin = "dynamic"
 			}
@@ -82,7 +147,8 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			continue
 		}
 		seen[key] = true
-		props := map[string]string{"kind": "cors_policy", "framework": "express", "origin_pattern": origin}
+		cred := strings.Contains(opts, "credentials") && regexp.MustCompile(`credentials\s*:\s*true`).MatchString(opts)
+		props := corsPolicyProps("express", origin, cred)
 		if mm := corsExpressMethodsRE.FindStringSubmatch(opts); mm != nil {
 			props["methods"] = mm[1]
 		}
@@ -94,19 +160,23 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			lineOf(src, m[0]), props))
 	}
 
-	// Spring: @CrossOrigin
+	// Spring: @CrossOrigin — per-route (or per-controller) configuration.
 	for idx, m := range corsSpringCrossOriRE.FindAllStringSubmatchIndex(src, -1) {
 		ann := src[m[0]:m[1]]
 		origin := "dynamic"
 		if om := corsSpringOriginsRE.FindStringSubmatch(ann); om != nil {
 			origin = om[1]
+		} else if strings.Contains(ann, "@CrossOrigin") && !strings.Contains(ann, "(") {
+			// Bare @CrossOrigin defaults to allowing all origins.
+			origin = "*"
 		}
 		key := fmt.Sprintf("spring_crossorigin:%d", idx)
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		props := map[string]string{"kind": "cors_policy", "framework": "spring", "origin_pattern": origin}
+		cred := corsSpringCredRE.MatchString(ann)
+		props := corsPolicyProps("spring", origin, cred)
 		if mm := corsSpringMethodsRE.FindStringSubmatch(ann); mm != nil {
 			props["methods"] = mm[1]
 		}
@@ -115,7 +185,7 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			lineOf(src, m[0]), props))
 	}
 
-	// Spring: addMapping("/**").allowedOrigins("...")
+	// Spring: addMapping("/**").allowedOrigins("...") — global CorsRegistry.
 	for idx, m := range corsSpringRegistryRE.FindAllStringSubmatchIndex(src, -1) {
 		mapping := src[m[2]:m[3]]
 		origin := "dynamic"
@@ -128,13 +198,15 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			continue
 		}
 		seen[key] = true
+		cred := corsSpringCredRE.MatchString(rest)
+		props := corsPolicyProps("spring", origin, cred)
+		props["mapping"] = mapping
 		results = append(results, makeEntity(filePath,
 			fmt.Sprintf("cors_policy_spring_registry_%d", idx), "SCOPE.Config", "cors_policy", language,
-			lineOf(src, m[0]),
-			map[string]string{"kind": "cors_policy", "framework": "spring", "origin_pattern": origin, "mapping": mapping}))
+			lineOf(src, m[0]), props))
 	}
 
-	// ASP.NET: builder.Services.AddCors(...)
+	// ASP.NET: builder.Services.AddCors(...) — global policy registration.
 	for idx, m := range corsASPNetAddCorsRE.FindAllStringSubmatchIndex(src, -1) {
 		policyName := "default"
 		rest := src[m[1]:]
@@ -146,13 +218,21 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			continue
 		}
 		seen[key] = true
+		cred := regexp.MustCompile(`AllowCredentials\s*\(`).MatchString(rest)
+		props := corsPolicyProps("aspnet", "dynamic", cred)
+		props["policy_name"] = policyName
+		// AllowAnyOrigin() → wildcard posture.
+		if regexp.MustCompile(`AllowAnyOrigin\s*\(`).MatchString(rest) {
+			props["origin_pattern"] = "*"
+			props["cors_origins"] = "*"
+			props["cors_wildcard"] = "true"
+		}
 		results = append(results, makeEntity(filePath,
 			"cors_policy_aspnet_"+policyName, "SCOPE.Config", "cors_policy", language,
-			lineOf(src, m[0]),
-			map[string]string{"kind": "cors_policy", "framework": "aspnet", "origin_pattern": "dynamic", "policy_name": policyName}))
+			lineOf(src, m[0]), props))
 	}
 
-	// ASP.NET: [EnableCors("PolicyName")]
+	// ASP.NET: [EnableCors("PolicyName")] — per-route attribute.
 	for _, m := range corsASPNetEnableCorsRE.FindAllStringSubmatchIndex(src, -1) {
 		policyName := src[m[2]:m[3]]
 		key := "aspnet_enablecors:" + policyName
@@ -160,19 +240,26 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			continue
 		}
 		seen[key] = true
+		props := corsPolicyProps("aspnet", "dynamic", false)
+		props["policy_name"] = policyName
 		results = append(results, makeEntity(filePath,
 			"cors_policy_aspnet_enable_"+policyName, "SCOPE.Config", "cors_policy", language,
-			lineOf(src, m[0]),
-			map[string]string{"kind": "cors_policy", "framework": "aspnet", "origin_pattern": "dynamic", "policy_name": policyName}))
+			lineOf(src, m[0]), props))
 	}
 
-	// FastAPI: add_middleware(CORSMiddleware, ...)
+	// FastAPI/Starlette: add_middleware(CORSMiddleware, ...) — global middleware.
 	for idx, m := range corsFastAPIRE.FindAllStringSubmatchIndex(src, -1) {
 		args := src[m[2]:m[3]]
 		origin := "dynamic"
 		if om := corsFastAPIOriginsRE.FindStringSubmatch(args); om != nil {
-			if lm := corsStringLiteralRE.FindStringSubmatch(om[1]); lm != nil {
-				origin = lm[1]
+			// Collect all string-literal origins; mark dynamic if none.
+			lits := corsStringLiteralRE.FindAllStringSubmatch(om[1], -1)
+			if len(lits) > 0 {
+				var origins []string
+				for _, lm := range lits {
+					origins = append(origins, lm[1])
+				}
+				origin = strings.Join(origins, ",")
 			}
 		}
 		key := fmt.Sprintf("fastapi:%d", idx)
@@ -180,7 +267,8 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			continue
 		}
 		seen[key] = true
-		props := map[string]string{"kind": "cors_policy", "framework": "fastapi", "origin_pattern": origin}
+		cred := corsFastAPICredRE.MatchString(args)
+		props := corsPolicyProps("fastapi", origin, cred)
 		if mm := corsFastAPIMethodsRE.FindStringSubmatch(args); mm != nil {
 			var methods []string
 			for _, mv := range corsStringLiteralRE.FindAllStringSubmatch(mm[1], -1) {
@@ -195,7 +283,84 @@ func (c *corsExtractor) Detect(filePath, language, src string) []types.EntityRec
 			lineOf(src, m[0]), props))
 	}
 
+	// django-cors-headers: settings.py module-level config — global.
+	results = append(results, c.detectDjango(filePath, language, src, seen)...)
+
+	// Rails rack-cors: Rack::Cors middleware block — global.
+	results = append(results, c.detectRack(filePath, language, src, seen)...)
+
 	return results
+}
+
+// detectDjango handles django-cors-headers settings. CORS_ALLOW_ALL_ORIGINS=True
+// is a wildcard; CORS_ALLOWED_ORIGINS=[...] is an explicit allowlist.
+func (c *corsExtractor) detectDjango(filePath, language, src string, seen map[string]bool) []types.EntityRecord {
+	allowAll := corsDjangoAllowAllRE.MatchString(src)
+	originsMatch := corsDjangoOriginsRE.FindStringSubmatch(src)
+	if !allowAll && originsMatch == nil {
+		return nil
+	}
+	if seen["django"] {
+		return nil
+	}
+	seen["django"] = true
+
+	origin := "dynamic"
+	if allowAll {
+		origin = "*"
+	} else if originsMatch != nil {
+		var origins []string
+		for _, lm := range corsStringLiteralRE.FindAllStringSubmatch(originsMatch[1], -1) {
+			origins = append(origins, lm[1])
+		}
+		if len(origins) > 0 {
+			origin = strings.Join(origins, ",")
+		}
+	}
+	cred := corsDjangoCredRE.MatchString(src)
+	props := corsPolicyProps("django-cors-headers", origin, cred)
+
+	line := 1
+	if loc := corsDjangoAllowAllRE.FindStringIndex(src); loc != nil {
+		line = lineOf(src, loc[0])
+	} else if loc := corsDjangoOriginsRE.FindStringIndex(src); loc != nil {
+		line = lineOf(src, loc[0])
+	}
+	return []types.EntityRecord{makeEntity(filePath,
+		"cors_policy_django", "SCOPE.Config", "cors_policy", language, line, props)}
+}
+
+// detectRack handles Rails rack-cors blocks. `origins '*'` is a wildcard;
+// `origins 'example.com'` is an explicit allowlist; `credentials true` sets
+// the credentials flag.
+func (c *corsExtractor) detectRack(filePath, language, src string, seen map[string]bool) []types.EntityRecord {
+	if !corsRackBlockRE.MatchString(src) {
+		return nil
+	}
+	if seen["rack"] {
+		return nil
+	}
+	seen["rack"] = true
+
+	origin := "dynamic"
+	if om := corsRackOriginsRE.FindStringSubmatch(src); om != nil {
+		var origins []string
+		for _, lm := range corsStringLiteralRE.FindAllStringSubmatch(om[1], -1) {
+			origins = append(origins, lm[1])
+		}
+		if len(origins) > 0 {
+			origin = strings.Join(origins, ",")
+		}
+	}
+	cred := corsRackCredRE.MatchString(src)
+	props := corsPolicyProps("rack-cors", origin, cred)
+
+	line := 1
+	if loc := corsRackBlockRE.FindStringIndex(src); loc != nil {
+		line = lineOf(src, loc[0])
+	}
+	return []types.EntityRecord{makeEntity(filePath,
+		"cors_policy_rack", "SCOPE.Config", "cors_policy", language, line, props)}
 }
 
 func init() {

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -126,33 +126,195 @@ func TestCORSExtractor_AppliesTo(t *testing.T) {
 	}
 }
 
+// corsProps runs the extractor and returns the single cors_policy's properties,
+// failing if the extractor did not produce exactly one policy.
+func corsProps(t *testing.T, lang, file, src string) map[string]string {
+	t.Helper()
+	d := &corsExtractor{}
+	results := d.Detect(file, lang, src)
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 cors_policy, got %d", len(results))
+	}
+	return results[0].Properties
+}
+
 func TestCORSExtractor_Detect_Express(t *testing.T) {
 	d := &corsExtractor{}
 	src := `app.use(cors({origin: "https://example.com", methods: "GET,POST"}))`
 	results := d.Detect("app.js", "javascript", src)
 	if len(results) == 0 {
-		t.Error("expected CORS entity")
+		t.Fatal("expected CORS entity")
 	}
-	if results[0].Properties["origin_pattern"] != "https://example.com" {
-		t.Errorf("expected origin_pattern=https://example.com, got %s", results[0].Properties["origin_pattern"])
+	p := results[0].Properties
+	if p["origin_pattern"] != "https://example.com" {
+		t.Errorf("expected origin_pattern=https://example.com, got %s", p["origin_pattern"])
+	}
+	if p["cors_origins"] != "https://example.com" {
+		t.Errorf("expected cors_origins=https://example.com, got %s", p["cors_origins"])
+	}
+	if p["cors_enabled"] != "true" {
+		t.Errorf("expected cors_enabled=true, got %q", p["cors_enabled"])
+	}
+	if p["cors_wildcard"] != "" {
+		t.Errorf("expected no cors_wildcard for explicit origin, got %q", p["cors_wildcard"])
+	}
+}
+
+// The dangerous combination: wildcard origin + credentials on a global Express
+// CORS middleware. Both flags must be stamped.
+func TestCORSExtractor_Express_WildcardCredentials(t *testing.T) {
+	p := corsProps(t, "javascript", "app.js",
+		`app.use(cors({origin: "*", credentials: true}))`)
+	if p["cors_enabled"] != "true" {
+		t.Errorf("cors_enabled: want true, got %q", p["cors_enabled"])
+	}
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("cors_wildcard: want true, got %q", p["cors_wildcard"])
+	}
+	if p["cors_credentials"] != "true" {
+		t.Errorf("cors_credentials: want true, got %q", p["cors_credentials"])
+	}
+	if p["origin_pattern"] != "*" {
+		t.Errorf("origin_pattern: want *, got %q", p["origin_pattern"])
+	}
+}
+
+// Express default cors() with no options reflects any origin → wildcard.
+func TestCORSExtractor_Express_DefaultWildcard(t *testing.T) {
+	p := corsProps(t, "javascript", "app.js", `app.use(cors())`)
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("default cors() should be wildcard, got %q", p["cors_wildcard"])
 	}
 }
 
 func TestCORSExtractor_Detect_Spring(t *testing.T) {
-	d := &corsExtractor{}
-	src := `@CrossOrigin(origins = "https://frontend.com")`
-	results := d.Detect("Controller.java", "java", src)
-	if len(results) == 0 {
-		t.Error("expected Spring CORS entity")
+	p := corsProps(t, "java", "Controller.java",
+		`@CrossOrigin(origins = "https://x")`)
+	if p["cors_origins"] != "https://x" {
+		t.Errorf("cors_origins: want https://x, got %q", p["cors_origins"])
+	}
+	if p["cors_wildcard"] != "" {
+		t.Errorf("expected no wildcard for explicit Spring origin, got %q", p["cors_wildcard"])
+	}
+}
+
+// Spring @CrossOrigin with allowCredentials=true and a wildcard origin pattern.
+func TestCORSExtractor_Spring_WildcardCredentials(t *testing.T) {
+	p := corsProps(t, "java", "Controller.java",
+		`@CrossOrigin(origins = "*", allowCredentials = "true")`)
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("cors_wildcard: want true, got %q", p["cors_wildcard"])
+	}
+	if p["cors_credentials"] != "true" {
+		t.Errorf("cors_credentials: want true, got %q", p["cors_credentials"])
 	}
 }
 
 func TestCORSExtractor_Detect_FastAPI(t *testing.T) {
+	p := corsProps(t, "python", "main.py",
+		`app.add_middleware(CORSMiddleware, allow_origins=["https://app.com"], allow_methods=["GET", "POST"])`)
+	if p["cors_origins"] != "https://app.com" {
+		t.Errorf("cors_origins: want https://app.com, got %q", p["cors_origins"])
+	}
+	if p["methods"] != "GET,POST" {
+		t.Errorf("methods: want GET,POST, got %q", p["methods"])
+	}
+	if p["cors_wildcard"] != "" {
+		t.Errorf("expected no wildcard, got %q", p["cors_wildcard"])
+	}
+}
+
+// FastAPI wildcard + credentials.
+func TestCORSExtractor_FastAPI_WildcardCredentials(t *testing.T) {
+	p := corsProps(t, "python", "main.py",
+		`app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True)`)
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("cors_wildcard: want true, got %q", p["cors_wildcard"])
+	}
+	if p["cors_credentials"] != "true" {
+		t.Errorf("cors_credentials: want true, got %q", p["cors_credentials"])
+	}
+}
+
+// django-cors-headers: CORS_ALLOW_ALL_ORIGINS=True → wildcard.
+func TestCORSExtractor_Django_AllowAll(t *testing.T) {
+	src := "CORS_ALLOW_ALL_ORIGINS = True\nCORS_ALLOW_CREDENTIALS = True\n"
+	p := corsProps(t, "python", "settings.py", src)
+	if p["framework"] != "django-cors-headers" {
+		t.Errorf("framework: want django-cors-headers, got %q", p["framework"])
+	}
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("cors_wildcard: want true, got %q", p["cors_wildcard"])
+	}
+	if p["cors_credentials"] != "true" {
+		t.Errorf("cors_credentials: want true, got %q", p["cors_credentials"])
+	}
+}
+
+// django-cors-headers explicit allowlist.
+func TestCORSExtractor_Django_Allowlist(t *testing.T) {
+	src := "CORS_ALLOWED_ORIGINS = [\n    'https://app.example.com',\n    'https://admin.example.com',\n]\n"
+	p := corsProps(t, "python", "settings.py", src)
+	if p["cors_origins"] != "https://app.example.com,https://admin.example.com" {
+		t.Errorf("cors_origins: got %q", p["cors_origins"])
+	}
+	if p["cors_wildcard"] != "" {
+		t.Errorf("expected no wildcard for allowlist, got %q", p["cors_wildcard"])
+	}
+}
+
+// Rails rack-cors: origins '*' → wildcard; credentials true.
+func TestCORSExtractor_Rack_Wildcard(t *testing.T) {
+	src := "Rack::Cors.new do\n  allow do\n    origins '*'\n    credentials true\n  end\nend\n"
+	p := corsProps(t, "ruby", "config/initializers/cors.rb", src)
+	if p["framework"] != "rack-cors" {
+		t.Errorf("framework: want rack-cors, got %q", p["framework"])
+	}
+	if p["cors_wildcard"] != "true" {
+		t.Errorf("cors_wildcard: want true, got %q", p["cors_wildcard"])
+	}
+	if p["cors_credentials"] != "true" {
+		t.Errorf("cors_credentials: want true, got %q", p["cors_credentials"])
+	}
+}
+
+// Rails rack-cors explicit origin.
+func TestCORSExtractor_Rack_Explicit(t *testing.T) {
+	src := "Rack::Cors.new do\n  allow do\n    origins 'example.com'\n  end\nend\n"
+	p := corsProps(t, "ruby", "config/initializers/cors.rb", src)
+	if p["cors_origins"] != "example.com" {
+		t.Errorf("cors_origins: want example.com, got %q", p["cors_origins"])
+	}
+	if p["cors_credentials"] != "" {
+		t.Errorf("expected no credentials, got %q", p["cors_credentials"])
+	}
+}
+
+// Negative: no CORS config → cors_enabled absent (no entity).
+func TestCORSExtractor_Negative_NoConfig(t *testing.T) {
 	d := &corsExtractor{}
-	src := `app.add_middleware(CORSMiddleware, allow_origins=["https://api.example.com"], allow_methods=["GET", "POST"])`
-	results := d.Detect("main.py", "python", src)
-	if len(results) == 0 {
-		t.Error("expected FastAPI CORS entity")
+	results := d.Detect("app.js", "javascript", `console.log("no cors here")`)
+	if len(results) != 0 {
+		t.Errorf("expected no cors_policy entities, got %d", len(results))
+	}
+}
+
+// Honest-partial: dynamic origin variable → origins omitted, not fabricated,
+// but cors_enabled still stamped.
+func TestCORSExtractor_DynamicOrigin_Omitted(t *testing.T) {
+	p := corsProps(t, "javascript", "app.js",
+		`app.use(cors({origin: allowedOriginsFn, credentials: true}))`)
+	if p["cors_enabled"] != "true" {
+		t.Errorf("cors_enabled: want true, got %q", p["cors_enabled"])
+	}
+	if p["origin_pattern"] != "dynamic" {
+		t.Errorf("origin_pattern: want dynamic, got %q", p["origin_pattern"])
+	}
+	if _, ok := p["cors_origins"]; ok {
+		t.Errorf("cors_origins must be omitted for dynamic origin, got %q", p["cors_origins"])
+	}
+	if p["cors_wildcard"] != "" {
+		t.Errorf("dynamic origin must not be flagged wildcard, got %q", p["cors_wildcard"])
 	}
 }
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -67,7 +67,7 @@ categories:
   platform:
     capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency]
   security:
-    capabilities: [auth_policy, secret_detection, sql_injection]
+    capabilities: [auth_policy, secret_detection, sql_injection, cors_policy]
   protocol:
     capabilities: [service_extraction, method_attribution, cross_repo_linkage, schema_extraction, field_extraction]
   ci_cd:


### PR DESCRIPTION
Closes #3822 (parent epic #3628).

## What
Enrich the `cors_policy` extractor so the graph answers **"what origins can call this API?"** and flags the dangerous permissive `*` + credentials combination — a security-relevant posture dimension alongside `auth_policy` / `csrf` / `secret_detection`.

## Signals (on SCOPE.Config / cors_policy nodes)
| prop | meaning |
|---|---|
| `cors_enabled` | policy site detected |
| `cors_origins` | resolved allowlist (**omitted, not fabricated**, when dynamic) |
| `cors_wildcard` | origin is `*` / reflects any origin |
| `cors_credentials` | credentials explicitly enabled |
| `methods`, `allowed_headers` | where statically resolvable |

## Global-vs-per-route model
Most CORS config is **global** (app/middleware level) and applies to every endpoint in that app; **per-route** config (Spring `@CrossOrigin`, ASP.NET `[EnableCors]`) is stamped on that route's scope. One `cors_policy` node per configuration site, matching the existing `auth_policy` posture model (no mutation of every endpoint op).

## Frameworks
- **Express** `app.use(cors(...))` — default `cors()` / `origin:true` resolve to wildcard
- **FastAPI/Starlette** `CORSMiddleware(allow_origins/allow_credentials/allow_methods)`
- **django-cors-headers** `CORS_ALLOW_ALL_ORIGINS` / `CORS_ALLOWED_ORIGINS` / `CORS_ALLOW_CREDENTIALS` *(new lane)*
- **Spring** `@CrossOrigin` + `CorsRegistry.addMapping().allowedOrigins()` (+ `allowCredentials`)
- **ASP.NET** `AddCors` / `[EnableCors]` (+ `AllowAnyOrigin` / `AllowCredentials`)
- **Rails rack-cors** `Rack::Cors` `origins '*'` / `credentials true` *(new lane)*

## Tests (value-asserting, not len>0)
- Express `cors({origin:'*', credentials:true})` → `cors_enabled=true cors_wildcard=true cors_credentials=true`
- FastAPI `CORSMiddleware(allow_origins=['https://app.com'])` → `cors_origins=https://app.com`, no wildcard
- django `CORS_ALLOW_ALL_ORIGINS=True` → `cors_wildcard=true`; allowlist → exact `cors_origins`, no wildcard
- Spring `@CrossOrigin(origins='*', allowCredentials='true')` → wildcard + credentials; explicit origin → `cors_origins=https://x`
- Rails rack-cors `origins '*'`+`credentials true` → wildcard + credentials
- **Negative:** no CORS config → no entity; dynamic origin var → `cors_enabled=true` but `cors_origins` omitted and **not** wildcard-flagged

## Coverage
- New `security.cors-policy` record, `cors_policy` lane = `full` citing the extractor
- `cors_policy` capability declared on the `security` taxonomy; docs regenerated (canonical)

## Verification
`go test ./internal/patterns/ ./internal/types/ ./tools/coverage/ ./internal/engine/` green · `go vet` clean · `gofmt -l` empty · `coverage validate` 0 errors · `fmt --check` canonical.

## DEPLOY-DEFERRED
Requires a coordinated live-daemon rebuild + reindex before the new signals appear in the served graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)