### PR TITLE
Surface DATA_FLOWS_TO into the graph + add archigraph_data_flows (#3867)

### DIFF
--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -12,10 +12,14 @@
 //
 // Properties carried: field, sink_kind, sink, hop_via (when one-hop).
 //
-// Links are persisted to <group>-links-data-flow.json (sidecar) so the
-// method-segregated rewrite logic in RunAllPasses is undisturbed, exactly
-// as the constant-propagation resolves-to pass does. A compact summary is
-// also stamped onto the handler entity:
+// Links are emitted into the MAIN group links document (the graph edge set
+// the MCP overlays) via method-segregated overwrite — exactly as the sibling
+// structural passes (import/label/string/http) do — AND mirrored to the
+// <group>-links-data-flow.json sidecar (#3867). The sidecar is the canonical
+// source for the dedicated archigraph_data_flows MCP tool, which surfaces the
+// per-flow field / sink_kind / hop_path provenance a plain edge-kind
+// projection cannot carry. A compact summary is also stamped onto the handler
+// entity:
 //
 //	data_flows        "<field>-><sink>(<kind>)[ via <hop>],..." (bounded)
 //	data_flows_count  "<n>"
@@ -157,13 +161,38 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 		}
 	}
 
-	res.LinksAdded = len(links)
 	res.Candidates = scanned
 
 	if paths.Links == "" {
+		// No on-disk links document configured (in-memory test harness path):
+		// report the computed link count so value-asserting tests can inspect
+		// it without a write target.
+		res.LinksAdded = len(links)
 		return res, nil
 	}
+
+	// (A) #3867 — emit DATA_FLOWS_TO into the MAIN links document (the group
+	// edge set the MCP overlays) via method-segregated overwrite, exactly as
+	// the sibling structural passes (import/label/string/http/...) do. Before
+	// this, the links lived ONLY in the sidecar below and were invisible to
+	// every graph reader. Method-segregation means a re-run rewrites only the
+	// MethodDataFlow rows and preserves every other pass's edges; the shared
+	// rejection set is honoured the same way as siblings (by source|target|
+	// method key — see replaceByMethod).
 	sort.Slice(links, func(i, j int) bool { return links[i].ID < links[j].ID })
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodDataFlow), links, rejects)
+	if err != nil {
+		return res, fmt.Errorf("emit data-flow links: %w", err)
+	}
+	res.LinksAdded = added
+	res.Skipped += skipped
+
+	// Keep the sidecar too: it carries the same DATA_FLOWS_TO rows and is the
+	// canonical source for the dedicated archigraph_data_flows MCP tool (which
+	// surfaces the per-flow field / sink_kind / hop_path provenance that a
+	// plain edge-kind projection cannot). The links list was already filtered
+	// through the rejection set by replaceByMethod above, so the sidecar and
+	// the graph stay in lock-step.
 	sidecar := strings.TrimSuffix(paths.Links, ".json") + "-data-flow.json"
 	doc := dataFlowDocument{Version: 1, Method: MethodDataFlow, Total: len(links), Links: links}
 	buf, err := json.MarshalIndent(doc, "", "  ")

--- a/internal/links/dataflow_pass_test.go
+++ b/internal/links/dataflow_pass_test.go
@@ -56,6 +56,109 @@ func readDataFlowSidecar(t *testing.T, linksPath string) []Link {
 	return doc.Links
 }
 
