### PR TITLE
feat(coverage): generalize hub→spoke cross-link beyond databases (#3873)

### DIFF
--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-06-02` | 3828 | `internal/engine/orm_queries_drivers_other.go` | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 | Resource extraction | 🟢 `partial` | `2026-06-02` | 3828 | `internal/engine/orm_queries_drivers_other.go` | Cassandra/Scylla CQL session.execute("... FROM table") across C#/PHP/Rust/Python/Java/Ruby/JS parses the FROM/INTO/UPDATE table into a Class:<Table> resource node + QUERIES dependency edge from the connecting function (emitCQLTargets). Runtime-built CQL honest-skipped. |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/iac_sns_edges.go` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.elasticsearch.md
+++ b/docs/coverage/detail/db.elasticsearch.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-06-02` | 3828 | `internal/engine/orm_queries_datastore_infra.go`<br>`internal/engine/orm_queries_jsts_drivers.go` | No resource/dependency extraction yet for this datastore; tracked in #3828 (sibling datastores done — genuine build-gap). |
 | Resource extraction | 🟢 `partial` | `2026-06-02` | 3828 | `internal/engine/orm_queries_datastore_infra.go`<br>`internal/engine/orm_queries_jsts_drivers.go` | Neo4j session.run("MATCH (n:Label) ...") Cypher (gated on neo4j / bolt:// / GraphDatabase / neomodel / neogma) parses the first node label into a Class:<Label> resource node + QUERIES dependency edge from the connecting function. JS via scanJSNeo4j (orm_queries_jsts_drivers.go); C#/PHP/Rust/Python/Java/Ruby/Go via emitCypherTargets (orm_queries_datastore_infra.go). Parameterised labels / runtime Cypher honest-skipped. |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
@@ -27,6 +27,7 @@ per-language driver/ORM records below — each one is a separate detail page.
 | [`lang.go.driver.neo4j`](./lang.go.driver.neo4j.md) | go | driver | 1 full, 2 partial, 3 missing, 5 n/a |
 | [`lang.java.orm.neo4j`](./lang.java.orm.neo4j.md) | java | orm | 1 full, 3 partial, 4 missing, 3 n/a |
 | [`lang.jsts.driver.neo4j`](./lang.jsts.driver.neo4j.md) | JS/TS | driver | 2 full, 2 partial, 3 missing, 4 n/a |
+| [`lang.jsts.ogm.grafeo`](./lang.jsts.ogm.grafeo.md) | JS/TS |  | 1 full, 2 partial, 2 missing, 6 n/a |
 | [`lang.php.driver.neo4j`](./lang.php.driver.neo4j.md) | php | driver | 1 full, 2 partial, 3 missing, 5 n/a |
 | [`lang.python.driver.neo4j`](./lang.python.driver.neo4j.md) | python | driver | 1 full, 2 partial, 4 missing, 4 n/a |
 | [`lang.ruby.driver.neo4j`](./lang.ruby.driver.neo4j.md) | ruby | driver | 1 full, 2 partial, 4 missing, 4 n/a |

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.redis.md
+++ b/docs/coverage/detail/db.redis.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -14,11 +14,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/sql` | — |
 
-## Code-level coverage
+## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|

--- a/docs/coverage/detail/infra.observability.dropwizard-metrics.md
+++ b/docs/coverage/detail/infra.observability.dropwizard-metrics.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Metric extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3856) | `internal/extractors/java/observability.go` | #3854 area #11: Dropwizard Metrics emit INSTRUMENTS edges (enclosing method -> metric:<name> stub) in Java: <registry>.meter/timer/counter/histogram("name") on a registry-like receiver. Honest-partial: a non-literal metric name yields traced=true+dynamic=true keyed on the method; calls on a receiver that does not look like a MetricRegistry are NOT emitted. |
 | Trace extraction | — `not_applicable` | — | — | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`infra.observability.prometheus`](./infra.observability.prometheus.md) hub record (Prometheus),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/infra.observability.micrometer.md
+++ b/docs/coverage/detail/infra.observability.micrometer.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Metric extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3856) | `internal/extractors/java/observability.go` | #3854 area #11: Micrometer metrics emit INSTRUMENTS edges (enclosing method -> metric:<name> stub) in Java. Registry-method form on a registry-like receiver: <reg>.counter/timer/gauge/summary/longTaskTimer/distributionSummary("name") -> metric:name. Builder form: Counter|Timer|Gauge|DistributionSummary|LongTaskTimer.builder("name") -> metric:name. Annotation form: @Timed("name") / @Counted("name") on a method -> metric:name. Honest-partial: a non-literal name (or a bare @Timed with no name) yields traced=true+dynamic=true keyed on the method without fabrication; a metric method on a receiver that does not look like a meter registry is NOT emitted (precision). |
 | Trace extraction | — `not_applicable` | — | — | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`infra.observability.prometheus`](./infra.observability.prometheus.md) hub record (Prometheus),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/infra.observability.prometheus.md
+++ b/docs/coverage/detail/infra.observability.prometheus.md
@@ -15,6 +15,17 @@ Auto-generated. Back to [summary](../summary.md).
 | Metric extraction | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3768) | `internal/engine/rules/_engine/comment_marker_extractor.yaml`<br>`internal/extractors/golang/observability.go`<br>`internal/extractors/javascript/observability.go`<br>`internal/extractors/python/observability.go` | #3628 area #11: prometheus client metrics emit INSTRUMENTS edges (enclosing op -> metric:<name> stub) in Python, Go and JS/TS. Python (#3762): module-level X = Counter|Gauge|Summary|Histogram("name") + @X.time()/X.inc()/observe(). Go: a metric var bound to prometheus.New{Counter,Gauge,Summary,Histogram}[Vec](prometheus.*Opts{Name:"x"}) (package- or fn-scope) resolves .Inc()/Dec()/Add()/Sub()/Observe()/Set() body calls to metric:x. JS/TS prom-client: a var bound to new client.{Counter,Gauge,Histogram,Summary}({name:'x'}) resolves .inc()/.dec()/.set()/.observe()/.startTimer() body calls to metric:x. Honest-partial: a non-literal metric name yields traced=true+dynamic=true; a metric method on a variable that is NOT a known metric declaration is NOT emitted (precision). |
 | Trace extraction | — `not_applicable` | — | — | — | — |
 
