### PR TITLE
feat(drf): surface endpoint posture on router-expanded DRF endpoints (#3864)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -221,6 +221,13 @@ type drfViewSetClass struct {
 	// its explicit `def <method>(` declaration. Empty entry means the method is
 	// inherited from a mixin and has no body in this file (#2677).
 	methodLines map[string]int
+	// posture carries the ViewSet-level endpoint posture (pagination /
+	// permission / authentication / throttle classes) declared as class
+	// attributes. In DRF these apply to EVERY router-generated route the
+	// ViewSet backs, so the DRF expansion pass stamps them onto each
+	// synthesized http_endpoint (#3864). Zero value means "nothing declared"
+	// (honest-partial — no fabricated posture).
+	posture drfPosture
 }
 
 // drfAction is a single @action-decorated method on a ViewSet.
@@ -237,6 +244,43 @@ type drfAction struct {
 	// source file. Captured so the emitted http_endpoint attributes to the
 	// decorated method body rather than routers.py (#2677).
 	methodLine int
+	// posture carries any per-@action posture override. DRF lets an @action
+	// pass `permission_classes=[...]`, `throttle_classes=[...]`,
+	// `pagination_class=X`, `authentication_classes=[...]` in the decorator;
+	// those apply to THAT action's route only and override the ViewSet-level
+	// posture for it (#3864). hasPosture distinguishes "override declared"
+	// (even if empty, e.g. permission_classes=[]) from "no override".
+	posture    drfPosture
+	hasPosture bool
+}
+
+// drfPosture captures the DRF endpoint-posture knobs that a ViewSet (or an
+// individual @action override) declares: the pagination class, and the
+// permission / authentication / throttle class lists. The DRF expansion pass
+// translates these into the cross-stack endpoint-property contract
+// (paginated/pagination_*, middleware_chain/auth_required, rate_limited) and
+// stamps them onto every router-generated http_endpoint the ViewSet backs —
+// closing the gap where the inline posture passes never saw these synthetics
+// because they live in a separate slice with Kind="http_endpoint" and a
+// SourceFile that points at the ViewSet rather than the routers file (#3864).
+type drfPosture struct {
+	// paginationClass is the final dotted-segment of `pagination_class = X`
+	// (e.g. "LimitOffsetPagination"), or "" when none is declared.
+	paginationClass string
+	// permissionClasses / authenticationClasses / throttleClasses are the
+	// class symbols (final dotted segment) declared in the respective
+	// `*_classes = [...]` attribute, in source order.
+	permissionClasses     []string
+	authenticationClasses []string
+	throttleClasses       []string
+}
+
+// empty reports whether the posture declares nothing at all.
+func (p drfPosture) empty() bool {
+	return p.paginationClass == "" &&
+		len(p.permissionClasses) == 0 &&
+		len(p.authenticationClasses) == 0 &&
+		len(p.throttleClasses) == 0
 }
 
 // ApplyDjangoDRFRoutes expands DRF router.register() calls into the full
@@ -286,7 +330,7 @@ func ApplyDjangoDRFRoutes(
 	// when the ViewSet class cannot be resolved). sourceLine is the 1-based
 	// line of `def <handler>(` (for explicit / @action methods) or the class
 	// def line (for inherited mixin methods). #2677.
-	emit := func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string) {
+	emit := func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture) {
 		if canonical == "" || canonical == "/" {
 			return
 		}
@@ -333,6 +377,14 @@ func ApplyDjangoDRFRoutes(
 				// so the resolver takes the NoHandlerProp keep-path.
 			}
 		}
