### PR TITLE
feat(custom/js): grafeo-ogm Neo4j OGM extraction + GRAPH_RELATES topology

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 155 records · **C/C++**: 7 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 6
+**Total**: 156 records · **C/C++**: 7 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 6
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -87,6 +87,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 11/11 | |
 | [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/4 | |
+| [JS/TS](../by-language/jsts.md) | [grafeo-ogm (Neo4j TS OGM, GraphQL-SDL-driven)](../detail/lang.jsts.ogm.grafeo.md) | 🟡 3/5 | |
 | [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/7 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 32 · **Tools**: 21 · **ORMs**: 18 · **Other**: 4
+**Frameworks**: 32 · **Tools**: 21 · **ORMs**: 19 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -142,6 +142,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | 🟢 11/11 | |
 | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | 🟡 1/4 | |
 | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | 🟡 1/4 | |
+| [grafeo-ogm (Neo4j TS OGM, GraphQL-SDL-driven)](../detail/lang.jsts.ogm.grafeo.md) | 🟡 3/5 | |
 | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | 🟡 1/4 | |
 | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | 🟡 1/4 | |
 | [neo4j-driver (JS) / neogma OGM](../detail/lang.jsts.driver.neo4j.md) | 🟡 4/7 | |

--- a/docs/coverage/detail/lang.jsts.ogm.grafeo.md
+++ b/docs/coverage/detail/lang.jsts.ogm.grafeo.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.ogm.grafeo` — grafeo-ogm (Neo4j TS OGM, GraphQL-SDL-driven)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | graph DB OGM — no relational table/model concept; the SCOPE.Schema/node is the unit (see schema_extraction). |
+| Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
+| Schema extraction | 🟢 `partial` | `2026-06-02` | 3628-grafeo | `internal/custom/javascript/grafeo.go`<br>`internal/custom/javascript/grafeo_test.go` | grafeo-ogm declares its graph model in GraphQL SDL (standalone .graphql file or inline `new OGM({ typeDefs })`). Each `type|interface X @node` is extracted as a SCOPE.Schema/node keyed on its Neo4j label (the type name, or the first entry of @node(labels:[...])). `@relationshipProperties` edge-property types are correctly EXCLUDED (negative case, value-asserted). Regex over the balanced type body; partial (scalar field types not individually emitted as property entities). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | 🟢 `partial` | — | 3628-grafeo | `internal/custom/javascript/grafeo.go` | grafeo @relationship fields are extracted as SCOPE.Component/relationship entities carrying relation_type, direction, field_name, owner_node, target_type, relationship_properties (the @relationshipProperties edge type) and target_node (when resolved). |
+| Foreign key extraction | — `not_applicable` | — | — | — | graph DB — no foreign-key concept |
+| Lazy loading recognition | — `not_applicable` | — | — | — | graph DB — no lazy-loading concept |
+| Relationship extraction | ✅ `full` | `2026-06-02` | 3628-grafeo | `internal/custom/javascript/grafeo.go`<br>`internal/custom/javascript/grafeo_test.go` | grafeo-ogm @relationship fields (`field: T @relationship(type:"REL", direction: OUT|IN, properties:"Props")`) are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-node -> target-node (mirrors the neomodel #3609 / neogma #3610 sibling OGMs and the Java SDN template #3663); the domain graph topology is a navigable subgraph rather than opaque string props. Full when the @relationship field's target GraphQL type resolves to a same-document @node type (value-asserting tests TestGrafeoGraphRelatesOutgoing: Book -GRAPH_RELATES(WRITTEN_BY,OUTGOING)-> Author; direction IN -> INCOMING; @node(labels:[...]) primary-label owner; self-edge). Cross-document / non-@node targets are honest-partial (kept as the target_type prop only, no edge). Works on both standalone .graphql schema files and inline `new OGM({ typeDefs })` TS template literals. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | — `not_applicable` | — | — | — | grafeo issues no hand-written Cypher/driver calls in user code — queries are compiled internally by the OGM from typed find/create/update/delete + select trees, so there is no user-authored query string to attribute. The graph node-label query attribution for the raw neo4j-driver is tracked on lang.jsts.driver.neo4j. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | — `not_applicable` | — | — | — | grafeo has no migration system — the GraphQL SDL schema IS the source of truth; there are no versioned migration files to parse. |
+| Migration schema ops | — `not_applicable` | — | — | — | no migration files — schema changes are made directly in the .graphql SDL. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | grafeo executes via the neo4j-driver session/transaction API under the hood; explicit transaction-function stamping is not yet modelled (shared with the sibling OGMs). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.ogm.grafeo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -39794,6 +39794,78 @@
       }
     },
     {
+      "id": "lang.jsts.ogm.grafeo",
+      "category": "orm",
+      "subcategory": "orm_mapper",
+      "language": "jsts",
+      "label": "grafeo-ogm (Neo4j TS OGM, GraphQL-SDL-driven)",
+      "capabilities": {
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable",
+            "notes": "graph DB OGM — no relational table/model concept; the SCOPE.Schema/node is the unit (see schema_extraction)."
+          },
+          "model_lifecycle_extraction": {
+            "status": "missing",
+            "issue": "3628"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/javascript/grafeo.go","internal/custom/javascript/grafeo_test.go"],
+            "issue": "3628-grafeo",
+            "notes": "grafeo-ogm declares its graph model in GraphQL SDL (standalone .graphql file or inline `new OGM({ typeDefs })`). Each `type|interface X @node` is extracted as a SCOPE.Schema/node keyed on its Neo4j label (the type name, or the first entry of @node(labels:[...])). `@relationshipProperties` edge-property types are correctly EXCLUDED (negative case, value-asserted). Regex over the balanced type body; partial (scalar field types not individually emitted as property entities).",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Relationships": {
+          "association_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/javascript/grafeo.go"],
+            "issue": "3628-grafeo",
+            "notes": "grafeo @relationship fields are extracted as SCOPE.Component/relationship entities carrying relation_type, direction, field_name, owner_node, target_type, relationship_properties (the @relationshipProperties edge type) and target_node (when resolved)."
+          },
+          "foreign_key_extraction": {
+            "status": "not_applicable",
+            "notes": "graph DB — no foreign-key concept"
+          },
+          "lazy_loading_recognition": {
+            "status": "not_applicable",
+            "notes": "graph DB — no lazy-loading concept"
+          },
+          "relationship_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/grafeo.go","internal/custom/javascript/grafeo_test.go"],
+            "issue": "3628-grafeo",
+            "notes": "grafeo-ogm @relationship fields (`field: T @relationship(type:\"REL\", direction: OUT|IN, properties:\"Props\")`) are extracted AND emitted as traversable GRAPH_RELATES graph-schema edges owner-node -\u003e target-node (mirrors the neomodel #3609 / neogma #3610 sibling OGMs and the Java SDN template #3663); the domain graph topology is a navigable subgraph rather than opaque string props. Full when the @relationship field's target GraphQL type resolves to a same-document @node type (value-asserting tests TestGrafeoGraphRelatesOutgoing: Book -GRAPH_RELATES(WRITTEN_BY,OUTGOING)-\u003e Author; direction IN -\u003e INCOMING; @node(labels:[...]) primary-label owner; self-edge). Cross-document / non-@node targets are honest-partial (kept as the target_type prop only, no edge). Works on both standalone .graphql schema files and inline `new OGM({ typeDefs })` TS template literals.",
+            "verified_at": "2026-06-02"
+          }
+        },
+        "Queries": {
+          "query_attribution": {
+            "status": "not_applicable",
+            "notes": "grafeo issues no hand-written Cypher/driver calls in user code — queries are compiled internally by the OGM from typed find/create/update/delete + select trees, so there is no user-authored query string to attribute. The graph node-label query attribution for the raw neo4j-driver is tracked on lang.jsts.driver.neo4j."
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable",
+            "notes": "grafeo has no migration system — the GraphQL SDL schema IS the source of truth; there are no versioned migration files to parse."
+          },
+          "migration_schema_ops": {
+            "status": "not_applicable",
+            "notes": "no migration files — schema changes are made directly in the .graphql SDL."
+          }
+        },
+        "Transactions": {
+          "transaction_function_stamping": {
+            "status": "missing",
+            "issue": "3628-transaction-function-stamping",
+            "notes": "grafeo executes via the neo4j-driver session/transaction API under the hood; explicit transaction-function stamping is not yet modelled (shared with the sibling OGMs)."
+          }
+        }
+      }
+    },
+    {
       "id": "lang.jsts.orm.drizzle",
       "category": "orm",
       "subcategory": "orm_mapper",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 155 · **Tools**: 111 · **Other**: 157
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 224 · **ORMs**: 156 · **Tools**: 111 · **Other**: 157
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 32 | 21 | 18 | 4 |
+| [JS/TS](by-language/jsts.md) | 32 | 21 | 19 | 4 |
 | [python](by-language/python.md) | 23 | 15 | 18 | 10 |
 | [java](by-language/java.md) | 22 | 10 | 15 | 4 |
 | [go](by-language/go.md) | 20 | 8 | 17 | 0 |
@@ -68,4 +68,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 224 frameworks · 111 tools · 155 ORMs · 157 other
+Total: 224 frameworks · 111 tools · 156 ORMs · 157 other

--- a/internal/custom/javascript/grafeo.go
+++ b/internal/custom/javascript/grafeo.go
@@ -1,0 +1,317 @@
+package javascript
+
+// grafeo.go — custom extractor for grafeo-ogm (Neo4j TS OGM) graph-schema
+// mappings.
+//
+// grafeo-ogm (https://github.com/neomodular/grafeo-ogm) is a type-safe
+// Object-Graph Mapper for Neo4j driven by GraphQL SDL. Unlike its sibling OGMs
+// neomodel (Python classes) and neogma (JS ModelFactory calls), grafeo declares
+// the entire graph model in GraphQL Schema Definition Language — either in a
+// standalone `.graphql` file or inline in a TS template literal passed as
+// `typeDefs` to `new OGM({ typeDefs, driver })`:
+//
+//	type Author @node implements Entity {
+//	  id: ID! @id @unique
+//	  name: String!
+//	  books: [Book!]! @relationship(type: "WRITTEN_BY", direction: IN, properties: "WrittenBy")
+//	}
+//
+//	type Book @node {
+//	  id: ID! @id @unique
+//	  title: String!
+//	  author: Author! @relationship(type: "WRITTEN_BY", direction: OUT)
+//	}
+//
+//	type WrittenBy @relationshipProperties {
+//	  role: String
+//	}
+//
+// A `type`/`interface` carrying the `@node` directive is the graph "node" (the
+// analogue of a SQL table); its Neo4j label is the type name (or the first
+// label in `@node(labels: [...])`). Each field carrying a `@relationship(type,
+// direction)` directive declares a typed, directed edge whose TARGET node is the
+// field's GraphQL type (the named, possibly list/non-null, output type).
+//
+// A `type ... @relationshipProperties` block is an EDGE-property type, NOT a
+// node, and is deliberately excluded (negative case) — matching grafeo's own
+// schema-parser which separates `nodes` from `relationshipProperties`.
+//
+// Extracted entities
+// ------------------
+//	SCOPE.Schema / node           — one per @node type/interface (label = label)
+//	SCOPE.Component / relationship — one per @relationship field
+//
+// GRAPH_RELATES topology (epic #3606, sibling #3609 neomodel / #3610 neogma)
+// -------------------------------------------------------------------------
+// Mirroring the neomodel/neogma/Java-SDN templates, every @relationship field
+// whose target GraphQL type resolves to a same-document @node type also emits a
+// traversable GRAPH_RELATES edge hanging off the owner node entity:
+//
+//	Book ──GRAPH_RELATES(rel_type=WRITTEN_BY, direction=OUTGOING)──▶ Class:Author
+//
+// direction OUT → OUTGOING, IN → INCOMING (grafeo has no NONE direction). The
+// ToID uses the "Class:<Label>" convention so the intra-repo resolver's byName
+// index links it to the target node entity (same convention as neomodel/neogma
+// and the Java SDN template). A relationship whose target GraphQL type is NOT a
+// declared @node type in the same document (e.g. a cross-file / external type)
+// is honest-partial: no edge is emitted, the topology stays only as the
+// `target_node` prop on the relationship Component.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_grafeo", &grafeoExtractor{})
+}
+
+type grafeoExtractor struct{}
+
+func (e *grafeoExtractor) Language() string { return "custom_js_grafeo" }
+
+var (
+	// Gate: the source must carry grafeo SDL signal — the @node directive plus a
+	// @relationship directive, OR an explicit grafeo-ogm import/marker. This keeps
+	// the extractor from firing on unrelated GraphQL SDL (e.g. Lighthouse) and on
+	// TS files that merely mention graphql.
+	grafeoNodeDirectiveRe = regexp.MustCompile(`@node\b`)
+	grafeoRelDirectiveRe  = regexp.MustCompile(`@relationship\b`)
+	grafeoMarkerRe        = regexp.MustCompile(`\bgrafeo-ogm\b|\bnew\s+OGM\s*\(`)
+
+	// type|interface <Name> ... { — the type-system definition header. Captures
+	// group1 = the keyword (type/interface), group2 = type name, group3 = the
+	// directives + implements clause up to the opening brace.
+	grafeoTypeHeaderRe = regexp.MustCompile(
+		`(?m)^[ \t]*(type|interface)\s+([A-Za-z_][\w]*)\b([^{]*)\{`)
+
+	// @node(labels: ["Entity", "User"]) — optional explicit label list. First
+	// label is the primary Neo4j node label.
+	grafeoNodeLabelsRe = regexp.MustCompile(`@node\s*\(\s*labels\s*:\s*\[\s*['"]([A-Za-z_][\w]*)['"]`)
+
+	// @relationshipProperties — marks an edge-property type (NOT a node).
+	grafeoRelPropsDirectiveRe = regexp.MustCompile(`@relationshipProperties\b`)
+
+	// A field line carrying a @relationship directive. Captures:
+	//   group1 field name
+	//   group2 the GraphQL output type (e.g. `[Book!]!`, `Author!`, `Author`)
+	// The @relationship(...) args are parsed separately (order-tolerant).
+	grafeoRelFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]*([A-Za-z_][\w]*)\s*:\s*([\[\]A-Za-z_!][\w!\[\] ]*?)\s+@relationship\b`)
+
+	grafeoRelTypeRe     = regexp.MustCompile(`@relationship\s*\([^)]*\btype\s*:\s*['"]([^'"]+)['"]`)
+	grafeoRelDirRe      = regexp.MustCompile(`@relationship\s*\([^)]*\bdirection\s*:\s*(OUT|IN)\b`)
+	grafeoRelPropsArgRe = regexp.MustCompile(`@relationship\s*\([^)]*\bproperties\s*:\s*['"]([^'"]+)['"]`)
+)
+
+// grafeoNamedType strips GraphQL list/non-null wrappers from a field output
+// type, returning the underlying named type: `[Book!]!` → `Book`, `Author!` →
+// `Author`, `Author` → `Author`.
+func grafeoNamedType(t string) string {
+	t = strings.TrimSpace(t)
+	t = strings.ReplaceAll(t, "[", "")
+	t = strings.ReplaceAll(t, "]", "")
+	t = strings.ReplaceAll(t, "!", "")
+	t = strings.TrimSpace(t)
+	// In case of trailing whitespace-separated tokens, keep the first.
+	if sp := strings.IndexAny(t, " \t"); sp >= 0 {
+		t = t[:sp]
+	}
+	return t
+}
+
+func (e *grafeoExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.grafeo_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "grafeo-ogm"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	switch lang {
+	case "typescript", "javascript", "graphql":
+	default:
+		return nil, nil
+	}
+
+	// Gate: require grafeo SDL signal. The schema must declare at least one
+	// @node and one @relationship (the OGM's defining surface), or carry an
+	// explicit grafeo-ogm marker alongside @node. This avoids firing on the
+	// Lighthouse PHP GraphQL schemas (which use @all/@paginate, never @node).
+	hasNode := grafeoNodeDirectiveRe.MatchString(src)
+	if !hasNode {
+		return nil, nil
+	}
+	if !grafeoRelDirectiveRe.MatchString(src) && !grafeoMarkerRe.MatchString(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) int {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return -1
+		}
+		seen[key] = true
+		out = append(out, ent)
+		return len(out) - 1
+	}
+
+	// --- Pass 1: discover @node types (the graph "nodes") ---
+	type nodeInfo struct {
+		typeName string // GraphQL type name (referenced by relationship targets)
+		label    string // Neo4j node label (typeName or @node(labels:[...]) first)
+		bodyOff  int    // byte offset of the '{' opening the type body
+		idx      int    // index into out of the node entity
+	}
+	var nodes []nodeInfo
+	// typeToLabel resolves a target GraphQL type name to its node label so the
+	// GRAPH_RELATES ToID uses the label, not the raw type name (they differ only
+	// when @node(labels:[...]) overrides). Only @node types are registered, so a
+	// relationship targeting a non-node (e.g. @relationshipProperties type or an
+	// external type) is honest-partial.
+	typeToLabel := make(map[string]string)
+
+	headers := grafeoTypeHeaderRe.FindAllStringSubmatchIndex(src, -1)
+	for _, h := range headers {
+		typeName := src[h[4]:h[5]]
+		directives := src[h[6]:h[7]]
+		braceOpen := h[1] - 1 // the matched '{'
+
+		// @relationshipProperties types are edge-property types, NOT nodes.
+		if grafeoRelPropsDirectiveRe.MatchString(directives) {
+			continue
+		}
+		// Only @node types/interfaces are graph nodes.
+		if !grafeoNodeDirectiveRe.MatchString(directives) {
+			continue
+		}
+
+		label := typeName
+		if lm := grafeoNodeLabelsRe.FindStringSubmatch(directives); lm != nil {
+			label = lm[1]
+		}
+
+		ent := makeEntity(label, "SCOPE.Schema", "node", file.Path, file.Language, lineOf(src, h[0]))
+		setProps(&ent, "framework", "grafeo-ogm",
+			"node_label", label,
+			"type_name", typeName,
+			"provenance", "INFERRED_FROM_NEO4J_GRAFEO_NODE")
+		idx := add(ent)
+		if idx >= 0 {
+			nodes = append(nodes, nodeInfo{typeName: typeName, label: label, bodyOff: braceOpen, idx: idx})
+			typeToLabel[typeName] = label
+		}
+	}
+
+	// --- Pass 2: relationships within each @node type body ---
+	for _, owner := range nodes {
+		body, _ := matchedBrace(src, owner.bodyOff)
+
+		for _, fm := range grafeoRelFieldRe.FindAllStringSubmatch(body, -1) {
+			fieldName := fm[1]
+			targetType := grafeoNamedType(fm[2])
+
+			// Locate the @relationship(...) args for this field. Scan from the
+			// field-name occurrence in the body.
+			relType := ""
+			direction := "OUTGOING"
+			relProps := ""
+
+			// Find the directive substring on this field's line.
+			fieldIdx := strings.Index(body, fm[0])
+			lineSeg := fm[0]
+			if fieldIdx >= 0 {
+				// Extend the segment to the end of the @relationship(...) args.
+				rest := body[fieldIdx:]
+				if end := strings.IndexByte(rest, '\n'); end >= 0 {
+					lineSeg = rest[:end]
+				} else {
+					lineSeg = rest
+				}
+			}
+			if tm := grafeoRelTypeRe.FindStringSubmatch(lineSeg); tm != nil {
+				relType = tm[1]
+			}
+			if dm := grafeoRelDirRe.FindStringSubmatch(lineSeg); dm != nil {
+				if dm[1] == "IN" {
+					direction = "INCOMING"
+				} else {
+					direction = "OUTGOING"
+				}
+			}
+			if pm := grafeoRelPropsArgRe.FindStringSubmatch(lineSeg); pm != nil {
+				relProps = pm[1]
+			}
+
+			name := relType
+			if name == "" {
+				name = fieldName
+			}
+			name = owner.label + "." + name
+
+			targetLabel := typeToLabel[targetType] // "" if target is not a @node type
+
+			relEnt := makeEntity(name, "SCOPE.Component", "relationship", file.Path, file.Language, lineOf(src, owner.bodyOff))
+			props := []string{
+				"framework", "grafeo-ogm",
+				"relation_type", relType,
+				"direction", direction,
+				"field_name", fieldName,
+				"owner_node", owner.label,
+				"target_type", targetType,
+				"provenance", "INFERRED_FROM_NEO4J_GRAFEO_RELATIONSHIP",
+			}
+			if relProps != "" {
+				props = append(props, "relationship_properties", relProps)
+			}
+			if targetLabel != "" {
+				props = append(props, "target_node", targetLabel)
+			}
+			setProps(&relEnt, props...)
+			add(relEnt)
+
+			// --- GRAPH_RELATES edge (epic #3606) ---
+			// Only when the target GraphQL type resolves to a same-document @node
+			// type — cross-file / non-node targets are honest-partial.
+			if targetLabel != "" {
+				edgeProps := map[string]string{
+					"framework":  "grafeo-ogm",
+					"rel_type":   relType,
+					"direction":  direction,
+					"field_name": fieldName,
+					"provenance": "INFERRED_FROM_NEO4J_GRAFEO_RELATIONSHIP",
+				}
+				if relProps != "" {
+					edgeProps["relationship_properties"] = relProps
+				}
+				out[owner.idx].Relationships = append(out[owner.idx].Relationships,
+					types.RelationshipRecord{
+						ToID:       "Class:" + targetLabel,
+						Kind:       string(types.RelationshipKindGraphRelates),
+						Properties: edgeProps,
+					})
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/javascript/grafeo_test.go
+++ b/internal/custom/javascript/grafeo_test.go
@@ -1,0 +1,365 @@
+package javascript_test
+
+// grafeo_test.go — tests for the custom_js_grafeo extractor (epic #3606).
+//
+// Covers grafeo-ogm (Neo4j TS OGM, GraphQL-SDL-driven) graph-schema extraction
+// and the headline GRAPH_RELATES topology edge: a @node type whose @relationship
+// field targets a same-document @node type emits a traversable
+// owner ──GRAPH_RELATES(rel_type,direction)──▶ Class:<TargetLabel> edge.
+// Mirrors the neomodel (#3609) / neogma (#3610) / Java SDN (#3663) templates.
+//
+// Fixtures use grafeo-ogm's ACTUAL SDL syntax, cited from the cloned repo:
+//   - examples/schema.graphql (Author/Book/Category/Review + WrittenBy @relationshipProperties)
+//   - README.md "Quick Start" Book/Author/Category schema
+//   - tests/schema-parser.spec.ts (@node(labels:[...]), @relationship direction)
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findGrafeoGraphRelates returns the GRAPH_RELATES edge from the node entity
+// labelled fromLabel to "Class:<toLabel>", or nil.
+func findGrafeoGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "node" && ents[i].Name == fromLabel) {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "Class:"+toLabel {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func grafeoHasNode(ents []types.EntityRecord, label string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "node" && e.Name == label {
+			return true
+		}
+	}
+	return false
+}
+
+func runGrafeo(t *testing.T, lang, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_grafeo")
+	if !ok {
+		t.Fatal("custom_js_grafeo not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "schema.graphql", Language: lang, Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// ---------------------------------------------------------------------------
+// node extraction — @node type label
+// ---------------------------------------------------------------------------
+
+// TestGrafeoNodesExtracted proves each @node type/interface becomes a
+// SCOPE.Schema/node, while a @relationshipProperties type is excluded (negative).
+// Fixture: examples/schema.graphql (verbatim shape).
+func TestGrafeoNodesExtracted(t *testing.T) {
+	src := `
+interface Entity @node {
+  id: ID! @id
+  name: String!
+}
+
+type Author @node implements Entity {
+  id: ID! @id @unique
+  name: String!
+  books: [Book!]! @relationship(type: "WRITTEN_BY", direction: IN, properties: "WrittenBy")
+}
+
+type Book @node {
+  id: ID! @id @unique
+  title: String!
+  author: Author! @relationship(type: "WRITTEN_BY", direction: OUT, properties: "WrittenBy")
+  categories: [Category!]! @relationship(type: "IN_CATEGORY", direction: OUT)
+}
+
+type Category @node {
+  id: ID! @id @unique
+  name: String!
+}
+
+type WrittenBy @relationshipProperties {
+  role: String
+  year: Int
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	for _, label := range []string{"Entity", "Author", "Book", "Category"} {
+		if !grafeoHasNode(ents, label) {
+			t.Errorf("expected @node entity %q, got %+v", label, ents)
+		}
+	}
+	// @relationshipProperties type must NOT become a node (negative).
+	if grafeoHasNode(ents, "WrittenBy") {
+		t.Errorf("@relationshipProperties type WrittenBy must NOT be a node, got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAPH_RELATES — the headline node→node topology edge
+// ---------------------------------------------------------------------------
+
+// TestGrafeoGraphRelatesOutgoing proves Book ─GRAPH_RELATES(WRITTEN_BY,OUTGOING)→
+// Class:Author for `author: Author! @relationship(type:"WRITTEN_BY", direction:OUT)`.
+// Fixture: examples/schema.graphql Book.author.
+func TestGrafeoGraphRelatesOutgoing(t *testing.T) {
+	src := `
+type Author @node {
+  id: ID! @id @unique
+  name: String!
+}
+
+type Book @node {
+  id: ID! @id @unique
+  title: String!
+  author: Author! @relationship(type: "WRITTEN_BY", direction: OUT, properties: "WrittenBy")
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	edge := findGrafeoGraphRelates(ents, "Book", "Author")
+	if edge == nil {
+		t.Fatalf("expected Book ─GRAPH_RELATES→ Class:Author edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "WRITTEN_BY" {
+		t.Errorf("rel_type: want WRITTEN_BY, got %q", edge.Properties["rel_type"])
+	}
+	if edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("direction: want OUTGOING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["field_name"] != "author" {
+		t.Errorf("field_name: want author, got %q", edge.Properties["field_name"])
+	}
+	if edge.Properties["framework"] != "grafeo-ogm" {
+		t.Errorf("framework: want grafeo-ogm, got %q", edge.Properties["framework"])
+	}
+	if edge.Properties["relationship_properties"] != "WrittenBy" {
+		t.Errorf("relationship_properties: want WrittenBy, got %q", edge.Properties["relationship_properties"])
+	}
+	// direction is a property, not endpoint-swapping: no reverse edge from this field.
+	if findGrafeoGraphRelates(ents, "Author", "Book") != nil {
+		t.Error("did not expect a reverse Author ─GRAPH_RELATES→ Book edge from Book.author")
+	}
+}
+
+// TestGrafeoGraphRelatesIncoming proves direction IN → INCOMING for
+// `books: [Book!]! @relationship(type:"WRITTEN_BY", direction:IN)`.
+// Fixture: examples/schema.graphql Author.books / README Author.books.
+func TestGrafeoGraphRelatesIncoming(t *testing.T) {
+	src := `
+type Book @node {
+  id: ID! @id @unique
+  title: String!
+}
+
+type Author @node {
+  id: ID! @id @unique
+  name: String!
+  books: [Book!]! @relationship(type: "WRITTEN_BY", direction: IN, properties: "WrittenBy")
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	edge := findGrafeoGraphRelates(ents, "Author", "Book")
+	if edge == nil {
+		t.Fatalf("expected Author ─GRAPH_RELATES→ Class:Book edge, got %+v", ents)
+	}
+	if edge.Properties["direction"] != "INCOMING" {
+		t.Errorf("direction: want INCOMING, got %q", edge.Properties["direction"])
+	}
+	if edge.Properties["rel_type"] != "WRITTEN_BY" {
+		t.Errorf("rel_type: want WRITTEN_BY, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestGrafeoInlineTypeDefs proves the extractor works on grafeo SDL embedded in
+// a TS template literal (the `new OGM({ typeDefs })` form), not just standalone
+// .graphql files. Fixture: README Quick Start + tests/tier1-features.spec.ts
+// (`typeDefs: \`type Book @node { ... }\“).
+func TestGrafeoInlineTypeDefs(t *testing.T) {
+	src := "import { OGM } from 'grafeo-ogm';\n" +
+		"const ogm = new OGM({\n" +
+		"  typeDefs: `\n" +
+		"    type Category @node {\n" +
+		"      id: ID! @id @unique\n" +
+		"      name: String!\n" +
+		"    }\n" +
+		"    type Book @node {\n" +
+		"      id: ID! @id @unique\n" +
+		"      categories: [Category!]! @relationship(type: \"IN_CATEGORY\", direction: OUT)\n" +
+		"    }\n" +
+		"  `,\n" +
+		"  driver,\n" +
+		"});\n"
+	ents := runGrafeo(t, "typescript", src)
+	if !grafeoHasNode(ents, "Book") || !grafeoHasNode(ents, "Category") {
+		t.Fatalf("expected Book + Category nodes from inline typeDefs, got %+v", ents)
+	}
+	edge := findGrafeoGraphRelates(ents, "Book", "Category")
+	if edge == nil {
+		t.Fatalf("expected Book ─GRAPH_RELATES→ Class:Category edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "IN_CATEGORY" || edge.Properties["direction"] != "OUTGOING" {
+		t.Errorf("want IN_CATEGORY/OUTGOING, got %q/%q",
+			edge.Properties["rel_type"], edge.Properties["direction"])
+	}
+}
+
+// TestGrafeoNodeLabelsDirective proves @node(labels: ["Entity","User"]) sets the
+// primary label to the first entry. Fixture: tests/schema-parser.spec.ts
+// "should parse @node labels directive".
+func TestGrafeoNodeLabelsDirective(t *testing.T) {
+	src := `
+type Permission @node {
+  id: ID! @id @unique
+}
+
+type User @node(labels: ["Entity", "User"]) {
+  id: ID! @id @unique
+  name: String!
+  permissions: [Permission!]! @relationship(type: "HAS_PERMISSION", direction: OUT)
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	if !grafeoHasNode(ents, "Entity") {
+		t.Fatalf("expected node labelled Entity (first @node label), got %+v", ents)
+	}
+	if grafeoHasNode(ents, "User") {
+		t.Errorf("primary label should be Entity, not the type name User; got %+v", ents)
+	}
+	// Owner label uses the primary label "Entity".
+	edge := findGrafeoGraphRelates(ents, "Entity", "Permission")
+	if edge == nil {
+		t.Fatalf("expected Entity ─GRAPH_RELATES→ Class:Permission edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "HAS_PERMISSION" {
+		t.Errorf("rel_type: want HAS_PERMISSION, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestGrafeoSelfEdge proves a self-referential relationship resolves:
+// User ─GRAPH_RELATES(FOLLOWS)→ User. Fixture: README "Social graphs" use case.
+func TestGrafeoSelfEdge(t *testing.T) {
+	src := `
+type User @node {
+  id: ID! @id @unique
+  follows: [User!]! @relationship(type: "FOLLOWS", direction: OUT)
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	edge := findGrafeoGraphRelates(ents, "User", "User")
+	if edge == nil {
+		t.Fatalf("expected User ─GRAPH_RELATES→ Class:User self-edge, got %+v", ents)
+	}
+	if edge.Properties["rel_type"] != "FOLLOWS" {
+		t.Errorf("rel_type: want FOLLOWS, got %q", edge.Properties["rel_type"])
+	}
+}
+
+// TestGrafeoCrossDocTargetDeferred proves honest-partial: a @relationship whose
+// target GraphQL type is NOT a @node in the same document emits no edge — the
+// topology stays only as the target_type prop on the relationship Component.
+func TestGrafeoCrossDocTargetDeferred(t *testing.T) {
+	src := `
+type Book @node {
+  id: ID! @id @unique
+  publisher: Publisher! @relationship(type: "PUBLISHED_BY", direction: OUT)
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("expected NO GRAPH_RELATES edge for non-node target, got %+v", r)
+			}
+		}
+	}
+	foundProp := false
+	for _, e := range ents {
+		if e.Subtype == "relationship" && e.Properties["target_type"] == "Publisher" {
+			foundProp = true
+			if _, ok := e.Properties["target_node"]; ok {
+				t.Errorf("target_node prop must be absent for deferred target, got %+v", e.Properties)
+			}
+		}
+	}
+	if !foundProp {
+		t.Errorf("expected relationship Component with target_type=Publisher prop, got %+v", ents)
+	}
+}
+
+// TestGrafeoPlainNodeNoEdge proves the negative: a @node with no @relationship
+// field emits no GRAPH_RELATES edge.
+func TestGrafeoPlainNodeNoEdge(t *testing.T) {
+	src := `
+type Category @node {
+  id: ID! @id @unique
+  name: String!
+}
+
+type Tag @node {
+  id: ID! @id @unique
+  label: String!
+}
+`
+	// No @relationship anywhere → gate requires @node + (@relationship OR marker).
+	// Add a marker so the gate fires but still no rel edges expected.
+	src = "import { OGM } from 'grafeo-ogm';\n" + src
+	ents := runGrafeo(t, "typescript", src)
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("plain @node must not emit GRAPH_RELATES, got %+v", r)
+			}
+		}
+	}
+}
+
+// TestGrafeoSkipsNonGrafeoSource proves the gate: a Lighthouse-style GraphQL
+// schema (server resolver directives, no @node) produces nothing.
+func TestGrafeoSkipsNonGrafeoSource(t *testing.T) {
+	src := `
+type Query {
+  users: [User!]! @all
+  user(id: ID! @eq): User @find
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+`
+	ents := runGrafeo(t, "graphql", src)
+	if len(ents) != 0 {
+		t.Errorf("grafeo extractor must not fire on Lighthouse (@all/@find) schema, got %+v", ents)
+	}
+}
+
+// TestGrafeoWrongLanguage proves the language gate: grafeo SDL content in a
+// non-{ts,js,graphql} language produces nothing.
+func TestGrafeoWrongLanguage(t *testing.T) {
+	src := `
+type Book @node {
+  author: Author! @relationship(type: "WRITTEN_BY", direction: OUT)
+}
+type Author @node { id: ID! @id }
+`
+	ents := runGrafeo(t, "python", src)
+	if len(ents) != 0 {
+		t.Errorf("grafeo extractor must not fire on language=python, got %+v", ents)
+	}
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -83,6 +83,21 @@ var customPrefixForLanguage = map[string]string{
 	"protobuf": "custom_cpp_",
 }
 
+// extraCustomPrefixesForLanguage lists ADDITIONAL custom-extractor prefixes a
+// language's files should be dispatched to, beyond its primary prefix in
+// customPrefixForLanguage. This covers files whose content is owned by more
+// than one language family.
+//
+// graphql: standalone `.graphql` SDL schema files are the model surface for the
+// grafeo-ogm Neo4j TS OGM (custom_js_grafeo), which declares its entire graph
+// model in GraphQL SDL — either inline in a TS template literal (handled by the
+// typescript/javascript primary prefix) or in a standalone `.graphql` file
+// (handled here). The grafeo extractor gates on a @node + @relationship signal,
+// so it no-ops on Lighthouse (custom_php_) GraphQL schemas and vice-versa.
+var extraCustomPrefixesForLanguage = map[string][]string{
+	"graphql": {"custom_js_"},
+}
+
 // CustomExtractorsFor returns all registered custom/framework extractors
 // whose registry key matches the custom-extractor prefix for the given
 // base language. The result is sorted by language key for deterministic
@@ -92,15 +107,26 @@ var customPrefixForLanguage = map[string]string{
 // or if no custom extractors are currently registered for that prefix.
 // Never returns nil.
 func CustomExtractorsFor(language string) []Extractor {
-	prefix, ok := customPrefixForLanguage[language]
-	if !ok {
+	prefixes := make([]string, 0, 2)
+	if prefix, ok := customPrefixForLanguage[language]; ok {
+		prefixes = append(prefixes, prefix)
+	}
+	prefixes = append(prefixes, extraCustomPrefixesForLanguage[language]...)
+	if len(prefixes) == 0 {
 		return []Extractor{}
 	}
 
+	keySet := make(map[string]bool)
 	var keys []string
 	for _, k := range extractor.List() {
-		if strings.HasPrefix(k, prefix) && len(k) > len(prefix) {
-			keys = append(keys, k)
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(k, prefix) && len(k) > len(prefix) {
+				if !keySet[k] {
+					keySet[k] = true
+					keys = append(keys, k)
+				}
+				break
+			}
 		}
 	}
 	sort.Strings(keys)


### PR DESCRIPTION
Closes #3850 (child of #3628, epic #3606).

## Audit: what is grafeo-ogm
[grafeo-ogm](https://github.com/neomodular/grafeo-ogm) is a **type-safe Object-Graph Mapper for Neo4j, written in TypeScript and driven by GraphQL SDL** (a community continuation of the deprecated `@neo4j/graphql-ogm`). It is the GraphQL-SDL **sibling** of the OGMs archigraph already supports: **neomodel** (Python classes, #3609) and **neogma** (JS ModelFactory, #3610).

Model/relationship API — declared entirely in GraphQL SDL, either a standalone `.graphql` file or inline in a TS template literal passed to `new OGM({ typeDefs, driver })`:

```graphql
type Author @node implements Entity {
  id: ID! @id @unique
  name: String!
  books: [Book!]! @relationship(type: "WRITTEN_BY", direction: IN, properties: "WrittenBy")
}
type Book @node {
  id: ID! @id @unique
  author: Author! @relationship(type: "WRITTEN_BY", direction: OUT, properties: "WrittenBy")
}
type WrittenBy @relationshipProperties { role: String }
```

- `type|interface X @node` (or `@node(labels: ["Primary", ...])`) → graph **node**; label = type name or first `labels` entry.
- `field: T @relationship(type: "REL", direction: OUT|IN, properties: "Props")` → typed, directed **edge**; target node = the field's GraphQL output type (list/non-null wrappers stripped).
- `type X @relationshipProperties` → edge-property type, **not** a node.

vs siblings: same node+directed-rel+rel-type+direction model, but the declaration lives in SDL directives rather than Python classes (neomodel) or JS config objects (neogma).

## Change
New extractor `custom_js_grafeo` (`internal/custom/javascript/grafeo.go`):
- `@node` type/interface → `SCOPE.Schema/node` (label + props).
- `@relationship` field → `SCOPE.Component/relationship` (relation_type, direction OUT→OUTGOING / IN→INCOMING, field_name, owner_node, target_type, relationship_properties, target_node).
- **GRAPH_RELATES** edge owner-node → `Class:<TargetLabel>` when the field's target GraphQL type resolves to a same-document `@node` type (mirrors neomodel/neogma/Java-SDN #3663). Cross-document / non-node targets honest-partial (`target_type` prop only, no edge).
- `@relationshipProperties` types correctly excluded (negative, value-asserted).
- Works on standalone `.graphql` files **and** inline `new OGM({ typeDefs })` TS template literals.

Dispatch (`internal/extractors/custom_dispatch.go`): registered under `custom_js_` (TS/JS) plus a new `graphql → custom_js_` secondary route (`extraCustomPrefixesForLanguage`) so standalone `.graphql` schema files reach it. Gated on a `@node` + `@relationship` signal, so it no-ops on Lighthouse PHP GraphQL schemas (and the existing custom_js extractors self-gate to ts/js, no-op on graphql).

## Node + GRAPH_RELATES edges asserted (value-asserting, real grafeo syntax)
Fixtures cite `examples/schema.graphql`, `README.md` Quick Start, `tests/schema-parser.spec.ts`:
- `Book ─GRAPH_RELATES(rel_type=WRITTEN_BY, direction=OUTGOING)→ Class:Author` (+ relationship_properties=WrittenBy, field_name=author).
- `Author ─GRAPH_RELATES(WRITTEN_BY, INCOMING)→ Class:Book` (direction IN).
- `@node(labels:["Entity","User"])` → owner label `Entity`; `Entity ─GRAPH_RELATES(HAS_PERMISSION)→ Class:Permission`.
- self-edge `User ─GRAPH_RELATES(FOLLOWS)→ Class:User`.
- inline `new OGM({ typeDefs })` TS template literal: `Book ─GRAPH_RELATES(IN_CATEGORY,OUTGOING)→ Class:Category`.
- Negatives: `@relationshipProperties` type not a node; cross-document target deferred (target_type prop, no edge); plain @node no edge; Lighthouse `@all/@find` schema → nothing; language=python → nothing.

## Coverage
New record `lang.jsts.ogm.grafeo` (mirrors `lang.jsts.driver.neo4j` / neogma):
- `relationship_extraction = full` (GRAPH_RELATES, value-asserted).
- `schema_extraction`, `association_extraction = partial` (cited; scalar field types not individually emitted).
- graph-DB cells `not_applicable` with notes (foreign_key, lazy_loading, model_extraction, query_attribution, migrations).
- `transaction_function_stamping = missing` (#3628, shared with sibling OGMs).

Docs regenerated; `coverage validate` 0 errors + `fmt --check` canonical; gofmt clean; go vet clean. Targeted tests green (`./internal/custom/... ./internal/extractors/... ./internal/types/ ./tools/coverage/`).

**DEPLOY-DEFERRED**: extractor + coverage only; live-daemon rebuild/reindex deferred to a coordinated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)