+## Related extraction records
+
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`infra.observability.dropwizard-metrics`](./infra.observability.dropwizard-metrics.md) | multi | observability | 1 partial, 2 n/a |
+| [`infra.observability.micrometer`](./infra.observability.micrometer.md) | multi | observability | 1 partial, 2 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -61,6 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.c-cpp.framework.librdkafka.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.librdkafka.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | 🟢 `partial` | `2026-05-31` | — | `internal/engine/kafka_edges.go` | Literal topics via rd_kafka_topic_new / RdKafka::Topic::create / producer->produce. No const/config resolution. |
 | Topic attribution | 🟢 `partial` | `2026-05-31` | — | `internal/engine/kafka_edges.go` | Canonical kafka:<topic> node shared with all other Kafka languages for cross-repo linkage. |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`msg.broker.kafka`](./msg.broker.kafka.md) hub record (Apache Kafka),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -61,6 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_csharp.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_csharp.go` | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
+++ b/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -61,6 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | 3613 | — | — |
 | Vulnerability finding | 🔴 `missing` | — | 3613 | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.driver.mongodb.md
+++ b/docs/coverage/detail/lang.java.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-graphql.md
+++ b/docs/coverage/detail/lang.java.framework.spring-graphql.md
@@ -130,6 +130,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.cassandra.md
+++ b/docs/coverage/detail/lang.jsts.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.elastic.md
+++ b/docs/coverage/detail/lang.jsts.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mongodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mysql.md
+++ b/docs/coverage/detail/lang.jsts.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.neo4j.md
+++ b/docs/coverage/detail/lang.jsts.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.postgres.md
+++ b/docs/coverage/detail/lang.jsts.driver.postgres.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.redis.md
+++ b/docs/coverage/detail/lang.jsts.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.sqlite.md
+++ b/docs/coverage/detail/lang.jsts.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -69,6 +69,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Dataloader extraction | 🟢 `partial` | `2026-06-02` | 3624 | `internal/extractors/javascript/graphql_dataloader.go`<br>`internal/extractors/javascript/issue3624_dataloader_test.go`<br>`internal/types/kinds.go` | new DataLoader(batchFn) (the 'dataloader' npm pkg) -> SCOPE.DataLoader entity named by the assigned const/field + BATCHES edge to the wrapped batch fn (bare ident or single-call delegating arrow); loader.load(id)/loadMany(ids) in a resolver body -> USES edge resolver->loader, via=graphql_dataloader. Value-asserted: userLoader BATCHES batchUsers + resolveAuthor USES userLoader. PARTIAL (honest): only statically-named loaders; dynamic/factory-built loaders and lambda batch fns get no BATCHES edge. |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.framework.type-graphql.md
+++ b/docs/coverage/detail/lang.jsts.framework.type-graphql.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | 3619 | — | — |
 | Vulnerability finding | 🔴 `missing` | — | 3619 | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.ogm.grafeo.md
+++ b/docs/coverage/detail/lang.jsts.ogm.grafeo.md
@@ -47,6 +47,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | grafeo executes via the neo4j-driver session/transaction API under the hood; explicit transaction-function stamping is not yet modelled (shared with the sibling OGMs). |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -56,11 +56,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Aggregation join extraction | ✅ `full` | — | 3844 | `internal/engine/orm_queries_jsts_mongo_agg.go`<br>`internal/engine/orm_queries_jsts_mongo_agg_test.go` | scanJSMongoAggregation parses Model.aggregate([...]) pipelines (inline array, same-scope variable binding, and fluent .build() builder forms), emitting one SCOPE.DataAccess stage node per stage and a JOINS_COLLECTION edge (Class:Model -> Class:from) for every $lookup / $graphLookup with a static from; matches the Python pymongo/motor contract and feeds shared_db_coupling.go (Pass 8.8). Dynamic from is honestly skipped |
 | Populate reference join extraction | ✅ `full` | — | 3844 | `internal/engine/orm_queries_jsts_mongoose_populate.go`<br>`internal/engine/orm_queries_jsts_mongoose_populate_test.go` | scanJSMongoosePopulateJoins emits a JOINS_COLLECTION edge for Mongoose ref:/@Prop(ref) fields that are traversed by a static .populate('field') — the dominant NestJS-target join idiom — bringing ref/populate to parity with the $lookup join contract |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.graphql-kotlin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.graphql-kotlin.md
@@ -130,6 +130,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.mongodb.md
+++ b/docs/coverage/detail/lang.python.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.graphene.md
+++ b/docs/coverage/detail/lang.python.framework.graphene.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | 3620 | — | — |
 | Vulnerability finding | 🔴 `missing` | — | 3620 | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🟢 `partial` | `2026-05-29` | 2972 | `internal/substrate/template_pattern_python.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | 🟢 `partial` | `2026-05-29` | 2972 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.mongodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
+++ b/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | 3621 | — | — |
 | Vulnerability finding | 🔴 `missing` | — | 3621 | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.cassandra`](./db.cassandra.md) infra record (Apache Cassandra (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.cassandra`](./db.cassandra.md) hub record (Apache Cassandra (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mongodb`](./db.mongodb.md) infra record (MongoDB (collections)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mongodb`](./db.mongodb.md) hub record (MongoDB (collections)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.mysql`](./db.mysql.md) infra record (MySQL / MariaDB (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.mysql`](./db.mysql.md) hub record (MySQL / MariaDB (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.neo4j`](./db.neo4j.md) infra record (Neo4j),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.neo4j`](./db.neo4j.md) hub record (Neo4j),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.postgres`](./db.postgres.md) infra record (PostgreSQL (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.postgres`](./db.postgres.md) hub record (PostgreSQL (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.redis`](./db.redis.md) infra record (Redis (keys)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.redis`](./db.redis.md) hub record (Redis (keys)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.async-graphql.md
+++ b/docs/coverage/detail/lang.rust.framework.async-graphql.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.framework.lapin.md
+++ b/docs/coverage/detail/lang.rust.framework.lapin.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | 🟢 `partial` | `2026-05-31` | 3558 | `internal/engine/rabbitmq_edges.go`<br>`internal/engine/rabbitmq_edges_test.go` | lapin channel.basic_publish("exchange","routing_key",...) -> PUBLISHES_TO (routing_key as queue identity, exchange recorded as edge prop) and basic_consume("queue",...) -> SUBSCRIBES_TO, plus queue_declare("queue",...) node; SCOPE.Queue keyed rabbitmq:<name> joins cross-repo, attributed to the enclosing fn. Partial: only literal exchange/queue/routing-key string args are resolved; dynamic/expression args and cross-file fn attribution are not modelled. |
 | Topic attribution | 🟢 `partial` | `2026-05-31` | 3558 | `internal/engine/rabbitmq_edges.go`<br>`internal/engine/rabbitmq_edges_test.go` | lapin channel.basic_publish("exchange","routing_key",...) -> PUBLISHES_TO (routing_key as queue identity, exchange recorded as edge prop) and basic_consume("queue",...) -> SUBSCRIBES_TO, plus queue_declare("queue",...) node; SCOPE.Queue keyed rabbitmq:<name> joins cross-repo, attributed to the enclosing fn. Partial: only literal exchange/queue/routing-key string args are resolved; dynamic/expression args and cross-file fn attribution are not modelled. |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`msg.broker.rabbitmq`](./msg.broker.rabbitmq.md) hub record (RabbitMQ),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.framework.rdkafka.md
+++ b/docs/coverage/detail/lang.rust.framework.rdkafka.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | 🟢 `partial` | `2026-05-31` | 3558 | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_edges_test.go` | rdkafka FutureRecord::to("topic")/BaseRecord::to("topic") -> PUBLISHES_TO and StreamConsumer .subscribe(&["a","b"]) -> SUBSCRIBES_TO, attributed to the enclosing fn (SCOPE.Operation); MessageTopic keyed kafka:<topic> joins cross-repo. Partial: only literal topic names are resolved (const/variable topics fall back to dynamic kafka:channel), and caller attribution is same-file nearest-fn. |
 | Topic attribution | 🟢 `partial` | `2026-05-31` | 3558 | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_edges_test.go` | rdkafka FutureRecord::to("topic")/BaseRecord::to("topic") -> PUBLISHES_TO and StreamConsumer .subscribe(&["a","b"]) -> SUBSCRIBES_TO, attributed to the enclosing fn (SCOPE.Operation); MessageTopic keyed kafka:<topic> joins cross-repo. Partial: only literal topic names are resolved (const/variable topics fall back to dynamic kafka:channel), and caller attribution is same-file nearest-fn. |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`msg.broker.kafka`](./msg.broker.kafka.md) hub record (Apache Kafka),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.framework.tonic.md
+++ b/docs/coverage/detail/lang.rust.framework.tonic.md
@@ -120,6 +120,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.sqlite`](./db.sqlite.md) infra record (SQLite (schema)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.sqlite`](./db.sqlite.md) hub record (SQLite (schema)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
+++ b/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
@@ -61,6 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.elasticsearch`](./db.elasticsearch.md) infra record (Elasticsearch (indices)),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.elasticsearch`](./db.elasticsearch.md) hub record (Elasticsearch (indices)),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -47,11 +47,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
 
