### PR TITLE
feat(mcp): MRO-aware get_source / inspect for inherited members (#3833)

### DIFF
--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -1,0 +1,520 @@
+package mcp
+
+// mro.go — MRO-aware member resolution for archigraph_get_source /
+// archigraph_inspect (epic #3829, ticket #3833 — PR A3).
+//
+// Problem (the rewrite agent's G2): when a class inherits a member it never
+// declares — a DRF `RoleViewSet(ModelViewSet)` inherits `retrieve` from
+// `rest_framework.mixins.RetrieveModelMixin`, a Go struct promotes an
+// embedded type's method — `get_source` and `inspect` previously resolved the
+// entity to the SUBCLASS file (or a bodyless synthetic with only a signature)
+// and stopped there. The caller never saw the DEFINING base body, the default
+// status, or even an indication that the member was inherited.
+//
+// resolveMember closes that gap. Given an entity that is an inherited member
+// (a bodyless DRF synthetic `SCOPE.Operation`, or a method whose owning class
+// declares it only via an inherited_methods annotation), it walks the owning
+// class's EXTENDS edges to find the DEFINING class:
+//
+//   (a) an INDEXED base class in the same repo that declares the member with a
+//       real body  -> resolve to that entity's body span (provenance
+//       inheritedInRepo), OR
+//   (b) an EXTERNAL library base the baseknowledge pack knows (DRF mixins,
+//       ...) -> synthesize an "external body" stub from the pack contract
+//       (defining class FQN, default status, behaviour, doc URL), provenance
+//       inheritedExternal.
+//
+// HONEST-PARTIAL (quality-first): when the member cannot be tied to a defining
+// class — unknown base, not in the pack, no in-repo declaration — resolveMember
+// returns an UNRESOLVED result and the callers fall back to the current
+// behaviour. It NEVER fabricates a body or a status.
+//
+// This is a pure read-path resolver; it adds no graph entities or edges. The
+// indexer-side INHERITS/OVERRIDES edge is a separate ticket (PR A2 #3832-era);
+// this PR is the MCP projection (DEPLOY-DEFERRED: needs a daemon rebuild to
+// serve).
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/frameworks/baseknowledge"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// memberProvenance classifies how resolveMember tied a member to its body.
+type memberProvenance string
+
+const (
+	// provExplicit: the entity declares its own body (StartLine span). Not
+	// inherited — callers keep the existing behaviour.
+	provExplicit memberProvenance = "explicit"
+	// provInheritedInRepo: resolved to a base class declared in the indexed
+	// repo whose body get_source should return instead of the subclass.
+	provInheritedInRepo memberProvenance = "inherited"
+	// provInheritedExternal: resolved to an external library base via the
+	// baseknowledge pack; the body is a synthesized contract stub.
+	provInheritedExternal memberProvenance = "inherited_external"
+	// provUnresolved: the member is inherited but no defining class could be
+	// found. Honest-partial: callers fall back, never fabricate.
+	provUnresolved memberProvenance = "unresolved"
+)
+
+// memberResolution is the outcome of resolveMember.
+type memberResolution struct {
+	// Provenance is the classification above.
+	Provenance memberProvenance
+
+	// Member is the inherited member's bare name (e.g. "retrieve"). Empty when
+	// the entity was not recognised as a member at all.
+	Member string
+
+	// OwningClass is the subclass that inherits the member (e.g.
+	// "RoleViewSet"). Empty when not determinable.
+	OwningClass string
+
+	// DefiningClass is the FQN of the class that actually defines the member's
+	// body — an in-repo base name or the external pack FQN
+	// (e.g. "rest_framework.mixins.RetrieveModelMixin"). Empty when unresolved.
+	DefiningClass string
+
+	// DefiningEntity is the in-repo entity whose body defines the member, set
+	// only for provInheritedInRepo. get_source returns this entity's source.
+	DefiningEntity *graph.Entity
+
+	// Contract is the pack member contract, set only for provInheritedExternal.
+	Contract *baseknowledge.Member
+
+	// Note explains an unresolved outcome (which base was unknown, etc.).
+	Note string
+}
+
+// IsInherited reports whether the member resolved to a defining class
+// different from the entity itself (in-repo base or external pack).
+func (r memberResolution) IsInherited() bool {
+	return r.Provenance == provInheritedInRepo || r.Provenance == provInheritedExternal
+}
+
+// resolveMember performs the MRO walk for entity e in repo lr. It is the
+// single shared resolver consumed by handleGetNodeSource and handleGetNode.
+//
+// Resolution steps:
+//  1. Classify the entity as a member and find its (member name, owning class).
+//     - A DRF synthetic op (pattern_type=drf_viewset_implicit_method) carries
+//     drf_method_origin + viewset_class explicitly.
+//     - Any other entity: derive member = leaf of the dotted name, owning
+//     class = the prefix; an entity with a real body is provExplicit.
+//  2. Find the owning class entity in the repo.
+//  3. BFS the owning class's EXTENDS edges. For each base, in declared order:
+//     (a) in-repo base entity declaring the member with a body -> resolve;
+//     (b) else pack.Member(base, member) -> external stub.
+//  4. Nothing matched -> provUnresolved.
+func resolveMember(lr *LoadedRepo, e *graph.Entity) memberResolution {
+	if lr == nil || lr.Doc == nil || e == nil {
+		return memberResolution{Provenance: provUnresolved, Note: "no repo/entity"}
+	}
+
+	member, owningName, isBodyless := classifyMember(e)
+	if member == "" || owningName == "" {
+		// Not a recognisable inherited member — treat as explicit (caller keeps
+		// existing behaviour).
+		return memberResolution{Provenance: provExplicit}
+	}
+
+	// An entity that already has its own real body is explicit UNLESS it is a
+	// bodyless synthetic (those carry a signature but no span). A DRF synthetic
+	// op is bodyless by construction.
+	if !isBodyless && hasRealBody(e) {
+		return memberResolution{Provenance: provExplicit, Member: member, OwningClass: owningName}
+	}
+
+	owning := findClassEntity(lr, owningName)
+	if owning == nil {
+		// We know the member name but not the class declaration. Can't walk
+		// EXTENDS — but a DRF synthetic still records its origin verb, so try
+		// the pack against the recorded mixin set if we have one; otherwise
+		// unresolved.
+		return memberResolution{
+			Provenance:  provUnresolved,
+			Member:      member,
+			OwningClass: owningName,
+			Note:        "owning class entity not found in index",
+		}
+	}
+
+	reg := baseknowledge.Default()
+
+	// BFS over EXTENDS edges in declared order. The first defining match wins
+	// (left-to-right, good enough for the flat framework-mixin case; full C3 is
+	// a documented non-goal for v1 per the plan's risk notes).
+	visited := map[string]bool{owning.ID: true}
+	frontier := extendsBases(lr, owning)
+	var unknownBases []string
+
+	for len(frontier) > 0 {
+		var next []baseRef
+		for _, b := range frontier {
+			// (a) in-repo base that declares the member with a body.
+			if b.entity != nil {
+				if def := classDeclaredMember(lr, b.entity, member); def != nil {
+					return memberResolution{
+						Provenance:     provInheritedInRepo,
+						Member:         member,
+						OwningClass:    owningName,
+						DefiningClass:  b.name,
+						DefiningEntity: def,
+					}
+				}
+			}
+			// (b) external library base known to the pack.
+			if m, ok := reg.Member(b.name, member); ok {
+				contract := m
+				defining := contract.DefiningClass
+				if defining == "" {
+					// The pack matched the base but didn't attribute a deeper
+					// defining class (member is owned by the base itself).
+					defining = canonicalBaseFQN(reg, b.name)
+				}
+				return memberResolution{
+					Provenance:    provInheritedExternal,
+					Member:        member,
+					OwningClass:   owningName,
+					DefiningClass: defining,
+					Contract:      &contract,
+				}
+			}
+			// Record an unknown base for the honest-partial note, then keep
+			// walking THROUGH in-repo bases (their own EXTENDS edges).
+			if _, known := reg.Lookup(b.name); !known && b.entity == nil {
+				unknownBases = append(unknownBases, b.name)
+			}
+			if b.entity != nil && !visited[b.entity.ID] {
+				visited[b.entity.ID] = true
+				next = append(next, extendsBases(lr, b.entity)...)
+			}
+		}
+		frontier = next
+	}
+
+	note := "no defining class found via EXTENDS or knowledge pack"
+	if len(unknownBases) > 0 {
+		sort.Strings(unknownBases)
+		note = "unrecognised base(s): " + strings.Join(dedupe(unknownBases), ", ")
+	}
+	return memberResolution{
+		Provenance:  provUnresolved,
+		Member:      member,
+		OwningClass: owningName,
+		Note:        note,
+	}
+}
+
+// classifyMember extracts (memberName, owningClassName, isBodylessSynthetic)
+// from an entity. Returns empty member when the entity is not a class member.
+func classifyMember(e *graph.Entity) (member, owning string, bodyless bool) {
+	// DRF synthetic implicit method: the engine stamps the origin verb and the
+	// owning ViewSet explicitly. These are bodyless by construction.
+	if e.Properties["pattern_type"] == "drf_viewset_implicit_method" {
+		m := e.Properties["drf_method_origin"]
+		o := e.Properties["viewset_class"]
+		if m == "" {
+			// Fall back to the dotted name leaf.
+			m = leafAfterDot(e.Name)
+		}
+		if o == "" {
+			o = prefixBeforeDot(e.Name)
+		}
+		return m, o, true
+	}
+
+	// A general method entity: name is "Owner.member" (qualified) — split it.
+	name := e.QualifiedName
+	if name == "" {
+		name = e.Name
+	}
+	if !strings.Contains(name, ".") {
+		return "", "", false
+	}
+	return leafAfterDot(name), prefixBeforeDot(name), false
+}
+
+// hasRealBody reports whether the entity carries a usable source span.
+func hasRealBody(e *graph.Entity) bool {
+	return e.StartLine > 0 && e.EndLine >= e.StartLine
+}
+
+// baseRef is a resolved EXTENDS target: the written base name plus, when the
+// base is declared in the indexed repo, the in-repo entity.
+type baseRef struct {
+	name   string        // base class name as written / FQN if available
+	entity *graph.Entity // non-nil when the base is an indexed class
+}
+
+// extendsBases returns the EXTENDS bases of class entity c, in edge order. The
+// base name prefers the edge's base_name property (the dotted FQN, PR A1) and
+// falls back to the ToID leaf / target entity name.
+func extendsBases(lr *LoadedRepo, c *graph.Entity) []baseRef {
+	adj := lr.getAdjacency()
+	rels := lr.Doc.Relationships
+	var out []baseRef
+	for _, ed := range adj.Outgoing(c.ID) {
+		if ed.kind != "EXTENDS" {
+			continue
+		}
+		name := ""
+		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
+			name = rels[ed.relIdx].Properties["base_name"]
+		}
+		target := lr.LabelIndex.ByID[ed.target]
+		if name == "" {
+			if target != nil && target.QualifiedName != "" {
+				name = target.QualifiedName
+			} else if target != nil {
+				name = target.Name
+			} else {
+				name = leafAfterColon(ed.target)
+			}
+		}
+		out = append(out, baseRef{name: name, entity: target})
+	}
+	return out
+}
+
+// findClassEntity finds the class/component entity for the given (possibly
+// dotted) class name in the repo. Prefers an exact label/qname match for a
+// class-kind entity.
+func findClassEntity(lr *LoadedRepo, name string) *graph.Entity {
+	leaf := leafAfterDot(name)
+	var fallback *graph.Entity
+	for _, cand := range []string{name, leaf} {
+		for _, e := range lr.LabelIndex.LookupAll(cand) {
+			if isClassEntity(e) {
+				return e
+			}
+			if fallback == nil {
+				fallback = e
+			}
+		}
+	}
+	return fallback
+}
+
+// isClassEntity reports whether e is a class/struct/component declaration that
+// can host members.
+func isClassEntity(e *graph.Entity) bool {
+	if e.Kind == "SCOPE.Component" {
+		return true
+	}
+	switch e.Subtype {
+	case "class", "struct", "interface":
+		return true
+	}
+	return false
+}
+
+// classDeclaredMember finds an in-repo member entity (method) named `member`
+// owned by class `cls` that carries a real body. Returns nil when the class
+// does not declare the member with a body in the index.
+func classDeclaredMember(lr *LoadedRepo, cls *graph.Entity, member string) *graph.Entity {
+	clsLeaf := leafAfterDot(cls.Name)
+	// Candidate qualified names a member method would carry, matched against
+	// the index's by-qualified-name map (members are keyed "Owner.member").
+	candidates := []string{clsLeaf + "." + member}
+	if cls.QualifiedName != "" && cls.QualifiedName != clsLeaf {
+		candidates = append(candidates, cls.QualifiedName+"."+member)
+	}
+	for _, qn := range candidates {
+		if e := lr.LabelIndex.ByQName[strings.ToLower(qn)]; e != nil &&
+			isMemberEntity(e) && hasRealBody(e) && e.SourceFile == cls.SourceFile {
+			return e
+		}
+	}
+	// Fall back to a same-file scan: a member whose leaf matches and whose
+	// owning prefix is the class (handles QName-shape variation).
+	for i := range lr.Doc.Entities {
+		e := &lr.Doc.Entities[i]
+		if e.SourceFile != cls.SourceFile || !isMemberEntity(e) || !hasRealBody(e) {
+			continue
+		}
+		qn := e.QualifiedName
+		if qn == "" {
+			qn = e.Name
+		}
+		if leafAfterDot(qn) == member && prefixBeforeDot(qn) == clsLeaf {
+			return e
+		}
+	}
+	return nil
+}
+
+// isMemberEntity reports whether e is a method/operation that can be a member
+// body.
+func isMemberEntity(e *graph.Entity) bool {
+	if e.Kind == "SCOPE.Operation" {
+		return true
+	}
+	switch e.Subtype {
+	case "method", "function":
+		return true
+	}
+	return false
+}
+
+// canonicalBaseFQN returns the pack's most-qualified FQN for a base name, so a
+// bare `RetrieveModelMixin` lookup reports the dotted defining class.
+func canonicalBaseFQN(reg *baseknowledge.Registry, name string) string {
+	if c, ok := reg.Lookup(name); ok && len(c.FQNs) > 0 {
+		return c.FQNs[0]
+	}
+	return name
+}
+
+// synthesizeExternalBody renders a get_source body view for an external,
+// pack-resolved member. It is explicitly marked as the DEFINING base contract,
+// NOT the subclass body, so the consumer is never misled into thinking it read
+// the subclass source.
+func synthesizeExternalBody(r memberResolution) string {
+	m := r.Contract
+	var b strings.Builder
+	fmt.Fprintf(&b, "# archigraph: synthesized inherited-member contract (NOT subclass source)\n")
+	fmt.Fprintf(&b, "# %s.%s is INHERITED — defined by %s\n", r.OwningClass, r.Member, r.DefiningClass)
+	fmt.Fprintf(&b, "# resolved via EXTENDS -> baseknowledge pack (external library base)\n")
+	if m != nil {
+		if m.HTTPVerb != "" {
+			fmt.Fprintf(&b, "# http_verb: %s\n", m.HTTPVerb)
+		}
+		if m.DefaultStatus != baseknowledge.StatusUnknown {
+			fmt.Fprintf(&b, "# default_status: %d\n", m.DefaultStatus)
+		}
+		if len(m.ErrorStatuses) > 0 {
+			parts := make([]string, len(m.ErrorStatuses))
+			for i, s := range m.ErrorStatuses {
+				parts[i] = fmt.Sprintf("%d", s)
+			}
+			fmt.Fprintf(&b, "# error_statuses: %s\n", strings.Join(parts, ", "))
+		}
+		if m.Behaviour != "" {
+			fmt.Fprintf(&b, "# behaviour: %s\n", m.Behaviour)
+		}
+		if m.DocURL != "" {
+			fmt.Fprintf(&b, "# doc: %s\n", m.DocURL)
+		}
+	}
+	fmt.Fprintf(&b, "#\n")
+	fmt.Fprintf(&b, "# The defining body lives in the external library %s and is not\n", r.DefiningClass)
+	fmt.Fprintf(&b, "# part of the indexed source tree; the contract above is from the\n")
+	fmt.Fprintf(&b, "# curated baseknowledge pack.\n")
+	return b.String()
+}
+
+// inspectInheritance builds the archigraph_inspect "inheritance" section for an
+// entity, surfacing the MRO resolution so the consumer knows the member is
+// inherited and from where (#3833). Returns nil when the entity is not an
+// inherited member (explicit bodies and non-members get no section, keeping the
+// envelope lean — the existing omit-when-empty convention).
+//
+// For an UNRESOLVED inherited member it still emits a section marked
+// resolved=false with the note, so the consumer learns the member is inherited
+// even when we can't name the defining class (honest-partial, not silent).
+func inspectInheritance(lr *LoadedRepo, e *graph.Entity) map[string]any {
+	res := resolveMember(lr, e)
+	switch res.Provenance {
+	case provInheritedInRepo:
+		out := map[string]any{
+			"inherited":      true,
+			"resolved":       true,
+			"member":         res.Member,
+			"owning_class":   res.OwningClass,
+			"defining_class": res.DefiningClass,
+			"resolved_from":  "extends_in_repo",
+		}
+		if res.DefiningEntity != nil {
+			out["defining_file"] = res.DefiningEntity.SourceFile
+			out["defining_line"] = res.DefiningEntity.StartLine
+		}
+		return out
+	case provInheritedExternal:
+		out := map[string]any{
+			"inherited":      true,
+			"resolved":       true,
+			"member":         res.Member,
+			"owning_class":   res.OwningClass,
+			"defining_class": res.DefiningClass,
+			"resolved_from":  "baseknowledge_pack",
+			"external":       true,
+		}
+		if m := res.Contract; m != nil {
+			if m.HTTPVerb != "" {
+				out["http_verb"] = m.HTTPVerb
+			}
+			if m.DefaultStatus != baseknowledge.StatusUnknown {
+				out["default_status"] = m.DefaultStatus
+			}
+			if len(m.ErrorStatuses) > 0 {
+				out["error_statuses"] = m.ErrorStatuses
+			}
+			if m.Behaviour != "" {
+				out["behaviour"] = m.Behaviour
+			}
+			if m.DocURL != "" {
+				out["doc_url"] = m.DocURL
+			}
+		}
+		return out
+	case provUnresolved:
+		// Only surface a section when the entity actually looks like an
+		// inherited member (member name known) — a plain top-level entity that
+		// happens to have no body should not grow an inheritance block.
+		if res.Member == "" {
+			return nil
+		}
+		return map[string]any{
+			"inherited":    true,
+			"resolved":     false,
+			"member":       res.Member,
+			"owning_class": res.OwningClass,
+			"note":         res.Note,
+		}
+	default:
+		return nil
+	}
+}
+
+// --- small string helpers ----------------------------------------------------
+
+func leafAfterDot(s string) string {
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// leafAfterColon returns the trailing colon-separated segment of an EXTENDS
+// edge ToID (the structural-ref shape ends with the bare class name).
+func leafAfterColon(s string) string {
+	if i := strings.LastIndexByte(s, ':'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+func prefixBeforeDot(s string) string {
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		return s[:i]
+	}
+	return ""
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/mcp/mro_3833_test.go
+++ b/internal/mcp/mro_3833_test.go
@@ -1,0 +1,244 @@
+package mcp
+
+// mro_3833_test.go — value-asserting coverage for MRO-aware get_source /
+// inspect (#3833). These assert the DEFINING-class resolution, not len>0:
+//
+//  1. get_source on a DRF inherited `retrieve` synthetic resolves to the
+//     RetrieveModelMixin contract (defining_class + default_status 200) via the
+//     baseknowledge pack, NOT the subclass file.
+//  2. inspect on the same synthetic surfaces inheritance{defining_class,
+//     resolved, external} so the consumer knows it is inherited and from where.
+//  3. get_source on an in-repo inherited member (base class indexed in the
+//     repo) returns the BASE's real body via the EXTENDS walk.
+//  4. An unresolvable inherited member returns the honest-unresolved section
+//     (no fabricated body / status).
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// drfViewSetDoc builds a graph for `class RoleViewSet(ModelViewSet)` with an
+// EXTENDS edge to an external ModelViewSet and a bodyless DRF synthetic
+// `retrieve` operation (exactly what the engine emits).
+func drfViewSetDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "vs", Name: "RoleViewSet", QualifiedName: "RoleViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "views.py", StartLine: 10, EndLine: 20, Language: "python",
+			},
+			// Bodyless DRF synthetic for the inherited retrieve verb.
+			{
+				ID: "op_retrieve", Name: "RoleViewSet.retrieve", QualifiedName: "RoleViewSet.retrieve",
+				Kind: "SCOPE.Operation", Subtype: "method", Language: "python",
+				SourceFile: "views.py", StartLine: 0, EndLine: 0,
+				Signature: "def retrieve(self, request, *args, **kwargs)",
+				Properties: map[string]string{
+					"pattern_type":      "drf_viewset_implicit_method",
+					"viewset_class":     "RoleViewSet",
+					"inherited_from":    "rest_framework",
+					"drf_method_origin": "retrieve",
+				},
+			},
+			// External base stub (SCOPE.External "ext:" placeholder).
+			{
+				ID: "ext_modelviewset", Name: "ModelViewSet", Kind: "SCOPE.External",
+				SourceFile: "", Language: "python",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID: "e1", FromID: "vs", ToID: "ext_modelviewset", Kind: "EXTENDS",
+				Properties: map[string]string{
+					"language":  "python",
+					"base_name": "rest_framework.viewsets.ModelViewSet",
+				},
+			},
+		},
+	}
+}
+
+// TestGetSource_DRFInheritedRetrieve_ResolvesToMixinContract — #3833 case 1.
+func TestGetSource_DRFInheritedRetrieve_ResolvesToMixinContract(t *testing.T) {
+	srv := newTestServer(t, drfViewSetDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "op_retrieve"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	// MUST identify the defining mixin, not the subclass file.
+	if !strings.Contains(text, "RetrieveModelMixin") {
+		t.Errorf("expected defining class RetrieveModelMixin in output, got:\n%s", text)
+	}
+	// MUST carry the pack's default status 200 for retrieve.
+	if !strings.Contains(text, "default_status: 200") {
+		t.Errorf("expected default_status: 200 from pack, got:\n%s", text)
+	}
+	// MUST be explicit that the body is NOT the subclass source.
+	if !strings.Contains(text, "NOT subclass source") {
+		t.Errorf("expected explicit not-subclass marker, got:\n%s", text)
+	}
+	// MUST NOT pretend to be reading views.py (the subclass file).
+	if strings.Contains(text, "views.py") {
+		t.Errorf("output should not reference the subclass file views.py:\n%s", text)
+	}
+}
+
+// TestInspect_DRFInheritedRetrieve_SurfacesDefiningClass — #3833 case 2.
+func TestInspect_DRFInheritedRetrieve_SurfacesDefiningClass(t *testing.T) {
+	srv := newTestServer(t, drfViewSetDoc())
+	out := callInspect(t, srv, "op_retrieve")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section, got keys: %v", mapKeys(out))
+	}
+	if inh["inherited"] != true {
+		t.Errorf("expected inherited=true, got %v", inh["inherited"])
+	}
+	if inh["resolved"] != true {
+		t.Errorf("expected resolved=true, got %v", inh["resolved"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "RetrieveModelMixin") {
+		t.Errorf("expected defining_class RetrieveModelMixin, got %q", dc)
+	}
+	if inh["external"] != true {
+		t.Errorf("expected external=true, got %v", inh["external"])
+	}
+	// default_status round-trips as float64 through JSON.
+	if ds, _ := inh["default_status"].(float64); int(ds) != 200 {
+		t.Errorf("expected default_status 200, got %v", inh["default_status"])
+	}
+}
+
+// TestGetSource_InRepoInheritedMember_ReturnsBaseBody — #3833 case 3. The base
+// class is declared in the indexed repo; get_source on the inherited verb must
+// return the BASE's real body via the EXTENDS walk.
+func TestGetSource_InRepoInheritedMember_ReturnsBaseBody(t *testing.T) {
+	dir := t.TempDir()
+	baseSrc := "" +
+		"class BaseService:\n" +
+		"    def handle(self, request):\n" +
+		"        return self.process(request)  # BASE_BODY_MARKER\n"
+	if err := os.WriteFile(filepath.Join(dir, "base.py"), []byte(baseSrc), 0o644); err != nil {
+		t.Fatalf("write base.py: %v", err)
+	}
+	srv := newTestServer(t, inRepoBaseDoc())
+	// Repoint the test repo at our temp dir so readSourceWindow finds base.py.
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "child_handle"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	if !strings.Contains(text, "BASE_BODY_MARKER") {
+		t.Errorf("expected base body (BASE_BODY_MARKER) via EXTENDS walk, got:\n%s", text)
+	}
+	if !strings.Contains(text, "INHERITED") || !strings.Contains(text, "BaseService") {
+		t.Errorf("expected inherited-from-BaseService header, got:\n%s", text)
+	}
+}
+
+// inRepoBaseDoc: ChildService(BaseService) where BaseService.handle is a real
+// in-repo method body and ChildService.handle is a bodyless inherited member.
+func inRepoBaseDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "base", Name: "BaseService", QualifiedName: "BaseService",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "base.py",
+				StartLine: 1, EndLine: 3, Language: "python"},
+			{ID: "base_handle", Name: "BaseService.handle", QualifiedName: "BaseService.handle",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.py",
+				StartLine: 2, EndLine: 3, Language: "python"},
+			{ID: "child", Name: "ChildService", QualifiedName: "ChildService",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "child.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			// Bodyless inherited member on the child.
+			{ID: "child_handle", Name: "ChildService.handle", QualifiedName: "ChildService.handle",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "child.py",
+				StartLine: 0, EndLine: 0, Language: "python",
+				Signature: "def handle(self, request)"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "child", ToID: "base", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "BaseService"}},
+		},
+	}
+}
+
+// TestInspect_UnresolvableInheritedMember_HonestUnresolved — #3833 case 4. A
+// bodyless member whose base is neither indexed nor in the pack must surface as
+// resolved=false with a note, and get_source must NOT fabricate a body.
+func TestInspect_UnresolvableInheritedMember_HonestUnresolved(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "cls", Name: "MysteryView", QualifiedName: "MysteryView",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "m.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			{ID: "op", Name: "MysteryView.frobnicate", QualifiedName: "MysteryView.frobnicate",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "m.py",
+				StartLine: 0, EndLine: 0, Language: "python",
+				Signature: "def frobnicate(self)",
+				Properties: map[string]string{
+					"pattern_type":      "drf_viewset_implicit_method",
+					"viewset_class":     "MysteryView",
+					"drf_method_origin": "frobnicate",
+				}},
+			{ID: "ext", Name: "WeirdBase", Kind: "SCOPE.External", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "cls", ToID: "ext", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "some.unknown.WeirdBase"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "op")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for unresolved member, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != false {
+		t.Errorf("expected resolved=false, got %v", inh["resolved"])
+	}
+	if _, hasDC := inh["defining_class"]; hasDC {
+		t.Errorf("unresolved member must NOT carry a defining_class, got %v", inh["defining_class"])
+	}
+	if note, _ := inh["note"].(string); note == "" {
+		t.Errorf("expected an honest-unresolved note, got empty")
+	}
+
+	// get_source must not fabricate an external body for the unresolved member.
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "op"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		return // an error (e.g. file not found) is acceptable — no fabrication
+	}
+	text := extractResultText(t, res)
+	if strings.Contains(text, "synthesized inherited-member contract") {
+		t.Errorf("unresolved member must not get a fabricated external body:\n%s", text)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1111,6 +1111,10 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				}
 				// #2642: metadata block with index provenance.
 				out["metadata"] = inspectMetadata(r)
