### PR TITLE
fix(resolve): kind-resolve the new semantic-edge taxonomy in hintKinds (#3930)

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1368,17 +1368,105 @@ var (
 		"Schema", "Field", "Property",
 		scopeKindPrefix + "Schema",
 	}
+	// componentOrOperationKindFamily is the union of the component- and
+	// operation-shaped kinds, for new semantic edges (#3930) whose
+	// real-code endpoint may be EITHER a class/component OR a free
+	// function/method depending on the framework. RENDERS (handler method
+	// vs. component class) and USES_TRANSLATION (enclosing function vs.
+	// React component) are the canonical mixed cases. uniqueMatchInFamily
+	// still only resolves when EXACTLY ONE entity across the whole union
+	// matches the bare name, so widening the family stays honest: it
+	// narrows an ambiguity only when the union is itself unambiguous, and
+	// otherwise leaves the endpoint unresolved.
+	componentOrOperationKindFamily = []string{
+		"Component", "Class", "View", "Model",
+		"Operation", "Function", "Method",
+		scopeKindPrefix + "Component",
+		scopeKindPrefix + "View",
+		scopeKindPrefix + "Model",
+		scopeKindPrefix + "Operation",
+	}
 )
 
 // hintKinds returns the entity-kind families preferred for a given
 // relationship kind. EXTENDS / IMPLEMENTS prefer Component-shaped kinds;
