### PR TITLE
feat(java): Spring Data MongoDB aggregation $lookup -> JOINS_COLLECTION (#3845)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -71,7 +71,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/6 | |
 | [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/6 | |
 | [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/10 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/6 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 1/6 | |
 | [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/6 | |
 | [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/9 | |
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -108,7 +108,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🔴 0/6 | |
 | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🔴 0/6 | |
 | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 5/10 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🔴 0/6 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 1/6 | |
 | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🔴 0/6 | |
 | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟡 6/9 | |
 

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -27,7 +27,7 @@ per-language driver/ORM records below — each one is a separate detail page.
 | [`lang.elixir.driver.mongodb`](./lang.elixir.driver.mongodb.md) | elixir | driver | 4 missing, 7 n/a |
 | [`lang.go.driver.mongodb`](./lang.go.driver.mongodb.md) | go | driver | 3 partial, 3 missing, 5 n/a |
 | [`lang.java.driver.mongodb`](./lang.java.driver.mongodb.md) | java | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.java.orm.spring-data-mongo`](./lang.java.orm.spring-data-mongo.md) | java | orm | 6 missing, 5 n/a |
+| [`lang.java.orm.spring-data-mongo`](./lang.java.orm.spring-data-mongo.md) | java | orm | 1 partial, 5 missing, 5 n/a |
 | [`lang.jsts.driver.mongodb`](./lang.jsts.driver.mongodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.jsts.orm.mongoose`](./lang.jsts.orm.mongoose.md) | JS/TS | orm | 7 full, 3 missing, 3 n/a |
 | [`lang.kotlin.orm.mongodb`](./lang.kotlin.orm.mongodb.md) | kotlin | orm | 2 full, 3 missing, 6 n/a |

--- a/docs/coverage/detail/lang.java.driver.mongodb.md
+++ b/docs/coverage/detail/lang.java.driver.mongodb.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | `internal/engine/orm_queries.go`<br>`internal/engine/orm_queries_drivers_other.go`<br>`internal/engine/orm_queries_drivers_other_test.go` | Driver topology: database.getCollection('x') literal captured via scanJavaDrivers (javaGetCollectionRe); QUERIES edge to Class:<Collection>; dynamic names honest-skipped. |
+| Query attribution | ✅ `full` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | `internal/engine/orm_queries.go`<br>`internal/engine/orm_queries_drivers_other.go`<br>`internal/engine/orm_queries_drivers_other_test.go`<br>`internal/engine/orm_queries_java_mongo_agg.go`<br>`internal/engine/orm_queries_java_mongo_agg_test.go` | Driver topology: database.getCollection('x') literal captured via scanJavaDrivers (javaGetCollectionRe); QUERIES edge to Class:<Collection>; dynamic names honest-skipped. Aggregation $lookup joins (scanJavaSpringMongoAggregation, #3845): each Spring Data MongoDB $lookup (fluent LookupOperation, positional Aggregation.lookup, or @Aggregation(pipeline={..}) string pipeline) emits a JOINS_COLLECTION edge aggregating-collection -> from collection plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose contract; dynamic from/collection honest-skipped. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | — | YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor. |
+| Query attribution | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | `internal/engine/orm_queries.go`<br>`internal/engine/orm_queries_java_mongo_agg.go`<br>`internal/engine/orm_queries_java_mongo_agg_test.go` | Spring Data MongoDB aggregation $lookup joins now extracted (scanJavaSpringMongoAggregation, #3845): each $lookup emits a JOINS_COLLECTION edge aggregating-collection -> from collection (Class:Book -> Class:Author) plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose contract. Three idioms: fluent LookupOperation.newLookup().from(..).localField(..).foreignField(..).as(..); positional Aggregation.lookup(from,lf,ff,as); and @Aggregation(pipeline={"{ $lookup: { from: 'authors' } }"}) string pipelines (fed to the shared JSON stage splitter). Aggregating collection resolved from mongoTemplate.aggregate(agg, "books"|Book.class, ..), same-file @Document(..), or the MongoRepository<Entity,..> generic. Honest-partial: dynamic .from(var)/dynamic collection -> no edge; general query attribution + model topology still missing. |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -23279,9 +23279,9 @@
         "Queries": {
           "query_attribution": {
             "status": "full",
-            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_drivers_other.go","internal/engine/orm_queries_drivers_other_test.go"],
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_drivers_other.go","internal/engine/orm_queries_drivers_other_test.go","internal/engine/orm_queries_java_mongo_agg.go","internal/engine/orm_queries_java_mongo_agg_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "Driver topology: database.getCollection('x') literal captured via scanJavaDrivers (javaGetCollectionRe); QUERIES edge to Class:\u003cCollection\u003e; dynamic names honest-skipped.",
+            "notes": "Driver topology: database.getCollection('x') literal captured via scanJavaDrivers (javaGetCollectionRe); QUERIES edge to Class:\u003cCollection\u003e; dynamic names honest-skipped. Aggregation $lookup joins (scanJavaSpringMongoAggregation, #3845): each Spring Data MongoDB $lookup (fluent LookupOperation, positional Aggregation.lookup, or @Aggregation(pipeline={..}) string pipeline) emits a JOINS_COLLECTION edge aggregating-collection -\u003e from collection plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose contract; dynamic from/collection honest-skipped.",
             "verified_at": "2026-06-02"
           }
         },
@@ -30624,9 +30624,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_java_mongo_agg.go","internal/engine/orm_queries_java_mongo_agg_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "notes": "Spring Data MongoDB aggregation $lookup joins now extracted (scanJavaSpringMongoAggregation, #3845): each $lookup emits a JOINS_COLLECTION edge aggregating-collection -\u003e from collection (Class:Book -\u003e Class:Author) plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose contract. Three idioms: fluent LookupOperation.newLookup().from(..).localField(..).foreignField(..).as(..); positional Aggregation.lookup(from,lf,ff,as); and @Aggregation(pipeline={\"{ $lookup: { from: 'authors' } }\"}) string pipelines (fed to the shared JSON stage splitter). Aggregating collection resolved from mongoTemplate.aggregate(agg, \"books\"|Book.class, ..), same-file @Document(..), or the MongoRepository\u003cEntity,..\u003e generic. Honest-partial: dynamic .from(var)/dynamic collection -\u003e no edge; general query attribution + model topology still missing.",
             "verified_at": "2026-06-02"
           }
         },

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -184,6 +184,15 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 		// DynamoDB SDK TableName, Cassandra CQL FROM/INTO (#3645).
 		scanJavaDrivers(src, funcs, emit)
 		scanInfra()
+		// Sibling pass: Spring Data MongoDB aggregation `$lookup` joins
+		// (fluent LookupOperation, positional Aggregation.lookup, and
+		// `@Aggregation(pipeline={...})` string pipelines) → per-$lookup
+		// SCOPE.DataAccess stage entities + JOINS_COLLECTION edges, matching
+		// the Python/Mongoose contract (#3845).
+		scanJavaSpringMongoAggregation(src, funcs, path, lang,
+			func(ent types.EntityRecord) { entities = append(entities, ent) },
+			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
+		)
 	case "ruby":
 		scanRubyORM(src, funcs, emit)
 		// Driver-topology: Mongo Ruby driver client[:coll], aws-sdk-dynamodb

--- a/internal/engine/orm_queries_java_mongo_agg.go
+++ b/internal/engine/orm_queries_java_mongo_agg.go
@@ -1,0 +1,328 @@
+// Spring Data MongoDB (Java) aggregation-pipeline internal extraction (#3845,
+// epic #3837).
+//
+// This is the Java sibling of orm_queries_python_mongo_agg.go (#3440) and
+// orm_queries_jsts_mongo_agg.go / orm_queries_jsts_mongoose_populate.go
+// (#3426/#3844). The existing Java ORM/driver scanners (scanJavaORM,
+// scanJavaDrivers) recognise the native driver `database.getCollection("x")`
+// target, but they do NOT understand a Spring Data MongoDB aggregation
+// pipeline, and a `$lookup` stage there is an implicit cross-collection JOIN
+// the migration must reason about (Mongo has no schema FK for it). This pass
+// recovers, in the SAME emission shape as the Python/Mongoose siblings:
+//
+//  1. JOINS_COLLECTION relationship — for every `$lookup` stage, an edge from
+//     the aggregating collection → the looked-up `from` collection. FromID /
+//     ToID are `Class:<capitalisedSingular(collection)>`, identical to the
+//     contract the Python/JS passes use, so a Spring Data `$lookup` from Book
+//     to authors lands on the SAME `Class:Author` node a Mongoose `ref:` or a
+//     pymongo `$lookup` would. Properties: local_field, foreign_field, as,
+//     stage="lookup".
+//
+//  2. SCOPE.DataAccess pipeline-stage entities — one per `$lookup`, anchored at
+//     the lookup site, subtype `$lookup`, stage_index preserved.
+//
+// Two Spring Data idioms are resolved:
+//
+//   - FLUENT `LookupOperation` (the canonical `MongoTemplate` form):
+//
+//     LookupOperation lookup = LookupOperation.newLookup()
+//     .from("authors").localField("authorId").foreignField("_id").as("authors");
+//     Aggregation agg = Aggregation.newAggregation(lookup, match);
+//     mongoTemplate.aggregate(agg, "books", Result.class);
+//
+//     The join fields come from the fluent `.from(..)/.localField(..)/...`
+//     method calls (NOT JSON keys). The aggregating collection is resolved from
+//     the `mongoTemplate.aggregate(agg, "books"|Book.class, ...)` executor call
+//     in the same file (string-literal collection wins; else the `X.class`
+//     entity name; else a same-file `@Document("books")` on the aggregating
+//     class). `Aggregation.lookup("authors","authorId","_id","authors")` — the
+//     positional static-factory shorthand — is also recovered.
+//
+//   - `@Aggregation(pipeline={ "{ $lookup: { from: 'authors', ... } }" })` on a
+//     repository method: the pipeline stages are MongoDB extended-JSON string
+//     literals. We concatenate the pipeline string array, feed it to the SAME
+//     JSON stage splitter/lookup parser the JS/Python passes use, and resolve
+//     the aggregating collection from the repository's `@Document`-typed entity
+//     (the `MongoRepository<Book, ...>` / `@Document` generic) when available,
+//     else from a class-name heuristic.
+//
+// HONEST LIMIT: a dynamic `from` (`.from(collVar)` / `.from(SOME_CONST)` with no
+// quoted value) yields NO edge — we never fabricate a join we cannot statically
+// resolve. A dynamic aggregating collection (`mongoTemplate.aggregate(agg,
+// resolveColl(), ...)`) leaves the FromID as the fallback class name rather
+// than guessing. Cross-file pipeline assembly is out of scope.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongoAggJavaGateRe gates the scan to files that plausibly use Spring Data
+// MongoDB aggregation, so we never scan arbitrary `.aggregate(` chains.
+var mongoAggJavaGateRe = regexp.MustCompile(
+	`\b(?:LookupOperation|Aggregation\.newAggregation|Aggregation\.lookup|MongoTemplate|mongoTemplate|@Aggregation|org\.springframework\.data\.mongodb)\b`,
+)
+
+// mongoAggJavaLookupOpRe locates a fluent `LookupOperation.newLookup()` chain
+// start. The full chain (`.from(..).localField(..).foreignField(..).as(..)`) is
+// recovered by scanning forward from the match.
+var mongoAggJavaLookupOpRe = regexp.MustCompile(`LookupOperation\s*\.\s*newLookup\s*\(\s*\)`)
+
+// mongoAggJavaFluentFieldRe captures a `.method("literal")` call within a
+// LookupOperation fluent chain (group 1 = method, group 2 = string literal).
+// Only quoted string args are captured — a variable arg (`.from(coll)`) yields
+// no match, which is the honest dynamic-skip.
+var mongoAggJavaFluentFieldRe = regexp.MustCompile(
+	`\.\s*(from|localField|foreignField|as)\s*\(\s*"([A-Za-z_][\w$.-]*)"\s*\)`,
+)
+
+// mongoAggJavaStaticLookupRe matches the positional static-factory shorthand
+// `Aggregation.lookup("authors", "authorId", "_id", "authors")`. Groups:
+// 1=from, 2=localField, 3=foreignField, 4=as. All four must be string literals;
+// a dynamic arg in any position fails the match (honest skip — the fluent path
+// or no edge).
+var mongoAggJavaStaticLookupRe = regexp.MustCompile(
+	`Aggregation\s*\.\s*lookup\s*\(\s*"([A-Za-z_][\w$.-]*)"\s*,\s*"([A-Za-z_][\w$.-]*)"\s*,\s*"([A-Za-z_][\w$.-]*)"\s*,\s*"([A-Za-z_][\w$.-]*)"\s*\)`,
+)
+
+// mongoAggJavaTemplateCollRe captures the aggregating collection from a
+// `mongoTemplate.aggregate(agg, "books", Result.class)` executor call where the
+// second argument is a quoted collection name.
+var mongoAggJavaTemplateCollStrRe = regexp.MustCompile(
+	`\.\s*aggregate\s*\(\s*[A-Za-z_]\w*\s*,\s*"([A-Za-z_][\w$.-]*)"`,
+)
+
+// mongoAggJavaTemplateCollClassRe captures the aggregating collection from a
+// `mongoTemplate.aggregate(agg, Book.class, Result.class)` executor call where
+// the second argument is an entity `.class` reference — the entity name is the
+// collection token (resolved via capitalisedSingular like every other path).
+var mongoAggJavaTemplateCollClassRe = regexp.MustCompile(
+	`\.\s*aggregate\s*\(\s*[A-Za-z_]\w*\s*,\s*([A-Z][A-Za-z0-9_$]*)\s*\.\s*class`,
+)
+
+// mongoAggJavaDocumentRe captures a `@Document("books")` /
+// `@Document(collection = "books")` / `@Document(value = "books")` collection
+// name. Used to resolve the aggregating collection from the same-file entity
+// when no executor-call collection is available.
+var mongoAggJavaDocumentRe = regexp.MustCompile(
+	`@Document\s*\(\s*(?:(?:collection|value)\s*=\s*)?"([A-Za-z_][\w$.-]*)"`,
+)
+
+// mongoAggJavaAggregationAnnoRe locates a repository-method `@Aggregation(`
+// annotation; the `pipeline = {...}` string array is recovered by scanning the
+// annotation argument.
+var mongoAggJavaAggregationAnnoRe = regexp.MustCompile(`@Aggregation\s*\(`)
+
+// mongoAggJavaRepoEntityRe captures the entity type parameter of a Spring Data
+// Mongo repository declaration: `interface BookRepository extends
+// MongoRepository<Book, String>` / `ReactiveMongoRepository<Book, ObjectId>` /
+// `CrudRepository<Book, String>`. Group 1 is the entity (the aggregating
+// collection token for an `@Aggregation` repository method).
+var mongoAggJavaRepoEntityRe = regexp.MustCompile(
+	`(?:Mongo|ReactiveMongo|Crud|PagingAndSorting)Repository\s*<\s*([A-Z][A-Za-z0-9_$]*)\s*,`,
+)
+
+// scanJavaSpringMongoAggregation walks `src`, finds Spring Data MongoDB
+// aggregation `$lookup` joins (fluent LookupOperation, positional
+// Aggregation.lookup, and `@Aggregation(pipeline={...})` string pipelines),
+// resolves the aggregating collection, and emits SCOPE.DataAccess stage
+// entities + JOINS_COLLECTION edges via the supplied appenders — matching the
+// Python/Mongoose contract exactly.
+func scanJavaSpringMongoAggregation(
+	src string,
+	funcs []funcSpan,
+	path string,
+	lang string,
+	emitStage func(ent types.EntityRecord),
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	if !mongoAggJavaGateRe.MatchString(src) {
+		return
+	}
+
+	// Resolve the aggregating collection ONCE per file: the executor call's
+	// quoted/`.class` second argument wins, else a same-file `@Document(...)`,
+	// else a `MongoRepository<Entity, ...>` entity. This is intentionally
+	// file-scoped — the canonical Spring Data shape has one aggregating entity
+	// per repository/service file.
+	coll := mongoAggJavaResolveCollection(src)
+
+	stageIdx := 0
+	emitLookup := func(off int, lk mongoAggLookup) {
+		if lk.from == "" || coll == "" {
+			return // dynamic from or unresolved collection — honest skip.
+		}
+		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+
+		props := map[string]string{
+			"pattern_type": mongoAggPatternType,
+			"collection":   coll,
+			"stage_index":  itoa(stageIdx),
+			"stage":        "$lookup",
+			"from":         lk.from,
+		}
+		if lk.localField != "" {
+			props["local_field"] = lk.localField
+		}
+		if lk.foreignField != "" {
+			props["foreign_field"] = lk.foreignField
+		}
+		if lk.as != "" {
+			props["as"] = lk.as
+		}
+		if caller := enclosingFuncAt(funcs, off); caller != "" {
+			props["caller"] = caller
+		}
+		emitStage(types.EntityRecord{
+			Name:               fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx),
+			Kind:               mongoAggStageEntityKind,
+			Subtype:            "$lookup",
+			SourceFile:         path,
+			StartLine:          lineOfOffset(src, off),
+			EndLine:            lineOfOffset(src, off),
+			Language:           lang,
+			Properties:         props,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+		stageIdx++
+	}
+
+	// Idiom 1a: positional static-factory `Aggregation.lookup(from, lf, ff, as)`.
+	for _, m := range mongoAggJavaStaticLookupRe.FindAllStringSubmatchIndex(src, -1) {
+		emitLookup(m[0], mongoAggLookup{
+			from:         src[m[2]:m[3]],
+			localField:   src[m[4]:m[5]],
+			foreignField: src[m[6]:m[7]],
+			as:           src[m[8]:m[9]],
+		})
+	}
+
+	// Idiom 1b: fluent `LookupOperation.newLookup().from(..)....as(..)`. Scan a
+	// bounded window forward from each chain start and pull the fluent fields.
+	for _, loc := range mongoAggJavaLookupOpRe.FindAllStringIndex(src, -1) {
+		lk := mongoAggJavaParseFluentLookup(src, loc[1])
+		emitLookup(loc[0], lk)
+	}
+
+	// Idiom 2: `@Aggregation(pipeline = { "{ $lookup: {...} }", ... })` repo
+	// method — extended-JSON string pipeline. Reuse the shared JSON splitter.
+	for _, loc := range mongoAggJavaAggregationAnnoRe.FindAllStringIndex(src, -1) {
+		openParen := loc[1] - 1
+		pipeline := mongoAggJavaPipelineLiteral(src, openParen)
+		if pipeline == "" {
+			continue
+		}
+		stages := mongoAggSplitStages(pipeline, 0)
+		for _, st := range stages {
+			if mongoAggFirstKey(st) != "$lookup" {
+				continue
+			}
+			emitLookup(loc[0], mongoAggParseLookup(st))
+		}
+	}
+}
+
+// mongoAggJavaParseFluentLookup scans forward from `from` (just past
+// `LookupOperation.newLookup()`) over a bounded window and recovers the fluent
+// `.from/.localField/.foreignField/.as` string-literal fields. A field bound to
+// a variable (no quoted literal) is left empty — honest: a missing `from` then
+// suppresses the edge in emitLookup.
+func mongoAggJavaParseFluentLookup(src string, from int) mongoAggLookup {
+	end := from + 400
+	if end > len(src) {
+		end = len(src)
+	}
+	window := src[from:end]
+	// Stop at the first statement terminator so we don't bleed into the next
+	// statement's `.from(..)` (the chain is a single expression up to `;`).
+	if semi := strings.IndexByte(window, ';'); semi >= 0 {
+		window = window[:semi]
+	}
+	var lk mongoAggLookup
+	for _, m := range mongoAggJavaFluentFieldRe.FindAllStringSubmatch(window, -1) {
+		switch m[1] {
+		case "from":
+			if lk.from == "" {
+				lk.from = m[2]
+			}
+		case "localField":
+			lk.localField = m[2]
+		case "foreignField":
+			lk.foreignField = m[2]
+		case "as":
+			lk.as = m[2]
+		}
+	}
+	return lk
+}
+
+// mongoAggJavaResolveCollection recovers the aggregating collection token for
+// the file: a `mongoTemplate.aggregate(agg, "books"|Book.class, ...)` executor
+// argument wins (string literal first, then the `.class` entity name), else a
+// same-file `@Document(...)` collection, else a `MongoRepository<Entity, ...>`
+// entity type. Returns "" when none is statically present.
+func mongoAggJavaResolveCollection(src string) string {
+	if m := mongoAggJavaTemplateCollStrRe.FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	if m := mongoAggJavaTemplateCollClassRe.FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	if m := mongoAggJavaDocumentRe.FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	if m := mongoAggJavaRepoEntityRe.FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// mongoAggJavaPipelineLiteral returns a synthesised JSON array literal
+// `[ <stage>, <stage> ]` built from the string elements of an `@Aggregation`
+// `pipeline = { "...", "..." }` argument whose `(` is at `openParen`. Each
+// quoted element is a MongoDB extended-JSON stage object; we join them into a
+// bracketed list so the shared mongoAggSplitStages can scan it. Returns "" when
+// no `pipeline = {...}` string array is present (e.g. only a `count`/`sort`
+// attribute) or the elements are not string literals.
+func mongoAggJavaPipelineLiteral(src string, openParen int) string {
+	// Bound the scan to this annotation's argument list (matching `)`).
+	close := mongoAggPyMatchParen(src, openParen)
+	if close < 0 {
+		return ""
+	}
+	arg := src[openParen+1 : close]
+	// Collect every double-quoted string element. Spring's extended-JSON uses
+	// single quotes for inner values (`from: 'authors'`), so the element
+	// delimiter is the double quote — inner single quotes never terminate it.
+	var elems []string
+	inStr := false
+	start := -1
+	for i := 0; i < len(arg); i++ {
+		c := arg[i]
+		if inStr {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '"' {
+				elems = append(elems, arg[start:i])
+				inStr = false
+			}
+			continue
+		}
+		if c == '"' {
+			inStr = true
+			start = i + 1
+		}
+	}
+	if len(elems) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(elems, ",") + "]"
+}

--- a/internal/engine/orm_queries_java_mongo_agg_test.go
+++ b/internal/engine/orm_queries_java_mongo_agg_test.go
@@ -1,0 +1,238 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runMongoAggJava drives scanJavaSpringMongoAggregation over `src` and collects
+// the emitted stage entities + join edges.
+func runMongoAggJava(t *testing.T, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	funcs := indexEnclosingFunctions("java", src)
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	scanJavaSpringMongoAggregation(src, funcs, "svc/BookService.java", "java",
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+	return ents, rels
+}
+
+func javaFindJoinTo(rels []types.RelationshipRecord, toClass string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].Kind == string(types.RelationshipKindJoinsCollection) &&
+			rels[i].ToID == "Class:"+toClass {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// Fluent LookupOperation with the aggregating collection resolved from the
+// `mongoTemplate.aggregate(agg, "books", ...)` executor string argument.
+// Asserts the JOINS_COLLECTION(Class:Book -> Class:Author) edge ids + props.
+func TestMongoAggJava_FluentLookup_TemplateStringCollection(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.LookupOperation;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+
+public class BookService {
+    public List<BookView> withAuthors() {
+        LookupOperation lookup = LookupOperation.newLookup()
+            .from("authors").localField("authorId").foreignField("_id").as("authors");
+        Aggregation agg = Aggregation.newAggregation(lookup);
+        return mongoTemplate.aggregate(agg, "books", BookView.class).getMappedResults();
+    }
+}
+`
+	ents, rels := runMongoAggJava(t, src)
+
+	if n := len(rels); n != 1 {
+		t.Fatalf("expected exactly 1 join edge, got %d: %+v", n, rels)
+	}
+	j := javaFindJoinTo(rels, "Author")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION edge to Class:Author; rels=%+v", rels)
+	}
+	if j.FromID != "Class:Book" {
+		t.Errorf("join FromID = %q, want Class:Book", j.FromID)
+	}
+	if j.ToID != "Class:Author" {
+		t.Errorf("join ToID = %q, want Class:Author", j.ToID)
+	}
+	if j.Properties["stage"] != "lookup" {
+		t.Errorf("join stage = %q, want lookup", j.Properties["stage"])
+	}
+	if j.Properties["local_field"] != "authorId" || j.Properties["foreign_field"] != "_id" || j.Properties["as"] != "authors" {
+		t.Errorf("join props = %+v", j.Properties)
+	}
+
+	// Stage entity: one $lookup, collection=books, on the right node kind.
+	if n := len(ents); n != 1 {
+		t.Fatalf("expected 1 stage entity, got %d: %+v", n, ents)
+	}
+	e := ents[0]
+	if e.Subtype != "$lookup" {
+		t.Errorf("stage subtype = %q, want $lookup", e.Subtype)
+	}
+	if e.Kind != string(types.EntityKindDataAccess) {
+		t.Errorf("stage kind = %q, want SCOPE.DataAccess", e.Kind)
+	}
+	if e.Properties["collection"] != "books" || e.Properties["from"] != "authors" {
+		t.Errorf("stage props = %+v", e.Properties)
+	}
+}
+
+// Aggregating collection resolved from a `Book.class` second argument.
+func TestMongoAggJava_FluentLookup_TemplateClassCollection(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.core.aggregation.LookupOperation;
+public class BookService {
+    public void run() {
+        LookupOperation lookup = LookupOperation.newLookup()
+            .from("publishers").localField("publisherId").foreignField("_id").as("pub");
+        Aggregation agg = Aggregation.newAggregation(lookup);
+        mongoTemplate.aggregate(agg, Book.class, BookView.class);
+    }
+}
+`
+	_, rels := runMongoAggJava(t, src)
+	j := javaFindJoinTo(rels, "Publisher")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION edge to Class:Publisher; rels=%+v", rels)
+	}
+	if j.FromID != "Class:Book" {
+		t.Errorf("join FromID = %q, want Class:Book (from Book.class)", j.FromID)
+	}
+}
+
+// Positional static-factory `Aggregation.lookup("authors","authorId","_id","authors")`.
+func TestMongoAggJava_StaticLookupShorthand(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+@Document("books")
+public class BookService {
+    public void run() {
+        Aggregation agg = Aggregation.newAggregation(
+            Aggregation.lookup("authors", "authorId", "_id", "authors"));
+        mongoTemplate.aggregate(agg, "books", BookView.class);
+    }
+}
+`
+	_, rels := runMongoAggJava(t, src)
+	if n := len(rels); n != 1 {
+		t.Fatalf("expected exactly 1 join edge, got %d: %+v", n, rels)
+	}
+	j := javaFindJoinTo(rels, "Author")
+	if j == nil || j.FromID != "Class:Book" {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Book -> Class:Author); rels=%+v", rels)
+	}
+	if j.Properties["local_field"] != "authorId" || j.Properties["foreign_field"] != "_id" {
+		t.Errorf("static-lookup props = %+v", j.Properties)
+	}
+}
+
+// `@Aggregation(pipeline={...})` repository-method string pipeline. The
+// aggregating collection comes from the `MongoRepository<Book, String>` entity.
+func TestMongoAggJava_AggregationAnnotationPipeline(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface BookRepository extends MongoRepository<Book, String> {
+    @Aggregation(pipeline = {
+        "{ $lookup: { from: 'authors', localField: 'authorId', foreignField: '_id', as: 'authors' } }",
+        "{ $match: { status: 'active' } }"
+    })
+    List<BookView> withAuthors();
+}
+`
+	ents, rels := runMongoAggJava(t, src)
+	if n := len(rels); n != 1 {
+		t.Fatalf("expected exactly 1 join edge, got %d: %+v", n, rels)
+	}
+	j := javaFindJoinTo(rels, "Author")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION edge to Class:Author; rels=%+v", rels)
+	}
+	if j.FromID != "Class:Book" {
+		t.Errorf("join FromID = %q, want Class:Book (from MongoRepository<Book,...>)", j.FromID)
+	}
+	if j.Properties["local_field"] != "authorId" || j.Properties["foreign_field"] != "_id" || j.Properties["as"] != "authors" {
+		t.Errorf("annotation $lookup props = %+v", j.Properties)
+	}
+	// One stage entity for the $lookup only ($match does not produce an edge,
+	// but the annotation path only emits stage entities for $lookup here).
+	if n := len(ents); n != 1 {
+		t.Fatalf("expected 1 $lookup stage entity, got %d: %+v", n, ents)
+	}
+	if ents[0].Properties["from"] != "authors" {
+		t.Errorf("stage from = %q, want authors", ents[0].Properties["from"])
+	}
+}
+
+// Two fluent lookups in one method → two distinct join edges to two collections.
+func TestMongoAggJava_TwoFluentLookups(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.core.aggregation.LookupOperation;
+public class BookService {
+    public void run() {
+        LookupOperation l1 = LookupOperation.newLookup().from("authors").localField("authorId").foreignField("_id").as("authors");
+        LookupOperation l2 = LookupOperation.newLookup().from("publishers").localField("publisherId").foreignField("_id").as("pub");
+        Aggregation agg = Aggregation.newAggregation(l1, l2);
+        mongoTemplate.aggregate(agg, "books", BookView.class);
+    }
+}
+`
+	_, rels := runMongoAggJava(t, src)
+	if n := len(rels); n != 2 {
+		t.Fatalf("expected 2 join edges, got %d: %+v", n, rels)
+	}
+	if javaFindJoinTo(rels, "Author") == nil {
+		t.Errorf("missing JOINS_COLLECTION to Class:Author; rels=%+v", rels)
+	}
+	if javaFindJoinTo(rels, "Publisher") == nil {
+		t.Errorf("missing JOINS_COLLECTION to Class:Publisher; rels=%+v", rels)
+	}
+}
+
+// NEGATIVE: a dynamic `from` (variable, not a string literal) → NO edge.
+func TestMongoAggJava_DynamicFrom_NoEdge(t *testing.T) {
+	src := `
+import org.springframework.data.mongodb.core.aggregation.LookupOperation;
+public class BookService {
+    public void run(String coll) {
+        LookupOperation lookup = LookupOperation.newLookup()
+            .from(coll).localField("authorId").foreignField("_id").as("authors");
+        Aggregation agg = Aggregation.newAggregation(lookup);
+        mongoTemplate.aggregate(agg, "books", BookView.class);
+    }
+}
+`
+	ents, rels := runMongoAggJava(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("dynamic .from(coll) must yield NO join edge, got %+v", rels)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("dynamic .from(coll) must yield NO stage entity, got %+v", ents)
+	}
+}
+
+// NEGATIVE: a non-mongo file (no gate signal) is never scanned.
+func TestMongoAggJava_GatedOut(t *testing.T) {
+	src := `
+public class PlainService {
+    public void run() {
+        list.aggregate(x);
+        something.from("authors");
+    }
+}
+`
+	ents, rels := runMongoAggJava(t, src)
+	if len(rels) != 0 || len(ents) != 0 {
+		t.Fatalf("non-spring-mongo file must be gated out, got ents=%+v rels=%+v", ents, rels)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `scanJavaSpringMongoAggregation` (`internal/engine/orm_queries_java_mongo_agg.go`), the **Java sibling** of the Python (`orm_queries_python_mongo_agg.go`, #3440) and Mongoose (`orm_queries_jsts_mongoose_populate.go`, #3844) aggregation-join passes — epic #3837.

Each Spring Data MongoDB `$lookup` now emits a **JOINS_COLLECTION** edge from the aggregating collection to the looked-up `from` collection, with `FromID`/`ToID` = `Class:<capitalisedSingular(collection)>` — the identical node-id contract the Python/JS passes use, so a Spring Data `$lookup` from `Book` to `authors` lands on the same `Class:Author` node a pymongo `$lookup` or a Mongoose `ref:` would. Each `$lookup` also emits a `SCOPE.DataAccess` stage entity (subtype `$lookup`, `stage_index` preserved).

### Idioms resolved (Spring Data Mongo)
- **Fluent** `LookupOperation.newLookup().from("authors").localField("authorId").foreignField("_id").as("authors")` — join fields come from the fluent method calls.
- **Positional** static-factory `Aggregation.lookup("authors","authorId","_id","authors")`.
- **`@Aggregation(pipeline={ "{ $lookup: { from: 'authors', ... } }" })`** repository-method extended-JSON string pipelines — fed to the **shared** `mongoAggSplitStages` / `mongoAggParseLookup` parsers reused from the JS/Python passes.

Aggregating collection resolved from `mongoTemplate.aggregate(agg, "books"|Book.class, ...)`, a same-file `@Document(..)`, or the `MongoRepository<Entity, ..>` generic.

**Honest-partial:** dynamic `.from(var)` or dynamic aggregating collection → **no edge** (no fabrication).

Wired into the `java` case of `applyORMQueries` (`internal/engine/orm_queries.go`).

## JOINS_COLLECTION edges asserted (value-asserting tests)
`internal/engine/orm_queries_java_mongo_agg_test.go`:
- Fluent + `mongoTemplate.aggregate(agg, "books", ..)` → **JOINS_COLLECTION(Class:Book -> Class:Author)** with `local_field=authorId`, `foreign_field=_id`, `as=authors`, `stage=lookup`; one `$lookup` SCOPE.DataAccess entity (`collection=books`, `from=authors`).
- Fluent + `Book.class` second arg → **Class:Book -> Class:Publisher**.
- Positional `Aggregation.lookup(..)` + `@Document("books")` → **Class:Book -> Class:Author**.
- `@Aggregation(pipeline={...})` + `MongoRepository<Book, String>` → **Class:Book -> Class:Author**.
- Two fluent lookups → **Class:Author** and **Class:Publisher** (2 distinct edges).
- **Negative:** dynamic `.from(coll)` → 0 edges, 0 stage entities.
- **Negative:** non-Spring-Mongo file → gated out (0/0).

## Quality gates
- `go test ./internal/engine/ ./internal/custom/... ./internal/types/ ./tools/coverage/` — green.
- `go test ./internal/types/` — green (entity Kind / relationship Kind registered).
- `go vet ./internal/engine/` — clean; `gofmt -l` — empty.
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical.

## Coverage
- `lang.java.orm.spring-data-mongo` → `Queries.query_attribution` **missing → partial** (agg `$lookup` joins extracted; general query/model topology still missing).
- `lang.java.driver.mongodb` → `Queries.query_attribution` note/cites refreshed (stays `full`).
Docs regenerated.

**DEPLOY-DEFERRED.**

Closes #3845

🤖 Generated with [Claude Code](https://claude.com/claude-code)