### PR TITLE
feat(java-auth): endpoint auth-coverage for JVM frameworks trailing Spring (#3862)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -143,25 +143,25 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 6/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 2/19 | |
 | [java](../by-language/java.md) | [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🟡 3/19 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
 | [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
 | [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 4/19 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
-| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
+| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 4/19 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 6/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟡 18/21 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 4/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
 | [java](../by-language/java.md) | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/6 | |
 | [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/19 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/9 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/9 | |
 | [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/19 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/15 | |
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/18 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -26,22 +26,22 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 6/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 2/19 | |
 | [Google Guice (DI)](../detail/lang.java.framework.guice.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🟡 3/19 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 1/16 | |
 | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
 | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 4/19 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
-| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
+| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 4/19 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 6/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟡 18/21 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 4/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 14/19 | |
 | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/23 | 🔴 0/19 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/6 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/23 | 🟡 3/10 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -28,7 +28,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 3/6 | |
 | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/19 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/9 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 5/9 | |
 | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/23 | 🟡 3/19 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 12/15 | |
 | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/24 | 🟡 6/18 | |

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/akka_http_routes.go`<br>`internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go` | #3862: framework_auth.go stamps the flat auth contract on Akka-HTTP route entities. authenticateOAuth2/authenticateBasic directives → auth_required=true + auth_mechanism=oauth2/basic; authorize(hasRole('X')) → auth_roles (medium confidence, directive subtree is file-level). Value-asserting tests: authenticateOAuth2 directive → auth_required=true auth_mechanism=oauth2; authenticateBasic + authorize(hasRole('ADMIN')) → auth_mechanism=basic auth_roles=ADMIN; plain route with no directive → auth_required absent. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.java.framework.dgs.md
+++ b/docs/coverage/detail/lang.java.framework.dgs.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/spring_graphql.go` | #3862: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). DGS mapping regexes now tolerate an interleaved security annotation. Value-asserting tests: @Secured("ROLE_ADMIN") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/dropwizard.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/dropwizard.go`<br>`internal/custom/java/framework_auth_test.go` | #3862: dropwizard.go stamps auth_guard (the signal archigraph_auth_coverage reads) + auth_roles on Dropwizard-Auth entities, plus @Auth principal-injection detection. @RolesAllowed("ADMIN") → auth_required + auth_roles=ADMIN + auth_guard=RolesAllowed; @Auth User param → auth_required + auth_guard=Auth; @Authenticated → auth_guard=Authenticated. JAX-RS @RolesAllowed/@PermitAll/@DenyAll on @Path resource methods also flow through engine ResolveJavaAuthPolicy. Value-asserting tests assert auth_required + auth_roles + auth_guard on the resource method. Honest-partial: the Authenticator wiring is config-level. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/javalin_routes.go` | #3862: framework_auth.go stamps the flat Spring-compatible auth contract (auth_required/auth_method/auth_confidence/auth_guard/auth_roles) directly on Javalin route entities. Per-route roles(Role.ADMIN) inline guard → auth_required=true + auth_roles (high confidence); app/config.accessManager wired → every route auth_required (low confidence). Value-asserting tests: roles(Role.ADMIN) on /admin → auth_required=true auth_roles=ADMIN; roles(Role.ADMIN, Role.STAFF) → ADMIN,STAFF; unprotected route with no accessManager → auth_required absent. Honest-partial: bare app.get(path, handler) is unprotected. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/struts_routes.go` | #3862: framework_auth.go stamps the flat auth contract on Struts route entities. struts.xml <interceptor-ref name="roles"> with <param name="allowedRoles"> → auth_required=true + auth_roles (high confidence); @InterceptorRef naming a secure/auth/roles stack on @Action → auth_required (low confidence). Value-asserting tests: roles interceptor allowedRoles=ADMIN,MANAGER on an XML action → auth_required=true auth_roles=ADMIN,MANAGER; struts.xml with no roles interceptor → auth_required absent. Honest-partial: Struts has no built-in auth; interceptor-stack contents are file-local. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/vertx_routes.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/vertx_routes.go` | #3862: framework_auth.go stamps the flat auth contract on Vert.x route entities. JWTAuthHandler/OAuth2AuthHandler/BasicAuthHandler mounted on the router → auth_required=true + auth_mechanism=jwt/oauth2/basic (medium confidence, file-level subtree attribution); @RolesAllowed → auth_roles. Value-asserting tests: JWTAuthHandler on a route → auth_required=true auth_mechanism=jwt; BasicAuthHandler + @RolesAllowed({ADMIN}) → auth_mechanism=basic auth_roles=ADMIN; router with no auth handler → auth_required absent. |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/javalin_routes.go` | JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/javalin_routes.go` | #3862: Kotlin Javalin uses the identical app.get(path, handler, roles(Role.X)) DSL; the same framework_auth.go stamping in javalin_routes.go applies. roles(...) inline guard → auth_required=true + auth_roles; accessManager → auth_required (low confidence). See java javalin tests. |
 
 ### Validation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -23350,9 +23350,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: framework_auth.go stamps the flat auth contract on Akka-HTTP route entities. authenticateOAuth2/authenticateBasic directives → auth_required=true + auth_mechanism=oauth2/basic; authorize(hasRole('X')) → auth_roles (medium confidence, directive subtree is file-level). Value-asserting tests: authenticateOAuth2 directive → auth_required=true auth_mechanism=oauth2; authenticateBasic + authorize(hasRole('ADMIN')) → auth_mechanism=basic auth_roles=ADMIN; plain route with no directive → auth_required absent.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -24114,8 +24116,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/spring_graphql.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). DGS mapping regexes now tolerate an interleaved security annotation. Value-asserting tests: @Secured(\"ROLE_ADMIN\") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -24382,9 +24387,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/dropwizard.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
+            "status": "partial",
+            "cites": ["internal/custom/java/dropwizard.go","internal/custom/java/framework_auth_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: dropwizard.go stamps auth_guard (the signal archigraph_auth_coverage reads) + auth_roles on Dropwizard-Auth entities, plus @Auth principal-injection detection. @RolesAllowed(\"ADMIN\") → auth_required + auth_roles=ADMIN + auth_guard=RolesAllowed; @Auth User param → auth_required + auth_guard=Auth; @Authenticated → auth_guard=Authenticated. JAX-RS @RolesAllowed/@PermitAll/@DenyAll on @Path resource methods also flow through engine ResolveJavaAuthPolicy. Value-asserting tests assert auth_required + auth_roles + auth_guard on the resource method. Honest-partial: the Authenticator wiring is config-level.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -25867,9 +25874,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/javalin_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: framework_auth.go stamps the flat Spring-compatible auth contract (auth_required/auth_method/auth_confidence/auth_guard/auth_roles) directly on Javalin route entities. Per-route roles(Role.ADMIN) inline guard → auth_required=true + auth_roles (high confidence); app/config.accessManager wired → every route auth_required (low confidence). Value-asserting tests: roles(Role.ADMIN) on /admin → auth_required=true auth_roles=ADMIN; roles(Role.ADMIN, Role.STAFF) → ADMIN,STAFF; unprotected route with no accessManager → auth_required absent. Honest-partial: bare app.get(path, handler) is unprotected.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -28838,11 +28847,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns",
-            "verified_at": "2026-05-29"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/struts_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: framework_auth.go stamps the flat auth contract on Struts route entities. struts.xml \u003cinterceptor-ref name=\"roles\"\u003e with \u003cparam name=\"allowedRoles\"\u003e → auth_required=true + auth_roles (high confidence); @InterceptorRef naming a secure/auth/roles stack on @Action → auth_required (low confidence). Value-asserting tests: roles interceptor allowedRoles=ADMIN,MANAGER on an XML action → auth_required=true auth_roles=ADMIN,MANAGER; struts.xml with no roles interceptor → auth_required absent. Honest-partial: Struts has no built-in auth; interceptor-stack contents are file-local.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -29374,10 +29383,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/vertx_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "verified_at": "2026-05-29"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: framework_auth.go stamps the flat auth contract on Vert.x route entities. JWTAuthHandler/OAuth2AuthHandler/BasicAuthHandler mounted on the router → auth_required=true + auth_mechanism=jwt/oauth2/basic (medium confidence, file-level subtree attribution); @RolesAllowed → auth_roles. Value-asserting tests: JWTAuthHandler on a route → auth_required=true auth_mechanism=jwt; BasicAuthHandler + @RolesAllowed({ADMIN}) → auth_mechanism=basic auth_roles=ADMIN; router with no auth handler → auth_required absent.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -42645,10 +42655,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "cites": ["internal/custom/java/javalin_routes.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/javalin_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3862",
+            "notes": "#3862: Kotlin Javalin uses the identical app.get(path, handler, roles(Role.X)) DSL; the same framework_auth.go stamping in javalin_routes.go applies. roles(...) inline guard → auth_required=true + auth_roles; accessManager → auth_required (low confidence). See java javalin tests.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {

--- a/internal/custom/java/akka_http_routes.go
+++ b/internal/custom/java/akka_http_routes.go
@@ -144,6 +144,45 @@ var (
 			`void\s+(\w+)\s*\(`)
 )
 
+// akkaHTTPHasRoleRE captures a literal role from a hasRole("ADMIN") check inside
+// an authorize(...) directive. A purely predicate-based authorize (no literal
+// role) is still recognised as auth_required but contributes no roles.
+var akkaHTTPHasRoleRE = regexp.MustCompile(`hasRole\s*\(\s*"([^"]+)"`)
+
+// akkaHTTPFileAuth resolves the file-level auth posture for an Akka-HTTP route
+// source. authenticateOAuth2 / authenticateBasic establish the authentication
+// mechanism; an authorize(...) directive adds authorization (role/permission)
+// checks. Returns the zero authStamp (method == "") when no auth directive is
+// present, so an unprotected route file stamps nothing.
+func akkaHTTPFileAuth(source string) authStamp {
+	var roles []string
+	// Pull roles from hasRole("X") inside any authorize(...) directive.
+	for _, m := range akkaHTTPHasRoleRE.FindAllStringSubmatch(source, -1) {
+		roles = append(roles, m[1])
+	}
+
+	switch {
+	case akkaHTTPAuthOAuth2RE.MatchString(source):
+		return authStamp{
+			required: true, method: "directive", confidence: "medium",
+			guard: "authenticateOAuth2", mechanism: "oauth2", roles: roles,
+		}
+	case akkaHTTPAuthBasicRE.MatchString(source):
+		return authStamp{
+			required: true, method: "directive", confidence: "medium",
+			guard: "authenticateBasic", mechanism: "basic", roles: roles,
+		}
+	case akkaHTTPAuthorizationRE.MatchString(source):
+		// authorize(...) without an authenticate* directive: authorization-only
+		// (authentication wired elsewhere) — still a real auth requirement.
+		return authStamp{
+			required: true, method: "directive", confidence: "medium",
+			guard: "authorize", roles: roles,
+		}
+	}
+	return authStamp{}
+}
+
 // ExtractAkkaHTTP runs the Akka-HTTP extractor for route, middleware, DTO,
 // auth, and test-linkage patterns.
 func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
@@ -161,6 +200,16 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 
 	seen := make(map[string]bool)
 	seenRels := make(map[relKey]bool)
+
+	// File-level auth posture (#3862). Akka-HTTP auth is directive-based:
+	// authenticateBasic / authenticateOAuth2 / authorize wrap a route subtree.
+	// Pinpointing the exact subtree a directive guards requires brace-matching
+	// the directive lambdas, which is beyond single-file regex; we instead
+	// resolve a file-level posture (mechanism + whether an authorize() directive
+	// adds role/permission checks) and stamp every route in the file. A route
+	// file that opens with authenticateOAuth2(...) is gating its routes. Honest-
+	// partial: confidence "medium". Files with no auth directive stamp nothing.
+	fileAuth := akkaHTTPFileAuth(ctx.Source)
 
 	// ---------------------------------------------------------------------------
 	// Route extraction + handler attribution
@@ -209,6 +258,13 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 			// pathPrefix-only or concat-wrapped route blocks).
 			verb := "ANY"
 			ref := fmt.Sprintf("akka-http:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+			props := map[string]any{
+				"http_verb":  verb,
+				"path":       rawPath,
+				"framework":  "akka-http",
+				"route_type": "directive_dsl",
+			}
+			fileAuth.stamp(props)
 			e := SecondaryEntity{
 				Name:       rawPath,
 				Kind:       "Route",
@@ -216,18 +272,20 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 				LineStart:  lineOf(ctx.Source, idx[0]),
 				Provenance: "INFERRED_FROM_AKKA_HTTP_PATH",
 				Ref:        ref,
-				Properties: map[string]any{
-					"http_verb":  verb,
-					"path":       rawPath,
-					"framework":  "akka-http",
-					"route_type": "directive_dsl",
-				},
+				Properties: props,
 			}
 			addEntity(&result, seen, e)
 		} else {
 			for _, mm := range methodMatches {
 				verb := strings.ToUpper(mm[1])
 				ref := fmt.Sprintf("akka-http:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+				props := map[string]any{
+					"http_verb":  verb,
+					"path":       rawPath,
+					"framework":  "akka-http",
+					"route_type": "directive_dsl",
+				}
+				fileAuth.stamp(props)
 				e := SecondaryEntity{
 					Name:       rawPath,
 					Kind:       "Route",
@@ -235,12 +293,7 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 					LineStart:  lineOf(ctx.Source, idx[0]),
 					Provenance: "INFERRED_FROM_AKKA_HTTP_PATH",
 					Ref:        ref,
-					Properties: map[string]any{
-						"http_verb":  verb,
-						"path":       rawPath,
-						"framework":  "akka-http",
-						"route_type": "directive_dsl",
-					},
+					Properties: props,
 				}
 				addEntity(&result, seen, e)
 
@@ -289,6 +342,13 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 		}
 		rawPrefix := ctx.Source[idx[2]:idx[3]]
 		ref := fmt.Sprintf("akka-http:route-prefix:%s:%s", rawPrefix, ctx.FilePath)
+		props := map[string]any{
+			"http_verb":  "ANY",
+			"path":       rawPrefix,
+			"framework":  "akka-http",
+			"route_type": "path_prefix",
+		}
+		fileAuth.stamp(props)
 		e := SecondaryEntity{
 			Name:       rawPrefix,
 			Kind:       "Route",
@@ -296,12 +356,7 @@ func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
 			LineStart:  lineOf(ctx.Source, idx[0]),
 			Provenance: "INFERRED_FROM_AKKA_HTTP_PATH_PREFIX",
 			Ref:        ref,
-			Properties: map[string]any{
-				"http_verb":  "ANY",
-				"path":       rawPrefix,
-				"framework":  "akka-http",
-				"route_type": "path_prefix",
-			},
+			Properties: props,
 		}
 		addEntity(&result, seen, e)
 	}

--- a/internal/custom/java/dropwizard.go
+++ b/internal/custom/java/dropwizard.go
@@ -1,6 +1,37 @@
 package java
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
+
+// dwRolesAllowedArgRE captures the @RolesAllowed argument list so the roles can
+// be surfaced as the auth_roles flat field (matching the Spring contract).
+var (
+	dwRolesAllowedArgRE = regexp.MustCompile(`@RolesAllowed\s*\(\s*([^)]*)\)`)
+	dwQuotedTokenRE     = regexp.MustCompile(`"([^"]+)"`)
+)
+
+// dwRolesFrom extracts the role names from the @RolesAllowed annotation at or
+// before methodOffset (the regex match anchors on the method declaration that
+// follows the annotation). Returns nil when no quoted role is present.
+func dwRolesFrom(source string, methodOffset int) []string {
+	// Scan a short window ending at the method declaration for the annotation.
+	start := methodOffset - 200
+	if start < 0 {
+		start = 0
+	}
+	window := source[start:methodOffset]
+	m := dwRolesAllowedArgRE.FindStringSubmatch(window)
+	if m == nil {
+		return nil
+	}
+	var roles []string
+	for _, q := range dwQuotedTokenRE.FindAllStringSubmatch(m[1], -1) {
+		roles = append(roles, q[1])
+	}
+	return roles
+}
 
 // Dropwizard custom extractor — DI, auth, middleware, transactions, DTO, tests.
 //
@@ -63,6 +94,16 @@ var (
 	dwPermitAllRE = regexp.MustCompile(
 		`(?s)@PermitAll\b[^{;]*?(?:(?:public|protected|private)\s+)?` +
 			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(`)
+
+	// Auth: @Auth principal injection on a resource method parameter, e.g.
+	//   public Response me(@Auth User user) { ... }
+	// Dropwizard-Auth resolves the @Auth-annotated parameter from the configured
+	// Authenticator, so the presence of @Auth on a method param means that method
+	// requires authentication. Capture group 1 = the enclosing resource method.
+	dwAuthPrincipalRE = regexp.MustCompile(
+		`(?s)(?:public|protected|private)\s+(?:static\s+)?` +
+			`(?:<[^>]*>\s*)?(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(` +
+			`[^)]*@Auth\b`)
 
 	// Middleware: ContainerRequestFilter implementation — middleware_coverage.
 	dwContainerFilterRE = regexp.MustCompile(
@@ -236,6 +277,33 @@ func ExtractDropwizard(ctx PatternContext) PatternResult {
 				"auth_annotation": "Authenticated",
 				"framework":       "dropwizard",
 				"auth_required":   true,
+				// auth_guard is the key archigraph_auth_coverage reads to count
+				// the co-located JAX-RS endpoint as covered (#3862).
+				"auth_guard": "Authenticated",
+			},
+		})
+	}
+
+	// @Auth principal injection — auth_coverage. A @Auth-annotated resource
+	// method parameter means Dropwizard-Auth authenticates the request.
+	for _, m := range dwAuthPrincipalRE.FindAllStringSubmatchIndex(source, -1) {
+		methodName := source[m[2]:m[3]]
+		ownerClass := findEnclosingClass(source, m[0])
+		fullName := methodName
+		if ownerClass != "" {
+			fullName = ownerClass + "." + methodName
+		}
+		ref := "scope:operation:dw_auth_principal:" + fp + ":" + fullName
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: fullName, Kind: "SCOPE.Operation", Subtype: "function",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_DROPWIZARD_AUTH_PRINCIPAL", Ref: ref,
+			Properties: map[string]any{
+				"auth_annotation": "Auth",
+				"framework":       "dropwizard",
+				"auth_required":   true,
+				"auth_guard":      "Auth",
 			},
 		})
 	}
@@ -249,16 +317,21 @@ func ExtractDropwizard(ctx PatternContext) PatternResult {
 			fullName = ownerClass + "." + methodName
 		}
 		ref := "scope:operation:dw_roles_allowed:" + fp + ":" + fullName
+		props := map[string]any{
+			"auth_annotation": "RolesAllowed",
+			"framework":       "dropwizard",
+			"auth_required":   true,
+			"auth_guard":      "RolesAllowed",
+		}
+		if roles := dwRolesFrom(source, m[2]); len(roles) > 0 {
+			props["auth_roles"] = strings.Join(roles, ",")
+		}
 		addEntity(&result, seenRefs, SecondaryEntity{
 			Name: fullName, Kind: "SCOPE.Operation", Subtype: "function",
 			SourceFile: fp,
 			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
 			Provenance: "INFERRED_FROM_DROPWIZARD_ROLES_ALLOWED", Ref: ref,
-			Properties: map[string]any{
-				"auth_annotation": "RolesAllowed",
-				"framework":       "dropwizard",
-				"auth_required":   true,
-			},
+			Properties: props,
 		})
 	}
 

--- a/internal/custom/java/framework_auth.go
+++ b/internal/custom/java/framework_auth.go
@@ -1,0 +1,140 @@
+package java
+
+// framework_auth.go — endpoint-level auth-policy stamping for the JVM web
+// frameworks that trail Spring on the auth_coverage capability cell
+// (#3862, epic #3854): Javalin, Vert.x, Akka-HTTP, Apache Struts, and
+// Netflix DGS.
+//
+// Spring (and JAX-RS, via internal/engine/java_annotation_routes.go +
+// java_auth_policy.go) already stamp a FLAT auth contract directly on each
+// synthetic http_endpoint:
+//
+//	auth_required    "true" | "false"          (string)
+//	auth_method      "annotation" | "middleware" | "directive" | ...
+//	auth_confidence  "high" | "medium" | "low"
+//	auth_guard       framework-specific guard name (read by archigraph_auth_coverage)
+//	auth_roles       comma-joined role names      (sorted, deterministic)
+//	auth_scopes      comma-joined OAuth2 scopes    (sorted)
+//	auth_permissions comma-joined fine-grained permissions (sorted)
+//
+// This file mirrors that EXACT contract so the trailing frameworks' route /
+// endpoint entities carry the same props. Because these extractors emit
+// SecondaryEntity.Properties as map[string]any, the helpers below write the
+// same string values Spring writes (so a downstream consumer sees an identical
+// shape regardless of language).
+//
+// HONEST-PARTIAL policy: a flat auth posture is stamped ONLY when a concrete,
+// statically-visible auth signal applies to the route (an inline role guard, an
+// auth directive/handler wrapping the route, a method-level JSR-250 annotation).
+// Dynamic / unclear protection (a hand-rolled header check, a named guard whose
+// roles we cannot read) is left UNSTAMPED — auth_required is simply absent and
+// the endpoint stays "unknown", exactly as Spring leaves an unannotated handler.
+
+import (
+	"sort"
+	"strings"
+)
+
+// authStamp is the resolved, framework-agnostic auth posture for one route.
+// It is the trailing-framework analogue of engine.AuthPolicy, reduced to the
+// flat fields the dashboard and archigraph_auth_coverage actually read.
+type authStamp struct {
+	required    bool
+	method      string // "annotation" | "middleware" | "directive" | "config"
+	confidence  string // "high" | "medium" | "low"
+	guard       string // framework guard name (e.g. "JWTAuthHandler", "roles(...)")
+	mechanism   string // "jwt" | "basic" | "oauth2" | "" (auth scheme, when known)
+	roles       []string
+	scopes      []string
+	permissions []string
+}
+
+// stamp writes the flat auth contract onto a route/endpoint entity's property
+// map, mirroring the Spring / JAX-RS flat field set exactly. It is a no-op when
+// the posture carries no signal (method == ""), leaving the endpoint "unknown".
+//
+// required=false (an explicit public marker, e.g. @PermitAll) is still stamped
+// so the dashboard can render "[Public]" rather than "[Auth: unknown]".
+func (a authStamp) stamp(props map[string]any) {
+	if props == nil || a.method == "" {
+		return
+	}
+	if a.required {
+		props["auth_required"] = "true"
+	} else {
+		props["auth_required"] = "false"
+	}
+	props["auth_method"] = a.method
+	if a.confidence != "" {
+		props["auth_confidence"] = a.confidence
+	}
+	// auth_guard is the key archigraph_auth_coverage reads to count an endpoint
+	// as covered (see internal/mcp/auth_coverage.go authPropertyKeys). Only set
+	// it for protected endpoints — a public endpoint is NOT covered.
+	if a.required && a.guard != "" {
+		props["auth_guard"] = a.guard
+	}
+	if a.mechanism != "" {
+		props["auth_mechanism"] = a.mechanism
+	}
+	if len(a.roles) > 0 {
+		r := dedupSorted(a.roles)
+		props["auth_roles"] = strings.Join(r, ",")
+	}
+	if len(a.scopes) > 0 {
+		s := dedupSorted(a.scopes)
+		props["auth_scopes"] = strings.Join(s, ",")
+	}
+	if len(a.permissions) > 0 {
+		p := dedupSorted(a.permissions)
+		props["auth_permissions"] = strings.Join(p, ",")
+	}
+}
+
+// dedupSorted returns a sorted, de-duplicated copy of in (drops empties) so the
+// stamped comma-joined fields are deterministic across runs — matching the
+// sort.Strings the Spring/JAX-RS stamper applies to roles/scopes/permissions.
+func dedupSorted(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ── Shared role/scope/authority classification (Spring-compatible) ──────────
+
+// authQuotedTokenRE pulls quoted (single- or double-quoted) tokens out of an
+// annotation argument list or DSL call. Reused by the per-framework parsers.
+//
+// (defined as a method-local helper to avoid a package-level regex name clash;
+// see the per-framework regexes for the call sites.)
+
+// classifyAuthority splits a Spring-style granted-authority token into the
+// roles/scopes/permissions buckets, applying the same prefix conventions the
+// Java auth-policy resolver uses (ROLE_ → role, SCOPE_/scope: → scope, else
+// permission). Used by frameworks layered on Spring Security (Struts+Spring,
+// DGS+Spring Security).
+func classifyAuthority(tok string, roles, scopes, perms *[]string) {
+	tok = strings.TrimSpace(strings.Trim(tok, `"'`))
+	if tok == "" {
+		return
+	}
+	switch {
+	case strings.HasPrefix(tok, "ROLE_"):
+		*roles = append(*roles, strings.TrimPrefix(tok, "ROLE_"))
+	case strings.HasPrefix(tok, "SCOPE_"):
+		*scopes = append(*scopes, strings.TrimPrefix(tok, "SCOPE_"))
+	case strings.HasPrefix(tok, "scope:"):
+		*scopes = append(*scopes, strings.TrimPrefix(tok, "scope:"))
+	default:
+		*perms = append(*perms, tok)
+	}
+}

--- a/internal/custom/java/framework_auth_test.go
+++ b/internal/custom/java/framework_auth_test.go
@@ -1,0 +1,420 @@
+package java
+
+import "testing"
+
+// framework_auth_test.go — value-asserting auth_coverage tests for the JVM
+// frameworks that trailed Spring on the Auth cell (#3862, epic #3854):
+// Javalin, Vert.x, Akka-HTTP, Struts, Dropwizard, Netflix DGS.
+//
+// Each test asserts the FLAT Spring-compatible auth contract on the SPECIFIC
+// endpoint/route entity for the named framework — not len>0 — plus a negative
+// case proving an unprotected route carries no auth_required.
+
+// routeWithPath returns the first Route/endpoint entity whose path property
+// equals path, or nil.
+func routeWithPath(r PatternResult, path string) *SecondaryEntity {
+	for i := range r.Entities {
+		e := &r.Entities[i]
+		if p, _ := e.Properties["path"].(string); p == path {
+			return e
+		}
+	}
+	return nil
+}
+
+func propStr(e *SecondaryEntity, key string) string {
+	if e == nil || e.Properties == nil {
+		return ""
+	}
+	s, _ := e.Properties[key].(string)
+	return s
+}
+
+// ── Javalin: roles(Role.ADMIN) on /admin → auth_required=true roles=[ADMIN] ──
+
+func TestJavalinAuth_RouteRoles_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import io.javalin.Javalin;
+import static io.javalin.security.RouteRole.roles;
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create(config -> config.accessManager(new MyAccessManager()));
+        app.get("/public", ctx -> ctx.result("ok"));
+        app.get("/admin", AdminHandler::handle, roles(Role.ADMIN));
+        app.post("/staff", ctx -> ctx.result("x"), roles(Role.ADMIN, Role.STAFF));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{Source: source, Language: "java", Framework: "javalin"})
+
+	admin := routeWithPath(r, "/admin")
+	if admin == nil {
+		t.Fatal("expected /admin route entity")
+	}
+	if got := propStr(admin, "auth_required"); got != "true" {
+		t.Errorf("/admin auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(admin, "auth_roles"); got != "ADMIN" {
+		t.Errorf("/admin auth_roles = %q, want \"ADMIN\"", got)
+	}
+
+	staff := routeWithPath(r, "/staff")
+	if got := propStr(staff, "auth_roles"); got != "ADMIN,STAFF" {
+		t.Errorf("/staff auth_roles = %q, want \"ADMIN,STAFF\" (sorted)", got)
+	}
+	if got := propStr(staff, "auth_required"); got != "true" {
+		t.Errorf("/staff auth_required = %q, want \"true\"", got)
+	}
+
+	// /public carries no inline roles, but the app wires an accessManager → it
+	// inherits a low-confidence auth_required (the manager gates every route).
+	pub := routeWithPath(r, "/public")
+	if got := propStr(pub, "auth_required"); got != "true" {
+		t.Errorf("/public auth_required = %q, want \"true\" (accessManager)", got)
+	}
+	if got := propStr(pub, "auth_confidence"); got != "low" {
+		t.Errorf("/public auth_confidence = %q, want \"low\"", got)
+	}
+}
+
+// Negative: no accessManager, no roles() → auth_required absent.
+func TestJavalinAuth_Unprotected_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import io.javalin.Javalin;
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create();
+        app.get("/health", ctx -> ctx.result("ok"));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{Source: source, Language: "java", Framework: "javalin"})
+	h := routeWithPath(r, "/health")
+	if h == nil {
+		t.Fatal("expected /health route")
+	}
+	if _, ok := h.Properties["auth_required"]; ok {
+		t.Errorf("/health should have no auth_required, got %v", h.Properties["auth_required"])
+	}
+}
+
+// ── Vert.x: JWTAuthHandler on a route → auth_required mechanism=jwt ──────────
+
+func TestVertxAuth_JWTHandler_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+public class ApiVerticle {
+    void routes(Router router) {
+        router.route("/api/*").handler(JWTAuthHandler.create(jwtAuth));
+        router.get("/api/orders").handler(ctx -> ctx.json(orders));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{Source: source, Language: "java", Framework: "vertx"})
+	orders := routeWithPath(r, "/api/orders")
+	if orders == nil {
+		t.Fatal("expected /api/orders route")
+	}
+	if got := propStr(orders, "auth_required"); got != "true" {
+		t.Errorf("/api/orders auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(orders, "auth_mechanism"); got != "jwt" {
+		t.Errorf("/api/orders auth_mechanism = %q, want \"jwt\"", got)
+	}
+}
+
+// Vert.x @RolesAllowed → roles surfaced; Basic mechanism precedence sanity.
+func TestVertxAuth_BasicAndRoles_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BasicAuthHandler;
+public class AdminVerticle {
+    void routes(Router router) {
+        router.route().handler(BasicAuthHandler.create(provider));
+        @RolesAllowed({"ADMIN"})
+        public void admin(RoutingContext ctx) {}
+        router.get("/admin").handler(this::admin);
+    }
+}
+`
+	r := ExtractVertx(PatternContext{Source: source, Language: "java", Framework: "vertx"})
+	admin := routeWithPath(r, "/admin")
+	if got := propStr(admin, "auth_mechanism"); got != "basic" {
+		t.Errorf("/admin auth_mechanism = %q, want \"basic\"", got)
+	}
+	if got := propStr(admin, "auth_roles"); got != "ADMIN" {
+		t.Errorf("/admin auth_roles = %q, want \"ADMIN\"", got)
+	}
+}
+
+// Negative: a Vert.x router with no auth handler → auth_required absent.
+func TestVertxAuth_Unprotected_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import io.vertx.ext.web.Router;
+public class PublicVerticle {
+    void routes(Router router) {
+        router.get("/ping").handler(ctx -> ctx.end("pong"));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{Source: source, Language: "java", Framework: "vertx"})
+	ping := routeWithPath(r, "/ping")
+	if ping == nil {
+		t.Fatal("expected /ping route")
+	}
+	if _, ok := ping.Properties["auth_required"]; ok {
+		t.Errorf("/ping should have no auth_required")
+	}
+}
+
+// ── Akka-HTTP: authenticateOAuth2 directive → auth_required mechanism=oauth2 ─
+
+func TestAkkaHTTPAuth_OAuth2Directive_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import static akka.http.javadsl.server.Directives.*;
+public class Routes {
+    Route createRoute() {
+        return authenticateOAuth2("realm", authenticator, token ->
+            path("orders", () ->
+                get(() -> complete("orders"))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{Source: source, Language: "java", Framework: "akka-http"})
+	orders := routeWithPath(r, "orders")
+	if orders == nil {
+		t.Fatal("expected orders route")
+	}
+	if got := propStr(orders, "auth_required"); got != "true" {
+		t.Errorf("orders auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(orders, "auth_mechanism"); got != "oauth2" {
+		t.Errorf("orders auth_mechanism = %q, want \"oauth2\"", got)
+	}
+}
+
+// Akka authorize(hasRole("ADMIN")) → roles surfaced.
+func TestAkkaHTTPAuth_AuthorizeRole_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import static akka.http.javadsl.server.Directives.*;
+public class Routes {
+    Route createRoute() {
+        return authenticateBasic("realm", auth, user ->
+            authorize(() -> user.hasRole("ADMIN"), () ->
+                path("admin", () -> get(() -> complete("ok")))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{Source: source, Language: "java", Framework: "akka-http"})
+	admin := routeWithPath(r, "admin")
+	if admin == nil {
+		t.Fatal("expected admin route")
+	}
+	if got := propStr(admin, "auth_required"); got != "true" {
+		t.Errorf("admin auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(admin, "auth_mechanism"); got != "basic" {
+		t.Errorf("admin auth_mechanism = %q, want \"basic\"", got)
+	}
+	if got := propStr(admin, "auth_roles"); got != "ADMIN" {
+		t.Errorf("admin auth_roles = %q, want \"ADMIN\"", got)
+	}
+}
+
+// Negative: a plain Akka route with no auth directive → auth_required absent.
+func TestAkkaHTTPAuth_Unprotected_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import static akka.http.javadsl.server.Directives.*;
+public class Routes {
+    Route createRoute() {
+        return path("health", () -> get(() -> complete("ok")));
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{Source: source, Language: "java", Framework: "akka-http"})
+	h := routeWithPath(r, "health")
+	if h == nil {
+		t.Fatal("expected health route")
+	}
+	if _, ok := h.Properties["auth_required"]; ok {
+		t.Errorf("health should have no auth_required")
+	}
+}
+
+// ── Struts: roles interceptor in struts.xml with allowedRoles → roles ───────
+
+func TestStrutsAuth_RolesInterceptorXML_Issue3862(t *testing.T) {
+	source := `<?xml version="1.0"?>
+<struts>
+  <package name="secure" namespace="/admin" extends="struts-default">
+    <interceptor-ref name="roles">
+      <param name="allowedRoles">ADMIN,MANAGER</param>
+    </interceptor-ref>
+    <action name="dashboard" class="com.example.DashboardAction" method="show">
+      <result>/dashboard.jsp</result>
+    </action>
+  </package>
+</struts>`
+	r := ExtractStruts(PatternContext{Source: source, Language: "java", Framework: "struts", FilePath: "struts.xml"})
+	dash := routeWithPath(r, "/admin/dashboard")
+	if dash == nil {
+		t.Fatal("expected /admin/dashboard route")
+	}
+	if got := propStr(dash, "auth_required"); got != "true" {
+		t.Errorf("dashboard auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(dash, "auth_roles"); got != "ADMIN,MANAGER" {
+		t.Errorf("dashboard auth_roles = %q, want \"ADMIN,MANAGER\"", got)
+	}
+}
+
+// Negative: struts.xml with no roles interceptor → auth_required absent.
+func TestStrutsAuth_UnprotectedXML_Issue3862(t *testing.T) {
+	source := `<?xml version="1.0"?>
+<struts>
+  <package name="public" namespace="/" extends="struts-default">
+    <action name="home" class="com.example.HomeAction" method="index">
+      <result>/home.jsp</result>
+    </action>
+  </package>
+</struts>`
+	r := ExtractStruts(PatternContext{Source: source, Language: "java", Framework: "struts", FilePath: "struts.xml"})
+	home := routeWithPath(r, "/home")
+	if home == nil {
+		t.Fatal("expected /home route")
+	}
+	if _, ok := home.Properties["auth_required"]; ok {
+		t.Errorf("/home should have no auth_required")
+	}
+}
+
+// ── Netflix DGS: @PreAuthorize / @Secured on @DgsQuery → auth on the endpoint ─
+
+func TestDGSAuth_SecuredQuery_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.DgsMutation;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@DgsComponent
+public class UserFetcher {
+    @DgsQuery
+    public List<User> users() { return repo.findAll(); }
+
+    @DgsQuery
+    @Secured("ROLE_ADMIN")
+    public List<User> allUsers() { return repo.findAll(); }
+
+    @PreAuthorize("hasRole('MANAGER') and hasAuthority('SCOPE_write')")
+    @DgsMutation
+    public User addUser(String name) { return repo.add(name); }
+}
+`
+	r := ExtractSpringGraphQL(PatternContext{Source: source, Language: "java", Framework: "dgs", FilePath: "UserFetcher.java"})
+
+	// @Secured("ROLE_ADMIN") on allUsers → Query.allUsers endpoint protected.
+	all := routeWithPath(r, "/graphql/Query/allUsers")
+	if all == nil {
+		t.Fatal("expected /graphql/Query/allUsers endpoint")
+	}
+	if got := propStr(all, "auth_required"); got != "true" {
+		t.Errorf("allUsers auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(all, "auth_roles"); got != "ADMIN" {
+		t.Errorf("allUsers auth_roles = %q, want \"ADMIN\" (ROLE_ stripped)", got)
+	}
+
+	// @PreAuthorize on addUser → role MANAGER + scope write.
+	add := routeWithPath(r, "/graphql/Mutation/addUser")
+	if add == nil {
+		t.Fatal("expected /graphql/Mutation/addUser endpoint")
+	}
+	if got := propStr(add, "auth_roles"); got != "MANAGER" {
+		t.Errorf("addUser auth_roles = %q, want \"MANAGER\"", got)
+	}
+	if got := propStr(add, "auth_scopes"); got != "write" {
+		t.Errorf("addUser auth_scopes = %q, want \"write\" (SCOPE_ stripped)", got)
+	}
+
+	// users() has no security annotation → unprotected resolver endpoint.
+	users := routeWithPath(r, "/graphql/Query/users")
+	if users == nil {
+		t.Fatal("expected /graphql/Query/users endpoint")
+	}
+	if _, ok := users.Properties["auth_required"]; ok {
+		t.Errorf("users should have no auth_required")
+	}
+}
+
+// ── Dropwizard: @RolesAllowed on a resource method → auth_required + roles ───
+
+func TestDropwizardAuth_RolesAllowed_Issue3862(t *testing.T) {
+	source := `
+package com.example;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.*;
+
+@Path("/admin")
+public class AdminResource {
+    @GET
+    @RolesAllowed("ADMIN")
+    public Response stats() { return Response.ok().build(); }
+
+    @GET
+    @Path("/me")
+    public Response me(@Auth User user) { return Response.ok(user).build(); }
+}
+`
+	r := ExtractDropwizard(PatternContext{Source: source, Language: "java", Framework: "dropwizard", FilePath: "AdminResource.java"})
+
+	// @RolesAllowed("ADMIN") auth entity carries auth_required + auth_roles +
+	// auth_guard (the signal archigraph_auth_coverage reads).
+	var rolesEnt, authEnt *SecondaryEntity
+	for i := range r.Entities {
+		switch propStr(&r.Entities[i], "auth_annotation") {
+		case "RolesAllowed":
+			rolesEnt = &r.Entities[i]
+		case "Auth":
+			authEnt = &r.Entities[i]
+		}
+	}
+	if rolesEnt == nil {
+		t.Fatal("expected a RolesAllowed auth entity")
+	}
+	if rolesEnt.Properties["auth_required"] != true {
+		t.Errorf("RolesAllowed auth_required = %v, want true", rolesEnt.Properties["auth_required"])
+	}
+	if got := propStr(rolesEnt, "auth_roles"); got != "ADMIN" {
+		t.Errorf("RolesAllowed auth_roles = %q, want \"ADMIN\"", got)
+	}
+	if got := propStr(rolesEnt, "auth_guard"); got != "RolesAllowed" {
+		t.Errorf("RolesAllowed auth_guard = %q, want \"RolesAllowed\"", got)
+	}
+
+	// @Auth principal injection → auth entity proving the method is authenticated.
+	if authEnt == nil {
+		t.Fatal("expected an @Auth principal auth entity")
+	}
+	if authEnt.Properties["auth_required"] != true {
+		t.Errorf("@Auth auth_required = %v, want true", authEnt.Properties["auth_required"])
+	}
+	if got := propStr(authEnt, "auth_guard"); got != "Auth" {
+		t.Errorf("@Auth auth_guard = %q, want \"Auth\"", got)
+	}
+}

--- a/internal/custom/java/javalin_routes.go
+++ b/internal/custom/java/javalin_routes.go
@@ -85,6 +85,20 @@ var (
 	javalinAccessManagerRE = regexp.MustCompile(
 		`(?m)\b(?:app|config)\s*\.\s*accessManager\s*\(`)
 
+	// Per-route role guard: the trailing roles(...) argument of a route
+	// registration, e.g.
+	//   app.get("/admin", handler, roles(Role.ADMIN))
+	//   app.post("/x", AdminHandler::handle, roles(Role.ADMIN, Role.USER))
+	// Javalin's AccessManager receives this RouteRole set; a non-empty set means
+	// the route requires those roles. Capture group 1 = the role argument list.
+	javalinRouteRolesRE = regexp.MustCompile(
+		`\broles\s*\(\s*([^)]*?)\s*\)`)
+
+	// A single role token inside roles(...): Role.ADMIN, MyRoles.USER, ADMIN,
+	// or "ADMIN". Capture group 1 = the role leaf name (enum constant or string).
+	javalinRoleTokenRE = regexp.MustCompile(
+		`(?:\w+\s*\.\s*)?(\w+)|"([^"]+)"`)
+
 	// Tests: JavalinTest.create / JavalinTest.test / TestUtil.test —
 	// Javalin's test utility setup detection. Both create (v4) and test (v5) forms.
 	javalinTestRE = regexp.MustCompile(
@@ -97,6 +111,49 @@ var (
 			`(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s*(?:public\s+|protected\s+|private\s+)?(?:\w+\s+)*` +
 			`void\s+(\w+)\s*\(`)
 )
+
+// javalinRouteRoles extracts the role names from an inline roles(...) guard in a
+// Javalin route registration. pathEnd is the offset just past the closing quote
+// of the route path; we scan the remainder of that statement (up to the next
+// route call or two newlines) for a roles(...) argument and return the role leaf
+// names. Returns nil when the route carries no roles(...) guard (honest-partial:
+// a bare app.get("/x", handler) is unprotected).
+func javalinRouteRoles(source string, pathEnd int) []string {
+	if pathEnd >= len(source) {
+		return nil
+	}
+	// Bound the scan to this route statement: stop at the next "app." route
+	// registration or after two newlines, whichever comes first, so a later
+	// route's roles(...) is never mis-attributed.
+	end := pathEnd
+	newlines := 0
+	for end < len(source) && newlines < 2 {
+		if source[end] == '\n' {
+			newlines++
+		}
+		if strings.HasPrefix(source[end:], "app.") || strings.HasPrefix(source[end:], "app ") {
+			break
+		}
+		end++
+	}
+	stmt := source[pathEnd:end]
+	m := javalinRouteRolesRE.FindStringSubmatch(stmt)
+	if m == nil {
+		return nil
+	}
+	var roles []string
+	for _, tm := range javalinRoleTokenRE.FindAllStringSubmatch(m[1], -1) {
+		tok := tm[1]
+		if tm[2] != "" { // quoted string form
+			tok = tm[2]
+		}
+		tok = strings.TrimSpace(tok)
+		if tok != "" {
+			roles = append(roles, tok)
+		}
+	}
+	return roles
+}
 
 // ExtractJavalin runs the Javalin extractor for route, middleware, DTO, auth,
 // and test-linkage patterns.
@@ -117,6 +174,14 @@ func ExtractJavalin(ctx PatternContext) PatternResult {
 	seen := make(map[string]bool)
 	seenRels := make(map[relKey]bool)
 
+	// File-level auth posture: an AccessManager wired on the app means EVERY
+	// route is gated through it. Routes that carry an explicit roles(...) set get
+	// a high-confidence role policy; routes with no inline roles inherit a
+	// low-confidence "auth required" posture (the AccessManager decides at
+	// runtime). Without an AccessManager and without inline roles we stamp
+	// nothing (honest-partial).
+	hasAccessManager := javalinAccessManagerRE.MatchString(ctx.Source)
+
 	// ---------------------------------------------------------------------------
 	// Route extraction + handler attribution
 	// ---------------------------------------------------------------------------
@@ -135,6 +200,32 @@ func ExtractJavalin(ctx PatternContext) PatternResult {
 		verb := strings.ToUpper(rawVerb)
 		ref := fmt.Sprintf("javalin:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
 
+		props := map[string]any{
+			"http_verb":  verb,
+			"path":       rawPath,
+			"framework":  "javalin",
+			"route_type": "lambda_dsl",
+		}
+
+		// Auth: inline roles(...) guard on this route registration, scanned from
+		// the route's own statement (path → end of statement).
+		if roles := javalinRouteRoles(ctx.Source, idx[5]); len(roles) > 0 {
+			authStamp{
+				required:   true,
+				method:     "middleware",
+				confidence: "high",
+				guard:      "roles(" + strings.Join(roles, ",") + ")",
+				roles:      roles,
+			}.stamp(props)
+		} else if hasAccessManager {
+			authStamp{
+				required:   true,
+				method:     "middleware",
+				confidence: "low",
+				guard:      "accessManager",
+			}.stamp(props)
+		}
+
 		e := SecondaryEntity{
 			Name:       rawPath,
 			Kind:       "Route",
@@ -142,12 +233,7 @@ func ExtractJavalin(ctx PatternContext) PatternResult {
 			LineStart:  lineOf(ctx.Source, idx[0]),
 			Provenance: "INFERRED_FROM_JAVALIN_ROUTE",
 			Ref:        ref,
-			Properties: map[string]any{
-				"http_verb":  verb,
-				"path":       rawPath,
-				"framework":  "javalin",
-				"route_type": "lambda_dsl",
-			},
+			Properties: props,
 		}
 		addEntity(&result, seen, e)
 

--- a/internal/custom/java/spring_graphql.go
+++ b/internal/custom/java/spring_graphql.go
@@ -95,6 +95,7 @@ var (
 	//   @SubscriptionMapping Flux<Event> events() {
 	reSpringGQLMapping = regexp.MustCompile(
 		`(?s)@(QueryMapping|MutationMapping|SubscriptionMapping)\b\s*(\([^)]*\))?\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
@@ -103,18 +104,24 @@ var (
 	// group 2 = method name (used as the field fallback when field= absent).
 	reSpringSchemaMapping = regexp.MustCompile(
 		`(?s)@SchemaMapping\b\s*(\([^)]*\))?\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
 	// Netflix DGS shorthand annotations whose operation is fixed by name.
+	// The (?:@\w+...)* segment tolerates a security annotation
+	// (@Secured / @PreAuthorize / @RolesAllowed) interleaved between the DGS
+	// mapping annotation and the resolver method (#3862).
 	reDgsShorthand = regexp.MustCompile(
 		`(?s)@(DgsQuery|DgsMutation|DgsSubscription)\b\s*(\([^)]*\))?\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
 	// Netflix DGS general @DgsData(parentType="Query", field="x").
 	reDgsData = regexp.MustCompile(
 		`(?s)@DgsData\b\s*(\([^)]*\))?\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
@@ -159,6 +166,186 @@ func firstArg(re *regexp.Regexp, args string) string {
 	return ""
 }
 
+// Spring Security annotation regexes used to gate GraphQL resolver methods.
+var (
+	gqlSecuredRE      = regexp.MustCompile(`@Secured\s*\(\s*([^)]*)\)`)
+	gqlPreAuthorizeRE = regexp.MustCompile(`@PreAuthorize\s*\(\s*"([^"]*)"\s*\)`)
+	gqlRolesAllowedRE = regexp.MustCompile(`@RolesAllowed\s*\(\s*([^)]*)\)`)
+	gqlPermitAllRE    = regexp.MustCompile(`@PermitAll\b`)
+	gqlQuotedRE       = regexp.MustCompile(`"([^"]+)"`)
+	gqlSpELRoleRE     = regexp.MustCompile(`(?:hasRole|hasAnyRole)\s*\(\s*([^)]+)\)`)
+	gqlSpELAuthRE     = regexp.MustCompile(`(?:hasAuthority|hasAnyAuthority)\s*\(\s*([^)]+)\)`)
+	gqlSpELQuotedRE   = regexp.MustCompile(`['"]([^'"]+)['"]`)
+)
+
+// gqlMethodAuth resolves the auth posture of a GraphQL resolver method from the
+// Spring Security annotations in the annotation block that decorates it.
+// `mapOffset` is the start offset of the resolver's mapping annotation
+// (@DgsQuery / @QueryMapping / ...); security annotations sit adjacent to it, so
+// we scan a window from a few lines before the mapping annotation up to the
+// method's opening paren. Returns the zero authStamp (method == "") when no
+// security annotation is present — an unauthenticated resolver stamps nothing.
+//
+// Mirrors the Spring MVC contract: @Secured/@PreAuthorize roles strip the
+// ROLE_ prefix; @PreAuthorize hasAuthority splits into scopes/permissions;
+// @PermitAll marks the operation explicitly public.
+func gqlMethodAuth(src string, mapOffset int, _ string) authStamp {
+	// The auth annotations for this resolver live in the contiguous annotation
+	// block that decorates the method: a run of `@Annotation(...)` tokens
+	// (possibly multi-line) ending at the method declaration. We collect that
+	// block starting from the mapping annotation (mapOffset) and walking forward
+	// over annotation tokens and modifiers until the method's return type +
+	// name + '(' — stopping BEFORE the next method so we never bleed across
+	// resolvers.
+	window := gqlMethodAnnotationBlock(src, mapOffset)
+
+	if gqlPermitAllRE.MatchString(window) {
+		return authStamp{required: false, method: "annotation", confidence: "high", guard: "PermitAll"}
+	}
+	var roles, scopes, perms []string
+	guard := ""
+	// @Secured("ROLE_ADMIN")
+	if m := gqlSecuredRE.FindStringSubmatch(window); m != nil {
+		guard = "Secured"
+		for _, q := range gqlQuotedRE.FindAllStringSubmatch(m[1], -1) {
+			classifyAuthority(q[1], &roles, &scopes, &perms)
+		}
+	}
+	// @RolesAllowed({"ADMIN"})
+	if m := gqlRolesAllowedRE.FindStringSubmatch(window); m != nil {
+		if guard == "" {
+			guard = "RolesAllowed"
+		}
+		for _, q := range gqlQuotedRE.FindAllStringSubmatch(m[1], -1) {
+			roles = append(roles, q[1])
+		}
+	}
+	// @PreAuthorize("hasRole('ADMIN') and hasAuthority('SCOPE_read')")
+	if m := gqlPreAuthorizeRE.FindStringSubmatch(window); m != nil {
+		if guard == "" {
+			guard = "PreAuthorize"
+		}
+		expr := m[1]
+		for _, rm := range gqlSpELRoleRE.FindAllStringSubmatch(expr, -1) {
+			for _, q := range gqlSpELQuotedRE.FindAllStringSubmatch(rm[1], -1) {
+				roles = append(roles, strings.TrimPrefix(q[1], "ROLE_"))
+			}
+		}
+		for _, am := range gqlSpELAuthRE.FindAllStringSubmatch(expr, -1) {
+			for _, q := range gqlSpELQuotedRE.FindAllStringSubmatch(am[1], -1) {
+				classifyAuthority(q[1], &roles, &scopes, &perms)
+			}
+		}
+	}
+	if guard == "" {
+		return authStamp{}
+	}
+	return authStamp{
+		required: true, method: "annotation", confidence: "high",
+		guard: guard, roles: roles, scopes: scopes, permissions: perms,
+	}
+}
+
+// gqlMethodAnnotationBlock returns the source span of the annotation block that
+// decorates the resolver method whose mapping annotation begins at mapOffset.
+// It walks BACK from mapOffset over any preceding annotation lines (so a
+// @PreAuthorize placed above the @DgsQuery is included) until a statement
+// boundary ('}' / ';' closing the previous member), and FORWARD from mapOffset
+// to the method's own parameter-list '(' (skipping annotation argument parens),
+// so a @Secured placed between @DgsQuery and the method is included — without
+// ever spilling into the next or previous resolver.
+func gqlMethodAnnotationBlock(src string, mapOffset int) string {
+	// Backward: stop at the nearest preceding '}' or ';' (end of the prior
+	// member). Everything after it up to mapOffset is leading annotations.
+	start := mapOffset
+	for i := mapOffset - 1; i >= 0; i-- {
+		if src[i] == '}' || src[i] == ';' || src[i] == '{' {
+			start = i + 1
+			break
+		}
+		if i == 0 {
+			start = 0
+		}
+	}
+	// Forward: from mapOffset, find the method param-list '(' at paren depth 0,
+	// skipping balanced annotation argument lists.
+	end := mapOffset
+	for end < len(src) {
+		c := src[end]
+		if c == '(' {
+			// Is this paren an annotation argument list? It is when the token
+			// chain immediately before it traces back to an '@name'. We detect a
+			// simpler sufficient condition: the identifier before '(' is preceded
+			// (ignoring whitespace/identifier chars) by '@'. If so, skip the
+			// balanced parens; otherwise this is the method param list.
+			if gqlIsAnnotationParen(src, start, end) {
+				end = gqlSkipBalancedParens(src, end)
+				continue
+			}
+			break
+		}
+		if c == '{' || c == ';' || c == '}' {
+			break
+		}
+		end++
+	}
+	if end > len(src) {
+		end = len(src)
+	}
+	if start > end {
+		start = end
+	}
+	return src[start:end]
+}
+
+// gqlIsAnnotationParen reports whether the '(' at parenPos opens an annotation
+// argument list (rather than a method parameter list). It walks back over the
+// identifier preceding the paren; if that identifier is immediately preceded by
+// '@' it is an annotation invocation.
+func gqlIsAnnotationParen(src string, lo, parenPos int) bool {
+	i := parenPos - 1
+	for i >= lo && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r') {
+		i--
+	}
+	// Skip the identifier characters.
+	end := i
+	for i >= lo && (isWordByte(src[i])) {
+		i--
+	}
+	if end == i { // no identifier before '('
+		return false
+	}
+	// Skip whitespace between '@' and the annotation name.
+	for i >= lo && (src[i] == ' ' || src[i] == '\t') {
+		i--
+	}
+	return i >= lo && src[i] == '@'
+}
+
+// gqlSkipBalancedParens returns the offset just past the matching ')' for the
+// '(' at open. Falls back to open+1 on imbalance.
+func gqlSkipBalancedParens(src string, open int) int {
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return open + 1
+}
+
+// isWordByte reports whether b is a Java identifier byte.
+func isWordByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 // ExtractSpringGraphQL emits canonical GraphQL operation endpoints for Spring
 // for GraphQL and Netflix DGS resolver methods, plus a HANDLES edge from each
 // endpoint to its resolver method.
@@ -200,6 +387,24 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 		path := "/graphql/" + operation + "/" + field
 		name := "GRAPHQL " + path
 
+		endpointProps := map[string]any{
+			"framework":         framework,
+			"http_method":       "GRAPHQL",
+			"verb":              "GRAPHQL",
+			"route_path":        path,
+			"path":              path,
+			"graphql_operation": operation,
+			"graphql_root":      owner,
+			"graphql_field":     field,
+			"resolver_method":   methodName,
+			"handler_name":      handlerName,
+		}
+		// Auth (#3862, DGS/Spring-for-GraphQL): @Secured / @PreAuthorize /
+		// @RolesAllowed on the resolver method (Spring Security under DGS) gate
+		// the GraphQL operation endpoint. Resolve the method's annotation block
+		// and stamp the flat auth contract on the endpoint, matching Spring MVC.
+		gqlMethodAuth(src, offset, owner+"."+methodName).stamp(endpointProps)
+
 		endpointRef := "scope:operation:" + framework + "_endpoint:" + fp + ":" + operation + "." + field
 		addEntity(&result, seenEnt, SecondaryEntity{
 			Name:       name,
@@ -210,18 +415,7 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 			LineEnd:    lineNo,
 			Provenance: provenance,
 			Ref:        endpointRef,
-			Properties: map[string]any{
-				"framework":         framework,
-				"http_method":       "GRAPHQL",
-				"verb":              "GRAPHQL",
-				"route_path":        path,
-				"path":              path,
-				"graphql_operation": operation,
-				"graphql_root":      owner,
-				"graphql_field":     field,
-				"resolver_method":   methodName,
-				"handler_name":      handlerName,
-			},
+			Properties: endpointProps,
 		})
 
 		// Resolver-method entity + HANDLES edge (endpoint → resolver).

--- a/internal/custom/java/struts_routes.go
+++ b/internal/custom/java/struts_routes.go
@@ -114,6 +114,26 @@ var (
 	strutsSecurityInterceptorRE = regexp.MustCompile(
 		`(?i)(?:security|auth(?:entication|orization)?|login)\s*interceptor`)
 
+	// Auth: the built-in Struts 2 `roles` interceptor reference in struts.xml,
+	// e.g. <interceptor-ref name="roles">. This is the canonical declarative
+	// role gate. Presence inside a <package>/<action> means those actions require
+	// the roles declared in the interceptor's allowedRoles / disallowedRoles
+	// params.
+	strutsRolesInterceptorRefRE = regexp.MustCompile(
+		`(?s)<interceptor-ref\b[^>]*\bname\s*=\s*"roles"[^>]*>(.*?)</interceptor-ref>`)
+
+	// Auth: a <param name="allowedRoles">ADMIN,USER</param> inside the roles
+	// interceptor-ref. Capture group 1 = the comma-separated role list.
+	strutsAllowedRolesParamRE = regexp.MustCompile(
+		`(?s)<param\b[^>]*\bname\s*=\s*"allowedRoles"[^>]*>\s*([^<]*?)\s*</param>`)
+
+	// Auth: @Action with a security interceptor stack referenced via
+	// interceptorRefs, e.g.
+	//   @Action(value="/admin", interceptorRefs={@InterceptorRef("secureStack")})
+	// We treat a referenced stack whose name names auth/security/roles as a gate.
+	strutsActionInterceptorRefRE = regexp.MustCompile(
+		`(?i)@InterceptorRef\s*\(\s*"([^"]*(?:secure|security|auth|roles|login)[^"]*)"`)
+
 	// ActionSupport subclass — the canonical Struts 2 action base class.
 	strutsActionSupportRE = regexp.MustCompile(
 		`\bextends\s+ActionSupport\b`)
@@ -282,6 +302,19 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 		}
 	}
 
+	// File-level auth posture for annotation routes (#3862). Struts has no
+	// intrinsic auth; protection comes from a security/roles interceptor in the
+	// stack. We recognise an @InterceptorRef naming a secure/auth/roles stack as
+	// a gate (low confidence — the stack contents live in struts.xml). Honest-
+	// partial: an action file with no such ref stamps nothing.
+	annotationAuth := authStamp{}
+	if m := strutsActionInterceptorRefRE.FindStringSubmatch(ctx.Source); m != nil {
+		annotationAuth = authStamp{
+			required: true, method: "middleware", confidence: "low",
+			guard: "interceptor:" + m[1],
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Route extraction: @Action annotation
 	// -------------------------------------------------------------------------
@@ -293,6 +326,14 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 		fullPath := joinStrutsPath(namespace, rawPath)
 		ref := fmt.Sprintf("struts:route:GET:%s:%s", fullPath, ctx.FilePath)
 
+		props := map[string]any{
+			"http_verb":  "ANY",
+			"path":       fullPath,
+			"framework":  "struts",
+			"route_type": "annotation",
+		}
+		annotationAuth.stamp(props)
+
 		e := SecondaryEntity{
 			Name:       fullPath,
 			Kind:       "Route",
@@ -300,12 +341,7 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 			LineStart:  lineOf(ctx.Source, idx[0]),
 			Provenance: "INFERRED_FROM_STRUTS_ACTION_ANNOTATION",
 			Ref:        ref,
-			Properties: map[string]any{
-				"http_verb":  "ANY",
-				"path":       fullPath,
-				"framework":  "struts",
-				"route_type": "annotation",
-			},
+			Properties: props,
 		}
 		addEntity(&result, seen, e)
 
@@ -340,6 +376,10 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 	// Route extraction: struts.xml <action> elements (XML-only path)
 	// -------------------------------------------------------------------------
 	if isXML {
+		// Resolve the file-level roles-interceptor posture: a <interceptor-ref
+		// name="roles"> with an allowedRoles param gates the package's actions.
+		xmlAuth := strutsXMLRolesAuth(ctx.Source)
+
 		pkgs := parseStrutsXML(ctx.Source)
 		for _, pkg := range pkgs {
 			ns := pkg.Namespace
@@ -355,6 +395,18 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 				}
 				ref := fmt.Sprintf("struts:route:xml:%s:%s", fullPath, ctx.FilePath)
 
+				props := map[string]any{
+					"http_verb":     "ANY",
+					"path":          fullPath,
+					"framework":     "struts",
+					"route_type":    "xml_config",
+					"action_class":  action.Class,
+					"action_method": method,
+					"package_name":  pkg.Name,
+					"namespace":     ns,
+				}
+				xmlAuth.stamp(props)
+
 				e := SecondaryEntity{
 					Name:       fullPath,
 					Kind:       "Route",
@@ -362,16 +414,7 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 					LineStart:  1,
 					Provenance: "INFERRED_FROM_STRUTS_XML_ACTION",
 					Ref:        ref,
-					Properties: map[string]any{
-						"http_verb":     "ANY",
-						"path":          fullPath,
-						"framework":     "struts",
-						"route_type":    "xml_config",
-						"action_class":  action.Class,
-						"action_method": method,
-						"package_name":  pkg.Name,
-						"namespace":     ns,
-					},
+					Properties: props,
 				}
 				addEntity(&result, seen, e)
 
@@ -559,6 +602,30 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 	extractStrutsRequestValidation(ctx, &result, seen)
 
 	return result
+}
+
+// strutsXMLRolesAuth resolves the auth posture declared by a Struts 2 `roles`
+// interceptor in a struts.xml document. A <interceptor-ref name="roles"> gates
+// the actions in its package; an allowedRoles param names the required roles.
+// Returns the zero authStamp (method == "") when no roles interceptor is
+// present, so a struts.xml with no role gate stamps nothing.
+func strutsXMLRolesAuth(content string) authStamp {
+	m := strutsRolesInterceptorRefRE.FindStringSubmatch(content)
+	if m == nil {
+		return authStamp{}
+	}
+	var roles []string
+	if pm := strutsAllowedRolesParamRE.FindStringSubmatch(m[1]); pm != nil {
+		for _, r := range strings.Split(pm[1], ",") {
+			if r = strings.TrimSpace(r); r != "" {
+				roles = append(roles, r)
+			}
+		}
+	}
+	return authStamp{
+		required: true, method: "middleware", confidence: "high",
+		guard: "roles-interceptor", roles: roles,
+	}
 }
 
 // joinStrutsPath joins a namespace prefix with an action path, ensuring

--- a/internal/custom/java/vertx_routes.go
+++ b/internal/custom/java/vertx_routes.go
@@ -120,6 +120,53 @@ var (
 			`void\s+(\w+)\s*\(`)
 )
 
+// vertxRolesAllowedRE matches @RolesAllowed({"ADMIN"}) / @RolesAllowed("ADMIN")
+// when a Vert.x app layers JAX-RS-style authorization annotations on handlers.
+var vertxRolesAllowedRE = regexp.MustCompile(`@RolesAllowed\s*\(\s*([^)]*)\)`)
+
+// vertxAuthTokenRE pulls quoted role tokens from a @RolesAllowed argument list.
+var vertxAuthTokenRE = regexp.MustCompile(`"([^"]+)"`)
+
+// vertxFileAuth resolves the file-level auth posture for a Vert.x router source:
+// the auth mechanism (jwt > oauth2 > basic, in decreasing specificity) wired via
+// an AuthenticationHandler, plus any @RolesAllowed roles. Returns the zero
+// authStamp (method == "") when the file carries no recognised auth handler /
+// annotation, so an unprotected router stamps nothing.
+func vertxFileAuth(source string) authStamp {
+	var roles []string
+	for _, m := range vertxRolesAllowedRE.FindAllStringSubmatch(source, -1) {
+		for _, t := range vertxAuthTokenRE.FindAllStringSubmatch(m[1], -1) {
+			roles = append(roles, t[1])
+		}
+	}
+
+	switch {
+	case vertxJWTAuthRE.MatchString(source):
+		return authStamp{
+			required: true, method: "middleware", confidence: "medium",
+			guard: "JWTAuthHandler", mechanism: "jwt", roles: roles,
+		}
+	case vertxOAuth2RE.MatchString(source):
+		return authStamp{
+			required: true, method: "middleware", confidence: "medium",
+			guard: "OAuth2AuthHandler", mechanism: "oauth2", roles: roles,
+		}
+	case vertxBasicAuthRE.MatchString(source):
+		return authStamp{
+			required: true, method: "middleware", confidence: "medium",
+			guard: "BasicAuthHandler", mechanism: "basic", roles: roles,
+		}
+	case len(roles) > 0:
+		// @RolesAllowed present without an explicit handler create() call (the
+		// handler may be wired in another file) — still a real role requirement.
+		return authStamp{
+			required: true, method: "annotation", confidence: "medium",
+			guard: "RolesAllowed", roles: roles,
+		}
+	}
+	return authStamp{}
+}
+
 // ExtractVertx runs the Vert.x extractor for route, middleware, DTO, auth,
 // and test-linkage patterns.
 func ExtractVertx(ctx PatternContext) PatternResult {
@@ -137,6 +184,16 @@ func ExtractVertx(ctx PatternContext) PatternResult {
 
 	seen := make(map[string]bool)
 	seenRels := make(map[relKey]bool)
+
+	// File-level auth posture (#3862). A Vert.x AuthenticationHandler mounted on
+	// the router protects the routes that follow it on the same router. Detecting
+	// the precise route-subtree a handler guards is beyond single-file regex, so
+	// we resolve a file-level mechanism (jwt/basic/oauth2) and stamp every route
+	// in the file with that posture — a router file that wires JWTAuthHandler is
+	// gating its routes. Honest-partial: confidence is "medium" (mechanism is
+	// certain, per-route attribution is not), and a file with NO auth handler
+	// stamps nothing.
+	fileAuth := vertxFileAuth(ctx.Source)
 
 	// ---------------------------------------------------------------------------
 	// Route extraction + handler attribution
@@ -158,6 +215,14 @@ func ExtractVertx(ctx PatternContext) PatternResult {
 
 		ref := fmt.Sprintf("vertx:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
 
+		props := map[string]any{
+			"http_verb":  verb,
+			"path":       rawPath,
+			"framework":  "vertx",
+			"route_type": "lambda_dsl",
+		}
+		fileAuth.stamp(props)
+
 		e := SecondaryEntity{
 			Name:       rawPath,
 			Kind:       "Route",
@@ -165,12 +230,7 @@ func ExtractVertx(ctx PatternContext) PatternResult {
 			LineStart:  lineOf(ctx.Source, idx[0]),
 			Provenance: "INFERRED_FROM_VERTX_ROUTE",
 			Ref:        ref,
-			Properties: map[string]any{
-				"http_verb":  verb,
-				"path":       rawPath,
-				"framework":  "vertx",
-				"route_type": "lambda_dsl",
-			},
+			Properties: props,
 		}
 		addEntity(&result, seen, e)
 


### PR DESCRIPTION
## Closes #3862 (epic #3854) — DEPLOY-DEFERRED

Mirrors the Spring/JAX-RS **flat auth-policy contract** on the route/endpoint entities of the JVM web frameworks whose `Auth/auth_coverage` cell was red: **Javalin, Vert.x, Akka-HTTP, Apache Struts, Dropwizard, Netflix DGS**.

### Contract
New `internal/custom/java/framework_auth.go` provides `authStamp.stamp`, writing the EXACT flat fields Spring writes — `auth_required`, `auth_method`, `auth_confidence`, `auth_guard`, `auth_mechanism`, `auth_roles` / `auth_scopes` / `auth_permissions` — onto the entity `Properties`. `archigraph_auth_coverage` reads `auth_guard` (so these endpoints now count as covered) and the dashboard sees an identical shape across languages. **Honest-partial**: a posture is stamped ONLY when a concrete static auth signal applies; dynamic/unclear protection is left unstamped (`auth_required` absent).

### Per framework
| Framework | Signal → props |
|---|---|
| **Javalin** | inline `roles(Role.ADMIN)` route guard → `auth_required` + `auth_roles` (high); `accessManager` → `auth_required` (low) |
| **Vert.x** | `JWTAuthHandler`/`OAuth2AuthHandler`/`BasicAuthHandler` → `auth_required` + `auth_mechanism`; `@RolesAllowed` → `auth_roles` |
| **Akka-HTTP** | `authenticateOAuth2`/`authenticateBasic` directive → `auth_required` + `auth_mechanism`; `authorize(hasRole('X'))` → `auth_roles` |
| **Struts** | struts.xml `roles` interceptor (`allowedRoles`) → `auth_required` + `auth_roles` (high); `@InterceptorRef` secure/auth/roles stack → `auth_required` (low) |
| **Dropwizard** | `@RolesAllowed`/`@Authenticated`/`@Auth` principal injection stamp `auth_guard` (+ `auth_roles`); JAX-RS annotations also flow through engine `ResolveJavaAuthPolicy` |
| **Netflix DGS** | `@Secured`/`@PreAuthorize`/`@RolesAllowed`/`@PermitAll` on a `@DgsQuery`/`@DgsMutation` resolver → Spring-compatible contract on the synthesized GRAPHQL endpoint (ROLE_/SCOPE_ split). DGS/Spring-GraphQL mapping regexes now tolerate an interleaved security annotation |

### Tests
`framework_auth_test.go` — value-asserting tests assert the auth props on the **specific named-framework endpoint** (e.g. Javalin `roles(Role.ADMIN)` on `/admin` → `auth_required=true auth_roles=ADMIN`; Vert.x `JWTAuthHandler` → `auth_mechanism=jwt`; Akka `authenticateOAuth2` → `auth_required=true`; DGS `@PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write'))` → `auth_roles=MANAGER auth_scopes=write`), plus a **negative unprotected** case per framework.

### Registry / docs
`Auth/auth_coverage` flipped **missing → partial** for akka-http, dgs, dropwizard, javalin, struts, vertx (+ kotlin javalin, shared extractor), each citing the extractor. Docs regenerated; registry canonical (`fmt --check` ok); `validate` 0 errors.

### Verification
`go test ./internal/custom/java/ ./internal/engine/ ./internal/types/ ./internal/mcp/ ./tools/coverage/` green; `go test ./internal/types/` green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors + `fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)