### PR TITLE
docs(coverage): cross-link db.<tech> infra records to per-language driver/ORM coverage

### DIFF
--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -14,6 +14,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🔴 `missing` | — | — | — | — |
 | Resource extraction | 🔴 `missing` | — | — | — | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.driver.cassandra`](./lang.csharp.driver.cassandra.md) | C# | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.elixir.driver.xandra`](./lang.elixir.driver.xandra.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.cassandra`](./lang.go.driver.cassandra.md) | go | driver | 2 partial, 3 missing, 6 n/a |
+| [`lang.java.orm.spring-data-cassandra`](./lang.java.orm.spring-data-cassandra.md) | java | orm | 6 missing, 5 n/a |
+| [`lang.jsts.driver.cassandra`](./lang.jsts.driver.cassandra.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.cassandra`](./lang.php.driver.cassandra.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.driver.cassandra`](./lang.python.driver.cassandra.md) | python | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.ruby.driver.cassandra`](./lang.ruby.driver.cassandra.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.rust.driver.cassandra`](./lang.rust.driver.cassandra.md) | rust | driver | 1 full, 3 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -14,6 +14,25 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/iac_sns_edges.go` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.driver.dynamodb`](./lang.csharp.driver.dynamodb.md) | C# | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.elixir.driver.dynamodb`](./lang.elixir.driver.dynamodb.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.dynamodb`](./lang.go.driver.dynamodb.md) | go | driver | 3 partial, 3 missing, 5 n/a |
+| [`lang.java.orm.dynamodb`](./lang.java.orm.dynamodb.md) | java | orm | 2 full, 1 partial, 3 missing, 5 n/a |
+| [`lang.jsts.driver.dynamodb`](./lang.jsts.driver.dynamodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.dynamodb`](./lang.php.driver.dynamodb.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.driver.dynamodb`](./lang.python.driver.dynamodb.md) | python | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.ruby.driver.dynamodb`](./lang.ruby.driver.dynamodb.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.rust.driver.dynamodb`](./lang.rust.driver.dynamodb.md) | rust | driver | 4 missing, 7 n/a |
+| [`lang.scala.orm.scanamo`](./lang.scala.orm.scanamo.md) | scala | orm | 1 full, 2 partial, 3 missing, 5 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.elasticsearch.md
+++ b/docs/coverage/detail/db.elasticsearch.md
@@ -14,6 +14,25 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.driver.elastic`](./lang.csharp.driver.elastic.md) | C# | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.elixir.driver.elastic`](./lang.elixir.driver.elastic.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.elastic`](./lang.go.driver.elastic.md) | go | driver | 4 partial, 3 missing, 4 n/a |
+| [`lang.java.orm.spring-data-elastic`](./lang.java.orm.spring-data-elastic.md) | java | orm | 6 missing, 5 n/a |
+| [`lang.jsts.driver.elastic`](./lang.jsts.driver.elastic.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.elastic`](./lang.php.driver.elastic.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.driver.elastic`](./lang.python.driver.elastic.md) | python | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.ruby.driver.elastic`](./lang.ruby.driver.elastic.md) | ruby | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.rust.driver.elastic`](./lang.rust.driver.elastic.md) | rust | driver | 4 missing, 7 n/a |
+| [`lang.scala.orm.elastic4s`](./lang.scala.orm.elastic4s.md) | scala | orm | 1 full, 2 partial, 3 missing, 5 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -14,6 +14,31 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.driver.mongocxx`](./lang.c-cpp.driver.mongocxx.md) | C/C++ | driver | 2 full, 1 partial, 3 missing, 5 n/a |
+| [`lang.csharp.driver.mongodb`](./lang.csharp.driver.mongodb.md) | C# | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.elixir.driver.mongodb`](./lang.elixir.driver.mongodb.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.mongodb`](./lang.go.driver.mongodb.md) | go | driver | 3 partial, 3 missing, 5 n/a |
+| [`lang.java.driver.mongodb`](./lang.java.driver.mongodb.md) | java | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.java.orm.spring-data-mongo`](./lang.java.orm.spring-data-mongo.md) | java | orm | 6 missing, 5 n/a |
+| [`lang.jsts.driver.mongodb`](./lang.jsts.driver.mongodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.jsts.orm.mongoose`](./lang.jsts.orm.mongoose.md) | JS/TS | orm | 3 full, 2 partial, 3 missing, 3 n/a |
+| [`lang.kotlin.orm.mongodb`](./lang.kotlin.orm.mongodb.md) | kotlin | orm | 2 full, 3 missing, 6 n/a |
+| [`lang.php.driver.mongodb`](./lang.php.driver.mongodb.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.driver.mongodb`](./lang.python.driver.mongodb.md) | python | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.orm.beanie`](./lang.python.orm.beanie.md) | python | orm | 5 partial, 4 missing, 2 n/a |
+| [`lang.python.orm.mongoengine`](./lang.python.orm.mongoengine.md) | python | orm | 5 partial, 4 missing, 2 n/a |
+| [`lang.ruby.driver.mongodb`](./lang.ruby.driver.mongodb.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.ruby.orm.mongoid`](./lang.ruby.orm.mongoid.md) | ruby | orm | 5 partial, 4 missing, 2 n/a |
+| [`lang.rust.driver.mongodb`](./lang.rust.driver.mongodb.md) | rust | driver | 1 full, 3 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -14,6 +14,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.driver.mysql-connector-cpp`](./lang.c-cpp.driver.mysql-connector-cpp.md) | C/C++ | driver | 3 full, 3 missing, 5 n/a |
+| [`lang.csharp.driver.mysql`](./lang.csharp.driver.mysql.md) | C# | driver | 4 missing, 7 n/a |
+| [`lang.elixir.driver.myxql`](./lang.elixir.driver.myxql.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.mysql`](./lang.go.driver.mysql.md) | go | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.jsts.driver.mysql`](./lang.jsts.driver.mysql.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.mysql`](./lang.php.driver.mysql.md) | php | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.python.driver.mysql`](./lang.python.driver.mysql.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.ruby.driver.mysql`](./lang.ruby.driver.mysql.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.rust.driver.mysql`](./lang.rust.driver.mysql.md) | rust | driver | 4 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -14,6 +14,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🔴 `missing` | — | — | — | — |
 | Resource extraction | 🔴 `missing` | — | — | — | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.driver.neo4j`](./lang.csharp.driver.neo4j.md) | C# | driver | 4 missing, 7 n/a |
