### PR TITLE
[datastore] infra-resource extraction for neo4j/cassandra/clickhouse/snowflake (sibling parity)

### DIFF
--- a/docs/coverage/by-category/databases.md
+++ b/docs/coverage/by-category/databases.md
@@ -8,14 +8,14 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | Language | Name | Dependency attribution | Resource extraction | Status | Notes |
 |---|---|---|---|---|---|
 | [multi](../by-language/multi.md) | [AWS DynamoDB](../detail/db.dynamodb.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Apache Cassandra (schema)](../detail/db.cassandra.md) | 🔴 | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [Apache Cassandra (schema)](../detail/db.cassandra.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Caching (regions/keys)](../detail/db.cache.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [ClickHouse](../detail/db.clickhouse.md) | 🔴 | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [ClickHouse](../detail/db.clickhouse.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Elasticsearch (indices)](../detail/db.elasticsearch.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [MongoDB (collections)](../detail/db.mongodb.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [MySQL / MariaDB (schema)](../detail/db.mysql.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Neo4j](../detail/db.neo4j.md) | 🔴 | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [Neo4j](../detail/db.neo4j.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [PostgreSQL (schema)](../detail/db.postgres.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Redis (keys)](../detail/db.redis.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [SQLite (schema)](../detail/db.sqlite.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Snowflake](../detail/db.snowflake.md) | 🔴 | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [Snowflake](../detail/db.snowflake.md) | 🟢 | 🟢 | 🟢 | |

--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_drivers_other.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_drivers_other.go` | Cassandra/Scylla CQL session.execute("... FROM table") across C#/PHP/Rust/Python/Java/Ruby/JS parses the FROM/INTO/UPDATE table into a Class:<Table> resource node + QUERIES dependency edge from the connecting function (emitCQLTargets). Runtime-built CQL honest-skipped. |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.clickhouse.md
+++ b/docs/coverage/detail/db.clickhouse.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go` | ClickHouse client.execute/query("... FROM table") (clickhouse-driver/clickhouse-connect/clickhouse-go, gated on clickhouse import / clickhouse:// / :8123) parses the SQL table into a Class:<Table> resource node + QUERIES dependency edge from the connecting function (emitClickHouseTargets, mirrors emitCQLTargets). Tableless/runtime SQL honest-skipped. |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go`<br>`internal/engine/orm_queries_jsts_drivers.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go`<br>`internal/engine/orm_queries_jsts_drivers.go` | Neo4j session.run("MATCH (n:Label) ...") Cypher (gated on neo4j / bolt:// / GraphDatabase / neomodel / neogma) parses the first node label into a Class:<Label> resource node + QUERIES dependency edge from the connecting function. JS via scanJSNeo4j (orm_queries_jsts_drivers.go); C#/PHP/Rust/Python/Java/Ruby/Go via emitCypherTargets (orm_queries_datastore_infra.go). Parameterised labels / runtime Cypher honest-skipped. |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.snowflake.md
+++ b/docs/coverage/detail/db.snowflake.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-06-02` | — | `internal/engine/orm_queries_datastore_infra.go` | Snowflake cursor.execute/query("... FROM table") (snowflake-connector-python, SQLAlchemy snowflake:// dialect, gosnowflake, JDBC; gated on snowflake / snowflake:// / snowflakecomputing.com) parses the SQL table into a Class:<Table> resource node + QUERIES dependency edge from the connecting function (emitSnowflakeTargets, mirrors emitCQLTargets). Tableless/runtime SQL honest-skipped. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1149,10 +1149,15 @@
       "label": "Apache Cassandra (schema)",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_drivers_other.go"],
+          "verified_at": "2026-06-02"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_drivers_other.go"],
+          "notes": "Cassandra/Scylla CQL session.execute(\"... FROM table\") across C#/PHP/Rust/Python/Java/Ruby/JS parses the FROM/INTO/UPDATE table into a Class:\u003cTable\u003e resource node + QUERIES dependency edge from the connecting function (emitCQLTargets). Runtime-built CQL honest-skipped.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -1163,10 +1168,15 @@
       "label": "ClickHouse",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go"],
+          "verified_at": "2026-06-02"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go"],
+          "notes": "ClickHouse client.execute/query(\"... FROM table\") (clickhouse-driver/clickhouse-connect/clickhouse-go, gated on clickhouse import / clickhouse:// / :8123) parses the SQL table into a Class:\u003cTable\u003e resource node + QUERIES dependency edge from the connecting function (emitClickHouseTargets, mirrors emitCQLTargets). Tableless/runtime SQL honest-skipped.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -1249,10 +1259,15 @@
       "label": "Neo4j",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go","internal/engine/orm_queries_jsts_drivers.go"],
+          "verified_at": "2026-06-02"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go","internal/engine/orm_queries_jsts_drivers.go"],
+          "notes": "Neo4j session.run(\"MATCH (n:Label) ...\") Cypher (gated on neo4j / bolt:// / GraphDatabase / neomodel / neogma) parses the first node label into a Class:\u003cLabel\u003e resource node + QUERIES dependency edge from the connecting function. JS via scanJSNeo4j (orm_queries_jsts_drivers.go); C#/PHP/Rust/Python/Java/Ruby/Go via emitCypherTargets (orm_queries_datastore_infra.go). Parameterised labels / runtime Cypher honest-skipped.",
+          "verified_at": "2026-06-02"
         }
       }
     },
@@ -1299,10 +1314,15 @@
       "label": "Snowflake",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go"],
+          "verified_at": "2026-06-02"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_datastore_infra.go"],
+          "notes": "Snowflake cursor.execute/query(\"... FROM table\") (snowflake-connector-python, SQLAlchemy snowflake:// dialect, gosnowflake, JDBC; gated on snowflake / snowflake:// / snowflakecomputing.com) parses the SQL table into a Class:\u003cTable\u003e resource node + QUERIES dependency edge from the connecting function (emitSnowflakeTargets, mirrors emitCQLTargets). Tableless/runtime SQL honest-skipped.",
+          "verified_at": "2026-06-02"
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,7 +32,7 @@
 
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
-| [Databases](by-category/databases.md) | 12 | 0 | 8 | 4 |
+| [Databases](by-category/databases.md) | 12 | 0 | 12 | 0 |
 | [Platform / k8s](by-category/platform.md) | 34 | 20 | 14 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 21 | 9 | 10 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
@@ -40,7 +40,7 @@
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 12 | 5 | 4 | 3 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 115 | 43 | 45 | 27 |
+| **Total** | 115 | 43 | 49 | 23 |
 
 ## Languages with extractor support, no records yet
 

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -135,12 +135,19 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 		})
 	}
 
+	// Datastore-infra resource attribution (Neo4j / ClickHouse / Snowflake)
+	// is language-agnostic in its call shapes (`session.run(<cypher>)`,
+	// `cursor.execute("SQL")`); run it for every supported language so the
+	// three datastores reach sibling parity with cassandra/mongo/elastic.
+	scanInfra := func() { scanDatastoreInfraDrivers(src, funcs, emit) }
+
 	switch lang {
 	case "python":
 		scanPythonORM(src, funcs, emit)
 		// Driver-topology: pymongo collection target, boto3 DynamoDB
 		// TableName, Elasticsearch index, Cassandra CQL (#3645).
 		scanPythonDrivers(src, funcs, emit)
+		scanInfra()
 		// Sibling pass: parse the pymongo `.aggregate(<pipeline>)` pipeline
 		// (inline list literal OR a same-function variable binding) into
 		// per-stage entities + $lookup/$graphLookup join edges (#3440).
@@ -151,6 +158,10 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 	case "javascript", "typescript":
 		scanJSORM(src, funcs, emit)
 		scanJSDrivers(src, funcs, emit)
+		// Neo4j (Cypher node-label) is already attributed by scanJSNeo4j
+		// inside scanJSDrivers; only the SQL datastores need adding here.
+		emitClickHouseTargets(src, funcs, emit)
+		emitSnowflakeTargets(src, funcs, emit)
 		// Sibling pass: parse the inline pipeline array of `.aggregate([...])`
 		// call sites into per-stage entities + $lookup/$graphLookup join
 		// edges. Does NOT re-emit the aggregate QUERIES edge (#3426).
@@ -160,22 +171,28 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 		)
 	case "go":
 		scanGoORM(src, funcs, emit)
+		scanInfra()
 	case "java":
 		scanJavaORM(src, funcs, emit)
 		// Driver-topology: native MongoDB Java driver getCollection("x"),
 		// DynamoDB SDK TableName, Cassandra CQL FROM/INTO (#3645).
 		scanJavaDrivers(src, funcs, emit)
+		scanInfra()
 	case "ruby":
 		scanRubyORM(src, funcs, emit)
 		// Driver-topology: Mongo Ruby driver client[:coll], aws-sdk-dynamodb
 		// table_name, Cassandra CQL (#3645).
 		scanRubyDrivers(src, funcs, emit)
+		scanInfra()
 	case "csharp":
 		scanCSharpDrivers(src, funcs, emit)
+		scanInfra()
 	case "php":
 		scanPHPDrivers(src, funcs, emit)
+		scanInfra()
 	case "rust":
 		scanRustDrivers(src, funcs, emit)
+		scanInfra()
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}

--- a/internal/engine/orm_queries_datastore_infra.go
+++ b/internal/engine/orm_queries_datastore_infra.go
@@ -1,0 +1,222 @@
+// Cross-language datastore-infra resource attribution for Neo4j, ClickHouse
+// and Snowflake (sibling parity with cassandra/mongodb/elasticsearch/dynamodb).
+//
+// The cross-language driver-topology pass in orm_queries_drivers_other.go
+// already attributes raw-driver call sites for Cassandra (CQL), MongoDB,
+// DynamoDB and Elasticsearch to the resource they touch, emitting a QUERIES
+// edge `Function:<caller> → Class:<Resource>`. That edge IS the
+// dependency-attribution + resource-extraction mechanism: the `Class:<Resource>`
+// node is the deployed datastore resource (graph label / table) and the edge
+// records which code module depends on it.
+//
+// Before this file, three sibling datastores had no such cross-language
+// attribution despite being first-class code-level citizens elsewhere:
+//
+//   - Neo4j      : the JS pass (orm_queries_jsts_drivers.go) recognised
+//     `session.run("MATCH (n:Label) ...")` and emitted the node label, but
+//     the cross-language driver pass (C#/PHP/Rust/Python/Java/Ruby) did not.
+//   - ClickHouse : speaks SQL over its own client/driver; no attribution.
+//   - Snowflake  : speaks SQL over the snowflake-connector / SQLAlchemy
+//     snowflake dialect; no attribution.
+//
+// This file closes that gap by mirroring emitCQLTargets EXACTLY:
+//
+//   - emitCypherTargets  — Neo4j: pulls the Cypher string out of a
+//     `session.run(...)` / `tx.run(...)` call, parses the first node label
+//     `(n:Label)` out of it (reusing the shared cypherLabelRe / cypherVerbRe
+//     from orm_queries_jsts_drivers.go), and emits a QUERIES edge to the
+//     `Class:<Label>` resource. Cypher whose label is not a static literal
+//     is honest-skipped — same precision bar as the CQL/dynamic-name skips.
+//   - emitClickHouseTargets / emitSnowflakeTargets — SQL datastores: pull the
+//     SQL string out of an execute/query call and reuse the shared
+//     extractSQLTable() FROM/INTO/UPDATE parser, emitting a QUERIES edge to
+//     the `Class:<Table>` resource. SQL whose table cannot be statically
+//     parsed (runtime-built string) is honest-skipped.
+//
+// Gating is import-/driver-sniff based (mentions*), identical to the existing
+// driver families, so the broad `.run(`/`.execute(`/`.query(` surface only
+// fires in files that actually import the datastore's client.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// scanDatastoreInfraDrivers runs the Neo4j / ClickHouse / Snowflake
+// datastore-infra resource attribution over `src`. Each family is
+// import-gated, so this is cheap for files that touch none of them. Called
+// from applyORMQueries for every supported language (the call shapes —
+// `session.run(...)`, `cursor.execute("SQL")` — are language-agnostic).
+func scanDatastoreInfraDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	emitCypherTargets(src, funcs, emit)
+	emitClickHouseTargets(src, funcs, emit)
+	emitSnowflakeTargets(src, funcs, emit)
+}
+
+// ---------------------------------------------------------------------------
+// Neo4j (Cypher node-label attribution — cross-language)
+// ---------------------------------------------------------------------------
+
+// cypherRunRe matches a Neo4j driver `session.run(...)` / `tx.run(...)` /
+// `txc.run(...)` / `driver.run(...)` call across languages. The receiver is
+// gated to the canonical Neo4j session/transaction identifiers so the broad
+// `.run(` surface does not fire on unrelated runners. Group 1 = the opening
+// paren, used to walk the call args.
+var cypherRunRe = regexp.MustCompile(
+	`\b(?:session|tx|txc|tx2|driver|neo4j|_session|graph|graphDb|graphDB)\.[Rr]un\s*\(`,
+)
+
+// mentionsNeo4jDriver reports whether the file imports / references a Neo4j
+// driver in any supported language: the official drivers expose `bolt://`
+// connection URLs and `neo4j`/`Neo4j` package symbols; neomodel/neogma/neogma
+// OGMs and the Spring/`GraphDatabase` Java API all reference the same tokens.
+func mentionsNeo4jDriver(src string) bool {
+	return strings.Contains(src, "neo4j") ||
+		strings.Contains(src, "Neo4j") ||
+		strings.Contains(src, "bolt://") ||
+		strings.Contains(src, "neobolt://") ||
+		strings.Contains(src, "GraphDatabase") ||
+		strings.Contains(src, "neomodel") ||
+		strings.Contains(src, "neogma")
+}
+
+// emitCypherTargets finds every Neo4j `session.run(<cypher>)` call matched by
+// cypherRunRe, pulls the Cypher string literal out of the call's first
+// argument, parses the first node label `(n:Label)` out of it, and emits a
+// QUERIES edge to that label. Cypher whose label cannot be statically parsed
+// (a runtime-built query string, or a parameterised label) is honest-skipped.
+func emitCypherTargets(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	if !mentionsNeo4jDriver(src) {
+		return
+	}
+	for _, m := range cypherRunRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		// The matcher ends at the opening paren of the call.
+		argsBlob := matchCall(src, m[1]-1, 4096)
+		cypher := firstStringLiteral(argsBlob)
+		if cypher == "" {
+			continue
+		}
+		lm := cypherLabelRe.FindStringSubmatch(cypher)
+		if lm == nil {
+			continue
+		}
+		label := lm[1]
+		op := "find"
+		if vm := cypherVerbRe.FindStringSubmatch(cypher); vm != nil {
+			switch strings.ToLower(vm[1]) {
+			case "create", "merge":
+				op = "create"
+			case "set":
+				op = "update"
+			case "delete", "remove":
+				op = "delete"
+			}
+		}
+		caller := enclosingFuncAt(funcs, m[0])
+		emit(caller, label, op, "", "neo4j", false)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClickHouse (SQL-over-HTTP/native client — table attribution)
+// ---------------------------------------------------------------------------
+
+// clickhouseExecRe matches a ClickHouse client query/execute/insert call:
+// `client.execute("SELECT ... FROM events")` (python clickhouse-driver),
+// `client.query("...")` (clickhouse-connect / clickhouse-go), `db.Query(...)`
+// (Go database/sql with the clickhouse driver), `client.insert(...)`.
+// The receiver is left open because the SQL string carries the table; the
+// import gate (mentionsClickHouse) keeps the broad surface from over-firing.
+var clickhouseExecRe = regexp.MustCompile(
+	`\b(?:[A-Za-z_$][\w$]*)\.(?:[Ee]xecute|[Qq]uery|[Ii]nsert|command|exec)\s*\(`,
+)
+
+// mentionsClickHouse reports whether the file imports / references a
+// ClickHouse client or driver: the python `clickhouse-driver` /
+// `clickhouse_connect`, the Go `clickhouse-go` (`ClickHouse/clickhouse-go`),
+// the JS `@clickhouse/client`, the JDBC `clickhouse-jdbc` URL, or a native
+// `clickhouse://` / `http://...:8123` endpoint.
+func mentionsClickHouse(src string) bool {
+	s := strings.ToLower(src)
+	return strings.Contains(s, "clickhouse") ||
+		strings.Contains(s, "clickhouse://") ||
+		strings.Contains(s, ":8123")
+}
+
+// emitClickHouseTargets finds every ClickHouse execute/query call, pulls the
+// SQL string out of its first argument, parses the FROM/INTO/UPDATE table out
+// of it (via the shared extractSQLTable), and emits a QUERIES edge to that
+// table. SQL whose table cannot be statically parsed is honest-skipped.
+func emitClickHouseTargets(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	if !mentionsClickHouse(src) {
+		return
+	}
+	emitSQLDatastoreTargets(src, funcs, emit, clickhouseExecRe, "clickhouse")
+}
+
+// ---------------------------------------------------------------------------
+// Snowflake (SQL warehouse — table attribution)
+// ---------------------------------------------------------------------------
+
+// snowflakeExecRe matches a Snowflake connector cursor/connection
+// execute/query call: `cur.execute("SELECT ... FROM orders")`
+// (snowflake-connector-python), `conn.cursor().execute(...)`, the Go
+// `gosnowflake` `db.Query(...)`, the Spark/JDBC `statement.executeQuery(...)`.
+// Receiver open; the import gate keeps it from over-firing.
+var snowflakeExecRe = regexp.MustCompile(
+	`\b(?:[A-Za-z_$][\w$]*)\.(?:execute|executeQuery|executeUpdate|[Qq]uery|exec)\s*\(`,
+)
+
+// mentionsSnowflake reports whether the file imports / references a Snowflake
+// connector: `snowflake-connector` / `snowflake.connector` (python), the
+// SQLAlchemy `snowflake://` dialect URL, the Go `gosnowflake` driver, the
+// JDBC `jdbc:snowflake:` URL, or a `*.snowflakecomputing.com` account URL.
+func mentionsSnowflake(src string) bool {
+	s := strings.ToLower(src)
+	return strings.Contains(s, "snowflake") ||
+		strings.Contains(s, "snowflake://") ||
+		strings.Contains(s, "snowflakecomputing.com")
+}
+
+// emitSnowflakeTargets finds every Snowflake cursor execute/query call, pulls
+// the SQL string out of its first argument, parses the table out of it, and
+// emits a QUERIES edge to that table. Unparseable SQL is honest-skipped.
+func emitSnowflakeTargets(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	if !mentionsSnowflake(src) {
+		return
+	}
+	emitSQLDatastoreTargets(src, funcs, emit, snowflakeExecRe, "snowflake")
+}
+
+// ---------------------------------------------------------------------------
+// Shared SQL-datastore emitter
+// ---------------------------------------------------------------------------
+
+// emitSQLDatastoreTargets is the SQL analogue of emitCQLTargets: for every
+// execute/query call matched by `callRe`, it pulls the SQL string literal out
+// of the call's first argument, parses the FROM/INTO/UPDATE table via the
+// shared extractSQLTable, and emits a QUERIES edge to `Class:<Table>` tagged
+// with `orm=<orm>`. SQL whose table cannot be statically parsed is skipped —
+// the same precision bar as the existing cassandra / dynamic-name skips.
+func emitSQLDatastoreTargets(src string, funcs []funcSpan, emit emitORMQueryFn, callRe *regexp.Regexp, orm string) {
+	for _, m := range callRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		argsBlob := matchCall(src, m[1]-1, 4096)
+		sql := firstStringLiteral(argsBlob)
+		if sql == "" {
+			continue
+		}
+		table, verb, isJoin := extractSQLTable(sql)
+		if table == "" {
+			continue
+		}
+		caller := enclosingFuncAt(funcs, m[0])
+		emit(caller, capitalisedSingular(table), sqlOp(verb), "", orm, isJoin)
+	}
+}

--- a/internal/engine/orm_queries_datastore_infra_test.go
+++ b/internal/engine/orm_queries_datastore_infra_test.go
@@ -1,0 +1,195 @@
+// Value-asserting tests for the datastore-infra resource attribution pass
+// (Neo4j / ClickHouse / Snowflake — sibling parity with cassandra/mongo/etc).
+//
+// Each test feeds a realistic driver call shape and asserts the EXACT resource
+// (graph node label / table) the call touches surfaces as a QUERIES edge target
+// `Class:<Resource>` from the connecting function. These are NOT len>0 smoke
+// tests: both the dependent (FromID) and the resource (ToID) are the
+// load-bearing claims. Negative tests prove the pass does not hallucinate a
+// resource for an unrelated image/string or an unparseable runtime query.
+package engine
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Neo4j — bolt:// driver + session.run("MATCH (n:Label) ...")
+// ---------------------------------------------------------------------------
+
+func TestInfra_Neo4jPythonBoltSessionRun(t *testing.T) {
+	src := `from neo4j import GraphDatabase
+
+driver = GraphDatabase.driver("bolt://graphdb:7687", auth=("neo4j", "pw"))
+
+def list_people():
+    with driver.session() as session:
+        return session.run("MATCH (p:Person) RETURN p")
+`
+	edges := detectORM(t, "python", "graph/people.py", src)
+	// Resource node = the Person graph label; dependent = list_people.
+	e := assertEdgeExists(t, edges, "Function:list_people", "Class:Person", "find")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
+func TestInfra_Neo4jGoSessionRunCreate(t *testing.T) {
+	src := `package store
+
+import "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
+func CreateMovie(session neo4j.Session) {
+	session.Run("CREATE (m:Movie {title: $title}) RETURN m", nil)
+}
+`
+	edges := detectORM(t, "go", "store/movie.go", src)
+	e := assertEdgeExists(t, edges, "Function:CreateMovie", "Class:Movie", "create")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
+func TestInfra_Neo4jJavaGraphDatabase(t *testing.T) {
+	src := `import org.neo4j.driver.GraphDatabase;
+public class GraphRepo {
+    public void load() {
+        session.run("MATCH (u:User)-[:FOLLOWS]->(f:User) RETURN f");
+    }
+}
+`
+	edges := detectORM(t, "java", "GraphRepo.java", src)
+	// First node label in the pattern is the attributed resource.
+	e := assertEdgeExists(t, edges, "Function:load", "Class:User", "find")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
+func TestInfra_Neo4jNoDriverNoEmit(t *testing.T) {
+	// A `session.run(...)` with NO neo4j/bolt import must NOT fire — the
+	// import gate keeps the broad `.run(` surface from over-firing.
+	src := `def go():
+    session.run("MATCH (p:Person) RETURN p")
+`
+	edges := detectORM(t, "python", "runner.py", src)
+	for _, e := range edges {
+		if e.ORM == "neo4j" {
+			t.Errorf("expected no neo4j edge without driver import, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClickHouse — clickhouse-driver client.execute("SELECT ... FROM events")
+// ---------------------------------------------------------------------------
+
+func TestInfra_ClickHousePythonExecute(t *testing.T) {
+	src := `from clickhouse_driver import Client
+
+client = Client(host="clickhouse")
+
+def recent_events():
+    return client.execute("SELECT event_id, ts FROM events WHERE ts > now() - 3600")
+`
+	edges := detectORM(t, "python", "analytics/events.py", src)
+	e := assertEdgeExists(t, edges, "Function:recent_events", "Class:Event", "find")
+	if e.ORM != "clickhouse" {
+		t.Errorf("expected orm=clickhouse, got %q", e.ORM)
+	}
+}
+
+func TestInfra_ClickHouseGoQuery(t *testing.T) {
+	src := `package metrics
+
+import _ "github.com/ClickHouse/clickhouse-go/v2"
+
+func CountHits(db *sql.DB) {
+	db.Query("SELECT count() FROM page_hits WHERE day = ?")
+}
+`
+	edges := detectORM(t, "go", "metrics/hits.go", src)
+	e := assertEdgeExists(t, edges, "Function:CountHits", "Class:Page_hit", "find")
+	if e.ORM != "clickhouse" {
+		t.Errorf("expected orm=clickhouse, got %q", e.ORM)
+	}
+}
+
+func TestInfra_ClickHouseNoClientNoEmit(t *testing.T) {
+	// An execute() call with no clickhouse signal must not be attributed to
+	// clickhouse (it would be a plain SQL driver handled elsewhere).
+	src := `def q():
+    conn.execute("SELECT id FROM widgets")
+`
+	edges := detectORM(t, "python", "plain.py", src)
+	for _, e := range edges {
+		if e.ORM == "clickhouse" {
+			t.Errorf("expected no clickhouse edge without client import, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snowflake — snowflake-connector cursor.execute("SELECT ... FROM orders")
+// ---------------------------------------------------------------------------
+
+func TestInfra_SnowflakePythonCursorExecute(t *testing.T) {
+	src := `import snowflake.connector
+
+conn = snowflake.connector.connect(account="acme.snowflakecomputing.com")
+
+def daily_orders():
+    cur = conn.cursor()
+    return cur.execute("SELECT order_id, total FROM orders WHERE day = current_date")
+`
+	edges := detectORM(t, "python", "warehouse/orders.py", src)
+	e := assertEdgeExists(t, edges, "Function:daily_orders", "Class:Order", "find")
+	if e.ORM != "snowflake" {
+		t.Errorf("expected orm=snowflake, got %q", e.ORM)
+	}
+}
+
+func TestInfra_SnowflakeSQLAlchemyDialectInsert(t *testing.T) {
+	src := `from sqlalchemy import create_engine
+
+engine = create_engine("snowflake://user:pw@acme/db/schema")
+
+def load_fact():
+    conn.execute("INSERT INTO sales_fact (amount) VALUES (1)")
+`
+	edges := detectORM(t, "python", "etl/load.py", src)
+	e := assertEdgeExists(t, edges, "Function:load_fact", "Class:Sales_fact", "create")
+	if e.ORM != "snowflake" {
+		t.Errorf("expected orm=snowflake, got %q", e.ORM)
+	}
+}
+
+func TestInfra_SnowflakeNoConnectorNoEmit(t *testing.T) {
+	src := `def q():
+    cur.execute("SELECT id FROM orders")
+`
+	edges := detectORM(t, "python", "plain.py", src)
+	for _, e := range edges {
+		if e.ORM == "snowflake" {
+			t.Errorf("expected no snowflake edge without connector import, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: an unrelated string in a clickhouse/snowflake file must not
+// produce a resource when the SQL carries no parseable table.
+// ---------------------------------------------------------------------------
+
+func TestInfra_UnparseableQuerySkipped(t *testing.T) {
+	src := `from clickhouse_driver import Client
+client = Client(host="clickhouse")
+
+def ping():
+    client.execute("SELECT 1")
+`
+	edges := detectORM(t, "python", "health.py", src)
+	for _, e := range edges {
+		if e.ORM == "clickhouse" {
+			t.Errorf("expected no clickhouse resource for tableless SELECT 1, got %+v", e)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3838 (child of #3628).

## What
Closes the coverage-registry gap where **db.neo4j, db.cassandra, db.clickhouse, db.snowflake** had `resource_extraction` + `dependency_attribution` = **missing** (uncited, no notes), while the 8 sibling datastores (postgres/mysql/redis/mongodb/elasticsearch/dynamodb/cache/sqlite) were **partial** + cited.

Extends the SAME cross-language driver-topology attribution the siblings use (`emitCQLTargets` for Cassandra in `orm_queries_drivers_other.go`). Each datastore now emits a `Class:<Resource>` resource node + a `QUERIES` dependency edge `Function:<caller> → Class:<Resource>`:

- **neo4j** — `session.run("MATCH (n:Label) ...")` Cypher node-label, gated on `neo4j` / `bolt://` / `GraphDatabase` / `neomodel` / `neogma`. JS already via `scanJSNeo4j`; C#/PHP/Rust/Python/Java/Ruby/Go added via new `emitCypherTargets`.
- **clickhouse** — `client.execute/query("... FROM table")`, gated on `clickhouse` / `clickhouse://` / `:8123` → `emitClickHouseTargets`.
- **snowflake** — `cursor.execute("... FROM table")`, gated on `snowflake` / `snowflake://` / `snowflakecomputing.com` → `emitSnowflakeTargets`.
- **cassandra** — already attributed by `emitCQLTargets`; registry flipped + cited.

Honest-partial: runtime-built / parameterised / tableless queries are skipped — same precision bar as the existing 8 siblings.

## New code
- `internal/engine/orm_queries_datastore_infra.go` — `emitCypherTargets` / `emitClickHouseTargets` / `emitSnowflakeTargets` + shared `emitSQLDatastoreTargets` (SQL analogue of `emitCQLTargets`), wired into `applyORMQueries` for every supported language.
- `internal/engine/orm_queries_datastore_infra_test.go` — 11 value-asserting tests: each asserts the exact resource node (graph label / table) + the dependent function; negatives prove no resource without the driver gate and no resource for tableless `SELECT 1`.

## Resources + dependents asserted
| datastore | call shape | resource node | dependent |
|---|---|---|---|
| neo4j (py) | `session.run("MATCH (p:Person)...")` | `Class:Person` | `Function:list_people` |
| neo4j (go) | `session.Run("CREATE (m:Movie)...")` | `Class:Movie` (op=create) | `Function:CreateMovie` |
| neo4j (java) | `session.run("MATCH (u:User)...")` | `Class:User` | `Function:load` |
| clickhouse (py) | `client.execute("... FROM events")` | `Class:Event` | `Function:recent_events` |
| clickhouse (go) | `db.Query("... FROM page_hits")` | `Class:Page_hit` | `Function:CountHits` |
| snowflake (py) | `cur.execute("... FROM orders")` | `Class:Order` | `Function:daily_orders` |
| snowflake (py) | `conn.execute("INSERT INTO sales_fact ...")` | `Class:Sales_fact` (op=create) | `Function:load_fact` |

## Validation
- `go test ./internal/engine/ ./internal/types/` green; new tests pass (11/11).
- `coverage validate` 0 errors; `coverage fmt --check` canonical; coverage docs regenerated via `coverage gen`.
- `gofmt -l` empty; `go vet` clean.

**DEPLOY-DEFERRED** — no live-daemon rebuild/reindex performed in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)