+
+		// #3864 — stamp endpoint posture (pagination / auth-middleware-chain /
+		// rate-limit) resolved from the backing ViewSet (or a per-@action
+		// override) onto this router-expanded synthetic. The inline posture
+		// passes never reach these entities (separate slice, Kind="http_endpoint",
+		// SourceFile=ViewSet not routers.py), so the DRF expansion is the only
+		// place ViewSet-level posture can be attributed to the generated routes.
+		stampDRFEndpointPosture(props, posture)
 
 		out = append(out, types.EntityRecord{
 			ID:                 id,
@@ -1028,7 +1080,7 @@ func expandRegisterPrefixes(
 // exactly ONE canonical placeholder per detail route — the ViewSet's
 // declared lookup_field (defaulting to "pk").
 func emitCRUDFamily(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
@@ -1053,7 +1105,7 @@ func crudMethodLine(vc drfViewSetClass, method string) int {
 // `lookup_field`) is the source of truth; subsequent calls with alternate
 // placeholders widen the cross-repo match surface (#704 companion).
 func emitOneCRUDFamily(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
 	fullPrefix string,
 	placeholder string,
 	vc drfViewSetClass,
@@ -1061,28 +1113,30 @@ func emitOneCRUDFamily(
 	viewSetName string,
 ) {
 	detailBase := fullPrefix + "/{" + placeholder + "}"
+	// #3864 — all CRUD routes inherit the ViewSet-level posture.
+	pos := vc.posture
 
 	if vc.crudMethods["list"] {
-		emit("GET", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "list"), viewSetName, "list")
+		emit("GET", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "list"), viewSetName, "list", pos)
 	}
 	if vc.crudMethods["create"] {
-		emit("POST", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "create"), viewSetName, "create")
+		emit("POST", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "create"), viewSetName, "create", pos)
 	}
 	hasDetailVerb := false
 	if vc.crudMethods["retrieve"] {
-		emit("GET", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "retrieve"), viewSetName, "retrieve")
+		emit("GET", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "retrieve"), viewSetName, "retrieve", pos)
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["update"] {
-		emit("PUT", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "update"), viewSetName, "update")
+		emit("PUT", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "update"), viewSetName, "update", pos)
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["partial_update"] {
-		emit("PATCH", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "partial_update"), viewSetName, "partial_update")
+		emit("PATCH", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "partial_update"), viewSetName, "partial_update", pos)
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["destroy"] {
-		emit("DELETE", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "destroy"), viewSetName, "destroy")
+		emit("DELETE", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "destroy"), viewSetName, "destroy", pos)
 		hasDetailVerb = true
 	}
 	// Emit an ANY-verb detail fallback ONLY when no per-verb detail routes
@@ -1092,7 +1146,7 @@ func emitOneCRUDFamily(
 	// verb-aware matcher must skip, and it defeated the iter3 calibration
 	// top add-rec #2 (detail routes still showing method=ANY). Fix #1692.
 	if !hasDetailVerb {
-		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "")
+		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "", pos)
 	}
 }
 
@@ -1100,13 +1154,19 @@ func emitOneCRUDFamily(
 // ViewSet. For detail=True actions the route is
 // /<prefix>/{lookup}/<url_path>/; for detail=False it is /<prefix>/<url_path>/.
 func emitActionRoutes(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
 	viewSetName string,
 ) {
 	for _, act := range vc.actions {
+		// #3864 — an @action's own posture override (if any) applies to its
+		// route; otherwise the route inherits the ViewSet-level posture.
+		actPosture := vc.posture
+		if act.hasPosture {
+			actPosture = act.posture
+		}
 		segment := act.urlPath
 		if segment == "" {
 			segment = act.methodName
@@ -1145,7 +1205,7 @@ func emitActionRoutes(
 				actionLine = vc.classDefLine
 			}
 			for _, verb := range methods {
-				emit(verb, canonical, sourceFile, actionLine, viewSetName, act.methodName)
+				emit(verb, canonical, sourceFile, actionLine, viewSetName, act.methodName, actPosture)
 			}
 		}
 	}
@@ -1213,6 +1273,102 @@ func emitViewSetMethodEntities(
 				"drf_method_origin": method,
 			},
 		})