+| [`lang.elixir.driver.neo4j`](./lang.elixir.driver.neo4j.md) | elixir | driver | 1 full, 2 partial, 3 missing, 5 n/a |
+| [`lang.go.driver.neo4j`](./lang.go.driver.neo4j.md) | go | driver | 1 full, 2 partial, 3 missing, 5 n/a |
+| [`lang.java.orm.neo4j`](./lang.java.orm.neo4j.md) | java | orm | 1 full, 3 partial, 4 missing, 3 n/a |
+| [`lang.jsts.driver.neo4j`](./lang.jsts.driver.neo4j.md) | JS/TS | driver | 2 full, 2 partial, 3 missing, 4 n/a |
+| [`lang.php.driver.neo4j`](./lang.php.driver.neo4j.md) | php | driver | 1 full, 2 partial, 3 missing, 5 n/a |
+| [`lang.python.driver.neo4j`](./lang.python.driver.neo4j.md) | python | driver | 1 full, 2 partial, 4 missing, 4 n/a |
+| [`lang.ruby.driver.neo4j`](./lang.ruby.driver.neo4j.md) | ruby | driver | 1 full, 2 partial, 4 missing, 4 n/a |
+| [`lang.rust.driver.neo4j`](./lang.rust.driver.neo4j.md) | rust | driver | 1 full, 2 partial, 3 missing, 5 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -14,6 +14,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.driver.libpqxx`](./lang.c-cpp.driver.libpqxx.md) | C/C++ | driver | 3 full, 3 missing, 5 n/a |
+| [`lang.csharp.driver.npgsql`](./lang.csharp.driver.npgsql.md) | C# | driver | 4 missing, 7 n/a |
+| [`lang.elixir.driver.postgrex`](./lang.elixir.driver.postgrex.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.orm.pgx`](./lang.go.orm.pgx.md) | go | orm | 1 full, 3 partial, 3 missing, 4 n/a |
+| [`lang.jsts.driver.postgres`](./lang.jsts.driver.postgres.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.postgres`](./lang.php.driver.postgres.md) | php | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.python.driver.postgres`](./lang.python.driver.postgres.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.ruby.driver.postgres`](./lang.ruby.driver.postgres.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.rust.driver.postgres`](./lang.rust.driver.postgres.md) | rust | driver | 4 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.redis.md
+++ b/docs/coverage/detail/db.redis.md
@@ -14,6 +14,25 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.driver.redis-plus-plus`](./lang.c-cpp.driver.redis-plus-plus.md) | C/C++ | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.csharp.driver.redis`](./lang.csharp.driver.redis.md) | C# | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.elixir.driver.redix`](./lang.elixir.driver.redix.md) | elixir | driver | 4 missing, 7 n/a |
+| [`lang.go.driver.redis`](./lang.go.driver.redis.md) | go | driver | 2 partial, 3 missing, 6 n/a |
+| [`lang.java.orm.spring-data-redis`](./lang.java.orm.spring-data-redis.md) | java | orm | 6 missing, 5 n/a |
+| [`lang.jsts.driver.redis`](./lang.jsts.driver.redis.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.redis`](./lang.php.driver.redis.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.python.driver.redis`](./lang.python.driver.redis.md) | python | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.ruby.driver.redis`](./lang.ruby.driver.redis.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.rust.driver.redis`](./lang.rust.driver.redis.md) | rust | driver | 1 full, 3 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -14,6 +14,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/sql` | — |
 
+## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.driver.sqlite`](./lang.csharp.driver.sqlite.md) | C# | driver | 4 missing, 7 n/a |
+| [`lang.elixir.orm.ecto-sqlite3`](./lang.elixir.orm.ecto-sqlite3.md) | elixir | orm | 6 full, 1 partial, 3 missing, 1 n/a |
+| [`lang.go.driver.sqlite`](./lang.go.driver.sqlite.md) | go | driver | 1 full, 3 partial, 3 missing, 4 n/a |
+| [`lang.jsts.driver.sqlite`](./lang.jsts.driver.sqlite.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.sqlite`](./lang.php.driver.sqlite.md) | php | driver | 1 partial, 4 missing, 6 n/a |
+| [`lang.python.driver.sqlite`](./lang.python.driver.sqlite.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.ruby.driver.sqlite`](./lang.ruby.driver.sqlite.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.rust.driver.sqlite`](./lang.rust.driver.sqlite.md) | rust | driver | 4 missing, 7 n/a |
+| [`lang.rust.orm.rusqlite`](./lang.rust.orm.rusqlite.md) | rust | orm | 1 full, 3 missing, 7 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.driver.mongodb.md
+++ b/docs/coverage/detail/lang.java.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.cassandra.md
+++ b/docs/coverage/detail/lang.jsts.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.elastic.md
+++ b/docs/coverage/detail/lang.jsts.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.mongodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.mysql.md
+++ b/docs/coverage/detail/lang.jsts.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.neo4j.md
+++ b/docs/coverage/detail/lang.jsts.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.postgres.md
+++ b/docs/coverage/detail/lang.jsts.driver.postgres.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.redis.md
+++ b/docs/coverage/detail/lang.jsts.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.driver.sqlite.md
+++ b/docs/coverage/detail/lang.jsts.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.mongodb.md
+++ b/docs/coverage/detail/lang.python.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.mongodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.redis`](./db.redis.md) infra record (Redis (keys)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
+## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
+which tracks datastore-level extraction for the same technology.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -264,6 +264,15 @@ type detailPageData struct {
 	Grouped           bool
 	FrameworkSpecific []frameworkSpecificView
 	TotalCells        int
+	// RelatedRecords is populated for `databases`-category infra records
+	// (db.<tech>): the per-language driver/ORM records that target the
+	// SAME datastore, each with a compact status digest. Empty (section
+	// omitted) for records with no related driver/ORM coverage.
+	RelatedRecords []relatedRecordDigest
+	// InfraRecord is populated for driver/ORM records: the
+	// `databases`-category infra record they target, rendered as a
+	// back-link. nil when the record targets no recognised datastore.
+	InfraRecord *relatedRecordDigest
 }
 
 // frameworkSpecificView is one free-form capability group rendered on a
@@ -829,6 +838,8 @@ func generate(reg *Registry, outRoot string) error {
 				Grouped:           view.Grouped,
 				FrameworkSpecific: fsViews,
 				TotalCells:        totalCells,
+				RelatedRecords:    relatedDriverORMRecords(rec, sortedRecs),
+				InfraRecord:       infraRecordFor(rec, sortedRecs),
 			}); err != nil {
 			return err
 		}

