### PR TITLE
[mongo][deploy-7-P0-B] resolve $lookup in imperatively-built (append/extend) pymongo pipelines (#229/#230)

### DIFF
--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -543,11 +543,25 @@ func mongoAggPyResolvePipeline(src string, openParen, dotPos int) string {
 		switch src[j] {
 		case ')':
 			// Form 2: bare identifier argument (`pipeline`).
-			// (a) nearest preceding `pipeline = [ ... ]` literal binding.
+			// (a) Shape C (#3928): pipeline built IMPERATIVELY in the same function
+			// via `pipeline = []; pipeline.append({...}); pipeline.extend([...])`,
+			// then `coll.aggregate(pipeline)`. Reconstruct it from the init +
+			// append/extend additions preceding the call. Tried FIRST because it
+			// subsumes a list-literal init (an `append`/`extend` after a non-empty
+			// literal would otherwise be lost by the plain-binding follow, and an
+			// EMPTY `pipeline = []` init followed only by appends has no useful
+			// literal at all). Fires only when an append/extend anchor contributes a
+			// stage; otherwise "" and we fall back to the plain literal binding.
+			if body := src[funcStart:dotPos]; mongoAggPyHasMutation(body, ident, len(body)) {
+				if lit := mongoAggPyImperativePipeline(body, ident, len(body)); lit != "" {
+					return lit
+				}
+			}
+			// (b) nearest preceding `pipeline = [ ... ]` literal binding.
 			if lit := mongoAggPyFollowBinding(src, ident, dotPos, funcStart); lit != "" {
 				return lit
 			}
-			// (b) builder indirection: `pipeline = build_fn()` → resolve the
+			// (c) builder indirection: `pipeline = build_fn()` → resolve the
 			// builder's definition and scan its body for the returned pipeline.
 			if fn := mongoAggPyFollowCallBinding(src, ident, dotPos, funcStart); fn != "" {
 				return mongoAggPyResolveBuilderBody(src, fn)
@@ -777,8 +791,20 @@ func mongoAggPyResolveBuilderBody(src, fnName string) string {
 	}
 
 	// Shape B: `return <ident>` where `<ident> = [ ... ]` earlier in the body.
-	if m := mongoAggPyReturnIdentRe.FindStringSubmatch(body); m != nil {
-		retIdent := m[1]
+	if m := mongoAggPyReturnIdentRe.FindStringSubmatchIndex(body); m != nil {
+		retIdent := body[m[2]:m[3]]
+		retPos := m[0] // offset of the `return <ident>` within the body
+		// Shape C (#3928): the pipeline var is built IMPERATIVELY via
+		// append/extend (with or without a list-literal init), then returned.
+		// Reconstruct it from init + append/extend additions preceding the return,
+		// but ONLY when a mutation is present — a plain `pipeline = [ ... ]; return
+		// pipeline` keeps using the literal-binding follow below (no behavior
+		// change vs #3866).
+		if mongoAggPyHasMutation(body, retIdent, retPos) {
+			if lit := mongoAggPyImperativePipeline(body, retIdent, retPos); lit != "" {
+				return lit
+			}
+		}
 		// usePos = end of body (the binding precedes the return); funcStart = 0
 		// because `body` is already sliced to this one function.
 		if lit := mongoAggPyFollowBinding(body, retIdent, len(body), 0); lit != "" {
@@ -786,6 +812,208 @@ func mongoAggPyResolveBuilderBody(src, fnName string) string {
 		}
 	}
 	return ""
+}
+
+// mongoAggPyAppendCallReCache caches per-ident `pipeline.append(` matchers.
+var mongoAggPyAppendCallReCache = map[string]*regexp.Regexp{}
+
+// mongoAggPyAppendCallRe matches a `<ident>.append(` call (a single-stage push
+// onto an imperatively-built pipeline), capturing nothing — the `(` index is
+// recovered from the match end so the dict-literal argument can be balanced.
+func mongoAggPyAppendCallRe(ident string) *regexp.Regexp {
+	if re, ok := mongoAggPyAppendCallReCache[ident]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(ident) + `\.append\s*\(`)
+	mongoAggPyAppendCallReCache[ident] = re
+	return re
+}
+
+// mongoAggPyExtendCallReCache caches per-ident `pipeline.extend(` matchers.
+var mongoAggPyExtendCallReCache = map[string]*regexp.Regexp{}
+
+// mongoAggPyExtendCallRe matches a `<ident>.extend(` call (a multi-stage splice
+// onto an imperatively-built pipeline).
+func mongoAggPyExtendCallRe(ident string) *regexp.Regexp {
+	if re, ok := mongoAggPyExtendCallReCache[ident]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(ident) + `\.extend\s*\(`)
+	mongoAggPyExtendCallReCache[ident] = re
+	return re
+}
+
+// mongoAggPyBraceBody returns the full balanced `{...}` object literal (braces
+// included) whose opening `{` is at `open`, string- and depth-aware. Returns ""
+// if unbalanced. Used to capture a single `pipeline.append({...})` stage dict.
+func mongoAggPyBraceBody(src string, open int) string {
+	if open >= len(src) || src[open] != '{' {
+		return ""
+	}
+	depth := 0
+	inStr := byte(0)
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// mongoAggPyHasMutation reports whether `ident` is mutated by at least one
+// `.append(`/`.extend(` call before `usePos` in `body`. Used to decide whether
+// the imperative reconstruction should take priority over a plain list-literal
+// binding follow: when there is NO mutation, the existing literal path handles
+// the pipeline unchanged (preserving all #3866 behavior); only the presence of
+// an append/extend warrants the new reconstruction.
+func mongoAggPyHasMutation(body, ident string, usePos int) bool {
+	if loc := mongoAggPyAppendCallRe(ident).FindStringIndex(body); loc != nil && loc[0] < usePos {
+		return true
+	}
+	if loc := mongoAggPyExtendCallRe(ident).FindStringIndex(body); loc != nil && loc[0] < usePos {
+		return true
+	}
+	return false
+}
+
+// mongoAggPyImperativePipeline reconstructs an imperatively-built pipeline.
+//
+// Given a function `body` (already sliced to ONE function), a pipeline variable
+// `ident`, and `usePos` (the offset within `body` of the consuming `return
+// pipeline` / `aggregate(pipeline)` — additions after this point are ignored),
+// it accumulates stages, in source order, from:
+//
+//	pipeline = []                          — empty init (zero stages), and
+//	pipeline = [ {stage}, ... ]            — list-literal init (its stages), then
+//	pipeline.append({ stage })             — one dict-literal stage appended, and
+//	pipeline.extend([ {stage}, ... ])      — list-literal stages spliced in.
+//
+// It returns a SYNTHETIC pipeline list literal `[ stage, stage, ... ]` built
+// from the accumulated stage substrings, suitable for mongoAggSplitStages, so
+// the rest of the pass (lookup parse, join edges, stage nodes) is unchanged.
+//
+// Honest-partial — an addition is contributed ONLY when its argument is a
+// literal of the right shape: append of a `{...}` dict literal, extend of a
+// `[...]` list literal. `pipeline.append(stage_var)` (a non-literal var),
+// `pipeline.extend(other_pipe)`, dynamic stage construction, or a non-`[]`
+// init (e.g. `pipeline = build_base()`) contribute NOTHING from that statement;
+// if NO recognised init AND no recognised additions exist, "" is returned and
+// the caller stays unresolved. We never fabricate a stage we cannot see.
+func mongoAggPyImperativePipeline(body, ident string, usePos int) string {
+	type acc struct {
+		pos   int
+		stage string
+	}
+	var stages []acc
+	hasAnchor := false // saw a `pipeline = []`/`[...]` init or any append/extend
+
+	// 1. Init binding: nearest `ident = [ ... ]` (possibly empty) before usePos.
+	//    We reuse the assignment matcher, then balance the bracket ourselves so an
+	//    empty `[]` is handled (zero stages but a valid anchor).
+	initRe := mongoAggPyAssignRe(ident)
+	initBracket := -1
+	for _, m := range initRe.FindAllStringIndex(body, -1) {
+		if m[0] >= usePos {
+			break
+		}
+		initBracket = m[1] - 1 // index of '['
+	}
+	if initBracket >= 0 {
+		hasAnchor = true
+		if lit := mongoAggPyBracketBody(body, initBracket); lit != "" {
+			for _, st := range mongoAggSplitStages(lit, 0) {
+				stages = append(stages, acc{pos: initBracket, stage: st})
+			}
+		}
+	}
+
+	// 2. `pipeline.append({...})` — each dict-literal arg is one stage.
+	for _, loc := range mongoAggPyAppendCallRe(ident).FindAllStringIndex(body, -1) {
+		callPos := loc[0]
+		if callPos >= usePos {
+			break
+		}
+		hasAnchor = true
+		open := loc[1] - 1 // index of '('
+		j := open + 1
+		for j < len(body) && (body[j] == ' ' || body[j] == '\t' || body[j] == '\n' || body[j] == '\r') {
+			j++
+		}
+		if j >= len(body) || body[j] != '{' {
+			continue // append of a non-dict-literal (var, call) — honest skip.
+		}
+		if obj := mongoAggPyBraceBody(body, j); obj != "" {
+			stages = append(stages, acc{pos: callPos, stage: obj})
+		}
+	}
+
+	// 3. `pipeline.extend([...])` — each list-literal element is one stage.
+	for _, loc := range mongoAggPyExtendCallRe(ident).FindAllStringIndex(body, -1) {
+		callPos := loc[0]
+		if callPos >= usePos {
+			break
+		}
+		hasAnchor = true
+		open := loc[1] - 1 // index of '('
+		j := open + 1
+		for j < len(body) && (body[j] == ' ' || body[j] == '\t' || body[j] == '\n' || body[j] == '\r') {
+			j++
+		}
+		if j >= len(body) || body[j] != '[' {
+			continue // extend of a non-list-literal (var, call) — honest skip.
+		}
+		if lit := mongoAggPyBracketBody(body, j); lit != "" {
+			for _, st := range mongoAggSplitStages(lit, 0) {
+				stages = append(stages, acc{pos: callPos, stage: st})
+			}
+		}
+	}
+
+	if !hasAnchor || len(stages) == 0 {
+		return ""
+	}
+
+	// Order stages by their source position so init → append → extend interleave
+	// exactly as written. sort.SliceStable preserves intra-statement order (the
+	// list-literal element order from a single init/extend).
+	sortStableByPos := func() {
+		for i := 1; i < len(stages); i++ {
+			for j := i; j > 0 && stages[j-1].pos > stages[j].pos; j-- {
+				stages[j-1], stages[j] = stages[j], stages[j-1]
+			}
+		}
+	}
+	sortStableByPos()
+
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, s := range stages {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s.stage)
+	}
+	b.WriteByte(']')
+	return b.String()
 }
 
 // mongoAggPyReturnListRe matches a `return [` (the start of a returned list

--- a/internal/engine/orm_queries_python_mongo_agg_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_test.go
@@ -581,6 +581,238 @@ def run(db):
 	}
 }
 
+// IMPERATIVE BUILDER (#3928, deploy-7 P0-B) — THE rewrite-blocking real shape.
+// A builder `def get_pipe()` starts `pipeline = []`, then `.append({$lookup})`
+// for one stage and `.extend([{$lookup}])` for more, then `return pipeline`; the
+// executor does `coll.aggregate(get_pipe())`. Both `from` collections
+// (inspection_groups via append, m_devices via extend) must resolve to their
+// NAMED collection nodes Class:Inspection_group AND Class:M_device, attributed
+// to the aggregating collection Class:Inspection. Mirrors
+// get_inspection_devices_pipeline in core/services/building/queries.py.
+func TestMongoAggPy_Imperative_AppendExtend_BuilderReturn(t *testing.T) {
+	src := `
+import pymongo
+from pymongo import MongoClient
+
+def get_pipe():
+    pipeline = []
+    pipeline.append({"$lookup": {"from": "inspection_groups", "localField": "group_id", "foreignField": "_id", "as": "g"}})
+    pipeline.extend([{"$lookup": {"from": "m_devices", "localField": "device_id", "foreignField": "_id", "as": "d"}}])
+    return pipeline
+
+def run(db):
+    return db.inspections.aggregate(get_pipe())
+`
+	ents, rels := runMongoAggPy(t, src)
+
+	if len(rels) != 2 {
+		t.Fatalf("expected exactly 2 join edges from append+extend, got %d: %+v", len(rels), rels)
+	}
+	// Named collection nodes (not raw strings dropped on the floor).
+	jg := pyFindJoinTo(rels, capitalisedSingular("inspection_groups"))
+	if jg == nil {
+		t.Fatalf("expected JOINS_COLLECTION to Class:Inspection_group (append stage); rels=%+v", rels)
+	}
+	if jg.ToID != "Class:"+capitalisedSingular("inspection_groups") {
+		t.Errorf("append join ToID = %q, want Class:Inspection_group", jg.ToID)
+	}
+	if jg.FromID != "Class:"+capitalisedSingular("inspections") {
+		t.Errorf("append join FromID = %q, want Class:Inspection (aggregating coll)", jg.FromID)
+	}
+	if jg.Properties["as"] != "g" || jg.Properties["local_field"] != "group_id" {
+		t.Errorf("append join props = %+v, want as=g local_field=group_id", jg.Properties)
+	}
+	jd := pyFindJoinTo(rels, capitalisedSingular("m_devices"))
+	if jd == nil {
+		t.Fatalf("expected JOINS_COLLECTION to Class:M_device (extend stage); rels=%+v", rels)
+	}
+	if jd.ToID != "Class:"+capitalisedSingular("m_devices") {
+		t.Errorf("extend join ToID = %q, want Class:M_device", jd.ToID)
+	}
+	if jd.FromID != "Class:"+capitalisedSingular("inspections") {
+		t.Errorf("extend join FromID = %q, want Class:Inspection", jd.FromID)
+	}
+	// Two stage nodes, append before extend (source order preserved).
+	got := pyStageSubtypesInOrder(ents)
+	want := []string{"$lookup", "$lookup"}
+	if len(got) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v", got, want)
+	}
+	if ents[0].Properties["from"] != "inspection_groups" {
+		t.Errorf("stage[0] from = %q, want inspection_groups (append first)", ents[0].Properties["from"])
+	}
+	if ents[1].Properties["from"] != "m_devices" {
+		t.Errorf("stage[1] from = %q, want m_devices (extend second)", ents[1].Properties["from"])
+	}
+	for i, e := range ents {
+		if e.Properties["collection"] != "inspections" {
+			t.Errorf("stage[%d] collection = %q, want inspections", i, e.Properties["collection"])
+		}
+		if e.Kind != string(types.EntityKindDataAccess) {
+			t.Errorf("stage[%d] kind = %q, want SCOPE.DataAccess", i, e.Kind)
+		}
+	}
+}
+
+// IMPERATIVE DIRECT EXECUTOR (#3928) — single inline append then aggregate,
+// no builder fn: `pipeline = []; pipeline.append({$lookup}); coll.aggregate(
+// pipeline)`. The bare-var follow finds no complete list literal, the imperative
+// reconstruction collects the appended stage → one join to the NAMED collection.
+func TestMongoAggPy_Imperative_DirectExecutor_SingleAppend(t *testing.T) {
+	src := `
+import pymongo
+
+def run(db):
+    pipeline = []
+    pipeline.append({"$lookup": {"from": "m_devices", "localField": "device_id", "foreignField": "_id", "as": "d"}})
+    return db.inspections.aggregate(pipeline)
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 1 {
+		t.Fatalf("expected exactly 1 join edge, got %d: %+v", len(rels), rels)
+	}
+	if rels[0].ToID != "Class:"+capitalisedSingular("m_devices") {
+		t.Errorf("join ToID = %q, want Class:M_device", rels[0].ToID)
+	}
+	if rels[0].FromID != "Class:"+capitalisedSingular("inspections") {
+		t.Errorf("join FromID = %q, want Class:Inspection", rels[0].FromID)
+	}
+	if len(ents) != 1 || ents[0].Subtype != "$lookup" {
+		t.Fatalf("expected 1 $lookup stage, got %+v", ents)
+	}
+}
+
+// IMPERATIVE with NON-EMPTY list-literal init + appends interleaved (#3928):
+// `pipeline = [{$match}]; pipeline.append({$lookup A}); pipeline.append(
+// {$lookup B})`. Init stage + both appends accumulate in source order; both
+// $lookup `from` collections resolve.
+func TestMongoAggPy_Imperative_LiteralInitPlusAppends(t *testing.T) {
+	src := `
+import pymongo
+
+def get_pipe():
+    pipeline = [{"$match": {"status": "active"}}]
+    pipeline.append({"$lookup": {"from": "inspection_groups", "localField": "g", "foreignField": "_id", "as": "grp"}})
+    pipeline.append({"$lookup": {"from": "m_buildings", "localField": "b", "foreignField": "_id", "as": "bld"}})
+    return pipeline
+
+def run(db):
+    return db.inspections.aggregate(get_pipe())
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 join edges, got %d: %+v", len(rels), rels)
+	}
+	if pyFindJoinTo(rels, capitalisedSingular("inspection_groups")) == nil {
+		t.Errorf("expected join to Class:Inspection_group; rels=%+v", rels)
+	}
+	if pyFindJoinTo(rels, capitalisedSingular("m_buildings")) == nil {
+		t.Errorf("expected join to Class:M_building; rels=%+v", rels)
+	}
+	got := pyStageSubtypesInOrder(ents)
+	want := []string{"$match", "$lookup", "$lookup"}
+	if len(got) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v (init match then 2 appends)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stage[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// IMPERATIVE $graphLookup via extend (#3928): a $graphLookup added through
+// `.extend([...])` produces a graphLookup join to the named target.
+func TestMongoAggPy_Imperative_GraphLookupViaExtend(t *testing.T) {
+	src := `
+import pymongo
+
+def get_pipe():
+    pipeline = []
+    pipeline.extend([{"$graphLookup": {"from": "categories", "startWith": "$cat", "connectFromField": "parent", "connectToField": "_id", "as": "tree"}}])
+    return pipeline
+
+def run(db):
+    return db["orders"].aggregate(get_pipe())
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 join edge, got %d: %+v", len(rels), rels)
+	}
+	if rels[0].ToID != "Class:"+capitalisedSingular("categories") {
+		t.Errorf("join ToID = %q, want Class:Category", rels[0].ToID)
+	}
+	if rels[0].Properties["stage"] != "graphLookup" {
+		t.Errorf("join stage = %q, want graphLookup", rels[0].Properties["stage"])
+	}
+	if len(ents) != 1 || ents[0].Subtype != "$graphLookup" {
+		t.Fatalf("expected 1 $graphLookup stage, got %+v", ents)
+	}
+}
+
+// NEGATIVE (#3928): `pipeline.append(stage_var)` where the argument is a
+// NON-literal variable must NOT fabricate a join/stage from that append. Only the
+// literal-dict appends contribute; a var append is an honest skip.
+func TestMongoAggPy_Imperative_NonLiteralAppend_Skipped(t *testing.T) {
+	src := `
+import pymongo
+
+def get_pipe(stage_var):
+    pipeline = []
+    pipeline.append(stage_var)
+    return pipeline
+
+def run(db, sv):
+    return db.inspections.aggregate(get_pipe(sv))
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 0 || len(ents) != 0 {
+		t.Fatalf("non-literal append must emit nothing, got rels=%d ents=%d", len(rels), len(ents))
+	}
+}
+
+// NEGATIVE (#3928): a $lookup whose `from` is a DYNAMIC value (a variable, not a
+// string literal) in an appended dict yields NO join edge — the stage node may
+// exist but mongoAggParseLookup finds no static `from`. Honest-partial.
+func TestMongoAggPy_Imperative_DynamicFrom_NoJoin(t *testing.T) {
+	src := `
+import pymongo
+
+def get_pipe(coll_name):
+    pipeline = []
+    pipeline.append({"$lookup": {"from": coll_name, "localField": "x", "foreignField": "_id", "as": "y"}})
+    return pipeline
+
+def run(db, cn):
+    return db.inspections.aggregate(get_pipe(cn))
+`
+	_, rels := runMongoAggPy(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("dynamic $lookup from must emit NO join edge, got %d: %+v", len(rels), rels)
+	}
+}
+
+// NEGATIVE (#3928): `pipeline.extend(other_pipe)` where the arg is a non-literal
+// variable contributes nothing. With no literal init and no literal additions,
+// the whole pipeline stays unresolved — no fabrication.
+func TestMongoAggPy_Imperative_NonLiteralExtend_Unresolved(t *testing.T) {
+	src := `
+import pymongo
+
+def get_pipe(other_pipe):
+    pipeline = []
+    pipeline.extend(other_pipe)
+    return pipeline
+
+def run(db, op):
+    return db.inspections.aggregate(get_pipe(op))
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 0 || len(ents) != 0 {
+		t.Fatalf("non-literal extend must emit nothing, got rels=%d ents=%d", len(rels), len(ents))
+	}
+}
+
 // Inline list-literal pipeline with $lookup + $graphLookup + $group + $facet,
 // receiver via db["collname"] subscript. Asserts both join kinds, the $group
 // _id/accumulators, and the $facet keys.


### PR DESCRIPTION
Closes #3928 (under epic #3628; part of cross-language epic #3837).

## DEPLOY-DEFERRED
Engine extractor change — requires a coordinated live-daemon rebuild + reindex to take effect on the served graph. Do NOT deploy in isolation; bundle with the next daemon rebuild.

## Problem (deploy-7-validation.md §2.8)
Mongo `JOINS_COLLECTION` was still **0 on real upvate-core code**. Production pymongo pipelines are assembled **imperatively**:

```python
def get_inspection_devices_pipeline():
    pipeline = []
    pipeline.append({"$lookup": {"from": "inspection_groups", ...}})
    pipeline.extend([{"$lookup": {"from": "m_devices", ...}}])
    return pipeline
```

#3866 followed inline list-literals, `pipeline = [literal]` bindings, and `return [...]` / `return pipeline` builder bodies — but NOT `.append(...)` / `.extend(...)` mutation. So the `$lookup` `from` collections (`inspection_groups`, `m_devices`) never reached the graph → `JOINS_COLLECTION=0`, effects `pure`.

## Fix (Python pymongo — the rewrite SOURCE)
`mongoAggPyImperativePipeline` reconstructs the pipeline var from its list-literal init plus `.append({...})` / `.extend([...])` additions, in source order, and synthesizes a `[...]` list literal fed to the existing `mongoAggSplitStages` — so lookup parsing, join edges, and stage nodes are unchanged downstream.

Wired into both entry points:
- **builder body** `def get_pipe(): pipeline=[]; ...append/extend...; return pipeline` then `coll.aggregate(get_pipe())`
- **direct executor** `pipeline=[]; pipeline.append({...}); coll.aggregate(pipeline)`

Gated on `mongoAggPyHasMutation`: the reconstruction only takes priority when an append/extend is actually present, so plain list-literal pipelines keep the exact #3866 behavior (regression-guarded by the existing suite).

## JOINS_COLLECTION edges now resolved on the append/extend shape
On the report's real shape (`pipeline.append({'$lookup':{'from':'inspection_groups'}})` + `pipeline.extend([{'$lookup':{'from':'m_devices'}}])`, executor `coll.aggregate(get_pipe())` on `inspections`):
- `JOINS_COLLECTION  Class:Inspection -> Class:Inspection_group` (stage=lookup, via append)
- `JOINS_COLLECTION  Class:Inspection -> Class:M_device` (stage=lookup, via extend)

plus the two ordered `SCOPE.DataAccess` `$lookup` stage nodes. `$graphLookup` via extend → `Class:Category` (stage=graphLookup) likewise.

## Honest-partial (no fabrication)
- `pipeline.append(stage_var)` (non-literal arg) → no edge/stage
- `pipeline.extend(other_pipe)` (non-literal arg) → no edge/stage
- dynamic `from` (`"from": coll_name`) → stage may exist, no join edge

## Out of scope
Generalize-cross-language (JS/TS/Go/Java imperative builders) tracked separately under epic #3837. This PR is the Python pymongo fix only.

## Tests
Value-asserting on the real report shape (named collection node IDs, not `len>0`): builder append+extend, direct-executor single append, non-empty literal-init + interleaved appends, `$graphLookup` via extend; negatives for non-literal append, non-literal extend, and dynamic `from`. `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` green; gofmt clean; go vet clean; coverage validate 0 errors + fmt canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)