### PR TITLE
[security] webhook-receiver detection + signature-verification posture

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -5,49 +5,49 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Consumer extraction | Producer extraction | Room channel grouping | Topic attribution | Status | Notes |
-|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [C#](../by-language/csharp.md) | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | — | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | ✅ | 🟢 | 🔴 | |
-| [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | 🟢 | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS SNS](../detail/msg.broker.sns.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [AWS SQS](../detail/msg.broker.sqs.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Apache Kafka](../detail/msg.broker.kafka.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Service Bus / Event Hubs](../detail/msg.broker.azure-service-bus.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Debezium (CDC)](../detail/msg.broker.debezium.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | 🔴 | 🔴 | — | — | 🔴 | |
-| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [NATS](../detail/msg.broker.nats.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [SignalR](../detail/msg.signalr.md) | 🔴 | ✅ | — | — | 🔴 | |
-| [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ✅ | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | — | 🟢 | 🟢 | |
-| [python](../by-language/python.md) | [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Django Channels](../detail/msg.django-channels.md) | — | — | ✅ | — | ✅ | |
-| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [ruby](../by-language/ruby.md) | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | — | ✅ | ✅ | |
-| [ruby](../by-language/ruby.md) | [Rails ActionCable](../detail/msg.actioncable.md) | — | — | ✅ | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Resque (Ruby task queue)](../detail/msg.resque.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | 🟢 | — | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | 🟢 | — | — | — | 🟢 | |
-| [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
-| [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
+| Language | Name | Consumer extraction | Producer extraction | Room channel grouping | Signature verification | Topic attribution | Status | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | — | — | — | — | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | ✅ | — | 🟢 | 🔴 | |
+| [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | 🟢 | — | — | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS SNS](../detail/msg.broker.sns.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AWS SQS](../detail/msg.broker.sqs.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Apache Kafka](../detail/msg.broker.kafka.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Service Bus / Event Hubs](../detail/msg.broker.azure-service-bus.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Debezium (CDC)](../detail/msg.broker.debezium.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | 🔴 | 🔴 | — | — | — | 🔴 | |
+| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [NATS](../detail/msg.broker.nats.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [SignalR](../detail/msg.signalr.md) | 🔴 | ✅ | — | — | — | 🔴 | |
+| [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ✅ | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | — | ✅ | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | 🟢 | — | — | — | — | 🟢 | |
+| [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Django Channels](../detail/msg.django-channels.md) | — | — | ✅ | — | — | ✅ | |
+| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | — | — | ✅ | |
+| [python](../by-language/python.md) | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [Rails ActionCable](../detail/msg.actioncable.md) | — | — | ✅ | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Resque (Ruby task queue)](../detail/msg.resque.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | — | — | 🟢 | |
+| [ruby](../by-language/ruby.md) | [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | 🟢 | — | — | — | — | 🟢 | |
+| [ruby](../by-language/ruby.md) | [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | 🟢 | — | — | — | — | 🟢 | |
+| [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+| [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |

--- a/docs/coverage/detail/msg.webhook.md
+++ b/docs/coverage/detail/msg.webhook.md
@@ -5,7 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -13,6 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Consumer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/webhooks_edges.go` | — |
 | Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/webhooks_edges.go` | — |
+| Signature verification | ✅ `full` | — | 3628 | `internal/engine/webhooks_edges.go`<br>`internal/engine/webhooks_edges_test.go` | [security] webhook-receiver signature-verification posture (#3628 child): every detected webhook endpoint carries webhook=true + webhook_provider + webhook_signature_verified=true|false so the graph answers 'which endpoints are webhook receivers, and do they verify signatures?'. webhookSignatureVerified asserts true ONLY on a concrete signal — a provider-SDK verify call (Stripe construct_event/constructEvent/ConstructEvent/Event.constructFrom, Twilio RequestValidator/validateRequest, Slack SignatureVerifier/verifyRequestSignature, GitHub github.ValidatePayload, Svix wh.verify) OR a *-Signature/*-Hmac request-header read paired with a generic HMAC compute/compare (hmac.new/compare_digest, crypto.createHmac+timingSafeEqual, Mac.getInstance/HmacUtils, hmac.New/hmac.Equal, OpenSSL::HMAC/secure_compare, verify_signature(...)). Providers: stripe/github/twilio/slack/shopify(new: X-Shopify-Hmac-Sha256)/mailgun/svix/generic. Honest-partial: an unverified-but-webhook route (path contains /webhook, no verification observed) is stamped webhook_signature_verified=false — the security-relevant finding (forgeable receiver). Value-asserting tests pin verified=true for Stripe/GitHub/Shopify/Twilio and verified=false for a bare /webhook body-parse handler; negatives: /users and an unrelated 'signature' mention emit no webhook. Langs: python/jsts/java+kotlin/go/ruby. DEPLOY-DEFERRED. |
 | Topic attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/webhooks_edges.go` | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -71402,6 +71402,12 @@
           "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
+        "signature_verification": {
+          "status": "full",
+          "cites": ["internal/engine/webhooks_edges.go","internal/engine/webhooks_edges_test.go"],
+          "issue": "3628",
+          "notes": "[security] webhook-receiver signature-verification posture (#3628 child): every detected webhook endpoint carries webhook=true + webhook_provider + webhook_signature_verified=true|false so the graph answers 'which endpoints are webhook receivers, and do they verify signatures?'. webhookSignatureVerified asserts true ONLY on a concrete signal — a provider-SDK verify call (Stripe construct_event/constructEvent/ConstructEvent/Event.constructFrom, Twilio RequestValidator/validateRequest, Slack SignatureVerifier/verifyRequestSignature, GitHub github.ValidatePayload, Svix wh.verify) OR a *-Signature/*-Hmac request-header read paired with a generic HMAC compute/compare (hmac.new/compare_digest, crypto.createHmac+timingSafeEqual, Mac.getInstance/HmacUtils, hmac.New/hmac.Equal, OpenSSL::HMAC/secure_compare, verify_signature(...)). Providers: stripe/github/twilio/slack/shopify(new: X-Shopify-Hmac-Sha256)/mailgun/svix/generic. Honest-partial: an unverified-but-webhook route (path contains /webhook, no verification observed) is stamped webhook_signature_verified=false — the security-relevant finding (forgeable receiver). Value-asserting tests pin verified=true for Stripe/GitHub/Shopify/Twilio and verified=false for a bare /webhook body-parse handler; negatives: /users and an unrelated 'signature' mention emit no webhook. Langs: python/jsts/java+kotlin/go/ruby. DEPLOY-DEFERRED."
+        },
         "topic_attribution": {
           "status": "partial",
           "cites": ["internal/engine/webhooks_edges.go"],

--- a/internal/engine/webhooks_edges.go
+++ b/internal/engine/webhooks_edges.go
@@ -2,9 +2,23 @@
 //
 // This pass identifies HTTP endpoints that are registered with an external
 // service to receive event callbacks ("inbound webhooks"). It tags matching
-// http_endpoint entities with `is_webhook=true` and `webhook_provider=<vendor>`.
-// It also emits a SUBSCRIBES_TO edge from the endpoint entity to a synthetic
-// SCOPE.External entity representing the external service.
+// http_endpoint entities with `is_webhook=true` / `webhook=true` and
+// `webhook_provider=<vendor>`. It also emits a SUBSCRIBES_TO edge from the
+// endpoint entity to a synthetic SCOPE.External entity representing the
+// external service.
+//
+// SECURITY POSTURE (#3628 child — webhook-receiver detection):
+// every webhook endpoint also carries `webhook_signature_verified=true|false`.
+// A receiver that does NOT verify the provider signature (e.g. a `/webhook`
+// route that just parses the body) is a security finding — an attacker can
+// forge events. The graph can therefore answer "which endpoints are webhook
+// receivers, and do they verify signatures?" and flag the unverified ones.
+// Verification is asserted ONLY when a concrete signal is present: a provider
+// SDK verify call (Stripe constructEvent, Twilio RequestValidator, Slack /
+// Shopify / GitHub HMAC over a `*-Signature`/`*-Hmac` header, Svix verify), or
+// a generic hmac compare over a signature header. Absent any such signal the
+// endpoint is stamped `webhook_signature_verified=false` (honest: no
+// verification was observed in the handler — the security-relevant case).
 //
 // A CONFIDENCE property is attached to every webhook entity based on how many
 // independent heuristics matched. High confidence (≥3): decorator name contains
@@ -16,6 +30,7 @@
 //   - GitHub       — X-Hub-Signature-256 + HMAC verification
 //   - Twilio       — twilio.request_validator / X-Twilio-Signature
 //   - Slack        — slack_sdk.signature / X-Slack-Signature
+//   - Shopify      — X-Shopify-Hmac-Sha256 + HMAC verification
 //   - SendGrid     — sendgrid + X-Twilio-Email-Event-Webhook-Signature
 //   - Mailgun      — mailgun + webhook + X-Mailgun-Signature
 //   - Svix (generic) — svix.Webhook / webhook.verify
@@ -58,6 +73,12 @@ func applyWebhookEdges(args DetectorPassArgs) DetectorPassResult {
 	}
 	src := string(content)
 
+	// Signature-verification posture is a per-file determination: did the
+	// handler verify the inbound webhook signature at all? An unverified
+	// receiver is the security-relevant finding.
+	verified := webhookSignatureVerified(src)
+	verifiedLabel := boolLabel(verified)
+
 	seenExternal := map[string]bool{}
 
 	emitWebhook := func(endpointID, provider, route string, confidence int) {
@@ -91,11 +112,13 @@ func applyWebhookEdges(args DetectorPassArgs) DetectorPassResult {
 			SourceFile: path,
 			Language:   lang,
 			Properties: map[string]string{
-				"is_webhook":       "true",
-				"webhook_provider": provider,
-				"route":            route,
-				"confidence":       confLabel,
-				"pattern_type":     "webhook_synthesis",
+				"is_webhook":                 "true",
+				"webhook":                    "true",
+				"webhook_provider":           provider,
+				"webhook_signature_verified": verifiedLabel,
+				"route":                      route,
+				"confidence":                 confLabel,
+				"pattern_type":               "webhook_synthesis",
 			},
 			EnrichmentRequired: false,
 			EnrichmentStatus:   types.StatusPending,
@@ -108,9 +131,10 @@ func applyWebhookEdges(args DetectorPassArgs) DetectorPassResult {
 			ToID:   fmt.Sprintf("%s:%s", webhookExternalKind, extID),
 			Kind:   subscribesToEdgeKind, // "SUBSCRIBES_TO" from kafka_edges.go
 			Properties: map[string]string{
-				"webhook_provider": provider,
-				"confidence":       confLabel,
-				"pattern_type":     "webhook_synthesis",
+				"webhook_provider":           provider,
+				"webhook_signature_verified": verifiedLabel,
+				"confidence":                 confLabel,
+				"pattern_type":               "webhook_synthesis",
 			},
 		})
 	}
@@ -359,6 +383,9 @@ func detectWebhookProvider(src, langHint string) (provider string, confidence in
 	case pySlackVerifierRe.MatchString(src) || nodeSlackVerifyRe.MatchString(src):
 		provider = "slack"
 		confidence += 2
+	case shopifyHmacHeaderRe.MatchString(src):
+		provider = "shopify"
+		confidence += 2
 	case pyMailgunSignatureRe.MatchString(src):
 		provider = "mailgun"
 		confidence += 2
@@ -406,8 +433,73 @@ func importConfirmation(src, provider, langHint string) bool {
 		return strings.Contains(src, "mailgun") || strings.Contains(src, "Mailgun")
 	case "svix":
 		return strings.Contains(src, "svix")
+	case "shopify":
+		return strings.Contains(src, "shopify") || strings.Contains(src, "Shopify") ||
+			strings.Contains(src, "@shopify/")
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// Signature-verification posture (security finding when absent)
+// ---------------------------------------------------------------------------
+
+// shopifyHmacHeaderRe detects the Shopify webhook HMAC header (case-insensitive
+// because frameworks normalise header casing differently).
+var shopifyHmacHeaderRe = regexp.MustCompile(`(?i)X-Shopify-Hmac-Sha256`)
+
+// sigVerifyProviderSDKRe matches a concrete provider-SDK verification call that
+// performs signature validation as a side effect. Presence ⇒ the receiver
+// verifies the signature.
+var sigVerifyProviderSDKRe = regexp.MustCompile(
+	`stripe\.Webhook\.construct_event\s*\(` + // Stripe (python/ruby snake)
+		`|stripe\.webhooks\.constructEvent\s*\(` + // Stripe (node)
+		`|Stripe::Webhook\.construct_event` + // Stripe (ruby)
+		`|stripe\.ConstructEvent\s*\(` + // Stripe (go)
+		`|Event\.constructFrom\b|com\.stripe\.net\.Webhook` + // Stripe (java)
+		`|RequestValidator\b|twilio\.request_validator|validateRequest\s*\(|validateExpressRequest` + // Twilio
+		`|SignatureVerifier\b|verifyRequestSignature\s*\(` + // Slack
+		`|github\.ValidatePayload\s*\(` + // GitHub (go-github)
+		`|wh\.verify\s*\(|svix\.Webhook`, // Svix
+)
+
+// sigHeaderRe matches a read of a `*-Signature` or `*-Hmac*` request header —
+// the canonical inbound-webhook signature header for Stripe/GitHub/Slack/
+// Shopify/Twilio and generic HMAC schemes.
+var sigHeaderRe = regexp.MustCompile(`(?i)\b[\w-]*(?:-Signature(?:-256)?|-Hmac(?:-Sha256)?)\b`)
+
+// hmacComputeRe matches a generic HMAC computation/compare that, paired with a
+// signature header read, constitutes an in-handler signature verification.
+var hmacComputeRe = regexp.MustCompile(
+	`hmac\.(?:new|compare_digest|HMAC)` + // python
+		`|crypto\.createHmac\s*\(|timingSafeEqual\s*\(` + // node
+		`|Mac\.getInstance\s*\(|HmacUtils\b|MessageDigest\.isEqual\s*\(` + // java
+		`|hmac\.New\s*\(|hmac\.Equal\s*\(` + // go
+		`|OpenSSL::HMAC|ActiveSupport::SecurityUtils\.secure_compare` + // ruby
+		`|verify_signature\s*\(|verifySignature\s*\(`, // generic verify helper
+)
+
+// webhookSignatureVerified reports whether the file's webhook handler verifies
+// the inbound signature. True when EITHER a provider-SDK verify call is present,
+// OR a signature/HMAC header is read AND a generic HMAC compute/compare runs in
+// the same file. Honest: a `/webhook` route that merely parses the body matches
+// neither branch ⇒ false (the unverified-receiver security finding).
+func webhookSignatureVerified(src string) bool {
+	if sigVerifyProviderSDKRe.MatchString(src) {
+		return true
+	}
+	if sigHeaderRe.MatchString(src) && hmacComputeRe.MatchString(src) {
+		return true
+	}
+	return false
+}
+
+// boolLabel renders a Go bool as the canonical lowercase string property value.
+func boolLabel(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // inferProviderFromPath attempts to derive the provider from path tokens like
@@ -427,6 +519,8 @@ func inferProviderFromPath(path string) string {
 		return "mailgun"
 	case strings.Contains(lower, "sendgrid"):
 		return "sendgrid"
+	case strings.Contains(lower, "shopify"):
+		return "shopify"
 	}
 	return "generic"
 }

--- a/internal/engine/webhooks_edges_test.go
+++ b/internal/engine/webhooks_edges_test.go
@@ -287,6 +287,173 @@ def stripe_wh2():
 }
 
 // ---------------------------------------------------------------------------
+// Signature-verification posture (#3628 child — security finding when absent)
+// ---------------------------------------------------------------------------
+
+// firstWebhook returns the first is_webhook entity, failing if none.
+func firstWebhook(t *testing.T, ents []types.EntityRecord) types.EntityRecord {
+	t.Helper()
+	hooks := webhookEntities(ents)
+	if len(hooks) == 0 {
+		t.Fatalf("expected at least 1 webhook entity, got 0 (entities=%v)", ents)
+	}
+	return hooks[0]
+}
+
+// Stripe constructEvent ⇒ webhook=true provider=stripe signature_verified=true.
+func TestWebhook_SigVerified_StripeConstructEvent(t *testing.T) {
+	src := `import stripe
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.post('/stripe/webhook')
+def stripe_webhook():
+    payload = request.data
+    sig_header = request.headers.get('Stripe-Signature')
+    event = stripe.Webhook.construct_event(payload, sig_header, 'whsec_xxx')
+    return '', 200
+`
+	ents, _ := runWebhookDetect(t, "python", "stripe_wh.py", src)
+	e := firstWebhook(t, ents)
+	if e.Properties["webhook"] != "true" {
+		t.Errorf("webhook = %q, want true", e.Properties["webhook"])
+	}
+	if e.Properties["webhook_provider"] != "stripe" {
+		t.Errorf("webhook_provider = %q, want stripe", e.Properties["webhook_provider"])
+	}
+	if e.Properties["webhook_signature_verified"] != "true" {
+		t.Errorf("webhook_signature_verified = %q, want true (constructEvent verifies)", e.Properties["webhook_signature_verified"])
+	}
+}
+
+// GitHub HMAC over X-Hub-Signature-256 ⇒ provider=github verified=true.
+func TestWebhook_SigVerified_GitHubHMAC(t *testing.T) {
+	src := `import hmac, hashlib
+from flask import request, abort
+
+@app.post('/webhooks/github')
+def github_webhook():
+    sig = request.headers.get('X-Hub-Signature-256')
+    if not verify_signature(request.data, sig):
+        abort(403)
+    return 'ok'
+`
+	ents, _ := runWebhookDetect(t, "python", "github_hook.py", src)
+	e := firstWebhook(t, ents)
+	if e.Properties["webhook_provider"] != "github" {
+		t.Errorf("webhook_provider = %q, want github", e.Properties["webhook_provider"])
+	}
+	if e.Properties["webhook_signature_verified"] != "true" {
+		t.Errorf("webhook_signature_verified = %q, want true (HMAC verify on X-Hub-Signature-256)", e.Properties["webhook_signature_verified"])
+	}
+}
+
+// Shopify HMAC over X-Shopify-Hmac-Sha256 ⇒ provider=shopify verified=true.
+func TestWebhook_SigVerified_ShopifyHMAC(t *testing.T) {
+	src := `const crypto = require('crypto');
+app.post('/webhooks/shopify', (req, res) => {
+  const hmacHeader = req.get('X-Shopify-Hmac-Sha256');
+  const digest = crypto.createHmac('sha256', SECRET).update(req.rawBody).digest('base64');
+  if (!crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(hmacHeader))) {
+    return res.status(401).send();
+  }
+  res.send('ok');
+});
+`
+	ents, _ := runWebhookDetect(t, "javascript", "shopify_hook.js", src)
+	e := firstWebhook(t, ents)
+	if e.Properties["webhook_provider"] != "shopify" {
+		t.Errorf("webhook_provider = %q, want shopify", e.Properties["webhook_provider"])
+	}
+	if e.Properties["webhook_signature_verified"] != "true" {
+		t.Errorf("webhook_signature_verified = %q, want true (Shopify HMAC compare)", e.Properties["webhook_signature_verified"])
+	}
+}
+
+// Twilio RequestValidator ⇒ verified=true.
+func TestWebhook_SigVerified_TwilioValidator(t *testing.T) {
+	src := `from twilio.request_validator import RequestValidator
+from flask import request
+
+@app.post('/twilio/webhook')
+def twilio_hook():
+    validator = RequestValidator('token')
+    if not validator.validate(request.url, request.form, request.headers.get('X-Twilio-Signature')):
+        return '', 403
+    return '', 200
+`
+	ents, _ := runWebhookDetect(t, "python", "twilio_hook.py", src)
+	e := firstWebhook(t, ents)
+	if e.Properties["webhook_provider"] != "twilio" {
+		t.Errorf("webhook_provider = %q, want twilio", e.Properties["webhook_provider"])
+	}
+	if e.Properties["webhook_signature_verified"] != "true" {
+		t.Errorf("webhook_signature_verified = %q, want true (RequestValidator)", e.Properties["webhook_signature_verified"])
+	}
+}
+
+// THE SECURITY FINDING: a /webhook route that just parses the body and does NO
+// signature verification ⇒ webhook=true signature_verified=false (flag it).
+func TestWebhook_SigUnverified_NoVerification_SecurityFlag(t *testing.T) {
+	src := `from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.post('/webhook')
+def generic_webhook():
+    data = request.json
+    process(data)
+    return 'ok'
+`
+	ents, _ := runWebhookDetect(t, "python", "handler.py", src)
+	e := firstWebhook(t, ents)
+	if e.Properties["webhook"] != "true" {
+		t.Errorf("webhook = %q, want true", e.Properties["webhook"])
+	}
+	if e.Properties["webhook_signature_verified"] != "false" {
+		t.Errorf("webhook_signature_verified = %q, want false (unverified receiver = security finding)", e.Properties["webhook_signature_verified"])
+	}
+}
+
+// Negative: a normal /users endpoint with no webhook signal emits no webhook.
+func TestWebhook_Negative_NormalEndpoint(t *testing.T) {
+	src := `from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.get('/users')
+def list_users():
+    return {'users': []}
+`
+	ents, rels := runWebhookDetect(t, "python", "users.py", src)
+	if len(webhookEntities(ents)) != 0 {
+		t.Errorf("expected no webhook entities for /users, got %d", len(webhookEntities(ents)))
+	}
+	if len(rels) != 0 {
+		t.Errorf("expected no edges for /users, got %d", len(rels))
+	}
+}
+
+// Negative: a handler that merely mentions "signature" unrelated to a webhook
+// (no webhook route, no provider SDK) is not a webhook.
+func TestWebhook_Negative_UnrelatedSignatureMention(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.post('/documents/sign')
+def sign_document():
+    # apply the author's signature to the PDF
+    return apply_signature(doc)
+`
+	ents, _ := runWebhookDetect(t, "python", "sign.py", src)
+	if len(webhookEntities(ents)) != 0 {
+		t.Errorf("expected no webhook entities for unrelated signature mention, got %d", len(webhookEntities(ents)))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Non-match: file with no webhook content emits nothing
 // ---------------------------------------------------------------------------
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -55,7 +55,7 @@ categories:
     capabilities: [model_extraction, query_attribution, migration_parsing, migration_schema_ops]
     subcategory_order: [orm_mapper]
   message_broker:
-    capabilities: [producer_extraction, consumer_extraction, topic_attribution, room_channel_grouping]
+    capabilities: [producer_extraction, consumer_extraction, topic_attribution, room_channel_grouping, signature_verification]
   observability:
     capabilities: [trace_extraction, metric_extraction, log_extraction]
   build_system:


### PR DESCRIPTION
Closes #3826 (child of #3628).

## Summary
The webhook pass (`internal/engine/webhooks_edges.go`, #728) detected `is_webhook` + `webhook_provider` but never modeled whether the receiver **verifies the inbound signature**. An unverified webhook receiver is forgeable — a security finding the graph couldn't answer. This PR adds the signature-verification posture.

Every detected webhook endpoint (and its `SUBSCRIBES_TO` edge) now also carries:
- `webhook=true` — alias of `is_webhook`, matching the flat endpoint-posture property contract (deprecation / rate-limit / auth passes)
- `webhook_signature_verified=true|false`

so the graph answers **"which endpoints are webhook receivers, and do they verify signatures?"** — and the `false` ones are flagged.

## Verification signals (assert `true` only on concrete evidence)
| Provider | Signal |
|---|---|
| Stripe | `Webhook.construct_event` / `webhooks.constructEvent` / `ConstructEvent` / `Event.constructFrom` |
| GitHub | HMAC over `X-Hub-Signature-256` / `github.ValidatePayload` |
| Twilio | `RequestValidator` / `validateRequest` |
| Slack | `SignatureVerifier` / `verifyRequestSignature` |
| Shopify | HMAC over `X-Shopify-Hmac-Sha256` (**provider newly added**) |
| Svix | `wh.verify` |
| Generic | a `*-Signature`/`*-Hmac` header read **paired with** an HMAC compute/compare (`hmac.new`/`compare_digest`, `crypto.createHmac`+`timingSafeEqual`, `Mac.getInstance`/`HmacUtils`, `hmac.New`/`hmac.Equal`, `OpenSSL::HMAC`/`secure_compare`, `verify_signature(...)`) |

## The unverified-webhook security flag
A `/webhook` route that just parses the body with **no** verification signal ⇒ `webhook=true`, `webhook_signature_verified=false` (forgeable receiver). Honest-partial: a provider is never fabricated.

## Webhook endpoints asserted by tests
- Stripe `/stripe/webhook` (py) → `webhook=true provider=stripe verified=true`
- GitHub `/webhooks/github` HMAC (py) → `provider=github verified=true`
- Shopify `/webhooks/shopify` HMAC (js) → `provider=shopify verified=true`
- Twilio `/twilio/webhook` RequestValidator (py) → `provider=twilio verified=true`
- **`/webhook` bare body-parse (py) → `webhook=true verified=false` (security flag)**
- Negatives: `/users` and an unrelated "signature" mention → no webhook entity

## Coverage / docs
- New `signature_verification` capability on `msg.webhook` (+ `signature_verification` added to the `message_broker` taxonomy in `capability-dictionary.yaml`).
- `coverage validate` 0 errors, registry canonical, docs regenerated (`detail/msg.webhook.md`, `by-category/message_broker.md`).

## Validation
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green
- `go vet` clean, `gofmt -l` empty
- append-only emission preserved (no existing entities/edges mutated)

## DEPLOY-DEFERRED
Live daemon rebuild/reindex deferred to the next coordinated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)