-// CALLS prefers Operation-shaped kinds. Everything else returns nil.
+// CALLS prefers Operation-shaped kinds.
+//
+// #3930 (epic #3929): the new semantic-edge taxonomy added by the graph
+// rewrite (NestJS/Spring/Angular DI, graph DBs, scheduled jobs, i18n,
+// feature flags, data-flow, …) is now kind-resolved too. The regression
+// these entries fix: when one endpoint of such an edge is addressed by a
+// bare name that is AMBIGUOUS — the classic shape being a real
+// `Class:DevicesWriteService` colliding with an OpenAPI/spec `module`
+// `Component` of the same name — hintKinds previously returned nil, so
+// LookupStatusHint fell straight to statusAmbiguous, rewriteOne left the
+// endpoint as a bare string, and buildAdjacency keyed it under a phantom
+// node: the edge became invisible to inspect / neighbors / subgraph. With
+// a family hint, lookupByKindHint's tier-1 pass prefers the REAL
+// source-bearing entity (Class/Component/Function/Method) over the
+// SCOPE.* / spec placeholder, so the edge resolves to the real node and
+// stays reachable. Generalised across the WHOLE taxonomy, not just DI.
+//
+// Family assignment follows each edge's real-code endpoint:
+//   - component-shaped endpoints (a class/component on at least one side):
+//     INJECTED_INTO, BINDS (DI token→impl), GRAPH_RELATES, REGISTERS,
+//     HANDLES_SIGNAL, FEDERATES.
+//   - operation-shaped endpoints (the real endpoint is a function/method;
+//     the other end is a synthetic SCOPE.* stub resolved structurally or
+//     by QualifiedName, never via this bare-name path):
+//     DEPENDS_ON_SERVICE, TRIGGERS, ENQUEUES, HANDLES_COMMAND, GATED_BY,
+//     DATA_FLOWS_TO, THROWS, CATCHES, INSTRUMENTS, CACHES, INVALIDATES,
+//     JOINS_CHANNEL, BROADCASTS_TO, RESOLVED_BY, VALIDATES, FETCHES,
+//     GRPC_IMPLEMENTS, GRPC_HANDLES, HANDLES, DISCRIMINATES_ON, BRANCHES_ON.
+//   - mixed (class OR free function depending on framework): RENDERS,
+//     USES_TRANSLATION — hinted to the component∪operation union, which
+//     resolves only when the union is itself unambiguous (honest widening).
+//
+// Honest scoping: edge kinds whose BOTH endpoints are synthetic stubs
+// (helm BINDS template→values_key, MODIFIES_TABLE/ACCESSES_TABLE/QUERIES →
+// table key, PUBLISHES_TO/SUBSCRIBES_TO → MessageTopic, JOINS_COLLECTION →
+// collection key, DEPENDS_ON_CONFIG → SCOPE.Config, SHARES_DATA →
+// Module, TRANSITIONS_TO → SCOPE.State, GATED_BY's flag end) are NOT hinted
+// here for the stub side — those resolve via byQualifiedName / structural
+// tiers BEFORE the ambiguous-bare-name branch is reached, so a code-entity
+// family hint would never apply (and adding one would be misleading). BINDS
+// is dual-use (Helm + DI); the Helm `helm_values:<path>` stub matches by
+// QualifiedName first, so the component hint only ever affects the DI
+// token→impl class case, which is exactly the target.
+//
+// Tie-break note (#3936): preferring the real source-bearing entity over a
+// synthetic/spec stub is handled by lookupByKindHint's tier-1
+// nameKindsReal pass (real kinds before SCOPE.* placeholders). This PR
+// scopes itself to the hintKinds family map; the broader real-vs-stub
+// tie-break hardening is tracked separately in #3936.
+//
+// Everything else returns nil.
 func hintKinds(relKind string) []string {
 	switch strings.ToUpper(relKind) {
 	case "EXTENDS", "IMPLEMENTS":
 		return componentKindFamily
 	case "CALLS":
 		return operationKindFamily
+	// #3930: component-shaped semantic edges — both real endpoints are
+	// classes/components (DI provider/consumer, graph @Node owner/target,
+	// admin/signal model registration, federation entity type).
+	case "INJECTED_INTO", "BINDS", "GRAPH_RELATES", "REGISTERS",
+		"HANDLES_SIGNAL", "FEDERATES":
+		return componentKindFamily
+	// #3930: operation-shaped semantic edges — the real endpoint is a
+	// function/method; the opposite endpoint is a synthetic SCOPE.* stub
+	// resolved on the QualifiedName / structural tiers, never here.
+	case "DEPENDS_ON_SERVICE", "TRIGGERS", "ENQUEUES", "HANDLES_COMMAND",
+		"GATED_BY", "DATA_FLOWS_TO", "THROWS", "CATCHES", "INSTRUMENTS",
+		"CACHES", "INVALIDATES", "JOINS_CHANNEL", "BROADCASTS_TO",
+		"RESOLVED_BY", "VALIDATES", "FETCHES", "GRPC_IMPLEMENTS",
+		"GRPC_HANDLES", "HANDLES", "DISCRIMINATES_ON", "BRANCHES_ON":
+		return operationKindFamily
+	// #3930: mixed endpoints — a handler method OR a component class
+	// depending on the framework. Honest widening: the union resolves only
+	// when it is itself unambiguous.
+	case "RENDERS", "USES_TRANSLATION":
+		return componentOrOperationKindFamily
 	}
 	return nil
 }