+	}
+}
+
+// stampDRFEndpointPosture translates a resolved drfPosture into the cross-stack
+// endpoint-property contract and writes it onto a router-expanded synthetic's
+// Properties map. It mirrors, byte-for-byte, the properties the inline posture
+// passes set on http_endpoint_definition entities so a router-expanded
+// http_endpoint is indistinguishable from a same-file synthesized one at the
+// MCP surface (#3864):
+//
+//   - pagination_class  → paginated=true + pagination_style / pagination_params /
+//     pagination_source (same shape as applyEndpointPagination /
+//     drfClassPaginationVerdict). Only recognised classes
+//     (drfPaginationClassStyle) flip paginated — an unknown custom paginator
+//     stays unstamped (honest-partial).
+//   - permission/authentication/throttle_classes → an ORDERED view-scope
+//     middleware_chain (same contract as applyPythonMiddlewareCoverage /
+//     indexDRFViewMiddleware) plus auth_required when a non-AllowAny permission
+//     or any authentication class is declared.
+//   - throttle_classes → rate_limited=true + rate_limit_source (the flat
+//     rate-limit contract stampJSRateLimit uses; the concrete rate lives in
+//     settings, not statically resolvable here, so rate_limit is omitted —
+//     honest-partial).
+//
+// No-op when the posture declares nothing (an un-configured ViewSet's routes
+// stay unstamped — the negative case the spec requires).
+func stampDRFEndpointPosture(props map[string]string, posture drfPosture) {
+	if props == nil || posture.empty() {
+		return
+	}
+
+	// Pagination — only a recognised DRF paginator flips `paginated`.
+	if posture.paginationClass != "" {
+		if style, known := drfPaginationClassStyle[posture.paginationClass]; known {
+			props["paginated"] = "true"
+			props["pagination_style"] = style
+			if params := drfDefaultParamsFor(style); len(params) > 0 {
+				props["pagination_params"] = strings.Join(uniqueSorted(params), ",")
+			}
+			props["pagination_source"] = "pagination_class=" + posture.paginationClass
+		}
+	}
+
+	// Middleware chain (view scope): permission → authentication → throttle, in
+	// the same order indexDRFViewMiddleware assembles them.
+	var chain []middlewareEntry
+	authRequired := false
+	for _, sym := range posture.permissionClasses {
+		ak := middlewareAuthKind(sym)
+		if ak == "" {
+			ak = "auth"
+		}
+		// AllowAny is an explicit "no auth" permission — it must NOT set
+		// auth_required, matching DRF semantics.
+		if !strings.EqualFold(sym, "AllowAny") {
+			authRequired = true
+		}
+		chain = append(chain, middlewareEntry{
+			Name:     sym,
+			Expr:     sym,
+			Scope:    pythonMWScopeView,
+			AuthKind: ak,
+		})
+	}
+	for _, sym := range posture.authenticationClasses {
+		ak := middlewareAuthKind(sym)
+		if ak == "" {
+			ak = "auth"
+		}
+		authRequired = true
+		chain = append(chain, middlewareEntry{
+			Name:     sym,
+			Expr:     sym,
+			Scope:    pythonMWScopeView,
+			AuthKind: ak,
+		})
+	}
+	for _, sym := range posture.throttleClasses {
+		chain = append(chain, middlewareEntry{
+			Name:  sym,
+			Expr:  sym,
+			Scope: pythonMWScopeView,
+		})
+	}
+	chain = dedupeMiddlewareEntries(chain)
+	stampMiddlewareChainEntries(props, chain, pythonMWScopeOrder)
+
+	if authRequired {
+		props["auth_required"] = "true"
+	}
+
+	// Throttle classes ⇒ the route is rate-limited.
+	if len(posture.throttleClasses) > 0 {
+		props["rate_limited"] = "true"
+		props["rate_limit_scope"] = "view"
+		props["rate_limit_source"] = "throttle_classes=" + strings.Join(posture.throttleClasses, ",")
 	}
 }
 
@@ -1400,6 +1556,11 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	if m := drfLookupFieldRe.FindStringSubmatch(classBody); len(m) >= 2 {
 		out.lookupField = m[1]
 	}
+	// #3864 — capture the ViewSet-level endpoint posture (pagination /
+	// permission / authentication / throttle classes) so the expansion pass
+	// can stamp it on every generated route. In DRF these class attributes
+	// apply to every action the ViewSet exposes.
+	out.posture = parseDRFPosture(classBody)
 	// classBody starts at classBodyStart in src; pass that offset so
 	// extractActions can compute absolute (src-relative) line numbers for
 	// each @action's `def NAME(` line (#2677).
@@ -1837,7 +1998,104 @@ func parseActionArgs(args, methodName string, defaultDetail bool) drfAction {
 			act.methods = append(act.methods, strings.ToUpper(tok))
 		}
 	}
+	// #3864 — a DRF @action may override the ViewSet's posture for its own
+	// route via `permission_classes=[...]`, `throttle_classes=[...]`,
+	// `authentication_classes=[...]`, `pagination_class=X` kwargs. When any of
+	// those appears in the decorator we record the override (hasPosture=true)
+	// so the expansion pass stamps the action's posture instead of the
+	// class-level one. An override that sets `permission_classes=[]` is a real
+	// "open this action" declaration and is honoured (hasPosture true, empty
+	// permissions).
+	if p, ok := parseActionPostureOverride(args); ok {
+		act.posture = p
+		act.hasPosture = true
+	}
 	return act
