### PR TITLE
feat(engine): Mongoid (Ruby) aggregation $lookup + association relations → JOINS_COLLECTION (#3847)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -135,7 +135,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | 🟢 11/11 | |
 | [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/11 | |
-| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/9 | |
+| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 6/9 | |
 | [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/11 | |
 | [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/11 | |
 | [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -58,7 +58,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/4 | |
 | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | 🟢 11/11 | |
 | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/11 | |
-| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 5/9 | |
+| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 6/9 | |
 | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/11 | |
 | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/11 | |
 | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -36,7 +36,7 @@ one is a separate detail page.
 | [`lang.python.orm.beanie`](./lang.python.orm.beanie.md) | python | orm | 5 partial, 4 missing, 2 n/a |
 | [`lang.python.orm.mongoengine`](./lang.python.orm.mongoengine.md) | python | orm | 5 partial, 4 missing, 2 n/a |
 | [`lang.ruby.driver.mongodb`](./lang.ruby.driver.mongodb.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.ruby.orm.mongoid`](./lang.ruby.orm.mongoid.md) | ruby | orm | 5 partial, 4 missing, 2 n/a |
+| [`lang.ruby.orm.mongoid`](./lang.ruby.orm.mongoid.md) | ruby | orm | 6 partial, 3 missing, 2 n/a |
 | [`lang.rust.driver.mongodb`](./lang.rust.driver.mongodb.md) | rust | driver | 1 full, 3 missing, 7 n/a |
 
 ## Provenance

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -23,16 +23,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | Mongoid has_many, belongs_to, has_one, has_and_belongs_to_many, embeds_many, embeds_one, embedded_in. Part of #3282. |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/orm_queries_ruby_mongoid_agg.go`<br>`internal/engine/orm_queries_ruby_mongoid_agg_test.go` | Mongoid association macros (belongs_to, has_many, has_one, embeds_many, embeds_one, embedded_in, has_and_belongs_to_many) declared inside an `include Mongoid::Document` class now emit a native JOINS_COLLECTION relation edge Class:<owning model> -> Class:<associated model> (scanRubyMongoidAssociations, #3847), matching the Mongoose ref/populate contract. Target model is the explicit `class_name:` option else the camelised-singular of the association symbol (has_many :line_items -> Class:LineItem). Honest-partial: dynamic class_name -> falls back to symbol; a macro outside a Mongoid::Document class is gated out. |
 | Foreign key extraction | — `not_applicable` | — | — | — | Mongoid uses document references, not relational foreign keys |
 | Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | Mongoid associations are lazy by default; includes/eager_load markers detected. Part of #3282. |
-| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | Mongoid has_many, belongs_to, embeds_many, embeds_one relationship macros. Part of #3282. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/orm_queries_ruby_mongoid_agg.go`<br>`internal/engine/orm_queries_ruby_mongoid_agg_test.go` | Mongoid relationship macros (belongs_to/has_many/embeds_many/embeds_one/embedded_in/has_one/has_and_belongs_to_many) emit JOINS_COLLECTION relation edges via scanRubyMongoidAssociations (#3847, epic #3837), the Ruby sibling of the Mongoose ref/populate relation pass. Part of #3282. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | — | YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor. |
+| Query attribution | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3645) | `internal/engine/orm_queries.go`<br>`internal/engine/orm_queries_ruby_mongoid_agg.go`<br>`internal/engine/orm_queries_ruby_mongoid_agg_test.go` | Mongoid `Model.collection.aggregate([...])` pipeline $lookup/$graphLookup joins now extracted (scanRubyMongoidAggregation, #3847, epic #3837): each $lookup emits a JOINS_COLLECTION edge aggregating-collection -> from collection (Class:Book -> Class:Author) plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose/Go/Java contract. Ruby hash-rocket (`'from' => 'authors'`) and symbol-colon separators both parsed; aggregating collection resolved from the model class name or `store_in collection: 'books'`. Honest-partial: dynamic from / variable-bound pipeline -> no edge; general query-verb attribution still missing (#3645). |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -62962,9 +62962,9 @@
         "Relationships": {
           "association_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
+            "cites": ["internal/engine/orm_queries_ruby_mongoid_agg.go","internal/engine/orm_queries_ruby_mongoid_agg_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Mongoid has_many, belongs_to, has_one, has_and_belongs_to_many, embeds_many, embeds_one, embedded_in. Part of #3282."
+            "notes": "Mongoid association macros (belongs_to, has_many, has_one, embeds_many, embeds_one, embedded_in, has_and_belongs_to_many) declared inside an `include Mongoid::Document` class now emit a native JOINS_COLLECTION relation edge Class:\u003cowning model\u003e -\u003e Class:\u003cassociated model\u003e (scanRubyMongoidAssociations, #3847), matching the Mongoose ref/populate contract. Target model is the explicit `class_name:` option else the camelised-singular of the association symbol (has_many :line_items -\u003e Class:LineItem). Honest-partial: dynamic class_name -\u003e falls back to symbol; a macro outside a Mongoid::Document class is gated out."
           },
           "foreign_key_extraction": {
             "status": "not_applicable",
@@ -62978,16 +62978,17 @@
           },
           "relationship_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
+            "cites": ["internal/engine/orm_queries_ruby_mongoid_agg.go","internal/engine/orm_queries_ruby_mongoid_agg_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Mongoid has_many, belongs_to, embeds_many, embeds_one relationship macros. Part of #3282."
+            "notes": "Mongoid relationship macros (belongs_to/has_many/embeds_many/embeds_one/embedded_in/has_one/has_and_belongs_to_many) emit JOINS_COLLECTION relation edges via scanRubyMongoidAssociations (#3847, epic #3837), the Ruby sibling of the Mongoose ref/populate relation pass. Part of #3282."
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_ruby_mongoid_agg.go","internal/engine/orm_queries_ruby_mongoid_agg_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3645",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "notes": "Mongoid `Model.collection.aggregate([...])` pipeline $lookup/$graphLookup joins now extracted (scanRubyMongoidAggregation, #3847, epic #3837): each $lookup emits a JOINS_COLLECTION edge aggregating-collection -\u003e from collection (Class:Book -\u003e Class:Author) plus a SCOPE.DataAccess stage entity, matching the Python/Mongoose/Go/Java contract. Ruby hash-rocket (`'from' =\u003e 'authors'`) and symbol-colon separators both parsed; aggregating collection resolved from the model class name or `store_in collection: 'books'`. Honest-partial: dynamic from / variable-bound pipeline -\u003e no edge; general query-verb attribution still missing (#3645).",
             "verified_at": "2026-06-02"
           }
         },

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -208,6 +208,15 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 		// table_name, Cassandra CQL (#3645).
 		scanRubyDrivers(src, funcs, emit)
 		scanInfra()
+		// Sibling pass: Mongoid `Model.collection.aggregate([...])` pipeline
+		// $lookup/$graphLookup joins → per-stage SCOPE.DataAccess entities +
+		// JOINS_COLLECTION edges, and Mongoid association macros
+		// (belongs_to/has_many/embeds_many/...) → JOINS_COLLECTION relation
+		// edges, matching the Python/Mongoose/Go/Java contract (#3847).
+		scanRubyMongoidAggregation(src, funcs, path, lang,
+			func(ent types.EntityRecord) { entities = append(entities, ent) },
+			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
+		)
 	case "csharp":
 		scanCSharpDrivers(src, funcs, emit)
 		scanInfra()

--- a/internal/engine/orm_queries_ruby_mongoid_agg.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg.go
@@ -1,0 +1,505 @@
+// Mongoid (Ruby) aggregation `$lookup` joins + association relations extraction
+// (#3847, epic #3837).
+//
+// This is the Ruby sibling of the four already-landed Mongo ODM passes:
+// orm_queries_jsts_mongo_agg.go (#3426), orm_queries_python_mongo_agg.go
+// (#3440), orm_queries_go_mongo_agg.go (#3846), and
+// orm_queries_java_mongo_agg.go (#3845), plus the Mongoose ref/populate relation
+// sibling orm_queries_jsts_mongoose_populate.go (#3844/#3889). The existing Ruby
+// surface (scanRubyORM / scanRubyDrivers) handles ActiveRecord verbs and the raw
+// Mongo Ruby driver `client[:coll]` topology, but it does NOT understand Mongoid:
+// neither the `Model.collection.aggregate([...])` pipeline (where a `$lookup`
+// stage is an implicit cross-collection JOIN) nor the Mongoid association macros
+// (`belongs_to` / `has_many` / `embeds_many` — the document-reference join the
+// rewrite target reasons about). This pass brings Mongoid up to the same
+// contract the other ODMs share:
+//
+//  1. JOINS_COLLECTION relationship — for every `$lookup` / `$graphLookup` stage
+//     in a `Model.collection.aggregate([...])` pipeline, an edge
+//     Class:<aggregating coll> -> Class:<from coll>; and for every Mongoid
+//     association macro in a `Mongoid::Document` class, an edge
+//     Class:<owning model> -> Class:<associated model>. The aggregating
+//     collection / owning model is resolved from the Ruby class name (its
+//     conventional collection) or an explicit `store_in collection: 'books'`.
+//
+//  2. SCOPE.DataAccess pipeline-stage entities — one per aggregation stage,
+//     anchored at the aggregate call site, subtype = the stage operator, stage
+//     order preserved as stage_index. Mirrors the JS/Python/Go/Java shape.
+//
+// MONGOID IDIOMS:
+//
+//   - Aggregation: `Book.collection.aggregate([{ '$lookup' => { 'from' =>
+//     'authors', 'localField' => 'author_id', 'foreignField' => '_id', 'as' =>
+//     'author' } }])`. Ruby hashes use the rocket `=>` (or, for symbol keys,
+//     `key:`) separator rather than the JS/JSON `:`; the stage key is a quoted
+//     string `'$lookup'`. We split the inline array literal into stages with the
+//     shared splitter and parse each with a Ruby-aware string-field reader that
+//     accepts BOTH `=>` and `:` separators.
+//   - Associations: inside a class that `include Mongoid::Document`, the macros
+//     `belongs_to :author`, `has_many :books`, `has_one :profile`,
+//     `embeds_many :pages`, `embeds_one :cover`, `embedded_in :book` declare a
+//     document reference. Each macro names an associated model (singularised /
+//     camelised from the association symbol, or an explicit `class_name:`).
+//
+// HONEST LIMIT: a dynamic aggregating collection (a non-class receiver we can't
+// resolve), a dynamic `from` (variable / expression, not a quoted literal), a
+// variable-bound pipeline (not an inline array literal), an association with a
+// dynamic `class_name:`, or any macro outside a `Mongoid::Document` class are
+// all left UNRESOLVED — we never fabricate a stage or a join we cannot
+// statically see. The inline `Model.collection.aggregate([...])` literal and the
+// static association macros are resolved; everything else is skipped.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongoidAggPatternType tags the aggregation-pipeline outputs of this pass.
+const mongoidAggPatternType = "mongoid_aggregation"
+
+// mongoidRelationPatternType tags the association-relation edges of this pass.
+const mongoidRelationPatternType = "mongoid_association"
+
+// mongoidGateRe gates the whole pass: only files that mention Mongoid are
+// scanned, so we never poach an arbitrary `.aggregate([...])` chain or a
+// `belongs_to` macro from a non-Mongoid (e.g. ActiveRecord) class.
+var mongoidGateRe = regexp.MustCompile(`\bMongoid\b`)
+
+// mongoidAggCallRe locates a `<Receiver>.collection.aggregate(` call site. The
+// receiver immediately preceding `.collection.aggregate` is the Mongoid model
+// class (`Book.collection.aggregate(...)`). Group 1 is the model class name.
+var mongoidAggCallRe = regexp.MustCompile(
+	`([A-Za-z_][A-Za-z0-9_:]*)\s*\.\s*collection\s*\.\s*aggregate\s*\(`,
+)
+
+// mongoidStringFieldReCache caches per-key Ruby string-field matchers.
+var mongoidStringFieldReCache = map[string]*regexp.Regexp{}
+
+// mongoidStringField pulls the quoted string value bound to `key` in a Ruby
+// hash, accepting BOTH the rocket (`'from' => 'authors'`) and the symbol-colon
+// (`from: 'authors'`) separators. The key itself may be quoted (`'from'`) or a
+// bare symbol-style identifier (`from`). Returns "" when the key is absent or
+// its value is not a plain quoted string literal (e.g. a variable / expression)
+// — honest: a dynamic value yields no field.
+func mongoidStringField(stage, key string) string {
+	re, ok := mongoidStringFieldReCache[key]
+	if !ok {
+		qk := regexp.QuoteMeta(key)
+		re = regexp.MustCompile(
+			`(?:['"]` + qk + `['"]|\b` + qk + `)\s*(?:=>|:)\s*['"]([a-zA-Z_][\w$.-]*)['"]`,
+		)
+		mongoidStringFieldReCache[key] = re
+	}
+	if m := re.FindStringSubmatch(stage); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// mongoidParseLookup extracts the join fields from a $lookup / $graphLookup
+// stage written in Ruby-hash syntax.
+func mongoidParseLookup(stage string) mongoAggLookup {
+	return mongoAggLookup{
+		from:         mongoidStringField(stage, "from"),
+		localField:   mongoidStringField(stage, "localField"),
+		foreignField: mongoidStringField(stage, "foreignField"),
+		as:           mongoidStringField(stage, "as"),
+	}
+}
+
+// scanRubyMongoidAggregation walks `src`, finds Mongoid
+// `Model.collection.aggregate([...])` call sites, resolves the aggregating
+// collection from the model class, parses each inline pipeline stage, and emits
+// SCOPE.DataAccess stage entities + $lookup/$graphLookup JOINS_COLLECTION edges.
+// Then it scans Mongoid association macros and emits a JOINS_COLLECTION relation
+// edge per declared document reference.
+func scanRubyMongoidAggregation(
+	src string,
+	funcs []funcSpan,
+	path string,
+	lang string,
+	emitStage func(ent types.EntityRecord),
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	if !mongoidGateRe.MatchString(src) {
+		return
+	}
+
+	scanRubyMongoidAggCalls(src, funcs, path, lang, emitStage, emitJoin)
+	scanRubyMongoidAssociations(src, emitJoin)
+}
+
+// scanRubyMongoidAggCalls handles the `Model.collection.aggregate([...])` path.
+func scanRubyMongoidAggCalls(
+	src string,
+	funcs []funcSpan,
+	path string,
+	lang string,
+	emitStage func(ent types.EntityRecord),
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	for _, m := range mongoidAggCallRe.FindAllStringSubmatchIndex(src, -1) {
+		model := src[m[2]:m[3]]
+		coll := mongoidCollectionForModel(src, model)
+		if coll == "" {
+			continue
+		}
+		openParen := m[1] - 1 // index of '('
+
+		listLiteral := mongoidAggPipelineLiteral(src, openParen)
+		if listLiteral == "" {
+			continue // dynamic / variable-bound pipeline — honest skip.
+		}
+		stages := mongoAggSplitStages(listLiteral, 0)
+		if len(stages) == 0 {
+			continue
+		}
+		caller := enclosingFuncAt(funcs, m[0])
+		callLine := lineOfOffset(src, m[0])
+
+		for idx, st := range stages {
+			op := mongoAggFirstKey(st)
+			if op == "" {
+				continue
+			}
+			props := map[string]string{
+				"pattern_type": mongoidAggPatternType,
+				"collection":   coll,
+				"stage_index":  itoa(idx),
+				"stage":        op,
+			}
+			if caller != "" {
+				props["caller"] = caller
+			}
+
+			switch op {
+			case "$lookup":
+				lk := mongoidParseLookup(st)
+				if lk.from != "" {
+					props["from"] = lk.from
+					if lk.localField != "" {
+						props["local_field"] = lk.localField
+					}
+					if lk.foreignField != "" {
+						props["foreign_field"] = lk.foreignField
+					}
+					if lk.as != "" {
+						props["as"] = lk.as
+					}
+					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+				}
+			case "$graphLookup":
+				lk := mongoidParseLookup(st)
+				if lk.from != "" {
+					props["from"] = lk.from
+					if lk.as != "" {
+						props["as"] = lk.as
+					}
+					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+				}
+			}
+
+			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+			emitStage(types.EntityRecord{
+				Name:       name,
+				Kind:       mongoAggStageEntityKind,
+				Subtype:    op,
+				SourceFile: path,
+				StartLine:  callLine,
+				EndLine:    callLine,
+				Language:   lang,
+				Properties: props,
+
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.8,
+			})
+		}
+	}
+}
+
+// mongoidStoreInReCache caches per-model `store_in collection:` matchers.
+var mongoidStoreInReCache = map[string]*regexp.Regexp{}
+
+// mongoidCollectionForModel returns the collection token used to anchor the
+// aggregating side of a join for the Mongoid model `model`. Preference order:
+//
+//  1. An explicit `store_in collection: 'books'` / `store_in collection: :books`
+//     declaration anywhere in the file (authoritative override of the default).
+//  2. The conventional collection derived from the class name — Mongoid
+//     pluralises+downcases the class to form the collection, but the shared
+//     `capitalisedSingular` (used on the FromID by mongoAggJoinEdge) canonicalises
+//     a collection token back to `Class:<Singular>`. To land the FromID on the
+//     same `Class:Book` node the model itself produces, we feed the bare class
+//     name (last `::` segment) — `capitalisedSingular("Book")` == "Book".
+//
+// Returns "" only for an empty/garbage model token.
+func mongoidCollectionForModel(src, model string) string {
+	// Last `::`-segment of a possibly namespaced class (`Catalog::Book` -> `Book`).
+	name := model
+	if i := strings.LastIndex(name, "::"); i >= 0 {
+		name = name[i+2:]
+	}
+	if name == "" {
+		return ""
+	}
+	re, ok := mongoidStoreInReCache[name]
+	if !ok {
+		// store_in collection: 'books' | "books" | :books  (same-file).
+		re = regexp.MustCompile(
+			`store_in\s+collection:\s*(?:['"]([a-zA-Z_][\w$.-]*)['"]|:([a-zA-Z_]\w*))`,
+		)
+		mongoidStoreInReCache[name] = re
+	}
+	if m := re.FindStringSubmatch(src); m != nil {
+		if m[1] != "" {
+			return m[1]
+		}
+		if m[2] != "" {
+			return m[2]
+		}
+	}
+	return name
+}
+
+// mongoidAggPipelineLiteral returns the full inline pipeline array literal
+// `[ ... ]` (brackets included) that is the first argument of an aggregate call
+// whose `(` is at `openParen`. Only an inline array literal is resolved; a
+// variable-bound pipeline (`aggregate(pipeline)`) is left unresolved — honest.
+func mongoidAggPipelineLiteral(src string, openParen int) string {
+	i := openParen + 1
+	for i < len(src) && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r') {
+		i++
+	}
+	if i >= len(src) || src[i] != '[' {
+		return ""
+	}
+	return mongoidBracketBody(src, i)
+}
+
+// mongoidBracketBody returns the full balanced `[...]` literal (brackets
+// included) whose opening `[` is at `open`, string- and depth-aware. Returns ""
+// if the bracket is unbalanced.
+func mongoidBracketBody(src string, open int) string {
+	if open >= len(src) || src[open] != '[' {
+		return ""
+	}
+	depth := 0
+	inStr := byte(0)
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return src[open : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Mongoid association macros (document-reference relations)
+// ---------------------------------------------------------------------------
+
+// mongoidClassHeaderRe matches a Ruby class header `class Book` /
+// `class Catalog::Book < Something`, capturing the class name (group 1).
+var mongoidClassHeaderRe = regexp.MustCompile(`(?m)^[ \t]*class\s+([A-Za-z_][\w:]*)`)
+
+// mongoidDocumentIncludeRe matches the `include Mongoid::Document` marker that
+// makes a class a Mongoid document.
+var mongoidDocumentIncludeRe = regexp.MustCompile(`include\s+Mongoid::Document`)
+
+// mongoidAssocRe matches a Mongoid association macro and captures the macro name
+// (group 1) and the association symbol (group 2):
+//
+//	belongs_to :author
+//	has_many   :books
+//	embeds_many :pages, class_name: 'Page'
+//	embedded_in :book
+var mongoidAssocRe = regexp.MustCompile(
+	`(?m)^[ \t]*(belongs_to|has_many|has_one|embeds_many|embeds_one|embedded_in|has_and_belongs_to_many)\s+:([A-Za-z_]\w*)`,
+)
+
+// mongoidClassNameOptRe captures an explicit `class_name: 'Author'` /
+// `class_name: "Author"` option on an association macro line, which overrides
+// the symbol-derived target model name. A dynamic class_name (a variable) does
+// not match — honest skip (we fall back to the symbol-derived name).
+var mongoidClassNameOptRe = regexp.MustCompile(
+	`class_name:\s*['"]([A-Za-z_][\w:]*)['"]`,
+)
+
+// scanRubyMongoidAssociations emits a JOINS_COLLECTION relation edge for each
+// Mongoid association macro declared inside a `Mongoid::Document` class. The
+// owning model is the enclosing class; the target model is the explicit
+// `class_name:` option, else the camelised singular of the association symbol.
+func scanRubyMongoidAssociations(src string, emitJoin func(rel types.RelationshipRecord)) {
+	classes := mongoidDocumentClassSpans(src)
+	if len(classes) == 0 {
+		return
+	}
+	seen := make(map[string]bool)
+	for _, m := range mongoidAssocRe.FindAllStringSubmatchIndex(src, -1) {
+		owner := mongoidEnclosingDocClass(classes, m[0])
+		if owner == "" {
+			continue // macro outside any Mongoid::Document class — gated out.
+		}
+		macro := src[m[2]:m[3]]
+		sym := src[m[4]:m[5]]
+
+		// The full macro line (to the end of the line) carries the options.
+		lineEnd := strings.IndexByte(src[m[0]:], '\n')
+		var line string
+		if lineEnd < 0 {
+			line = src[m[0]:]
+		} else {
+			line = src[m[0] : m[0]+lineEnd]
+		}
+
+		target := ""
+		if cm := mongoidClassNameOptRe.FindStringSubmatch(line); cm != nil {
+			target = mongoidLastSegment(cm[1])
+		} else {
+			target = mongoidSymbolToModel(sym, macro)
+		}
+		from := capitalisedSingular(mongoidLastSegment(owner))
+		to := capitalisedSingular(target)
+		if from == "" || to == "" || from == to {
+			continue
+		}
+		key := from + "->" + to + ":" + sym
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		emitJoin(types.RelationshipRecord{
+			FromID: fmt.Sprintf("Class:%s", from),
+			ToID:   fmt.Sprintf("Class:%s", to),
+			Kind:   string(types.RelationshipKindJoinsCollection),
+			Properties: map[string]string{
+				"pattern_type": mongoidRelationPatternType,
+				"via":          macro,
+				"association":  sym,
+			},
+		})
+	}
+}
+
+// mongoidDocClassSpan is the [start,end) byte span of a class that includes
+// Mongoid::Document, together with its class name.
+type mongoidDocClassSpan struct {
+	name  string
+	start int
+	end   int
+}
+
+// mongoidDocumentClassSpans locates every `class X ... include Mongoid::Document`
+// block and computes its body span (header start to the next class header at the
+// same-or-shallower position, else EOF) so an association macro can be attributed
+// to the owning model. Only classes that actually include Mongoid::Document are
+// returned — a plain ActiveRecord class is excluded.
+func mongoidDocumentClassSpans(src string) []mongoidDocClassSpan {
+	headers := mongoidClassHeaderRe.FindAllStringSubmatchIndex(src, -1)
+	var spans []mongoidDocClassSpan
+	for i, h := range headers {
+		start := h[0]
+		end := len(src)
+		if i+1 < len(headers) {
+			end = headers[i+1][0]
+		}
+		// Only a class whose body includes Mongoid::Document is a Mongoid doc.
+		if !mongoidDocumentIncludeRe.MatchString(src[start:end]) {
+			continue
+		}
+		spans = append(spans, mongoidDocClassSpan{
+			name:  src[h[2]:h[3]],
+			start: start,
+			end:   end,
+		})
+	}
+	return spans
+}
+
+// mongoidEnclosingDocClass returns the name of the Mongoid document class whose
+// span contains `pos`, or "" if none.
+func mongoidEnclosingDocClass(spans []mongoidDocClassSpan, pos int) string {
+	for _, s := range spans {
+		if pos >= s.start && pos < s.end {
+			return s.name
+		}
+	}
+	return ""
+}
+
+// mongoidLastSegment returns the last `::`-separated segment of a (possibly
+// namespaced) class name: `Catalog::Book` -> `Book`.
+func mongoidLastSegment(name string) string {
+	if i := strings.LastIndex(name, "::"); i >= 0 {
+		return name[i+2:]
+	}
+	return name
+}
+
+// mongoidSymbolToModel converts an association symbol to its target model name.
+// Collection macros (has_many / embeds_many / has_and_belongs_to_many) take a
+// plural symbol, so the symbol is singularised; reference macros (belongs_to /
+// has_one / embeds_one / embedded_in) already name a singular. The result is
+// camelised: `books` -> `Book`, `author` -> `Author`, `blog_posts` ->
+// `BlogPost`. capitalisedSingular (applied by the caller) is a no-op on an
+// already-singular CamelCase token.
+func mongoidSymbolToModel(sym, macro string) string {
+	base := sym
+	switch macro {
+	case "has_many", "embeds_many", "has_and_belongs_to_many":
+		base = mongoidSingularise(base)
+	}
+	return mongoidCamelise(base)
+}
+
+// mongoidSingularise applies the same lightweight pluralisation rules as
+// capitalisedSingular (ies->y, ses->s, trailing-s drop) to a lower_snake symbol.
+func mongoidSingularise(s string) string {
+	switch {
+	case strings.HasSuffix(s, "ies") && len(s) > 3:
+		return s[:len(s)-3] + "y"
+	case strings.HasSuffix(s, "ses") && len(s) > 3:
+		return s[:len(s)-2]
+	case strings.HasSuffix(s, "s") && len(s) > 1:
+		return s[:len(s)-1]
+	}
+	return s
+}
+
+// mongoidCamelise turns a lower_snake_case association symbol into a CamelCase
+// model name: `blog_post` -> `BlogPost`, `author` -> `Author`.
+func mongoidCamelise(s string) string {
+	parts := strings.Split(s, "_")
+	var b strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(p[:1]))
+		b.WriteString(p[1:])
+	}
+	return b.String()
+}

--- a/internal/engine/orm_queries_ruby_mongoid_agg_test.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg_test.go
@@ -1,0 +1,247 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runMongoidAgg drives scanRubyMongoidAggregation over `src` and collects the
+// emitted stage entities + join/relation edges.
+func runMongoidAgg(t *testing.T, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	funcs := indexEnclosingFunctions("ruby", src)
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	scanRubyMongoidAggregation(src, funcs, "app/models/book.rb", "ruby",
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+	return ents, rels
+}
+
+func mongoidFindJoin(rels []types.RelationshipRecord, from, to string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].Kind == string(types.RelationshipKindJoinsCollection) &&
+			rels[i].FromID == "Class:"+from && rels[i].ToID == "Class:"+to {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// Aggregation $lookup with Ruby hash-rocket syntax. Asserts the exact
+// JOINS_COLLECTION(Class:Book -> Class:Author) edge ids + the join sub-fields,
+// plus the SCOPE.DataAccess stage entity.
+func TestMongoidAgg_Lookup_HashRocket(t *testing.T) {
+	src := `
+class Book
+  include Mongoid::Document
+  def self.with_authors
+    collection.aggregate([
+      { '$lookup' => { 'from' => 'authors', 'localField' => 'author_id', 'foreignField' => '_id', 'as' => 'author' } }
+    ])
+  end
+end
+
+result = Book.collection.aggregate([
+  { '$lookup' => { 'from' => 'authors', 'localField' => 'author_id', 'foreignField' => '_id', 'as' => 'author' } }
+])
+`
+	ents, rels := runMongoidAgg(t, src)
+
+	j := mongoidFindJoin(rels, "Book", "Author")
+	if j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Book -> Class:Author); rels=%+v", rels)
+	}
+	if got := j.Properties["local_field"]; got != "author_id" {
+		t.Errorf("local_field = %q, want author_id", got)
+	}
+	if got := j.Properties["foreign_field"]; got != "_id" {
+		t.Errorf("foreign_field = %q, want _id", got)
+	}
+	if got := j.Properties["as"]; got != "author" {
+		t.Errorf("as = %q, want author", got)
+	}
+	// The JOINS_COLLECTION edge carries the SHARED mongoAggPatternType (the
+	// shared mongoAggJoinEdge builder), matching the JS/Python/Go/Java siblings;
+	// the stage ENTITY carries the Mongoid-specific tag (asserted below).
+	if got := j.Properties["pattern_type"]; got != mongoAggPatternType {
+		t.Errorf("edge pattern_type = %q, want %q", got, mongoAggPatternType)
+	}
+
+	// Stage entity asserted.
+	var foundStage bool
+	for _, e := range ents {
+		if e.Kind == mongoAggStageEntityKind && e.Subtype == "$lookup" &&
+			e.Properties["collection"] == "Book" && e.Properties["from"] == "authors" {
+			foundStage = true
+		}
+	}
+	if !foundStage {
+		t.Errorf("expected a $lookup SCOPE.DataAccess stage entity for Book; ents=%+v", ents)
+	}
+}
+
+// store_in collection override resolves the aggregating collection token, but
+// capitalisedSingular canonicalises it back to the same Class node.
+func TestMongoidAgg_StoreInCollection(t *testing.T) {
+	src := `
+class Book
+  include Mongoid::Document
+  store_in collection: 'tomes'
+end
+
+Book.collection.aggregate([
+  { '$lookup' => { 'from' => 'authors', 'as' => 'author' } }
+])
+`
+	_, rels := runMongoidAgg(t, src)
+	// "tomes" -> capitalisedSingular -> "Tome".
+	if j := mongoidFindJoin(rels, "Tome", "Author"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Tome -> Class:Author) via store_in; rels=%+v", rels)
+	}
+}
+
+// Association macros in a Mongoid::Document class emit relation edges.
+// belongs_to :author -> Book->Author ; has_many :reviews -> Book->Review.
+func TestMongoidAssociations_BelongsToHasMany(t *testing.T) {
+	src := `
+class Book
+  include Mongoid::Document
+  belongs_to :author
+  has_many :reviews
+  embeds_many :pages
+end
+`
+	_, rels := runMongoidAgg(t, src)
+
+	if j := mongoidFindJoin(rels, "Book", "Author"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Book -> Class:Author) for belongs_to; rels=%+v", rels)
+	} else {
+		if j.Properties["via"] != "belongs_to" {
+			t.Errorf("via = %q, want belongs_to", j.Properties["via"])
+		}
+		if j.Properties["association"] != "author" {
+			t.Errorf("association = %q, want author", j.Properties["association"])
+		}
+	}
+	// has_many :reviews -> singularised Review.
+	if j := mongoidFindJoin(rels, "Book", "Review"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Book -> Class:Review) for has_many :reviews; rels=%+v", rels)
+	}
+	// embeds_many :pages -> singularised Page.
+	if j := mongoidFindJoin(rels, "Book", "Page"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Book -> Class:Page) for embeds_many :pages; rels=%+v", rels)
+	}
+}
+
+// Explicit class_name: overrides the symbol-derived target; snake symbols
+// camelise.
+func TestMongoidAssociations_ClassNameAndCamelise(t *testing.T) {
+	src := `
+class Order
+  include Mongoid::Document
+  belongs_to :buyer, class_name: 'Customer'
+  has_many :line_items
+end
+`
+	_, rels := runMongoidAgg(t, src)
+
+	if j := mongoidFindJoin(rels, "Order", "Customer"); j == nil {
+		t.Fatalf("expected class_name override JOINS_COLLECTION(Class:Order -> Class:Customer); rels=%+v", rels)
+	}
+	// has_many :line_items -> singularise + camelise -> LineItem.
+	if j := mongoidFindJoin(rels, "Order", "LineItem"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Order -> Class:LineItem); rels=%+v", rels)
+	}
+}
+
+// Negative: a dynamic `from` (variable, not a quoted literal) yields NO join edge
+// (the stage entity may exist but carries no from / no JOINS_COLLECTION).
+func TestMongoidAgg_DynamicFrom_NoJoin(t *testing.T) {
+	src := `
+class Book
+  include Mongoid::Document
+end
+
+from_coll = 'authors'
+Book.collection.aggregate([
+  { '$lookup' => { 'from' => from_coll, 'as' => 'author' } }
+])
+`
+	_, rels := runMongoidAgg(t, src)
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindJoinsCollection) {
+			t.Fatalf("expected NO join edge for dynamic from; got %+v", r)
+		}
+	}
+}
+
+// Negative: a non-Mongoid Ruby class (no include Mongoid::Document) is gated out
+// — its belongs_to macro must NOT emit a relation edge. The file mentions
+// Mongoid only incidentally so the pass gate opens but the class span filter
+// excludes it.
+func TestMongoidAssociations_NonMongoidClass_Gated(t *testing.T) {
+	src := `
+# references Mongoid in a comment so the file gate opens
+class LegacyUser < ActiveRecord::Base
+  belongs_to :account
+end
+`
+	_, rels := runMongoidAgg(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges from a non-Mongoid::Document class; got %+v", rels)
+	}
+}
+
+// Negative: a variable-bound pipeline (not an inline array literal) is left
+// unresolved — no stage entities, no join edges.
+func TestMongoidAgg_VariableBoundPipeline_Skipped(t *testing.T) {
+	src := `
+class Book
+  include Mongoid::Document
+end
+
+pipeline = [{ '$lookup' => { 'from' => 'authors', 'as' => 'author' } }]
+Book.collection.aggregate(pipeline)
+`
+	ents, rels := runMongoidAgg(t, src)
+	for _, r := range rels {
+		if r.Properties["pattern_type"] == mongoidAggPatternType {
+			t.Fatalf("expected no agg join edge for variable-bound pipeline; got %+v", r)
+		}
+	}
+	for _, e := range ents {
+		if e.Properties["pattern_type"] == mongoidAggPatternType {
+			t.Fatalf("expected no agg stage entity for variable-bound pipeline; got %+v", e)
+		}
+	}
+}
+
+// $graphLookup is recognised and emits a join + stage.
+func TestMongoidAgg_GraphLookup(t *testing.T) {
+	src := `
+class Category
+  include Mongoid::Document
+end
+
+Category.collection.aggregate([
+  { '$graphLookup' => { 'from' => 'categories', 'startWith' => '$parent_id', 'as' => 'ancestors' } }
+])
+`
+	ents, rels := runMongoidAgg(t, src)
+	// categories -> capitalisedSingular -> Category (self-referential graph lookup).
+	if j := mongoidFindJoin(rels, "Category", "Category"); j == nil {
+		t.Fatalf("expected JOINS_COLLECTION(Class:Category -> Class:Category) for graphLookup; rels=%+v", rels)
+	}
+	var found bool
+	for _, e := range ents {
+		if e.Subtype == "$graphLookup" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a $graphLookup stage entity; ents=%+v", ents)
+	}
+}


### PR DESCRIPTION
Closes #3847 (epic #3837). **DEPLOY-DEFERRED.**

Ruby sibling of the four already-landed Mongo ODM passes — JS `$lookup` (#3426), Python pymongo (#3440), Go driver (#3846), Java Spring Data (#3845) — plus the Mongoose ref/populate relation pass (#3844). Brings Mongoid up to the same JOINS_COLLECTION contract.

## What it does
New extractor `scanRubyMongoidAggregation` (`internal/engine/orm_queries_ruby_mongoid_agg.go`), wired into the `ruby` case of `applyORMQueries`:

1. **Aggregation joins** — `Model.collection.aggregate([{ '$lookup' => { 'from' => 'authors', 'localField' => 'author_id', 'foreignField' => '_id', 'as' => 'author' } }])` → `JOINS_COLLECTION(Class:Book → Class:Author)` + one `SCOPE.DataAccess` stage entity per pipeline stage. Ruby hash-rocket (`=>`) **and** symbol-colon (`:`) separators both parsed (new `mongoidStringField`). Aggregating collection resolved from the model class name, or an explicit `store_in collection: 'books'` override. `$graphLookup` handled (recovers `from` + `as`).

2. **Association relations** — `belongs_to` / `has_many` / `has_one` / `embeds_many` / `embeds_one` / `embedded_in` / `has_and_belongs_to_many` declared inside an `include Mongoid::Document` class → `JOINS_COLLECTION(Class:<owning model> → Class:<associated model>)`, mirroring the Mongoose ref/populate relation convention. Target model = explicit `class_name:` option, else camelised-singular of the association symbol (`has_many :line_items` → `Class:LineItem`).

## Honest-partial (gated out, no fabricated edges)
- Dynamic `from` (variable / expression) → no join edge.
- Variable-bound pipeline (`aggregate(pipeline)`, not an inline array literal) → unresolved.
- Dynamic `class_name:` → falls back to the symbol-derived name.
- Association macro outside a `Mongoid::Document` class (e.g. an ActiveRecord class) → excluded by the class-span filter.

## Edges asserted by the value-asserting tests
- `$lookup`: `JOINS_COLLECTION(Class:Book → Class:Author)` with `local_field=author_id`, `foreign_field=_id`, `as=author`; stage entity `collection=Book`, `from=authors`.
- `store_in collection: 'tomes'` → `JOINS_COLLECTION(Class:Tome → Class:Author)`.
- `belongs_to :author` → `Class:Book → Class:Author` (via=belongs_to, association=author); `has_many :reviews` → `Class:Book → Class:Review`; `embeds_many :pages` → `Class:Book → Class:Page`.
- `class_name: 'Customer'` override → `Class:Order → Class:Customer`; `has_many :line_items` → `Class:Order → Class:LineItem`.
- `$graphLookup` self-ref → `Class:Category → Class:Category`.
- Negatives: dynamic `from` → 0 edges; non-Mongoid class → 0 edges; variable-bound pipeline → 0 agg edges/entities.

## Checks
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green; `./internal/custom/...` green.
- `gofmt -l` empty; `go vet ./internal/engine/` clean.
- `coverage validate`: 0 errors (pre-existing capability-map warnings only); `coverage fmt --check` canonical; docs regenerated (no drift).
- Coverage updated: `lang.ruby.orm.mongoid` `Queries.query_attribution` missing→partial; `Relationships.association_extraction`/`relationship_extraction` re-cited to the new extractor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)