--- a/internal/resolve/semantic_hintkinds_test.go
+++ b/internal/resolve/semantic_hintkinds_test.go
@@ -1,0 +1,234 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #3930 (epic #3929): the rewrite agent's #1 regression — NestJS/Spring/
+// Angular DI edges (INJECTED_INTO/BINDS) and the rest of the new semantic-
+// edge taxonomy ORPHANED when an endpoint name was ambiguous, because
+// hintKinds() returned nil for those kinds. With a kind hint, an ambiguous
+// endpoint resolves to the REAL source-bearing entity (Class/Component/
+// Function/Method) rather than collapsing to statusAmbiguous → phantom node.
+//
+// These tests are VALUE-ASSERTING: they assert the resolved FromID/ToID is
+// the specific real entity, and that the edge is reachable in adjacency
+// (not left as a bare stub), not merely that some rewrite happened.
+
+// devicesWriteServiceFixture reproduces the confirmed real-world collision:
+// a real source-bearing Class:DevicesWriteService plus a synthetic spec /
+// OpenAPI SCOPE.Component("module") placeholder of the SAME bare name. The
+// controller and the service are the two consumers/providers in the DI graph.
+func devicesWriteServiceFixture() []types.EntityRecord {
+	return []types.EntityRecord{
+		// The REAL service class (source-bearing).
+		entAt("aaaaaaaaaaaaaaaa", "Class", "DevicesWriteService", "devices/devices-write.service.ts"),
+		// The spec/OpenAPI `module` Component stub of the same name — the
+		// phantom that previously won (or rather, made resolution ambiguous).
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Component", "DevicesWriteService", "openapi/spec.yaml"),
+		// The DI consumer (controller) and a second consumer (another service).
+		entAt("cccccccccccccccc", "Class", "DevicesController", "devices/devices.controller.ts"),
+		entAt("dddddddddddddddd", "Class", "DevicesOrchestrator", "devices/devices.orchestrator.ts"),
+	}
+}
+
+// TestHintKinds_InjectedInto_AmbiguousProviderResolvesToRealClass is the
+// headline P0-A assertion: provider name DevicesWriteService is ambiguous
+// (real Class + spec Component); the INJECTED_INTO edge must bind its
+// provider endpoint to the REAL Class, NOT the spec stub, and the edge must
+// be present in adjacency for BOTH consumers.
+func TestHintKinds_InjectedInto_AmbiguousProviderResolvesToRealClass(t *testing.T) {
+	idx := BuildIndex(devicesWriteServiceFixture())
+	rels := []types.RelationshipRecord{
+		// provider INJECTED_INTO consumer (FromID = provider service name).
+		{FromID: "DevicesWriteService", ToID: "cccccccccccccccc", Kind: "INJECTED_INTO"},
+		{FromID: "DevicesWriteService", ToID: "dddddddddddddddd", Kind: "INJECTED_INTO"},
+	}
+	stats := References(rels, idx)
+
+	for i, r := range rels {
+		if r.FromID != "aaaaaaaaaaaaaaaa" {
+			t.Fatalf("edge %d: provider resolved to %q, want real Class aaaaaaaaaaaaaaaa (not spec stub bbbbbbbbbbbbbbbb / phantom)", i, r.FromID)
+		}
+		if r.FromID == "bbbbbbbbbbbbbbbb" {
+			t.Fatalf("edge %d: provider bound to the spec Component placeholder", i)
+		}
+	}
+	if stats.Ambiguous != 0 {
+		t.Fatalf("expected 0 ambiguous, got %+v (edge would orphan to a phantom node)", stats)
+	}
+
+	// Reachability: both edges now share a real From endpoint, so a
+	// provider→consumers adjacency keyed on the resolved real Class ID
+	// contains both consumers — i.e. neither edge is orphaned under a
+	// phantom bare-name key.
+	adj := map[string][]string{}
+	for _, r := range rels {
+		adj[r.FromID] = append(adj[r.FromID], r.ToID)
+	}
+	got := adj["aaaaaaaaaaaaaaaa"]
+	if len(got) != 2 {
+		t.Fatalf("provider adjacency = %v, want both consumers reachable from the real Class", got)
+	}
+	if _, phantom := adj["DevicesWriteService"]; phantom {
+		t.Fatalf("an edge remained keyed under the phantom bare-name 'DevicesWriteService'")
+	}
+}
+
+// TestHintKinds_Binds_AmbiguousImplResolvesToRealClass — a DI BINDS
+// token→impl edge whose impl name is ambiguous (real Class + spec stub)
+// resolves to the real impl Class.
+func TestHintKinds_Binds_AmbiguousImplResolvesToRealClass(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("1111111111111111", "Class", "DevicesWriteService", "impl/devices-write.service.ts"),
+		entAt("2222222222222222", "SCOPE.Component", "DevicesWriteService", "openapi/spec.yaml"),
+		entAt("3333333333333333", "Class", "DevicesWriteToken", "di/tokens.ts"),
+	}
+	idx := BuildIndex(entities)
+	// token BINDS impl (ToID = impl class name, ambiguous).
+	rels := []types.RelationshipRecord{
+		{FromID: "3333333333333333", ToID: "DevicesWriteService", Kind: "BINDS"},
+	}
+	stats := References(rels, idx)
+	if rels[0].ToID != "1111111111111111" {
+		t.Fatalf("BINDS impl resolved to %q, want real Class 1111111111111111", rels[0].ToID)
+	}
+	if stats.Ambiguous != 0 {
+		t.Fatalf("BINDS: expected 0 ambiguous, got %+v", stats)
+	}
+}
+
+// TestHintKinds_DependsOnService_AmbiguousCallerResolvesToRealFunction —
+// the FROM endpoint is a function whose bare name collides with a spec
+// Component. operationKindFamily must pick the real Function.
+func TestHintKinds_DependsOnService_AmbiguousCallerResolvesToRealFunction(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaa0000aaaa0000", "Function", "chargeCustomer", "billing/charge.ts"),
+		// A same-named spec/OpenAPI Component stub that previously made the
+		// caller endpoint ambiguous.
+		entAt("bbbb0000bbbb0000", "SCOPE.Component", "chargeCustomer", "openapi/spec.yaml"),
+		// The synthetic external-service target resolves by QualifiedName,
+		// not via this bare-name path; modelled as a plain stub the resolver
+		// leaves alone.
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "chargeCustomer", ToID: "service:stripe", Kind: "DEPENDS_ON_SERVICE"},
+	}
+	stats := References(rels, idx)
+	if rels[0].FromID != "aaaa0000aaaa0000" {
+		t.Fatalf("DEPENDS_ON_SERVICE caller resolved to %q, want real Function aaaa0000aaaa0000", rels[0].FromID)
+	}
+	_ = stats
+}
+
+// TestHintKinds_JoinsChannel_AmbiguousHandlerResolvesToRealMethod — confirms
+// an operation-shaped semantic edge with an ambiguous handler endpoint
+// resolves to the right (Method) kind rather than a colliding Component.
+func TestHintKinds_JoinsChannel_AmbiguousHandlerResolvesToRealMethod(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("cccc0000cccc0000", "Method", "onConnect", "ws/gateway.ts"),
+		entAt("dddd0000dddd0000", "Component", "onConnect", "ui/OnConnect.tsx"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "onConnect", ToID: "channel:lobby", Kind: "JOINS_CHANNEL"},
+	}
+	stats := References(rels, idx)
+	if rels[0].FromID != "cccc0000cccc0000" {
+		t.Fatalf("JOINS_CHANNEL handler resolved to %q, want real Method cccc0000cccc0000", rels[0].FromID)
+	}
+	_ = stats
+}
+
+// TestHintKinds_GraphRelates_AmbiguousNodeResolvesToRealClass — Neo4j
+// @Node→@Node edge: both endpoints are domain classes; an ambiguous target
+// node name must bind to the real Class.
+func TestHintKinds_GraphRelates_AmbiguousNodeResolvesToRealClass(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("eeee0000eeee0000", "Class", "Movie", "graph/Movie.java"),
+		entAt("ffff0000ffff0000", "SCOPE.Component", "Movie", "openapi/spec.yaml"),
+		entAt("9999000099990000", "Class", "Person", "graph/Person.java"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "9999000099990000", ToID: "Movie", Kind: "GRAPH_RELATES"},
+	}
+	stats := References(rels, idx)
+	if rels[0].ToID != "eeee0000eeee0000" {
+		t.Fatalf("GRAPH_RELATES target resolved to %q, want real Class eeee0000eeee0000", rels[0].ToID)
+	}
+	if stats.Ambiguous != 0 {
+		t.Fatalf("GRAPH_RELATES: expected 0 ambiguous, got %+v", stats)
+	}
+}
+
+// TestHintKinds_Renders_MixedFamilyResolvesUnambiguousUnion — RENDERS uses
+// the component∪operation union. When the union has exactly one match
+// (a real Component, with only a spec-stub collision) it resolves; the
+// next test asserts the honest negative.
+func TestHintKinds_Renders_MixedFamilyResolvesUnambiguousUnion(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aabb0000aabb0000", "Component", "UserCard", "ui/UserCard.tsx"),
+		entAt("ccdd0000ccdd0000", "SCOPE.Component", "UserCard", "openapi/spec.yaml"),
+		entAt("eeff0000eeff0000", "Method", "renderProfile", "ui/Profile.tsx"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "eeff0000eeff0000", ToID: "UserCard", Kind: "RENDERS"},
+	}
+	stats := References(rels, idx)
+	if rels[0].ToID != "aabb0000aabb0000" {
+		t.Fatalf("RENDERS target resolved to %q, want real Component aabb0000aabb0000", rels[0].ToID)
+	}
+	_ = stats
+}
+
+// TestHintKinds_GenuinelyUnresolvable_StaysUnresolved is the HONEST negative:
+// when a name is ambiguous across TWO real source-bearing entities of kinds
+// the hint cannot separate (two real Classes), the edge must NOT be forced
+// to a wrong single resolution — it stays a stub.
+func TestHintKinds_GenuinelyUnresolvable_StaysUnresolved(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("a1a1a1a1a1a1a1a1", "Class", "Repo", "a/Repo.ts"),
+		entAt("b2b2b2b2b2b2b2b2", "Class", "Repo", "b/Repo.ts"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "Repo", ToID: "cccccccccccccccc", Kind: "INJECTED_INTO"},
+	}
+	stats := References(rels, idx)
+	if rels[0].FromID == "a1a1a1a1a1a1a1a1" || rels[0].FromID == "b2b2b2b2b2b2b2b2" {
+		t.Fatalf("two-real-class ambiguity was silently forced to %q", rels[0].FromID)
+	}
+	if rels[0].FromID != "Repo" {
+		t.Fatalf("FromID mutated unexpectedly to %q (want preserved stub 'Repo')", rels[0].FromID)
+	}
+	if stats.Ambiguous != 1 {
+		t.Fatalf("expected 1 honest ambiguous, got %+v", stats)
+	}
+}
+
+// TestHintKinds_NonAmbiguous_StillResolves guards against a regression where
+// adding the hint would somehow change the unambiguous path: a DI edge whose
+// endpoint is unique still resolves (this is the DataSource-ctor-dep case the
+// diagnosis said already survived; it must keep surviving).
+func TestHintKinds_NonAmbiguous_StillResolves(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("1212121212121212", "Class", "DataSource", "db/data-source.ts"),
+		entAt("3434343434343434", "Class", "RepoModule", "db/repo.module.ts"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "DataSource", ToID: "3434343434343434", Kind: "INJECTED_INTO"},
+	}
+	stats := References(rels, idx)
+	if rels[0].FromID != "1212121212121212" {
+		t.Fatalf("non-ambiguous DI provider resolved to %q, want 1212121212121212", rels[0].FromID)
+	}
+	if stats.Rewritten < 1 {
+		t.Fatalf("expected the unambiguous provider edge to rewrite, got %+v", stats)
+	}
+}