--- a/tools/coverage/related.go
+++ b/tools/coverage/related.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Cross-linking infra `databases`-category records to the per-language
+// driver/ORM records that target the SAME datastore (#3628 child).
+//
+// The honesty problem this solves: an infra record like `db.mongodb`
+// renders as a thin 2-cell page (resource_extraction + dependency_
+// attribution) that looks almost empty, even though the SAME technology
+// has rich code-level extraction spread across ~15 separate
+// `lang.*.{driver,orm}.*` records (mongoose, mongoengine, mongoid,
+// spring-data-mongo, the per-language native drivers, ...). The detail-
+// page generator renders each record in ISOLATION, so the infra page
+// never surfaces the real coverage and badly undersells it.
+//
+// We fix this in the GENERATOR (no extractor change): a curated alias
+// map associates each datastore with the id-substrings of the records
+// that genuinely target it, and the detail page grows a "Code-level
+// coverage" section (on the infra page) plus a back-link (on each
+// driver/ORM page).
+
+// datastoreAliases maps a `databases`-category record ID to the set of
+// id-substrings that identify the per-language driver/ORM records
+// targeting that SAME datastore.
+//
+// Honesty rules baked into this map:
+//
+//   - ODMs/OGMs rarely name their datastore, so they are listed
+//     explicitly: mongoose/mongoengine/mongoid/beanie/spring-data-mongo
+//     are MongoDB; neomodel/neogma/grafeo/activegraph/bolt-sips are
+//     Neo4j; spring-data-redis/ioredis/redix are Redis; xandra/scylla
+//     are Cassandra; elastic4s/nest are Elasticsearch; scanamo is
+//     DynamoDB; npgsql/postgrex/libpqxx/pgx are PostgreSQL; etc.
+//   - GENERAL-PURPOSE SQL ORMs/query-builders (gorm, prisma, sqlalchemy,
+//     hibernate, ecto, diesel, sequelize, knex, dapper, doctrine,
+//     eloquent, slick, ...) target MULTIPLE SQL stores and do NOT name a
+//     single one — linking them under postgres OR mysql OR sqlite would
+//     mis-attribute their coverage, so they are deliberately OMITTED.
+//     A db.postgres page only lists records that are unambiguously
+//     PostgreSQL (the pg drivers + Postgres-specific libraries).
+//   - Substrings match against the record ID's terminal token (the
+//     library slug), never against arbitrary substrings of the dotted
+//     path, so "redis" cannot accidentally match an unrelated id.
+//
+// A substring entry is matched against the record's terminal id segment
+// AND against the whole id; either hit associates the record. Keep this
+// map honest: only add a substring when the record genuinely targets the
+// datastore.
+var datastoreAliases = map[string][]string{
+	"db.mongodb": {
+		"mongodb", "mongo", "mongoose", "mongoengine", "mongoid",
+		"beanie", "spring-data-mongo", "mongocxx",
+	},
+	"db.neo4j": {
+		"neo4j", "neomodel", "neogma", "spring-data-neo4j", "grafeo",
+		"activegraph", "bolt-sips", "bolt_sips", "neo4rs",
+	},
+	"db.redis": {
+		"redis", "ioredis", "spring-data-redis", "redix", "predis",
+	},
+	"db.cassandra": {
+		"cassandra", "spring-data-cassandra", "scylla", "xandra",
+	},
+	"db.elasticsearch": {
+		"elasticsearch", "elastic", "elastic4s",
+	},
+	"db.dynamodb": {
+		"dynamodb", "scanamo",
+	},
+	"db.postgres": {
+		"postgres", "postgrex", "psycopg", "asyncpg", "npgsql",
+		"libpqxx", "pgx", "node-postgres",
+	},
+	"db.mysql": {
+		"mysql", "mariadb", "myxql", "mysql2", "mysql-connector",
+		"mysqlconnector", "pymysql", "mysqlclient", "go-sql-driver",
+	},
+	"db.sqlite": {
+		"sqlite", "rusqlite", "better-sqlite", "ecto-sqlite", "ecto_sqlite3",
+	},
+	"db.clickhouse": {
+		"clickhouse",
+	},
+	"db.snowflake": {
+		"snowflake",
+	},
+}
+
+// relatedRecordDigest is one related driver/ORM record rendered under
+// the infra page's "Code-level coverage" section, or the single infra
+// record back-linked from a driver/ORM page.
+type relatedRecordDigest struct {
+	ID       string // e.g. lang.jsts.orm.mongoose
+	Label    string // e.g. Mongoose
+	Language string // e.g. jsts
+	Kind     string // "driver" or "orm" (from the id), "" for infra
+	Digest   string // compact status digest, e.g. "3 full, 2 partial"
+}
+
+// terminalSegment returns the last dotted segment of a record ID
+// (the library slug), e.g. "mongoose" for "lang.jsts.orm.mongoose".
+func terminalSegment(id string) string {
+	if i := strings.LastIndex(id, "."); i >= 0 {
+		return id[i+1:]
+	}
+	return id
+}
+
+// recordKind extracts the driver/orm/odm classifier from a record ID
+// (the segment immediately before the terminal slug), e.g. "orm" for
+// "lang.jsts.orm.mongoose". Returns "" when the id has no such segment.
+func recordKind(id string) string {
+	parts := strings.Split(id, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	switch parts[len(parts)-2] {
+	case "driver", "orm", "odm":
+		return parts[len(parts)-2]
+	}
+	return ""
+}
+
+// matchesDatastore reports whether a driver/ORM record (by its ID)
+// targets the datastore identified by db (a `db.<tech>` infra id). The
+// match is against the record's terminal slug so an alias substring
+// never bleeds across unrelated dotted segments.
+func matchesDatastore(db, recID string) bool {
+	subs, ok := datastoreAliases[db]
+	if !ok {
+		return false
+	}
+	seg := terminalSegment(recID)
+	for _, s := range subs {
+		if strings.Contains(seg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// statusDigest renders a compact per-status digest for one record, e.g.
+// "3 full, 2 partial" or "5 partial" or "all not applicable". Counts are
+// taken over every capability cell on the record (canonical + framework-
+// specific). Statuses are listed in severity order (full, partial,
+// missing, not_applicable); zero-count statuses are omitted. An empty
+// record (no cells) renders "no cells".
+func statusDigest(rec Record) string {
+	caps := rec.AllCapabilitiesIncludingFrameworkSpecific()
+	if len(caps) == 0 {
+		return "no cells"
+	}
+	var full, partial, missing, na int
+	for _, c := range caps {
+		switch c.Status {
+		case StatusFull:
+			full++
+		case StatusPartial:
+			partial++
+		case StatusMissing:
+			missing++
+		case StatusNotApplicable:
+			na++
+		}
+	}
+	parts := make([]string, 0, 4)
+	if full > 0 {
+		parts = append(parts, fmt.Sprintf("%d full", full))
+	}
+	if partial > 0 {
+		parts = append(parts, fmt.Sprintf("%d partial", partial))
+	}
+	if missing > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing", missing))
+	}
+	if na > 0 {
+		parts = append(parts, fmt.Sprintf("%d n/a", na))
+	}
+	if len(parts) == 0 {
+		return "no cells"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// relatedDriverORMRecords returns the driver/ORM records that target the
+// same datastore as the given infra record (a `databases`-category
+// `db.<tech>` record), each with a compact status digest, sorted by
+// (language, id) for deterministic output. Returns nil when the record
+// is not a recognised infra record or has no related records — the
+// caller omits the section entirely in that case (never fabricates).
+func relatedDriverORMRecords(infra Record, all []Record) []relatedRecordDigest {
+	if infra.Category != "databases" {
+		return nil
+	}
+	if _, ok := datastoreAliases[infra.ID]; !ok {
+		return nil
+	}
+	out := make([]relatedRecordDigest, 0, 16)
+	for _, r := range all {
+		if r.ID == infra.ID {
+			continue
+		}
+		kind := recordKind(r.ID)
+		if kind == "" {
+			continue
+		}
+		if !matchesDatastore(infra.ID, r.ID) {
+			continue
+		}
+		out = append(out, relatedRecordDigest{
+			ID:       r.ID,
+			Label:    r.Label,
+			Language: r.Language,
+			Kind:     kind,
+			Digest:   statusDigest(r),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Language != out[j].Language {
+			return out[i].Language < out[j].Language
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// infraRecordFor returns the `databases`-category infra record that the
+// given driver/ORM record targets, or nil when there is none. A
+// driver/ORM record matches an infra record when the infra's alias map
+// associates it (the same association used by relatedDriverORMRecords,
+// kept symmetric). Returns nil for non-driver/ORM records.
+func infraRecordFor(rec Record, all []Record) *relatedRecordDigest {
+	if recordKind(rec.ID) == "" {
+		return nil
+	}
+	// Find the infra record whose alias set claims this record. There is
+	// at most one per datastore; iterate the infra records deterministically.
+	infraByID := map[string]Record{}
+	infraIDs := make([]string, 0, len(datastoreAliases))
+	for _, r := range all {
+		if r.Category == "databases" {
+			if _, ok := datastoreAliases[r.ID]; ok {
+				infraByID[r.ID] = r
+				infraIDs = append(infraIDs, r.ID)
+			}
+		}
+	}
+	sort.Strings(infraIDs)
+	for _, id := range infraIDs {
+		if matchesDatastore(id, rec.ID) {
+			r := infraByID[id]
+			return &relatedRecordDigest{
+				ID:       r.ID,
+				Label:    r.Label,
+				Language: r.Language,
+				Kind:     "",
+				Digest:   statusDigest(r),
+			}
+		}
+	}
+	return nil
+}

--- a/tools/coverage/related_test.go
+++ b/tools/coverage/related_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testRegistryWithDatastores builds a small registry exercising the
+// cross-link logic: a MongoDB infra record plus mongoose/mongoengine/go
+// driver records, a Neo4j infra record plus neomodel/neogma/grafeo
+// records, and a ClickHouse infra record with NO related driver/ORM
+// records (negative case).
+func testRegistryWithDatastores() *Registry {
+	return &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{ID: "db.mongodb", Category: "databases", Language: "multi", Label: "MongoDB (collections)",
+				Capabilities: map[string]Capability{
+					"resource_extraction":    {Status: StatusPartial},
+					"dependency_attribution": {Status: StatusPartial},
+				}},
+			{ID: "lang.jsts.orm.mongoose", Category: "orm", Language: "jsts", Label: "Mongoose",
+				Groups: map[string]map[string]Capability{
+					"Models":        {"a": {Status: StatusFull}, "b": {Status: StatusFull}, "c": {Status: StatusFull}},
+					"Relationships": {"d": {Status: StatusPartial}, "e": {Status: StatusPartial}},
+				}},
+			{ID: "lang.python.orm.mongoengine", Category: "orm", Language: "python", Label: "MongoEngine",
+				Capabilities: map[string]Capability{
+					"a": {Status: StatusPartial}, "b": {Status: StatusPartial},
+				}},
+			{ID: "lang.go.driver.mongodb", Category: "orm", Language: "go", Label: "mongo-go-driver",
+				Capabilities: map[string]Capability{
+					"a": {Status: StatusFull}, "b": {Status: StatusMissing},
+				}},
+			{ID: "db.neo4j", Category: "databases", Language: "multi", Label: "Neo4j",
+				Capabilities: map[string]Capability{
+					"resource_extraction":    {Status: StatusMissing},
+					"dependency_attribution": {Status: StatusMissing},
+				}},
+			{ID: "lang.python.orm.neomodel", Category: "orm", Language: "python", Label: "neomodel",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}}},
+			{ID: "lang.jsts.orm.neogma", Category: "orm", Language: "jsts", Label: "neogma",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+			{ID: "lang.java.orm.grafeo", Category: "orm", Language: "java", Label: "grafeo",
+				Capabilities: map[string]Capability{"a": {Status: StatusMissing}}},
+			// ClickHouse infra record with no related driver/ORM records.
+			{ID: "db.clickhouse", Category: "databases", Language: "multi", Label: "ClickHouse",
+				Capabilities: map[string]Capability{
+					"resource_extraction": {Status: StatusMissing},
+				}},
+			// A general-SQL ORM that must NOT be linked to any datastore.
+			{ID: "lang.go.orm.gorm", Category: "orm", Language: "go", Label: "GORM",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}}},
+		},
+	}
+}
+
+func TestStatusDigest(t *testing.T) {
+	rec := Record{Groups: map[string]map[string]Capability{
+		"G": {
+			"a": {Status: StatusFull}, "b": {Status: StatusFull}, "c": {Status: StatusFull},
+			"d": {Status: StatusPartial}, "e": {Status: StatusPartial},
+			"f": {Status: StatusMissing},
+			"g": {Status: StatusNotApplicable},
+		},
+	}}
+	got := statusDigest(rec)
+	want := "3 full, 2 partial, 1 missing, 1 n/a"
+	if got != want {
+		t.Fatalf("statusDigest = %q, want %q", got, want)
+	}
+	if got := statusDigest(Record{}); got != "no cells" {
+		t.Fatalf("empty statusDigest = %q, want %q", got, "no cells")
+	}
+}
+
+func TestRelatedDriverORMRecords(t *testing.T) {
+	reg := testRegistryWithDatastores()
+	mongo := reg.Records[0] // db.mongodb
+	related := relatedDriverORMRecords(mongo, reg.Records)
+	ids := make([]string, len(related))
+	for i, r := range related {
+		ids[i] = r.ID
+	}
+	for _, want := range []string{"lang.jsts.orm.mongoose", "lang.python.orm.mongoengine", "lang.go.driver.mongodb"} {
+		found := false
+		for _, id := range ids {
+			if id == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("db.mongodb related missing %s; got %v", want, ids)
+		}
+	}
+	// gorm (general SQL ORM) must never be linked under a datastore.
+	for _, id := range ids {
+		if strings.Contains(id, "gorm") {
+			t.Errorf("gorm wrongly linked under db.mongodb: %v", ids)
+		}
+	}
+	// Digest count assertion for mongoose (3 full + 2 partial).
+	for _, r := range related {
+		if r.ID == "lang.jsts.orm.mongoose" {
+			if r.Digest != "3 full, 2 partial" {
+				t.Errorf("mongoose digest = %q, want %q", r.Digest, "3 full, 2 partial")
+			}
+		}
+	}
+
+	// Neo4j: neomodel/neogma/grafeo all associate.
+	neo := reg.Records[4] // db.neo4j
+	neoRelated := relatedDriverORMRecords(neo, reg.Records)
+	neoIDs := map[string]bool{}
+	for _, r := range neoRelated {
+		neoIDs[r.ID] = true
+	}
+	for _, want := range []string{"lang.python.orm.neomodel", "lang.jsts.orm.neogma", "lang.java.orm.grafeo"} {
+		if !neoIDs[want] {
+			t.Errorf("db.neo4j related missing %s; got %v", want, neoIDs)
+		}
+	}
+
+	// ClickHouse: no related records → nil section.
+	ch := reg.Records[8]
+	if got := relatedDriverORMRecords(ch, reg.Records); got != nil {
+		t.Errorf("db.clickhouse should have no related records, got %v", got)
+	}
+}
+
+func TestInfraRecordFor(t *testing.T) {
+	reg := testRegistryWithDatastores()
+	mongoose := reg.Records[1]
+	infra := infraRecordFor(mongoose, reg.Records)
+	if infra == nil || infra.ID != "db.mongodb" {
+		t.Fatalf("mongoose infra = %v, want db.mongodb", infra)
+	}
+	// gorm (general SQL) targets no recognised datastore → nil.
+	gorm := reg.Records[9]
+	if infra := infraRecordFor(gorm, reg.Records); infra != nil {
+		t.Errorf("gorm should have no infra record, got %v", infra)
+	}
+	// An infra record itself is not a driver/ORM → nil.
+	if infra := infraRecordFor(reg.Records[0], reg.Records); infra != nil {
+		t.Errorf("db.mongodb should not back-link to an infra record, got %v", infra)
+	}
+}
+
+// TestGenRelatedRecordsSection is the end-to-end gen-level assertion:
+// db.mongodb's page lists the mongoose/mongoengine/go-driver records with
+// links and a digest; mongoose backlinks to db.mongodb; db.clickhouse has
+// no Code-level section (negative).
+func TestGenRelatedRecordsSection(t *testing.T) {
+	reg := testRegistryWithDatastores()
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	read := func(id string) string {
+		data, err := os.ReadFile(filepath.Join(root, "docs", "coverage", "detail", id+".md"))
+		if err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		return string(data)
+	}
+
+	mongo := read("db.mongodb")
+	if !strings.Contains(mongo, "## Code-level coverage") {
+		t.Errorf("db.mongodb missing Code-level coverage section:\n%s", mongo)
+	}
+	for _, want := range []string{
+		"[`lang.jsts.orm.mongoose`](./lang.jsts.orm.mongoose.md)",
+		"[`lang.python.orm.mongoengine`](./lang.python.orm.mongoengine.md)",
+		"[`lang.go.driver.mongodb`](./lang.go.driver.mongodb.md)",
+		"3 full, 2 partial", // mongoose digest
+	} {
+		if !strings.Contains(mongo, want) {
+			t.Errorf("db.mongodb missing %q:\n%s", want, mongo)
+		}
+	}
+	if strings.Contains(mongo, "gorm") {
+		t.Errorf("db.mongodb wrongly lists gorm:\n%s", mongo)
+	}
+
+	// neo4j lists neomodel/neogma/grafeo.
+	neo := read("db.neo4j")
+	for _, want := range []string{"neomodel", "neogma", "grafeo"} {
+		if !strings.Contains(neo, want) {
+			t.Errorf("db.neo4j missing %q:\n%s", want, neo)
+		}
+	}
+
+	// mongoose backlinks to db.mongodb.
+	mg := read("lang.jsts.orm.mongoose")
+	if !strings.Contains(mg, "## Datastore") {
+		t.Errorf("mongoose missing Datastore back-link section:\n%s", mg)
+	}
+	if !strings.Contains(mg, "[`db.mongodb`](./db.mongodb.md)") {
+		t.Errorf("mongoose missing db.mongodb back-link:\n%s", mg)
+	}
+
+	// clickhouse: no Code-level section (negative).
+	ch := read("db.clickhouse")
+	if strings.Contains(ch, "## Code-level coverage") {
+		t.Errorf("db.clickhouse should have no Code-level coverage section:\n%s", ch)
+	}
+
+	// gorm: no Datastore back-link (negative).
+	gorm := read("lang.go.orm.gorm")
+	if strings.Contains(gorm, "## Datastore") {
+		t.Errorf("gorm should have no Datastore back-link:\n%s", gorm)
+	}
+}
+
+// TestDatastoreAliasesNoCollision guards that no driver/ORM record in the
+// LIVE registry associates with more than one datastore — a collision
+// would mean an alias substring is too broad and mis-attributes coverage.
+func TestDatastoreAliasesNoCollision(t *testing.T) {
+	reg, err := loadRegistry(filepath.Join("..", "..", "docs", "coverage", "registry.json"))
+	if err != nil {
+		t.Skipf("live registry unavailable: %v", err)
+	}
+	for _, r := range reg.Records {
+		if recordKind(r.ID) == "" {
+			continue
+		}
+		var hits []string
+		for db := range datastoreAliases {
+			if matchesDatastore(db, r.ID) {
+				hits = append(hits, db)
+			}
+		}
+		if len(hits) > 1 {
+			t.Errorf("record %s matches multiple datastores %v (alias too broad)", r.ID, hits)
+		}
+	}
+}

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -36,6 +36,24 @@ Auto-generated. Back to [summary](../summary.md).
 | {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{renderIssue .Cap.Issue}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
+{{end}}{{if .RelatedRecords}}## Code-level coverage
+
+This infra record tracks datastore-level extraction (resources, dependency
+attribution). The deep, code-level coverage for this technology lives in the
+per-language driver/ORM records below — each one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+{{- range .RelatedRecords}}
+| [`{{.ID}}`](./{{.ID}}.md) | {{langDsp .Language}} | {{.Kind}} | {{.Digest}} |
+{{- end}}
+
+{{end}}{{if .InfraRecord}}## Datastore
+
+This driver/ORM record provides code-level coverage for the
+[`{{.InfraRecord.ID}}`](./{{.InfraRecord.ID}}.md) infra record ({{.InfraRecord.Label}}),
+which tracks datastore-level extraction for the same technology.
+
 {{end}}## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON


### PR DESCRIPTION
Closes #3852 (child of #3628).

## Honesty rationale
A `databases`-category infra record like `db.mongodb` renders as a thin 2-cell detail page (`resource_extraction` + `dependency_attribution`) that "looks almost empty" — even though the SAME technology has rich code-level extraction across ~15 separate `lang.*.{driver,orm}.*` records (mongoose 3-full/2-partial, mongoengine, mongoid, beanie, spring-data-mongo, the per-language native drivers). The detail-page generator rendered each record in ISOLATION, so the infra page never surfaced the real coverage and badly undersold every datastore (db.neo4j, db.redis, db.postgres, ...).

## Change (generator-only, deterministic)
- **"Code-level coverage"** section on each `db.<tech>` page: lists every related driver/ORM record with a one-line status digest (`3 full, 2 partial`) linking to its detail page. Omitted entirely when a datastore has no related records (db.clickhouse, db.snowflake) — never fabricated.
- **"Datastore"** back-link on each driver/ORM page → its `db.<tech>` infra record (symmetric).
- **Curated alias map** `db.<tech> -> [id-substrings]` (`related.go`): ODMs/OGMs rarely name their store, so mongoose/mongoengine/mongoid/beanie/spring-data-mongo→MongoDB; neomodel/neogma/grafeo/neo4rs/bolt-sips→Neo4j; spring-data-redis/ioredis/redix→Redis; xandra/scylla→Cassandra; elastic4s→Elasticsearch; scanamo→DynamoDB; npgsql/postgrex/libpqxx/pgx→Postgres; etc. **General-purpose SQL ORMs (gorm/prisma/sqlalchemy/hibernate/ecto/...) are deliberately OMITTED** — they target multiple SQL stores, so linking them under one would mis-attribute coverage. Substrings match the terminal id slug only, so an alias can't bleed across dotted segments.

## Cross-links rendered (examples)
- `db.mongodb` → mongoose (`3 full, 2 partial`), mongoengine, mongoid, beanie, spring-data-mongo, mongocxx, + go/python/jsts/java/csharp/ruby/rust/kotlin/php/elixir drivers (16 records).
- `db.neo4j` → neomodel (via python driver record), neogma (via jsts driver record), java orm.neo4j, + go/php/rust/elixir/csharp/ruby drivers (9 records).
- `lang.jsts.orm.mongoose` → back-links to `db.mongodb`.

## Validation
- `go test ./tools/coverage/` green (value-asserting tests: db.mongodb lists mongoose+mongoengine+go-driver with digests; db.neo4j lists neomodel/neogma/grafeo; db.clickhouse has no section; mongoose backlinks; gorm never linked; live-registry collision guard).
- `gen` idempotent (twice → identical); `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean. Registry unchanged.

DEPLOY-DEFERRED: docs-only generator change, no daemon/index impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)