### PR TITLE
[sbom] Converged SCOPE.Package node + DEPENDS_ON_PACKAGE edge + Gradle parser

### DIFF
--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | — | 🔴 | ✅ | — | |
 | [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | — | 🔴 | — | |
 | [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | — | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🔴 | — | |
+| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🟢 | — | |
 | [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | — | ✅ | — | |
 | [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | — | ✅ | ✅ | — | |
 | [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | — | ✅ | — | — | — | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -86,7 +86,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Mockito](../detail/test.mockito.md) | 🔴 | — | — | — | 🟢 | |
 | [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | — | 🔴 | |
 | [TestNG](../detail/test.testng.md) | 🔴 | — | — | — | 🟢 | |
-| [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🔴 | — | |
+| [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🟢 | — | |
 | [pom.xml](../detail/pkg.pom.md) | — | — | — | ✅ | — | |
 
 ## ORMs

--- a/docs/coverage/detail/pkg.gradle.md
+++ b/docs/coverage/detail/pkg.gradle.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Lockfile parsing | 🔴 `missing` | — | — | — | — |
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Manifest parsing | 🟢 `partial` | `2026-06-02` | 3628 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/extractor_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.npm.md
+++ b/docs/coverage/detail/pkg.npm.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Lockfile parsing | ✅ `full` | — | 2865 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/extractor_test.go` | — |
-| Manifest parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/cross/manifest/extractor.go` | — |
+| Manifest parsing | ✅ `full` | `2026-06-02` | — | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/extractor_test.go` | Also emits the converged file/repo-agnostic SCOPE.Package SBOM node + DEPENDS_ON_PACKAGE edge via buildEntitiesAndRels (shared across all ecosystems); see internal/types/kinds.go EntityKindPackage / RelationshipKindDependsOnPackage. [sbom #3628] |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -71555,7 +71555,10 @@
           "status": "missing"
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go","internal/extractors/cross/manifest/extractor_test.go"],
+          "issue": "3628",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -71583,8 +71586,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/extractors/cross/manifest/extractor.go","internal/extractors/cross/manifest/extractor_test.go"],
+          "notes": "Also emits the converged file/repo-agnostic SCOPE.Package SBOM node + DEPENDS_ON_PACKAGE edge via buildEntitiesAndRels (shared across all ecosystems); see internal/types/kinds.go EntityKindPackage / RelationshipKindDependsOnPackage. [sbom #3628]",
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -93,6 +93,38 @@ func projectRef(filePath string) string {
 }
 
 // ---------------------------------------------------------------------------
+// [sbom] Converged package node (SCOPE.Package) — file/repo-agnostic
+// ---------------------------------------------------------------------------
+//
+// Distinct from the per-manifest SCOPE.Component(external_dependency) record:
+// the SCOPE.Package node is the SBOM convergence point. Its identity is
+// (ecosystem, name) ONLY — version is intentionally excluded so the same
+// package declared across many manifests/repos collapses to one node (the
+// per-edge DEPENDS_ON_PACKAGE carries version + dev scope). This mirrors the
+// SCOPE.ExternalService synthetic-SourceFile model.
+
+// PackageSourceFile is the synthetic, constant SourceFile assigned to every
+// SCOPE.Package entity so identical ecosystem:name pairs converge to a single
+// graph node under EntityRecord.ComputeID (SourceFile+Kind+Name).
+const PackageSourceFile = "<package>"
+
+// packageName returns the canonical entity Name for a converged package node,
+// namespaced so it never collides with a same-named code symbol, e.g.
+// "package:npm:react", "package:maven:org.springframework:spring-core".
+func packageName(packageManager, name string) string {
+	return "package:" + packageManager + ":" + name
+}
+
+// packageTargetID returns the structural-ref ToID for a DEPENDS_ON_PACKAGE edge
+// pointing at a package node. This value is ALSO the package entity's
+// QualifiedName, so the resolver's byQualifiedName exact-match tier binds the
+// edge without any new linker code. Constant across files and repos so the same
+// dependency converges everywhere.
+func packageTargetID(packageManager, name string) string {
+	return "scope:package:" + packageManager + ":" + name
+}
+
+// ---------------------------------------------------------------------------
 // Manifest detection
 // ---------------------------------------------------------------------------
 
@@ -131,6 +163,9 @@ var exactManifestNames = map[string]bool{
 	// PHP / Composer
 	"composer.json": true,
 	"composer.lock": true,
+	// Java / Kotlin — Gradle build scripts (Groovy DSL + Kotlin DSL)
+	"build.gradle":     true,
+	"build.gradle.kts": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -177,6 +212,9 @@ func detectPackageManager(filePath string) string {
 		// PHP / Composer
 		"composer.json": "composer",
 		"composer.lock": "composer",
+		// Java / Kotlin — Gradle
+		"build.gradle":     "gradle",
+		"build.gradle.kts": "gradle",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -1410,6 +1448,87 @@ func parseComposerLock(source string) []dep {
 }
 
 // ---------------------------------------------------------------------------
+// Parser: build.gradle / build.gradle.kts (Gradle, Groovy + Kotlin DSL)
+// ---------------------------------------------------------------------------
+//
+// Parses dependency declarations inside the `dependencies { ... }` block.
+// Both the short "group:artifact:version" string notation and the Kotlin-DSL
+// quote style are handled:
+//
+//	implementation 'org.springframework:spring-core:5.3.0'
+//	implementation("com.google.guava:guava:31.0-jre")
+//	testImplementation 'junit:junit:4.13.2'
+//	api "io.reactivex:rxjava:2.2.21"
+//	compileOnly 'org.projectlombok:lombok:1.18.24'
+//
+// The configuration keyword (implementation/api/runtimeOnly/... vs
+// testImplementation/testRuntimeOnly/...) determines runtime-vs-dev scope.
+// Map-style notation (group: '...', name: '...', version: '...') and dependency
+// constraints are out of scope — honest-partial: those lines are skipped rather
+// than emitting a malformed package.
+var gradleDepLineRE = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z][A-Za-z0-9]*)\s*[ (]\s*['"]([^'"\s]+:[^'"\s]+)['"]`,
+)
+
+// gradleConfigs is the set of recognised Gradle dependency configurations.
+// Anything outside this set (e.g. a custom function call that happens to take a
+// quoted "a:b:c" string) is ignored — precision over recall.
+var gradleConfigs = map[string]bool{
+	"implementation":            true,
+	"api":                       true,
+	"compileOnly":               true,
+	"runtimeOnly":               true,
+	"compile":                   true, // legacy
+	"runtime":                   true, // legacy
+	"annotationProcessor":       true,
+	"kapt":                      true,
+	"testImplementation":        true,
+	"testCompileOnly":           true,
+	"testRuntimeOnly":           true,
+	"testCompile":               true, // legacy
+	"androidTestImplementation": true,
+	"developmentOnly":           true,
+}
+
+// gradleConfigIsDev reports whether a configuration keyword denotes a
+// test/dev-only dependency.
+func gradleConfigIsDev(cfg string) bool {
+	return strings.HasPrefix(cfg, "test") || strings.HasPrefix(cfg, "androidTest")
+}
+
+func parseBuildGradle(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+	for _, m := range gradleDepLineRE.FindAllStringSubmatch(source, -1) {
+		cfg := m[1]
+		if !gradleConfigs[cfg] {
+			continue
+		}
+		coord := m[2] // group:artifact[:version]
+		parts := strings.Split(coord, ":")
+		if len(parts) < 2 {
+			continue
+		}
+		name := parts[0] + ":" + parts[1]
+		version := ""
+		if len(parts) >= 3 {
+			version = parts[2]
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		isDev := gradleConfigIsDev(cfg)
+		kind := "runtime"
+		if isDev {
+			kind = "dev"
+		}
+		out = append(out, dep{name: name, version: version, isDev: isDev, kind: kind})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
 
 type parserFn func(source string) []dep
 
@@ -1440,6 +1559,9 @@ var parsers = map[string]parserFn{
 	// PHP / Composer
 	"composer.json": parseComposerJSON,
 	"composer.lock": parseComposerLock,
+	// Java / Kotlin — Gradle
+	"build.gradle":     parseBuildGradle,
+	"build.gradle.kts": parseBuildGradle,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {
@@ -1553,6 +1675,47 @@ func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.E
 			},
 			QualityScore: 0.8,
 		})
+
+		// [sbom] Converged package node + DEPENDS_ON_PACKAGE edge. The node is
+		// file/repo-agnostic (synthetic SourceFile) so the SAME ecosystem:name
+		// across every manifest in the group collapses to ONE node — the
+		// software-bill-of-materials convergence point. The DEPENDS_ON_PACKAGE
+		// edge from the project anchor carries the per-declaration version +
+		// dev scope (which are NOT part of the node identity). Mirrors the
+		// SCOPE.ExternalService synthetic-node model.
+		pkgID := packageTargetID(packageManager, d.name)
+		pkgEnt := types.EntityRecord{
+			Name:          packageName(packageManager, d.name),
+			QualifiedName: pkgID,
+			Kind:          string(types.EntityKindPackage),
+			Subtype:       "package",
+			SourceFile:    PackageSourceFile,
+			Language:      "",
+			StartLine:     1,
+			EndLine:       1,
+			Properties: map[string]string{
+				"package":         d.name,
+				"package_manager": packageManager,
+				"ref":             pkgID,
+			},
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: projRef,
+					ToID:   pkgID,
+					Kind:   string(types.RelationshipKindDependsOnPackage),
+					Properties: map[string]string{
+						"package_manager": packageManager,
+						"version":         d.version,
+						"dev":             isDev,
+						"dependency_kind": depKind,
+						"indirect":        indirect,
+					},
+				},
+			},
+			QualityScore: 0.8,
+		}
+		pkgEnt.ID = pkgEnt.ComputeID()
+		out = append(out, pkgEnt)
 	}
 	return out
 }

--- a/internal/extractors/cross/manifest/extractor_test.go
+++ b/internal/extractors/cross/manifest/extractor_test.go
@@ -1154,3 +1154,316 @@ func TestComposerJSON_PackageManager(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// build.gradle / build.gradle.kts — Gradle (Java/Kotlin)
+// ---------------------------------------------------------------------------
+
+func TestGradle_GroovyDSL(t *testing.T) {
+	src := `
+dependencies {
+    implementation 'org.springframework:spring-core:5.3.0'
+    api "io.reactivex:rxjava:2.2.21"
+    testImplementation 'junit:junit:4.13.2'
+    compileOnly 'org.projectlombok:lombok:1.18.24'
+}
+`
+	records := runExtract(t, "app/build.gradle", src)
+	deps := depEntities(records)
+	byName := map[string]types.EntityRecord{}
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+	// spring-core: group:artifact name, version, runtime scope, maven-style PM=gradle.
+	spring, ok := byName["org.springframework:spring-core"]
+	if !ok {
+		t.Fatalf("expected org.springframework:spring-core dep, got %v", keysOf(byName))
+	}
+	if spring.Properties["version"] != "5.3.0" {
+		t.Errorf("spring-core version=%q want 5.3.0", spring.Properties["version"])
+	}
+	if spring.Properties["package_manager"] != "gradle" {
+		t.Errorf("spring-core package_manager=%q want gradle", spring.Properties["package_manager"])
+	}
+	if spring.Properties["dependency_kind"] != "runtime" {
+		t.Errorf("spring-core dependency_kind=%q want runtime", spring.Properties["dependency_kind"])
+	}
+	// junit declared via testImplementation -> dev scope.
+	junit, ok := byName["junit:junit"]
+	if !ok {
+		t.Fatalf("expected junit:junit dep")
+	}
+	if junit.Properties["is_dev"] != "true" {
+		t.Errorf("junit is_dev=%q want true (testImplementation)", junit.Properties["is_dev"])
+	}
+	if junit.Properties["version"] != "4.13.2" {
+		t.Errorf("junit version=%q want 4.13.2", junit.Properties["version"])
+	}
+	// rxjava declared with double-quotes + api config -> runtime.
+	if byName["io.reactivex:rxjava"].Properties["version"] != "2.2.21" {
+		t.Errorf("rxjava version=%q want 2.2.21", byName["io.reactivex:rxjava"].Properties["version"])
+	}
+}
+
+func TestGradle_KotlinDSL(t *testing.T) {
+	src := `
+dependencies {
+    implementation("com.google.guava:guava:31.0-jre")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
+}
+`
+	records := runExtract(t, "build.gradle.kts", src)
+	deps := depEntities(records)
+	byName := map[string]types.EntityRecord{}
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+	guava, ok := byName["com.google.guava:guava"]
+	if !ok {
+		t.Fatalf("expected com.google.guava:guava dep, got %v", keysOf(byName))
+	}
+	if guava.Properties["version"] != "31.0-jre" {
+		t.Errorf("guava version=%q want 31.0-jre", guava.Properties["version"])
+	}
+	if guava.Properties["package_manager"] != "gradle" {
+		t.Errorf("guava package_manager=%q want gradle", guava.Properties["package_manager"])
+	}
+	if byName["org.junit.jupiter:junit-jupiter"].Properties["is_dev"] != "true" {
+		t.Errorf("junit-jupiter should be is_dev=true")
+	}
+}
+
+// Negative: a quoted "a:b:c" string outside a recognised dependency
+// configuration (e.g. a plugin id or a custom function) emits no package.
+func TestGradle_IgnoresNonDependencyConfigs(t *testing.T) {
+	src := `
+plugins {
+    id 'java'
+}
+someCustomTask 'org.evil:not-a-dep:1.0.0'
+dependencies {
+    implementation 'org.real:dep:1.0.0'
+}
+`
+	records := runExtract(t, "build.gradle", src)
+	deps := depEntities(records)
+	byName := map[string]types.EntityRecord{}
+	for _, d := range deps {
+		byName[d.Name] = d
+	}
+	if _, ok := byName["org.evil:not-a-dep"]; ok {
+		t.Errorf("custom-task coordinate must NOT be emitted as a dependency")
+	}
+	if _, ok := byName["org.real:dep"]; !ok {
+		t.Errorf("real implementation dep must be emitted")
+	}
+}
+
+func TestGradle_IsManifest(t *testing.T) {
+	for _, p := range []string{"build.gradle", "app/build.gradle.kts"} {
+		if !IsManifest(p) {
+			t.Errorf("IsManifest(%q)=false want true", p)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// [sbom] Converged SCOPE.Package node + DEPENDS_ON_PACKAGE edge
+// ---------------------------------------------------------------------------
+
+// packageEntities returns the converged SCOPE.Package nodes.
+func packageEntities(records []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range records {
+		if r.Kind == "SCOPE.Package" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// dependsOnPackageRels returns every DEPENDS_ON_PACKAGE edge across records.
+func dependsOnPackageRels(records []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range records {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "DEPENDS_ON_PACKAGE" {
+				out = append(out, rel)
+			}
+		}
+	}
+	return out
+}
+
+func keysOf(m map[string]types.EntityRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestSBOM_PackageNode_NPM(t *testing.T) {
+	src := `{
+  "dependencies": {"react": "^18.2.0"},
+  "devDependencies": {"jest": "^29.0.0"}
+}`
+	records := runExtract(t, "frontend/package.json", src)
+	pkgs := packageEntities(records)
+	byName := map[string]types.EntityRecord{}
+	for _, p := range pkgs {
+		byName[p.Name] = p
+	}
+
+	react, ok := byName["package:npm:react"]
+	if !ok {
+		t.Fatalf("expected converged node package:npm:react, got %v", keysOf(byName))
+	}
+	// Node identity: file-agnostic synthetic SourceFile so cross-repo converges.
+	if react.SourceFile != PackageSourceFile {
+		t.Errorf("react SourceFile=%q want %q (synthetic)", react.SourceFile, PackageSourceFile)
+	}
+	if react.QualifiedName != "scope:package:npm:react" {
+		t.Errorf("react QualifiedName=%q want scope:package:npm:react", react.QualifiedName)
+	}
+	if react.Properties["package"] != "react" {
+		t.Errorf("react package prop=%q want react", react.Properties["package"])
+	}
+	// Version is NOT on the node (lives on the edge) — assert it's absent.
+	if _, has := react.Properties["version"]; has {
+		t.Errorf("node must NOT carry version (it is edge-scoped for convergence)")
+	}
+
+	// Edge: DEPENDS_ON_PACKAGE(project -> package:npm:react) version="^18.2.0" dev=false.
+	rels := dependsOnPackageRels(records)
+	byTo := map[string]types.RelationshipRecord{}
+	for _, r := range rels {
+		byTo[r.ToID] = r
+	}
+	rreact, ok := byTo["scope:package:npm:react"]
+	if !ok {
+		t.Fatalf("expected DEPENDS_ON_PACKAGE edge to react")
+	}
+	if rreact.FromID != "scope:component:project:frontend/package.json" {
+		t.Errorf("edge FromID=%q want project anchor ref", rreact.FromID)
+	}
+	if rreact.Properties["version"] != "^18.2.0" {
+		t.Errorf("react edge version=%q want ^18.2.0", rreact.Properties["version"])
+	}
+	if rreact.Properties["dev"] != "false" {
+		t.Errorf("react edge dev=%q want false", rreact.Properties["dev"])
+	}
+	if rreact.Properties["package_manager"] != "npm" {
+		t.Errorf("react edge package_manager=%q want npm", rreact.Properties["package_manager"])
+	}
+	// jest is a devDependency -> dev=true on its edge.
+	jest, ok := byTo["scope:package:npm:jest"]
+	if !ok {
+		t.Fatalf("expected DEPENDS_ON_PACKAGE edge to jest")
+	}
+	if jest.Properties["dev"] != "true" {
+		t.Errorf("jest edge dev=%q want true", jest.Properties["dev"])
+	}
+}
+
+func TestSBOM_PackageNode_GoMod(t *testing.T) {
+	src := `module example.com/app
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.0
+`
+	records := runExtract(t, "go.mod", src)
+	pkgs := packageEntities(records)
+	var gin *types.EntityRecord
+	for i := range pkgs {
+		if pkgs[i].Name == "package:go_modules:github.com/gin-gonic/gin" {
+			gin = &pkgs[i]
+		}
+	}
+	if gin == nil {
+		t.Fatalf("expected converged node for gin")
+	}
+	if gin.QualifiedName != "scope:package:go_modules:github.com/gin-gonic/gin" {
+		t.Errorf("gin QualifiedName=%q", gin.QualifiedName)
+	}
+	rels := dependsOnPackageRels(records)
+	var found bool
+	for _, r := range rels {
+		if r.ToID == "scope:package:go_modules:github.com/gin-gonic/gin" {
+			found = true
+			if r.Properties["version"] != "v1.9.0" {
+				t.Errorf("gin edge version=%q want v1.9.0", r.Properties["version"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected DEPENDS_ON_PACKAGE edge to gin")
+	}
+}
+
+// Convergence: the SAME ecosystem:name declared in two different manifest
+// files produces SCOPE.Package nodes with the IDENTICAL ComputeID — i.e. they
+// collapse to one node when merged into the graph (cross-repo SBOM).
+func TestSBOM_CrossFileConvergence(t *testing.T) {
+	srcA := `{"dependencies": {"lodash": "^4.17.21"}}`
+	srcB := `{"dependencies": {"lodash": "^4.17.0"}}`
+	recA := runExtract(t, "repo-a/package.json", srcA)
+	recB := runExtract(t, "repo-b/package.json", srcB)
+
+	idOf := func(recs []types.EntityRecord) string {
+		for _, r := range recs {
+			if r.Kind == "SCOPE.Package" && r.Name == "package:npm:lodash" {
+				return r.ID
+			}
+		}
+		return ""
+	}
+	idA := idOf(recA)
+	idB := idOf(recB)
+	if idA == "" || idB == "" {
+		t.Fatalf("missing lodash package node: idA=%q idB=%q", idA, idB)
+	}
+	if idA != idB {
+		t.Errorf("convergence broken: idA=%q idB=%q (same ecosystem:name must share ID)", idA, idB)
+	}
+}
+
+func TestSBOM_MavenPackageNode(t *testing.T) {
+	src := `<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.0</version>
+    </dependency>
+  </dependencies>
+</project>`
+	records := runExtract(t, "pom.xml", src)
+	pkgs := packageEntities(records)
+	var found bool
+	for _, p := range pkgs {
+		if p.Name == "package:maven:org.springframework:spring-core" {
+			found = true
+			if p.QualifiedName != "scope:package:maven:org.springframework:spring-core" {
+				t.Errorf("maven QualifiedName=%q", p.QualifiedName)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected converged maven node for spring-core, got %d package nodes", len(pkgs))
+	}
+	rels := dependsOnPackageRels(records)
+	var edgeFound bool
+	for _, r := range rels {
+		if r.ToID == "scope:package:maven:org.springframework:spring-core" {
+			edgeFound = true
+			if r.Properties["version"] != "5.3.0" {
+				t.Errorf("spring-core edge version=%q want 5.3.0", r.Properties["version"])
+			}
+		}
+	}
+	if !edgeFound {
+		t.Fatalf("expected DEPENDS_ON_PACKAGE edge to spring-core")
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -254,6 +254,26 @@ const (
 	//                    "rails_enum", "csharp_enum").
 	// See internal/extractor/enum_valueset.go.
 	EntityKindEnum EntityKind = "SCOPE.Enum"
+	// [sbom] EntityKindPackage is a synthetic, file-agnostic node representing a
+	// single declared EXTERNAL package (dependency) by its ecosystem-qualified
+	// name — e.g. "npm:react", "go_modules:github.com/gin-gonic/gin",
+	// "pip:requests", "maven:org.springframework:spring-core", "cargo:serde".
+	// It is the convergence point for the software-bill-of-materials (SBOM)
+	// capability (child of epic #3628): every manifest that declares the SAME
+	// package — across files, modules, AND repos in a group — resolves to ONE
+	// node, so the graph answers "which repos depend on package X, and at what
+	// versions?" (a package's inbound DEPENDS_ON_PACKAGE edges are its full
+	// usage footprint) and conversely "what is this repo's full dependency
+	// set?". Like SCOPE.ExternalService it carries a constant synthetic
+	// SourceFile (PackageSourceFile) so EntityRecord.ComputeID
+	// (SourceFile+Kind+Name) collapses the same ecosystem:name across every
+	// manifest into a single node — distinct from the per-manifest
+	// SCOPE.Component(subtype=external_dependency) record (which stays
+	// file-scoped for license/version provenance). The version is NOT part of
+	// the identity (two repos pinning different versions of react converge on
+	// one node); per-edge `version` + `dev` scope live on the DEPENDS_ON_PACKAGE
+	// edge. Emitted by internal/extractors/cross/manifest/extractor.go.
+	EntityKindPackage EntityKind = "SCOPE.Package"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -334,6 +354,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindChannel,
 		// #3628 data-model: enum / value-set node.
 		EntityKindEnum,
+		// [sbom] synthetic package convergence node (child of #3628).
+		EntityKindPackage,
 	}
 }
 
@@ -1111,6 +1133,22 @@ const (
 	// this edge; dynamic / computed types do not. See
 	// internal/extractor/enum_valueset.go.
 	RelationshipKindTypedAs RelationshipKind = "TYPED_AS"
+	// [sbom] DEPENDS_ON_PACKAGE points a manifest's project-anchor entity at a
+	// synthetic SCOPE.Package node (Name "package:<ecosystem>:<name>") it
+	// declares as an external dependency. Distinct from the file-scoped
+	// DEPENDS_ON(kind=external_dependency) edge: this edge targets the
+	// CONVERGED, file/repo-agnostic package node so the SAME package declared in
+	// many repos shares one inbound set — the graph's software bill-of-materials
+	// (SBOM). ToID is the package entity's QualifiedName so the resolver binds
+	// it via the byQualifiedName exact-match tier. Edge properties:
+	//   "package_manager" : ecosystem (npm, pip, go_modules, maven, gradle,
+	//                       cargo, bundler, composer, ...).
+	//   "version"         : the declared version range / pin (verbatim; "" when
+	//                       the manifest omits it — honest-partial).
+	//   "dev"             : "true" when the package is a dev/test-only dependency.
+	//   "dependency_kind" : runtime|dev|peer|locked|indirect (from the manifest).
+	// Emitted by internal/extractors/cross/manifest/extractor.go.
+	RelationshipKindDependsOnPackage RelationshipKind = "DEPENDS_ON_PACKAGE"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1254,6 +1292,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindThrows,
 		RelationshipKindCatches,
 		RelationshipKindDependsOnService,
+		// [sbom] manifest project-anchor → synthetic package convergence node.
+		RelationshipKindDependsOnPackage,
 		// [realtime] WS room/channel grouping: JOINS_CHANNEL / BROADCASTS_TO.
 		RelationshipKindJoinsChannel,
 		RelationshipKindBroadcastsTo,

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -15928,6 +15928,27 @@ records:
         issues_implemented: ["3211"]
         verified_at: "2026-05-30"
 
+  pkg.gradle:
+    capabilities:
+      manifest_parsing:
+        # parseBuildGradle parses the `dependencies { ... }` block of
+        # build.gradle (Groovy DSL) and build.gradle.kts (Kotlin DSL),
+        # extracting group:artifact:version coordinates from string-notation
+        # declarations (implementation/api/compileOnly/runtimeOnly/... and the
+        # test* / androidTest* configurations -> dev scope). Honest-partial:
+        # map-style notation and dependency constraints are skipped rather than
+        # emitting malformed packages; only recognised dependency configurations
+        # in gradleConfigs are matched (a quoted "a:b:c" outside a dependency
+        # configuration emits no package).
+        status: partial
+        symbols:
+          - file: internal/extractors/cross/manifest/extractor.go
+            functions: [parseBuildGradle, gradleConfigIsDev, detectPackageManager, IsManifest, dispatchParser]
+        tests:
+          - file: internal/extractors/cross/manifest/extractor_test.go
+        issues_implemented: ["3628"]
+        verified_at: "2026-06-02"
+
   # ---------------------------------------------------------------------------
   # Ruby framework middleware + routing cells (Part of #3282)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3824 (child of #3628).

## What
Models the software bill-of-materials (SBOM) as graph nodes+edges, layered on the existing cross-language manifest extractor (`_cross_manifest`).

### Node model (mirrors `SCOPE.ExternalService` convergence)
- **`SCOPE.Package`** — synthetic, file/repo-agnostic node, Name `package:<ecosystem>:<name>` (e.g. `package:npm:react`, `package:go_modules:github.com/gin-gonic/gin`, `package:maven:org.springframework:spring-core`). A constant synthetic SourceFile (`PackageSourceFile = "<package>"`) makes `EntityRecord.ComputeID` collapse the same `ecosystem:name` across every manifest AND repo into ONE node. Version is deliberately **not** part of identity, so two repos pinning different versions of a package converge — the cross-repo SBOM query surface.
- **`DEPENDS_ON_PACKAGE`** edge (manifest project-anchor → package node) carries the per-declaration `version`, `dev` scope, `dependency_kind` (runtime|dev|peer|locked|indirect), `package_manager`. ToID == the package node's QualifiedName, so it binds via the resolver's `byQualifiedName` exact-match tier — no new linker code.

This is distinct from the pre-existing per-file `SCOPE.Component(subtype=external_dependency)` + `DEPENDS_ON(kind=external_dependency)` records, which stay file-scoped for license/version provenance.

### Ecosystem coverage (reuses existing parsers, no reparse)
npm (package.json), pip/poetry/pipenv (requirements.txt, pyproject.toml, Pipfile), go_modules (go.mod), maven (pom.xml), **gradle (new)**, cargo (Cargo.toml), bundler (Gemfile), composer (composer.json), nuget (*.csproj), pub (pubspec.yaml), conan/vcpkg/cmake — plus npm/yarn/pnpm/poetry/uv/pdm/nuget/composer lockfiles.

### New: Gradle parser
`parseBuildGradle` handles `build.gradle` (Groovy DSL) + `build.gradle.kts` (Kotlin DSL): `group:artifact:version` string notation, runtime vs `test*`/`androidTest*` dev scope. Honest-partial — map-style notation and dependency constraints are skipped, and only coordinates inside a recognised dependency configuration are emitted (a quoted `"a:b:c"` in a custom task / plugin block produces no package). Fills the `pkg.gradle` Java-lane gap (`manifest_parsing` was `missing`).

## Tests (value-asserting)
- `package:npm:react` node id + `scope:package:npm:react` QualifiedName; edge `version="^18.2.0"` `dev=false`; `jest` devDependency → `dev=true`; node carries NO version (edge-scoped).
- go.mod `github.com/gin-gonic/gin v1.9.0` → node + edge `version=v1.9.0`.
- maven `org.springframework:spring-core 5.3.0` → converged node + edge.
- Cross-file convergence: `lodash` declared in two package.json files → identical `ComputeID`.
- Gradle Groovy + Kotlin DSL: version + dev-scope assertions; negative (non-dependency-config coordinate emits no package); IsManifest.

## Quality gates
`go test` (types, manifest, engine, extractors/..., custom/..., coverage) green; coverage `validate` 0 errors; `fmt --check` canonical; gofmt/`go vet` clean. Coverage docs regenerated.

## DEPLOY-DEFERRED
New entity/relationship kinds require a live-daemon rebuild + reindex to populate the graph; not done here (live daemon serves the rewrite agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)