### PR DESCRIPTION
Closes #3930 (epic #3929) — deploy-7 P0-A. The rewrite agent's #1 regression.

## Problem
The graph rewrite added a large new semantic-edge taxonomy (NestJS/Spring/Angular DI `INJECTED_INTO` + `BINDS`, Neo4j `GRAPH_RELATES`, scheduled-job `TRIGGERS`, `DEPENDS_ON_SERVICE`, `RENDERS`, `GATED_BY`, `USES_TRANSLATION`, `DATA_FLOWS_TO`, `CACHES`/`INVALIDATES`, `JOINS_CHANNEL`, …). These edges **orphaned** whenever one endpoint was addressed by an **ambiguous bare name** — the confirmed shape being a real source-bearing `Class:DevicesWriteService` colliding with an OpenAPI/spec `SCOPE.Component("module")` placeholder of the same name (two `DevicesWriteService` Components in the indexed graph).

### Root cause
`internal/resolve/refs.go` `hintKinds()` maps an edge kind → the candidate entity Kinds its endpoint should resolve to, so an ambiguous name picks the right node. It returned **nil** for every new edge kind. With nil + an ambiguous name, `LookupStatusHint` fell straight to `statusAmbiguous`, `rewriteOne` left the endpoint as a bare string, and `buildAdjacency` keyed it under a **phantom node** — the edge became invisible to `inspect` / `neighbors` / `subgraph`. Non-ambiguous edges (e.g. a unique `DataSource` ctor-dep) survived, proving the resolver — not the extractor — was the break.

