### PR TITLE
feat(drf): route provenance + defining_class on router-expanded endpoints (#3831)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -228,6 +228,72 @@ type drfViewSetClass struct {
 	// synthesized http_endpoint (#3864). Zero value means "nothing declared"
 	// (honest-partial — no fabricated posture).
 	posture drfPosture
+	// resolved reports whether the ViewSet class was actually located and
+	// parsed on disk (parseViewSetClass found the `class <name>(...)`
+	// declaration). When false, the caller fell back to modelViewSetMethods()
+	// without ever reading a class body, so a CRUD verb's body presence is
+	// unknown — its route provenance is `synthesized`, not `inherited` (#3831).
+	resolved bool
+}
+
+// crudVerbDefiningMixin maps each DRF CRUD method name to the rest_framework
+// mixin class that implements it (the DRF dispatch table). Used to stamp
+// `defining_class` on router-expanded routes whose verb is INHERITED from a
+// mixin rather than overridden in the ViewSet body (#3831). This is the
+// canonical DRF wiring: rest_framework.mixins.{List,Create,Retrieve,Update,
+// Destroy}ModelMixin. Both `update` and `partial_update` are implemented by
+// UpdateModelMixin (update() + partial_update() live in the same mixin).
+var crudVerbDefiningMixin = map[string]string{
+	"list":           "ListModelMixin",
+	"create":         "CreateModelMixin",
+	"retrieve":       "RetrieveModelMixin",
+	"update":         "UpdateModelMixin",
+	"partial_update": "UpdateModelMixin",
+	"destroy":        "DestroyModelMixin",
+}
+
+// Route-provenance tag values stamped onto router-expanded http_endpoint
+// synthetics (#3831). They answer the #278 disambiguation: is a verb on a
+// generated route overridden in the ViewSet body, inherited from a mixin, an
+// @action custom route, or a pure router default with no body anywhere?
+const (
+	// drfProvExplicit — the handler method is defined directly in the ViewSet
+	// class body (overridden). defining_class is the ViewSet itself.
+	drfProvExplicit = "explicit"
+	// drfProvInherited — a CRUD verb the ViewSet exposes via a mixin it does
+	// not override. defining_class is the implementing mixin (best-effort).
+	drfProvInherited = "inherited"
+	// drfProvAction — an @action / @detail_route / @list_route custom route.
+	// The decorated method lives in the ViewSet body, so defining_class is the
+	// ViewSet.
+	drfProvAction = "action"
+	// drfProvSynthesized — a router default route for a ViewSet that could not
+	// be resolved on disk: the CRUD family is assumed (modelViewSetMethods)
+	// with no class body ever read, so no body presence is known anywhere.
+	drfProvSynthesized = "synthesized"
+)
+
+// drfCRUDProvenance computes the (provenance, defining_class) pair for a CRUD
+// route on the given ViewSet (#3831).
+//
+//   - The ViewSet overrides the method in its body  → explicit, defining_class
+//     = the ViewSet class.
+//   - The ViewSet was resolved and the method is inherited from a mixin →
+//     inherited, defining_class = the implementing mixin from
+//     crudVerbDefiningMixin (or "" when the verb maps to an unknown custom
+//     base — honest-partial: provenance stays inherited, defining_class
+//     omitted).
+//   - The ViewSet could NOT be resolved on disk → synthesized (the whole CRUD
+//     family is an assumed router default; no body presence is known).
+func drfCRUDProvenance(vc drfViewSetClass, viewSetName, method string) (provenance, definingClass string) {
+	if vc.explicitMethods[method] {
+		return drfProvExplicit, viewSetName
+	}
+	if !vc.resolved {
+		// No class body was ever read — the verb is an assumed router default.
+		return drfProvSynthesized, ""
+	}
+	return drfProvInherited, crudVerbDefiningMixin[method]
 }
 
 // drfAction is a single @action-decorated method on a ViewSet.