+// readMainLinks reads the MAIN links document (the group edge set), not the
+// data-flow sidecar, so a test can assert the DATA_FLOWS_TO edge is reachable
+// the way a sibling structural link edge is (#3867).
+func readMainLinks(t *testing.T, linksPath string) []Link {
+	t.Helper()
+	doc, err := readDoc(linksPath)
+	if err != nil {
+		t.Fatalf("read main links: %v", err)
+	}
+	return doc.Links
+}
+
+// TestDataFlowPass_EmitsEdgeIntoMainGraph is the #3867 value assertion: after
+// the pass runs on a request-field→DB-sink fixture, the SPECIFIC DATA_FLOWS_TO
+// edge is present in the MAIN links document (the graph edge set the MCP
+// overlays) — not only in the sidecar. Asserts the exact from/to/field, the
+// way a sibling link edge would be queried.
+func TestDataFlowPass_EmitsEdgeIntoMainGraph(t *testing.T) {
+	root := t.TempDir()
+	file := "src/users.ts"
+	content := `
+function createUser(req, res) {
+  const name = req.body.name;
+  await User.create({ name });
+}
+`
+	writeFile(t, root, file, content)
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{{ID: "h1", Name: "createUser", Kind: "function", SourceFile: file}},
+	}}
+	linksPath := root + "/.archigraph/links.json"
+	if _, err := runDataFlowPass(graphs, Paths{Links: linksPath}, nil); err != nil {
+		t.Fatalf("pass error: %v", err)
+	}
+
+	// The edge must be in the MAIN links document, reachable exactly like a
+	// sibling structural edge — by relation kind + endpoint id.
+	main := readMainLinks(t, linksPath)
+	l := findLink(main, func(l Link) bool {
+		return l.Relation == string(types.RelationshipKindDataFlowsTo) &&
+			l.Source == "repo-a::h1" &&
+			l.Properties["field"] == "name" &&
+			l.Properties["sink"] == "User.create"
+	})
+	if l == nil {
+		t.Fatalf("DATA_FLOWS_TO edge absent from MAIN links document; got %+v", main)
+	}
+	if l.Method != MethodDataFlow {
+		t.Errorf("method = %q, want %q", l.Method, MethodDataFlow)
+	}
+	// And the sidecar still carries the same edge (no regression for the
+	// dedicated MCP tool / any future sidecar reader).
+	side := readDataFlowSidecar(t, linksPath)
+	if findLink(side, func(s Link) bool { return s.ID == l.ID }) == nil {
+		t.Errorf("edge %s present in main links but missing from sidecar", l.ID)
+	}
+}
+
+// TestDataFlowPass_MethodSegregated_PreservesOtherEdges asserts the
+// method-segregated overwrite contract: re-emitting DATA_FLOWS_TO rows leaves
+// a foreign-method edge (e.g. an import edge) untouched in the main document.
+func TestDataFlowPass_MethodSegregated_PreservesOtherEdges(t *testing.T) {
+	root := t.TempDir()
+	file := "src/users.ts"
+	content := `
+function createUser(req, res) {
+  const name = req.body.name;
+  await User.create({ name });
+}
+`
+	writeFile(t, root, file, content)
+	linksPath := root + "/.archigraph/links.json"
+	// Seed the main document with a pre-existing import edge owned by another
+	// pass.
+	seed := Link{
+		ID: "seedimp1", Source: "repo-a::x", Target: "repo-b::y",
+		Relation: RelationImports, Method: MethodImport, Confidence: 1,
+	}
+	if err := os.MkdirAll(root+"/.archigraph", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeDoc(linksPath, &Document{Version: SchemaVersion, Links: []Link{seed}}); err != nil {
+		t.Fatal(err)
+	}
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{{ID: "h1", Name: "createUser", Kind: "function", SourceFile: file}},
+	}}
+	if _, err := runDataFlowPass(graphs, Paths{Links: linksPath}, nil); err != nil {
+		t.Fatalf("pass error: %v", err)
+	}
+	main := readMainLinks(t, linksPath)
+	if findLink(main, func(l Link) bool { return l.ID == "seedimp1" }) == nil {
+		t.Errorf("import edge was clobbered by the data-flow pass; method-segregation broken")
+	}
+	if findLink(main, func(l Link) bool { return l.Relation == string(types.RelationshipKindDataFlowsTo) }) == nil {
+		t.Errorf("data-flow pass did not add its own DATA_FLOWS_TO edge")
+	}
+}
+
 func TestDataFlowPass_JSTS_DBWrite_EmitsEdge(t *testing.T) {
 	content := `
 function createUser(req, res) {

--- a/internal/mcp/data_flows_tool_test.go
+++ b/internal/mcp/data_flows_tool_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// writeDataFlowSidecar writes a data-flow sidecar for group "test" under a
+// temp HOME so handleDataFlows (which resolves via os.UserHomeDir) reads it.
+func writeDataFlowSidecar(t *testing.T, doc dataFlowSidecarDoc) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".archigraph", "groups")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "test-links-data-flow.json"), buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDataFlowsTool_ProjectsEdge is the #3867 MCP-projection value assertion:
+// the archigraph_data_flows tool surfaces the SPECIFIC DATA_FLOWS_TO edge from
+// the sidecar — with its field / sink_kind / sink provenance — so the rewrite
+// agent can query payload-shape flows. Before #3867 no tool projected it.
+func TestDataFlowsTool_ProjectsEdge(t *testing.T) {
+	writeDataFlowSidecar(t, dataFlowSidecarDoc{
+		Version: 1, Method: "data_flow", Total: 1,
+		Links: []dataFlowLinkSidecar{{
+			ID:         "df01",
+			Source:     "repo-a::createUser",
+			Target:     "repo-a::create",
+			Relation:   "DATA_FLOWS_TO",
+			Method:     "data_flow",
+			Confidence: 0.85,
+			Properties: map[string]string{
+				"field": "name", "sink_kind": "db_write", "sink": "User.create",
+			},
+		}},
+	})
+
+	srv := newTestServer(t, &graph.Document{Repo: "repo-a"})
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{})
+
+	if src, _ := out["source"].(string); src != "sidecar" {
+		t.Fatalf("source = %q, want sidecar (sidecar must be read)", src)
+	}
+	flows, ok := out["data_flows"].([]any)
+	if !ok || len(flows) != 1 {
+		t.Fatalf("data_flows = %v, want exactly one edge", out["data_flows"])
+	}
+	rec := flows[0].(map[string]any)
+	if rec["from"] != "repo-a::createUser" {
+		t.Errorf("from = %v, want repo-a::createUser", rec["from"])
+	}
+	if rec["to"] != "repo-a::create" {
+		t.Errorf("to = %v, want repo-a::create", rec["to"])
+	}
+	if rec["relation"] != "DATA_FLOWS_TO" {
+		t.Errorf("relation = %v, want DATA_FLOWS_TO", rec["relation"])
+	}
+	if rec["field"] != "name" {
+		t.Errorf("field = %v, want name", rec["field"])
+	}
+	if rec["sink_kind"] != "db_write" {
+		t.Errorf("sink_kind = %v, want db_write", rec["sink_kind"])
+	}
+	if rec["sink"] != "User.create" {
+		t.Errorf("sink = %v, want User.create", rec["sink"])
+	}
+}
+
+// TestDataFlowsTool_SinkKindFilter asserts the sink_kind filter narrows the
+// projection to matching edges only.
+func TestDataFlowsTool_SinkKindFilter(t *testing.T) {
+	writeDataFlowSidecar(t, dataFlowSidecarDoc{
+		Version: 1, Method: "data_flow", Total: 2,
+		Links: []dataFlowLinkSidecar{
+			{ID: "a", Source: "repo-a::h1", Target: "repo-a::s1", Relation: "DATA_FLOWS_TO",
+				Properties: map[string]string{"sink_kind": "db_write", "sink": "X.create"}},
+			{ID: "b", Source: "repo-a::h2", Target: "repo-a::s2", Relation: "DATA_FLOWS_TO",
+				Properties: map[string]string{"sink_kind": "http", "sink": "fetch"}},
+		},
+	})
+	srv := newTestServer(t, &graph.Document{Repo: "repo-a"})
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "http"})
+	flows, _ := out["data_flows"].([]any)
+	if len(flows) != 1 {
+		t.Fatalf("expected 1 http-sink flow, got %d: %v", len(flows), flows)
+	}
+	if flows[0].(map[string]any)["sink"] != "fetch" {
+		t.Errorf("filtered flow sink = %v, want fetch", flows[0].(map[string]any)["sink"])
+	}
+}
+
+// TestDataFlowsTool_MissingSidecar asserts the honest empty/missing contract.
+func TestDataFlowsTool_MissingSidecar(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no sidecar written
+	srv := newTestServer(t, &graph.Document{Repo: "repo-a"})
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{})
+	if src, _ := out["source"].(string); src != "missing" {
+		t.Errorf("source = %v, want missing", out["source"])
+	}
+	if c, _ := out["count"].(float64); c != 0 {
+		t.Errorf("count = %v, want 0", out["count"])
+	}
+}

--- a/internal/mcp/phase3_tools.go
+++ b/internal/mcp/phase3_tools.go
@@ -317,6 +317,140 @@ func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*m
 }
 
 // ---------------------------------------------------------------------
+// #3867 — archigraph_data_flows
+// ---------------------------------------------------------------------
+//
+// Surfaces the request-input → sink DATA_FLOWS_TO edges computed by the
+// data-flow link pass (internal/links/dataflow_pass.go). Before #3867 those
+// edges lived ONLY in the sidecar with no reader, so `neighbors
+// fields:[data_flows_to]` returned nothing. The pass now also emits them into
+// the main links document (so they ride the cross-repo/overlay edge surface),
+// and this tool projects the sidecar so a caller gets the full per-flow
+// provenance — the tainted request `field`, the `sink_kind`, the resolved
+// `sink`, and the inter-procedural `hop_path` — that a bare edge-kind filter
+// cannot carry.
+
+// dataFlowLinkSidecar mirrors the subset of internal/links.Link the data-flow
+// sidecar persists (it serialises the full Link, we read what we project).
+type dataFlowLinkSidecar struct {
+	ID         string            `json:"id"`
+	Source     string            `json:"source"`
+	Target     string            `json:"target"`
+	Relation   string            `json:"relation"`
+	Method     string            `json:"method"`
+	Confidence float64           `json:"confidence"`
+	Properties map[string]string `json:"properties,omitempty"`
+}
+
+type dataFlowSidecarDoc struct {
+	Version int                   `json:"version"`
+	Method  string                `json:"method"`
+	Total   int                   `json:"total_flows"`
+	Links   []dataFlowLinkSidecar `json:"links"`
+}
+
+// dataFlowEndpointRepo extracts the "<repo>" prefix from a links-pass
+// "<repo>::<localId>" endpoint key. Synthetic `sink:` residues (no repo
+// prefix) yield "" — they are kept but never repo-filtered out.
+func dataFlowEndpointRepo(key string) string {
+	if i := strings.Index(key, "::"); i > 0 {
+		return key[:i]
+	}
+	return ""
+}
+
+func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName, _, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoFilter := map[string]bool{}
+	for _, r := range argStringSlice(req, "repo_filter") {
+		repoFilter[r] = true
+	}
+	entityFilter := strings.TrimSpace(argString(req, "entity_id", ""))
+	sinkKindFilter := strings.ToLower(strings.TrimSpace(argString(req, "sink_kind", "")))
+	limit := argInt(req, "limit", 100)
+
+	var doc dataFlowSidecarDoc
+	path := sidecarPath(groupName, "data-flow")
+	if !loadSidecar(path, &doc) {
+		return jsonResult(map[string]any{
+			"data_flows": []any{},
+			"count":      0,
+			"total":      0,
+			"source":     "missing",
+			"note":       "Data-flow sidecar absent — run the link passes to generate it (#3867).",
+		}), nil
+	}
+
+	out := make([]map[string]any, 0, len(doc.Links))
+	for _, l := range doc.Links {
+		srcRepo := dataFlowEndpointRepo(l.Source)
+		if len(repoFilter) > 0 && !repoFilter[srcRepo] {
+			continue
+		}
+		if entityFilter != "" && l.Source != entityFilter {
+			continue
+		}
+		props := l.Properties
+		if props == nil {
+			props = map[string]string{}
+		}
+		if sinkKindFilter != "" && strings.ToLower(props["sink_kind"]) != sinkKindFilter {
+			continue
+		}
+		rec := map[string]any{
+			"id":         l.ID,
+			"from":       l.Source,
+			"to":         l.Target,
+			"relation":   l.Relation,
+			"confidence": l.Confidence,
+			"field":      props["field"],
+			"sink_kind":  props["sink_kind"],
+			"sink":       props["sink"],
+		}
+		if v := props["hop_via"]; v != "" {
+			rec["hop_via"] = v
+		}
+		if v := props["hop_path"]; v != "" {
+			rec["hop_path"] = v
+		}
+		if v := props["hop_count"]; v != "" {
+			rec["hop_count"] = v
+		}
+		out = append(out, rec)
+	}
+	// Stable order: by from-endpoint, then sink, then id.
+	sort.SliceStable(out, func(i, j int) bool {
+		fi, fj := fmt.Sprint(out[i]["from"]), fmt.Sprint(out[j]["from"])
+		if fi != fj {
+			return fi < fj
+		}
+		si, sj := fmt.Sprint(out[i]["sink"]), fmt.Sprint(out[j]["sink"])
+		if si != sj {
+			return si < sj
+		}
+		return fmt.Sprint(out[i]["id"]) < fmt.Sprint(out[j]["id"])
+	})
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"data_flows": out,
+		"count":      len(out),
+		"total":      total,
+		"truncated":  total > len(out),
+		"source":     "sidecar",
+		"note": "Request-input → sink DATA_FLOWS_TO edges (intra-function + bounded inter-procedural hops). " +
+			"`from` is the request handler, `to` the resolved sink entity (or a synthetic sink: residue), " +
+			"`field` the tainted request field, `hop_path` the inter-procedural chain. " +
+			"Precision-first: a flow the sniffer did not soundly follow is never fabricated (#3867).",
+	}), nil
+}
+
+// ---------------------------------------------------------------------
 // 3D — archigraph_template_patterns
 // ---------------------------------------------------------------------
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -580,6 +580,20 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_def_use", s.handleDefUse))
 