## Fix — generalised to the WHOLE taxonomy, not just DI
Added `hintKinds` entries so an ambiguous endpoint resolves to the **correct kind of node**, preferring the real code entity over a spec/OpenAPI stub:

- **component-shaped** endpoints → `componentKindFamily`: `INJECTED_INTO`, `BINDS` (DI token→impl), `GRAPH_RELATES`, `REGISTERS`, `HANDLES_SIGNAL`, `FEDERATES`.
- **operation-shaped** endpoints → `operationKindFamily`: `DEPENDS_ON_SERVICE`, `TRIGGERS`, `ENQUEUES`, `HANDLES_COMMAND`, `GATED_BY`, `DATA_FLOWS_TO`, `THROWS`, `CATCHES`, `INSTRUMENTS`, `CACHES`, `INVALIDATES`, `JOINS_CHANNEL`, `BROADCASTS_TO`, `RESOLVED_BY`, `VALIDATES`, `FETCHES`, `GRPC_IMPLEMENTS`, `GRPC_HANDLES`, `HANDLES`, `DISCRIMINATES_ON`, `BRANCHES_ON`.
- **mixed** (class OR free function depending on framework) → new `componentOrOperationKindFamily` union: `RENDERS`, `USES_TRANSLATION`. Honest widening — `uniqueMatchInFamily` resolves only when the union is itself unambiguous.

