### PR TITLE
fix(effects): inherit task-body effects on SCOPE.ScheduledJob nodes (#3869)

### DIFF
--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -407,6 +407,23 @@ func newEffectBinder(graphs []repoGraph) *effectBinder {
 			// Accumulate (never overwrite) so a decorator-wrapper node and
 			// its Operation body — same (file, name) — both bind.
 			fileIdx[e.Name] = append(fileIdx[e.Name], e.ID)
+			// #3869: a synthetic SCOPE.ScheduledJob node (e.g. Celery's
+			// `celery:<path>:<fn>`) carries its task-body function name in the
+			// `handler` property, NOT in e.Name — e.Name is the synthetic job
+			// ID. The substrate sniffer attributes a sink to the bare function
+			// name (`<fn>`), so unless we ALSO index the ScheduledJob node under
+			// its handler name, the binder's (file, name) match fails and the
+			// wrapper stays `pure` even though its body does IO. Index by the
+			// handler name too (when it differs from e.Name) so the existing
+			// #2804 stamp-every-matching-entity machinery reaches the
+			// ScheduledJob node. Honest: this only adds a binding key; if no
+			// task-body def with that name exists in the file, the sniffer
+			// produces no match and nothing is fabricated.
+			if isScheduledJobKind(e.Kind) {
+				if h := e.Properties["handler"]; h != "" && h != e.Name {
+					fileIdx[h] = append(fileIdx[h], e.ID)
+				}
+			}
 		}
 	}
 	return b
@@ -472,6 +489,20 @@ func isFunctionLikeKind(kind string) bool {
 	case "function", "method", "operation":
 		return true
 	case "Task", "ScheduledJob", "Process":
+		return true
+	}
+	return false
+}
+
+// isScheduledJobKind reports whether kind names a synthetic scheduled-job
+// wrapper entity whose backing function name lives in the `handler` property
+// rather than in e.Name (#3869). The scheduled-job synthesis pass keys these
+// nodes on a framework-namespaced job ID (e.g. `celery:<path>:<fn>`), so the
+// binder needs the `handler` value to match the sniffer's bare-name sink
+// attribution.
+func isScheduledJobKind(kind string) bool {
+	switch kind {
+	case "SCOPE.ScheduledJob", "ScheduledJob", "SCOPE.Task", "Task":
 		return true
 	}
 	return false

--- a/internal/links/effect_propagation_test.go
+++ b/internal/links/effect_propagation_test.go
@@ -333,6 +333,101 @@ class HealthView:
 	}
 }
 
