### PR TITLE
feat(mcp): project NestJS DI edges (INJECTED_INTO/BINDS) in inspect + expand

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -347,6 +347,18 @@ Previously named `archigraph_describe` (renamed in #668).
 
 Both arrays are omitted entirely when no CALLS edges exist (additive, backward-compatible — consumers reading only `id`/`name`/`kind`/`file`/`line` are unaffected).
 
+When the entity participates in dependency-injection wiring, a `di_edges` array
+surfaces the `INJECTED_INTO` (provider→consumer) and `BINDS`
+(module/token→impl) edges emitted by the per-language DI extractors (#3870).
+Each row is `{ "kind", "direction", "other", "line" }` where `direction` is
+`"outbound"` (the inspected entity is the edge `FromID` — e.g. a provider
+injected into others, or a module/token that binds) or `"inbound"` (the
+inspected entity is the `ToID` — e.g. a controller a provider is injected into,
+or an impl a token binds to), `other` is the entity on the far side, and `line`
+is the source line the extractor recorded (`0` when absent). The section is
+omitted entirely when the entity has no DI edges. Before #3870 these edges were
+in the graph but no read tool projected them — only CALLS was visible.
+
 With `verbose=true`, the response also includes `end_line`, `language`, `repo`,
 `pagerank`, `community_id`, and `properties`.
 
@@ -400,6 +412,14 @@ Previously named `archigraph_related` (renamed in #668).
 ```
 
 Cross-repo overlay entries carry `cross_repo: true` and the link `kind`.
+
+Direct (depth-1) neighbours connected by a dependency-injection edge
+(`INJECTED_INTO` or `BINDS`) additionally carry `di_kind` (the on-graph
+relationship kind) and `di_direction` (`"outbound"` when the queried node is the
+edge `FromID`, `"inbound"` when it is the `ToID`). This lets a consumer tell a
+provider→consumer injection from a plain `CALLS` neighbour — before #3870 the
+connecting edge kind was dropped from neighbour rows entirely. Fields are absent
+on neighbours that are not connected by a DI edge.
 
 ---
 

--- a/internal/mcp/di_projection_3870_test.go
+++ b/internal/mcp/di_projection_3870_test.go
@@ -1,0 +1,251 @@
+package mcp
+
+// di_projection_3870_test.go — #3870: surface NestJS-style dependency-injection
+// edges (INJECTED_INTO / BINDS) in the MCP read tools.
+//
+// Before #3870 these edges were emitted by the per-language DI extractors (e.g.
+// internal/custom/javascript/nestjs_di.go) and wired into the graph, but no MCP
+// read tool projected them: inspect surfaced only CALLS (calls/called_by) +
+// DISCRIMINATES_ON, and expand dropped the connecting edge kind entirely. The
+// rewrite agent could therefore see CALLS but not provider→consumer injection.
+//
+// These tests are VALUE-ASSERTING: they assert the specific DI edge surfaces
+// with the right kind + direction + far-side entity where it previously did
+// not — not merely that some non-empty output exists.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// makeNestDIDoc builds a graph mirroring the nestjs_di.go emission shape:
+//
+//	UsersService  --INJECTED_INTO-->  UsersController   (provider → consumer)
+//	UsersModule   --BINDS-->          USERS_TOKEN       (module → token)
+//	USERS_TOKEN   --BINDS-->          UsersServiceImpl  (token → impl)
+//	UsersController --CALLS-->        UsersService      (so we can prove the DI
+//	                                                     edge surfaces ALONGSIDE
+//	                                                     CALLS, not instead of it)
+func makeNestDIDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "api",
+		Entities: []graph.Entity{
+			{ID: "svc", Name: "UsersService", Kind: "SCOPE.Component", SourceFile: "users.service.ts", StartLine: 1},
+			{ID: "ctrl", Name: "UsersController", Kind: "SCOPE.Component", SourceFile: "users.controller.ts", StartLine: 1},
+			{ID: "mod", Name: "UsersModule", Kind: "SCOPE.Component", SourceFile: "users.module.ts", StartLine: 1},
+			{ID: "tok", Name: "USERS_TOKEN", Kind: "SCOPE.Component", SourceFile: "users.module.ts", StartLine: 5},
+			{ID: "impl", Name: "UsersServiceImpl", Kind: "SCOPE.Component", SourceFile: "users.impl.ts", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			// provider INJECTED_INTO consumer (FromID=provider, ToID=consumer)
+			{ID: "d1", FromID: "svc", ToID: "ctrl", Kind: "INJECTED_INTO", Properties: map[string]string{"line": "12"}},
+			// module BINDS token, token BINDS impl
+			{ID: "d2", FromID: "mod", ToID: "tok", Kind: "BINDS", Properties: map[string]string{"line": "8"}},
+			{ID: "d3", FromID: "tok", ToID: "impl", Kind: "BINDS", Properties: map[string]string{"line": "9"}},
+			// a plain CALLS so we can assert DI surfaces alongside it
+			{ID: "c1", FromID: "ctrl", ToID: "svc", Kind: "CALLS", Properties: map[string]string{"line": "20"}},
+		},
+	}
+}
+
+func callNeighbors(t *testing.T, srv *Server, args map[string]any) []any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleGetNeighbors(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetNeighbors error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("neighbors tool error: %v", res)
+	}
+	text := extractResultText(t, res)
+	var arr []any
+	if err := json.Unmarshal([]byte(text), &arr); err != nil {
+		t.Fatalf("neighbors result not a JSON array: %v\nraw: %s", err, text)
+	}
+	return arr
+}
+
+// TestInspect_SurfacesInjectedInto_OnConsumer asserts that inspecting the
+// consumer (controller) surfaces the INJECTED_INTO edge as an INBOUND DI edge
+// from the provider — previously inspect projected only CALLS, so this edge was
+// invisible.
+func TestInspect_SurfacesInjectedInto_OnConsumer(t *testing.T) {
+	srv := newTestServer(t, makeNestDIDoc())
+
+	out := callInspectWithArgs(t, srv, map[string]any{
+		"group":     "test",
+		"entity_id": "ctrl",
+	})
+
+	di, ok := out["di_edges"]
+	if !ok {
+		t.Fatalf("expected di_edges on consumer inspect; keys: %v", mapKeys(out))
+	}
+	rows, ok := di.([]any)
+	if !ok || len(rows) == 0 {
+		t.Fatalf("di_edges is %T len=%d, want non-empty []any", di, len(rows))
+	}
+	// Find the INJECTED_INTO inbound edge to the provider "svc".
+	found := false
+	for _, r := range rows {
+		m := r.(map[string]any)
+		if m["kind"] == "INJECTED_INTO" && m["direction"] == "inbound" && m["other"] == "svc" {
+			found = true
+			if line, _ := m["line"].(float64); line != 12 {
+				t.Errorf("INJECTED_INTO line = %v, want 12", m["line"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("did not find INJECTED_INTO(inbound, other=svc) in di_edges: %v", rows)
+	}
+	// Sanity: CALLS projection still works alongside DI (called_by from svc).
+	if _, ok := out["called_by"]; !ok {
+		t.Errorf("expected called_by to coexist with di_edges")
+	}
+}
+
+// TestInspect_SurfacesInjectedInto_OnProvider asserts the provider sees the
+// same edge as OUTBOUND (it is the FromID).
+func TestInspect_SurfacesInjectedInto_OnProvider(t *testing.T) {
+	srv := newTestServer(t, makeNestDIDoc())
+
+	out := callInspectWithArgs(t, srv, map[string]any{
+		"group":     "test",
+		"entity_id": "svc",
+	})
+	di, ok := out["di_edges"].([]any)
+	if !ok {
+		t.Fatalf("expected di_edges on provider inspect; keys: %v", mapKeys(out))
+	}
+	found := false
+	for _, r := range di {
+		m := r.(map[string]any)
+		if m["kind"] == "INJECTED_INTO" && m["direction"] == "outbound" && m["other"] == "ctrl" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("did not find INJECTED_INTO(outbound, other=ctrl) on provider: %v", di)
+	}
+}
+
+// TestInspect_SurfacesBinds_TokenToImpl asserts a BINDS(token→impl) edge
+// surfaces on the token as an outbound BINDS to the impl.
+func TestInspect_SurfacesBinds_TokenToImpl(t *testing.T) {
+	srv := newTestServer(t, makeNestDIDoc())
+
+	out := callInspectWithArgs(t, srv, map[string]any{
+		"group":     "test",
+		"entity_id": "tok",
+	})
+	di, ok := out["di_edges"].([]any)
+	if !ok {
+		t.Fatalf("expected di_edges on token inspect; keys: %v", mapKeys(out))
+	}
+	// token has: inbound BINDS from module, outbound BINDS to impl.
+	sawTokenToImpl := false
+	sawModuleToToken := false
+	for _, r := range di {
+		m := r.(map[string]any)
+		if m["kind"] != "BINDS" {
+			t.Errorf("unexpected non-BINDS di edge on token: %v", m)
+		}
+		if m["direction"] == "outbound" && m["other"] == "impl" {
+			sawTokenToImpl = true
+		}
+		if m["direction"] == "inbound" && m["other"] == "mod" {
+			sawModuleToToken = true
+		}
+	}
+	if !sawTokenToImpl {
+		t.Errorf("did not find BINDS(outbound, other=impl) on token: %v", di)
+	}
+	if !sawModuleToToken {
+		t.Errorf("did not find BINDS(inbound, other=mod) on token: %v", di)
+	}
+}
+
+// TestInspect_NoDIEdges_OmitsSection asserts the section is omitted entirely for
+// an entity with no DI edges (additive / backward compatible).
+func TestInspect_NoDIEdges_OmitsSection(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "api",
+		Entities: []graph.Entity{
+			{ID: "lonely", Name: "Lonely", Kind: "SCOPE.Operation", SourceFile: "x.ts", StartLine: 1},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspectWithArgs(t, srv, map[string]any{"group": "test", "entity_id": "lonely"})
+	if _, ok := out["di_edges"]; ok {
+		t.Fatalf("di_edges should be omitted when entity has no DI edges")
+	}
+}
+
+// TestNeighbors_AnnotatesInjectedIntoEdge asserts that archigraph_expand on the
+// consumer annotates the provider neighbour with di_kind=INJECTED_INTO and
+// di_direction=inbound — distinguishing it from a plain CALLS neighbour, which
+// it previously could NOT do (the edge kind was dropped from neighbour rows).
+func TestNeighbors_AnnotatesInjectedIntoEdge(t *testing.T) {
+	srv := newTestServer(t, makeNestDIDoc())
+
+	rows := callNeighbors(t, srv, map[string]any{
+		"group":        "test",
+		"entity_id":    "ctrl",
+		"depth":        1,
+		"token_budget": 5000,
+	})
+
+	// The provider "svc" is both a CALLS target and an INJECTED_INTO source for
+	// the controller. Assert the neighbour row carries the DI annotation.
+	var svcRow map[string]any
+	for _, r := range rows {
+		m := r.(map[string]any)
+		if m["id"] == "api::svc" {
+			svcRow = m
+		}
+	}
+	if svcRow == nil {
+		t.Fatalf("provider neighbour api::svc not present in expand output: %v", rows)
+	}
+	if svcRow["di_kind"] != "INJECTED_INTO" {
+		t.Errorf("di_kind = %v, want INJECTED_INTO", svcRow["di_kind"])
+	}
+	if svcRow["di_direction"] != "inbound" {
+		t.Errorf("di_direction = %v, want inbound", svcRow["di_direction"])
+	}
+}
+
+// TestNeighbors_NonDINeighborUnannotated asserts neighbours not connected by a
+// DI edge do NOT carry the DI annotation (no false positives).
+func TestNeighbors_NonDINeighborUnannotated(t *testing.T) {
+	srv := newTestServer(t, makeNestDIDoc())
+	// Inspect from the module: it BINDS the token (DI) but reaches impl at
+	// depth 2 via token. At depth 1 only "tok" is a direct DI neighbour.
+	rows := callNeighbors(t, srv, map[string]any{
+		"group":        "test",
+		"entity_id":    "mod",
+		"depth":        2,
+		"token_budget": 5000,
+	})
+	for _, r := range rows {
+		m := r.(map[string]any)
+		if m["id"] == "api::tok" {
+			if m["di_kind"] != "BINDS" || m["di_direction"] != "outbound" {
+				t.Errorf("module's direct BINDS neighbour tok mis-annotated: %v", m)
+			}
+		}
+		// impl is depth-2 from module (not a DIRECT edge of mod) → no annotation.
+		if m["id"] == "api::impl" {
+			if _, has := m["di_kind"]; has {
+				t.Errorf("depth-2 neighbour impl should NOT carry di_kind: %v", m)
+			}
+		}
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1098,6 +1098,11 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				if discs := inspectDiscriminators(r, e, scopeIsOne); len(discs) > 0 {
 					out["discriminators"] = discs
 				}
+				// #3870: dependency-injection edges (INJECTED_INTO / BINDS).
+				// Section omitted entirely when the entity has no DI edges.
+				if di := inspectDIEdges(r, e, scopeIsOne); len(di) > 0 {
+					out["di_edges"] = di
+				}
 				// #2642: metadata block with index provenance.
 				out["metadata"] = inspectMetadata(r)
 				return jsonResult(out), nil
@@ -1159,6 +1164,11 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	// edges. Section is omitted entirely when no discriminator edges exist.
 	if discs := inspectDiscriminators(m.repo, m.ent, scopeIsOne); len(discs) > 0 {
 		out["discriminators"] = discs
+	}
+	// #3870: dependency-injection edges (INJECTED_INTO / BINDS).
+	// Section omitted entirely when the entity has no DI edges.
+	if di := inspectDIEdges(m.repo, m.ent, scopeIsOne); len(di) > 0 {
+		out["di_edges"] = di
 	}
 	// #2642: metadata block with index provenance.
 	out["metadata"] = inspectMetadata(m.repo)
@@ -1456,6 +1466,110 @@ func inspectDiscriminators(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []m
 	return out
 }
 
+// inspectDIEdges returns rows for every dependency-injection edge attached to
+// entity e — INJECTED_INTO (provider→consumer) and BINDS (module/token→impl).
+// These edges are emitted by the per-language DI extractors (e.g.
+// internal/custom/javascript/nestjs_di.go) and wired into the graph, but before
+// #3870 no MCP read tool projected them: inspect surfaced only CALLS
+// (calls/called_by) and DISCRIMINATES_ON, so a consumer could not see
+// provider→consumer wiring at all.
+//
+// Each row carries:
+//
+//	kind      — "INJECTED_INTO" or "BINDS"
+//	direction — "outbound" (this entity is the FromID, e.g. a provider injected
+//	            into others / a module that binds) or "inbound" (this entity is
+//	            the ToID, e.g. a controller a provider is injected into / an impl
+//	            a token binds to)
+//	other     — the entity on the other side of the edge (ToID for outbound,
+//	            FromID for inbound)
+//	line      — Properties["line"] when the extractor recorded one (0 otherwise)
+//
+// Returns nil when the entity has no DI edges so the inspect envelope can omit
+// the section entirely (mirrors inspectDiscriminators, #2666). (#3870)
+func inspectDIEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
+	if lr == nil || lr.Doc == nil || e == nil {
+		return nil
+	}
+	isDIKind := func(k string) bool {
+		return strings.EqualFold(k, string(types.RelationshipKindInjectedInto)) ||
+			strings.EqualFold(k, string(types.RelationshipKindBinds))
+	}
+	out := []map[string]any{}
+	rels := lr.Doc.Relationships
+	emit := func(ed edge, direction string) {
+		other := ed.target
+		if !scopeIsOne {
+			other = prefixedID(lr.Repo, other)
+		}
+		// ed.kind preserves the on-graph relationship casing (buildAdjacency
+		// copies r.Kind verbatim), so consumers can match the constant directly.
+		entry := map[string]any{
+			"kind":      ed.kind,
+			"direction": direction,
+			"other":     other,
+			"line":      0,
+		}
+		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
+			if v := rels[ed.relIdx].Properties["line"]; v != "" {
+				if n, err := strconv.Atoi(v); err == nil {
+					entry["line"] = n
+				}
+			}
+		}
+		out = append(out, entry)
+	}
+	adj := lr.getAdjacency()
+	for _, ed := range adj.Outgoing(e.ID) {
+		if isDIKind(ed.kind) {
+			emit(ed, "outbound")
+		}
+	}
+	for _, ed := range adj.Incoming(e.ID) {
+		if isDIKind(ed.kind) {
+			emit(ed, "inbound")
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// diNeighbor describes the dependency-injection edge connecting a start node to
+// one of its direct neighbours (used to annotate archigraph_expand rows, #3870).
+type diNeighbor struct {
+	kind      string // "INJECTED_INTO" or "BINDS" (on-graph casing)
+	direction string // "outbound" (start is FromID) or "inbound" (start is ToID)
+}
+
+// directDIEdges indexes the INJECTED_INTO / BINDS edges directly incident on
+// startID, keyed by the neighbour entity id. Outbound edges (start is the
+// provider/module/token FromID) take precedence over inbound when an id appears
+// on both sides. Returns an empty (non-nil) map when there are no DI edges.
+// (#3870)
+func directDIEdges(adj *adjacency, startID string) map[string]diNeighbor {
+	res := map[string]diNeighbor{}
+	if adj == nil {
+		return res
+	}
+	isDI := func(k string) bool {
+		return strings.EqualFold(k, string(types.RelationshipKindInjectedInto)) ||
+			strings.EqualFold(k, string(types.RelationshipKindBinds))
+	}
+	for _, ed := range adj.Incoming(startID) {
+		if isDI(ed.kind) {
+			res[ed.target] = diNeighbor{kind: ed.kind, direction: "inbound"}
+		}
+	}
+	for _, ed := range adj.Outgoing(startID) {
+		if isDI(ed.kind) {
+			res[ed.target] = diNeighbor{kind: ed.kind, direction: "outbound"}
+		}
+	}
+	return res
+}
+
 // inspectMetadata returns index-staleness fields for the inspect response.
 // Surfaces indexed_at and age_seconds so agents know whether the line-number
 // data might be stale. (#2642)
@@ -1581,6 +1695,13 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 	}
 	adj := startRepo.getAdjacency() // built lazily, cached until reload (#3367)
 	vis := bfs(adj, start.ID, depth, nil)
+	// #3870: dependency-injection edges (INJECTED_INTO / BINDS) are emitted by
+	// the per-language DI extractors and live in the graph, but neighbors
+	// previously dropped the connecting edge kind entirely — so a consumer could
+	// not tell a provider→consumer injection from a plain CALLS neighbour. Index
+	// the start node's direct DI edges by neighbour id so the matching output
+	// rows can be annotated with {di_kind, di_direction} below.
+	diByNeighbor := directDIEdges(adj, start.ID)
 	out := []map[string]any{}
 	for nid, d := range vis {
 		if nid == start.ID {
@@ -1590,13 +1711,18 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 		if e == nil {
 			continue
 		}
-		out = append(out, map[string]any{
+		row := map[string]any{
 			"id":          prefixedID(startRepo.Repo, e.ID),
 			"label":       e.Name,
 			"depth":       d,
 			"source_file": e.SourceFile,
 			"start_line":  e.StartLine,
-		})
+		}
+		if di, ok := diByNeighbor[nid]; ok {
+			row["di_kind"] = di.kind
+			row["di_direction"] = di.direction
+		}
+		out = append(out, row)
 	}
 	// include cross-repo overlay edges from this node.
 	// linksForSourceRepo consults the CrossLinkCache (issue #2224) so that


### PR DESCRIPTION
Closes #3870 (epic #3860).

## Problem
The per-language DI extractors (e.g. `internal/custom/javascript/nestjs_di.go`) emit `INJECTED_INTO` (provider→consumer) and `BINDS` (module/token→impl) edges and wire them into the graph — the edges exist. But the MCP read tools did not **project** them: `inspect` surfaced only CALLS (`calls`/`called_by`) + `DISCRIMINATES_ON`, and `expand` dropped the connecting edge kind from neighbour rows entirely. So the rewrite agent could see CALLS but never provider→consumer injection wiring. Root cause confirmed: NOT-PROJECTED-BY-MCP, not missing extraction.

## Change
- **`archigraph_inspect`**: new additive `di_edges` section — `{kind, direction, other, line}` per DI edge, both inbound and outbound, omitted entirely when the entity has no DI edges. Mirrors the `inspectDiscriminators` (#2666) projection pattern. (`inspectDIEdges`)
- **`archigraph_expand`**: direct (depth-1) neighbours connected by a DI edge now carry `di_kind` + `di_direction`, distinguishing an injection from a plain CALLS neighbour. Absent on non-DI neighbours and on depth>1 neighbours. (`directDIEdges`)
- **SCHEMA.md** updated for both tools.

`direction` is `outbound` when the queried entity is the edge `FromID` (provider / module / token) and `inbound` when it is the `ToID` (consumer / impl). Edge-kind casing is preserved verbatim (`INJECTED_INTO`/`BINDS`) so consumers match the constant directly.

## Tests (value-asserting, `di_projection_3870_test.go`)
- provider `INJECTED_INTO` controller → surfaces on the controller as `inbound` (other=provider) AND on the provider as `outbound` (other=consumer), coexisting with `called_by`.
- `BINDS(module→token)` and `BINDS(token→impl)` surface with correct direction.
- section omitted when the entity has no DI edges (backward-compatible).
- `expand` annotates the provider neighbour with `di_kind=INJECTED_INTO`, `di_direction=inbound`; depth-2 neighbours are NOT annotated (no false positives).

## Gates
`go test ./internal/mcp/... ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet ./internal/mcp/` clean.

## DEPLOY-DEFERRED
Projection-only change to the MCP read path. Requires a coordinated live-daemon rebuild to take effect on the running MCP. No re-index needed — the DI edges are already in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)