### PR TITLE
docs(coverage): annotate 86 BARE-MISSING cells (honest issue links + scope notes)

### DIFF
--- a/docs/coverage/detail/build.makefile.md
+++ b/docs/coverage/detail/build.makefile.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 | Target extraction | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/config/discover.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/build.mill.md
+++ b/docs/coverage/detail/build.mill.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.rake.md
+++ b/docs/coverage/detail/build.rake.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 | Target extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/build_tools.yaml` | — |
 
 ## Provenance

--- a/docs/coverage/detail/ci.drone.md
+++ b/docs/coverage/detail/ci.drone.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Env resolution | 🔴 `missing` | — | — | — | — |
-| File parsing | 🔴 `missing` | — | — | — | — |
+| Env resolution | 🔴 `missing` | — | 3828 | — | No file/env parsing yet for this CI system; tracked in #3828. |
+| File parsing | 🔴 `missing` | — | 3828 | — | No file/env parsing yet for this CI system; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.jenkins.md
+++ b/docs/coverage/detail/ci.jenkins.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Env resolution | 🔴 `missing` | — | — | — | — |
+| Env resolution | 🔴 `missing` | — | 3828 | — | No file/env parsing yet for this CI system; tracked in #3828. |
 | File parsing | 🔴 `missing` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/config.jenkins.md
+++ b/docs/coverage/detail/config.jenkins.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| File parsing | 🔴 `missing` | — | — | — | — |
+| File parsing | 🔴 `missing` | — | 3828 | — | No file/env parsing yet for this CI system; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
+| Resource extraction | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.clickhouse.md
+++ b/docs/coverage/detail/db.clickhouse.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
+| Resource extraction | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
+| Resource extraction | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.snowflake.md
+++ b/docs/coverage/detail/db.snowflake.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
+| Resource extraction | 🔴 `missing` | — | 3828 | — | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.datadog.md
+++ b/docs/coverage/detail/infra.observability.datadog.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
-| Metric extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Metric extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 | Trace extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3768) | `internal/extractors/golang/observability.go`<br>`internal/extractors/javascript/observability.go`<br>`internal/extractors/python/observability.go` | #3628 area #11: ddtrace span-creation sites now emit INSTRUMENTS edges (enclosing op -> span:<name> stub) in Python, Go and JS/TS. Python (#3762): @tracer.wrap()/tracer.trace("op"). Go: tracer.StartSpan("web.request") and tracer.StartSpanFromContext(ctx, "op") take the first string-literal arg as the span name. JS/TS dd-trace: tracer.trace('op', cb) / tracer.wrap('op', fn) take the first string-literal arg. Honest-partial: dynamic span names emit traced=true+dynamic=true keyed on the enclosing fn without a fabricated name; .StartSpan/.trace on a non-tracer receiver is not emitted (precision). |
 
 ## Provenance

--- a/docs/coverage/detail/infra.observability.elastic-apm.md
+++ b/docs/coverage/detail/infra.observability.elastic-apm.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
-| Metric extraction | 🔴 `missing` | — | — | — | — |
-| Trace extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Metric extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Trace extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.grafana-loki.md
+++ b/docs/coverage/detail/infra.observability.grafana-loki.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 | Metric extraction | — `not_applicable` | — | — | — | — |
 | Trace extraction | — `not_applicable` | — | — | — | — |
 

--- a/docs/coverage/detail/infra.observability.honeycomb.md
+++ b/docs/coverage/detail/infra.observability.honeycomb.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
-| Metric extraction | 🔴 `missing` | — | — | — | — |
-| Trace extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Metric extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Trace extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.newrelic.md
+++ b/docs/coverage/detail/infra.observability.newrelic.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
-| Metric extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Metric extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 | Trace extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3762) | `internal/extractors/python/observability.go` | #3628 area #11: New Relic Python agent trace decorators emit INSTRUMENTS edges (enclosing op -> span:<name> stub). @newrelic.agent.function_trace() / @function_trace() / @background_task() / @web_transaction() default the span name to the function name; name="..." uses the explicit name. Honest-partial: dynamic names emit traced=true+dynamic=true without fabrication; only Python is covered. |
 
 ## Provenance

--- a/docs/coverage/detail/infra.observability.opentelemetry.md
+++ b/docs/coverage/detail/infra.observability.opentelemetry.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 | Metric extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/event_bus_edges.go` | — |
 | Trace extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3689) | `internal/extractors/golang/tracing.go`<br>`internal/extractors/java/tracing.go`<br>`internal/extractors/javascript/tracing.go`<br>`internal/extractors/python/tracing.go` | OpenTelemetry span-creation sites: emits INSTRUMENTS edges (enclosing op -> span:<name> stub) for the dominant span-start idioms in Python (start_as_current_span/start_span + decorator), Go (tracer.Start), JS/TS (startSpan/startActiveSpan), Java (@WithSpan + spanBuilder().startSpan()). Honest-partial: dynamic/variable span names emit traced=true without a fabricated name; non-OTel vendors and other langs not yet covered. |
 