+				// #3833: surface MRO resolution for inherited members.
+				if inh := inspectInheritance(r, e); inh != nil {
+					out["inheritance"] = inh
+				}
 				return jsonResult(out), nil
 			}
 		}
@@ -1184,6 +1188,10 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	}
 	// #2642: metadata block with index provenance.
 	out["metadata"] = inspectMetadata(m.repo)
+	// #3833: surface MRO resolution for inherited members.
+	if inh := inspectInheritance(m.repo, m.ent); inh != nil {
+		out["inheritance"] = inh
+	}
 	return jsonResult(out), nil
 }
 
@@ -2197,6 +2205,42 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 		e = cands[0].ent
 		lr = cands[0].repo
 	}
+
+	// #3833 — MRO-aware resolution. When the entity is an INHERITED member (a
+	// bodyless DRF synthetic, or a method resolved via EXTENDS to a base that
+	// defines it) resolve it to the DEFINING class body instead of returning the
+	// subclass file:
+	//   - external library base (DRF mixin) -> synthesize the pack contract as
+	//     an explicit "external body" stub (no in-repo source exists);
+	//   - in-repo base -> redirect get_source to the base's real body span.
+	// Honest-partial: an unresolved inherited member falls through to the
+	// current behaviour (the subclass entity's own span).
+	if res := resolveMember(lr, e); res.IsInherited() {
+		switch res.Provenance {
+		case provInheritedExternal:
+			return mcpapi.NewToolResultText(synthesizeExternalBody(res)), nil
+		case provInheritedInRepo:
+			if res.DefiningEntity != nil {
+				// Read the base's real body; prepend an explicit provenance
+				// header so the caller knows it is the inherited definition.
+				header := fmt.Sprintf(
+					"# archigraph: %s.%s is INHERITED — body defined by %s (resolved via EXTENDS)\n",
+					res.OwningClass, res.Member, res.DefiningClass,
+				)
+				e = res.DefiningEntity
+				abs := e.SourceFile
+				if !filepath.IsAbs(abs) && lr.Path != "" {
+					abs = filepath.Join(lr.Path, e.SourceFile)
+				}
+				body, rerr := readInheritedBody(ctx, abs, e, contextLines)
+				if rerr != nil {
+					return mcpapi.NewToolResultError(rerr.Error()), nil
+				}
+				return mcpapi.NewToolResultText(header + body), nil
+			}
+		}
+	}
+
 	abs := e.SourceFile
 	if !filepath.IsAbs(abs) && lr.Path != "" {
 		abs = filepath.Join(lr.Path, e.SourceFile)
@@ -2266,6 +2310,50 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 			"get_source: read timed out after 5s on %s (file may be on a stalled filesystem or watched-path kernel stall); node_id=%s",
 			abs, nodeID,
 		)), nil
