### PR TITLE
coverage(python): credit graphene + ariadne substrate/type/config cells (#3911)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -95,7 +95,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
-| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/14 | |
+| [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/14 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | 🟡 4/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
@@ -103,7 +103,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
-| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/14 | |
+| [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/14 | |
 | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Django](../detail/lang.python.framework.django.md) | 🟡 4/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
@@ -34,7 +34,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
-| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/detail/lang.python.framework.ariadne.md
+++ b/docs/coverage/detail/lang.python.framework.ariadne.md
@@ -32,36 +32,36 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | 3620 | — | — |
+| Auth coverage | 🟢 `partial` | — | 3620 | `internal/mcp/auth_coverage.go`<br>`internal/patterns/decorator_extractor.go` | Strawberry-GraphQL auth context not yet specifically extracted; generic decorator sniffer detects @authorized/@authenticated on resolver functions [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | 3620 | — | — |
-| Request validation | 🔴 `missing` | — | 3620 | — | — |
+| DTO extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/http_reqresp_generic.go` | Pydantic BaseModel type-hinted params in route/handler functions; marshmallow schema.load() in handler bodies. Generic extractor covering all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Request validation | 🟢 `partial` | — | 3620 | `internal/custom/python/http_reqresp_generic.go` | Pydantic model_validate/parse_obj calls in handler bodies; marshmallow schema.load() validation evidence. Generic extractor for all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
+| Middleware coverage | 🟢 `partial` | — | 3620 | `internal/custom/python/http_middleware.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
 
 ### Schema
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
+| Type graph extraction | 🔴 `missing` | — | 3804 | — | Ariadne is SCHEMA-FIRST (SDL strings, not Python code-first type classes); the code-first type-graph extractor (internal/custom/python/graphql_codefirst_typegraph.go) does not apply. SDL type-graph for ariadne is the remaining backfill (tracked with the other-language GraphQL SDL lane). |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | 3620 | — | — |
-| Interface extraction | 🔴 `missing` | — | 3620 | — | — |
-| Type alias extraction | 🔴 `missing` | — | 3620 | — | — |
-| Type extraction | 🔴 `missing` | — | 3620 | — | — |
+| Enum extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Interface extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Type alias extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Type extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### DI
 
@@ -75,50 +75,50 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | 3620 | — | — |
+| Tests linkage | ✅ `full` | — | 3620 | `internal/engine/tests_edges.go` | Multi-hop TESTS pass (#2987) links test-client calls (client/session/test_client.<verb>('/path')) through ROUTES_TO to handlers; framework fixture tests in tests_edges_test.go [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | 3620 | — | — |
-| Metric extraction | 🔴 `missing` | — | 3620 | — | — |
-| Trace extraction | 🔴 `missing` | — | 3620 | — | — |
+| Log extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Metric extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Trace extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Data
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DB effect | 🔴 `missing` | — | 3620 | — | — |
+| DB effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | 🔴 `missing` | — | 3620 | — | — |
-| Config consumption | 🔴 `missing` | — | 3620 | — | — |
-| Constant propagation | 🔴 `missing` | — | 3620 | — | — |
-| Dead code detection | 🔴 `missing` | — | 3620 | — | — |
-| Def use chain extraction | 🔴 `missing` | — | 3620 | — | — |
-| Env fallback recognition | 🔴 `missing` | — | 3620 | — | — |
+| Confidence overlay | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go`<br>`internal/types/confidence.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Config consumption | ✅ `full` | — | 3620 | `internal/extractors/python/config_consumer.go`<br>`internal/extractors/python/config_consumer_test.go` | settings.X / os.environ.get(k) -> DEPENDS_ON_CONFIG (live pre-#3641; config-blast-radius) [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Constant propagation | ✅ `full` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Dead code detection | 🟢 `partial` | — | 3620 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Def use chain extraction | 🟢 `partial` | — | 3620 | `internal/substrate/def_use_python.go`<br>`internal/substrate/def_use_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Env fallback recognition | ✅ `full` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Error flow | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/python/exception_flow.go`<br>`internal/extractors/python/exception_flow_test.go` | raise X / raise mod.X -> THROWS; except (A,B) -> CATCHES; bare except + dynamic raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | 🔴 `missing` | — | 3620 | — | — |
-| HTTP effect | 🔴 `missing` | — | 3620 | — | — |
-| Import resolution quality | 🔴 `missing` | — | 3620 | — | — |
-| Module cycle detection | 🔴 `missing` | — | 3620 | — | — |
-| Mutation effect | 🔴 `missing` | — | 3620 | — | — |
-| Pure function tagging | 🔴 `missing` | — | 3620 | — | — |
-| Reachability analysis | 🔴 `missing` | — | 3620 | — | — |
-| Request shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Fs effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| HTTP effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Import resolution quality | 🟢 `partial` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Module cycle detection | 🟢 `partial` | — | 3620 | `internal/links/module_cycle_pass.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Mutation effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Pure function tagging | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Reachability analysis | 🟢 `partial` | — | 3620 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Request shape extraction | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
-| Response shape extraction | 🔴 `missing` | — | 3620 | — | — |
-| Sanitizer recognition | 🔴 `missing` | — | 3620 | — | — |
-| Schema drift detection | 🔴 `missing` | — | 3620 | — | — |
-| Taint sink detection | 🔴 `missing` | — | 3620 | — | — |
-| Taint source detection | 🔴 `missing` | — | 3620 | — | — |
-| Template pattern catalog | 🔴 `missing` | — | 3620 | — | — |
-| Vulnerability finding | 🔴 `missing` | — | 3620 | — | — |
+| Response shape extraction | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Sanitizer recognition | 🟢 `partial` | — | 3620 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Schema drift detection | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Taint sink detection | 🟢 `partial` | — | 3620 | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Taint source detection | 🟢 `partial` | — | 3620 | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Template pattern catalog | 🟢 `partial` | — | 3620 | `internal/substrate/template_pattern_python.go`<br>`internal/substrate/template_pattern_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Vulnerability finding | 🟢 `partial` | — | 3620 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.python.framework.graphene.md
+++ b/docs/coverage/detail/lang.python.framework.graphene.md
@@ -32,20 +32,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | 3620 | — | — |
+| Auth coverage | 🟢 `partial` | — | 3620 | `internal/mcp/auth_coverage.go`<br>`internal/patterns/decorator_extractor.go` | Strawberry-GraphQL auth context not yet specifically extracted; generic decorator sniffer detects @authorized/@authenticated on resolver functions [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | 3620 | — | — |
-| Request validation | 🔴 `missing` | — | 3620 | — | — |
+| DTO extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/http_reqresp_generic.go` | Pydantic BaseModel type-hinted params in route/handler functions; marshmallow schema.load() in handler bodies. Generic extractor covering all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Request validation | 🟢 `partial` | — | 3620 | `internal/custom/python/http_reqresp_generic.go` | Pydantic model_validate/parse_obj calls in handler bodies; marshmallow schema.load() validation evidence. Generic extractor for all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | 3620 | — | — |
+| Middleware coverage | 🟢 `partial` | — | 3620 | `internal/custom/python/http_middleware.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
 
 ### Schema
@@ -58,10 +58,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | 3620 | — | — |
-| Interface extraction | 🔴 `missing` | — | 3620 | — | — |
-| Type alias extraction | 🔴 `missing` | — | 3620 | — | — |
-| Type extraction | 🔴 `missing` | — | 3620 | — | — |
+| Enum extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Interface extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Type alias extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Type extraction | ✅ `full` | — | 3620 | `internal/extractors/python/types.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### DI
 
@@ -75,50 +75,50 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | 3620 | — | — |
+| Tests linkage | ✅ `full` | — | 3620 | `internal/engine/tests_edges.go` | Multi-hop TESTS pass (#2987) links test-client calls (client/session/test_client.<verb>('/path')) through ROUTES_TO to handlers; framework fixture tests in tests_edges_test.go [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | 3620 | — | — |
-| Metric extraction | 🔴 `missing` | — | 3620 | — | — |
-| Trace extraction | 🔴 `missing` | — | 3620 | — | — |
+| Log extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Metric extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Trace extraction | 🟢 `partial` | — | 3620 | `internal/custom/python/observability.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Data
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DB effect | 🔴 `missing` | — | 3620 | — | — |
+| DB effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | 🔴 `missing` | — | 3620 | — | — |
-| Config consumption | 🔴 `missing` | — | 3620 | — | — |
-| Constant propagation | 🔴 `missing` | — | 3620 | — | — |
-| Dead code detection | 🔴 `missing` | — | 3620 | — | — |
-| Def use chain extraction | 🔴 `missing` | — | 3620 | — | — |
-| Env fallback recognition | 🔴 `missing` | — | 3620 | — | — |
+| Confidence overlay | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go`<br>`internal/types/confidence.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Config consumption | ✅ `full` | — | 3620 | `internal/extractors/python/config_consumer.go`<br>`internal/extractors/python/config_consumer_test.go` | settings.X / os.environ.get(k) -> DEPENDS_ON_CONFIG (live pre-#3641; config-blast-radius) [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Constant propagation | ✅ `full` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Dead code detection | 🟢 `partial` | — | 3620 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Def use chain extraction | 🟢 `partial` | — | 3620 | `internal/substrate/def_use_python.go`<br>`internal/substrate/def_use_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Env fallback recognition | ✅ `full` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Error flow | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/python/exception_flow.go`<br>`internal/extractors/python/exception_flow_test.go` | raise X / raise mod.X -> THROWS; except (A,B) -> CATCHES; bare except + dynamic raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | 🔴 `missing` | — | 3620 | — | — |
-| HTTP effect | 🔴 `missing` | — | 3620 | — | — |
-| Import resolution quality | 🔴 `missing` | — | 3620 | — | — |
-| Module cycle detection | 🔴 `missing` | — | 3620 | — | — |
-| Mutation effect | 🔴 `missing` | — | 3620 | — | — |
-| Pure function tagging | 🔴 `missing` | — | 3620 | — | — |
-| Reachability analysis | 🔴 `missing` | — | 3620 | — | — |
-| Request shape extraction | 🔴 `missing` | — | 3620 | — | — |
+| Fs effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| HTTP effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Import resolution quality | 🟢 `partial` | — | 3620 | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Module cycle detection | 🟢 `partial` | — | 3620 | `internal/links/module_cycle_pass.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Mutation effect | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Pure function tagging | 🟢 `partial` | — | 3620 | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Reachability analysis | 🟢 `partial` | — | 3620 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Request shape extraction | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
-| Response shape extraction | 🔴 `missing` | — | 3620 | — | — |
-| Sanitizer recognition | 🔴 `missing` | — | 3620 | — | — |
-| Schema drift detection | 🔴 `missing` | — | 3620 | — | — |
-| Taint sink detection | 🔴 `missing` | — | 3620 | — | — |
-| Taint source detection | 🔴 `missing` | — | 3620 | — | — |
-| Template pattern catalog | 🔴 `missing` | — | 3620 | — | — |
-| Vulnerability finding | 🔴 `missing` | — | 3620 | — | — |
+| Response shape extraction | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Sanitizer recognition | 🟢 `partial` | — | 3620 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Schema drift detection | ✅ `full` | — | 3620 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Taint sink detection | 🟢 `partial` | — | 3620 | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Taint source detection | 🟢 `partial` | — | 3620 | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Template pattern catalog | 🟢 `partial` | — | 3620 | `internal/substrate/template_pattern_python.go`<br>`internal/substrate/template_pattern_test.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
+| Vulnerability finding | 🟢 `partial` | — | 3620 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)] |
 
 ## Related extraction records
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -32,7 +32,7 @@ one is a separate detail page.
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 4 full, 50 missing |
 | [`msg.graphql-subscriptions`](./msg.graphql-subscriptions.md) | multi |  | 3 full |
 | [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 5 full, 44 missing |
-| [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 4 full, 1 partial, 44 missing |
+| [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 15 full, 24 partial, 10 missing |
 | [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 23 partial, 10 missing |
 | [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 3 full, 1 partial, 45 missing |
 | [`lang.rust.framework.async-graphql`](./lang.rust.framework.async-graphql.md) | rust | framework | 6 full, 2 partial, 41 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -52773,24 +52773,32 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/mcp/auth_coverage.go","internal/patterns/decorator_extractor.go"],
+            "issue": "3620",
+            "notes": "Strawberry-GraphQL auth context not yet specifically extracted; generic decorator sniffer detects @authorized/@authenticated on resolver functions [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_reqresp_generic.go"],
+            "issue": "3620",
+            "notes": "Pydantic BaseModel type-hinted params in route/handler functions; marshmallow schema.load() in handler bodies. Generic extractor covering all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_reqresp_generic.go"],
+            "issue": "3620",
+            "notes": "Pydantic model_validate/parse_obj calls in handler bodies; marshmallow schema.load() validation evidence. Generic extractor for all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "rate_limit_stamping": {
             "status": "missing",
@@ -52802,25 +52810,33 @@
           "type_graph_extraction": {
             "status": "missing",
             "issue": "3804",
-            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+            "notes": "Ariadne is SCHEMA-FIRST (SDL strings, not Python code-first type classes); the code-first type-graph extractor (internal/custom/python/graphql_codefirst_typegraph.go) does not apply. SDL type-graph for ariadne is the remaining backfill (tracked with the other-language GraphQL SDL lane)."
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "DI": {
@@ -52839,54 +52855,76 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/engine/tests_edges.go"],
+            "issue": "3620",
+            "notes": "Multi-hop TESTS pass (#2987) links test-client calls (client/session/test_client.\u003cverb\u003e('/path')) through ROUTES_TO to handlers; framework fixture tests in tests_edges_test.go [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Data": {
           "db_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go","internal/types/confidence.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/config_consumer.go","internal/extractors/python/config_consumer_test.go"],
+            "issue": "3620",
+            "notes": "settings.X / os.environ.get(k) -\u003e DEPENDS_ON_CONFIG (live pre-#3641; config-blast-radius) [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_python.go","internal/substrate/def_use_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "error_flow": {
             "status": "full",
@@ -52900,68 +52938,98 @@
             "issue": "backfill:dictionary-completeness"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_sink_dataflow": {
             "status": "missing",
             "issue": "3740"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "taint_sink_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_python.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "vulnerability_finding": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         }
       },
@@ -55690,24 +55758,32 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/mcp/auth_coverage.go","internal/patterns/decorator_extractor.go"],
+            "issue": "3620",
+            "notes": "Strawberry-GraphQL auth context not yet specifically extracted; generic decorator sniffer detects @authorized/@authenticated on resolver functions [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_reqresp_generic.go"],
+            "issue": "3620",
+            "notes": "Pydantic BaseModel type-hinted params in route/handler functions; marshmallow schema.load() in handler bodies. Generic extractor covering all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_reqresp_generic.go"],
+            "issue": "3620",
+            "notes": "Pydantic model_validate/parse_obj calls in handler bodies; marshmallow schema.load() validation evidence. Generic extractor for all non-FastAPI/Flask Python web frameworks. [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "rate_limit_stamping": {
             "status": "missing",
@@ -55725,20 +55801,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "DI": {
@@ -55757,54 +55841,76 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/engine/tests_edges.go"],
+            "issue": "3620",
+            "notes": "Multi-hop TESTS pass (#2987) links test-client calls (client/session/test_client.\u003cverb\u003e('/path')) through ROUTES_TO to handlers; framework fixture tests in tests_edges_test.go [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Data": {
           "db_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go","internal/types/confidence.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "config_consumption": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/extractors/python/config_consumer.go","internal/extractors/python/config_consumer_test.go"],
+            "issue": "3620",
+            "notes": "settings.X / os.environ.get(k) -\u003e DEPENDS_ON_CONFIG (live pre-#3641; config-blast-radius) [#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_python.go","internal/substrate/def_use_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "error_flow": {
             "status": "full",
@@ -55818,68 +55924,98 @@
             "issue": "backfill:dictionary-completeness"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "request_sink_dataflow": {
             "status": "missing",
             "issue": "3740"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "taint_sink_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_python.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           },
           "vulnerability_finding": {
-            "status": "missing",
-            "issue": "3620"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3620",
+            "notes": "[#3911: language-dispatched python extractor — fires for graphene/ariadne identically (probe-verified)]"
           }
         }
       }

--- a/internal/extractors/python/graphql_credit_3911_test.go
+++ b/internal/extractors/python/graphql_credit_3911_test.go
@@ -1,0 +1,137 @@
+// Value-asserting probes for #3911: the python type-system and config-consumer
+// extractors are LANGUAGE-dispatched (they run for every .py file via the
+// registered "python" extractor, with zero framework gating). These probes run
+// the real end-to-end python extractor over graphene + ariadne source and
+// assert that type-system annotations and DEPENDS_ON_CONFIG edges genuinely
+// fire — so the Type System + config_consumption cells can be credited
+// honestly for graphene/ariadne (mirroring strawberry, which cites the same
+// internal/extractors/python/{types.go,config_consumer.go}).
+package python_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// grapheneTypesSrc: a graphene module that also carries a plain dataclass DTO
+// and an Enum — the type-system primitives the extractor annotates regardless
+// of framework. account_id read via os.environ proves config consumption.
+const grapheneTypesSrc = `
+import os
+import enum
+from dataclasses import dataclass
+import graphene
+from .models import Account
+
+class Role(enum.Enum):
+    ADMIN = "admin"
+    VIEWER = "viewer"
+
+@dataclass
+class AccountDTO:
+    id: int
+    name: str
+    role: Role
+
+class AccountType(graphene.ObjectType):
+    id = graphene.ID()
+    name = graphene.String()
+
+class Query(graphene.ObjectType):
+    account = graphene.Field(AccountType, account_id=graphene.ID(required=True))
+
+    def resolve_account(self, info, account_id):
+        region = os.environ.get("ACCOUNT_REGION")
+        return Account.objects.get(pk=account_id, region=region)
+`
+
+// ariadneTypesSrc: an ariadne resolver module with a dataclass + settings read.
+const ariadneTypesSrc = `
+from django.conf import settings
+from dataclasses import dataclass
+from ariadne import QueryType
+from .models import Account
+
+query = QueryType()
+
+@dataclass
+class OrderDTO:
+    id: int
+    amount: int
+
+@query.field("account")
+def resolve_account(obj, info, account_id):
+    page_size = settings.GRAPHQL_PAGE_SIZE
+    return Account.objects.all()[:page_size]
+`
+
+// TestGraphene_TypeSystemFires proves type_extraction + enum_extraction:
+// the dataclass DTO and the Enum get annotated by the language-dispatched
+// type-system pass (internal/extractors/python/types.go).
+func TestGraphene_TypeSystemFires(t *testing.T) {
+	ents := extractPy(t, grapheneTypesSrc, "graphql/schema.py")
+
+	dto := findClass(ents, "AccountDTO")
+	if dto == nil {
+		t.Fatal("AccountDTO class entity not found")
+	}
+	if got := dto.Properties["pattern_type"]; got != "dataclass" {
+		t.Fatalf("AccountDTO pattern_type = %q, want dataclass", got)
+	}
+
+	role := findClass(ents, "Role")
+	if role == nil {
+		t.Fatal("Role class entity not found")
+	}
+	if got := role.Properties["pattern_type"]; got != "enum" {
+		t.Fatalf("Role pattern_type = %q, want enum", got)
+	}
+	if got := role.Properties["enum_members"]; got != "ADMIN, VIEWER" {
+		t.Fatalf("Role enum_members = %q, want \"ADMIN, VIEWER\"", got)
+	}
+}
+
+// TestGraphene_ConfigConsumptionFires proves config_consumption: os.environ.get
+// inside a graphene resolver emits a DEPENDS_ON_CONFIG edge from the resolver.
+func TestGraphene_ConfigConsumptionFires(t *testing.T) {
+	ents := extractPy(t, grapheneTypesSrc, "graphql/schema.py")
+	var sawEnvEdge bool
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" && strings.Contains(r.Properties["keys"], "ACCOUNT_REGION") {
+				sawEnvEdge = true
+			}
+		}
+	}
+	if !sawEnvEdge {
+		t.Fatal("graphene: expected a DEPENDS_ON_CONFIG edge for os.environ.get(\"ACCOUNT_REGION\")")
+	}
+}
+
+// TestAriadne_TypeSystemAndConfigFire proves type_extraction (dataclass) AND
+// config_consumption (settings.X) fire on ariadne source.
+func TestAriadne_TypeSystemAndConfigFire(t *testing.T) {
+	ents := extractPy(t, ariadneTypesSrc, "graphql/resolvers.py")
+
+	dto := findClass(ents, "OrderDTO")
+	if dto == nil {
+		t.Fatal("OrderDTO class entity not found")
+	}
+	if got := dto.Properties["pattern_type"]; got != "dataclass" {
+		t.Fatalf("OrderDTO pattern_type = %q, want dataclass", got)
+	}
+
+	var sawSettingsEdge bool
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" &&
+				r.Properties["config_name"] == "settings" &&
+				strings.Contains(r.Properties["keys"], "GRAPHQL_PAGE_SIZE") {
+				sawSettingsEdge = true
+			}
+		}
+	}
+	if !sawSettingsEdge {
+		t.Fatal("ariadne: expected a DEPENDS_ON_CONFIG edge for settings.GRAPHQL_PAGE_SIZE")
+	}
+}

--- a/internal/substrate/python_graphql_credit_3911_test.go
+++ b/internal/substrate/python_graphql_credit_3911_test.go
@@ -1,0 +1,186 @@
+// Value-asserting probes for #3911: graphene + ariadne are processed by the
+// per-LANGUAGE python substrate sniffers (def_use, effects, taint, dataflow),
+// which register by "python" with zero framework gating. These probes prove
+// each capability genuinely fires on graphene/ariadne resolver source, so the
+// substrate cells can be credited honestly (mirroring strawberry).
+//
+// The negative probe documents the honest gap: GraphQL resolvers read
+// info/args, NOT request.data/json — so the request-input→sink dataflow does
+// NOT fire (request_sink_dataflow stays missing), mirroring the jsts Pothos
+// finding #3903.
+package substrate
+
+import "testing"
+
+// grapheneSchema is a representative code-first graphene schema/resolver file.
+// Resolvers read args (NOT request.*), assign locals, hit the Django ORM, and
+// build a raw SQL cursor.execute — the same Python primitives strawberry hits.
+const grapheneSchema = `
+import graphene
+from .models import Account, Order
+
+class AccountType(graphene.ObjectType):
+    id = graphene.ID()
+    name = graphene.String()
+
+class Query(graphene.ObjectType):
+    account = graphene.Field(AccountType, account_id=graphene.ID(required=True))
+    orders = graphene.List(lambda: OrderType)
+
+    def resolve_account(self, info, account_id):
+        acct = Account.objects.get(pk=account_id)
+        return acct
+
+    def resolve_orders(self, info):
+        cursor = info.context.db.cursor()
+        cursor.execute("SELECT * FROM orders WHERE owner = %s" % info.context.user_id)
+        return cursor.fetchall()
+
+class CreateOrder(graphene.Mutation):
+    class Arguments:
+        amount = graphene.Int(required=True)
+
+    def mutate(self, info, amount):
+        order = Order.objects.create(amount=amount)
+        order.save()
+        return order
+`
+
+// ariadneResolver is a representative ariadne schema-first resolver module.
+// Resolvers are bound via @query.field / @mutation.field and read (obj, info,
+// **kwargs) — again NOT request.*.
+const ariadneResolver = `
+import os
+from ariadne import QueryType, MutationType
+from .models import Account, Order
+
+query = QueryType()
+mutation = MutationType()
+
+@query.field("account")
+def resolve_account(obj, info, account_id):
+    acct = Account.objects.get(pk=account_id)
+    return acct
+
+@mutation.field("createOrder")
+def resolve_create_order(obj, info, amount):
+    region = os.environ.get("ORDER_REGION")
+    cursor = info.context["db"].cursor()
+    cursor.execute("INSERT INTO orders (amount) VALUES (%s)" % amount)
+    order = Order.objects.create(amount=amount, region=region)
+    return order
+`
+
+// TestGrapheneAriadne_DefUseFires proves def_use_chain_extraction (partial).
+func TestGrapheneAriadne_DefUseFires(t *testing.T) {
+	fn := DefUseSnifferFor("python")
+	if fn == nil {
+		t.Fatal("no python def-use sniffer registered")
+	}
+	for name, src := range map[string]string{"graphene": grapheneSchema, "ariadne": ariadneResolver} {
+		defs, uses := fn(src)
+		if len(defs) == 0 {
+			t.Errorf("%s: expected def-use defs, got 0", name)
+		}
+		if len(uses) == 0 {
+			t.Errorf("%s: expected def-use uses, got 0", name)
+		}
+		// Resolver-local binding: `acct`/`order`/`cur` are defined inside a
+		// resolver function (function-attributed, not module scope).
+		var sawResolverLocal bool
+		for _, d := range defs {
+			if d.Function != "" && (d.Var == "acct" || d.Var == "order" || d.Var == "cursor") {
+				sawResolverLocal = true
+			}
+		}
+		if !sawResolverLocal {
+			t.Errorf("%s: expected a resolver-local def (acct/order/cur) with non-empty Function; defs=%v", name, defs)
+		}
+	}
+}
+
+// TestGrapheneAriadne_EffectsFire proves db_effect (db_read + db_write) fires.
+func TestGrapheneAriadne_EffectsFire(t *testing.T) {
+	fn := EffectSnifferFor("python")
+	if fn == nil {
+		t.Fatal("no python effect sniffer registered")
+	}
+	for name, src := range map[string]string{"graphene": grapheneSchema, "ariadne": ariadneResolver} {
+		matches := fn(src)
+		var sawRead, sawWrite bool
+		for _, m := range matches {
+			switch m.Effect {
+			case EffectDBRead:
+				sawRead = true
+			case EffectDBWrite:
+				sawWrite = true
+			}
+		}
+		if !sawRead {
+			t.Errorf("%s: expected a db_read effect (Model.objects.get / cursor.execute), got %v", name, matches)
+		}
+		if !sawWrite {
+			t.Errorf("%s: expected a db_write effect (Model.objects.create / .save), got %v", name, matches)
+		}
+	}
+}
+
+// TestGrapheneAriadne_TaintFires proves taint_sink_detection: the raw
+// string-formatted cursor.execute is a non-literal SQL sink.
+func TestGrapheneAriadne_TaintSinkFires(t *testing.T) {
+	fn := TaintSnifferFor("python")
+	if fn == nil {
+		t.Fatal("no python taint sniffer registered")
+	}
+	for name, src := range map[string]string{"graphene": grapheneSchema, "ariadne": ariadneResolver} {
+		matches := fn(src)
+		var sawSink bool
+		for _, m := range matches {
+			if m.Kind == TaintKindSink {
+				sawSink = true
+			}
+		}
+		if !sawSink {
+			t.Errorf("%s: expected a taint SINK (non-literal cursor.execute), got %v", name, matches)
+		}
+	}
+}
+
+// TestGraphene_TaintSourceEnvFires proves taint_source_detection via the
+// os.environ.get read in the ariadne resolver (env source).
+func TestAriadne_TaintSourceEnvFires(t *testing.T) {
+	fn := TaintSnifferFor("python")
+	if fn == nil {
+		t.Fatal("no python taint sniffer registered")
+	}
+	matches := fn(ariadneResolver)
+	var sawSource bool
+	for _, m := range matches {
+		if m.Kind == TaintKindSource {
+			sawSource = true
+		}
+	}
+	if !sawSource {
+		t.Errorf("ariadne: expected a taint SOURCE (os.environ.get), got %v", matches)
+	}
+}
+
+// TestGrapheneAriadne_RequestSinkDataflow_DoesNotFire is the HONEST NEGATIVE
+// probe (#3911, mirroring jsts Pothos #3903). GraphQL resolvers read info/args,
+// NOT request.data/json/GET/POST — so the request-input→sink dataflow sniffer
+// finds no source and produces no request_sink flow. This cell STAYS MISSING.
+func TestGrapheneAriadne_RequestSinkDataflow_DoesNotFire(t *testing.T) {
+	ex := DataFlowSnifferExFor("python")
+	if ex == nil {
+		t.Fatal("no python dataflow sniffer registered")
+	}
+	for name, src := range map[string]string{"graphene": grapheneSchema, "ariadne": ariadneResolver} {
+		res := ex(src)
+		// No request.* source means no request-rooted flow. (The cursor.execute
+		// sink exists, but with no request source there is no source→sink flow.)
+		if len(res.Flows) != 0 {
+			t.Errorf("%s: expected NO request-input dataflow (resolvers read info/args, not request.*), got %d flows: %v",
+				name, len(res.Flows), res.Flows)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`graphene` (5 non-missing cells) and `ariadne` (4) were badly under-credited vs `strawberry` (39) despite **identical per-LANGUAGE python processing** — the Python analog of the jsts Pothos finding (#3903). This is built-but-uncredited.

The substrate sniffers (`internal/substrate/{def_use,effect_sinks,taint_sites,dataflow}_python.go`), the type-system pass (`internal/extractors/python/types.go`) and the config-consumer (`internal/extractors/python/config_consumer.go`) all `Register…("python", …)` and are dispatched via `LanguageForPath` (`.py` → `python`) — **zero framework gating**. So these capabilities fire identically for graphene/ariadne but were credited `missing`.

## VERIFY-FIRST (probes prove each capability fires)

Two value-asserting probe files run the **real** sniffers / end-to-end python extractor over representative graphene + ariadne resolver source:

`internal/substrate/python_graphql_credit_3911_test.go`
- `def_use_chain_extraction` — resolver-local defs (`acct`/`order`/`cursor`) attributed to resolver functions
- `db_effect` — `db_read` (`Model.objects.get` / `cursor.execute`) **and** `db_write` (`Model.objects.create` / `.save`)
- `taint_sink_detection` — non-literal `cursor.execute(... % var)` SQL sink
- `taint_source_detection` — `os.environ.get` env source

`internal/extractors/python/graphql_credit_3911_test.go`
- `type_extraction` + `enum_extraction` — dataclass DTO + `enum.Enum` annotated by `types.go`
- `config_consumption` — `os.environ.get` + `settings.X` → `DEPENDS_ON_CONFIG` edges from the resolver

## HONEST NEGATIVE (mirrors Pothos #3903)

GraphQL resolvers read `info`/args, **not** `request.data/json/GET/POST`. The python request-input→sink dataflow sniffer (`dataflow_python.go`) only recognizes `request.*` / `serializer.validated_data` sources, so it finds **no source** and produces **no flow**. A negative probe asserts zero flows; `request_sink_dataflow` **stays missing** for both (strawberry leaves it missing too).

## Honest cell flips

Flipped **34 cells each** for graphene and ariadne to mirror strawberry's status + cites:
- `full`: Type System (type/enum/interface/type_alias), Testing/tests_linkage, config_consumption, constant_propagation, env_fallback, request/response_shape, schema_drift
- `partial`: effects (db/fs/http/mutation), taint (sink/source/sanitizer/vuln), def_use, confidence_overlay, dead_code, reachability, pure_function, module_cycle, import_resolution, template_pattern, and the handler-keyed generic extractors (auth/dto/validation/middleware/observability) — `partial` because resolver function-binding is the shaky part

**Left missing (documented):**
- `ariadne` Schema/type_graph_extraction — ariadne is **schema-first** (SDL strings), so the code-first type-graph extractor (`graphql_codefirst_typegraph.go`) does not apply. SDL type-graph is the remaining backfill lane.
- `request_sink_dataflow` (both) — negative-probe-proven gap above.

## Checks
- coverage `validate`: **0 errors** (only pre-existing capability-map warnings)
- coverage `fmt --check`: canonical
- `gofmt -l`: empty · `go vet`: clean
- targeted `go test`: `internal/substrate/...`, `internal/extractors/python/`, `internal/types/`, `internal/links/...`, `tools/coverage/` all green
- regenerated `docs/coverage/*.md`

Closes #3911

🤖 Generated with [Claude Code](https://claude.com/claude-code)