-## Datastore
+## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`db.dynamodb`](./db.dynamodb.md) infra record (AWS DynamoDB),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`db.dynamodb`](./db.dynamodb.md) hub record (AWS DynamoDB),
+which tracks the same technology at a higher level.
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.kafka.md
+++ b/docs/coverage/detail/msg.broker.kafka.md
@@ -15,6 +15,18 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_wrapper_edges.go` | — |
 | Topic attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/kafka_edges.go` | — |
 
+## Related extraction records
+
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.framework.librdkafka`](./lang.c-cpp.framework.librdkafka.md) | C/C++ | framework | 3 partial |
+| [`msg.kafka-streams`](./msg.kafka-streams.md) | multi |  | 2 missing |
+| [`lang.rust.framework.rdkafka`](./lang.rust.framework.rdkafka.md) | rust | framework | 3 partial |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/msg.broker.rabbitmq.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq.md
@@ -15,6 +15,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rabbitmq_edges.go` | — |
 | Topic attribution | ✅ `full` | `2026-06-02` | — | `internal/engine/rabbitmq_edges.go`<br>`internal/links/topic_pass.go` | rabbitmq:<queue/exchange> SCOPE.Queue node; topic_pass.go joins a PUBLISHES_TO producer (exchange 'orders') to a SUBSCRIBES_TO consumer of queue/exchange 'orders' sharing the node Name into a cross-repo producer->consumer topology edge (channel=rabbitmq). |
 
+## Related extraction records
+
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.rust.framework.lapin`](./lang.rust.framework.lapin.md) | rust | framework | 3 partial |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/msg.graphql-subscriptions.md
+++ b/docs/coverage/detail/msg.graphql-subscriptions.md
@@ -15,6 +15,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/graphql_subscriptions.go` | — |
 | Topic attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/graphql_subscriptions.go` | — |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/msg.kafka-streams.md
+++ b/docs/coverage/detail/msg.kafka-streams.md
@@ -14,6 +14,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Consumer extraction | 🔴 `missing` | — | 3828 | — | No producer/consumer extraction yet for this broker variant; tracked in #3828. |
 | Producer extraction | 🔴 `missing` | — | 3828 | — | No producer/consumer extraction yet for this broker variant; tracked in #3828. |
 
+## Related extraction records
+
+This record provides code-level coverage for the
+[`msg.broker.kafka`](./msg.broker.kafka.md) hub record (Apache Kafka),
+which tracks the same technology at a higher level.
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -15,6 +15,28 @@ Auto-generated. Back to [summary](../summary.md).
 | Method attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/graphql_subscriptions.go` | — |
 | Service extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/graphql_subscriptions.go`<br>`internal/engine/rules/graphql/frameworks/graphql_schema.yaml` | — |
 
+## Related extraction records
+
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 3 full, 1 partial, 45 missing |
+| [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
+| [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 1 partial, 44 missing |
+| [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 1 partial, 49 missing |
+| [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 1 missing, 1 n/a |
+| [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 1 partial, 44 missing |
+| [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 4 full, 50 missing |
+| [`msg.graphql-subscriptions`](./msg.graphql-subscriptions.md) | multi |  | 3 full |
+| [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 5 full, 44 missing |
+| [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 4 full, 1 partial, 44 missing |
+| [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 23 partial, 10 missing |
+| [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 3 full, 1 partial, 45 missing |
+| [`lang.rust.framework.async-graphql`](./lang.rust.framework.async-graphql.md) | rust | framework | 6 full, 2 partial, 41 missing |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -15,6 +15,20 @@ Auto-generated. Back to [summary](../summary.md).
 | Method attribution | ✅ `full` | `2026-06-02` | — | `internal/engine/grpc_edges.go`<br>`internal/engine/grpc_edges_test.go` | — |
 | Service extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/grpc_edges.go` | — |
 
