### PR TITLE
docs(coverage): platform subcategory redesign + IaC summary discoverability

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -5,45 +5,69 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Dependency attribution | Env resolution | External service dependency | File parsing | Resource extraction | Shared data coupling | Translation key usage | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | — | — | ✅ | — | — | — | ✅ | |
-| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | — | — | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | — | ✅ | — | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | — | — | 🟢 | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | — | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | — | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Frontend route → component graph (SPA client routing)](../detail/frontend.routing.spa-route-component.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | — | 🟢 | — | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | — | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [i18n translation-key usage (USES_TRANSLATION)](../detail/analysis.localization.i18n-keys.md) | — | — | — | — | — | — | 🟢 | 🟢 | |
-| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | — | — | — | 🟢 | — | — | 🟢 | |
+
+
+## IaC / Provisioning
+
+| Language | Name | Dependency attribution | Resource extraction | Status | Notes |
+|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | ✅ | ✅ | |
+
+## Containers & Orchestration
+
+| Language | Name | Dependency attribution | Env resolution | Resource extraction | Status | Notes |
+|---|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | — | ✅ | ✅ | |
+
+## Config Files
+
+| Language | Name | Env resolution | File parsing | Status | Notes |
+|---|---|---|---|---|---|
+| [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [.env (names-only — values stripped at extraction boundary)](../detail/config.dotenv.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | ✅ | ✅ | |
+
+## Workflow / DAG & State Machines
+
+| Language | Name | Dependency attribution | Resource extraction | Status | Notes |
+|---|---|---|---|---|---|
+| [java](../by-language/java.md) | [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | 🟢 | 🟢 | |
+| [javascript](../by-language/javascript.md) | [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Apache Airflow (DAG topology)](../detail/infra.orchestration.airflow.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Argo Workflows (DAG topology)](../detail/infra.orchestration.argo.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Celery canvas (chain/group/chord topology)](../detail/infra.orchestration.celery-canvas.md) | 🟢 | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | 🟢 | 🟢 | |
+
+## App Topology & Integration
+
+| Language | Name | Dependency attribution | External service dependency | Resource extraction | Shared data coupling | Translation key usage | Status | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Frontend route → component graph (SPA client routing)](../detail/frontend.routing.spa-route-component.md) | 🟢 | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | 🟢 | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | 🟢 | — | — | — | 🟢 | |
+| [multi](../by-language/multi.md) | [i18n translation-key usage (USES_TRANSLATION)](../detail/analysis.localization.i18n-keys.md) | — | — | — | — | 🟢 | 🟢 | |

--- a/docs/coverage/by-category/validation.md
+++ b/docs/coverage/by-category/validation.md
@@ -5,5 +5,15 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Constraint extraction | Custom validator extraction | Nested model extraction | Schema extraction | Tests linkage | Type coercion recognition | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|
+
+
+## Validation
+
+| Language | Name | Testing | Other capabilities | Status | Notes |
+|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [nlohmann/json (C++)](../detail/lang.c-cpp.framework.nlohmann-json.md) | ✅ 1/1 | 🟡 3/5 | 🔴 | |
+| [java](../by-language/java.md) | [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | 🔴 0/1 | ✅ 4/4 | 🔴 | |
+| [python](../by-language/python.md) | [Pydantic](../detail/lang.python.validation.pydantic.md) | 🟢 1/1 | 🟢 5/5 | 🟢 | |
+| [python](../by-language/python.md) | [attrs](../detail/lang.python.validation.attrs.md) | 🟢 1/1 | 🟢 5/5 | 🟢 | |
+| [python](../by-language/python.md) | [marshmallow](../detail/lang.python.validation.marshmallow.md) | 🟢 1/1 | 🟢 5/5 | 🟢 | |
+| [rust](../by-language/rust.md) | [validator](../detail/lang.rust.validation.validator.md) | 🟢 1/1 | ✅ 4/4 | 🟢 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -117,9 +117,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Category | Status | Notes |
 |---|---|---|---|
-| [.properties (application.properties)](../detail/config.properties.md) | [platform](../by-category/platform.md) | ✅ | |
 | [Auth policy resolver (Java/Kotlin — Phase 1 of #1942)](../detail/security.auth-java.md) | [security](../by-category/security.md) | ✅ | |
-| [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | [platform](../by-category/platform.md) | 🟢 | |
+
+### Config Files
+
+| Name | Env resolution | File parsing | Notes |
+|---|---|---|---|
+| [.properties (application.properties)](../detail/config.properties.md) | — | ✅ | |
+
+
+### Workflow / DAG & State Machines
+
+| Name | Dependency attribution | Resource extraction | Notes |
+|---|---|---|---|
+| [Spring StateMachine (FSM topology)](../detail/infra.state-machine.spring-statemachine.md) | 🟢 | 🟢 | |
+
 
 ### Validation
 

--- a/docs/coverage/by-language/javascript.md
+++ b/docs/coverage/by-language/javascript.md
@@ -21,6 +21,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
+
+### Workflow / DAG & State Machines
+
+| Name | Dependency attribution | Resource extraction | Notes |
 |---|---|---|---|
-| [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | [platform](../by-category/platform.md) | 🟢 | |
+| [XState (FSM topology)](../detail/infra.state-machine.xstate.md) | 🟢 | 🟢 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -156,4 +156,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [tsconfig.json](../detail/config.tsconfig.md) | [platform](../by-category/platform.md) | ✅ | |
+
+### Config Files
+
+| Name | Env resolution | File parsing | Notes |
+|---|---|---|---|
+| [tsconfig.json](../detail/config.tsconfig.md) | — | ✅ | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -120,7 +120,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | [platform](../by-category/platform.md) | 🟢 | |
+
+### Workflow / DAG & State Machines
+
+| Name | Dependency attribution | Resource extraction | Notes |
+|---|---|---|---|
+| [Python transitions (FSM topology)](../detail/infra.state-machine.python-transitions.md) | 🟢 | 🟢 | |
+
 
 ### Validation
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -78,7 +78,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [Rails ActionCable](../detail/msg.actioncable.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [Resque (Ruby task queue)](../detail/msg.resque.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | [platform](../by-category/platform.md) | 🟢 | |
 | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
 | [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
 | [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Workflow / DAG & State Machines
+
+| Name | Dependency attribution | Resource extraction | Notes |
+|---|---|---|---|
+| [Ruby AASM (FSM topology)](../detail/infra.state-machine.aasm.md) | 🟢 | 🟢 | |

--- a/docs/coverage/detail/analysis.architecture.shared-db-coupling.md
+++ b/docs/coverage/detail/analysis.architecture.shared-db-coupling.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/analysis.architecture.structural-coupling.md
+++ b/docs/coverage/detail/analysis.architecture.structural-coupling.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/analysis.integration.third-party-sdk.md
+++ b/docs/coverage/detail/analysis.integration.third-party-sdk.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/analysis.localization.i18n-keys.md
+++ b/docs/coverage/detail/analysis.localization.i18n-keys.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.docker-compose.md
+++ b/docs/coverage/detail/config.docker-compose.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.dotenv.md
+++ b/docs/coverage/detail/config.dotenv.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/config.ini.md
+++ b/docs/coverage/detail/config.ini.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.properties.md
+++ b/docs/coverage/detail/config.properties.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.toml.md
+++ b/docs/coverage/detail/config.toml.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.tsconfig.md
+++ b/docs/coverage/detail/config.tsconfig.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/config.yaml.md
+++ b/docs/coverage/detail/config.yaml.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Config Files
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/frontend.routing.spa-route-component.md
+++ b/docs/coverage/detail/frontend.routing.spa-route-component.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.container.docker-compose.md
+++ b/docs/coverage/detail/infra.container.docker-compose.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Containers & Orchestration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.container.dockerfile.md
+++ b/docs/coverage/detail/infra.container.dockerfile.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Containers & Orchestration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.container.helm.md
+++ b/docs/coverage/detail/infra.container.helm.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Containers & Orchestration
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Containers & Orchestration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.container.kustomize.md
+++ b/docs/coverage/detail/infra.container.kustomize.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Containers & Orchestration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.deployment.request-topology.md
+++ b/docs/coverage/detail/infra.deployment.request-topology.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.gateway.api-routing.md
+++ b/docs/coverage/detail/infra.gateway.api-routing.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.ansible.md
+++ b/docs/coverage/detail/infra.iac.ansible.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.bicep.md
+++ b/docs/coverage/detail/infra.iac.bicep.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.cdk.md
+++ b/docs/coverage/detail/infra.iac.cdk.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.cloudformation.md
+++ b/docs/coverage/detail/infra.iac.cloudformation.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.opentofu.md
+++ b/docs/coverage/detail/infra.iac.opentofu.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.pulumi.md
+++ b/docs/coverage/detail/infra.iac.pulumi.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.serverless-framework.md
+++ b/docs/coverage/detail/infra.iac.serverless-framework.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.iac.terraform.md
+++ b/docs/coverage/detail/infra.iac.terraform.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.orchestration.airflow.md
+++ b/docs/coverage/detail/infra.orchestration.airflow.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.orchestration.argo.md
+++ b/docs/coverage/detail/infra.orchestration.argo.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.orchestration.celery-canvas.md
+++ b/docs/coverage/detail/infra.orchestration.celery-canvas.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.aws-cdk.md
+++ b/docs/coverage/detail/infra.resource.aws-cdk.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.cloudformation.md
+++ b/docs/coverage/detail/infra.resource.cloudformation.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.helm.md
+++ b/docs/coverage/detail/infra.resource.helm.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.kubernetes.md
+++ b/docs/coverage/detail/infra.resource.kubernetes.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.pulumi.md
+++ b/docs/coverage/detail/infra.resource.pulumi.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/infra.resource.terraform.md
+++ b/docs/coverage/detail/infra.resource.terraform.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** App Topology & Integration
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.state-machine.aasm.md
+++ b/docs/coverage/detail/infra.state-machine.aasm.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.state-machine.python-transitions.md
+++ b/docs/coverage/detail/infra.state-machine.python-transitions.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.state-machine.spring-statemachine.md
+++ b/docs/coverage/detail/infra.state-machine.spring-statemachine.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/infra.state-machine.xstate.md
+++ b/docs/coverage/detail/infra.state-machine.xstate.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** Workflow / DAG & State Machines
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4,6 +4,7 @@
     {
       "id": "analysis.architecture.shared-db-coupling",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Shared-database cross-service coupling (SHARES_DATA)",
       "capabilities": {
@@ -18,6 +19,7 @@
     {
       "id": "analysis.architecture.structural-coupling",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Structural coupling metrics (Ca/Ce/instability)",
       "capabilities": {
@@ -46,6 +48,7 @@
     {
       "id": "analysis.integration.third-party-sdk",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Third-party SDK service dependencies (DEPENDS_ON_SERVICE)",
       "capabilities": {
@@ -61,6 +64,7 @@
     {
       "id": "analysis.localization.i18n-keys",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "i18n translation-key usage (USES_TRANSLATION)",
       "capabilities": {
@@ -991,6 +995,7 @@
     {
       "id": "config.docker-compose",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "multi",
       "label": "docker-compose.yml",
       "capabilities": {
@@ -1004,6 +1009,7 @@
     {
       "id": "config.dotenv",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "multi",
       "label": ".env (names-only — values stripped at extraction boundary)",
       "capabilities": {
@@ -1048,6 +1054,7 @@
     {
       "id": "config.ini",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "multi",
       "label": ".ini / setup.cfg / flake8 / mypy / pytest.ini",
       "capabilities": {
@@ -1072,6 +1079,7 @@
     {
       "id": "config.properties",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "java",
       "label": ".properties (application.properties)",
       "capabilities": {
@@ -1085,6 +1093,7 @@
     {
       "id": "config.toml",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "multi",
       "label": ".toml",
       "capabilities": {
@@ -1098,6 +1107,7 @@
     {
       "id": "config.tsconfig",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "jsts",
       "label": "tsconfig.json",
       "capabilities": {
@@ -1112,6 +1122,7 @@
     {
       "id": "config.yaml",
       "category": "platform",
+      "subcategory": "config_files",
       "language": "multi",
       "label": ".yaml / .yml",
       "capabilities": {
@@ -1327,6 +1338,7 @@
     {
       "id": "frontend.routing.spa-route-component",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Frontend route → component graph (SPA client routing)",
       "capabilities": {
@@ -1347,6 +1359,7 @@
     {
       "id": "infra.container.docker-compose",
       "category": "platform",
+      "subcategory": "container_orchestration",
       "language": "multi",
       "label": "docker-compose.yml",
       "capabilities": {
@@ -1365,6 +1378,7 @@
     {
       "id": "infra.container.dockerfile",
       "category": "platform",
+      "subcategory": "container_orchestration",
       "language": "multi",
       "label": "Dockerfile",
       "capabilities": {
@@ -1383,6 +1397,7 @@
     {
       "id": "infra.container.helm",
       "category": "platform",
+      "subcategory": "container_orchestration",
       "language": "multi",
       "label": "Helm charts",
       "capabilities": {
@@ -1407,6 +1422,7 @@
     {
       "id": "infra.container.kubernetes",
       "category": "platform",
+      "subcategory": "container_orchestration",
       "language": "multi",
       "label": "Kubernetes manifests",
       "capabilities": {
@@ -1427,6 +1443,7 @@
     {
       "id": "infra.container.kustomize",
       "category": "platform",
+      "subcategory": "container_orchestration",
       "language": "multi",
       "label": "Kustomize",
       "capabilities": {
@@ -1445,6 +1462,7 @@
     {
       "id": "infra.deployment.request-topology",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Reverse-proxy / gateway request topology",
       "capabilities": {
@@ -1465,6 +1483,7 @@
     {
       "id": "infra.gateway.api-routing",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "API-gateway route topology (application frameworks)",
       "capabilities": {
@@ -1486,6 +1505,7 @@
     {
       "id": "infra.iac.ansible",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "Ansible (playbooks)",
       "capabilities": {
@@ -1504,6 +1524,7 @@
     {
       "id": "infra.iac.bicep",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "Azure Bicep",
       "capabilities": {
@@ -1524,6 +1545,7 @@
     {
       "id": "infra.iac.cdk",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "AWS CDK",
       "capabilities": {
@@ -1546,6 +1568,7 @@
     {
       "id": "infra.iac.cloudformation",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "AWS CloudFormation",
       "capabilities": {
@@ -1564,6 +1587,7 @@
     {
       "id": "infra.iac.opentofu",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "OpenTofu (HCL)",
       "capabilities": {
@@ -1584,6 +1608,7 @@
     {
       "id": "infra.iac.pulumi",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "Pulumi",
       "capabilities": {
@@ -1606,6 +1631,7 @@
     {
       "id": "infra.iac.serverless-framework",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "Serverless Framework",
       "capabilities": {
@@ -1624,6 +1650,7 @@
     {
       "id": "infra.iac.terraform",
       "category": "platform",
+      "subcategory": "iac_provisioning",
       "language": "multi",
       "label": "Terraform (HCL)",
       "capabilities": {
@@ -1815,6 +1842,7 @@
     {
       "id": "infra.orchestration.airflow",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "multi",
       "label": "Apache Airflow (DAG topology)",
       "capabilities": {
@@ -1835,6 +1863,7 @@
     {
       "id": "infra.orchestration.argo",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "multi",
       "label": "Argo Workflows (DAG topology)",
       "capabilities": {
@@ -1855,6 +1884,7 @@
     {
       "id": "infra.orchestration.celery-canvas",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "multi",
       "label": "Celery canvas (chain/group/chord topology)",
       "capabilities": {
@@ -1875,6 +1905,7 @@
     {
       "id": "infra.resource.aws-cdk",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "AWS CDK",
       "capabilities": {
@@ -1890,6 +1921,7 @@
     {
       "id": "infra.resource.cloudformation",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "AWS CloudFormation",
       "capabilities": {
@@ -1909,6 +1941,7 @@
     {
       "id": "infra.resource.helm",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Helm charts",
       "capabilities": {
@@ -1922,6 +1955,7 @@
     {
       "id": "infra.resource.kubernetes",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Kubernetes manifests",
       "capabilities": {
@@ -1935,6 +1969,7 @@
     {
       "id": "infra.resource.pulumi",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Pulumi",
       "capabilities": {
@@ -1950,6 +1985,7 @@
     {
       "id": "infra.resource.terraform",
       "category": "platform",
+      "subcategory": "app_topology",
       "language": "multi",
       "label": "Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint",
       "capabilities": {
@@ -1969,6 +2005,7 @@
     {
       "id": "infra.state-machine.aasm",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "ruby",
       "label": "Ruby AASM (FSM topology)",
       "capabilities": {
@@ -1991,6 +2028,7 @@
     {
       "id": "infra.state-machine.python-transitions",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "python",
       "label": "Python transitions (FSM topology)",
       "capabilities": {
@@ -2013,6 +2051,7 @@
     {
       "id": "infra.state-machine.spring-statemachine",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "java",
       "label": "Spring StateMachine (FSM topology)",
       "capabilities": {
@@ -2035,6 +2074,7 @@
     {
       "id": "infra.state-machine.xstate",
       "category": "platform",
+      "subcategory": "workflow_dag",
       "language": "javascript",
       "label": "XState (FSM topology)",
       "capabilities": {

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -42,6 +42,18 @@
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
 | **Total** | 115 | 43 | 45 | 27 |
 
+### Platform subcategories
+
+The [Platform / k8s](by-category/platform.md) category splits into the lanes below. Infrastructure-as-Code (Terraform, OpenTofu, Pulumi, AWS CDK, CloudFormation, Bicep, Serverless) lives under **IaC / Provisioning**.
+
+| Lane | Records | Tools |
+|---|---:|---|
+| [IaC / Provisioning](by-category/platform.md#iac--provisioning) | 8 | AWS CDK, AWS CloudFormation, Ansible, Azure Bicep, … |
+| [Containers & Orchestration](by-category/platform.md#containers--orchestration) | 5 | Dockerfile, Helm charts, Kubernetes manifests, Kustomize, … |
+| [Config Files](by-category/platform.md#config-files) | 7 | .env, .ini, .properties, .toml, … |
+| [Workflow / DAG & State Machines](by-category/platform.md#workflow--dag--state-machines) | 7 | Apache Airflow, Argo Workflows, Celery canvas, Python transitions, … |
+| [App Topology & Integration](by-category/platform.md#app-topology--integration) | 13 | API-gateway route topology, AWS CDK, AWS CloudFormation, Frontend route, … |
+
 ## Languages with extractor support, no records yet
 
 (archigraph has tree-sitter / extractor coverage for these but no framework/ORM/tool records tracked — contribute via `go run ./tools/coverage add`)

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -66,6 +66,7 @@ categories:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
     capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency, translation_key_usage]
+    subcategory_order: [iac_provisioning, container_orchestration, config_files, workflow_dag, app_topology]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection, cors_policy]
   protocol:
@@ -631,3 +632,58 @@ subcategories:
         keys: [type_coercion_recognition]
       - name: Testing
         keys: [tests_linkage]
+
+  # Platform subcategories (#3628 child). The platform category was a
+  # grab-bag rendering one 7-wide union pivot in which most cells were
+  # "—". These lanes carve it into coherent groups whose per-capability
+  # column sets only include the capabilities the lane's records actually
+  # carry, so each pivot is dense. The iac vs resource-graph duplicate-
+  # looking pairs (AWS CDK, Helm, Kubernetes, CloudFormation, Pulumi —
+  # an infra.iac.* declarative record + an infra.resource.* attribution
+  # record) are split across iac_provisioning vs app_topology so they no
+  # longer sit adjacent as apparent duplicates. No group taxonomy: these
+  # lanes render per-capability columns (the union machinery's don't-
+  # strand guard is N/A — every declared column is used by ≥1 record).
+  iac_provisioning:
+    display: "IaC / Provisioning"
+    parent_category: platform
+    capabilities:
+      - resource_extraction
+      - dependency_attribution
+    groups: []
+
+  container_orchestration:
+    display: "Containers & Orchestration"
+    parent_category: platform
+    capabilities:
+      - resource_extraction
+      - dependency_attribution
+      - env_resolution
+    groups: []
+
+  config_files:
+    display: "Config Files"
+    parent_category: platform
+    capabilities:
+      - file_parsing
+      - env_resolution
+    groups: []
+
+  workflow_dag:
+    display: "Workflow / DAG & State Machines"
+    parent_category: platform
+    capabilities:
+      - resource_extraction
+      - dependency_attribution
+    groups: []
+
+  app_topology:
+    display: "App Topology & Integration"
+    parent_category: platform
+    capabilities:
+      - resource_extraction
+      - dependency_attribution
+      - shared_data_coupling
+      - external_service_dependency
+      - translation_key_usage
+    groups: []

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -124,6 +124,23 @@ type placeholderLanguage struct {
 	Display string
 }
 
+// platformSubcatRow is one entry in the summary's "Platform subcategories"
+// discoverability section (#3628 child). The platform category is a
+// cross-cutting grab-bag whose internal lanes (IaC / Provisioning,
+// Containers & Orchestration, Config Files, ...) were previously invisible
+// from summary.md — a user scanning the summary could not tell that
+// Terraform / Pulumi / CDK / CloudFormation coverage existed without
+// opening by-category/platform.md. This row surfaces each lane by display
+// heading, its record count, and a short representative tool list so IaC
+// (and the other lanes) are named and discoverable. Anchor links into the
+// per-subcategory section heading on the platform by-category page.
+type platformSubcatRow struct {
+	Heading string // subcategory display heading (e.g. "IaC / Provisioning")
+	Anchor  string // GitHub-style heading anchor on by-category/platform.md
+	Records int
+	Tools   string // comma-joined sample of record labels, truncated
+}
+
 // bucketSection is one rendered section on a by-language page. When a
 // bucket contains records with subcategories the section is split into
 // Subsections (one per subcategory, ordered by subcategoryOrder) and a
@@ -164,19 +181,20 @@ type subSection struct {
 // ActiveLanguages and PlaceholderLanguages totals power the headline
 // banner ("16 active · 22 placeholder").
 type summaryData struct {
-	Marker            string
-	TotalLanguages    int
-	ActiveLanguages   int
-	PlaceholderCount  int
-	TotalFrameworks   int
-	TotalTools        int
-	TotalORMs         int
-	TotalOther        int
-	ActiveRows        []pivotRow
-	CrossCutting      []crossCuttingRow
-	CrossCuttingTotal crossCuttingRow
-	EmptyCrossCutting []crossCuttingRow
-	PlaceholderLangs  []placeholderLanguage
+	Marker                string
+	TotalLanguages        int
+	ActiveLanguages       int
+	PlaceholderCount      int
+	TotalFrameworks       int
+	TotalTools            int
+	TotalORMs             int
+	TotalOther            int
+	ActiveRows            []pivotRow
+	CrossCutting          []crossCuttingRow
+	CrossCuttingTotal     crossCuttingRow
+	EmptyCrossCutting     []crossCuttingRow
+	PlaceholderLangs      []placeholderLanguage
+	PlatformSubcategories []platformSubcatRow
 }
 
 // languagePageData feeds by-language/<lang>.md.tmpl.
@@ -658,6 +676,12 @@ func generate(reg *Registry, outRoot string) error {
 	// "tracked but no records" section instead (omitted when empty).
 	activeCC, emptyCC, ccTotal := buildCrossCuttingRows(byCat)
 
+	// Platform subcategory discoverability rows (#3628 child): surface
+	// IaC / Provisioning, Containers, Config Files, ... by name in the
+	// summary so a reader sees Terraform / Pulumi / CDK exists without
+	// opening the by-category page.
+	platformSubcats := buildPlatformSubcatRows(byCat)
+
 	// Extractor-supported but record-free languages form the placeholder
 	// table at the bottom. Sorted by display name for human scanability.
 	supported := SupportedLanguages(outRoot)
@@ -677,19 +701,20 @@ func generate(reg *Registry, outRoot string) error {
 
 	activeLangCount := len(activeRows)
 	if err := renderToFile(tmpls, "summary.md.tmpl", filepath.Join(root, "summary.md"), summaryData{
-		Marker:            doNotEditMarker,
-		TotalLanguages:    activeLangCount + len(placeholderLangs),
-		ActiveLanguages:   activeLangCount,
-		PlaceholderCount:  len(placeholderLangs),
-		TotalFrameworks:   totals.Frameworks,
-		TotalTools:        totals.Tools,
-		TotalORMs:         totals.ORMs,
-		TotalOther:        totals.Other,
-		ActiveRows:        activeRows,
-		CrossCutting:      activeCC,
-		CrossCuttingTotal: ccTotal,
-		EmptyCrossCutting: emptyCC,
-		PlaceholderLangs:  placeholderLangs,
+		Marker:                doNotEditMarker,
+		TotalLanguages:        activeLangCount + len(placeholderLangs),
+		ActiveLanguages:       activeLangCount,
+		PlaceholderCount:      len(placeholderLangs),
+		TotalFrameworks:       totals.Frameworks,
+		TotalTools:            totals.Tools,
+		TotalORMs:             totals.ORMs,
+		TotalOther:            totals.Other,
+		ActiveRows:            activeRows,
+		CrossCutting:          activeCC,
+		CrossCuttingTotal:     ccTotal,
+		EmptyCrossCutting:     emptyCC,
+		PlaceholderLangs:      placeholderLangs,
+		PlatformSubcategories: platformSubcats,
 	}); err != nil {
 		return err
 	}
@@ -895,6 +920,96 @@ func buildCrossCuttingRows(byCat map[string][]recordView) ([]crossCuttingRow, []
 		total.Missing += row.Missing
 	}
 	return active, empty, total
+}
+
+// headingAnchor converts a markdown heading into a GitHub-style fragment
+// anchor: lowercase, drop characters that are not alphanumeric / space /
+// hyphen, then replace each space run's individual spaces with hyphens
+// (GitHub does NOT collapse runs, so "IaC / Provisioning" → the dropped
+// "/" leaves two spaces → "iac--provisioning"). Deterministic and pure.
+func headingAnchor(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		default:
+			// drop everything else (slashes, punctuation)
+		}
+	}
+	return b.String()
+}
+
+// buildPlatformSubcatRows produces the summary's "Platform subcategories"
+// discoverability rows (#3628 child) from the platform records in byCat.
+// Rows follow the dictionary's canonical subcategory order; each carries
+// the lane's display heading, an anchor link into by-category/platform.md,
+// the record count, and a short de-duplicated representative tool list so
+// IaC / Terraform / Pulumi / CDK (and the other lanes) are named and
+// scannable from the summary instead of buried under "Other → platform".
+// Returns nil when platform has no subcategorised records.
+func buildPlatformSubcatRows(byCat map[string][]recordView) []platformSubcatRow {
+	const category = "platform"
+	bySub := map[string][]string{}
+	present := map[string]bool{}
+	for _, rv := range byCat[category] {
+		if rv.Subcategory == "" {
+			continue
+		}
+		present[rv.Subcategory] = true
+		bySub[rv.Subcategory] = append(bySub[rv.Subcategory], rv.Label)
+	}
+	if len(present) == 0 {
+		return nil
+	}
+	const sampleN = 4
+	out := make([]platformSubcatRow, 0, len(present))
+	for _, sub := range orderedSubcategories(category, present) {
+		labels := bySub[sub]
+		sort.Strings(labels)
+		samples := platformToolSamples(labels, sampleN)
+		heading := subcategoryHeading(sub)
+		out = append(out, platformSubcatRow{
+			Heading: heading,
+			Anchor:  headingAnchor(heading),
+			Records: len(labels),
+			Tools:   samples,
+		})
+	}
+	return out
+}
+
+// platformToolSamples renders up to n short tool names from a sorted
+// label slice as a comma-joined string, appending "…" when truncated.
+// Labels are shortened to their leading token before any parenthetical or
+// slash qualifier so the summary cell stays compact (e.g. "Terraform
+// (HCL)" → "Terraform"). Deterministic.
+func platformToolSamples(labels []string, n int) string {
+	short := make([]string, 0, len(labels))
+	seen := map[string]bool{}
+	for _, l := range labels {
+		s := l
+		if i := strings.IndexAny(s, "(/→"); i > 0 {
+			s = strings.TrimSpace(s[:i])
+		}
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		short = append(short, s)
+	}
+	truncated := false
+	if len(short) > n {
+		short = short[:n]
+		truncated = true
+	}
+	joined := strings.Join(short, ", ")
+	if truncated {
+		joined += ", …"
+	}
+	return joined
 }
 
 // nonStrandedGroupNames is the don't-strand render guard (#2902/#2899).

--- a/tools/coverage/platform_subcategory_test.go
+++ b/tools/coverage/platform_subcategory_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// platformReg builds an in-memory registry covering the platform
+// subcategory lanes (#3628 child). It includes the iac vs resource-graph
+// duplicate-looking pairs (AWS CDK + Helm) so tests can assert they no
+// longer render adjacently, plus the analysis.* integration/i18n records
+// whose columns were structurally sparse in the old wide union.
+func platformReg() *Registry {
+	rec := func(id, sub string, caps map[string]string) Record {
+		c := map[string]Capability{}
+		for k, s := range caps {
+			c[k] = Capability{Status: s}
+		}
+		return Record{
+			ID: id, Category: "platform", Subcategory: sub,
+			Language: "multi", Label: labelFor(id), Capabilities: c,
+		}
+	}
+	return &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			// IaC / Provisioning
+			rec("infra.iac.terraform", "iac_provisioning", map[string]string{"resource_extraction": "full", "dependency_attribution": "full"}),
+			rec("infra.iac.pulumi", "iac_provisioning", map[string]string{"resource_extraction": "partial", "dependency_attribution": "partial"}),
+			rec("infra.iac.cdk", "iac_provisioning", map[string]string{"resource_extraction": "partial", "dependency_attribution": "partial"}),
+			// Containers & Orchestration
+			rec("infra.container.helm", "container_orchestration", map[string]string{"resource_extraction": "full", "dependency_attribution": "full", "env_resolution": "full"}),
+			// Config Files
+			rec("config.dotenv", "config_files", map[string]string{"file_parsing": "full", "env_resolution": "full"}),
+			// Workflow / DAG
+			rec("infra.orchestration.airflow", "workflow_dag", map[string]string{"resource_extraction": "partial", "dependency_attribution": "partial"}),
+			// App Topology & Integration (resource-graph dup pairs + analysis records)
+			rec("infra.resource.aws-cdk", "app_topology", map[string]string{"resource_extraction": "partial"}),
+			rec("infra.resource.helm", "app_topology", map[string]string{"resource_extraction": "full"}),
+			rec("infra.resource.cloudformation", "app_topology", map[string]string{"resource_extraction": "full", "dependency_attribution": "full"}),
+			rec("analysis.architecture.shared-db-coupling", "app_topology", map[string]string{"shared_data_coupling": "full"}),
+			rec("analysis.integration.third-party-sdk", "app_topology", map[string]string{"external_service_dependency": "partial"}),
+			rec("analysis.localization.i18n-keys", "app_topology", map[string]string{"translation_key_usage": "partial"}),
+		},
+	}
+}
+
+func labelFor(id string) string {
+	switch id {
+	case "infra.iac.terraform":
+		return "Terraform (HCL)"
+	case "infra.iac.pulumi", "infra.resource.pulumi":
+		return "Pulumi"
+	case "infra.iac.cdk", "infra.resource.aws-cdk":
+		return "AWS CDK"
+	case "infra.resource.cloudformation":
+		return "AWS CloudFormation"
+	case "analysis.architecture.shared-db-coupling":
+		return "Shared-database cross-service coupling"
+	case "infra.container.helm", "infra.resource.helm":
+		return "Helm charts"
+	case "config.dotenv":
+		return ".env"
+	case "infra.orchestration.airflow":
+		return "Apache Airflow (DAG topology)"
+	case "analysis.integration.third-party-sdk":
+		return "Third-party SDK service dependencies"
+	case "analysis.localization.i18n-keys":
+		return "i18n translation-key usage"
+	}
+	return id
+}
+
+// TestPlatformByCategoryRendersSubcategoryLanes asserts the platform
+// by-category page splits into the named subcategory lanes instead of one
+// wide sparse union, that each lane's pivot only declares the capability
+// columns its records use, and that the iac vs resource-graph
+// duplicate-name pairs no longer sit adjacent.
+func TestPlatformByCategoryRendersSubcategoryLanes(t *testing.T) {
+	root := t.TempDir()
+	if err := generate(platformReg(), root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	page := readFile(t, filepath.Join(root, "docs/coverage/by-category/platform.md"))
+
+	// Each lane renders as its own section heading.
+	for _, h := range []string{
+		"## IaC / Provisioning",
+		"## Containers & Orchestration",
+		"## Config Files",
+		"## Workflow / DAG & State Machines",
+		"## App Topology & Integration",
+	} {
+		if !strings.Contains(page, h) {
+			t.Errorf("platform.md missing subcategory section %q\n%s", h, page)
+		}
+	}
+
+	// IaC lane is discoverable with its flagship tools.
+	iac := sectionBody(page, "## IaC / Provisioning")
+	for _, tool := range []string{"Terraform", "Pulumi", "AWS CDK"} {
+		if !strings.Contains(iac, tool) {
+			t.Errorf("IaC lane missing %q\n%s", tool, iac)
+		}
+	}
+
+	// No 7-wide union: the legacy union header listed all of these columns
+	// in a single table. The IaC lane must NOT carry the config/coupling/
+	// i18n columns — it declares only resource/dependency columns.
+	iacHeader := firstTableHeader(iac)
+	for _, col := range []string{"File parsing", "Shared data coupling", "Translation key usage", "External service dependency"} {
+		if strings.Contains(iacHeader, col) {
+			t.Errorf("IaC lane header should not contain %q (sparse-union leak): %s", col, iacHeader)
+		}
+	}
+	if !strings.Contains(iacHeader, "Resource extraction") || !strings.Contains(iacHeader, "Dependency attribution") {
+		t.Errorf("IaC lane header missing its own columns: %s", iacHeader)
+	}
+
+	// The AWS CDK duplicate-name pair must land in different lanes
+	// (iac_provisioning vs app_topology) so they are not adjacent rows.
+	idxIac := strings.Index(page, "infra.iac.cdk")
+	idxRes := strings.Index(page, "infra.resource.aws-cdk")
+	if idxIac < 0 || idxRes < 0 {
+		t.Fatalf("expected both CDK records present")
+	}
+	if !strings.Contains(iac, "infra.iac.cdk") {
+		t.Errorf("infra.iac.cdk should be in the IaC lane")
+	}
+	appTopo := sectionBody(page, "## App Topology & Integration")
+	if !strings.Contains(appTopo, "infra.resource.aws-cdk") {
+		t.Errorf("infra.resource.aws-cdk should be in the App Topology lane")
+	}
+	if strings.Contains(iac, "infra.resource.aws-cdk") {
+		t.Errorf("resource-graph CDK record leaked into the IaC lane (apparent dup)")
+	}
+
+	// No structurally-always-empty column: every column header in every
+	// lane table must be backed by at least one non-"—" cell.
+	assertNoAlwaysEmptyColumn(t, page)
+}
+
+// TestSummarySurfacesIaC asserts the summary's Platform subcategories
+// discoverability section names IaC with a link into the platform page
+// and lists Terraform-class tools.
+func TestSummarySurfacesIaC(t *testing.T) {
+	root := t.TempDir()
+	if err := generate(platformReg(), root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	summary := readFile(t, filepath.Join(root, "docs/coverage/summary.md"))
+
+	if !strings.Contains(summary, "Platform subcategories") {
+		t.Fatalf("summary.md missing Platform subcategories section:\n%s", summary)
+	}
+	if !strings.Contains(summary, "[IaC / Provisioning](by-category/platform.md#iac--provisioning)") {
+		t.Errorf("summary.md missing linked IaC / Provisioning entry:\n%s", summary)
+	}
+	// Tool names should be discoverable in the IaC row.
+	iacRow := lineContaining(summary, "IaC / Provisioning")
+	for _, tool := range []string{"Terraform", "AWS CDK"} {
+		if !strings.Contains(iacRow, tool) {
+			t.Errorf("summary IaC row missing tool %q: %q", tool, iacRow)
+		}
+	}
+}
+
+func TestHeadingAnchor(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"IaC / Provisioning", "iac--provisioning"},
+		{"Containers & Orchestration", "containers--orchestration"},
+		{"Config Files", "config-files"},
+		{"Workflow / DAG & State Machines", "workflow--dag--state-machines"},
+		{"App Topology & Integration", "app-topology--integration"},
+	}
+	for _, c := range cases {
+		if got := headingAnchor(c.in); got != c.want {
+			t.Errorf("headingAnchor(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPlatformToolSamples(t *testing.T) {
+	in := []string{"Terraform (HCL)", "Pulumi", "AWS CDK", "Azure Bicep", "Serverless Framework"}
+	got := platformToolSamples(in, 4)
+	want := "Terraform, Pulumi, AWS CDK, Azure Bicep, …"
+	if got != want {
+		t.Errorf("platformToolSamples = %q, want %q", got, want)
+	}
+	// De-duplication on the shortened leading token.
+	dup := platformToolSamples([]string{"Helm charts", "Helm charts"}, 4)
+	if dup != "Helm charts" {
+		t.Errorf("platformToolSamples dedup = %q, want %q", dup, "Helm charts")
+	}
+}
+
+// --- helpers ---
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// sectionBody returns the text from heading up to (not including) the next
+// "## " heading at the same level.
+func sectionBody(page, heading string) string {
+	i := strings.Index(page, heading)
+	if i < 0 {
+		return ""
+	}
+	rest := page[i+len(heading):]
+	if j := strings.Index(rest, "\n## "); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+func firstTableHeader(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "| Language | Name |") {
+			return line
+		}
+	}
+	return ""
+}
+
+func lineContaining(s, sub string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}
+
+// assertNoAlwaysEmptyColumn checks every markdown table on the page: each
+// capability column (those between "Name" and the trailing Status/Notes
+// columns) must have at least one non-"—" data cell across the table's
+// rows.
+func assertNoAlwaysEmptyColumn(t *testing.T, page string) {
+	t.Helper()
+	lines := strings.Split(page, "\n")
+	var headers []string
+	var dataRows [][]string
+	flush := func() {
+		if len(headers) == 0 {
+			return
+		}
+		// Columns: skip 0 (empty), 1 (Language), 2 (Name); drop the last
+		// two (Status, Notes) — capability columns are the middle ones.
+		for col := 3; col < len(headers)-2; col++ {
+			name := strings.TrimSpace(headers[col])
+			if name == "" {
+				continue
+			}
+			seen := false
+			for _, r := range dataRows {
+				if col < len(r) && strings.TrimSpace(r[col]) != "—" && strings.TrimSpace(r[col]) != "" {
+					seen = true
+					break
+				}
+			}
+			if len(dataRows) > 0 && !seen {
+				t.Errorf("column %q is structurally always-empty (all —) in a platform table", name)
+			}
+		}
+		headers = nil
+		dataRows = nil
+	}
+	for _, ln := range lines {
+		trimmed := strings.TrimSpace(ln)
+		switch {
+		case strings.HasPrefix(trimmed, "| Language | Name |"):
+			flush()
+			headers = strings.Split(ln, "|")
+		case strings.HasPrefix(trimmed, "|---"):
+			// separator row — ignore
+		case strings.HasPrefix(trimmed, "|") && headers != nil:
+			dataRows = append(dataRows, strings.Split(ln, "|"))
+		default:
+			flush()
+		}
+	}
+	flush()
+}

--- a/tools/coverage/templates/by-category.md.tmpl
+++ b/tools/coverage/templates/by-category.md.tmpl
@@ -6,12 +6,48 @@
 Back to [summary](../summary.md). Bucket: **{{.Bucket}}**.
 
 {{if eq .Bucket "Other" -}}
+{{- if .Subsections -}}
+{{- range .Subsections}}
+
+## {{.Heading}}
+{{if .GroupNames}}
+| Language | Name |{{range .GroupNames}} {{.}} |{{end}} Status | Notes |
+|---|---|{{range .GroupNames}}---|{{end}}---|---|
+{{- $groups := .GroupNames}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $groups}} {{groupCell $rec.GroupDigestByName .}} |{{end}} {{glyph $rec.Digest}} | |
+{{- end}}
+{{- else}}
 | Language | Name |{{range .CapabilityKeys}} {{humanizeCapKey .}} |{{end}} Status | Notes |
 |---|---|{{range .CapabilityKeys}}---|{{end}}---|---|
 {{- $caps := .CapabilityKeys}}
 {{- range .Records}}
 {{- $rec := .}}
 | [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} {{glyph $rec.Digest}} | |
+{{- end}}
+{{- end}}
+{{- end}}
+{{- if .Records}}
+
+## Other
+
+| Language | Name |{{range .CapabilityKeys}} {{humanizeCapKey .}} |{{end}} Status | Notes |
+|---|---|{{range .CapabilityKeys}}---|{{end}}---|---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} {{glyph $rec.Digest}} | |
+{{- end}}
+{{- end}}
+{{- else -}}
+| Language | Name |{{range .CapabilityKeys}} {{humanizeCapKey .}} |{{end}} Status | Notes |
+|---|---|{{range .CapabilityKeys}}---|{{end}}---|---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} {{glyph $rec.Digest}} | |
+{{- end}}
 {{- end}}
 {{- else -}}
 {{- if .Subsections}}

--- a/tools/coverage/templates/summary.md.tmpl
+++ b/tools/coverage/templates/summary.md.tmpl
@@ -20,6 +20,17 @@
 {{- end}}
 | **Total** | {{.CrossCuttingTotal.Records}} | {{.CrossCuttingTotal.Full}} | {{.CrossCuttingTotal.Partial}} | {{.CrossCuttingTotal.Missing}} |
 {{end}}
+{{- if .PlatformSubcategories}}
+### Platform subcategories
+
+The [Platform / k8s](by-category/platform.md) category splits into the lanes below. Infrastructure-as-Code (Terraform, OpenTofu, Pulumi, AWS CDK, CloudFormation, Bicep, Serverless) lives under **IaC / Provisioning**.
+
+| Lane | Records | Tools |
+|---|---:|---|
+{{- range .PlatformSubcategories}}
+| [{{.Heading}}](by-category/platform.md#{{.Anchor}}) | {{.Records}} | {{.Tools}} |
+{{- end}}
+{{end}}
 {{- if .PlaceholderLangs}}
 ## Languages with extractor support, no records yet
 

--- a/tools/coverage/testdata/fixture-out/by-category/validation.md
+++ b/tools/coverage/testdata/fixture-out/by-category/validation.md
@@ -5,5 +5,10 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Constraint extraction | Custom validator extraction | Nested model extraction | Schema extraction | Tests linkage | Type coercion recognition | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|
+
+
+## Validation
+
+| Language | Name | Testing | Other capabilities | Status | Notes |
+|---|---|---|---|---|---|
+| [python](../by-language/python.md) | [Pydantic](../detail/lang.python.validation.pydantic.md) | 🔴 0/1 | 🟡 1/5 | 🔴 | |


### PR DESCRIPTION
Closes #3861 (child of #3628).

## What
Redesign the `platform` coverage category's taxonomy + rendering so its by-category page stops being a sparse, repeated-name union table, and make IaC tooling discoverable from the summary. Generator + taxonomy only — **no extractor code**.

## The subcategory split
`platform`'s 40 records now land in 5 coherent lanes (mirroring the `http_framework` subcategory precedent), each declaring only the capability columns its records actually use:

| Lane | Records | Columns |
|---|---|---|
| IaC / Provisioning | `infra.iac.*` (8) | Resource extraction, Dependency attribution |
| Containers & Orchestration | `infra.container.*` (5) | + Env resolution |
| Config Files | `config.*` (7) | File parsing, Env resolution |
| Workflow / DAG & State Machines | `infra.orchestration.*` + `infra.state-machine.*` (7) | Resource extraction, Dependency attribution |
| App Topology & Integration | `infra.resource.*`, gateway/deployment/frontend routing, `analysis.*` (13) | + Shared data coupling, External service dependency, Translation key usage |

No more 7-wide union: each lane's pivot is dense.

## Repeated-name fix
The declarative `infra.iac.cdk` / `infra.iac.cloudformation` / `infra.iac.pulumi` (+ Helm/k8s) records stay in **IaC / Provisioning**; the resource-graph attribution `infra.resource.aws-cdk` / `infra.resource.cloudformation` / `infra.resource.pulumi` / `infra.resource.helm` / `infra.resource.kubernetes` records move to **App Topology & Integration**. The CDK/Helm/k8s/CFN/Pulumi pairs no longer sit adjacent as apparent dupes. No records merged (distinct cites preserved).

## Honest-column decision
The previously-near-empty `external_service_dependency` / `translation_key_usage` / `shared_data_coupling` columns are carried by the `analysis.*` records (#3789/#3817). Rather than drop them, they now live in the App Topology lane where they are backed by real records, and they no longer leave empty columns across the IaC/config/container rows. Every column in every lane is backed by ≥1 record — a value-asserting test enforces no structurally-always-empty column.

## Summary IaC entry
`summary.md` gains a **Platform subcategories** section:

```
### Platform subcategories

The [Platform / k8s](by-category/platform.md) category splits into the lanes below. Infrastructure-as-Code (Terraform, OpenTofu, Pulumi, AWS CDK, CloudFormation, Bicep, Serverless) lives under IaC / Provisioning.

| Lane | Records | Tools |
| [IaC / Provisioning](by-category/platform.md#iac--provisioning) | 8 | AWS CDK, AWS CloudFormation, Ansible, Azure Bicep, … |
| [Containers & Orchestration](…) | 5 | Dockerfile, Helm charts, Kubernetes manifests, Kustomize, … |
| [Config Files](…) | 7 | .env, .ini, .properties, .toml, … |
| [Workflow / DAG & State Machines](…) | 7 | Apache Airflow, Argo Workflows, Celery canvas, Python transitions, … |
| [App Topology & Integration](…) | 13 | API-gateway route topology, AWS CDK, AWS CloudFormation, Frontend route, … |
```

## Generator change
The by-category template's `Bucket == "Other"` branch previously forced a flat union, ignoring subcategories. It now renders subcategory subsections (per-capability and group-digest tables, both keeping the Status column). Side benefit: `validation.md` (also Other-bucket, subcategorised) previously rendered a column header with **zero data rows** — now it renders its `validation_lib` lane correctly.

## Quality
- `go test ./tools/coverage/` green (incl. new value-asserting `platform_subcategory_test.go` + regenerated golden fixture)
- `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean
- `gen` idempotent (twice → identical)
- Regenerated docs committed

**DEPLOY-DEFERRED**: docs-only / generator change. No daemon rebuild or reindex required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)