--- a/docs/coverage/detail/infra.observability.sentry.md
+++ b/docs/coverage/detail/infra.observability.sentry.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | — | — | — |
-| Metric extraction | 🔴 `missing` | — | — | — | — |
+| Log extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
+| Metric extraction | 🔴 `missing` | — | 3828 | — | No log/metric/trace extraction yet for this vendor; tracked in #3828. |
 | Trace extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3768) | `internal/extractors/golang/observability.go`<br>`internal/extractors/javascript/observability.go`<br>`internal/extractors/python/observability.go` | #3628 area #11: Sentry performance-tracing sites emit INSTRUMENTS edges (enclosing op -> span:<name> stub) in Python, Go and JS/TS. Python (#3762): @sentry_sdk.trace, start_transaction/start_span. Go: sentry.StartSpan(ctx, "op") takes the first string-literal arg as the span name. JS/TS: Sentry.startSpan({name:'op'}, cb) / Sentry.startTransaction({name:'op'}) / startInactiveSpan take the `name` property of the first object-literal arg. Honest-partial: dynamic names emit traced=true+dynamic=true keyed on the enclosing fn without fabrication; .StartSpan on a non-sentry receiver is not emitted. |
 
 ## Provenance

--- a/docs/coverage/detail/lang.c-cpp.tool.buck2.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.buck2.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.build2.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.build2.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
+| Manifest parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.hunter.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.hunter.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
+| Manifest parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.make.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.make.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.meson.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.meson.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.ninja.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.ninja.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.xmake.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.xmake.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.ueberauth.md
+++ b/docs/coverage/detail/lang.elixir.framework.ueberauth.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-31` | — | `internal/custom/elixir/ueberauth.go`<br>`internal/custom/elixir/ueberauth_test.go` | plug Ueberauth entrypoint + configured Ueberauth.Strategy.* OAuth providers + handle_request!/handle_callback! handlers emitted as auth entities (auth=true, auth_provider=<provider>, auth_method=oauth2) consumed by archigraph_auth_coverage. |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/msg.kafka-streams.md
+++ b/docs/coverage/detail/msg.kafka-streams.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Consumer extraction | 🔴 `missing` | — | — | — | — |
-| Producer extraction | 🔴 `missing` | — | — | — | — |
+| Consumer extraction | 🔴 `missing` | — | 3828 | — | No producer/consumer extraction yet for this broker variant; tracked in #3828. |
+| Producer extraction | 🔴 `missing` | — | 3828 | — | No producer/consumer extraction yet for this broker variant; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.cargo.md
+++ b/docs/coverage/detail/pkg.cargo.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 | Manifest parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/pkg.gemfile.md
+++ b/docs/coverage/detail/pkg.gemfile.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 | Manifest parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/pkg.gradle.md
+++ b/docs/coverage/detail/pkg.gradle.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 | Manifest parsing | 🟢 `partial` | `2026-06-02` | 3628 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/extractor_test.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/pkg.mix.md
+++ b/docs/coverage/detail/pkg.mix.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Manifest parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pubspec.md
+++ b/docs/coverage/detail/pkg.pubspec.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 | Manifest parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/pkg.sbt.md
+++ b/docs/coverage/detail/pkg.sbt.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Manifest parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.swift-package.md
+++ b/docs/coverage/detail/pkg.swift-package.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Manifest parsing | 🔴 `missing` | — | 3828 | — | No lockfile/manifest parsing yet for this package manager; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.jsonrpc.md
+++ b/docs/coverage/detail/protocol.jsonrpc.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Cross repo linkage | 🟢 `partial` | `2026-06-02` | 3750 | `internal/engine/http_endpoint_jsonrpc.go`<br>`internal/links/http_pass.go` | #3628 — client/server synthetics keyed http:JSONRPC:/jsonrpc/<method> join via the Name-based HTTP linker; round-trip covered in TestHTTPPass_JSONRPCCrossRepoMatch. JS jayson + Python ServerProxy clients; jayson method-map + register_function producers. Partial: dynamic method names honest-partial skipped |
 | Method attribution | 🟢 `partial` | `2026-06-02` | 3750 | `internal/engine/http_endpoint_jsonrpc.go` | #3628 — literal method names from client.request('m') / ServerProxy.<m>() and jayson method-map / register_function keys; dynamic names skipped |
-| Service extraction | 🔴 `missing` | — | — | — | — |
+| Service extraction | 🔴 `missing` | — | 3828 | — | No service/schema extraction yet for this protocol; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.basic.md
+++ b/docs/coverage/detail/security.auth.basic.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-28` | — | `internal/engine/java_auth_policy.go` | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/security.auth.jwt.md
+++ b/docs/coverage/detail/security.auth.jwt.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-28` | — | `internal/engine/java_auth_policy.go` | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/security.auth.oauth2.md
+++ b/docs/coverage/detail/security.auth.oauth2.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-28` | — | `internal/engine/java_auth_policy.go` | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/security.auth.oidc.md
+++ b/docs/coverage/detail/security.auth.oidc.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-28` | — | `internal/engine/java_auth_policy.go` | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/security.auth.saml.md
+++ b/docs/coverage/detail/security.auth.saml.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth policy | 🔴 `missing` | — | — | — | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Auth policy | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/security.auth.session.md
+++ b/docs/coverage/detail/security.auth.session.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Auth policy | 🟢 `partial` | `2026-05-28` | — | `internal/engine/java_auth_policy.go` | — |
-| Secret detection | 🔴 `missing` | — | — | — | — |
+| Secret detection | 🔴 `missing` | — | 3828 | — | No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off). |
 | SQL injection | — `not_applicable` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/test.assertj.md
+++ b/docs/coverage/detail/test.assertj.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.boost-test.md
+++ b/docs/coverage/detail/test.boost-test.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.catch2.md
+++ b/docs/coverage/detail/test.catch2.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cppunit.md
+++ b/docs/coverage/detail/test.cppunit.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cpputest.md
+++ b/docs/coverage/detail/test.cpputest.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cucumber.md
+++ b/docs/coverage/detail/test.cucumber.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.doctest-cpp.md
+++ b/docs/coverage/detail/test.doctest-cpp.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.fluentassertions.md
+++ b/docs/coverage/detail/test.fluentassertions.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.gtest.md
+++ b/docs/coverage/detail/test.gtest.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.mockito.md
+++ b/docs/coverage/detail/test.mockito.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 | Target extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3753) | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Mockito when(svc.method()).thenReturn(...) stubs resolve to a medium-confidence TESTS edge on the stubbed production method via testmap mockSetupREs; direct calls on the SUT in @Test bodies resolve high. |
 
 ## Provenance

--- a/docs/coverage/detail/test.restassured.md
+++ b/docs/coverage/detail/test.restassured.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.spock.md
+++ b/docs/coverage/detail/test.spock.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
+| Target extraction | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.testng.md
+++ b/docs/coverage/detail/test.testng.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🔴 `missing` | — | 3828 | — | No build-graph/target extraction yet for this tool/test-runner; tracked in #3828. |
 | Target extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3753) | `internal/engine/rules/java/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | TestNG @Test methods in *Test.java files route through testmap detectJUnit (filename hint); org.testng import-hint not yet registered, so import-only TestNG files are a known partial miss. |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -397,7 +397,9 @@
       "label": "Makefile",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
           "status": "partial",