`lookupByKindHint`'s existing tier-1 `nameKindsReal` pass then prefers the **real** `Class`/`Component`/`Function`/`Method` over the `SCOPE.*` / spec placeholder, so the edge binds to the real node and stays reachable.

### Honest scoping
Edge kinds whose endpoints are **synthetic stubs** (table keys for `MODIFIES_TABLE`/`ACCESSES_TABLE`/`QUERIES`, `MessageTopic` for `PUBLISHES_TO`/`SUBSCRIBES_TO`, `service:`/`feature:`/`channel:`/`cache:` nodes, `SCOPE.Config`, `SCOPE.State`, Helm `helm_values:<path>`) resolve on the `byQualifiedName` / structural tiers **before** the ambiguous-bare-name branch is reached, so a code-entity family hint would never apply and is deliberately omitted. `BINDS` is dual-use (Helm + DI); the Helm stub matches by QualifiedName first, so the component hint only affects the DI token→impl class case — exactly the target.

The broader real-vs-synthetic/spec tie-break hardening is noted and tracked separately in **#3936**; this PR scopes itself to the `hintKinds` family map.

## Tests — value-asserting
`internal/resolve/semantic_hintkinds_test.go`:
- ambiguous `INJECTED_INTO` provider (real `Class` + spec `Component`) → resolves to the **real Class** (asserts the exact ID, not `len>0`); edge present in adjacency for **both** consumers; no phantom bare-name key.
- ambiguous `BINDS` token→impl → resolves to the real impl Class.
- ambiguous `DEPENDS_ON_SERVICE` / `JOINS_CHANNEL` handler → resolves to the right Function/Method kind.
- ambiguous `GRAPH_RELATES` target → real Class.
- `RENDERS` mixed-family union → real Component.
- **Honest negative**: two real same-named Classes → stays an unresolved stub (1 ambiguous), never force-bound.
- regression guard: a non-ambiguous DI provider still resolves.

## Gates
`go test ./internal/resolve/... ./internal/types/ ./internal/links/...` green; `tools/coverage` tests green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## ⚠️ DEPLOY-DEFERRED
Reference resolution happens at **INDEX time**. This fix takes effect only after a **daemon rebuild AND a reindex** — a plain restart is NOT sufficient. The live daemon serving the rewrite agent was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)