+	}
+}
+
+// readInheritedBody computes the windowed source span for entity e (reusing
+// the same degenerate-span clamp + hard cap + 5s read-timeout discipline as the
+// main get_source path) and returns the body text. Used by the #3833 MRO
+// redirect to read an in-repo base class's defining body.
+func readInheritedBody(ctx context.Context, abs string, e *graph.Entity, contextLines int) (string, error) {
+	const fallbackSpan = 60
+	const hardMaxLines = 200
+
+	startLine := e.StartLine
+	endLine := e.EndLine
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine <= startLine || e.StartLine == 0 || e.EndLine == 0 {
+		endLine = startLine + fallbackSpan
+	}
+	start := startLine - contextLines
+	if start < 1 {
+		start = 1
+	}
+	end := endLine + contextLines
+	if end-start+1 > hardMaxLines {
+		end = start + hardMaxLines - 1
+	}
+
+	readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer readCancel()
+	type readOut struct {
+		text string
+		err  error
+	}
+	resCh := make(chan readOut, 1)
+	go func() {
+		text, rerr := readSourceWindow(abs, start, end)
+		resCh <- readOut{text: text, err: rerr}
+	}()
+	select {
+	case out := <-resCh:
+		return out.text, out.err
+	case <-readCtx.Done():
+		return "", fmt.Errorf("get_source: read timed out after 5s on %s (inherited body)", abs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes `archigraph_get_source` / `archigraph_inspect` **MRO-aware** so an inherited member resolves to its **defining base/mixin body** instead of the subclass file — closing the rewrite agent's **G2** ("get_source on an inherited DRF verb returns the subclass file, not the `RetrieveModelMixin` body; no inheritance edge"). Epic #3829, PR A3.

## What it does

New shared resolver `internal/mcp/mro.go` (`resolveMember`). For an inherited member — a bodyless DRF synthetic `SCOPE.Operation` (`pattern_type=drf_viewset_implicit_method`) or any member whose owning class inherits it — it walks the owning class's `EXTENDS` edges to find the defining class:

- **(a) in-repo base** declaring the member with a real body → `get_source` **redirects** to that body span, prefixed with an explicit `# archigraph: <Sub>.<member> is INHERITED — body defined by <Base> (resolved via EXTENDS)` header.
- **(b) external library base** known to the `baseknowledge` pack (DRF mixins, #3906) → `get_source` returns a **synthesized external-body stub** carrying the defining-class FQN, default status, error statuses, behaviour note and doc URL, explicitly marked `NOT subclass source`.

`inspect` gains an `inheritance` section (`resolved_from`, `defining_class`, `inherited`, and for external mixins `http_verb` / `default_status` / `error_statuses` / `behaviour` / `doc_url`) so the consumer knows the member is inherited and from where.

### Honest-partial (quality-first)
An inherited member whose base is neither indexed nor in the pack returns `unresolved`: `inspect` marks `resolved=false` with a note; `get_source` falls back to the current behaviour. **Never fabricates a body or a status.** The DRF generic CBVs whose `default_status` is `StatusUnknown` stay unstamped.

## Resolution asserted by tests (value-asserting, not `len>0`)

- **DRF external mixin**: `get_source` on an inherited `retrieve` synthetic → identifies `defining_class = RetrieveModelMixin` with `default_status: 200` via the pack, NOT the subclass `views.py`.
- **inspect**: same entity → `inheritance.defining_class` contains `RetrieveModelMixin`, `external=true`, `default_status=200`.
- **in-repo base** (`ChildService(BaseService)`): `get_source` on the inherited verb returns the **base's real body** via the EXTENDS walk (asserts the base body marker + inherited header).
- **unresolvable**: `inspect` → `resolved=false` + note, no `defining_class`; `get_source` does not fabricate an external body.

## Scope / deploy

Pure read-path projection — adds **no** graph entities or edges. **DEPLOY-DEFERRED**: this is the MCP projection only; it needs a live-daemon rebuild + restart to serve the rewrite agent. The indexer-side `INHERITS`/`OVERRIDES` edge (uniform graph-walker traversal) is a separate ticket.

## Validation

- `go test ./internal/mcp/... ./internal/frameworks/... ./internal/types/` — green
- `go vet` clean, `gofmt -l` empty
- `coverage validate` exit 0, `coverage fmt --check` canonical

Closes #3833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)