### PR TITLE
mongo(jsts): Mongoose ref/populate + $lookup → JOINS_COLLECTION (#3844)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -80,7 +80,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
-| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/8 | |
+| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |
 | [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/11 | |
 | [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/10 | |
 | [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 11/11 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -135,7 +135,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
-| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 5/8 | |
+| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |
 | [Objection.js](../detail/lang.jsts.orm.objection.md) | 🟡 8/11 | |
 | [Prisma](../detail/lang.jsts.orm.prisma.md) | 🟡 8/10 | |
 | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | 🟢 11/11 | |

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
-- **Capability cells:** 11
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -23,10 +23,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mongoose.go` | reMongoosePopulate captures .populate() traversal calls (navigate-to-ref); the definition-side ref: field in Schema() is not extracted, so reference declarations are missing |
+| Association extraction | ✅ `full` | — | 3844 | `internal/custom/javascript/mongoose.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate_test.go` | scanJSMongoosePopulateJoins (#3844) now parses the definition-side ref: field in both new Schema({...}) literals and @nestjs/mongoose @Prop({ref:'X'}) decorators, couples it to a static .populate('field') traversal, and emits a JOINS_COLLECTION edge (Class:Model -> Class:ref) matching the $lookup contract; reMongoosePopulate also still captures the populate call as a query entity |
 | Foreign key extraction | — `not_applicable` | — | 3064 | — | MongoDB is a document-oriented database; there is no relational FK concept |
 | Lazy loading recognition | — `not_applicable` | — | 3064 | — | Mongoose/MongoDB has no lazy-loading mechanism |
-| Relationship extraction | 🟢 `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mongoose.go` | .populate() traversals are captured as query entities; schema-level ref: declarations (the definition side of Mongoose associations) are not parsed |
+| Relationship extraction | ✅ `full` | — | 3844 | `internal/custom/javascript/mongoose.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate_test.go` | schema-level ref: declarations (the definition side of Mongoose associations) are now parsed from new Schema({...}) literals and @nestjs/mongoose @Prop({ref:'X'}) decorators and, when traversed by a static .populate('field'), emitted as JOINS_COLLECTION reference-join edges (#3844); dynamic ref / dynamic populate stay unresolved (honest-partial boundary) |
 
 ### Queries
 
@@ -46,6 +46,15 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
+
+## Framework-specific
+
+### Aggregation Joins
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Aggregation join extraction | ✅ `full` | — | 3844 | `internal/engine/orm_queries_jsts_mongo_agg.go`<br>`internal/engine/orm_queries_jsts_mongo_agg_test.go` | scanJSMongoAggregation parses Model.aggregate([...]) pipelines (inline array, same-scope variable binding, and fluent .build() builder forms), emitting one SCOPE.DataAccess stage node per stage and a JOINS_COLLECTION edge (Class:Model -> Class:from) for every $lookup / $graphLookup with a static from; matches the Python pymongo/motor contract and feeds shared_db_coupling.go (Pass 8.8). Dynamic from is honestly skipped |
+| Populate reference join extraction | ✅ `full` | — | 3844 | `internal/engine/orm_queries_jsts_mongoose_populate.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate_test.go` | scanJSMongoosePopulateJoins emits a JOINS_COLLECTION edge for Mongoose ref:/@Prop(ref) fields that are traversed by a static .populate('field') — the dominant NestJS-target join idiom — bringing ref/populate to parity with the $lookup join contract |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -40052,10 +40052,10 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mongoose.go"],
-            "issue": "3064",
-            "notes": "reMongoosePopulate captures .populate() traversal calls (navigate-to-ref); the definition-side ref: field in Schema() is not extracted, so reference declarations are missing"
+            "status": "full",
+            "cites": ["internal/custom/javascript/mongoose.go","internal/engine/orm_queries_jsts_mongoose_populate.go","internal/engine/orm_queries_jsts_mongoose_populate_test.go"],
+            "issue": "3844",
+            "notes": "scanJSMongoosePopulateJoins (#3844) now parses the definition-side ref: field in both new Schema({...}) literals and @nestjs/mongoose @Prop({ref:'X'}) decorators, couples it to a static .populate('field') traversal, and emits a JOINS_COLLECTION edge (Class:Model -\u003e Class:ref) matching the $lookup contract; reMongoosePopulate also still captures the populate call as a query entity"
           },
           "foreign_key_extraction": {
             "status": "not_applicable",
@@ -40068,10 +40068,10 @@
             "notes": "Mongoose/MongoDB has no lazy-loading mechanism"
           },
           "relationship_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mongoose.go"],
-            "issue": "3064",
-            "notes": ".populate() traversals are captured as query entities; schema-level ref: declarations (the definition side of Mongoose associations) are not parsed"
+            "status": "full",
+            "cites": ["internal/custom/javascript/mongoose.go","internal/engine/orm_queries_jsts_mongoose_populate.go","internal/engine/orm_queries_jsts_mongoose_populate_test.go"],
+            "issue": "3844",
+            "notes": "schema-level ref: declarations (the definition side of Mongoose associations) are now parsed from new Schema({...}) literals and @nestjs/mongoose @Prop({ref:'X'}) decorators and, when traversed by a static .populate('field'), emitted as JOINS_COLLECTION reference-join edges (#3844); dynamic ref / dynamic populate stay unresolved (honest-partial boundary)"
           }
         },
         "Queries": {
@@ -40094,6 +40094,22 @@
           "transaction_function_stamping": {
             "status": "missing",
             "issue": "3628-transaction-function-stamping"
+          }
+        }
+      },
+      "framework_specific": {
+        "Aggregation Joins": {
+          "aggregation_join_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_mongo_agg.go","internal/engine/orm_queries_jsts_mongo_agg_test.go"],
+            "issue": "3844",
+            "notes": "scanJSMongoAggregation parses Model.aggregate([...]) pipelines (inline array, same-scope variable binding, and fluent .build() builder forms), emitting one SCOPE.DataAccess stage node per stage and a JOINS_COLLECTION edge (Class:Model -\u003e Class:from) for every $lookup / $graphLookup with a static from; matches the Python pymongo/motor contract and feeds shared_db_coupling.go (Pass 8.8). Dynamic from is honestly skipped"
+          },
+          "populate_reference_join_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_mongoose_populate.go","internal/engine/orm_queries_jsts_mongoose_populate_test.go"],
+            "issue": "3844",
+            "notes": "scanJSMongoosePopulateJoins emits a JOINS_COLLECTION edge for Mongoose ref:/@Prop(ref) fields that are traversed by a static .populate('field') — the dominant NestJS-target join idiom — bringing ref/populate to parity with the $lookup join contract"
           }
         }
       }

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -158,6 +158,12 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 			func(ent types.EntityRecord) { entities = append(entities, ent) },
 			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
 		)
+		// Sibling pass: Mongoose / @nestjs/mongoose `ref:` + `.populate()`
+		// reference joins → JOINS_COLLECTION edges, matching the $lookup
+		// contract (#3844). Captures the dominant NestJS-target join idiom.
+		scanJSMongoosePopulateJoins(src, path, lang,
+			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
+		)
 	case "go":
 		scanGoORM(src, funcs, emit)
 	case "java":

--- a/internal/engine/orm_queries_jsts_mongo_agg_test.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg_test.go
@@ -622,3 +622,36 @@ async function joined() {
 		t.Errorf("correlated join must not carry local/foreign fields: %+v", jg.Properties)
 	}
 }
+
+// #3844: Mongoose model with two $lookup stages → two distinct
+// JOINS_COLLECTION edges with the joined-collection node ids asserted.
+func TestMongoAgg_Mongoose_MultiLookup_3844(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+async function withRefs() {
+  return Book.aggregate([
+    { $lookup: { from: 'authors', localField: 'authorId', foreignField: '_id', as: 'author' } },
+    { $lookup: { from: 'publishers', localField: 'publisherId', foreignField: '_id', as: 'publisher' } },
+  ]);
+}
+`
+	_, rels := runMongoAgg(t, src)
+
+	ja := findJoinTo(rels, "Author")
+	if ja == nil {
+		t.Fatalf("expected JOINS_COLLECTION Class:Book -> Class:Author; rels=%+v", rels)
+	}
+	if ja.FromID != "Class:Book" {
+		t.Errorf("author join from = %q, want Class:Book", ja.FromID)
+	}
+	if ja.Properties["as"] != "author" {
+		t.Errorf("author join as = %q, want author", ja.Properties["as"])
+	}
+	jp := findJoinTo(rels, "Publisher")
+	if jp == nil || jp.FromID != "Class:Book" {
+		t.Fatalf("expected JOINS_COLLECTION Class:Book -> Class:Publisher; rels=%+v", rels)
+	}
+	if len(rels) != 2 {
+		t.Fatalf("expected exactly 2 $lookup join edges, got %d: %+v", len(rels), rels)
+	}
+}

--- a/internal/engine/orm_queries_jsts_mongoose_populate.go
+++ b/internal/engine/orm_queries_jsts_mongoose_populate.go
@@ -1,0 +1,387 @@
+// Mongoose / @nestjs/mongoose `ref` + `.populate()` join-equivalent extraction
+// for JS/TS (#3844, epic #3837).
+//
+// MongoDB's dominant application-side "join" in the Mongoose / NestJS world is
+// NOT `$lookup` — it is a schema reference field declared with `ref:` plus a
+// runtime `.populate('field')` call. The `$lookup` aggregation case is already
+// handled by scanJSMongoAggregation (orm_queries_jsts_mongo_agg.go) which emits
+// JOINS_COLLECTION edges. This sibling pass brings the ref/populate idiom up to
+// PARITY with that contract so the implicit reference join surfaces the same
+// way a `$lookup` does — which is what the NestJS rewrite target needs for
+// data-join topology comparison against the Django parity oracle.
+//
+// Two declaration forms feed the ref side:
+//
+//  1. Classic Mongoose schema literal — a field whose definition object carries
+//     `ref: 'Author'`:
+//     const BookSchema = new mongoose.Schema({
+//     author: { type: Schema.Types.ObjectId, ref: 'Author' },
+//     });
+//     The owning collection/model is recovered from the schema variable
+//     (`BookSchema` → `Book`) or, preferentially, from a `mongoose.model('Book',
+//     BookSchema)` registration in the same file.
+//
+//  2. @nestjs/mongoose decorator — a `@Prop({ ..., ref: 'Author' })` property
+//     inside a `@Schema()`-annotated class:
+//     @Schema()
+//     class Book {
+//     @Prop({ type: Types.ObjectId, ref: 'Author' }) author: Author;
+//     }
+//     The owning model is the decorated class name (`Book`).
+//
+// The runtime side is a static `.populate('author')` call. The field named in
+// the populate must match a declared `ref:` field for the join to be emitted —
+// this couples the reference declaration to its actual traversal and keeps the
+// edge honest (a `ref:` that is never populated, or a populate of a field with
+// no static `ref:`, is not a confirmed application-side join here).
+//
+// EMITTED EDGE. For each (ref-field, populate-field) match with a STATICALLY
+// resolvable `ref:` target and owning model, one JOINS_COLLECTION relationship
+// matching the Python/$lookup contract:
+//   - FromID = Class:<capitalisedSingular(owning model/collection)>
+//   - ToID   = Class:<capitalisedSingular(ref target)>
+//   - Properties: pattern_type=mongoose_populate, via=populate, ref_field,
+//     ref, plus the populated field.
+//
+// Downstream shared_db_coupling.go (Pass 8.8) consumes JOINS_COLLECTION the
+// same way it does for $lookup.
+//
+// HONEST LIMIT. A dynamic `ref:` (e.g. `ref: refVar` / `refPath: ...`) or a
+// dynamic `.populate(field)` (a bare identifier / member expression rather than
+// a string literal) is NOT resolvable statically and yields NO edge — never a
+// fabricated join. Resolution is file-local: the owning model and the ref
+// target must both be recoverable from the current file.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongoosePopulatePatternType tags every edge this pass emits.
+const mongoosePopulatePatternType = "mongoose_populate"
+
+// reMongooseModelRegistration captures a `mongoose.model('Book', BookSchema)`
+// registration so the owning collection name can be taken from the registered
+// model name (authoritative) rather than inferred from the schema variable.
+var reMongooseModelRegistration = regexp.MustCompile(
+	`(?:mongoose\.)?model\s*(?:<[^>]*>)?\s*\(\s*['"` + "`" + `]([A-Za-z0-9_]+)['"` + "`" + `]\s*,\s*([A-Za-z_$][\w$]*)\s*`,
+)
+
+// reMongooseSchemaVar captures a `const BookSchema = new (mongoose.)Schema(`
+// schema-variable declaration.
+var reMongooseSchemaVar = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*new\s+(?:mongoose\.)?Schema\s*\(`,
+)
+
+// reNestSchemaClass captures a `@Schema()` decorated class name in a
+// @nestjs/mongoose definition: `@Schema(...) ... class Book {`.
+var reNestSchemaClass = regexp.MustCompile(
+	`@Schema\s*\([^)]*\)\s*(?:export\s+)?class\s+([A-Za-z_$][\w$]*)`,
+)
+
+// reMongoosePopulateField matches a static `.populate('field')` call and
+// captures the populated field name. A dynamic populate (bare identifier /
+// member access, no string literal) does not match — honest skip.
+var reMongoosePopulateField = regexp.MustCompile(
+	`\.populate\s*\(\s*['"` + "`" + `]([A-Za-z_$][\w$.]*)['"` + "`" + `]`,
+)
+
+// reNestPropRef matches a `@Prop({ ... ref: 'Author' ... }) fieldName` NestJS
+// decorator and captures (refTarget, fieldName). The decorator object must
+// carry a static string `ref:`; the property name follows on the same/next
+// tokens. refPath / dynamic refs are not matched.
+var reNestPropRef = regexp.MustCompile(
+	`@Prop\s*\(\s*\{[^}]*\bref\s*:\s*['"` + "`" + `]([A-Za-z0-9_]+)['"` + "`" + `][^}]*\}\s*\)\s*(?:readonly\s+)?([A-Za-z_$][\w$]*)`,
+)
+
+// reStaticRefValue matches a static string `ref: 'Author'` value (used to gate
+// out dynamic refs when scanning a schema field object).
+var reStaticRefValue = regexp.MustCompile(
+	`\bref\s*:\s*['"` + "`" + `]([A-Za-z0-9_]+)['"` + "`" + `]`,
+)
+
+// mongooseRefField is a declared reference field: the property name, its `ref:`
+// target collection/model, and the owning model the field belongs to.
+type mongooseRefField struct {
+	field string // schema field / property name (e.g. "author")
+	ref   string // ref target model name (e.g. "Author")
+	owner string // owning model/collection name (e.g. "Book")
+}
+
+// scanJSMongoosePopulateJoins finds Mongoose / @nestjs/mongoose reference
+// fields (`ref:` in a schema literal or a `@Prop`) that are actually traversed
+// by a static `.populate('field')`, and emits one JOINS_COLLECTION edge per
+// confirmed (owner → ref) application-side join, matching the $lookup contract.
+func scanJSMongoosePopulateJoins(
+	src string,
+	path string,
+	lang string,
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	// Gate: only run where a mongoose surface is plausible. @nestjs/mongoose
+	// re-exports Schema/Prop from 'mongoose', so the mongoose import gate also
+	// covers the Nest decorator form.
+	if !mentionsMongooseSequelize(src) {
+		return
+	}
+
+	// The populated fields actually traversed at runtime (static literals only).
+	populated := mongoosePopulatedFields(src)
+	if len(populated) == 0 {
+		// No static populate traversal → no confirmed reference join to emit.
+		return
+	}
+
+	// Collect declared ref fields from both forms.
+	refFields := mongooseCollectSchemaRefs(src)
+	refFields = append(refFields, mongooseCollectNestPropRefs(src)...)
+	if len(refFields) == 0 {
+		return
+	}
+
+	seen := make(map[string]bool)
+	for _, rf := range refFields {
+		if rf.ref == "" || rf.owner == "" || rf.field == "" {
+			continue
+		}
+		if !populated[rf.field] {
+			// Declared but never populated → not a confirmed traversal here.
+			continue
+		}
+		from := capitalisedSingular(rf.owner)
+		to := capitalisedSingular(rf.ref)
+		if from == "" || to == "" {
+			continue
+		}
+		key := from + "->" + to + ":" + rf.field
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		emitJoin(types.RelationshipRecord{
+			FromID: fmt.Sprintf("Class:%s", from),
+			ToID:   fmt.Sprintf("Class:%s", to),
+			Kind:   string(types.RelationshipKindJoinsCollection),
+			Properties: map[string]string{
+				"pattern_type": mongoosePopulatePatternType,
+				"via":          "populate",
+				"ref":          rf.ref,
+				"ref_field":    rf.field,
+			},
+		})
+	}
+}
+
+// mongoosePopulatedFields returns the set of field names traversed by a static
+// `.populate('field')` call. Nested paths (`author.publisher`) contribute their
+// first segment so a top-level ref field still matches.
+func mongoosePopulatedFields(src string) map[string]bool {
+	out := make(map[string]bool)
+	for _, m := range reMongoosePopulateField.FindAllStringSubmatch(src, -1) {
+		field := m[1]
+		if i := strings.IndexByte(field, '.'); i >= 0 {
+			field = field[:i]
+		}
+		if field != "" {
+			out[field] = true
+		}
+	}
+	return out
+}
+
+// mongooseCollectSchemaRefs finds, for every classic `new Schema({...})`
+// literal, the fields declared with a static `ref:` and binds them to the
+// owning model (resolved from a `model('Name', SchemaVar)` registration, else
+// the schema variable name with a trailing "Schema"/"Model" stripped).
+func mongooseCollectSchemaRefs(src string) []mongooseRefField {
+	// Map schema-variable → registered model name.
+	schemaToModel := make(map[string]string)
+	for _, m := range reMongooseModelRegistration.FindAllStringSubmatch(src, -1) {
+		modelName, schemaVar := m[1], m[2]
+		schemaToModel[schemaVar] = modelName
+	}
+
+	var out []mongooseRefField
+	for _, loc := range reMongooseSchemaVar.FindAllStringSubmatchIndex(src, -1) {
+		schemaVar := src[loc[2]:loc[3]]
+		owner := schemaToModel[schemaVar]
+		if owner == "" {
+			owner = mongooseModelFromSchemaVar(schemaVar)
+		}
+		if owner == "" {
+			continue
+		}
+		// Parse the schema-definition object that opens at the `(` after
+		// `Schema`. loc[1] is the byte just past the matched `(`.
+		body, ok := mongooseSchemaObjectBody(src, loc[1]-1)
+		if !ok {
+			continue
+		}
+		for _, kv := range mongoAggTopLevelKeys(body) {
+			ref := mongooseStaticRefOf(kv.val)
+			if ref == "" {
+				continue
+			}
+			out = append(out, mongooseRefField{field: kv.key, ref: ref, owner: owner})
+		}
+	}
+	return out
+}
+
+// mongooseStaticRefOf returns the static `ref:` target inside a schema-field
+// value object, or "" when the field has no ref or a dynamic ref (a non-string
+// value such as `ref: refVar`). A `ref:` whose value is not a string literal is
+// rejected by the string-anchored regex, so dynamic refs honestly yield no
+// join.
+func mongooseStaticRefOf(fieldVal string) string {
+	m := reStaticRefValue.FindStringSubmatch(fieldVal)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// mongooseCollectNestPropRefs finds `@Prop({ ref: 'X' }) field` declarations
+// and binds each to its enclosing `@Schema()` class (the owning model). A Prop
+// declared outside any @Schema class is skipped (no owner).
+func mongooseCollectNestPropRefs(src string) []mongooseRefField {
+	classSpans := mongooseNestSchemaClassSpans(src)
+	if len(classSpans) == 0 {
+		return nil
+	}
+	var out []mongooseRefField
+	for _, m := range reNestPropRef.FindAllStringSubmatchIndex(src, -1) {
+		ref := src[m[2]:m[3]]
+		field := src[m[4]:m[5]]
+		owner := mongooseOwnerClassAt(classSpans, m[0])
+		if owner == "" {
+			continue
+		}
+		out = append(out, mongooseRefField{field: field, ref: ref, owner: owner})
+	}
+	return out
+}
+
+// mongooseNestSchemaClass is the [start,end) byte span of a `@Schema()` class
+// body together with its model name.
+type mongooseNestSchemaClass struct {
+	name  string
+	start int
+	end   int
+}
+
+// mongooseNestSchemaClassSpans locates every `@Schema()`-decorated class and
+// computes its body span (the matching-brace range of the class block) so a
+// @Prop can be attributed to the correct owning model.
+func mongooseNestSchemaClassSpans(src string) []mongooseNestSchemaClass {
+	var spans []mongooseNestSchemaClass
+	for _, m := range reNestSchemaClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// Find the class body `{` after the match end.
+		i := m[1]
+		for i < len(src) && src[i] != '{' {
+			i++
+		}
+		if i >= len(src) {
+			continue
+		}
+		end := mongooseMatchBrace(src, i)
+		if end < 0 {
+			end = len(src)
+		}
+		spans = append(spans, mongooseNestSchemaClass{name: name, start: i, end: end})
+	}
+	return spans
+}
+
+// mongooseOwnerClassAt returns the model name of the @Schema class whose body
+// contains `pos`, or "" if none.
+func mongooseOwnerClassAt(spans []mongooseNestSchemaClass, pos int) string {
+	for _, s := range spans {
+		if pos >= s.start && pos < s.end {
+			return s.name
+		}
+	}
+	return ""
+}
+
+// mongooseModelFromSchemaVar derives a model name from a schema variable when
+// there is no explicit `model()` registration: `BookSchema` → `Book`,
+// `bookSchema` → `Book`, `UserModel` → `User`. Returns "" if nothing
+// meaningful remains.
+func mongooseModelFromSchemaVar(v string) string {
+	base := v
+	switch {
+	case strings.HasSuffix(base, "Schema") && len(base) > len("Schema"):
+		base = base[:len(base)-len("Schema")]
+	case strings.HasSuffix(base, "Model") && len(base) > len("Model"):
+		base = base[:len(base)-len("Model")]
+	}
+	if base == "" {
+		return ""
+	}
+	return strings.ToUpper(base[:1]) + base[1:]
+}
+
+// mongooseSchemaObjectBody returns the body text inside the first object
+// literal argument of a `new Schema(` call, given the index of that call's `(`.
+// It skips whitespace to the `{`, then returns the balanced-brace, string-aware
+// contents. Reports ok=false when the first argument is not an object literal
+// (e.g. a variable) — honest skip.
+func mongooseSchemaObjectBody(src string, openParen int) (string, bool) {
+	if openParen < 0 || openParen >= len(src) || src[openParen] != '(' {
+		return "", false
+	}
+	i := openParen + 1
+	for i < len(src) && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r') {
+		i++
+	}
+	if i >= len(src) || src[i] != '{' {
+		return "", false
+	}
+	end := mongooseMatchBrace(src, i)
+	if end < 0 {
+		return "", false
+	}
+	return src[i+1 : end], true
+}
+
+// mongooseMatchBrace returns the index of the `}` matching the `{` at `open`,
+// string-aware (single/double/backtick quotes with escapes), or -1 if
+// unbalanced.
+func mongooseMatchBrace(src string, open int) int {
+	if open >= len(src) || src[open] != '{' {
+		return -1
+	}
+	depth := 0
+	inStr := byte(0)
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inStr = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/internal/engine/orm_queries_jsts_mongoose_populate_test.go
+++ b/internal/engine/orm_queries_jsts_mongoose_populate_test.go
@@ -1,0 +1,233 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runMongoosePopulate drives scanJSMongoosePopulateJoins over `src` and
+// collects the emitted JOINS_COLLECTION edges.
+func runMongoosePopulate(t *testing.T, src string) []types.RelationshipRecord {
+	t.Helper()
+	var rels []types.RelationshipRecord
+	scanJSMongoosePopulateJoins(src, "svc/book.ts", "typescript",
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+	return rels
+}
+
+// findPopulateJoin returns the JOINS_COLLECTION edge from→to emitted by the
+// populate pass (pattern_type=mongoose_populate), or nil.
+func findPopulateJoin(rels []types.RelationshipRecord, fromClass, toClass string) *types.RelationshipRecord {
+	for i := range rels {
+		r := &rels[i]
+		if r.Kind == string(types.RelationshipKindJoinsCollection) &&
+			r.Properties["pattern_type"] == "mongoose_populate" &&
+			r.FromID == "Class:"+fromClass && r.ToID == "Class:"+toClass {
+			return r
+		}
+	}
+	return nil
+}
+
+// Classic Mongoose schema literal: a `ref: 'Author'` field that is actually
+// populated → JOINS_COLLECTION(Class:Book → Class:Author).
+func TestMongoosePopulate_SchemaRef_Join(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const BookSchema = new mongoose.Schema({
+  title: { type: String },
+  author: { type: Schema.Types.ObjectId, ref: 'Author' },
+});
+
+const Book = mongoose.model('Book', BookSchema);
+
+async function withAuthor(id) {
+  return Book.findById(id).populate('author');
+}
+`
+	rels := runMongoosePopulate(t, src)
+
+	j := findPopulateJoin(rels, "Book", "Author")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION Class:Book -> Class:Author, got %+v", rels)
+	}
+	if j.Properties["via"] != "populate" {
+		t.Errorf("via = %q, want populate", j.Properties["via"])
+	}
+	if j.Properties["ref"] != "Author" {
+		t.Errorf("ref = %q, want Author", j.Properties["ref"])
+	}
+	if j.Properties["ref_field"] != "author" {
+		t.Errorf("ref_field = %q, want author", j.Properties["ref_field"])
+	}
+}
+
+// Model name resolution falls back to the schema variable when there is no
+// explicit model() registration: `BookSchema` → owner `Book`.
+func TestMongoosePopulate_SchemaVarOwnerFallback(t *testing.T) {
+	src := `
+import mongoose, { Schema } from 'mongoose';
+
+const BookSchema = new Schema({
+  author: { type: Schema.Types.ObjectId, ref: 'Author' },
+});
+
+function load() {
+  return query.populate('author');
+}
+`
+	rels := runMongoosePopulate(t, src)
+	if findPopulateJoin(rels, "Book", "Author") == nil {
+		t.Fatalf("expected Class:Book -> Class:Author from schema-var fallback, got %+v", rels)
+	}
+}
+
+// @nestjs/mongoose: `@Prop({ ref: 'Author' }) author` in a `@Schema()` class +
+// a `.populate('author')` → JOINS_COLLECTION(Class:Book → Class:Author).
+func TestMongoosePopulate_NestProp_Join(t *testing.T) {
+	src := `
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import * as mongoose from 'mongoose';
+import { Types } from 'mongoose';
+
+@Schema()
+export class Book {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Author' })
+  author: Author;
+}
+
+export const BookSchema = SchemaFactory.createForClass(Book);
+
+async function detail(model) {
+  return model.findOne().populate('author');
+}
+`
+	rels := runMongoosePopulate(t, src)
+
+	j := findPopulateJoin(rels, "Book", "Author")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION Class:Book -> Class:Author from @Prop ref, got %+v", rels)
+	}
+	if j.Properties["ref_field"] != "author" {
+		t.Errorf("ref_field = %q, want author", j.Properties["ref_field"])
+	}
+}
+
+// Multiple ref fields, multiple populates → multiple distinct join edges.
+func TestMongoosePopulate_MultipleRefs(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const BookSchema = new mongoose.Schema({
+  author: { type: Schema.Types.ObjectId, ref: 'Author' },
+  publisher: { type: Schema.Types.ObjectId, ref: 'Publishers' },
+  ignored: { type: Schema.Types.ObjectId, ref: 'Reviewer' },
+});
+
+const Book = mongoose.model('Book', BookSchema);
+
+function full() {
+  return Book.find().populate('author').populate('publisher');
+}
+`
+	rels := runMongoosePopulate(t, src)
+
+	if findPopulateJoin(rels, "Book", "Author") == nil {
+		t.Errorf("missing Class:Book -> Class:Author; rels=%+v", rels)
+	}
+	// 'Publishers' singularises to 'Publisher'.
+	if findPopulateJoin(rels, "Book", "Publisher") == nil {
+		t.Errorf("missing Class:Book -> Class:Publisher; rels=%+v", rels)
+	}
+	// 'Reviewer' has a ref but is never populated → no edge.
+	if findPopulateJoin(rels, "Book", "Reviewer") != nil {
+		t.Errorf("did not expect Class:Book -> Class:Reviewer (ref never populated)")
+	}
+	// Exactly two populate joins.
+	count := 0
+	for _, r := range rels {
+		if r.Properties["pattern_type"] == "mongoose_populate" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("populate join count = %d, want 2; rels=%+v", count, rels)
+	}
+}
+
+// Negative: a ref declared but never populated yields NO edge.
+func TestMongoosePopulate_RefNotPopulated_NoEdge(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+const BookSchema = new mongoose.Schema({
+  author: { type: Schema.Types.ObjectId, ref: 'Author' },
+});
+const Book = mongoose.model('Book', BookSchema);
+function bare() { return Book.find(); }
+`
+	rels := runMongoosePopulate(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges when ref is never populated, got %+v", rels)
+	}
+}
+
+// Negative: a dynamic `.populate(fieldVar)` (no string literal) yields NO edge,
+// even though the ref is declared.
+func TestMongoosePopulate_DynamicPopulate_NoEdge(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+const BookSchema = new mongoose.Schema({
+  author: { type: Schema.Types.ObjectId, ref: 'Author' },
+});
+const Book = mongoose.model('Book', BookSchema);
+function dyn(field) { return Book.find().populate(field); }
+`
+	rels := runMongoosePopulate(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges for dynamic populate(field), got %+v", rels)
+	}
+}
+
+// Negative: a dynamic `ref:` (variable, not a string literal) yields NO edge
+// even though the field is populated.
+func TestMongoosePopulate_DynamicRef_NoEdge(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+const refTarget = 'Author';
+const BookSchema = new mongoose.Schema({
+  author: { type: Schema.Types.ObjectId, ref: refTarget },
+});
+const Book = mongoose.model('Book', BookSchema);
+function load() { return Book.find().populate('author'); }
+`
+	rels := runMongoosePopulate(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges for dynamic ref, got %+v", rels)
+	}
+}
+
+// Gate: a non-mongoose file is never scanned (no false joins on arbitrary
+// `.populate(...)` from other libraries).
+func TestMongoosePopulate_NonMongooseGate(t *testing.T) {
+	src := `
+function render() {
+  grid.populate('rows');
+}
+const config = { ref: 'Author' };
+`
+	rels := runMongoosePopulate(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges in non-mongoose file, got %+v", rels)
+	}
+}


### PR DESCRIPTION
**Closes #3844** (epic #3837). **DEPLOY-DEFERRED.**

Generalizes the MongoDB aggregation/`$lookup` JOINS_COLLECTION extraction to the **Mongoose / @nestjs/mongoose** idioms the NestJS rewrite target uses, matching the Python pymongo/motor contract so the source↔target oracle can compare data-join topology. Both edges feed `shared_db_coupling.go` (Pass 8.8).

## What changed

### 1. `$lookup` (already implemented, now Mongoose-asserted)
`scanJSMongoAggregation` already emits `SCOPE.DataAccess` stage nodes + `JOINS_COLLECTION(Class:Model → Class:from)` for `Model.aggregate([{ $lookup }])`. Added a value-asserting **Mongoose multi-`$lookup`** test pinning the joined-collection node ids.

### 2. `ref` / `populate` join-equivalent (new) — `orm_queries_jsts_mongoose_populate.go`
`scanJSMongoosePopulateJoins` parses the definition-side `ref:` target in:
- classic `new Schema({ author: { type: ObjectId, ref: 'Author' } })` literals (owner from `model('Book', BookSchema)`, the schema-var name, or fallback), and
- `@nestjs/mongoose` `@Prop({ ref: 'Author' }) author` decorators in a `@Schema()` class (owner = class name),

couples it to a **static `.populate('author')`** traversal, and emits a join-equivalent `JOINS_COLLECTION(Class:Model → Class:ref)` so the dominant NestJS join idiom surfaces like a `$lookup`.

### Honest-partial boundary
A dynamic `ref:` (variable) or dynamic `.populate(field)` (non-literal) yields **NO edge** — no fabricated joins. Covered by negative tests.

## JOINS_COLLECTION edges asserted

| Form | Source | Edge |
|---|---|---|
| `$lookup` ×2 | `Book.aggregate([{$lookup:{from:'authors',as:'author'}}, {$lookup:{from:'publishers',...}}])` | `Class:Book → Class:Author`, `Class:Book → Class:Publisher` |
| schema `ref` + populate | `BookSchema { author: { ref:'Author' } }` + `.populate('author')` | `Class:Book → Class:Author` (`via=populate`) |
| `@Prop(ref)` + populate | `@Schema() class Book { @Prop({ref:'Author'}) author }` + `.populate('author')` | `Class:Book → Class:Author` |
| multi-ref | `ref:'Author'` + `ref:'Publishers'` both populated; `ref:'Reviewer'` not populated | `Class:Book → Class:Author`, `Class:Book → Class:Publisher` (no Reviewer edge) |
| negative: ref not populated / dynamic populate / dynamic ref / non-mongoose | — | no edge |

## Coverage
`lang.jsts.orm.mongoose`: `relationship_extraction` + `association_extraction` partial→**full** (schema `ref:` now parsed); new `framework_specific` "Aggregation Joins" group documenting both the `$lookup` and `ref`/`populate` JOINS_COLLECTION capabilities, citing the extractors.

## Validation
- `go test ./internal/engine/ ./internal/custom/... ./internal/types/ ./tools/coverage/` — green
- `coverage validate` 0 errors, `fmt --check` canonical, `gofmt -l` empty, `go vet` clean
- Coverage docs regenerated (mongoose record only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)