### PR TITLE
[mcp] project all semantic edge kinds in inspect/expand (#3897)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -359,6 +359,23 @@ is the source line the extractor recorded (`0` when absent). The section is
 omitted entirely when the entity has no DI edges. Before #3870 these edges were
 in the graph but no read tool projected them — only CALLS was visible.
 
+A `semantic_edges` array generalizes the `di_edges` projection to the full set
+of semantically meaningful, **non-structural** relationship kinds (#3897). Each
+row has the same `{ "kind", "direction", "other", "line" }` shape as `di_edges`,
+where `kind` is the on-graph relationship kind verbatim. The projected kinds are:
+`JOINS_COLLECTION`, `GRAPH_RELATES`, `DEPENDS_ON_SERVICE`, `THROWS`, `CATCHES`,
+`MODIFIES_TABLE`, `ACCESSES_TABLE`, `QUERIES`, `RENDERS`, `USES_TRANSLATION`,
+`TRIGGERS`, `ENQUEUES`, `PUBLISHES_TO`, `SUBSCRIBES_TO`, `CACHES`, `INVALIDATES`,
+`GATED_BY`, `HANDLES_COMMAND`, `DATA_FLOWS_TO`, `INJECTED_INTO`, `BINDS`, and
+`DEPENDS_ON_CONFIG`. Structural / high-volume kinds are deliberately excluded
+because they have their own sections or are pure scaffolding: `CALLS`
+(`calls`/`called_by`), `DISCRIMINATES_ON` (`discriminators`), `IMPORTS`, and
+`CONTAINS`. The DI kinds (`INJECTED_INTO`/`BINDS`) appear in **both** `di_edges`
+(backward-compatible subset) and `semantic_edges` (superset). The section is
+omitted entirely when the entity has no semantic edges. Before #3897 these edges
+were in the graph but invisible to read tools — only CALLS + the DI subset were
+projected.
+
 With `verbose=true`, the response also includes `end_line`, `language`, `repo`,
 `pagerank`, `community_id`, and `properties`.
 
@@ -420,6 +437,15 @@ edge `FromID`, `"inbound"` when it is the `ToID`). This lets a consumer tell a
 provider→consumer injection from a plain `CALLS` neighbour — before #3870 the
 connecting edge kind was dropped from neighbour rows entirely. Fields are absent
 on neighbours that are not connected by a DI edge.
+
+Generalizing this (#3897), direct neighbours connected by ANY projected semantic
+edge (the `semantic_edges` kind set documented under `archigraph_inspect`)
+additionally carry `semantic_kind` and `semantic_direction` (same semantics as
+`di_kind`/`di_direction`). This lets a consumer distinguish e.g. a
+`DEPENDS_ON_SERVICE`, `THROWS`, or `DATA_FLOWS_TO` neighbour from a plain `CALLS`
+one. For DI neighbours, both the legacy `di_*` and the generalized `semantic_*`
+fields are present. Fields are absent on neighbours not connected by a projected
+semantic edge.
 
 ---
 

--- a/internal/mcp/semantic_edge_projection_3897_test.go
+++ b/internal/mcp/semantic_edge_projection_3897_test.go
@@ -1,0 +1,268 @@
+package mcp
+
+// semantic_edge_projection_3897_test.go — #3897: surface ALL semantically
+// meaningful, non-structural edge kinds in the MCP read tools, generalizing the
+// DI-only #3870/#3894 projection.
+//
+// Before #3897 inspect projected only CALLS (calls/called_by), DISCRIMINATES_ON
+// (discriminators) and the DI subset (di_edges); expand annotated only CALLS
+// depth + di_kind/di_direction. A node could carry a JOINS_COLLECTION /
+// GRAPH_RELATES / DEPENDS_ON_SERVICE / THROWS / CATCHES / DATA_FLOWS_TO edge and
+// the rewrite agent would never see it.
+//
+// These tests are VALUE-ASSERTING: each asserts the SPECIFIC semantic edge
+// surfaces with the right kind + direction + far-side entity in the new
+// `semantic_edges` inspect section and the new {semantic_kind, semantic_direction}
+// expand annotation — not merely that some non-empty output exists. They also
+// guard the #3870 regressions (di_edges, CALLS sections) and the exclusion of
+// structural kinds.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeSemanticEdgeDoc builds a graph exercising a representative spread of the
+// projected semantic edge kinds plus a structural CALLS edge (which must NOT
+// appear in semantic_edges) and a DI edge (which must appear in BOTH di_edges
+// and semantic_edges).
+//
+//	repo:    handler --DEPENDS_ON_SERVICE--> paymentSvc
+//	         handler --THROWS--------------> appError
+//	         handler --CATCHES-------------> dbError
+//	         handler --DATA_FLOWS_TO-------> sink
+//	         model   --JOINS_COLLECTION----> orders     (model → collection)
+//	         model   --GRAPH_RELATES-------> userNode
+//	         provider --INJECTED_INTO------> handler     (DI: also in di_edges)
+//	         handler --CALLS---------------> paymentSvc  (structural: excluded)
+func makeSemanticEdgeDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "api",
+		Entities: []graph.Entity{
+			{ID: "handler", Name: "OrderHandler", Kind: "SCOPE.Operation", SourceFile: "order.ts", StartLine: 1},
+			{ID: "paymentSvc", Name: "PaymentService", Kind: "SCOPE.Component", SourceFile: "payment.ts", StartLine: 1},
+			{ID: "appError", Name: "AppError", Kind: "SCOPE.Type", SourceFile: "errors.ts", StartLine: 1},
+			{ID: "dbError", Name: "DbError", Kind: "SCOPE.Type", SourceFile: "errors.ts", StartLine: 10},
+			{ID: "sink", Name: "AuditSink", Kind: "SCOPE.Operation", SourceFile: "audit.ts", StartLine: 1},
+			{ID: "model", Name: "OrderModel", Kind: "SCOPE.Type", SourceFile: "model.ts", StartLine: 1},
+			{ID: "orders", Name: "orders", Kind: "SCOPE.Datastore", SourceFile: "model.ts", StartLine: 1},
+			{ID: "userNode", Name: "UserNode", Kind: "SCOPE.Type", SourceFile: "graph.ts", StartLine: 1},
+			{ID: "provider", Name: "OrderProvider", Kind: "SCOPE.Component", SourceFile: "provider.ts", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "handler", ToID: "paymentSvc", Kind: "DEPENDS_ON_SERVICE", Properties: map[string]string{"line": "5"}},
+			{ID: "r2", FromID: "handler", ToID: "appError", Kind: "THROWS", Properties: map[string]string{"line": "12"}},
+			{ID: "r3", FromID: "handler", ToID: "dbError", Kind: "CATCHES", Properties: map[string]string{"line": "18"}},
+			{ID: "r4", FromID: "handler", ToID: "sink", Kind: "DATA_FLOWS_TO", Properties: map[string]string{"line": "22"}},
+			{ID: "r5", FromID: "model", ToID: "orders", Kind: "JOINS_COLLECTION", Properties: map[string]string{"line": "3"}},
+			{ID: "r6", FromID: "model", ToID: "userNode", Kind: "GRAPH_RELATES", Properties: map[string]string{"line": "7"}},
+			{ID: "r7", FromID: "provider", ToID: "handler", Kind: "INJECTED_INTO", Properties: map[string]string{"line": "2"}},
+			// structural CALLS — must be EXCLUDED from semantic_edges.
+			{ID: "c1", FromID: "handler", ToID: "paymentSvc", Kind: "CALLS", Properties: map[string]string{"line": "5"}},
+		},
+	}
+}
+
+// findSemEdge returns the first semantic_edges row matching kind/direction/other.
+func findSemEdge(rows []any, kind, direction, other string) map[string]any {
+	for _, r := range rows {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["kind"] == kind && m["direction"] == direction && m["other"] == other {
+			return m
+		}
+	}
+	return nil
+}
+
+func semanticEdgesOf(t *testing.T, srv *Server, entityID string) []any {
+	t.Helper()
+	out := callInspectWithArgs(t, srv, map[string]any{"group": "test", "entity_id": entityID})
+	sem, ok := out["semantic_edges"]
+	if !ok {
+		t.Fatalf("expected semantic_edges on inspect of %s; keys: %v", entityID, mapKeys(out))
+	}
+	rows, ok := sem.([]any)
+	if !ok || len(rows) == 0 {
+		t.Fatalf("semantic_edges is %T len=%d on %s, want non-empty []any", sem, len(rows), entityID)
+	}
+	return rows
+}
+
+// TestInspect_SurfacesDependsOnService asserts a DEPENDS_ON_SERVICE edge surfaces
+// outbound on the handler — a kind that was previously invisible to inspect.
+func TestInspect_SurfacesDependsOnService(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := semanticEdgesOf(t, srv, "handler")
+	got := findSemEdge(rows, "DEPENDS_ON_SERVICE", "outbound", "paymentSvc")
+	if got == nil {
+		t.Fatalf("did not find DEPENDS_ON_SERVICE(outbound, other=paymentSvc): %v", rows)
+	}
+	if line, _ := got["line"].(float64); line != 5 {
+		t.Errorf("DEPENDS_ON_SERVICE line = %v, want 5", got["line"])
+	}
+}
+
+// TestInspect_SurfacesErrorFlow asserts both THROWS and CATCHES surface on the
+// handler — the error-flow edge family was previously invisible.
+func TestInspect_SurfacesErrorFlow(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := semanticEdgesOf(t, srv, "handler")
+	if findSemEdge(rows, "THROWS", "outbound", "appError") == nil {
+		t.Errorf("did not find THROWS(outbound, other=appError): %v", rows)
+	}
+	if findSemEdge(rows, "CATCHES", "outbound", "dbError") == nil {
+		t.Errorf("did not find CATCHES(outbound, other=dbError): %v", rows)
+	}
+}
+
+// TestInspect_SurfacesDataFlowsTo asserts a DATA_FLOWS_TO edge surfaces.
+func TestInspect_SurfacesDataFlowsTo(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := semanticEdgesOf(t, srv, "handler")
+	if findSemEdge(rows, "DATA_FLOWS_TO", "outbound", "sink") == nil {
+		t.Errorf("did not find DATA_FLOWS_TO(outbound, other=sink): %v", rows)
+	}
+}
+
+// TestInspect_SurfacesJoinsCollectionAndGraphRelates asserts the data-layer
+// (JOINS_COLLECTION) and graph-DB (GRAPH_RELATES) edges surface on the model.
+func TestInspect_SurfacesJoinsCollectionAndGraphRelates(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := semanticEdgesOf(t, srv, "model")
+	if findSemEdge(rows, "JOINS_COLLECTION", "outbound", "orders") == nil {
+		t.Errorf("did not find JOINS_COLLECTION(outbound, other=orders): %v", rows)
+	}
+	if findSemEdge(rows, "GRAPH_RELATES", "outbound", "userNode") == nil {
+		t.Errorf("did not find GRAPH_RELATES(outbound, other=userNode): %v", rows)
+	}
+}
+
+// TestInspect_SurfacesInboundSemanticEdge asserts the far side of a semantic edge
+// sees it as INBOUND — e.g. appError is THROWN by the handler.
+func TestInspect_SurfacesInboundSemanticEdge(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := semanticEdgesOf(t, srv, "appError")
+	if findSemEdge(rows, "THROWS", "inbound", "handler") == nil {
+		t.Fatalf("did not find THROWS(inbound, other=handler) on appError: %v", rows)
+	}
+}
+
+// TestInspect_DIEdgeAppearsInBothSections asserts the DI subset (INJECTED_INTO)
+// surfaces in BOTH the legacy di_edges section (regression) AND the new
+// semantic_edges section (superset).
+func TestInspect_DIEdgeAppearsInBothSections(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	out := callInspectWithArgs(t, srv, map[string]any{"group": "test", "entity_id": "handler"})
+
+	di, ok := out["di_edges"].([]any)
+	if !ok || len(di) == 0 {
+		t.Fatalf("regression: di_edges missing/empty on handler; keys: %v", mapKeys(out))
+	}
+	if findSemEdge(di, "INJECTED_INTO", "inbound", "provider") == nil {
+		t.Errorf("di_edges should contain INJECTED_INTO(inbound, other=provider): %v", di)
+	}
+
+	sem := out["semantic_edges"].([]any)
+	if findSemEdge(sem, "INJECTED_INTO", "inbound", "provider") == nil {
+		t.Errorf("semantic_edges should ALSO contain INJECTED_INTO(inbound, other=provider): %v", sem)
+	}
+}
+
+// TestInspect_ExcludesStructuralCalls asserts the structural CALLS edge does NOT
+// leak into semantic_edges (it has its own calls/called_by sections).
+func TestInspect_ExcludesStructuralCalls(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	out := callInspectWithArgs(t, srv, map[string]any{"group": "test", "entity_id": "handler"})
+
+	sem, _ := out["semantic_edges"].([]any)
+	for _, r := range sem {
+		if m, ok := r.(map[string]any); ok && m["kind"] == "CALLS" {
+			t.Errorf("CALLS must NOT appear in semantic_edges: %v", m)
+		}
+	}
+	// CALLS still surfaces via its dedicated section (regression guard).
+	if _, ok := out["calls"]; !ok {
+		t.Errorf("regression: calls section missing")
+	}
+}
+
+// TestInspect_NoSemanticEdges_OmitsSection asserts the section is omitted for an
+// entity with only structural edges (additive / backward compatible).
+func TestInspect_NoSemanticEdges_OmitsSection(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "api",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.ts", StartLine: 1},
+			{ID: "b", Name: "B", Kind: "SCOPE.Operation", SourceFile: "b.ts", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c", FromID: "a", ToID: "b", Kind: "CALLS"},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspectWithArgs(t, srv, map[string]any{"group": "test", "entity_id": "a"})
+	if _, ok := out["semantic_edges"]; ok {
+		t.Fatalf("semantic_edges should be omitted when entity has only structural edges")
+	}
+}
+
+// TestNeighbors_AnnotatesSemanticEdge asserts expand annotates a non-DI semantic
+// neighbour (DEPENDS_ON_SERVICE) with semantic_kind/semantic_direction — which it
+// previously could NOT do (only di_kind/di_direction existed).
+func TestNeighbors_AnnotatesSemanticEdge(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := callNeighbors(t, srv, map[string]any{
+		"group":        "test",
+		"entity_id":    "handler",
+		"depth":        1,
+		"token_budget": 8000,
+	})
+	var svcRow map[string]any
+	for _, r := range rows {
+		if m, ok := r.(map[string]any); ok && m["id"] == "api::paymentSvc" {
+			svcRow = m
+		}
+	}
+	if svcRow == nil {
+		t.Fatalf("neighbour api::paymentSvc not present: %v", rows)
+	}
+	if svcRow["semantic_kind"] != "DEPENDS_ON_SERVICE" {
+		t.Errorf("semantic_kind = %v, want DEPENDS_ON_SERVICE", svcRow["semantic_kind"])
+	}
+	if svcRow["semantic_direction"] != "outbound" {
+		t.Errorf("semantic_direction = %v, want outbound", svcRow["semantic_direction"])
+	}
+}
+
+// TestNeighbors_DIStillAnnotated asserts the DI annotation (di_kind/di_direction)
+// is preserved on the expand row alongside the new semantic_* annotation
+// (regression for #3870).
+func TestNeighbors_DIStillAnnotated(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	rows := callNeighbors(t, srv, map[string]any{
+		"group":        "test",
+		"entity_id":    "handler",
+		"depth":        1,
+		"token_budget": 8000,
+	})
+	var provRow map[string]any
+	for _, r := range rows {
+		if m, ok := r.(map[string]any); ok && m["id"] == "api::provider" {
+			provRow = m
+		}
+	}
+	if provRow == nil {
+		t.Fatalf("DI neighbour api::provider not present: %v", rows)
+	}
+	if provRow["di_kind"] != "INJECTED_INTO" || provRow["di_direction"] != "inbound" {
+		t.Errorf("regression: DI annotation lost: di_kind=%v di_direction=%v", provRow["di_kind"], provRow["di_direction"])
+	}
+	// And the generalized annotation also covers it.
+	if provRow["semantic_kind"] != "INJECTED_INTO" {
+		t.Errorf("semantic_kind = %v, want INJECTED_INTO", provRow["semantic_kind"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1103,6 +1103,12 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				if di := inspectDIEdges(r, e, scopeIsOne); len(di) > 0 {
 					out["di_edges"] = di
 				}
+				// #3897: full semantic, non-structural edge set (JOINS_COLLECTION,
+				// GRAPH_RELATES, DEPENDS_ON_SERVICE, THROWS/CATCHES, DATA_FLOWS_TO,
+				// …). Generalizes the DI-only #3870 projection; omitted when empty.
+				if sem := inspectSemanticEdges(r, e, scopeIsOne, isSemanticEdgeKind); len(sem) > 0 {
+					out["semantic_edges"] = sem
+				}
 				// #2642: metadata block with index provenance.
 				out["metadata"] = inspectMetadata(r)
 				return jsonResult(out), nil
@@ -1169,6 +1175,12 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	// Section omitted entirely when the entity has no DI edges.
 	if di := inspectDIEdges(m.repo, m.ent, scopeIsOne); len(di) > 0 {
 		out["di_edges"] = di
+	}
+	// #3897: full semantic, non-structural edge set (JOINS_COLLECTION,
+	// GRAPH_RELATES, DEPENDS_ON_SERVICE, THROWS/CATCHES, DATA_FLOWS_TO, …).
+	// Generalizes the DI-only #3870 projection; omitted when empty.
+	if sem := inspectSemanticEdges(m.repo, m.ent, scopeIsOne, isSemanticEdgeKind); len(sem) > 0 {
+		out["semantic_edges"] = sem
 	}
 	// #2642: metadata block with index provenance.
 	out["metadata"] = inspectMetadata(m.repo)
@@ -1466,34 +1478,86 @@ func inspectDiscriminators(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []m
 	return out
 }
 
-// inspectDIEdges returns rows for every dependency-injection edge attached to
-// entity e — INJECTED_INTO (provider→consumer) and BINDS (module/token→impl).
-// These edges are emitted by the per-language DI extractors (e.g.
-// internal/custom/javascript/nestjs_di.go) and wired into the graph, but before
-// #3870 no MCP read tool projected them: inspect surfaced only CALLS
-// (calls/called_by) and DISCRIMINATES_ON, so a consumer could not see
-// provider→consumer wiring at all.
+// semanticEdgeKinds is the configurable set of NON-STRUCTURAL, semantically
+// meaningful relationship kinds that the MCP read tools project in inspect's
+// `semantic_edges` section and in expand's per-neighbour annotation. (#3897,
+// generalizing the DI-only #3870/#3894 projection.)
+//
+// These edges are emitted by the per-language extractors and wired into the
+// graph, but before #3897 no MCP read tool surfaced them — inspect projected
+// only CALLS (calls/called_by), DISCRIMINATES_ON (discriminators) and the DI
+// subset (di_edges); expand annotated only CALLS depth + the DI subset. A node
+// could carry a JOINS_COLLECTION / GRAPH_RELATES / DEPENDS_ON_SERVICE / error-
+// flow edge and the rewrite agent would never see it.
+//
+// Deliberately EXCLUDED (handled elsewhere or pure scaffolding):
+//   - CALLS              — has dedicated calls/called_by sections + expand depth.
+//   - DISCRIMINATES_ON   — has the dedicated `discriminators` section (#2666).
+//   - IMPORTS / CONTAINS — structural scaffolding, high-volume + low-signal.
+//
+// The map keys are stored UPPER-cased; membership is matched case-insensitively
+// against the on-graph relationship casing (buildAdjacency copies r.Kind
+// verbatim). The DI kinds (INJECTED_INTO / BINDS) are members so the generalized
+// projection is a strict superset of the #3870 behaviour.
+var semanticEdgeKinds = map[string]struct{}{
+	string(types.RelationshipKindJoinsCollection):  {},
+	string(types.RelationshipKindGraphRelates):     {},
+	string(types.RelationshipKindDependsOnService): {},
+	string(types.RelationshipKindThrows):           {},
+	string(types.RelationshipKindCatches):          {},
+	string(types.RelationshipKindModifiesTable):    {},
+	string(types.RelationshipKindAccessesTable):    {},
+	string(types.RelationshipKindQueries):          {},
+	string(types.RelationshipKindRenders):          {},
+	string(types.RelationshipKindUsesTranslation):  {},
+	string(types.RelationshipKindTriggers):         {},
+	string(types.RelationshipKindEnqueues):         {},
+	string(types.RelationshipKindPublishesTo):      {},
+	string(types.RelationshipKindSubscribesTo):     {},
+	string(types.RelationshipKindCaches):           {},
+	string(types.RelationshipKindInvalidates):      {},
+	string(types.RelationshipKindGatedBy):          {},
+	string(types.RelationshipKindHandlesCommand):   {},
+	string(types.RelationshipKindDataFlowsTo):      {},
+	string(types.RelationshipKindInjectedInto):     {},
+	string(types.RelationshipKindBinds):            {},
+	string(types.RelationshipKindDependsOnConfig):  {},
+}
+
+// isSemanticEdgeKind reports whether k is one of the projected semantic edge
+// kinds (case-insensitive against the on-graph casing). (#3897)
+func isSemanticEdgeKind(k string) bool {
+	_, ok := semanticEdgeKinds[strings.ToUpper(k)]
+	return ok
+}
+
+// diEdgeKinds is the dependency-injection SUBSET of semanticEdgeKinds, retained
+// so the backward-compatible `di_edges` section / di_kind|di_direction
+// annotation can be derived without re-listing the kinds. (#3870, #3897)
+func isDIEdgeKind(k string) bool {
+	return strings.EqualFold(k, string(types.RelationshipKindInjectedInto)) ||
+		strings.EqualFold(k, string(types.RelationshipKindBinds))
+}
+
+// inspectSemanticEdges returns rows for every projected semantic edge attached
+// to entity e (see semanticEdgeKinds). Generalizes inspectDIEdges (#3870) to
+// cover the full meaningful, non-structural edge set (#3897).
 //
 // Each row carries:
 //
-//	kind      — "INJECTED_INTO" or "BINDS"
-//	direction — "outbound" (this entity is the FromID, e.g. a provider injected
-//	            into others / a module that binds) or "inbound" (this entity is
-//	            the ToID, e.g. a controller a provider is injected into / an impl
-//	            a token binds to)
-//	other     — the entity on the other side of the edge (ToID for outbound,
-//	            FromID for inbound)
+//	kind      — the on-graph relationship kind verbatim (e.g. "JOINS_COLLECTION")
+//	direction — "outbound" (this entity is the FromID) or "inbound" (ToID)
+//	other     — the entity on the other side (ToID for outbound, FromID inbound),
+//	            repo-prefixed when scopeIsOne is false
 //	line      — Properties["line"] when the extractor recorded one (0 otherwise)
 //
-// Returns nil when the entity has no DI edges so the inspect envelope can omit
-// the section entirely (mirrors inspectDiscriminators, #2666). (#3870)
-func inspectDIEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
+// Returns nil when the entity has no semantic edges so the inspect envelope can
+// omit the section entirely (mirrors inspectDiscriminators, #2666). The `accept`
+// predicate selects which kinds to emit — callers pass isSemanticEdgeKind for
+// the full `semantic_edges` set or isDIEdgeKind for the legacy `di_edges` subset.
+func inspectSemanticEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, accept func(string) bool) []map[string]any {
 	if lr == nil || lr.Doc == nil || e == nil {
 		return nil
-	}
-	isDIKind := func(k string) bool {
-		return strings.EqualFold(k, string(types.RelationshipKindInjectedInto)) ||
-			strings.EqualFold(k, string(types.RelationshipKindBinds))
 	}
 	out := []map[string]any{}
 	rels := lr.Doc.Relationships
@@ -1521,12 +1585,12 @@ func inspectDIEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[stri
 	}
 	adj := lr.getAdjacency()
 	for _, ed := range adj.Outgoing(e.ID) {
-		if isDIKind(ed.kind) {
+		if accept(ed.kind) {
 			emit(ed, "outbound")
 		}
 	}
 	for _, ed := range adj.Incoming(e.ID) {
-		if isDIKind(ed.kind) {
+		if accept(ed.kind) {
 			emit(ed, "inbound")
 		}
 	}
@@ -1536,38 +1600,51 @@ func inspectDIEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[stri
 	return out
 }
 
-// diNeighbor describes the dependency-injection edge connecting a start node to
-// one of its direct neighbours (used to annotate archigraph_expand rows, #3870).
-type diNeighbor struct {
-	kind      string // "INJECTED_INTO" or "BINDS" (on-graph casing)
+// inspectDIEdges is the backward-compatible DI-only projection (#3870), now a
+// thin wrapper over the generalized inspectSemanticEdges (#3897). Returns rows
+// for INJECTED_INTO / BINDS edges only, preserving the legacy `di_edges` shape.
+func inspectDIEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
+	return inspectSemanticEdges(lr, e, scopeIsOne, isDIEdgeKind)
+}
+
+// semanticNeighbor describes the semantic edge connecting a start node to one of
+// its direct neighbours (used to annotate archigraph_expand rows). (#3897)
+type semanticNeighbor struct {
+	kind      string // on-graph relationship casing (e.g. "JOINS_COLLECTION")
 	direction string // "outbound" (start is FromID) or "inbound" (start is ToID)
 }
 
-// directDIEdges indexes the INJECTED_INTO / BINDS edges directly incident on
-// startID, keyed by the neighbour entity id. Outbound edges (start is the
-// provider/module/token FromID) take precedence over inbound when an id appears
-// on both sides. Returns an empty (non-nil) map when there are no DI edges.
-// (#3870)
-func directDIEdges(adj *adjacency, startID string) map[string]diNeighbor {
-	res := map[string]diNeighbor{}
+// diNeighbor is the DI-specific alias retained for the legacy di_kind/
+// di_direction annotation. (#3870)
+type diNeighbor = semanticNeighbor
+
+// directSemanticEdges indexes the projected semantic edges directly incident on
+// startID, keyed by the neighbour entity id. Outbound edges take precedence over
+// inbound when an id appears on both sides. Returns an empty (non-nil) map when
+// there are no matching edges. The `accept` predicate selects the kind subset
+// (isSemanticEdgeKind for the full set, isDIEdgeKind for the DI subset). (#3897)
+func directSemanticEdges(adj *adjacency, startID string, accept func(string) bool) map[string]semanticNeighbor {
+	res := map[string]semanticNeighbor{}
 	if adj == nil {
 		return res
 	}
-	isDI := func(k string) bool {
-		return strings.EqualFold(k, string(types.RelationshipKindInjectedInto)) ||
-			strings.EqualFold(k, string(types.RelationshipKindBinds))
-	}
 	for _, ed := range adj.Incoming(startID) {
-		if isDI(ed.kind) {
-			res[ed.target] = diNeighbor{kind: ed.kind, direction: "inbound"}
+		if accept(ed.kind) {
+			res[ed.target] = semanticNeighbor{kind: ed.kind, direction: "inbound"}
 		}
 	}
 	for _, ed := range adj.Outgoing(startID) {
-		if isDI(ed.kind) {
-			res[ed.target] = diNeighbor{kind: ed.kind, direction: "outbound"}
+		if accept(ed.kind) {
+			res[ed.target] = semanticNeighbor{kind: ed.kind, direction: "outbound"}
 		}
 	}
 	return res
+}
+
+// directDIEdges is the backward-compatible DI-only neighbour index (#3870), now
+// delegating to directSemanticEdges with the DI subset predicate. (#3897)
+func directDIEdges(adj *adjacency, startID string) map[string]diNeighbor {
+	return directSemanticEdges(adj, startID, isDIEdgeKind)
 }
 
 // inspectMetadata returns index-staleness fields for the inspect response.
@@ -1702,6 +1779,12 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 	// the start node's direct DI edges by neighbour id so the matching output
 	// rows can be annotated with {di_kind, di_direction} below.
 	diByNeighbor := directDIEdges(adj, start.ID)
+	// #3897: same idea, generalized to the full semantic edge set. Annotates the
+	// neighbour row with {semantic_kind, semantic_direction} for ANY projected
+	// non-structural edge (JOINS_COLLECTION, GRAPH_RELATES, DEPENDS_ON_SERVICE,
+	// THROWS/CATCHES, DATA_FLOWS_TO, …) — not just DI. di_kind/di_direction are
+	// retained above for backward compatibility on the DI subset.
+	semByNeighbor := directSemanticEdges(adj, start.ID, isSemanticEdgeKind)
 	out := []map[string]any{}
 	for nid, d := range vis {
 		if nid == start.ID {
@@ -1721,6 +1804,10 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 		if di, ok := diByNeighbor[nid]; ok {
 			row["di_kind"] = di.kind
 			row["di_direction"] = di.direction
+		}
+		if sem, ok := semByNeighbor[nid]; ok {
+			row["semantic_kind"] = sem.kind
+			row["semantic_direction"] = sem.direction
 		}
 		out = append(out, row)
 	}


### PR DESCRIPTION
Closes #3897. Part of epic #3860.

## Problem
The MCP read tools only projected a tiny slice of the semantic relationship kinds the extractors build into the graph. `inspect` surfaced CALLS (`calls`/`called_by`), DISCRIMINATES_ON (`discriminators`), and — after #3870/#3894 — the DI subset (`di_edges`). `expand` annotated only CALLS depth + `di_kind`/`di_direction`. Every other semantic edge built this session (JOINS_COLLECTION, GRAPH_RELATES, DEPENDS_ON_SERVICE, error-flow, data-flow, eventing, caching, i18n, …) was **invisible** to the rewrite agent — a node could carry such an edge and no read tool would surface it.

#3870 fixed exactly one family (DI) with a DI-specific helper. This PR **generalizes** that extension point to the full meaningful, non-structural edge set.

## Generalized projection
New configurable `semanticEdgeKinds` set drives both tools. Edge kinds now surfaced:

`JOINS_COLLECTION`, `GRAPH_RELATES`, `DEPENDS_ON_SERVICE`, `THROWS`, `CATCHES`, `MODIFIES_TABLE`, `ACCESSES_TABLE`, `QUERIES`, `RENDERS`, `USES_TRANSLATION`, `TRIGGERS`, `ENQUEUES`, `PUBLISHES_TO`, `SUBSCRIBES_TO`, `CACHES`, `INVALIDATES`, `GATED_BY`, `HANDLES_COMMAND`, `DATA_FLOWS_TO`, `INJECTED_INTO`, `BINDS`, `DEPENDS_ON_CONFIG`.

Deliberately **excluded** (own sections / pure scaffolding): `CALLS`, `DISCRIMINATES_ON`, `IMPORTS`, `CONTAINS`.

- **inspect** (`handleGetNode`): new `semantic_edges` array of `{kind, direction, other, line}` rows (mirrors the `di_edges` shape; `kind` = on-graph casing verbatim). Omitted when empty.
- **expand** (`handleGetNeighbors`): neighbour row annotated with `semantic_kind` + `semantic_direction`.

## Backward compatibility
`di_edges` and `di_kind`/`di_direction` still work — the DI kinds are a subset and appear in **both** the legacy DI section/annotation and the new generalized ones. `inspectDIEdges`/`directDIEdges` now delegate to the generalized helpers (`inspectSemanticEdges`/`directSemanticEdges`) with a DI-subset predicate. CALLS sections unchanged.

## Tests (value-asserting)
`internal/mcp/semantic_edge_projection_3897_test.go` asserts the SPECIFIC edge surfaces where it previously did not: DEPENDS_ON_SERVICE, THROWS/CATCHES, DATA_FLOWS_TO, JOINS_COLLECTION, GRAPH_RELATES (inbound + outbound), DI in both sections, structural CALLS excluded, section omitted when empty, expand annotation for a non-DI semantic neighbour, and DI-annotation regression. `go test ./internal/mcp/... ./internal/types/` green; gofmt/vet clean; coverage validate 0 errors + fmt canonical.

## Deploy
**DEPLOY-DEFERRED**: projection-only (no extractor/index changes). Needs a daemon rebuild to take effect; **no reindex** required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)