+// TestEffectPropagation_ScheduledJobInheritsTaskBodyEffects is the #3869
+// regression. A Celery SCOPE.ScheduledJob node is keyed on the synthetic job
+// ID `celery:<path>:<fn>` (in e.Name) while its backing task function name
+// lives in the `handler` property. The substrate sniffer attributes the task
+// body's db_write sink to the bare function name, so before the fix the
+// ScheduledJob node's (file, name) bind failed and it reported `pure` despite
+// its body doing IO. After the fix the node inherits the task body's effects.
+func TestEffectPropagation_ScheduledJobInheritsTaskBodyEffects(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "tasks.py", `
+from celery import shared_task
+
+@shared_task
+def send_me_notifications():
+    Notification.objects.create(user_id=1, body="hi")
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			// The Operation body, named with the bare function name.
+			{ID: "op", Name: "send_me_notifications", Kind: "SCOPE.Operation", SourceFile: "tasks.py"},
+			// The synthetic ScheduledJob node, as scheduled_jobs_edges.go emits
+			// it: Name is the celery job ID, the bare task name is in `handler`.
+			{ID: "job", Name: "celery:tasks.py:send_me_notifications", Kind: "SCOPE.ScheduledJob",
+				SourceFile: "tasks.py", Properties: map[string]string{
+					"handler":   "send_me_notifications",
+					"framework": "celery",
+				}},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Locate the ScheduledJob node specifically and assert db_write on it.
+	var job *entityNode
+	for i := range graphs[0].Entities {
+		if graphs[0].Entities[i].Kind == "SCOPE.ScheduledJob" {
+			job = &graphs[0].Entities[i]
+		}
+	}
+	if job == nil {
+		t.Fatal("ScheduledJob entity missing from graph")
+	}
+	if job.Properties == nil {
+		t.Fatal("ScheduledJob node left unstamped — #3869 binding regression")
+	}
+	effs := job.Properties[EffectPropertyKeyList]
+	if !strings.Contains(effs, "db_write") {
+		t.Fatalf("ScheduledJob (celery:...:send_me_notifications) effects=%q; "+
+			"want db_write inherited from the task body (#3869)", effs)
+	}
+}
+
+// TestEffectPropagation_ScheduledJobPureBodyStaysPure is the #3869 negative:
+// a ScheduledJob whose task body genuinely does no IO must NOT acquire a
+// fabricated effect. The binder only adds a name key — it never invents a sink.
+func TestEffectPropagation_ScheduledJobPureBodyStaysPure(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "tasks.py", `
+from celery import shared_task
+
+@shared_task
+def add_numbers():
+    return 1 + 2
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "op", Name: "add_numbers", Kind: "SCOPE.Operation", SourceFile: "tasks.py"},
+			{ID: "job", Name: "celery:tasks.py:add_numbers", Kind: "SCOPE.ScheduledJob",
+				SourceFile: "tasks.py", Properties: map[string]string{
+					"handler":   "add_numbers",
+					"framework": "celery",
+				}},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	var job *entityNode
+	for i := range graphs[0].Entities {
+		if graphs[0].Entities[i].Kind == "SCOPE.ScheduledJob" {
+			job = &graphs[0].Entities[i]
+		}
+	}
+	if job == nil {
+		t.Fatal("ScheduledJob entity missing from graph")
+	}
+	if v, ok := job.Properties[EffectPropertyKeyList]; ok {
+		t.Errorf("pure-bodied ScheduledJob carries fabricated effects=%q; want unstamped", v)
+	}
+}
+
 func confFromProps(props map[string]string, effect string) float64 {
 	if props == nil {
 		return 0


### PR DESCRIPTION
## Summary

A Celery `SCOPE.ScheduledJob` node showed `effects:pure` even when its backing task function did IO (e.g. `db_write`). This closes the last of the 6 deploy-6 asks under epic #3860.

## Root cause

The wrapper-effect-inheritance machinery exists (#2804) but never reached the separate `SCOPE.ScheduledJob` node. The scheduled-job synthesis pass (`scheduled_jobs_edges.go`) keys the node on a framework-namespaced job ID — `celery:<path>:<fn>` — stored in `e.Name`, while the **bare task function name** lives in the `handler` property. The substrate sniffer attributes a sink to the bare function name, so the effect binder's `(file, name)` match never matched the ScheduledJob node: it bound to nothing and stayed `pure`. This is failure mode **(b)** from the diagnosis — a `(file,name)` match failure for the celery decorator shape.

## Fix

In `newEffectBinder`, additionally index `SCOPE.ScheduledJob`/`Task` nodes under their `handler` property name (when it differs from `e.Name`). This lets the existing #2804 stamp-every-matching-entity machinery reach the wrapper, so it inherits the same effects its task body resolves.

Honest-partial: this only **adds a binding key** — if no task-body def with that name exists in the file, the sniffer produces no match and nothing is fabricated.

## Tests (value-asserting)

- **Positive**: `@shared_task def send_me_notifications(): Notification.objects.create(...)` → the `celery:...:send_me_notifications` ScheduledJob node carries `db_write` (asserted on the ScheduledJob node specifically, not `len>0`).
- **Negative**: a genuinely pure task body (`return 1 + 2`) leaves the ScheduledJob node unstamped — no fabricated effect.
- Confirmed load-bearing: neutralizing the fix makes the positive test fail with `effects=""`.

## Verification

- `go test ./internal/links/ ./internal/types/ ./internal/engine/ ./tools/coverage/` green
- `go vet` clean, `gofmt -l` empty
- `coverage validate` 0 errors, `coverage fmt --check` canonical (registry untouched)

## Effect now inherited

The `SCOPE.ScheduledJob` node (`celery:<path>:<fn>`) now carries the same effects its task body resolves — e.g. `db_write` for a body that calls `Model.objects.create(...)` — instead of `pure`.

DEPLOY-DEFERRED: in-memory effect-propagation change; takes effect on next index/daemon rebuild.

Closes #3869

🤖 Generated with [Claude Code](https://claude.com/claude-code)