@@ -330,7 +396,7 @@ func ApplyDjangoDRFRoutes(
 	// when the ViewSet class cannot be resolved). sourceLine is the 1-based
 	// line of `def <handler>(` (for explicit / @action methods) or the class
 	// def line (for inherited mixin methods). #2677.
-	emit := func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture) {
+	emit := func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture, provenance, definingClass string) {
 		if canonical == "" || canonical == "/" {
 			return
 		}
@@ -385,6 +451,18 @@ func ApplyDjangoDRFRoutes(
 		// SourceFile=ViewSet not routers.py), so the DRF expansion is the only
 		// place ViewSet-level posture can be attributed to the generated routes.
 		stampDRFEndpointPosture(props, posture)
+
+		// #3831 — stamp route provenance (explicit | inherited | action |
+		// synthesized) + the defining_class so consumers can disambiguate an
+		// overridden verb from an inherited one (the #278 question). provenance
+		// is always set for a router-expanded route; defining_class is omitted
+		// only in the honest-partial case (unknown custom base).
+		if provenance != "" {
+			props["provenance"] = provenance
+		}
+		if definingClass != "" {
+			props["defining_class"] = definingClass
+		}
 
 		out = append(out, types.EntityRecord{
 			ID:                 id,
@@ -1080,7 +1158,7 @@ func expandRegisterPrefixes(
 // exactly ONE canonical placeholder per detail route — the ViewSet's
 // declared lookup_field (defaulting to "pk").
 func emitCRUDFamily(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture, provenance, definingClass string),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
@@ -1105,7 +1183,7 @@ func crudMethodLine(vc drfViewSetClass, method string) int {
 // `lookup_field`) is the source of truth; subsequent calls with alternate
 // placeholders widen the cross-repo match surface (#704 companion).
 func emitOneCRUDFamily(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture, provenance, definingClass string),
 	fullPrefix string,
 	placeholder string,
 	vc drfViewSetClass,
@@ -1116,27 +1194,35 @@ func emitOneCRUDFamily(
 	// #3864 — all CRUD routes inherit the ViewSet-level posture.
 	pos := vc.posture
 
+	// emitCRUD wraps emit with the #3831 provenance/defining_class computed for
+	// the given CRUD method, so each route is tagged explicit | inherited |
+	// synthesized with the right defining class.
+	emitCRUD := func(verb, canonical string, line int, method string) {
+		prov, defClass := drfCRUDProvenance(vc, viewSetName, method)
+		emit(verb, canonical, sourceFile, line, viewSetName, method, pos, prov, defClass)
+	}
+
 	if vc.crudMethods["list"] {
-		emit("GET", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "list"), viewSetName, "list", pos)
+		emitCRUD("GET", canonicalDjango(fullPrefix), crudMethodLine(vc, "list"), "list")
 	}
 	if vc.crudMethods["create"] {
-		emit("POST", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "create"), viewSetName, "create", pos)
+		emitCRUD("POST", canonicalDjango(fullPrefix), crudMethodLine(vc, "create"), "create")
 	}
 	hasDetailVerb := false
 	if vc.crudMethods["retrieve"] {
-		emit("GET", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "retrieve"), viewSetName, "retrieve", pos)
+		emitCRUD("GET", canonicalDjango(detailBase), crudMethodLine(vc, "retrieve"), "retrieve")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["update"] {
-		emit("PUT", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "update"), viewSetName, "update", pos)
+		emitCRUD("PUT", canonicalDjango(detailBase), crudMethodLine(vc, "update"), "update")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["partial_update"] {
-		emit("PATCH", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "partial_update"), viewSetName, "partial_update", pos)
+		emitCRUD("PATCH", canonicalDjango(detailBase), crudMethodLine(vc, "partial_update"), "partial_update")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["destroy"] {
-		emit("DELETE", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "destroy"), viewSetName, "destroy", pos)
+		emitCRUD("DELETE", canonicalDjango(detailBase), crudMethodLine(vc, "destroy"), "destroy")
 		hasDetailVerb = true
 	}
 	// Emit an ANY-verb detail fallback ONLY when no per-verb detail routes
@@ -1146,7 +1232,10 @@ func emitOneCRUDFamily(
 	// verb-aware matcher must skip, and it defeated the iter3 calibration
 	// top add-rec #2 (detail routes still showing method=ANY). Fix #1692.
 	if !hasDetailVerb {
-		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "", pos)
+		// The ANY catch-all only appears when the ViewSet could not be resolved
+		// (empty crudMethods), so the detail route is a pure router default with
+		// no body anywhere → synthesized, no defining_class (#3831).
+		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "", pos, drfProvSynthesized, "")
 	}
 }
 
@@ -1154,7 +1243,7 @@ func emitOneCRUDFamily(
 // ViewSet. For detail=True actions the route is
 // /<prefix>/{lookup}/<url_path>/; for detail=False it is /<prefix>/<url_path>/.
 func emitActionRoutes(
-	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string, posture drfPosture, provenance, definingClass string),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
@@ -1205,7 +1294,10 @@ func emitActionRoutes(
 				actionLine = vc.classDefLine
 			}
 			for _, verb := range methods {
-				emit(verb, canonical, sourceFile, actionLine, viewSetName, act.methodName, actPosture)
+				// #3831 — an @action route's handler is the decorated method,
+				// which lives in the ViewSet body, so defining_class is the
+				// ViewSet itself.
+				emit(verb, canonical, sourceFile, actionLine, viewSetName, act.methodName, actPosture, drfProvAction, viewSetName)
 			}
 		}
 	}
@@ -1542,6 +1634,10 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	if classBodyStart == -1 {
 		return out
 	}
+	// The class declaration was located and its body is about to be parsed —
+	// mark the ViewSet resolved so route provenance can distinguish inherited
+	// (real mixin, body read) from synthesized (assumed default, no body) (#3831).
+	out.resolved = true
 
 	// 1-based line of the `class X(...)` declaration. Used as the fallback
 	// StartLine for inherited CRUD methods (#2677).

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -2729,3 +2729,131 @@ class CustomViewSet(ModelViewSet):
 	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
 	assertNoProp(t, got, "http:GET:/custom", "paginated")
 }