@@ -431,10 +433,14 @@
       "label": "Mill",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -621,7 +627,9 @@
       "label": "Rake",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
           "status": "partial",
@@ -886,10 +894,14 @@
       "label": "Drone CI",
       "capabilities": {
         "env_resolution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No file/env parsing yet for this CI system; tracked in #3828."
         },
         "file_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No file/env parsing yet for this CI system; tracked in #3828."
         }
       }
     },
@@ -936,7 +948,9 @@
       "label": "Jenkins (Jenkinsfile)",
       "capabilities": {
         "env_resolution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No file/env parsing yet for this CI system; tracked in #3828."
         },
         "file_parsing": {
           "status": "missing",
@@ -1065,7 +1079,9 @@
       "label": "Jenkinsfile / Jenkins Pipeline DSL",
       "capabilities": {
         "file_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No file/env parsing yet for this CI system; tracked in #3828."
         }
       }
     },
@@ -1149,10 +1165,14 @@
       "label": "Apache Cassandra (schema)",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         }
       }
     },
@@ -1163,10 +1183,14 @@
       "label": "ClickHouse",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         }
       }
     },
@@ -1249,10 +1273,14 @@
       "label": "Neo4j",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         }
       }
     },
@@ -1299,10 +1327,14 @@
       "label": "Snowflake",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap)."
         }
       }
     },