+}
+
+// drfActionPaginationClassRe captures `pagination_class=X` (or
+// `pagination_class = X`) inside an @action decorator's argument list. Group 1
+// is the (possibly dotted) class reference.
+var drfActionPaginationClassRe = regexp.MustCompile(
+	`pagination_class\s*=\s*([A-Za-z_][\w.]*)`,
+)
+
+// parseActionPostureOverride scans an @action decorator argument string for any
+// of the posture kwargs (permission_classes / authentication_classes /
+// throttle_classes / pagination_class). Returns the resolved posture and true
+// when at least one appears, or (zero, false) when the decorator declares no
+// posture override at all (the route then inherits the ViewSet posture).
+func parseActionPostureOverride(args string) (drfPosture, bool) {
+	var p drfPosture
+	found := false
+	for _, am := range drfClassesAttrRe.FindAllStringSubmatch(args, -1) {
+		found = true
+		kind := am[1] // permission | authentication | throttle
+		names := finalDottedSegments(drfClassNames(am[2]))
+		switch kind {
+		case "permission":
+			p.permissionClasses = names
+		case "authentication":
+			p.authenticationClasses = names
+		case "throttle":
+			p.throttleClasses = names
+		}
+	}
+	if m := drfActionPaginationClassRe.FindStringSubmatch(args); len(m) >= 2 {
+		found = true
+		p.paginationClass = finalDottedSegment(m[1])
+	}
+	return p, found
+}
+
+// parseDRFPosture extracts the ViewSet-level posture from a class body: the
+// `pagination_class` assignment and the permission/authentication/throttle
+// `*_classes` lists. Only the FIRST assignment of each kind in the body is
+// used (DRF allows exactly one). Returns the zero value when nothing is
+// declared (honest-partial).
+func parseDRFPosture(classBody string) drfPosture {
+	var p drfPosture
+	seenKind := map[string]bool{}
+	for _, am := range drfClassesAttrRe.FindAllStringSubmatch(classBody, -1) {
+		kind := am[1]
+		if seenKind[kind] {
+			continue
+		}
+		seenKind[kind] = true
+		names := finalDottedSegments(drfClassNames(am[2]))
+		switch kind {
+		case "permission":
+			p.permissionClasses = names
+		case "authentication":
+			p.authenticationClasses = names
+		case "throttle":
+			p.throttleClasses = names
+		}
+	}
+	if cls, ok := nearestPaginationClass(classBody, 0); ok {
+		p.paginationClass = cls
+	}
+	return p
+}
+
+// finalDottedSegment returns the last `.`-separated segment of a dotted ref
+// (e.g. "permissions.IsAdminUser" → "IsAdminUser").
+func finalDottedSegment(ref string) string {
+	if idx := strings.LastIndex(ref, "."); idx >= 0 {
+		return ref[idx+1:]
+	}
+	return ref
+}
+
+// finalDottedSegments maps finalDottedSegment over a slice, dropping empties.
+func finalDottedSegments(refs []string) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		if s := finalDottedSegment(strings.TrimSpace(r)); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -2555,3 +2555,177 @@ func TestScanBalancedClose(t *testing.T) {
 		}
 	}
 }
