### PR TITLE
feat(frameworks): typed base-class knowledge catalog + DRF pack (#3832)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/frameworks/baseknowledge"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -1692,38 +1693,43 @@ func extractClassBody(src string, offset int) string {
 func classifyViewSetParent(base string) map[string]bool {
 	out := map[string]bool{}
 	hasKnownBase := false
+
+	// addVerbs pulls the CRUD verb set the named DRF base contributes from
+	// the shared knowledge catalog (internal/frameworks/baseknowledge, DRF
+	// pack — the single source of truth #3832) and unions it into `out`.
+	// We still drive WHICH bases to look for from the literal base-list
+	// text via containsIdent so the whole-identifier matching and the
+	// substring-trap guard (ReadOnlyModelViewSet vs ModelViewSet) are
+	// preserved exactly; only the verb sets are sourced from the pack
+	// instead of being duplicated here.
+	addVerbs := func(baseName string) {
+		hasKnownBase = true
+		for verb := range baseknowledge.Default().MembersOf(baseName) {
+			out[verb] = true
+		}
+	}
+
 	// Check ReadOnlyModelViewSet first since "ModelViewSet" is a substring
 	// of it; ordering matters.
 	if containsIdent(base, "ReadOnlyModelViewSet") {
-		hasKnownBase = true
-		out["list"] = true
-		out["retrieve"] = true
+		addVerbs("ReadOnlyModelViewSet")
 	} else if containsIdent(base, "ModelViewSet") {
-		hasKnownBase = true
-		for _, m := range []string{"list", "create", "retrieve", "update", "partial_update", "destroy"} {
-			out[m] = true
-		}
+		addVerbs("ModelViewSet")
 	}
 	if containsIdent(base, "ListModelMixin") {
-		hasKnownBase = true
-		out["list"] = true
+		addVerbs("ListModelMixin")
 	}
 	if containsIdent(base, "CreateModelMixin") {
-		hasKnownBase = true
-		out["create"] = true
+		addVerbs("CreateModelMixin")
 	}
 	if containsIdent(base, "RetrieveModelMixin") {
-		hasKnownBase = true
-		out["retrieve"] = true
+		addVerbs("RetrieveModelMixin")
 	}
 	if containsIdent(base, "UpdateModelMixin") {
-		hasKnownBase = true
-		out["update"] = true
-		out["partial_update"] = true
+		addVerbs("UpdateModelMixin")
 	}
 	if containsIdent(base, "DestroyModelMixin") {
-		hasKnownBase = true
-		out["destroy"] = true
+		addVerbs("DestroyModelMixin")
 	}
 	if containsIdent(base, "GenericViewSet") || containsIdent(base, "ViewSet") {
 		hasKnownBase = true
@@ -1776,14 +1782,11 @@ func isIdentByte(b byte) bool {
 // modelViewSetMethods is the canonical full CRUD set for a
 // rest_framework.viewsets.ModelViewSet.
 func modelViewSetMethods() map[string]bool {
-	return map[string]bool{
-		"list":           true,
-		"create":         true,
-		"retrieve":       true,
-		"update":         true,
-		"partial_update": true,
-		"destroy":        true,
+	out := map[string]bool{}
+	for verb := range baseknowledge.Default().MembersOf("ModelViewSet") {
+		out[verb] = true
 	}
+	return out
 }
 
 // extractActions returns every @action / @detail_route / @list_route

--- a/internal/extractors/python/cbv_inherited_methods.go
+++ b/internal/extractors/python/cbv_inherited_methods.go
@@ -31,66 +31,28 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/frameworks/baseknowledge"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// cbvBaseInheritedMethods maps the bare leaf name of each recognised
-// Django / DRF generic base class to the set of method names it
-// contributes to its subclass's HTTP surface.
+// The recognised Django / DRF generic base classes and the HTTP-handler
+// method names they contribute to a subclass's surface now live in the
+// shared, typed catalog `internal/frameworks/baseknowledge` (DRF pack) —
+// the single source of truth that MRO resolution (#3833) and
+// effective-contract synthesis (#3835) also consume.
 //
-// Source: Django docs (generic class-based views) + DRF docs (generic
-// viewsets / generic API views). The list intentionally covers ONLY
-// the canonical HTTP-handler methods — helpers like `get_queryset`,
-// `get_serializer_class`, `perform_create` etc. are excluded because
-// subclasses override them as customization hooks rather than treat
-// them as part of the public API contract.
-var cbvBaseInheritedMethods = map[string][]string{
-	// Django generic class-based views (django.views.generic.*).
-	"View":             {"get", "post", "put", "patch", "delete", "head", "options", "trace"},
-	"TemplateView":     {"get"},
-	"RedirectView":     {"get", "post", "put", "patch", "delete", "head", "options"},
-	"ListView":         {"get"},
-	"DetailView":       {"get"},
-	"FormView":         {"get", "post"},
-	"CreateView":       {"get", "post"},
-	"UpdateView":       {"get", "post"},
-	"DeleteView":       {"get", "post", "delete"},
-	"ArchiveIndexView": {"get"},
-	"YearArchiveView":  {"get"},
-	"MonthArchiveView": {"get"},
-	"DayArchiveView":   {"get"},
-	"WeekArchiveView":  {"get"},
-	"TodayArchiveView": {"get"},
-	"DateDetailView":   {"get"},
-	"ProcessFormView":  {"get", "post"},
-	"BaseCreateView":   {"get", "post"},
-	"BaseUpdateView":   {"get", "post"},
-	"BaseDeleteView":   {"get", "post", "delete"},
-
-	// DRF generic API views (rest_framework.generics.*).
-	"GenericAPIView":               {},
-	"CreateAPIView":                {"post"},
-	"ListAPIView":                  {"get"},
-	"RetrieveAPIView":              {"get"},
-	"DestroyAPIView":               {"delete"},
-	"UpdateAPIView":                {"put", "patch"},
-	"ListCreateAPIView":            {"get", "post"},
-	"RetrieveUpdateAPIView":        {"get", "put", "patch"},
-	"RetrieveDestroyAPIView":       {"get", "delete"},
-	"RetrieveUpdateDestroyAPIView": {"get", "put", "patch", "delete"},
-
-	// DRF viewsets (rest_framework.viewsets.*).
-	"ViewSet":              {},
-	"GenericViewSet":       {},
-	"ReadOnlyModelViewSet": {"list", "retrieve"},
-	"ModelViewSet":         {"list", "retrieve", "create", "update", "partial_update", "destroy"},
-
-	// DRF mixins (rest_framework.mixins.*).
-	"CreateModelMixin":   {"create"},
-	"ListModelMixin":     {"list"},
-	"RetrieveModelMixin": {"retrieve"},
-	"UpdateModelMixin":   {"update", "partial_update"},
-	"DestroyModelMixin":  {"destroy"},
+// `cbvInheritedMembers` resolves a base-class leaf name to the inherited
+// method names that base contributes, via the catalog. It returns the
+// method names (the property this annotation stamps is name-only by
+// design — Option A, #2011) and whether the base is recognised at all
+// (so empty-but-known bases like GenericViewSet still register as
+// `cbv_bases` without adding methods, exactly as the old map did).
+func cbvInheritedMembers(baseLeaf string) (methods []string, known bool) {
+	c, ok := baseknowledge.Default().Lookup(baseLeaf)
+	if !ok {
+		return nil, false
+	}
+	return c.MemberNames(), true
 }
 
 // emitCBVInheritedMethodAnnotations walks every class entity in the
@@ -130,7 +92,7 @@ func emitCBVInheritedMethodAnnotations(_ *sitter.Node, file extractor.FileInput,
 			if dot := strings.LastIndexByte(baseLeaf, '.'); dot >= 0 {
 				baseLeaf = baseLeaf[dot+1:]
 			}
-			methods, ok := cbvBaseInheritedMethods[baseLeaf]
+			methods, ok := cbvInheritedMembers(baseLeaf)
 			if !ok {
 				continue
 			}
@@ -165,7 +127,7 @@ func emitCBVInheritedMethodAnnotations(_ *sitter.Node, file extractor.FileInput,
 			if dot := strings.LastIndexByte(baseLeaf, '.'); dot >= 0 {
 				baseLeaf = baseLeaf[dot+1:]
 			}
-			if _, ok := cbvBaseInheritedMethods[baseLeaf]; ok {
+			if _, ok := cbvInheritedMembers(baseLeaf); ok {
 				bases = append(bases, baseLeaf)
 			}
 		}

--- a/internal/frameworks/baseknowledge/baseknowledge.go
+++ b/internal/frameworks/baseknowledge/baseknowledge.go
@@ -1,0 +1,150 @@
+// Package baseknowledge is a typed, shared catalog of framework
+// base-class / mixin contracts.
+//
+// Motivation (epic #3829, ticket #3832 — PR A0)
+//
+// Many web frameworks ship base classes and mixins whose subclasses
+// inherit a fixed contract of HTTP-handler methods, default status
+// codes, and behavioural guarantees WITHOUT declaring any of it in the
+// user's source. A Django REST Framework `class RoleViewSet(ModelViewSet)`
+// exposes `list / retrieve / create / update / partial_update / destroy`,
+// each with a well-known default HTTP status (create -> 201, destroy ->
+// 204, ...) and behaviour (e.g. `UpdateModelMixin.update` calls
+// `serializer.is_valid(raise_exception=True)`, so an invalid payload
+// yields 400 — the #278 parity-defect fact). None of this appears in the
+// subclass body.
+//
+// Until now this knowledge lived in ad-hoc, per-language maps scattered
+// across the extractors (`python.cbvBaseInheritedMethods`, the Laravel
+// Eloquent map, the JPA/Panache map). Those maps are name-only and cannot
+// feed MRO resolution (#3833) or effective-contract synthesis (#3835),
+// which need the DEFINING class per member plus the default status and
+// behavioural facts so they can synthesize an external mixin body the
+// user's code never declares.
+//
+// This package is the single-source-of-truth catalog those downstream
+// passes consume. It is intentionally language- AND framework-agnostic:
+// a DRF pack, a Spring Data pack, a NestJS Crud pack, an ActiveRecord
+// pack and an Eloquent pack all register through the same Pack interface
+// (see pack.go) and are queried through the same Registry lookups
+// (Lookup / MembersOf / Member / ResolveVerb).
+//
+// QUALITY NOTE: packs are curated DATA. When a behavioural fact is
+// unknown we leave the field zero/empty rather than guess — never
+// fabricate a status. Callers must treat DefaultStatus == 0 as "unknown,
+// fall back to a body parse", not as a real status.
+package baseknowledge
+
+// Member is the inherited contract a single base-class member contributes
+// to its subclasses. A "member" is a method the subclass inherits without
+// declaring it (e.g. the DRF `create` verb from `CreateModelMixin`).
+//
+// For route-handler members HTTPVerb / DefaultStatus / the *Applicable
+// fields carry the per-verb default contract facts that effective-contract
+// synthesis (#3835) stamps onto synthesized routes. For non-route members
+// HTTPVerb is "" and DefaultStatus is 0 (StatusUnknown).
+type Member struct {
+	// Name is the inherited method name as the framework names it — the
+	// DRF verb method ("create", "partial_update", ...) or a generic CBV
+	// HTTP handler ("get", "post", ...).
+	Name string
+
+	// DefiningClass is the FQN of the base class / mixin that actually
+	// defines this member's body. This is the load-bearing field for MRO
+	// resolution (#3833): given an inherited member, it names the external
+	// class whose body get_source should synthesize. Always set.
+	DefiningClass string
+
+	// HTTPVerb is the upper-case HTTP method this member handles when it is
+	// a route handler ("POST", "PATCH", ...). Empty for members that are
+	// not HTTP route handlers.
+	HTTPVerb string
+
+	// DefaultStatus is the default success HTTP status the member returns
+	// (201 create, 200 update/list/retrieve, 204 destroy). StatusUnknown
+	// (0) means "no curated default — do not fabricate one". Callers must
+	// not treat 0 as a real status.
+	DefaultStatus int
+
+	// ErrorStatuses lists non-success statuses the member can produce as a
+	// documented part of its contract (e.g. DRF update -> 400 on invalid
+	// payload via is_valid(raise_exception=True), the #278 fact). May be
+	// empty.
+	ErrorStatuses []int
+
+	// Behaviour is a short, human-readable description of the member's
+	// load-bearing runtime behaviour — e.g.
+	// "is_valid(raise_exception=True) -> 400 on invalid payload".
+	// Empty when no notable behaviour is curated.
+	Behaviour string
+
+	// PaginationApplicable is true when the framework applies the project's
+	// default pagination to this member's response by default (DRF list).
+	PaginationApplicable bool
+
+	// PermissionApplicable is true when the framework applies the class /
+	// project default permission classes to this member by default (true
+	// for every DRF route handler).
+	PermissionApplicable bool
+
+	// DocURL optionally links the upstream documentation for the member's
+	// contract. May be empty.
+	DocURL string
+}
+
+// StatusUnknown is the sentinel DefaultStatus value meaning "no curated
+// default status is known for this member". Callers MUST NOT treat it as a
+// real HTTP status; it signals a fallback (e.g. parse the explicit body)
+// is required.
+const StatusUnknown = 0
+
+// IsRoute reports whether the member is an HTTP route handler (carries a
+// verb). Non-route members (helper hooks, finders) return false.
+func (m Member) IsRoute() bool { return m.HTTPVerb != "" }
+
+// BaseClassContract is the inherited contract of a single framework base
+// class or mixin. It is the catalog's primary record: one per known base
+// class (ModelViewSet, CreateModelMixin, JpaRepository, ...).
+type BaseClassContract struct {
+	// FQNs are the match keys for this base class, most-qualified first:
+	// e.g. {"rest_framework.viewsets.ModelViewSet", "ModelViewSet"}. Lookup
+	// matches any entry; leaf-only matching is supported via the registry's
+	// leaf index so a subclass written `class X(ModelViewSet)` resolves
+	// even without the dotted import path.
+	FQNs []string
+
+	// Language is the source language the base class belongs to ("python",
+	// "java", "php", "ruby", "typescript", "go").
+	Language string
+
+	// Framework is the owning framework key ("drf", "django", "spring-data",
+	// "eloquent", "activerecord", "nestjsx-crud").
+	Framework string
+
+	// Members maps the inherited member name to its contract. Includes only
+	// the members this base class contributes directly (NOT members it would
+	// itself inherit — composition is the registry's job via the base's own
+	// declared bases, kept flat here for the framework-mixin case).
+	Members map[string]Member
+}
+
+// Leaf returns the bare class name (last dotted segment of the first FQN).
+// Empty when the contract has no FQNs.
+func (c BaseClassContract) Leaf() string {
+	if len(c.FQNs) == 0 {
+		return ""
+	}
+	return leaf(c.FQNs[0])
+}
+
+// MemberNames returns the inherited member names this base contributes, in
+// stable sorted order. Useful for the name-set use (the old
+// cbvBaseInheritedMethods consumer).
+func (c BaseClassContract) MemberNames() []string {
+	names := make([]string, 0, len(c.Members))
+	for n := range c.Members {
+		names = append(names, n)
+	}
+	sortStrings(names)
+	return names
+}

--- a/internal/frameworks/baseknowledge/drf.go
+++ b/internal/frameworks/baseknowledge/drf.go
@@ -1,0 +1,201 @@
+package baseknowledge
+
+// drf.go — Django REST Framework + Django generic class-based view
+// knowledge pack.
+//
+// This is the reference pack for the catalog. It ports the name-only
+// `python.cbvBaseInheritedMethods` map into the typed model and ADDS the
+// per-verb default contract facts (default status, error statuses,
+// behaviour, pagination / permission applicability, defining mixin) that
+// MRO resolution (#3833) and effective-contract synthesis (#3835) need.
+//
+// Sources: DRF docs (generic viewsets, generic API views, mixins) and the
+// DRF source. Default statuses are the framework defaults:
+//   - create          -> 201 (mixins.CreateModelMixin.create)
+//   - update           -> 200 (mixins.UpdateModelMixin.update)
+//   - partial_update   -> 200 (mixins.UpdateModelMixin.partial_update)
+//   - destroy          -> 204 (mixins.DestroyModelMixin.destroy)
+//   - list             -> 200 (mixins.ListModelMixin.list, paginated)
+//   - retrieve         -> 200 (mixins.RetrieveModelMixin.retrieve)
+//
+// The #278 fact: CreateModelMixin.create and UpdateModelMixin.update both
+// call `serializer.is_valid(raise_exception=True)`, so an invalid payload
+// yields HTTP 400. We record that as ErrorStatuses=[400] + Behaviour text
+// so downstream contract synthesis surfaces the implicit 400 the user's
+// code never declares.
+
+// DRF FQN roots for the catalogued classes.
+const (
+	drfMixinsRoot   = "rest_framework.mixins."
+	drfViewSetsRoot = "rest_framework.viewsets."
+	drfGenericsRoot = "rest_framework.generics."
+	drfViewsRoot    = "rest_framework.views."
+	djangoCBVRoot   = "django.views.generic."
+)
+
+// drfVerb builds a route-handler Member with the standard DRF
+// per-verb defaults (permission always applies; pagination only when
+// asked). definingFQN is the mixin/base that owns the body.
+func drfVerb(name, verb string, status int, definingFQN string, paginated bool, errs []int, behaviour string) Member {
+	return Member{
+		Name:                 name,
+		DefiningClass:        definingFQN,
+		HTTPVerb:             verb,
+		DefaultStatus:        status,
+		ErrorStatuses:        errs,
+		Behaviour:            behaviour,
+		PaginationApplicable: paginated,
+		PermissionApplicable: true,
+	}
+}
+
+// The five canonical CRUD verb contracts, each attributed to its defining
+// mixin. These are the building blocks composed into the viewset bases.
+var (
+	drfCreate = drfVerb(
+		"create", "POST", 201, drfMixinsRoot+"CreateModelMixin", false,
+		[]int{400},
+		"serializer.is_valid(raise_exception=True) -> 400 on invalid payload; returns 201 with the created representation (#278)",
+	)
+	drfRetrieve = drfVerb(
+		"retrieve", "GET", 200, drfMixinsRoot+"RetrieveModelMixin", false,
+		nil,
+		"returns the serialized instance; 404 when the lookup misses",
+	)
+	drfUpdate = drfVerb(
+		"update", "PUT", 200, drfMixinsRoot+"UpdateModelMixin", false,
+		[]int{400},
+		"serializer.is_valid(raise_exception=True) -> 400 on invalid payload; returns 200 with the updated representation (#278)",
+	)
+	drfPartialUpdate = drfVerb(
+		"partial_update", "PATCH", 200, drfMixinsRoot+"UpdateModelMixin", false,
+		[]int{400},
+		"calls update(partial=True); is_valid(raise_exception=True) -> 400 on invalid payload; returns 200 (#278)",
+	)
+	drfDestroy = drfVerb(
+		"destroy", "DELETE", 204, drfMixinsRoot+"DestroyModelMixin", false,
+		nil,
+		"deletes the instance and returns 204 No Content with an empty body",
+	)
+	drfList = drfVerb(
+		"list", "GET", 200, drfMixinsRoot+"ListModelMixin", true,
+		nil,
+		"returns the (optionally paginated) serialized queryset; pagination applies when DEFAULT_PAGINATION_CLASS is set",
+	)
+)
+
+// members builds a name->Member map from the given verb contracts.
+func members(ms ...Member) map[string]Member {
+	out := make(map[string]Member, len(ms))
+	for _, m := range ms {
+		out[m.Name] = m
+	}
+	return out
+}
+
+// drfPack is the DRF + Django-CBV knowledge pack.
+type drfPack struct{}
+
+func (drfPack) Framework() string { return "drf" }
+
+func (drfPack) Contracts() []BaseClassContract {
+	py := func(fwk string, fqns []string, m map[string]Member) BaseClassContract {
+		return BaseClassContract{FQNs: fqns, Language: "python", Framework: fwk, Members: m}
+	}
+
+	return []BaseClassContract{
+		// --- DRF mixins (rest_framework.mixins.*) ------------------------
+		py("drf", []string{drfMixinsRoot + "CreateModelMixin", "CreateModelMixin"}, members(drfCreate)),
+		py("drf", []string{drfMixinsRoot + "RetrieveModelMixin", "RetrieveModelMixin"}, members(drfRetrieve)),
+		py("drf", []string{drfMixinsRoot + "UpdateModelMixin", "UpdateModelMixin"}, members(drfUpdate, drfPartialUpdate)),
+		py("drf", []string{drfMixinsRoot + "DestroyModelMixin", "DestroyModelMixin"}, members(drfDestroy)),
+		py("drf", []string{drfMixinsRoot + "ListModelMixin", "ListModelMixin"}, members(drfList)),
+
+		// --- DRF viewsets (rest_framework.viewsets.*) --------------------
+		// ViewSet / GenericViewSet contribute no CRUD verbs on their own
+		// (action-only / mixin host) — recorded with empty member sets so
+		// they are still "known" bases (KnownBases / cbv_bases parity).
+		py("drf", []string{drfViewSetsRoot + "ViewSet", "ViewSet"}, members()),
+		py("drf", []string{drfViewSetsRoot + "GenericViewSet", "GenericViewSet"}, members()),
+		py("drf", []string{drfViewSetsRoot + "ReadOnlyModelViewSet", "ReadOnlyModelViewSet"},
+			members(drfList, drfRetrieve)),
+		py("drf", []string{drfViewSetsRoot + "ModelViewSet", "ModelViewSet"},
+			members(drfList, drfRetrieve, drfCreate, drfUpdate, drfPartialUpdate, drfDestroy)),
+
+		// --- DRF generic API views (rest_framework.generics.*) -----------
+		py("drf", []string{drfGenericsRoot + "GenericAPIView", "GenericAPIView"}, members()),
+		py("drf", []string{drfGenericsRoot + "CreateAPIView", "CreateAPIView"}, httpMembers("post")),
+		py("drf", []string{drfGenericsRoot + "ListAPIView", "ListAPIView"}, httpMembers("get")),
+		py("drf", []string{drfGenericsRoot + "RetrieveAPIView", "RetrieveAPIView"}, httpMembers("get")),
+		py("drf", []string{drfGenericsRoot + "DestroyAPIView", "DestroyAPIView"}, httpMembers("delete")),
+		py("drf", []string{drfGenericsRoot + "UpdateAPIView", "UpdateAPIView"}, httpMembers("put", "patch")),
+		py("drf", []string{drfGenericsRoot + "ListCreateAPIView", "ListCreateAPIView"}, httpMembers("get", "post")),
+		py("drf", []string{drfGenericsRoot + "RetrieveUpdateAPIView", "RetrieveUpdateAPIView"}, httpMembers("get", "put", "patch")),
+		py("drf", []string{drfGenericsRoot + "RetrieveDestroyAPIView", "RetrieveDestroyAPIView"}, httpMembers("get", "delete")),
+		py("drf", []string{drfGenericsRoot + "RetrieveUpdateDestroyAPIView", "RetrieveUpdateDestroyAPIView"}, httpMembers("get", "put", "patch", "delete")),
+
+		// --- Django generic class-based views (django.views.generic.*) ---
+		// HTTP-verb method handlers. These are name/verb only — Django sets
+		// no single framework-default success status (the view renders a
+		// template or redirects), so DefaultStatus stays StatusUnknown.
+		py("django", []string{djangoCBVRoot + "View", "View"}, httpMembers("get", "post", "put", "patch", "delete", "head", "options", "trace")),
+		py("django", []string{djangoCBVRoot + "TemplateView", "TemplateView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "RedirectView", "RedirectView"}, httpMembers("get", "post", "put", "patch", "delete", "head", "options")),
+		py("django", []string{djangoCBVRoot + "ListView", "ListView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "DetailView", "DetailView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "FormView", "FormView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "CreateView", "CreateView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "UpdateView", "UpdateView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "DeleteView", "DeleteView"}, httpMembers("get", "post", "delete")),
+		py("django", []string{djangoCBVRoot + "ArchiveIndexView", "ArchiveIndexView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "YearArchiveView", "YearArchiveView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "MonthArchiveView", "MonthArchiveView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "DayArchiveView", "DayArchiveView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "WeekArchiveView", "WeekArchiveView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "TodayArchiveView", "TodayArchiveView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "DateDetailView", "DateDetailView"}, httpMembers("get")),
+		py("django", []string{djangoCBVRoot + "ProcessFormView", "ProcessFormView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "BaseCreateView", "BaseCreateView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "BaseUpdateView", "BaseUpdateView"}, httpMembers("get", "post")),
+		py("django", []string{djangoCBVRoot + "BaseDeleteView", "BaseDeleteView"}, httpMembers("get", "post", "delete")),
+	}
+}
+
+// httpMembers builds a member map for bare HTTP-verb handler methods
+// ("get", "post", ...) with no curated default status — used for the
+// Django generic CBVs and DRF generic API views whose verbs map 1:1 to a
+// lower-case method name and whose success status is not a single
+// framework constant.
+func httpMembers(verbs ...string) map[string]Member {
+	out := make(map[string]Member, len(verbs))
+	for _, v := range verbs {
+		out[v] = Member{
+			Name:                 v,
+			HTTPVerb:             httpVerbUpper(v),
+			DefaultStatus:        StatusUnknown,
+			PermissionApplicable: true,
+		}
+	}
+	return out
+}
+
+func httpVerbUpper(v string) string {
+	switch v {
+	case "get", "post", "put", "patch", "delete", "head", "options", "trace":
+		return upper(v)
+	default:
+		return upper(v)
+	}
+}
+
+func upper(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+func init() { Register(drfPack{}) }

--- a/internal/frameworks/baseknowledge/drf_test.go
+++ b/internal/frameworks/baseknowledge/drf_test.go
@@ -1,0 +1,219 @@
+package baseknowledge
+
+import (
+	"reflect"
+	"testing"
+)
+
+// reg returns a registry containing only the DRF pack so tests are
+// independent of process-global registration order.
+func reg() *Registry { return NewRegistry(drfPack{}) }
+
+// TestModelViewSetInheritsFiveCRUDVerbsWithStatuses asserts the headline
+// contract: a ModelViewSet exposes the 6 CRUD verbs, each attributed to
+// the right defining mixin with the right default status. (ModelViewSet =
+// list + retrieve + create + update + partial_update + destroy.)
+func TestModelViewSetInheritsCRUDVerbsWithStatuses(t *testing.T) {
+	r := reg()
+
+	want := []struct {
+		verb     string
+		method   string // HTTP method
+		status   int
+		defining string
+	}{
+		{"create", "POST", 201, "rest_framework.mixins.CreateModelMixin"},
+		{"retrieve", "GET", 200, "rest_framework.mixins.RetrieveModelMixin"},
+		{"update", "PUT", 200, "rest_framework.mixins.UpdateModelMixin"},
+		{"partial_update", "PATCH", 200, "rest_framework.mixins.UpdateModelMixin"},
+		{"destroy", "DELETE", 204, "rest_framework.mixins.DestroyModelMixin"},
+		{"list", "GET", 200, "rest_framework.mixins.ListModelMixin"},
+	}
+
+	for _, w := range want {
+		m, ok := r.Member("ModelViewSet", w.verb)
+		if !ok {
+			t.Fatalf("ModelViewSet missing inherited verb %q", w.verb)
+		}
+		if m.HTTPVerb != w.method {
+			t.Errorf("verb %q: HTTPVerb = %q, want %q", w.verb, m.HTTPVerb, w.method)
+		}
+		if m.DefaultStatus != w.status {
+			t.Errorf("verb %q: DefaultStatus = %d, want %d", w.verb, m.DefaultStatus, w.status)
+		}
+		if m.DefiningClass != w.defining {
+			t.Errorf("verb %q: DefiningClass = %q, want %q", w.verb, m.DefiningClass, w.defining)
+		}
+		if !m.PermissionApplicable {
+			t.Errorf("verb %q: expected PermissionApplicable true (DRF applies perms to every handler)", w.verb)
+		}
+	}
+
+	// Exactly the 6 CRUD verbs, nothing extra.
+	got := r.MembersOf("ModelViewSet")
+	if len(got) != 6 {
+		t.Errorf("ModelViewSet member count = %d, want 6 (got %v)", len(got), keys(got))
+	}
+}
+
+// TestUpdateIsValid400Fact asserts the #278 fact: update / partial_update /
+// create carry the implicit 400-on-invalid contract via
+// is_valid(raise_exception=True).
+func TestUpdateIsValid400Fact(t *testing.T) {
+	r := reg()
+	for _, verb := range []string{"create", "update", "partial_update"} {
+		m, ok := r.Member("ModelViewSet", verb)
+		if !ok {
+			t.Fatalf("missing %q", verb)
+		}
+		if !contains(m.ErrorStatuses, 400) {
+			t.Errorf("verb %q: ErrorStatuses %v missing 400 (the #278 is_valid fact)", verb, m.ErrorStatuses)
+		}
+		if m.Behaviour == "" {
+			t.Errorf("verb %q: expected a behaviour note describing is_valid(raise_exception=True)", verb)
+		}
+	}
+	// retrieve / destroy must NOT claim a 400 — they don't validate input.
+	for _, verb := range []string{"retrieve", "destroy"} {
+		m, _ := r.Member("ModelViewSet", verb)
+		if contains(m.ErrorStatuses, 400) {
+			t.Errorf("verb %q should not carry a 400 contract", verb)
+		}
+	}
+}
+
+// TestListPaginationApplicable asserts only `list` advertises pagination.
+func TestListPaginationApplicable(t *testing.T) {
+	r := reg()
+	if m, _ := r.Member("ModelViewSet", "list"); !m.PaginationApplicable {
+		t.Error("list should advertise PaginationApplicable")
+	}
+	for _, verb := range []string{"retrieve", "create", "update", "partial_update", "destroy"} {
+		if m, _ := r.Member("ModelViewSet", verb); m.PaginationApplicable {
+			t.Errorf("verb %q should not advertise pagination", verb)
+		}
+	}
+}
+
+// TestReadOnlyModelViewSetIsListRetrieveOnly guards the substring trap.
+func TestReadOnlyModelViewSetIsListRetrieveOnly(t *testing.T) {
+	r := reg()
+	got := r.MembersOf("ReadOnlyModelViewSet")
+	want := map[string]bool{"list": true, "retrieve": true}
+	if len(got) != len(want) {
+		t.Fatalf("ReadOnlyModelViewSet members = %v, want list+retrieve", keys(got))
+	}
+	for n := range want {
+		if _, ok := got[n]; !ok {
+			t.Errorf("ReadOnlyModelViewSet missing %q", n)
+		}
+	}
+}
+
+// TestMixinsDefineTheirOwnVerbs asserts each mixin contributes exactly its
+// verb(s) with the right status, independent of any viewset.
+func TestMixinsDefineTheirOwnVerbs(t *testing.T) {
+	r := reg()
+	cases := map[string]map[string]int{
+		"CreateModelMixin":   {"create": 201},
+		"RetrieveModelMixin": {"retrieve": 200},
+		"UpdateModelMixin":   {"update": 200, "partial_update": 200},
+		"DestroyModelMixin":  {"destroy": 204},
+		"ListModelMixin":     {"list": 200},
+	}
+	for mixin, verbs := range cases {
+		ms := r.MembersOf(mixin)
+		if len(ms) != len(verbs) {
+			t.Errorf("%s members = %v, want %v", mixin, keys(ms), verbs)
+		}
+		for v, status := range verbs {
+			m, ok := ms[v]
+			if !ok {
+				t.Errorf("%s missing verb %q", mixin, v)
+				continue
+			}
+			if m.DefaultStatus != status {
+				t.Errorf("%s.%s status = %d, want %d", mixin, v, m.DefaultStatus, status)
+			}
+		}
+	}
+}
+
+// TestFQNAndLeafLookup asserts lookup works by both dotted FQN and leaf.
+func TestFQNAndLeafLookup(t *testing.T) {
+	r := reg()
+	if _, ok := r.Lookup("rest_framework.viewsets.ModelViewSet"); !ok {
+		t.Error("FQN lookup of ModelViewSet failed")
+	}
+	if _, ok := r.Lookup("ModelViewSet"); !ok {
+		t.Error("leaf lookup of ModelViewSet failed")
+	}
+	if _, ok := r.Lookup("rest_framework.mixins.CreateModelMixin"); !ok {
+		t.Error("FQN lookup of CreateModelMixin failed")
+	}
+	if _, ok := r.Lookup("totally.unknown.Base"); ok {
+		t.Error("unknown base should not resolve")
+	}
+}
+
+// TestMemberNamesUnion reproduces the old cbvBaseInheritedMethods union
+// semantics: combining mixins yields the union of their verbs, sorted.
+func TestMemberNamesUnion(t *testing.T) {
+	r := reg()
+	got := r.MemberNames("ListModelMixin", "CreateModelMixin", "RetrieveModelMixin", "UpdateModelMixin", "DestroyModelMixin")
+	want := []string{"create", "destroy", "list", "partial_update", "retrieve", "update"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MemberNames union = %v, want %v", got, want)
+	}
+}
+
+// TestGenericViewSetHasNoVerbs asserts the action-only hosts are known but
+// empty (so they participate in cbv_bases without adding CRUD verbs).
+func TestGenericViewSetHasNoVerbs(t *testing.T) {
+	r := reg()
+	for _, base := range []string{"ViewSet", "GenericViewSet", "GenericAPIView"} {
+		c, ok := r.Lookup(base)
+		if !ok {
+			t.Fatalf("%s should be a known base", base)
+		}
+		if len(c.Members) != 0 {
+			t.Errorf("%s should contribute no verbs, got %v", base, keys(c.Members))
+		}
+	}
+}
+
+// TestDjangoCBVVerbsHaveNoFabricatedStatus asserts the never-fabricate
+// rule: Django generic CBV handlers carry the verb but StatusUnknown.
+func TestDjangoCBVVerbsHaveNoFabricatedStatus(t *testing.T) {
+	r := reg()
+	m, ok := r.Member("ListView", "get")
+	if !ok {
+		t.Fatal("ListView.get missing")
+	}
+	if m.DefaultStatus != StatusUnknown {
+		t.Errorf("ListView.get DefaultStatus = %d, want StatusUnknown (no fabricated status)", m.DefaultStatus)
+	}
+	if m.HTTPVerb != "GET" {
+		t.Errorf("ListView.get HTTPVerb = %q, want GET", m.HTTPVerb)
+	}
+}
+
+// --- test helpers -------------------------------------------------------
+
+func keys(m map[string]Member) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sortStrings(out)
+	return out
+}
+
+func contains(xs []int, v int) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/frameworks/baseknowledge/pack.go
+++ b/internal/frameworks/baseknowledge/pack.go
@@ -1,0 +1,179 @@
+package baseknowledge
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Pack is the extension interface every framework knowledge pack
+// implements. A pack is a curated, read-only bundle of BaseClassContracts
+// for one framework (DRF, Spring Data, NestJS Crud, ActiveRecord,
+// Eloquent, ...). New framework packs (ticket T9 #3841) slot in by
+// implementing this interface and registering through Register — no change
+// to the registry or to downstream consumers is required.
+type Pack interface {
+	// Framework is the pack's framework key ("drf", "spring-data", ...).
+	// Must be stable and unique across registered packs.
+	Framework() string
+
+	// Contracts returns every base-class / mixin contract the pack knows.
+	// The slice must be stable across calls (packs are curated data).
+	Contracts() []BaseClassContract
+}
+
+// Registry is an indexed, query-friendly view over one or more Packs. It
+// builds FQN and leaf-name indexes so lookups by either the dotted import
+// path or the bare class name resolve in O(1). A Registry is immutable
+// once built; build it once (e.g. via Default) and share it.
+type Registry struct {
+	packs []Pack
+
+	byFQN  map[string]BaseClassContract // exact FQN -> contract
+	byLeaf map[string]BaseClassContract // bare leaf name -> contract (last wins on collision; see note)
+}
+
+// NewRegistry builds a Registry from the given packs. Later packs override
+// earlier packs on FQN collision (so a more specific framework pack can
+// shadow a generic one). Leaf-index collisions keep the first registration
+// to stay deterministic and to avoid a generic framework silently winning
+// a bare-name lookup.
+func NewRegistry(packs ...Pack) *Registry {
+	r := &Registry{
+		packs:  append([]Pack(nil), packs...),
+		byFQN:  map[string]BaseClassContract{},
+		byLeaf: map[string]BaseClassContract{},
+	}
+	for _, p := range r.packs {
+		for _, c := range p.Contracts() {
+			for _, fqn := range c.FQNs {
+				r.byFQN[fqn] = c
+				lf := leaf(fqn)
+				if _, exists := r.byLeaf[lf]; !exists {
+					r.byLeaf[lf] = c
+				}
+			}
+		}
+	}
+	return r
+}
+
+// Lookup resolves a base class to its contract. It matches on the exact
+// dotted FQN first, then falls back to the bare leaf name (so
+// `class X(ModelViewSet)` resolves even without the import path). The
+// boolean reports whether a contract was found.
+func (r *Registry) Lookup(name string) (BaseClassContract, bool) {
+	if name == "" {
+		return BaseClassContract{}, false
+	}
+	if c, ok := r.byFQN[name]; ok {
+		return c, true
+	}
+	if c, ok := r.byLeaf[leaf(name)]; ok {
+		return c, true
+	}
+	return BaseClassContract{}, false
+}
+
+// MembersOf returns the inherited members a base class contributes, keyed
+// by member name. Returns nil when the base class is unknown.
+func (r *Registry) MembersOf(baseName string) map[string]Member {
+	c, ok := r.Lookup(baseName)
+	if !ok {
+		return nil
+	}
+	return c.Members
+}
+
+// Member resolves a single (base-class, member-name) pair to its contract.
+// This is the lookup-by-(framework,base-class,verb) entry point the
+// effective-contract synthesizer (#3835) uses to fetch the default status
+// and behaviour for one inherited verb. The boolean reports a match.
+func (r *Registry) Member(baseName, memberName string) (Member, bool) {
+	c, ok := r.Lookup(baseName)
+	if !ok {
+		return Member{}, false
+	}
+	m, ok := c.Members[memberName]
+	return m, ok
+}
+
+// MemberNames returns the union of inherited member names contributed by
+// the given base classes, deduplicated and sorted. Unknown bases
+// contribute nothing. This reproduces the old cbvBaseInheritedMethods
+// union semantics from a single source of truth.
+func (r *Registry) MemberNames(baseNames ...string) []string {
+	seen := map[string]struct{}{}
+	for _, b := range baseNames {
+		for name := range r.MembersOf(b) {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// KnownBases returns, from the given candidate base names, those the
+// registry recognises, preserving input order and de-duplicating. Mirrors
+// the old `cbv_bases` annotation: the recognised subset of a class's bases.
+func (r *Registry) KnownBases(candidates ...string) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	for _, c := range candidates {
+		if _, ok := r.Lookup(c); !ok {
+			continue
+		}
+		key := leaf(c)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+// Packs returns the packs the registry was built from, in registration
+// order.
+func (r *Registry) Packs() []Pack { return append([]Pack(nil), r.packs...) }
+
+// --- default registry ---------------------------------------------------
+
+var (
+	defaultOnce     sync.Once
+	defaultRegistry *Registry
+	registeredPacks []Pack
+)
+
+// Register adds a pack to the set the Default registry is built from. Call
+// it from a pack's init() (see drf.go). Registration is process-global and
+// must happen before the first Default() call; once Default is built,
+// further Register calls have no effect on it.
+func Register(p Pack) {
+	registeredPacks = append(registeredPacks, p)
+}
+
+// Default returns the process-wide Registry built from every pack
+// registered via Register (DRF and any future framework packs). It is
+// built lazily and once.
+func Default() *Registry {
+	defaultOnce.Do(func() {
+		defaultRegistry = NewRegistry(registeredPacks...)
+	})
+	return defaultRegistry
+}
+
+// --- helpers ------------------------------------------------------------
+
+func leaf(name string) string {
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+func sortStrings(s []string) { sort.Strings(s) }


### PR DESCRIPTION
Closes #3832. PR A0 of epic #3829 (Universal MRO / inheritance resolution + framework effective-contract). This is the critical-path PR that unblocks T3 (MRO-aware get_source/inspect, #3833) and T5 (effective contract, #3835).

## The package: `internal/frameworks/baseknowledge`

A shared, typed catalog of framework base-class / mixin contracts — replacing the ad-hoc, name-only, per-language maps scattered across extractors with one source of truth that downstream MRO + contract synthesis can consume to materialize external mixin bodies the user's code never declares.

- **`BaseClassContract`** — one per known base class: `FQNs` (match keys), `Language`, `Framework`, and `Members` (name → contract).
- **`Member`** — `DefiningClass` (the mixin FQN that owns the body — load-bearing for MRO resolution), `HTTPVerb`, `DefaultStatus`, `ErrorStatuses`, `Behaviour`, `PaginationApplicable`, `PermissionApplicable`, `DocURL`. `StatusUnknown` (0) is the never-fabricate sentinel.
- **`Pack`** — the extension interface. A framework pack returns `Contracts()`; future packs (Spring Data, NestJS Crud, ActiveRecord, Eloquent — T9 #3841) slot in by implementing it and calling `Register`. No registry or consumer change needed.
- **`Registry`** — indexes contracts by exact FQN and by bare leaf name; `Lookup` / `MembersOf` / `Member(base,verb)` / `MemberNames(...)` / `KnownBases(...)`. `Default()` is the lazy process-wide registry.

## DRF pack (`drf.go`) — the reference pack

Ports the existing `python.cbvBaseInheritedMethods` knowledge into the typed model and adds the per-verb contract facts:

| Base | Verbs (defining mixin → default status) |
|---|---|
| `ModelViewSet` | create→`CreateModelMixin`/201, retrieve→`RetrieveModelMixin`/200, update→`UpdateModelMixin`/200, partial_update→`UpdateModelMixin`/200, destroy→`DestroyModelMixin`/204, list→`ListModelMixin`/200 |
| `ReadOnlyModelViewSet` | list/200, retrieve/200 |
| `ViewSet` / `GenericViewSet` / `GenericAPIView` | known, contribute no CRUD verbs (action/mixin hosts) |
| 5 mixins | each contributes exactly its verb(s) with the status above |
| DRF generic API views + Django generic CBVs | verb-only, `StatusUnknown` (no fabricated status) |

**The #278 fact** is encoded: `create` / `update` / `partial_update` carry `ErrorStatuses=[400]` + a behaviour note ("`is_valid(raise_exception=True)` → 400 on invalid payload"), since the mixin bodies validate input. `retrieve` / `destroy` do not. `list` is the only verb with `PaginationApplicable=true`. Every DRF handler has `PermissionApplicable=true`.

## Consume-not-duplicate refactor (behavior preserved)

- `python/cbv_inherited_methods.go`: deletes the private `cbvBaseInheritedMethods` map; reads inherited member names + known bases from the catalog. Option A (#2011) name-only annotation unchanged.
- `engine/django_drf_actions.go`: `classifyViewSetParent` and `modelViewSetMethods` source their CRUD verb sets from the DRF pack, while keeping the exact `containsIdent` whole-identifier matching, the ReadOnlyModelViewSet/ModelViewSet substring-trap guard, and the unknown-base → full-ModelViewSet fallback.

Existing engine + python extractor tests pass **unchanged** — DRF route-synthesis behavior is identical.

## Quality
Value-asserting tests assert specific facts (verb → defining mixin + status, the 400 fact, list-only pagination, GenericViewSet-empty, FQN/leaf lookup, union semantics) — not `len>0`. `go test ./internal/frameworks/... ./internal/engine/ ./internal/extractors/python/ ./internal/types/` green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors + `fmt --check` canonical; no gen drift.

## DEPLOY-DEFERRED
Pure indexer-side data + a behavior-preserving refactor. No daemon rebuild, MCP change, or reindex required to land. Downstream PRs (#3833, #3835) consume this catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)