+	// #3867 — request-input → sink DATA_FLOWS_TO projection. Surfaces the
+	// data-flow edges (with field / sink_kind / hop_path provenance) the
+	// dataflow link pass emits. Before #3867 these lived only in an unread
+	// sidecar and were invisible to every graph reader.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_data_flows",
+		mcpapi.WithDescription("Request-input→sink DATA_FLOWS_TO edges (field/sink_kind/hop_path)."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithString("entity_id", mcpapi.Description("Optional: restrict to flows from one handler entity id (<repo>::<localId>).")),
+		mcpapi.WithString("sink_kind", mcpapi.Description("Optional: filter by sink kind (e.g. db, http, fs).")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_data_flows", s.handleDataFlows))
+
 	// #2774 / #2775 — Phase 3D template-pattern catalog. Surfaces
 	// every i18n key, log-format string, and SQL template literal
 	// across the group's source files.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -594,6 +594,7 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_pure_functions",
 		"archigraph_import_cycles",
 		"archigraph_def_use",
+		"archigraph_data_flows",
 		"archigraph_template_patterns",
 	}
 	for _, n := range wantPresent {
@@ -683,8 +684,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_security_findings (#2772 Phase 2B taint-flow).
 	// +4 archigraph_pure_functions/_import_cycles/_def_use/_template_patterns (#2774/#2775 Phase 3 misc).
 	// +1 archigraph_feedback_event (#3204 agent-experience feedback, internal test harness).
-	if got := len(allRegisteredTools); got != 54 {
-		t.Errorf("expected 54 registered tools, got %d — update this count if tools are added/removed (added archigraph_feedback_event #3204)", got)
+	// +1 archigraph_data_flows (#3867 request-input→sink DATA_FLOWS_TO projection).
+	if got := len(allRegisteredTools); got != 55 {
+		t.Errorf("expected 55 registered tools, got %d — update this count if tools are added/removed (added archigraph_data_flows #3867)", got)
 	}
 }
 
@@ -3194,6 +3196,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_pure_functions":    {"group": "g"},
 		"archigraph_import_cycles":     {"group": "g"},
 		"archigraph_def_use":           {"group": "g"},
+		"archigraph_data_flows":        {"group": "g"},
 		"archigraph_template_patterns": {"group": "g"},
 	}
 
@@ -3239,8 +3242,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 54 {
-		t.Errorf("expected 54 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_feedback_event #3204)", len(tools))
+	if len(tools) != 55 {
+		t.Errorf("expected 55 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_data_flows #3867)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
Closes #3867 (epic #3860).

## Problem
The request-input → sink dataflow pass (`internal/links/dataflow_pass.go`) *computed* `DATA_FLOWS_TO` links but persisted them **only** to the `<group>-links-data-flow.json` sidecar — and nothing read that sidecar back into the graph, nor did any MCP tool project the edge kind. So `neighbors fields:[data_flows_to]` returned nothing and the edges were invisible to every graph reader, even though the pass runs for python + jsts. (The separate `def_use` count:0 limit, #2774, is unrelated and out of scope.)

## Fix
**(A) Graph emission.** `runDataFlowPass` now emits its `DATA_FLOWS_TO` links into the **main group links document** via method-segregated `replaceByMethod(MethodDataFlow, …)` — the exact mechanism the sibling structural passes (import / label / string / http / openapi / grpc) use to land their edges in the graph edge set the MCP overlays. The shared rejection set is now honoured the same way as siblings. The sidecar is still written (a mirror of the graph rows) as the canonical source for the new tool, so no future sidecar reader regresses.

**(B) MCP projection.** New `archigraph_data_flows` tool (`internal/mcp/phase3_tools.go`, registered in `server.go`) projects the sidecar with full per-flow provenance — the tainted request `field`, the `sink_kind`, the resolved `sink`, and the inter-procedural `hop_path` — that a bare edge-kind filter cannot carry. Supports `repo_filter` / `entity_id` / `sink_kind` filters and the honest missing-sidecar contract mirroring the existing Phase 3 tools. The `DATA_FLOWS_TO` edges also now ride the cross-repo/overlay edge surface (`archigraph_expand`, `archigraph_cross_links`) since they live in the main links doc.

## How DATA_FLOWS_TO now surfaces
- **Dedicated tool:** `archigraph_data_flows` → each record is `{from, to, relation:"DATA_FLOWS_TO", field, sink_kind, sink, hop_via, hop_path, hop_count, confidence}`. This is the payload-shape-tracing surface for the rewrite agent.
- **Edge set:** the edges are in the main `links.json` with `relation=DATA_FLOWS_TO`, `method=data_flow`, so they appear wherever the overlay edges do.

## Tests (value-asserting)
- `TestDataFlowPass_EmitsEdgeIntoMainGraph` — the *specific* edge (from `repo-a::createUser`, `field=name`, `sink=User.create`) is present in the MAIN links document, not only the sidecar.
- `TestDataFlowPass_MethodSegregated_PreservesOtherEdges` — a foreign import edge survives a data-flow re-emit.
- `TestDataFlowsTool_ProjectsEdge` / `_SinkKindFilter` / `_MissingSidecar` — the MCP tool projects the exact edge with provenance, filters by sink_kind, and honours the missing-sidecar contract.

## Validation
- `go test ./internal/links/... ./internal/mcp/... ./internal/types/ ./tools/coverage/` green.
- `go vet` clean; `gofmt -l` empty.
- `coverage validate` 0 errors; `coverage fmt --check` canonical; `coverage gen` no doc drift.

## DEPLOY-DEFERRED
The live daemon must be rebuilt and the group reindexed for the `DATA_FLOWS_TO` edges to materialise in the served graph. No live daemon was touched (sandboxed worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)