+
+// recordByID returns the EntityRecord with the given ID, or nil.
+func recordByID(records []types.EntityRecord, id string) *types.EntityRecord {
+	for i := range records {
+		if records[i].ID == id {
+			return &records[i]
+		}
+	}
+	return nil
+}
+
+// assertProp asserts a property key has an exact value on the named endpoint.
+func assertEndpointProp(t *testing.T, records []types.EntityRecord, id, key, want string) {
+	t.Helper()
+	e := recordByID(records, id)
+	if e == nil {
+		t.Fatalf("endpoint %q not emitted; got %v", id, idsFromRecords(records))
+	}
+	if got := e.Properties[key]; got != want {
+		t.Errorf("endpoint %q prop %q = %q, want %q", id, key, got, want)
+	}
+}
+
+// assertNoProp asserts a property key is absent (or empty) on the named endpoint.
+func assertNoProp(t *testing.T, records []types.EntityRecord, id, key string) {
+	t.Helper()
+	e := recordByID(records, id)
+	if e == nil {
+		t.Fatalf("endpoint %q not emitted; got %v", id, idsFromRecords(records))
+	}
+	if got, ok := e.Properties[key]; ok && got != "" {
+		t.Errorf("endpoint %q prop %q = %q, want absent", id, key, got)
+	}
+}
+
+// TestApplyDjangoDRFRoutes_PostureOnAllRouterExpandedRoutes is the #3864
+// value-asserting test: a ViewSet declaring pagination_class +
+// permission_classes + throttle_classes must propagate that posture onto
+// EVERY router-expanded route (list/create/retrieve/update/...), so the
+// endpoint posture is visible on the exact http_endpoint entities the MCP
+// `endpoints definitions` query returns.
+func TestApplyDjangoDRFRoutes_PostureOnAllRouterExpandedRoutes(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ReportViewSet
+
+router = routers.DefaultRouter()
+router.register(r"reports", ReportViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.throttling import UserRateThrottle
+
+class ReportViewSet(ModelViewSet):
+    pagination_class = LimitOffsetPagination
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// Every CRUD route must carry pagination + auth + rate-limit posture.
+	allRoutes := []string{
+		"http:GET:/reports",
+		"http:POST:/reports",
+		"http:GET:/reports/{pk}",
+		"http:PUT:/reports/{pk}",
+		"http:PATCH:/reports/{pk}",
+		"http:DELETE:/reports/{pk}",
+	}
+	for _, id := range allRoutes {
+		assertEndpointProp(t, got, id, "paginated", "true")
+		assertEndpointProp(t, got, id, "pagination_style", "offset")
+		assertEndpointProp(t, got, id, "pagination_params", "limit,offset")
+		assertEndpointProp(t, got, id, "pagination_source", "pagination_class=LimitOffsetPagination")
+		assertEndpointProp(t, got, id, "auth_required", "true")
+		assertEndpointProp(t, got, id, "rate_limited", "true")
+		assertEndpointProp(t, got, id, "rate_limit_source", "throttle_classes=UserRateThrottle")
+		// Middleware chain carries the permission + throttle classes (view scope).
+		assertEndpointProp(t, got, id, "middleware_names", "IsAuthenticated,UserRateThrottle")
+		assertEndpointProp(t, got, id, "middleware_scope", "view")
+		assertEndpointProp(t, got, id, "middleware_count", "2")
+	}
+}
+
+// TestApplyDjangoDRFRoutes_ActionPostureOverride verifies that a per-@action
+// posture override applies to that action's route ONLY, while the CRUD routes
+// keep the ViewSet-level posture.
+func TestApplyDjangoDRFRoutes_ActionPostureOverride(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import DocViewSet
+
+router = routers.DefaultRouter()
+router.register(r"docs", DocViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, AllowAny
+
+class DocViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticated]
+
+    @action(detail=False, methods=["get"], url_path="public", permission_classes=[AllowAny])
+    def public_docs(self, request):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// CRUD route keeps the ViewSet-level auth.
+	assertEndpointProp(t, got, "http:GET:/docs", "auth_required", "true")
+	assertEndpointProp(t, got, "http:GET:/docs", "middleware_names", "IsAuthenticated")
+	// The @action route overrode permission_classes=[AllowAny] → not required,
+	// and the chain reflects AllowAny rather than IsAuthenticated.
+	assertEndpointProp(t, got, "http:GET:/docs/public", "middleware_names", "AllowAny")
+	assertNoProp(t, got, "http:GET:/docs/public", "auth_required")
+}
+
+// TestApplyDjangoDRFRoutes_NoPostureNegative verifies the negative case: a
+// ViewSet that declares no pagination/permission/throttle gets NO posture
+// props on its routes (no fabricated posture — honest-partial).
+func TestApplyDjangoDRFRoutes_NoPostureNegative(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import BareViewSet
+
+router = routers.DefaultRouter()
+router.register(r"bare", BareViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class BareViewSet(ModelViewSet):
+    queryset = None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	for _, id := range []string{"http:GET:/bare", "http:GET:/bare/{pk}"} {
+		assertNoProp(t, got, id, "paginated")
+		assertNoProp(t, got, id, "auth_required")
+		assertNoProp(t, got, id, "rate_limited")
+		assertNoProp(t, got, id, "middleware_chain")
+	}
+}
+
+// TestApplyDjangoDRFRoutes_UnknownPaginatorNotStamped verifies honest-partial:
+// a custom (unrecognised) pagination class does NOT flip `paginated`.
+func TestApplyDjangoDRFRoutes_UnknownPaginatorNotStamped(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import CustomViewSet
+
+router = routers.DefaultRouter()
+router.register(r"custom", CustomViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class CustomViewSet(ModelViewSet):
+    pagination_class = MyWeirdPaginator
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	assertNoProp(t, got, "http:GET:/custom", "paginated")
+}


### PR DESCRIPTION
## Closes #3864 (epic #3860)

### Problem
`ApplyDjangoDRFRoutes` (`internal/engine/django_drf_actions.go`, invoked from `cmd/archigraph/index.go:~2810`) emits the router-EXPANDED synthetic endpoints in a **separate slice** with `Kind:"http_endpoint"` and a `SourceFile` that points at the ViewSet (not `routers.py`, per #2677). Every endpoint-posture pass (pagination, python middleware/auth, deprecation, response_codes, rate_limit) runs **inline** inside `applyHTTPEndpointSynthesis` and gates on:

```go
if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path { continue }
```

So the posture passes **triple-missed** the router-expanded synthetics: wrong kind (`http_endpoint` vs `http_endpoint_definition`), different slice (emitted in a later standalone pass), and the same-file gate (ViewSet file ≠ routers file). Result: `auth_required` / `paginated` / `rate_limited` / `middleware_chain` were INVISIBLE on exactly the entities `endpoints definitions` returns. MCP surfacing was already correct (`format:full` copies all props), so the break was purely at STAMP time.

### Fix (option B — ViewSet-resolved posture)
Parse the backing ViewSet's posture once and stamp it onto each generated route, because that is precisely how DRF works: ViewSet-level `pagination_class` / `permission_classes` / `authentication_classes` / `throttle_classes` apply to **every** router-generated route; a per-`@action` decorator override applies to **that action's route only**.

- `parseViewSetClass` now extracts a `drfPosture` (pagination + permission/auth/throttle class lists) from the class body.
- `parseActionArgs` extracts a per-`@action` posture override from the decorator kwargs.
- `emit` (and `emitCRUDFamily` / `emitActionRoutes`) thread the resolved posture and call the new `stampDRFEndpointPosture`, which emits the **same cross-stack property contract** the inline passes use.

### Posture props now reaching DRF router-expanded endpoints
| Source (ViewSet attr / @action kwarg) | Endpoint props stamped |
|---|---|
| `pagination_class = LimitOffsetPagination` | `paginated=true`, `pagination_style=offset`, `pagination_params=limit,offset`, `pagination_source=pagination_class=LimitOffsetPagination` |
| `permission_classes` / `authentication_classes` / `throttle_classes` | `middleware_chain` (ordered, view-scope), `middleware_count`, `middleware_names`, `middleware_scope=view` |
| `permission_classes=[IsAuthenticated]` (non-AllowAny) or any `authentication_classes` | `auth_required=true` |
| `throttle_classes=[UserRateThrottle]` | `rate_limited=true`, `rate_limit_scope=view`, `rate_limit_source=throttle_classes=UserRateThrottle` |

### ViewSet→routes propagation rules
- **CRUD routes** (list/create/retrieve/update/partial_update/destroy) inherit the ViewSet-level posture.
- **@action routes** use the action's own posture override when the decorator declares one (`@action(..., permission_classes=[...], throttle_classes=[...], pagination_class=X)`), otherwise inherit the ViewSet posture.
- **AllowAny** is an explicit "no auth" permission — it appears in `middleware_chain` but does **not** set `auth_required`.
- **Honest-partial**: an unrecognised custom paginator does NOT flip `paginated`; a ViewSet declaring nothing gets NO posture props (negative case asserted). The concrete throttle rate lives in settings (not statically resolvable here) so `rate_limit` is intentionally omitted.

No MCP change required — `endpoint_tools.go` `format:full` already copies all properties through.

### Tests (value-asserting, real DRF forms)
- `TestApplyDjangoDRFRoutes_PostureOnAllRouterExpandedRoutes` — a `ModelViewSet(pagination_class=LimitOffsetPagination, permission_classes=[IsAuthenticated], throttle_classes=[UserRateThrottle])` → ALL six router-expanded routes carry `paginated` + `auth_required` + `rate_limited` + the view-scope `middleware_chain`, asserted on the exact `http:VERB:/path` entities.
- `TestApplyDjangoDRFRoutes_ActionPostureOverride` — `@action(permission_classes=[AllowAny])` applies to that action's route only; CRUD routes keep ViewSet auth.
- `TestApplyDjangoDRFRoutes_NoPostureNegative` — un-configured ViewSet → no posture props.
- `TestApplyDjangoDRFRoutes_UnknownPaginatorNotStamped` — custom paginator does not flip `paginated`.

### Validation
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green.
- `gofmt -l` empty; `go vet ./internal/engine/` clean.
- `coverage fmt --check` canonical; `coverage validate` 0 errors (exit 0); `coverage gen` no doc drift.

**DEPLOY-DEFERRED** — landed but not yet rebuilt/reindexed into the live daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)