@@ -1648,10 +1680,14 @@
       "label": "Datadog",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "trace_extraction": {
           "status": "partial",
@@ -1669,13 +1705,19 @@
       "label": "Elastic APM",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "trace_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         }
       }
     },
@@ -1686,7 +1728,9 @@
       "label": "Grafana Loki",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
           "status": "not_applicable"
@@ -1703,13 +1747,19 @@
       "label": "Honeycomb",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "trace_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         }
       }
     },
@@ -1733,10 +1783,14 @@
       "label": "New Relic",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "trace_extraction": {
           "status": "partial",
@@ -1754,7 +1808,9 @@
       "label": "OpenTelemetry (OTEL)",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
           "status": "partial",
@@ -1798,10 +1854,14 @@
       "label": "Sentry",
       "capabilities": {
         "log_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No log/metric/trace extraction yet for this vendor; tracked in #3828."
         },
         "trace_extraction": {
           "status": "partial",
@@ -7367,10 +7427,14 @@
       "label": "Buck2",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -7381,10 +7445,14 @@
       "label": "build2",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         }
       }
     },
@@ -7434,10 +7502,14 @@
       "label": "Hunter",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         }
       }
     },
@@ -7448,10 +7520,14 @@
       "label": "GNU Make",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -7462,10 +7538,14 @@
       "label": "Meson",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -7476,10 +7556,14 @@
       "label": "Ninja",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -7510,10 +7594,14 @@
       "label": "xmake",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -16328,7 +16416,9 @@
           "verified_at": "2026-05-31"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -73292,10 +73382,14 @@
       "label": "Kafka Streams / Faust",
       "capabilities": {
         "consumer_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No producer/consumer extraction yet for this broker variant; tracked in #3828."
         },
         "producer_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No producer/consumer extraction yet for this broker variant; tracked in #3828."
         }
       }
     },
@@ -73600,7 +73694,9 @@
       "label": "Cargo.toml",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
           "status": "full",
@@ -73656,7 +73752,9 @@
       "label": "Gemfile",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
           "status": "full",
@@ -73690,7 +73788,9 @@
       "label": "build.gradle / build.gradle.kts",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
           "status": "partial",
@@ -73707,7 +73807,9 @@
       "label": "mix.exs",
       "capabilities": {
         "manifest_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         }
       }
     },
@@ -73770,7 +73872,9 @@
       "label": "pubspec.yaml",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         },
         "manifest_parsing": {
           "status": "full",
@@ -73818,7 +73922,9 @@
       "label": "build.sbt",
       "capabilities": {
         "manifest_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         }
       }
     },