+
+// TestApplyDjangoDRFRoutes_ProvenanceMixedViewSet is the #3831 value-asserting
+// test. A ModelViewSet that OVERRIDES `list` in its body but INHERITS
+// retrieve/update/partial_update/destroy from the DRF mixins, plus an @action,
+// must tag each router-expanded route with the right provenance + defining_class:
+//
+//   - GET /things         (list, overridden)        → explicit, ThingViewSet
+//   - GET /things/{pk}     (retrieve, inherited)      → inherited, RetrieveModelMixin
+//   - PUT /things/{pk}     (update, inherited)        → inherited, UpdateModelMixin
+//   - PATCH /things/{pk}   (partial_update, inherited)→ inherited, UpdateModelMixin
+//   - DELETE /things/{pk}  (destroy, inherited)       → inherited, DestroyModelMixin
+//   - POST /things         (create, inherited)        → inherited, CreateModelMixin
+//   - POST /things/{pk}/archive (@action)            → action, ThingViewSet
+func TestApplyDjangoDRFRoutes_ProvenanceMixedViewSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ThingViewSet
+
+router = routers.DefaultRouter()
+router.register(r"things", ThingViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class ThingViewSet(ModelViewSet):
+    def list(self, request, *args, **kwargs):
+        return None
+
+    @action(detail=True, methods=["post"], url_path="archive")
+    def archive(self, request, pk=None):
+        return None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// list is overridden in the body → explicit, defining_class = the ViewSet.
+	assertEndpointProp(t, got, "http:GET:/things", "provenance", drfProvExplicit)
+	assertEndpointProp(t, got, "http:GET:/things", "defining_class", "ThingViewSet")
+
+	// retrieve is inherited from RetrieveModelMixin.
+	assertEndpointProp(t, got, "http:GET:/things/{pk}", "provenance", drfProvInherited)
+	assertEndpointProp(t, got, "http:GET:/things/{pk}", "defining_class", "RetrieveModelMixin")
+
+	// update / partial_update both come from UpdateModelMixin.
+	assertEndpointProp(t, got, "http:PUT:/things/{pk}", "provenance", drfProvInherited)
+	assertEndpointProp(t, got, "http:PUT:/things/{pk}", "defining_class", "UpdateModelMixin")
+	assertEndpointProp(t, got, "http:PATCH:/things/{pk}", "provenance", drfProvInherited)
+	assertEndpointProp(t, got, "http:PATCH:/things/{pk}", "defining_class", "UpdateModelMixin")
+
+	// destroy is inherited from DestroyModelMixin.
+	assertEndpointProp(t, got, "http:DELETE:/things/{pk}", "provenance", drfProvInherited)
+	assertEndpointProp(t, got, "http:DELETE:/things/{pk}", "defining_class", "DestroyModelMixin")
+
+	// create is inherited from CreateModelMixin.
+	assertEndpointProp(t, got, "http:POST:/things", "provenance", drfProvInherited)
+	assertEndpointProp(t, got, "http:POST:/things", "defining_class", "CreateModelMixin")
+
+	// The @action route is provenance=action, defining_class = the ViewSet
+	// (the decorated method lives in the ViewSet body).
+	assertEndpointProp(t, got, "http:POST:/things/{pk}/archive", "provenance", drfProvAction)
+	assertEndpointProp(t, got, "http:POST:/things/{pk}/archive", "defining_class", "ThingViewSet")
+}
+
+// TestApplyDjangoDRFRoutes_ProvenanceAllExplicit is the #3831 negative case: a
+// ViewSet that overrides EVERY CRUD method in its body → every route is
+// provenance=explicit with defining_class = the ViewSet, and NO route carries
+// an inherited mixin defining_class.
+func TestApplyDjangoDRFRoutes_ProvenanceAllExplicit(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import FullViewSet
+
+router = routers.DefaultRouter()
+router.register(r"items", FullViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class FullViewSet(ModelViewSet):
+    def list(self, request, *a, **k): return None
+    def create(self, request, *a, **k): return None
+    def retrieve(self, request, *a, **k): return None
+    def update(self, request, *a, **k): return None
+    def partial_update(self, request, *a, **k): return None
+    def destroy(self, request, *a, **k): return None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	for _, id := range []string{
+		"http:GET:/items",
+		"http:POST:/items",
+		"http:GET:/items/{pk}",
+		"http:PUT:/items/{pk}",
+		"http:PATCH:/items/{pk}",
+		"http:DELETE:/items/{pk}",
+	} {
+		assertEndpointProp(t, got, id, "provenance", drfProvExplicit)
+		assertEndpointProp(t, got, id, "defining_class", "FullViewSet")
+	}
+}
+
+// TestApplyDjangoDRFRoutes_ProvenanceUnresolvedIsSynthesized verifies that when
+// the ViewSet class cannot be located on disk (no body ever read), the assumed
+// CRUD family is tagged provenance=synthesized with no defining_class — the
+// honest-partial case distinct from `inherited` (#3831).
+func TestApplyDjangoDRFRoutes_ProvenanceUnresolvedIsSynthesized(t *testing.T) {
+	files := fileMap{
+		// No views.py — MysteryViewSet is never resolvable, so the pass falls
+		// back to the full CRUD family without reading any class body.
+		"urls.py": `
+from rest_framework import routers
+from somewhere.unknown import MysteryViewSet
+
+router = routers.DefaultRouter()
+router.register(r"mystery", MysteryViewSet)
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py"}, files.reader)
+
+	assertEndpointProp(t, got, "http:GET:/mystery", "provenance", drfProvSynthesized)
+	assertNoProp(t, got, "http:GET:/mystery", "defining_class")
+	assertEndpointProp(t, got, "http:DELETE:/mystery/{pk}", "provenance", drfProvSynthesized)
+	assertNoProp(t, got, "http:DELETE:/mystery/{pk}", "defining_class")
+}


### PR DESCRIPTION
## What

The FIRST/highest-value MRO PR (epic #3829). Tags every DRF router-expanded `http_endpoint` synthetic with two new properties so consumers can answer the #278 question — *is a verb on a generated route overridden in the ViewSet, or inherited from a mixin?* — across the ~45-55% of the DRF route surface that comes from router expansion.

Builds on #3890 (ViewSet-resolved posture stamping in the same file); reuses the data the synthesizer already computes.

### New properties (on `pattern_type=drf_router_expanded` entities)

| provenance | meaning | defining_class |
|---|---|---|
| `explicit` | CRUD method overridden in the ViewSet body | the ViewSet |
| `inherited` | CRUD verb from a mixin the ViewSet doesn't override | the implementing mixin (DRF dispatch table) |
| `action` | `@action` / `@detail_route` / `@list_route` route | the ViewSet (decorated method is in its body) |
| `synthesized` | router default for a ViewSet not resolvable on disk (no body read anywhere) | omitted |

`defining_class` for inherited verbs maps via the canonical DRF wiring: `list→ListModelMixin`, `create→CreateModelMixin`, `retrieve→RetrieveModelMixin`, `update`/`partial_update→UpdateModelMixin`, `destroy→DestroyModelMixin`.

### Honest-partial discipline
- A ViewSet resolved with an **unknown custom base** stays `inherited` with `defining_class` best-effort (omitted if the verb maps to no known mixin) — never fabricated.
- A ViewSet that **cannot be located on disk** is `synthesized` (the whole CRUD family is an assumed router default), distinct from `inherited`. A new `resolved` flag on `drfViewSetClass`, set in `parseViewSetClass` once the class decl is found, draws that line.

## Tests (value-asserting, not len>0)
- `ProvenanceMixedViewSet`: a `ModelViewSet` overriding `list`, inheriting retrieve/update/partial_update/destroy/create, plus an `@action` — asserts provenance + defining_class on each specific route (GET /things = explicit/ThingViewSet; GET /things/{pk} = inherited/RetrieveModelMixin; PUT & PATCH = inherited/UpdateModelMixin; DELETE = inherited/DestroyModelMixin; POST = inherited/CreateModelMixin; @action = action/ThingViewSet).
- `ProvenanceAllExplicit` (negative): a ViewSet overriding every CRUD method → all routes explicit/ViewSet.
- `ProvenanceUnresolvedIsSynthesized`: unresolvable ViewSet → synthesized, no defining_class.

## Gates
`go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green · `gofmt -l` empty · `go vet` clean · coverage `validate` 0 errors · `fmt --check` canonical.

Closes #3831

**DEPLOY-DEFERRED**: requires a coordinated daemon rebuild + reindex to surface on the graph; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)