### PR TITLE
credit(coverage): gqlgen substrate cells via verify-first Go per-language probes (#3918)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -59,7 +59,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 6/11 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -41,7 +41,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -89,7 +89,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DB effect | 🔴 `missing` | — | 3613 | — | — |
+| DB effect | 🟢 `partial` | `2026-06-02` | 3918 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go` | #3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go db_read/db_write detectors (goDBReadRe: .Query/.First/.Find/.Take/.Scan incl. GORM+sqlx; goDBWriteRe: .Exec/.Create/.Save/.Update/.Delete) match on any receiver and fire on gqlgen resolver bodies, attributed to the enclosing resolver method. Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (db_read+db_write attributed to CreateTodo, db_read to Todos via gorm First/Create/Find). partial: method-name heuristic (conf 0.85), no gqlgen-dataloader-aware batching modelled. |
 
 ### Substrate
 
@@ -99,24 +99,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | 🔴 `missing` | — | 3613 | — | — |
 | Dead code detection | 🔴 `missing` | — | 3613 | — | — |
-| Def use chain extraction | 🔴 `missing` | — | 3613 | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-06-02` | 3918 | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_golang.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go` | #3918 (verify-first): def_use_golang.go is registered per-LANGUAGE via RegisterDefUseSniffer("go", …) — file-extension dispatch (LanguageForPath: .go→go), zero framework refs. sniffDefUseGo extracts intra-procedural defs/uses and attributes them to the enclosing function via scanGoFuncHeaders, which strips the gqlgen generated `(r *mutationResolver)` receiver and binds to the bare method name. Proven by TestSubstrate_Go_Gqlgen_DefUseAttributes (def+use of a local in CreateTodo). partial: standard local-binding chains attribute; full reaching-defs across the receiver/field graph not modelled. |
 | Env fallback recognition | 🔴 `missing` | — | 3613 | — | — |
 | Error flow | ✅ `full` | `2026-06-02` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/golang/exception_flow.go`<br>`internal/extractors/golang/exception_flow_test.go` | return ErrX / fmt.Errorf %w -> THROWS; errors.Is/As -> CATCHES; named sentinels only (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | 3613 | — | — |
-| HTTP effect | 🔴 `missing` | — | 3613 | — | — |
+| HTTP effect | 🟢 `partial` | `2026-06-02` | 3918 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go` | #3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go http_out detector (http.Get/Post, client.Do) fires on gqlgen resolver .go bodies and attributes to the enclosing resolver method (receiver stripped by scanGoFuncHeaders). Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (http_out attributed to CreateTodo). partial: detector + attribution on the standard call forms; no gqlgen-specific dataloader/HTTP-client modelling. |
 | Import resolution quality | 🔴 `missing` | — | 3613 | — | — |
 | Module cycle detection | 🔴 `missing` | — | 3613 | — | — |
-| Mutation effect | 🔴 `missing` | — | 3613 | — | — |
+| Mutation effect | 🟢 `partial` | `2026-06-02` | 3918 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go` | #3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go mutation detector (goMutationRe: recv.field = …) fires on gqlgen resolver bodies and attributes to the enclosing method. Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (mutation `created.Done = true` attributed to CreateTodo). partial: single-identifier-receiver field writes only (conf 0.6). |
 | Pure function tagging | 🔴 `missing` | — | 3613 | — | — |
 | Reachability analysis | 🔴 `missing` | — | 3613 | — | — |
 | Request shape extraction | 🔴 `missing` | — | 3613 | — | — |
-| Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
+| Request sink dataflow | 🔴 `missing` | `2026-06-02` | 3918 | `internal/substrate/dataflow.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go` | #3918 (verify-first NEGATIVE, stays missing): there is NO Go dataflow sniffer registered at all — only "jsts" and "python" call RegisterDataFlowSnifferEx (dataflow_jsts.go / dataflow_python.go). DataFlowSnifferFor("go") is nil, so the request_sink flow cannot fire for ANY Go framework; and gqlgen reads typed args, not req.body, regardless. Doubly N/A. Proven by TestSubstrate_Go_Gqlgen_NoGoDataFlowSniffer. |
 | Response shape extraction | 🔴 `missing` | — | 3613 | — | — |
 | Sanitizer recognition | 🔴 `missing` | — | 3613 | — | — |
 | Schema drift detection | 🔴 `missing` | — | 3613 | — | — |
-| Taint sink detection | 🔴 `missing` | — | 3613 | — | — |
-| Taint source detection | 🔴 `missing` | — | 3613 | — | — |
+| Taint sink detection | 🟢 `partial` | `2026-06-02` | 3918 | `internal/links/taint_flow.go`<br>`internal/substrate/substrate_golang_graphql_gqlgen_test.go`<br>`internal/substrate/taint_sites_golang.go` | #3918 (verify-first): the per-LANGUAGE taint_sites_golang.go SQL-injection sink (goSinkSQLRe: db/tx/stmt/conn .Query/Exec with fmt.Sprintf or ident-concat) fires on gqlgen resolver bodies. Proven by TestSubstrate_Go_Gqlgen_TaintSinkFires (db.Query(fmt.Sprintf(…)) flagged sql_injection). partial: anchors on a bare receiver token db|tx|stmt|conn, so the common `db := r.DB; db.Query(...)` handle form fires but the field-receiver `r.DB.Query(...)` form and the `"literal"+var` concat shape do NOT — documented in the test. |
+| Taint source detection | 🔴 `missing` | `2026-06-02` | 3918 | `internal/substrate/substrate_golang_graphql_gqlgen_test.go`<br>`internal/substrate/taint_sites_golang.go` | #3918 (verify-first NEGATIVE, stays missing): the per-LANGUAGE Go taint SOURCE regexes key on net/http request accessors (r.URL.Query/Form/Body) and gin/chi/echo/fiber context getters. A gqlgen resolver receives untrusted input via typed resolver args (function parameters) + ctx, NOT those accessors, so no taint source fires. Proven by TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire (zero sources). Crediting would require a gqlgen-arg-aware source model (future work). |
 | Template pattern catalog | 🔴 `missing` | — | 3613 | — | — |
 | Vulnerability finding | 🔴 `missing` | — | 3613 | — | — |
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 |--------|----------|------|--------|
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 3 full, 1 partial, 45 missing |
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
-| [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 1 partial, 44 missing |
+| [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 6 partial, 39 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 1 partial, 49 missing |
 | [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 1 missing, 1 n/a |
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -20528,8 +20528,11 @@
         },
         "Data": {
           "db_effect": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go db_read/db_write detectors (goDBReadRe: .Query/.First/.Find/.Take/.Scan incl. GORM+sqlx; goDBWriteRe: .Exec/.Create/.Save/.Update/.Delete) match on any receiver and fire on gqlgen resolver bodies, attributed to the enclosing resolver method. Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (db_read+db_write attributed to CreateTodo, db_read to Todos via gorm First/Create/Find). partial: method-name heuristic (conf 0.85), no gqlgen-dataloader-aware batching modelled.",
+            "verified_at": "2026-06-02"
           }
         },
         "Substrate": {
@@ -20550,8 +20553,11 @@
             "issue": "3613"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_golang.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first): def_use_golang.go is registered per-LANGUAGE via RegisterDefUseSniffer(\"go\", …) — file-extension dispatch (LanguageForPath: .go→go), zero framework refs. sniffDefUseGo extracts intra-procedural defs/uses and attributes them to the enclosing function via scanGoFuncHeaders, which strips the gqlgen generated `(r *mutationResolver)` receiver and binds to the bare method name. Proven by TestSubstrate_Go_Gqlgen_DefUseAttributes (def+use of a local in CreateTodo). partial: standard local-binding chains attribute; full reaching-defs across the receiver/field graph not modelled.",
+            "verified_at": "2026-06-02"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -20573,8 +20579,11 @@
             "issue": "3613"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go http_out detector (http.Get/Post, client.Do) fires on gqlgen resolver .go bodies and attributes to the enclosing resolver method (receiver stripped by scanGoFuncHeaders). Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (http_out attributed to CreateTodo). partial: detector + attribution on the standard call forms; no gqlgen-specific dataloader/HTTP-client modelling.",
+            "verified_at": "2026-06-02"
           },
           "import_resolution_quality": {
             "status": "missing",
@@ -20585,8 +20594,11 @@
             "issue": "3613"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first): the per-LANGUAGE effect_sinks_golang.go mutation detector (goMutationRe: recv.field = …) fires on gqlgen resolver bodies and attributes to the enclosing method. Proven by TestSubstrate_Go_Gqlgen_EffectsAttribute (mutation `created.Done = true` attributed to CreateTodo). partial: single-identifier-receiver field writes only (conf 0.6).",
+            "verified_at": "2026-06-02"
           },
           "pure_function_tagging": {
             "status": "missing",
@@ -20602,7 +20614,10 @@
           },
           "request_sink_dataflow": {
             "status": "missing",
-            "issue": "3740"
+            "cites": ["internal/substrate/dataflow.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first NEGATIVE, stays missing): there is NO Go dataflow sniffer registered at all — only \"jsts\" and \"python\" call RegisterDataFlowSnifferEx (dataflow_jsts.go / dataflow_python.go). DataFlowSnifferFor(\"go\") is nil, so the request_sink flow cannot fire for ANY Go framework; and gqlgen reads typed args, not req.body, regardless. Doubly N/A. Proven by TestSubstrate_Go_Gqlgen_NoGoDataFlowSniffer.",
+            "verified_at": "2026-06-02"
           },
           "response_shape_extraction": {
             "status": "missing",
@@ -20617,12 +20632,18 @@
             "issue": "3613"
           },
           "taint_sink_detection": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/substrate_golang_graphql_gqlgen_test.go","internal/substrate/taint_sites_golang.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first): the per-LANGUAGE taint_sites_golang.go SQL-injection sink (goSinkSQLRe: db/tx/stmt/conn .Query/Exec with fmt.Sprintf or ident-concat) fires on gqlgen resolver bodies. Proven by TestSubstrate_Go_Gqlgen_TaintSinkFires (db.Query(fmt.Sprintf(…)) flagged sql_injection). partial: anchors on a bare receiver token db|tx|stmt|conn, so the common `db := r.DB; db.Query(...)` handle form fires but the field-receiver `r.DB.Query(...)` form and the `\"literal\"+var` concat shape do NOT — documented in the test.",
+            "verified_at": "2026-06-02"
           },
           "taint_source_detection": {
             "status": "missing",
-            "issue": "3613"
+            "cites": ["internal/substrate/substrate_golang_graphql_gqlgen_test.go","internal/substrate/taint_sites_golang.go"],
+            "issue": "3918",
+            "notes": "#3918 (verify-first NEGATIVE, stays missing): the per-LANGUAGE Go taint SOURCE regexes key on net/http request accessors (r.URL.Query/Form/Body) and gin/chi/echo/fiber context getters. A gqlgen resolver receives untrusted input via typed resolver args (function parameters) + ctx, NOT those accessors, so no taint source fires. Proven by TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire (zero sources). Crediting would require a gqlgen-arg-aware source model (future work).",
+            "verified_at": "2026-06-02"
           },
           "template_pattern_catalog": {
             "status": "missing",

--- a/internal/substrate/substrate_golang_graphql_gqlgen_test.go
+++ b/internal/substrate/substrate_golang_graphql_gqlgen_test.go
@@ -1,0 +1,156 @@
+package substrate
+
+import "testing"
+
+// substrate_golang_graphql_gqlgen_test.go — issue #3918: prove the
+// framework-blind, per-LANGUAGE Go substrate sniffers fire on gqlgen
+// (Go GraphQL) generated-resolver source. This is the Go analog of the
+// jsts-Pothos (#3903) and python-graphene (#3911) verify-first credits.
+//
+// Every Go substrate sniffer is registered on the "go" language slug and
+// dispatched solely by file extension via LanguageForPath (see
+// internal/substrate/substrate.go LanguageForPath: ".go" -> "go"). None of
+// def_use_golang.go / effect_sinks_golang.go / taint_sites_golang.go / golang.go
+// contains a single framework reference; they Register("go", …) /
+// RegisterDefUseSniffer("go", …) / RegisterEffectSniffer("go", …) /
+// RegisterTaintSniffer("go", …) unconditionally. gqlgen resolvers live in
+// ordinary Go (.go) files and therefore already receive these passes.
+//
+// VERIFY-FIRST findings encoded as assertions below:
+//
+//  1. The substrate primitive DETECTORS fire on a gqlgen generated-resolver
+//     body and ATTRIBUTE to the enclosing resolver method:
+//       - db_read  (gorm .First / .Find)            — proven
+//       - db_write (gorm .Create / .Save)           — proven
+//       - http_out (http.Get / client.Do)           — proven
+//       - mutation (recv.field = …)                 — proven
+//       - def/use chains over locals                — proven
+//       - SQL-injection taint SINK (db.Query(fmt.Sprintf …)) — proven
+//     Attribution succeeds for the gqlgen generated receiver form
+//     `func (r *mutationResolver) CreateTodo(ctx …) (…)` because the Go
+//     func-header scanner (goFuncHeaderRe in effect_sinks_golang.go) strips the
+//     `(r *mutationResolver)` receiver and binds to the bare method name.
+//
+//     VERIFY-FIRST CAVEAT (why `partial`, not `full`): the SQL-sink regex
+//     goSinkSQLRe anchors on a bare receiver token `db|tx|stmt|conn`, so it
+//     fires on the common `db := r.DB; db.Query(fmt.Sprintf(…))` handle form
+//     (and a package-level `db`) but NOT on the field-receiver `r.DB.Query(…)`
+//     form, nor on the `"literal" + var` concat shape (only `ident + …` or
+//     fmt.Sprintf). The effect detectors (.First/.Create/.Find/.Save) match on
+//     any receiver and so fire on both `r.DB.X` and `db.X`. Hence partial.
+//
+//  2. Honest NEGATIVES (left `missing`/`n-a` with documented reason):
+//       - taint SOURCE: the Go source regexes key on net/http request
+//         accessors (r.URL.Query/Form/Body) and gin/chi/echo/fiber context
+//         getters. A gqlgen resolver receives untrusted input via typed
+//         resolver `args` (function parameters) + `ctx`, NOT those request
+//         accessors, so no taint source fires. (#3918 negative probe.)
+//       - request_sink_dataflow: there is NO Go dataflow sniffer registered at
+//         all (only "jsts" and "python" call RegisterDataFlowSnifferEx in
+//         dataflow_jsts.go / dataflow_python.go). The request_sink flow cannot
+//         fire for ANY Go framework, and gqlgen reads args not req.body anyway.
+//         Doubly N/A. (#3918 negative probe.)
+//       - Type System / DTO: gqlgen is SDL-driven (schema-first); the object
+//         type graph is parsed from *.graphql by the shared graphql extractor
+//         (already credited under Schema -> Type graph extraction `full`).
+//         Generated Go resolvers carry operation glue only, no code-first Go
+//         type declarations, so no Go type/DTO extractor applies.
+//
+// These probes justify flipping the per-language Substrate effect / mutation /
+// def_use / taint-sink + Data DB-effect cells on the gqlgen record to `partial`
+// (honest: detectors fire + attribute on the generated resolver form), while
+// leaving taint-source, request_sink_dataflow, and the code-first Type System /
+// DTO cells `missing`.
+
+// gqlgenResolverSrc is a representative gqlgen generated-resolver module: the
+// canonical `func (r *mutationResolver) <Field>(ctx, args…)` receiver form,
+// performing a gorm DB read + write, an outbound HTTP call, a struct-field
+// mutation, and a raw-SQL concat sink.
+const gqlgenResolverSrc = `
+package graph
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// CreateTodo is the resolver for the createTodo field.
+func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (*Todo, error) {
+	text := input.Text
+	db := r.DB
+	existing := &Todo{}
+	db.First(existing, "text = ?", text)
+	created := &Todo{Text: text, UserID: input.UserID}
+	db.Create(created)
+	created.Done = true
+	http.Get("https://audit.example.com/log")
+	rows, _ := db.Query(fmt.Sprintf("SELECT * FROM todos WHERE text = '%s'", text))
+	_ = rows
+	return created, nil
+}
+
+// Todos is the resolver for the todos query field.
+func (r *queryResolver) Todos(ctx context.Context) ([]*Todo, error) {
+	out := []*Todo{}
+	r.DB.Find(&out)
+	return out, nil
+}
+`
+
+// --- gqlgen positive probes -------------------------------------------------
+
+func TestSubstrate_Go_Gqlgen_DefUseAttributes(t *testing.T) {
+	defs, uses := sniffDefUseGo(gqlgenResolverSrc)
+	if !hasDefIn(defs, "text", "CreateTodo") {
+		t.Errorf("def_use: expected def of `text` in CreateTodo, defs=%+v", defs)
+	}
+	if !hasUseIn(uses, "text", "CreateTodo") {
+		t.Errorf("def_use: expected use of `text` in CreateTodo, uses=%+v", uses)
+	}
+}
+
+func TestSubstrate_Go_Gqlgen_EffectsAttribute(t *testing.T) {
+	ms := sniffEffectsGo(gqlgenResolverSrc)
+	for _, want := range []Effect{EffectDBRead, EffectDBWrite, EffectHTTPOut, EffectMutation} {
+		if !hasEffectIn(ms, want, "CreateTodo") {
+			t.Errorf("effects: expected %s attributed to CreateTodo, got %+v", want, ms)
+		}
+	}
+	// db_read also fires + attributes on the second (query) resolver.
+	if !hasEffectIn(ms, EffectDBRead, "Todos") {
+		t.Errorf("effects: expected db_read attributed to Todos, got %+v", ms)
+	}
+}
+
+func TestSubstrate_Go_Gqlgen_TaintSinkFires(t *testing.T) {
+	ms := sniffTaintGo(gqlgenResolverSrc)
+	if countTaint(ms, TaintKindSink, TaintCategorySQL) == 0 {
+		t.Errorf("taint: expected a SQL-injection sink (raw db.Query concat), got %+v", ms)
+	}
+}
+
+// --- gqlgen negative probes (honest non-credit) -----------------------------
+
+// TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire documents WHY
+// taint_source_detection is left `missing`: the Go taint SOURCE regexes key on
+// net/http request accessors (r.URL.Query/Form/Body) and gin/chi/echo/fiber
+// context getters. A gqlgen resolver receives untrusted input via typed
+// resolver args (function parameters), so no taint source is produced.
+func TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire(t *testing.T) {
+	ms := sniffTaintGo(gqlgenResolverSrc)
+	if n := countTaint(ms, TaintKindSource, TaintCategoryGeneric); n != 0 {
+		t.Errorf("expected NO taint source (resolver reads typed args, not r.URL/ctx getters); got %d: %+v", n, ms)
+	}
+}
+
+// TestSubstrate_Go_Gqlgen_NoGoDataFlowSniffer documents WHY
+// request_sink_dataflow is left `missing`: no Go dataflow sniffer is registered
+// at all — only "jsts" and "python" appear in the dataflow registry. The flow
+// therefore cannot fire for any Go framework, and gqlgen reads args not
+// req.body regardless.
+func TestSubstrate_Go_Gqlgen_NoGoDataFlowSniffer(t *testing.T) {
+	if DataFlowSnifferFor("go") != nil || DataFlowSnifferExFor("go") != nil {
+		t.Errorf("expected NO registered Go dataflow sniffer (request_sink is jsts/python only); one was found")
+	}
+}


### PR DESCRIPTION
## Summary
gqlgen (Go GraphQL) had its entire **Substrate tier + Type System + DTO** marked `missing` despite identical per-LANGUAGE Go substrate processing — the Go analog of jsts-Pothos (#3903) and python-graphene (#3911). This **verify-first** PR confirms the Go sniffers are framework-blind and credits only what value-asserting probes prove fires.

## Verify-first findings
The Go substrate sniffers register per-LANGUAGE on `"go"` (file-extension dispatch via `LanguageForPath`: `.go`→`go`, **zero** framework gating):
- `def_use_golang.go` → `RegisterDefUseSniffer("go", …)`
- `effect_sinks_golang.go` → `RegisterEffectSniffer("go", …)`
- `taint_sites_golang.go` → `RegisterTaintSniffer("go", …)`
- `golang.go` → `Register("go", …)`

New probe file `internal/substrate/substrate_golang_graphql_gqlgen_test.go` exercises a gqlgen generated-resolver `.go` body (`func (r *mutationResolver) CreateTodo(ctx, args…)`) — 5 assertions, all green.

## Cells flipped → `partial` (proven fire + attribute on the gqlgen resolver method)
| Tier | Cell | Probe |
|---|---|---|
| Substrate | `def_use_chain_extraction` | def+use of a local attributed to `CreateTodo` |
| Substrate | `http_effect` | `http.Get` → http_out on `CreateTodo` |
| Substrate | `mutation_effect` | `created.Done = true` → mutation on `CreateTodo` |
| Substrate | `taint_sink_detection` | `db.Query(fmt.Sprintf(…))` → sql_injection sink |
| Data | `db_effect` | gorm `First`/`Create`/`Find` → db_read/db_write |

Receiver attribution works because `scanGoFuncHeaders` strips the gqlgen `(r *mutationResolver)` receiver and binds to the bare method name.

`taint_sink` is **partial, not full**: `goSinkSQLRe` anchors on a bare receiver token `db|tx|stmt|conn`, so the common `db := r.DB; db.Query(...)` handle form fires but the field-receiver `r.DB.Query(...)` form and the `"literal"+var` concat shape do **not** — documented in the test.

## Left `missing` with documented verify-first NEGATIVES
- **`taint_source_detection`** — Go taint SOURCE regexes key on `r.URL.Query/Form/Body` + gin/chi/echo/fiber context getters. A gqlgen resolver reads **typed args + ctx**, not those accessors → no source fires. Proven by `TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire`.
- **`request_sink_dataflow`** — there is **NO Go dataflow sniffer registered at all** (only `jsts`+`python` call `RegisterDataFlowSnifferEx`); `DataFlowSnifferFor("go")==nil`. Cannot fire for any Go framework, and gqlgen reads args not `req.body`. Doubly N/A. Proven by `TestSubstrate_Go_Gqlgen_NoGoDataFlowSniffer`.
- **Type System (type/enum/interface/alias) + Validation (DTO/request)** — gqlgen is SDL-driven; the object type graph is parsed from `*.graphql` (already credited under `Schema → Type graph extraction` = `full`). Generated Go resolvers carry operation glue only; no code-first Go type extractor applies.

This mirrors the conservative pothos/graphene precedent (those credited only def_use/http_effect/taint_sink partial and left Type System + DTO missing).

## Checks
- `go test ./internal/substrate/... ./internal/links/... ./internal/types/ ./internal/extractors/... ./tools/coverage/` — green
- `go run ./tools/coverage validate` — 0 errors; `fmt --check` canonical
- `gofmt -l` empty; `go vet ./internal/substrate/` clean
- docs regenerated via `tools/coverage gen`

Closes #3918

🤖 Generated with [Claude Code](https://claude.com/claude-code)