@@ -73829,7 +73935,9 @@
       "label": "Package.swift / Podfile",
       "capabilities": {
         "manifest_parsing": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No lockfile/manifest parsing yet for this package manager; tracked in #3828."
         }
       }
     },
@@ -74020,7 +74128,9 @@
           "verified_at": "2026-06-02"
         },
         "service_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No service/schema extraction yet for this protocol; tracked in #3828."
         }
       }
     },
@@ -74148,7 +74258,9 @@
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74167,7 +74279,9 @@
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74186,7 +74300,9 @@
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74205,7 +74321,9 @@
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74219,10 +74337,14 @@
       "label": "SAML",
       "capabilities": {
         "auth_policy": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74241,7 +74363,9 @@
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No extraction yet for this capability on this auth/security record; tracked in #3828 (may be reclassified not_applicable pending owner sign-off)."
         },
         "sql_injection": {
           "status": "not_applicable"
@@ -74307,10 +74431,14 @@
       "label": "AssertJ",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74357,10 +74485,14 @@
       "label": "Boost.Test",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74389,10 +74521,14 @@
       "label": "Catch2",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74421,10 +74557,14 @@
       "label": "CppUnit",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74435,10 +74575,14 @@
       "label": "CppUTest",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74467,10 +74611,14 @@
       "label": "Cucumber",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74525,10 +74673,14 @@
       "label": "doctest (C++)",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74557,10 +74709,14 @@
       "label": "FluentAssertions",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74631,10 +74787,14 @@
       "label": "GoogleTest (gtest)",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74788,7 +74948,9 @@
       "label": "Mockito",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
           "status": "partial",
@@ -74958,10 +75120,14 @@
       "label": "REST-assured",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -74990,10 +75156,14 @@
       "label": "Spock",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         }
       }
     },
@@ -75062,7 +75232,9 @@
       "label": "TestNG",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "missing",
+          "issue": "3828",
+          "notes": "No build-graph/target extraction yet for this tool/test-runner; tracked in #3828."
         },
         "target_extraction": {
           "status": "partial",


### PR DESCRIPTION
## What
An audit of `docs/coverage/registry.json` (triggered by `db.neo4j` reading as a forgotten/empty cell) found **86 capability cells** with `status=missing` and **no cites, no notes, AND no issue link** — they read as "forgotten" rather than "honestly-known-TODO". Same defect class across 8 categories.

This is an **annotation-only** pass: every bare-missing cell gets a tracking-issue link (#3828, under epic #3628) and a one-line per-category scope note, all via `tools/coverage update` surgical edits. **No extractor code. No `not_applicable` reclassification** (deferred to owner sign-off). Status stays `missing`.

## Census fixed
| Category | Cells |
|---|---|
| build_system | 38 |
| observability | 14 |
| package_manager | 11 |
| databases | 8 (cassandra, clickhouse, neo4j, snowflake) |
| security | 8 |
| ci_cd | 4 |
| message_broker | 2 |
| protocol | 1 |

**BARE-MISSING 86 → 0; HONEST-MISSING 13 → 99.**

## Confirmed: databases 8-vs-4
8 datastores fully extracted (cache, dynamodb, elasticsearch, mongodb, mysql, postgres, redis, sqlite); 4 bare (cassandra, clickhouse, neo4j, snowflake) — all recognized drivers in `discover.go`, so genuine build-gaps. Other unfinished-lane clusters: C/C++ build tools + JVM/C++ test runners, observability vendor APM log/metric, package-manager lockfiles.

## Validation
- `coverage fmt --check`: registry is canonical
- `coverage validate`: **0 errors** (warnings dropped 7921 → 7835 — change only *reduced* warnings)
- Derived `docs/coverage/*.md` regenerated via `coverage gen`
- Diff touches only `docs/coverage/**`

## Follow-up
Real build-gaps (datastore extraction, C/C++ build graphs, observability log/metric, lockfile parsing) tracked for Phase-2 tickets under #3628 — see #3828 for the prioritized backlog.

Refs #3828 #3628

🤖 Generated with [Claude Code](https://claude.com/claude-code)