+## Related extraction records
+
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
+
+| Record | Language | Kind | Status |
+|--------|----------|------|--------|
+| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 6 partial, 22 missing, 2 n/a |
+| [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 4 full, 22 partial, 2 missing, 2 n/a |
+| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 6 partial, 22 missing, 2 n/a |
+| [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 5 full, 3 partial, 40 missing, 1 n/a |
+| [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 2 full, 4 partial, 22 missing, 2 n/a |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -282,15 +282,17 @@ type detailPageData struct {
 	Grouped           bool
 	FrameworkSpecific []frameworkSpecificView
 	TotalCells        int
-	// RelatedRecords is populated for `databases`-category infra records
-	// (db.<tech>): the per-language driver/ORM records that target the
-	// SAME datastore, each with a compact status digest. Empty (section
-	// omitted) for records with no related driver/ORM coverage.
+	// RelatedRecords is populated for cross-cutting HUB records (db.<tech>,
+	// protocol.grpc, msg.broker.kafka, observability vendors, ...): the
+	// per-technology spoke records that target the SAME tech/concept, each
+	// with a compact status digest. Empty (section omitted) for records
+	// that resolve to no spokes. (#3873, generalizing #3853.)
 	RelatedRecords []relatedRecordDigest
-	// InfraRecord is populated for driver/ORM records: the
-	// `databases`-category infra record they target, rendered as a
-	// back-link. nil when the record targets no recognised datastore.
-	InfraRecord *relatedRecordDigest
+	// HubRecord is populated for SPOKE records (a driver/ORM/framework/
+	// client record): the cross-cutting hub record they provide coverage
+	// for, rendered as a back-link. nil when the record targets no
+	// recognised hub.
+	HubRecord *relatedRecordDigest
 }
 
 // frameworkSpecificView is one free-form capability group rendered on a
@@ -863,8 +865,8 @@ func generate(reg *Registry, outRoot string) error {
 				Grouped:           view.Grouped,
 				FrameworkSpecific: fsViews,
 				TotalCells:        totalCells,
-				RelatedRecords:    relatedDriverORMRecords(rec, sortedRecs),
-				InfraRecord:       infraRecordFor(rec, sortedRecs),
+				RelatedRecords:    relatedSpokeRecords(rec, sortedRecs),
+				HubRecord:         hubRecordFor(rec, sortedRecs),
 			}); err != nil {
 			return err
 		}

--- a/tools/coverage/related.go
+++ b/tools/coverage/related.go
@@ -6,99 +6,169 @@ import (
 	"strings"
 )
 
-// Cross-linking infra `databases`-category records to the per-language
-// driver/ORM records that target the SAME datastore (#3628 child).
+// Cross-linking cross-cutting "hub" records to the per-technology "spoke"
+// records whose REAL extraction coverage lives elsewhere — often in a
+// different category (#3873, generalizing #3853).
 //
-// The honesty problem this solves: an infra record like `db.mongodb`
-// renders as a thin 2-cell page (resource_extraction + dependency_
-// attribution) that looks almost empty, even though the SAME technology
-// has rich code-level extraction spread across ~15 separate
-// `lang.*.{driver,orm}.*` records (mongoose, mongoengine, mongoid,
-// spring-data-mongo, the per-language native drivers, ...). The detail-
-// page generator renders each record in ISOLATION, so the infra page
-// never surfaces the real coverage and badly undersells it.
+// The honesty problem this solves: a hub record like `db.mongodb`,
+// `protocol.grpc`, `msg.broker.kafka` or an observability vendor renders
+// as a thin page that looks almost empty, even though the SAME technology
+// has rich code-level extraction spread across many separate per-language
+// records (mongoose / mongoengine / the native drivers for MongoDB;
+// tonic / grpc++ / grpc-dotnet / elixir-grpc for gRPC; rdkafka /
+// librdkafka for Kafka; ...). The detail-page generator renders each
+// record in ISOLATION, so the hub page never surfaces the real coverage
+// and badly undersells it.
 //
-// We fix this in the GENERATOR (no extractor change): a curated alias
-// map associates each datastore with the id-substrings of the records
-// that genuinely target it, and the detail page grows a "Code-level
-// coverage" section (on the infra page) plus a back-link (on each
-// driver/ORM page).
+// We fix this in the GENERATOR (no extractor change): a curated set of
+// hub→spoke groups associates each hub record with the id-substrings of
+// the per-technology records that genuinely target the SAME tech/concept,
+// constrained to a whitelist of spoke categories so an alias can never
+// bleed into an unrelated record. The detail page grows a "Related
+// extraction records" section (on the hub page, listing the spokes with a
+// status digest) plus a back-link (on each spoke page, pointing at its
+// hub). Rendering is deterministic and idempotent.
+//
+// HONESTY rules (apply to every group, not just databases):
+//
+//   - Only associate a spoke when it genuinely targets the SAME
+//     technology/concept as the hub. General-purpose abstractions that
+//     span many technologies (e.g. general SQL ORMs gorm/prisma/
+//     sqlalchemy that target Postgres OR MySQL OR SQLite) are OMITTED —
+//     linking them under one store would mis-attribute their coverage.
+//   - Substrings match against the record ID's TERMINAL segment (the
+//     library slug) and against the whole id; either hit associates the
+//     record. They never match an arbitrary middle segment of the dotted
+//     path.
+//   - A spoke must live in one of the hub group's whitelisted spoke
+//     categories. This is what keeps the grpc/graphql aliases (which
+//     resolve into `http_framework`) from colliding with anything else.
+//   - If a hub resolves to ZERO spokes, the section is omitted entirely
+//     (no fabrication). protocol.soap / protocol.jsonrpc currently have
+//     no per-language spoke records and therefore render no section.
 
-// datastoreAliases maps a `databases`-category record ID to the set of
-// id-substrings that identify the per-language driver/ORM records
-// targeting that SAME datastore.
-//
-// Honesty rules baked into this map:
-//
-//   - ODMs/OGMs rarely name their datastore, so they are listed
-//     explicitly: mongoose/mongoengine/mongoid/beanie/spring-data-mongo
-//     are MongoDB; neomodel/neogma/grafeo/activegraph/bolt-sips are
-//     Neo4j; spring-data-redis/ioredis/redix are Redis; xandra/scylla
-//     are Cassandra; elastic4s/nest are Elasticsearch; scanamo is
-//     DynamoDB; npgsql/postgrex/libpqxx/pgx are PostgreSQL; etc.
-//   - GENERAL-PURPOSE SQL ORMs/query-builders (gorm, prisma, sqlalchemy,
-//     hibernate, ecto, diesel, sequelize, knex, dapper, doctrine,
-//     eloquent, slick, ...) target MULTIPLE SQL stores and do NOT name a
-//     single one — linking them under postgres OR mysql OR sqlite would
-//     mis-attribute their coverage, so they are deliberately OMITTED.
-//     A db.postgres page only lists records that are unambiguously
-//     PostgreSQL (the pg drivers + Postgres-specific libraries).
-//   - Substrings match against the record ID's terminal token (the
-//     library slug), never against arbitrary substrings of the dotted
-//     path, so "redis" cannot accidentally match an unrelated id.
-//
-// A substring entry is matched against the record's terminal id segment
-// AND against the whole id; either hit associates the record. Keep this
-// map honest: only add a substring when the record genuinely targets the
-// datastore.
-var datastoreAliases = map[string][]string{
-	"db.mongodb": {
-		"mongodb", "mongo", "mongoose", "mongoengine", "mongoid",
-		"beanie", "spring-data-mongo", "mongocxx",
-	},
-	"db.neo4j": {
-		"neo4j", "neomodel", "neogma", "spring-data-neo4j", "grafeo",
-		"activegraph", "bolt-sips", "bolt_sips", "neo4rs",
-	},
-	"db.redis": {
-		"redis", "ioredis", "spring-data-redis", "redix", "predis",
-	},
-	"db.cassandra": {
-		"cassandra", "spring-data-cassandra", "scylla", "xandra",
-	},
-	"db.elasticsearch": {
-		"elasticsearch", "elastic", "elastic4s",
-	},
-	"db.dynamodb": {
-		"dynamodb", "scanamo",
-	},
-	"db.postgres": {
-		"postgres", "postgrex", "psycopg", "asyncpg", "npgsql",
-		"libpqxx", "pgx", "node-postgres",
-	},
-	"db.mysql": {
-		"mysql", "mariadb", "myxql", "mysql2", "mysql-connector",
-		"mysqlconnector", "pymysql", "mysqlclient", "go-sql-driver",
-	},
-	"db.sqlite": {
-		"sqlite", "rusqlite", "better-sqlite", "ecto-sqlite", "ecto_sqlite3",
-	},
-	"db.clickhouse": {
-		"clickhouse",
-	},
-	"db.snowflake": {
-		"snowflake",
-	},
+// crossLinkGroup describes one hub→spoke association rule. Each hub record
+// (identified by HubID) links to every spoke record whose terminal slug or
+// id contains one of MatchSubstrings AND whose category is in SpokeCats.
+type crossLinkGroup struct {
+	HubID           string   // e.g. "protocol.grpc", "msg.broker.kafka", "db.mongodb"
+	HubCategory     string   // category the hub record must belong to
+	MatchSubstrings []string // id-slug substrings identifying the spokes
+	SpokeCats       []string // whitelisted categories a spoke may live in
 }
 
-// relatedRecordDigest is one related driver/ORM record rendered under
-// the infra page's "Code-level coverage" section, or the single infra
-// record back-linked from a driver/ORM page.
+// crossLinkGroups is the curated set of hub→spoke rules across every
+// cross-cutting hub category. Keep it HONEST: only add a substring when
+// the spoke genuinely targets the hub's technology, and only widen
+// SpokeCats when a real spoke lives there.
+//
+// databases: the original #3853 rules, now expressed as generic groups.
+// General-purpose SQL ORMs (gorm/prisma/sqlalchemy/hibernate/ecto/diesel/
+// sequelize/knex/dapper/doctrine/eloquent/slick) are deliberately absent —
+// they target multiple SQL stores and naming one would mis-attribute.
+//
+// protocol: grpc/graphql resolve into per-language http_framework records
+// (tonic, grpc++, grpc-dotnet, gqlgen, graphene, strawberry, ...) plus,
+// for graphql, the msg.graphql-subscriptions transport record. soap and
+// jsonrpc currently have NO per-language spoke records → no section.
+//
+// message_broker: kafka/rabbitmq broker hubs resolve to the per-language
+// client records that live in the SAME message_broker category but are
+// modelled as `lang.*.framework.*` rows (rdkafka, librdkafka, lapin).
+//
+// observability: vendor hubs resolve to the per-language/JVM facade
+// records that export to them (Prometheus ← Micrometer / Dropwizard; the
+// rest currently have no separate per-language spoke records → no
+// section, honestly omitted rather than fabricated).
+var crossLinkGroups = []crossLinkGroup{
+	// ---- databases (preserved from #3853) -------------------------------
+	{HubID: "db.mongodb", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"mongodb", "mongo", "mongoose", "mongoengine", "mongoid", "beanie", "spring-data-mongo", "mongocxx"}},
+	{HubID: "db.neo4j", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"neo4j", "neomodel", "neogma", "spring-data-neo4j", "grafeo", "activegraph", "bolt-sips", "bolt_sips", "neo4rs"}},
+	{HubID: "db.redis", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"redis", "ioredis", "spring-data-redis", "redix", "predis"}},
+	{HubID: "db.cassandra", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"cassandra", "spring-data-cassandra", "scylla", "xandra"}},
+	{HubID: "db.elasticsearch", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"elasticsearch", "elastic", "elastic4s"}},
+	{HubID: "db.dynamodb", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"dynamodb", "scanamo"}},
+	{HubID: "db.postgres", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"postgres", "postgrex", "psycopg", "asyncpg", "npgsql", "libpqxx", "pgx", "node-postgres"}},
+	{HubID: "db.mysql", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"mysql", "mariadb", "myxql", "mysql2", "mysql-connector", "mysqlconnector", "pymysql", "mysqlclient", "go-sql-driver"}},
+	{HubID: "db.sqlite", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"sqlite", "rusqlite", "better-sqlite", "ecto-sqlite", "ecto_sqlite3"}},
+	{HubID: "db.clickhouse", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"clickhouse"}},
+	{HubID: "db.snowflake", HubCategory: "databases", SpokeCats: []string{"orm"},
+		MatchSubstrings: []string{"snowflake"}},
+
+	// ---- protocol -------------------------------------------------------
+	// gRPC: the per-language gRPC server/stub frameworks. Each names gRPC
+	// explicitly (grpc++/grpc-net/elixir-grpc) or is a dedicated gRPC impl
+	// (tonic = Rust gRPC; scalapb-grpc = Scala gRPC).
+	{HubID: "protocol.grpc", HubCategory: "protocol", SpokeCats: []string{"http_framework", "orm"},
+		MatchSubstrings: []string{"grpc", "tonic", "scalapb-grpc", "zio-grpc"}},
+	// GraphQL: the per-language GraphQL frameworks/resolvers + the GraphQL
+	// subscriptions transport record. Every entry is a dedicated GraphQL
+	// library, so the slug match is unambiguous.
+	{HubID: "protocol.graphql", HubCategory: "protocol", SpokeCats: []string{"http_framework", "message_broker"},
+		MatchSubstrings: []string{"graphql", "gqlgen", "graphene", "strawberry", "absinthe", "hotchocolate", "type-graphql"}},
+	// soap / jsonrpc: no per-language spoke records exist in the registry
+	// today, so they are intentionally absent (the section is omitted).
+
+	// ---- message_broker -------------------------------------------------
+	// Kafka clients live in the same message_broker category but as
+	// per-language `lang.*.framework.*` rows. rdkafka/librdkafka are
+	// dedicated Kafka clients; kafka-streams is the Kafka streaming layer.
+	{HubID: "msg.broker.kafka", HubCategory: "message_broker", SpokeCats: []string{"message_broker"},
+		MatchSubstrings: []string{"rdkafka", "librdkafka", "kafka-streams"}},
+	// RabbitMQ / AMQP: lapin is the dedicated Rust AMQP/RabbitMQ client.
+	{HubID: "msg.broker.rabbitmq", HubCategory: "message_broker", SpokeCats: []string{"message_broker"},
+		MatchSubstrings: []string{"lapin"}},
+
+	// ---- observability --------------------------------------------------
+	// Prometheus: Micrometer (JVM metrics facade) and Dropwizard Metrics
+	// export to Prometheus; they are the per-runtime instrumentation that
+	// feeds the Prometheus hub. Honest cross-link within observability.
+	{HubID: "infra.observability.prometheus", HubCategory: "observability", SpokeCats: []string{"observability"},
+		MatchSubstrings: []string{"micrometer", "dropwizard-metrics"}},
+	// Other vendors (datadog/sentry/newrelic/otel) currently have no
+	// separate per-language spoke records → no section (honestly omitted).
+}
+
+// crossLinkGroupByHubID indexes the curated groups by hub record ID for
+// O(1) hub lookup. Built once at init.
+var crossLinkGroupByHubID = func() map[string]crossLinkGroup {
+	m := make(map[string]crossLinkGroup, len(crossLinkGroups))
+	for _, g := range crossLinkGroups {
+		m[g.HubID] = g
+	}
+	return m
+}()
+
+// datastoreAliases is retained as a derived view of the database groups so
+// existing callers/tests that key off `db.<tech>` continue to work.
+var datastoreAliases = func() map[string][]string {
+	m := map[string][]string{}
+	for _, g := range crossLinkGroups {
+		if g.HubCategory == "databases" {
+			m[g.HubID] = g.MatchSubstrings
+		}
+	}
+	return m
+}()
+
+// relatedRecordDigest is one related spoke record rendered under the hub
+// page's "Related extraction records" section, or the single hub record
+// back-linked from a spoke page.
 type relatedRecordDigest struct {
-	ID       string // e.g. lang.jsts.orm.mongoose
-	Label    string // e.g. Mongoose
-	Language string // e.g. jsts
-	Kind     string // "driver" or "orm" (from the id), "" for infra
+	ID       string // e.g. lang.jsts.orm.mongoose, lang.rust.framework.tonic
+	Label    string // e.g. Mongoose, Tonic
+	Language string // e.g. jsts, rust
+	Kind     string // classifier from the id (driver/orm/odm/framework/broker), "" for hub
 	Digest   string // compact status digest, e.g. "3 full, 2 partial"
 }
 
@@ -111,37 +181,67 @@ func terminalSegment(id string) string {
 	return id
 }
 
-// recordKind extracts the driver/orm/odm classifier from a record ID
-// (the segment immediately before the terminal slug), e.g. "orm" for
-// "lang.jsts.orm.mongoose". Returns "" when the id has no such segment.
+// recordKind extracts the classifier from a record ID (the segment
+// immediately before the terminal slug), e.g. "orm" for
+// "lang.jsts.orm.mongoose" or "framework" for "lang.rust.framework.tonic".
+// Returns "" when the id has no recognised classifier segment.
 func recordKind(id string) string {
 	parts := strings.Split(id, ".")
 	if len(parts) < 2 {
 		return ""
 	}
 	switch parts[len(parts)-2] {
-	case "driver", "orm", "odm":
+	case "driver", "orm", "odm", "framework", "broker", "observability":
 		return parts[len(parts)-2]
 	}
 	return ""
 }
 
-// matchesDatastore reports whether a driver/ORM record (by its ID)
-// targets the datastore identified by db (a `db.<tech>` infra id). The
-// match is against the record's terminal slug so an alias substring
-// never bleeds across unrelated dotted segments.
-func matchesDatastore(db, recID string) bool {
-	subs, ok := datastoreAliases[db]
-	if !ok {
-		return false
-	}
+// matchesSlug reports whether recID's terminal slug (or whole id) contains
+// any of the group's match substrings. Matching the terminal slug keeps an
+// alias substring from bleeding across unrelated dotted segments.
+func matchesSlug(subs []string, recID string) bool {
 	seg := terminalSegment(recID)
 	for _, s := range subs {
-		if strings.Contains(seg, s) {
+		if strings.Contains(seg, s) || strings.Contains(recID, s) {
 			return true
 		}
 	}
 	return false
+}
+
+// inCategorySet reports whether cat is one of the whitelisted categories.
+func inCategorySet(cats []string, cat string) bool {
+	for _, c := range cats {
+		if c == cat {
+			return true
+		}
+	}
+	return false
+}
+
+// spokeMatches reports whether spoke record `rec` is a genuine spoke of
+// the given hub group: its category is whitelisted and its slug matches.
+// The hub record itself never matches (HubID guard).
+func spokeMatches(g crossLinkGroup, rec Record) bool {
+	if rec.ID == g.HubID {
+		return false
+	}
+	if !inCategorySet(g.SpokeCats, rec.Category) {
+		return false
+	}
+	return matchesSlug(g.MatchSubstrings, rec.ID)
+}
+
+// matchesDatastore is the database-only predicate retained for the
+// collision-guard test. It reports whether a record (by ID) matches the
+// db.<tech> hub's alias substrings, irrespective of category.
+func matchesDatastore(db, recID string) bool {
+	g, ok := crossLinkGroupByHubID[db]
+	if !ok || g.HubCategory != "databases" {
+		return false
+	}
+	return matchesSlug(g.MatchSubstrings, recID)
 }
 
 // statusDigest renders a compact per-status digest for one record, e.g.
@@ -187,36 +287,26 @@ func statusDigest(rec Record) string {
 	return strings.Join(parts, ", ")
 }
 
-// relatedDriverORMRecords returns the driver/ORM records that target the
-// same datastore as the given infra record (a `databases`-category
-// `db.<tech>` record), each with a compact status digest, sorted by
-// (language, id) for deterministic output. Returns nil when the record
-// is not a recognised infra record or has no related records — the
+// relatedSpokeRecords returns the spoke records that target the same
+// technology/concept as the given hub record, each with a compact status
+// digest, sorted by (language, id) for deterministic output. Returns nil
+// when the record is not a recognised hub or resolves to no spokes — the
 // caller omits the section entirely in that case (never fabricates).
-func relatedDriverORMRecords(infra Record, all []Record) []relatedRecordDigest {
-	if infra.Category != "databases" {
-		return nil
-	}
-	if _, ok := datastoreAliases[infra.ID]; !ok {
+func relatedSpokeRecords(hub Record, all []Record) []relatedRecordDigest {
+	g, ok := crossLinkGroupByHubID[hub.ID]
+	if !ok || hub.Category != g.HubCategory {
 		return nil
 	}
 	out := make([]relatedRecordDigest, 0, 16)
 	for _, r := range all {
-		if r.ID == infra.ID {
-			continue
-		}
-		kind := recordKind(r.ID)
-		if kind == "" {
-			continue
-		}
-		if !matchesDatastore(infra.ID, r.ID) {
+		if !spokeMatches(g, r) {
 			continue
 		}
 		out = append(out, relatedRecordDigest{
 			ID:       r.ID,
 			Label:    r.Label,
 			Language: r.Language,
-			Kind:     kind,
+			Kind:     recordKind(r.ID),
 			Digest:   statusDigest(r),
 		})
 	}
@@ -232,31 +322,39 @@ func relatedDriverORMRecords(infra Record, all []Record) []relatedRecordDigest {
 	return out
 }
 
-// infraRecordFor returns the `databases`-category infra record that the
-// given driver/ORM record targets, or nil when there is none. A
-// driver/ORM record matches an infra record when the infra's alias map
-// associates it (the same association used by relatedDriverORMRecords,
-// kept symmetric). Returns nil for non-driver/ORM records.
-func infraRecordFor(rec Record, all []Record) *relatedRecordDigest {
-	if recordKind(rec.ID) == "" {
+// relatedDriverORMRecords is the database-specific alias retained for the
+// existing #3853 tests. It delegates to the generic resolver but only for
+// `databases`-category hubs.
+func relatedDriverORMRecords(hub Record, all []Record) []relatedRecordDigest {
+	if hub.Category != "databases" {
 		return nil
 	}
-	// Find the infra record whose alias set claims this record. There is
-	// at most one per datastore; iterate the infra records deterministically.
-	infraByID := map[string]Record{}
-	infraIDs := make([]string, 0, len(datastoreAliases))
+	return relatedSpokeRecords(hub, all)
+}
+
+// hubRecordFor returns the hub record that the given spoke record targets,
+// or nil when there is none. A spoke matches a hub when the hub's group
+// claims it (the same association used by relatedSpokeRecords, kept
+// symmetric). When more than one hub could claim a spoke, the
+// lexicographically-smallest hub ID wins for determinism (the live
+// registry has no such collisions — guarded by test).
+func hubRecordFor(spoke Record, all []Record) *relatedRecordDigest {
+	// Index hub records present in `all` by ID for label/digest lookup.
+	hubByID := map[string]Record{}
 	for _, r := range all {
-		if r.Category == "databases" {
-			if _, ok := datastoreAliases[r.ID]; ok {
-				infraByID[r.ID] = r
-				infraIDs = append(infraIDs, r.ID)
-			}
+		if g, ok := crossLinkGroupByHubID[r.ID]; ok && r.Category == g.HubCategory {
+			hubByID[r.ID] = r
 		}
 	}
-	sort.Strings(infraIDs)
-	for _, id := range infraIDs {
-		if matchesDatastore(id, rec.ID) {
-			r := infraByID[id]
+	hubIDs := make([]string, 0, len(hubByID))
+	for id := range hubByID {
+		hubIDs = append(hubIDs, id)
+	}
+	sort.Strings(hubIDs)
+	for _, id := range hubIDs {
+		g := crossLinkGroupByHubID[id]
+		if spokeMatches(g, spoke) {
+			r := hubByID[id]
 			return &relatedRecordDigest{
 				ID:       r.ID,
 				Label:    r.Label,
@@ -267,4 +365,24 @@ func infraRecordFor(rec Record, all []Record) *relatedRecordDigest {
 		}
 	}
 	return nil
+}
+
+// infraRecordFor is the database-specific alias retained for the existing
+// #3853 tests. It returns the `databases`-category hub a driver/ORM record
+// targets, or nil. Delegates to hubRecordFor but restricts the result to
+// database hubs and driver/ORM spokes.
+func infraRecordFor(spoke Record, all []Record) *relatedRecordDigest {
+	switch recordKind(spoke.ID) {
+	case "driver", "orm", "odm":
+	default:
+		return nil
+	}
+	hub := hubRecordFor(spoke, all)
+	if hub == nil {
+		return nil
+	}
+	if g, ok := crossLinkGroupByHubID[hub.ID]; !ok || g.HubCategory != "databases" {
+		return nil
+	}
+	return hub
 }

--- a/tools/coverage/related_test.go
+++ b/tools/coverage/related_test.go
@@ -167,8 +167,8 @@ func TestGenRelatedRecordsSection(t *testing.T) {
 	}
 
 	mongo := read("db.mongodb")
-	if !strings.Contains(mongo, "## Code-level coverage") {
-		t.Errorf("db.mongodb missing Code-level coverage section:\n%s", mongo)
+	if !strings.Contains(mongo, "## Related extraction records") {
+		t.Errorf("db.mongodb missing Related extraction records section:\n%s", mongo)
 	}
 	for _, want := range []string{
 		"[`lang.jsts.orm.mongoose`](./lang.jsts.orm.mongoose.md)",
@@ -194,23 +194,207 @@ func TestGenRelatedRecordsSection(t *testing.T) {
 
 	// mongoose backlinks to db.mongodb.
 	mg := read("lang.jsts.orm.mongoose")
-	if !strings.Contains(mg, "## Datastore") {
-		t.Errorf("mongoose missing Datastore back-link section:\n%s", mg)
+	if !strings.Contains(mg, "## Related extraction records") {
+		t.Errorf("mongoose missing back-link section:\n%s", mg)
 	}
 	if !strings.Contains(mg, "[`db.mongodb`](./db.mongodb.md)") {
 		t.Errorf("mongoose missing db.mongodb back-link:\n%s", mg)
 	}
 
-	// clickhouse: no Code-level section (negative).
+	// clickhouse: no related section (negative).
 	ch := read("db.clickhouse")
-	if strings.Contains(ch, "## Code-level coverage") {
-		t.Errorf("db.clickhouse should have no Code-level coverage section:\n%s", ch)
+	if strings.Contains(ch, "## Related extraction records") {
+		t.Errorf("db.clickhouse should have no Related extraction records section:\n%s", ch)
 	}
 
-	// gorm: no Datastore back-link (negative).
+	// gorm: no back-link (negative).
 	gorm := read("lang.go.orm.gorm")
-	if strings.Contains(gorm, "## Datastore") {
-		t.Errorf("gorm should have no Datastore back-link:\n%s", gorm)
+	if strings.Contains(gorm, "## Related extraction records") {
+		t.Errorf("gorm should have no back-link:\n%s", gorm)
+	}
+}
+
+// testRegistryGeneralizedHubs builds a registry exercising the
+// generalized hub→spoke cross-link beyond databases: a gRPC protocol hub
+// with per-language http_framework spokes, a Kafka broker hub with
+// per-language client spokes, a Prometheus observability hub with a
+// Micrometer facade spoke, and a SOAP hub with NO spokes (negative).
+func testRegistryGeneralizedHubs() *Registry {
+	return &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			// protocol.grpc hub + per-language gRPC framework spokes.
+			{ID: "protocol.grpc", Category: "protocol", Language: "multi", Label: "gRPC",
+				Capabilities: map[string]Capability{"resource_extraction": {Status: StatusPartial}}},
+			{ID: "lang.rust.framework.tonic", Category: "http_framework", Language: "rust", Label: "Tonic",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}, "b": {Status: StatusFull}, "c": {Status: StatusPartial}}},
+			{ID: "lang.csharp.framework.grpc-net", Category: "http_framework", Language: "csharp", Label: "grpc-dotnet",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+			// A non-gRPC http_framework that must NOT be linked under grpc.
+			{ID: "lang.go.framework.gin", Category: "http_framework", Language: "go", Label: "Gin",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}}},
+
+			// protocol.soap hub with no spokes (negative).
+			{ID: "protocol.soap", Category: "protocol", Language: "multi", Label: "SOAP / WSDL",
+				Capabilities: map[string]Capability{"resource_extraction": {Status: StatusMissing}}},
+
+			// msg.broker.kafka hub + per-language Kafka client spokes.
+			{ID: "msg.broker.kafka", Category: "message_broker", Language: "multi", Label: "Apache Kafka",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+			{ID: "lang.rust.framework.rdkafka", Category: "message_broker", Language: "rust", Label: "rdkafka (Kafka)",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}, "b": {Status: StatusFull}}},
+			{ID: "lang.c-cpp.framework.librdkafka", Category: "message_broker", Language: "c-cpp", Label: "librdkafka",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+			// A non-Kafka broker client that must NOT be linked under kafka.
+			{ID: "lang.rust.framework.lapin", Category: "message_broker", Language: "rust", Label: "lapin (AMQP/RabbitMQ)",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}}},
+			{ID: "msg.broker.rabbitmq", Category: "message_broker", Language: "multi", Label: "RabbitMQ",
+				Capabilities: map[string]Capability{"a": {Status: StatusMissing}}},
+
+			// observability: Prometheus hub + Micrometer facade spoke.
+			{ID: "infra.observability.prometheus", Category: "observability", Language: "multi", Label: "Prometheus",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+			{ID: "infra.observability.micrometer", Category: "observability", Language: "multi", Label: "Micrometer",
+				Capabilities: map[string]Capability{"a": {Status: StatusFull}, "b": {Status: StatusPartial}}},
+			// A vendor with no spokes (negative).
+			{ID: "infra.observability.datadog", Category: "observability", Language: "multi", Label: "Datadog",
+				Capabilities: map[string]Capability{"a": {Status: StatusPartial}}},
+		},
+	}
+}
+
+// TestGeneralizedHubSpokeResolver is the value-asserting end-to-end test
+// for the generalized cross-link: protocol.grpc lists tonic/grpc-net with
+// a digest and tonic backlinks; msg.broker.kafka lists rdkafka/librdkafka;
+// Prometheus lists Micrometer; SOAP and Datadog (no spokes) render no
+// section. Negative: gin/lapin are not mis-attributed.
+func TestGeneralizedHubSpokeResolver(t *testing.T) {
+	reg := testRegistryGeneralizedHubs()
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	read := func(id string) string {
+		data, err := os.ReadFile(filepath.Join(root, "docs", "coverage", "detail", id+".md"))
+		if err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		return string(data)
+	}
+
+	// protocol.grpc lists its per-language gRPC frameworks with a digest.
+	grpc := read("protocol.grpc")
+	if !strings.Contains(grpc, "## Related extraction records") {
+		t.Errorf("protocol.grpc missing Related extraction records section:\n%s", grpc)
+	}
+	for _, want := range []string{
+		"[`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md)",
+		"[`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md)",
+		"2 full, 1 partial", // tonic digest
+	} {
+		if !strings.Contains(grpc, want) {
+			t.Errorf("protocol.grpc missing %q:\n%s", want, grpc)
+		}
+	}
+	if strings.Contains(grpc, "framework.gin") {
+		t.Errorf("protocol.grpc wrongly lists gin (non-gRPC framework):\n%s", grpc)
+	}
+	// tonic backlinks to protocol.grpc.
+	tonic := read("lang.rust.framework.tonic")
+	if !strings.Contains(tonic, "[`protocol.grpc`](./protocol.grpc.md)") {
+		t.Errorf("tonic missing protocol.grpc back-link:\n%s", tonic)
+	}
+
+	// protocol.soap: no spokes → no section (negative).
+	soap := read("protocol.soap")
+	if strings.Contains(soap, "## Related extraction records") {
+		t.Errorf("protocol.soap should have no Related extraction records section:\n%s", soap)
+	}
+
+	// msg.broker.kafka lists rdkafka/librdkafka; not lapin.
+	kafka := read("msg.broker.kafka")
+	for _, want := range []string{
+		"[`lang.rust.framework.rdkafka`](./lang.rust.framework.rdkafka.md)",
+		"[`lang.c-cpp.framework.librdkafka`](./lang.c-cpp.framework.librdkafka.md)",
+		"2 full", // rdkafka digest
+	} {
+		if !strings.Contains(kafka, want) {
+			t.Errorf("msg.broker.kafka missing %q:\n%s", want, kafka)
+		}
+	}
+	if strings.Contains(kafka, "lapin") {
+		t.Errorf("msg.broker.kafka wrongly lists lapin (RabbitMQ client):\n%s", kafka)
+	}
+	// rdkafka backlinks to the kafka hub.
+	rdkafka := read("lang.rust.framework.rdkafka")
+	if !strings.Contains(rdkafka, "[`msg.broker.kafka`](./msg.broker.kafka.md)") {
+		t.Errorf("rdkafka missing msg.broker.kafka back-link:\n%s", rdkafka)
+	}
+	// lapin backlinks to rabbitmq (not kafka).
+	lapin := read("lang.rust.framework.lapin")
+	if !strings.Contains(lapin, "[`msg.broker.rabbitmq`](./msg.broker.rabbitmq.md)") {
+		t.Errorf("lapin missing msg.broker.rabbitmq back-link:\n%s", lapin)
+	}
+
+	// observability: Prometheus lists Micrometer.
+	prom := read("infra.observability.prometheus")
+	if !strings.Contains(prom, "[`infra.observability.micrometer`](./infra.observability.micrometer.md)") {
+		t.Errorf("prometheus missing micrometer spoke:\n%s", prom)
+	}
+	if !strings.Contains(prom, "1 full, 1 partial") {
+		t.Errorf("prometheus missing micrometer digest:\n%s", prom)
+	}
+	// datadog: no spokes → no section (negative).
+	dd := read("infra.observability.datadog")
+	if strings.Contains(dd, "## Related extraction records") {
+		t.Errorf("datadog should have no Related extraction records section:\n%s", dd)
+	}
+}
+
+// TestGeneralizedHubIdempotent guards that generating twice yields byte-
+// identical hub pages (deterministic/idempotent).
+func TestGeneralizedHubIdempotent(t *testing.T) {
+	reg := testRegistryGeneralizedHubs()
+	r1, r2 := t.TempDir(), t.TempDir()
+	if err := generate(reg, r1); err != nil {
+		t.Fatalf("generate r1: %v", err)
+	}
+	if err := generate(reg, r2); err != nil {
+		t.Fatalf("generate r2: %v", err)
+	}
+	for _, id := range []string{"protocol.grpc", "msg.broker.kafka", "infra.observability.prometheus", "lang.rust.framework.tonic"} {
+		a, err := os.ReadFile(filepath.Join(r1, "docs", "coverage", "detail", id+".md"))
+		if err != nil {
+			t.Fatalf("read r1 %s: %v", id, err)
+		}
+		b, err := os.ReadFile(filepath.Join(r2, "docs", "coverage", "detail", id+".md"))
+		if err != nil {
+			t.Fatalf("read r2 %s: %v", id, err)
+		}
+		if string(a) != string(b) {
+			t.Errorf("non-idempotent output for %s", id)
+		}
+	}
+}
+
+// TestCrossLinkNoCollision guards that no spoke record in the LIVE
+// registry associates with more than one hub — a collision would mean a
+// match substring is too broad and mis-attributes coverage.
+func TestCrossLinkNoCollision(t *testing.T) {
+	reg, err := loadRegistry(filepath.Join("..", "..", "docs", "coverage", "registry.json"))
+	if err != nil {
+		t.Skipf("live registry unavailable: %v", err)
+	}
+	for _, r := range reg.Records {
+		var hits []string
+		for _, g := range crossLinkGroups {
+			if spokeMatches(g, r) {
+				hits = append(hits, g.HubID)
+			}
+		}
+		if len(hits) > 1 {
+			t.Errorf("record %s matches multiple hubs %v (match too broad)", r.ID, hits)
+		}
 	}
 }
 

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -36,11 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 | {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{renderIssue .Cap.Issue}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
-{{end}}{{if .RelatedRecords}}## Code-level coverage
+{{end}}{{if .RelatedRecords}}## Related extraction records
 
-This infra record tracks datastore-level extraction (resources, dependency
-attribution). The deep, code-level coverage for this technology lives in the
-per-language driver/ORM records below — each one is a separate detail page.
+This hub record tracks the technology at a high level. The deep, code-level
+coverage for this technology lives in the per-language records below — each
+one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
@@ -48,11 +48,11 @@ per-language driver/ORM records below — each one is a separate detail page.
 | [`{{.ID}}`](./{{.ID}}.md) | {{langDsp .Language}} | {{.Kind}} | {{.Digest}} |
 {{- end}}
 
-{{end}}{{if .InfraRecord}}## Datastore
+{{end}}{{if .HubRecord}}## Related extraction records
 
-This driver/ORM record provides code-level coverage for the
-[`{{.InfraRecord.ID}}`](./{{.InfraRecord.ID}}.md) infra record ({{.InfraRecord.Label}}),
-which tracks datastore-level extraction for the same technology.
+This record provides code-level coverage for the
+[`{{.HubRecord.ID}}`](./{{.HubRecord.ID}}.md) hub record ({{.HubRecord.Label}}),
+which tracks the same technology at a higher level.
 
 {{end}}## Provenance
 


### PR DESCRIPTION
## Summary

Generalizes the "Related extraction records" cross-link — introduced for **databases** in #3853 (built on platform redesign #3865) — into a **category-agnostic hub→spoke resolver**. A curated set of `crossLinkGroup` rules associates each cross-cutting HUB record with the per-technology SPOKE records that carry its real code-level coverage (often in a *different* category), constrained to a whitelist of spoke categories so an alias can never bleed into an unrelated record.

## Categories now cross-linked (databases preserved as a regression)

| Hub | Spokes rendered |
|-----|-----------------|
| `protocol.grpc` | per-language gRPC frameworks: tonic, grpc++, grpc-net, elixir-grpc, scalapb-grpc |
| `protocol.graphql` | gqlgen, graphene, strawberry, absinthe, hotchocolate, type-graphql, graphql-resolvers, spring-graphql, graphql-kotlin, graphql-php, graphql-ruby, async-graphql + `msg.graphql-subscriptions` |
| `protocol.soap` / `protocol.jsonrpc` | none → section honestly omitted |
| `msg.broker.kafka` | rdkafka, librdkafka, kafka-streams |
| `msg.broker.rabbitmq` | lapin |
| `infra.observability.prometheus` | micrometer, dropwizard-metrics (runtime facades that export to it) |
| datadog / sentry / newrelic / otel | none → section honestly omitted |

## Design

- Generic `crossLinkGroup{HubID, HubCategory, MatchSubstrings, SpokeCats}` rule set; `relatedSpokeRecords` (hub→spokes, with status digest) and `hubRecordFor` (spoke→hub back-link) drive both directions.
- **HONEST by construction**: a spoke must match a slug substring AND live in a whitelisted spoke category; a hub with zero resolvable spokes omits the section (no fabrication); general-purpose SQL ORMs stay unlinked.
- **Deterministic & idempotent**: spokes sorted by (language, id); `gen` twice → byte-identical.
- The database-specific helpers (`datastoreAliases`, `relatedDriverORMRecords`, `infraRecordFor`, `matchesDatastore`) are kept as thin views over the generic resolver so the #3853 tests + collision guard keep passing.
- Detail-page heading unified to **"Related extraction records"** (was "Code-level coverage" / "Datastore").

## Rendered examples

**`protocol.grpc`** lists 5 per-language gRPC frameworks with digests (e.g. tonic → `5 full, 3 partial, 40 missing, 1 n/a`); **tonic** back-links to `protocol.grpc`.
**`msg.broker.kafka`** lists librdkafka/rdkafka/kafka-streams (lapin correctly excluded).
**`infra.observability.prometheus`** lists micrometer + dropwizard-metrics.

## Tests

Value-asserting: protocol.grpc lists tonic w/ digest + tonic back-links; msg.broker.kafka lists rdkafka but **not** lapin; prometheus lists micrometer; soap/datadog (no spokes) render no section (negative); db.mongodb still works (regression); `gen` twice byte-identical (idempotent); live no-collision guard across all hubs. `go test ./tools/coverage/` green, `validate` 0 errors, `fmt --check` canonical, `gofmt -l` empty, `go vet` clean.

## Deploy

**DEPLOY-DEFERRED** — docs-only generator change (no extractor/daemon/index touch). Regenerated `docs/coverage/*.md` committed (130 pages).

Closes #3873. Epic #3871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)