### PR TITLE
feat(python/drf): resolve per-action permissions from get_permissions overrides (#3933)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -229,6 +229,17 @@ type drfViewSetClass struct {
 	// synthesized http_endpoint (#3864). Zero value means "nothing declared"
 	// (honest-partial — no fabricated posture).
 	posture drfPosture
+	// actionPermissions maps a DRF action name (a CRUD verb like "create" /
+	// "list" or an @action method name) to the permission-class list that the
+	// ViewSet's `def get_permissions(self):` override or a
+	// `permission_classes_by_action = {...}` dict resolves for THAT action
+	// (#3933). When present, the per-action list overrides the flat
+	// permission_classes union for the matching route. A key of "" carries the
+	// default branch (`return [IsAuthenticated()]` / dict `default`) that
+	// applies to every action not otherwise listed. nil means no statically
+	// resolvable per-action override exists — the route falls back to the flat
+	// union posture (honest-partial).
+	actionPermissions map[string][]string
 	// resolved reports whether the ViewSet class was actually located and
 	// parsed on disk (parseViewSetClass found the `class <name>(...)`
 	// declaration). When false, the caller fell back to modelViewSetMethods()
@@ -1192,14 +1203,16 @@ func emitOneCRUDFamily(
 	viewSetName string,
 ) {
 	detailBase := fullPrefix + "/{" + placeholder + "}"
-	// #3864 — all CRUD routes inherit the ViewSet-level posture.
-	pos := vc.posture
 
 	// emitCRUD wraps emit with the #3831 provenance/defining_class computed for
 	// the given CRUD method, so each route is tagged explicit | inherited |
-	// synthesized with the right defining class.
+	// synthesized with the right defining class. #3864 — each CRUD route inherits
+	// the ViewSet-level posture; #3933 — when get_permissions / a
+	// permission_classes_by_action dict resolves a per-action permission for this
+	// method, that overrides the flat-union permission_classes for THIS route only.
 	emitCRUD := func(verb, canonical string, line int, method string) {
 		prov, defClass := drfCRUDProvenance(vc, viewSetName, method)
+		pos := postureForAction(vc, method)
 		emit(verb, canonical, sourceFile, line, viewSetName, method, pos, prov, defClass)
 	}
 
@@ -1236,7 +1249,7 @@ func emitOneCRUDFamily(
 		// The ANY catch-all only appears when the ViewSet could not be resolved
 		// (empty crudMethods), so the detail route is a pure router default with
 		// no body anywhere → synthesized, no defining_class (#3831).
-		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "", pos, drfProvSynthesized, "")
+		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "", vc.posture, drfProvSynthesized, "")
 	}
 }
 
@@ -1253,9 +1266,15 @@ func emitActionRoutes(
 	for _, act := range vc.actions {
 		// #3864 — an @action's own posture override (if any) applies to its
 		// route; otherwise the route inherits the ViewSet-level posture.
+		// #3933 — precedence: an explicit `permission_classes=[...]` kwarg on the
+		// @action decorator wins outright; failing that, a per-action permission
+		// resolved from get_permissions / permission_classes_by_action overrides
+		// the flat-union permission_classes for this action's route.
 		actPosture := vc.posture
 		if act.hasPosture {
 			actPosture = act.posture
+		} else {
+			actPosture = postureForAction(vc, act.methodName)
 		}
 		segment := act.urlPath
 		if segment == "" {
@@ -1658,6 +1677,13 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	// can stamp it on every generated route. In DRF these class attributes
 	// apply to every action the ViewSet exposes.
 	out.posture = parseDRFPosture(classBody)
+	// #3933 — resolve per-action permission overrides from a
+	// `def get_permissions(self):` body that branches on `self.action`, or from a
+	// `permission_classes_by_action = {...}` dict idiom. These attach the right
+	// permission to the right route (e.g. POST /x → IsAdminUser, GET /x → AllowAny)
+	// instead of the flat union parseDRFPosture stamps. Dynamic / non-literal
+	// conditions are left unresolved (honest-partial → flat-union fallback).
+	out.actionPermissions = parseDRFActionPermissions(classBody)
 	// classBody starts at classBodyStart in src; pass that offset so
 	// extractActions can compute absolute (src-relative) line numbers for
 	// each @action's `def NAME(` line (#2677).

--- a/internal/engine/django_drf_get_permissions.go
+++ b/internal/engine/django_drf_get_permissions.go
@@ -1,0 +1,292 @@
+// django_drf_get_permissions.go — per-action DRF permission resolution (#3933).
+//
+// # Why this exists
+//
+// DRF ViewSets routinely vary their authorisation surface PER ACTION rather
+// than declaring a single class-level `permission_classes`. The two canonical
+// idioms are:
+//
+//	# (1) get_permissions() branching on self.action
+//	class OrderViewSet(ModelViewSet):
+//	    def get_permissions(self):
+//	        if self.action == 'create':
+//	            return [IsAdminUser()]
+//	        elif self.action in ['list', 'retrieve']:
+//	            return [AllowAny()]
+//	        return [IsAuthenticated()]          # default
+//
+//	# (2) permission_classes_by_action dict
+//	class OrderViewSet(ModelViewSet):
+//	    permission_classes_by_action = {
+//	        'create': [IsAdminUser],
+//	        'list': [AllowAny],
+//	        'default': [IsAuthenticated],
+//	    }
+//	    def get_permissions(self):
+//	        try:
+//	            return [p() for p in self.permission_classes_by_action[self.action]]
+//	        except KeyError:
+//	            return [p() for p in self.permission_classes_by_action['default']]
+//
+// Before #3933 the DRF expansion pass stamped only the flat class-level
+// `permission_classes` union (via parseDRFPosture). A get_permissions override
+// that branched per action collapsed to whatever flat `permission_classes`
+// attribute happened to exist (often `IsAuthenticated`), so POST /orders
+// (create → IsAdminUser) and GET /orders (list → AllowAny) both showed the same
+// union — wrong on both the over- and under-protective sides.
+//
+// This pass parses the two idioms into a per-action permission map. The DRF
+// expansion pass (emitOneCRUDFamily / emitActionRoutes) then overrides the flat
+// posture's permission_classes with the per-action list for the matching CRUD
+// or @action route, attaching the right permission to the right route.
+//
+// Honest-partial: a branch whose condition is not a statically resolvable
+// `self.action == '<literal>'` / `self.action in [<literals>]` (e.g.
+// `if self.request.user.is_staff:` or a computed action set) is skipped — the
+// affected routes fall back to the flat-union posture (the pre-#3933 behaviour).
+
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// drfGetPermissionsDefRe locates the `def get_permissions(self...):` declaration
+// in a ViewSet class body. Group boundaries are unused — the match index marks
+// where the method body parsing begins.
+var drfGetPermissionsDefRe = regexp.MustCompile(`(?m)^[ \t]*def[ \t]+get_permissions[ \t]*\(`)
+
+// drfSelfActionEqRe matches a `self.action == '<literal>'` (or `!=` is NOT
+// matched — only equality narrows to a single action) condition. Group 1 is the
+// quoted action name.
+var drfSelfActionEqRe = regexp.MustCompile(`self\.action\s*==\s*["']([^"']+)["']`)
+
+// drfSelfActionInRe matches a `self.action in [ '<a>', '<b>', ... ]` (or tuple /
+// set) condition. Group 1 is the raw bracketed body of action-name literals.
+var drfSelfActionInRe = regexp.MustCompile(`self\.action\s+in\s+[\[(\{]([^\])\}]*)[\])\}]`)
+
+// drfReturnPermsRe matches a `return [ ... ]` (list/tuple) statement and
+// captures the bracketed body so the permission class symbols can be pulled out
+// with drfClassNames. The leading `return` keeps it from matching arbitrary
+// list literals.
+var drfReturnPermsRe = regexp.MustCompile(`return\s+[\[(]([^\])]*)[\])]`)
+
+// drfPermissionsByActionDictRe locates a `permission_classes_by_action = { ... }`
+// (or `_perms_by_action` style) dict assignment and captures the brace body.
+// (?s) lets the dict span multiple lines. The first `}` closes it — DRF maps are
+// flat string→list dicts, so nested braces do not occur in practice.
+var drfPermissionsByActionDictRe = regexp.MustCompile(`(?s)permission_classes_by_action\s*=\s*\{([^}]*)\}`)
+
+// drfDictEntryRe matches a `'<action>': [ <perms> ]` entry inside a
+// permission_classes_by_action dict body. Group 1 is the action key, group 2 is
+// the bracketed permission list body. Entries whose value is not a list literal
+// are skipped (honest-partial).
+var drfDictEntryRe = regexp.MustCompile(`["']([^"']+)["']\s*:\s*[\[(]([^\])]*)[\])]`)
+
+// drfStringLiteralRe pulls the individual quoted string literals out of a
+// `self.action in [...]` body.
+var drfStringLiteralRe = regexp.MustCompile(`["']([^"']+)["']`)
+
+// parseDRFActionPermissions resolves a per-action permission map from a ViewSet
+// class body, handling both the get_permissions(self) self.action-branch idiom
+// and the permission_classes_by_action dict idiom. Returns nil when neither is
+// present or nothing statically resolvable was found (the routes then fall back
+// to the flat-union posture — honest-partial).
+//
+// The returned map keys are DRF action names (CRUD verbs or @action method
+// names); the value is the ordered list of permission-class leaf symbols. A key
+// of "" carries the default branch that applies to any action not otherwise
+// listed.
+func parseDRFActionPermissions(classBody string) map[string][]string {
+	out := map[string][]string{}
+
+	// Idiom (2): permission_classes_by_action dict. Parsed first so an explicit
+	// get_permissions self.action branch (idiom 1) can refine / override it.
+	if m := drfPermissionsByActionDictRe.FindStringSubmatch(classBody); len(m) >= 2 {
+		for _, e := range drfDictEntryRe.FindAllStringSubmatch(m[1], -1) {
+			action := e[1]
+			perms := finalDottedSegments(drfClassNames(e[2]))
+			key := action
+			if action == "default" {
+				key = ""
+			}
+			// Always record the key (even when perms is empty, e.g. `[]` = open)
+			// so the route is recognised as explicitly resolved.
+			out[key] = perms
+		}
+	}
+
+	// Idiom (1): get_permissions(self) branching on self.action.
+	mergeGetPermissionsBranches(classBody, out)
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeGetPermissionsBranches parses the body of `def get_permissions(self):`
+// and merges its per-action permission resolutions into out. Each block (the
+// suite under an `if/elif self.action ...:` header, or the method-level default
+// `return [...]`) is matched to the `return [...]` it owns.
+//
+// The parser is line-oriented and indentation-aware: it splits the method body
+// into header→return blocks. A header that is a resolvable self.action condition
+// binds its return's permissions to the named action(s); a `return [...]` that
+// is NOT guarded by a self.action condition (the method-level fallthrough or an
+// `else:`) binds to the default key "". Non-resolvable conditions
+// (`if self.request...`, computed sets) are skipped — honest-partial.
+func mergeGetPermissionsBranches(classBody string, out map[string][]string) {
+	loc := drfGetPermissionsDefRe.FindStringIndex(classBody)
+	if loc == nil {
+		return
+	}
+	// Body is everything after the def line until the next def/class at the
+	// method's own (or lower) indentation. extractMethodBody handles dedent
+	// boundary detection.
+	body := extractDefBody(classBody[loc[0]:])
+	if body == "" {
+		return
+	}
+
+	lines := strings.Split(body, "\n")
+	// pendingActions holds the action names that the *next* `return [...]` should
+	// bind to. Empty slice + pendingDefault=false means "no guard seen yet" — a
+	// return found in that state is the method-level default.
+	var pendingActions []string
+	pendingResolvable := true // whether the current guard was statically resolvable
+
+	bindReturn := func(perms []string) {
+		if len(pendingActions) == 0 {
+			// Unguarded return → default branch.
+			if pendingResolvable {
+				if _, exists := out[""]; !exists {
+					out[""] = perms
+				}
+			}
+			return
+		}
+		for _, a := range pendingActions {
+			if _, exists := out[a]; !exists {
+				out[a] = perms
+			}
+		}
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "if ") || strings.HasPrefix(trimmed, "elif "):
+			actions, resolvable := resolveActionCondition(trimmed)
+			pendingActions = actions
+			pendingResolvable = resolvable
+		case strings.HasPrefix(trimmed, "else:"):
+			// else binds to the default key.
+			pendingActions = nil
+			pendingResolvable = true
+		case strings.HasPrefix(trimmed, "return "):
+			if rm := drfReturnPermsRe.FindStringSubmatch(trimmed); len(rm) >= 2 {
+				perms := finalDottedSegments(drfClassNames(rm[1]))
+				bindReturn(perms)
+			}
+			// A return that is not a list literal (e.g. a dict-lookup
+			// comprehension) is left unresolved here — the dict idiom (parsed
+			// separately) covers the common `permission_classes_by_action` case.
+			// Reset the guard after every return so a subsequent top-level return
+			// is treated as the default branch.
+			pendingActions = nil
+			pendingResolvable = true
+		}
+	}
+}
+
+// resolveActionCondition parses an `if`/`elif` header into the set of action
+// names it narrows `self.action` to, and whether the condition was statically
+// resolvable. `self.action == 'x'` → (["x"], true); `self.action in ['a','b']`
+// → (["a","b"], true). Any other condition (computed, user-based, negated) →
+// (nil, false) so the guarded return is skipped — honest-partial.
+func resolveActionCondition(header string) (actions []string, resolvable bool) {
+	if m := drfSelfActionEqRe.FindStringSubmatch(header); len(m) >= 2 {
+		return []string{m[1]}, true
+	}
+	if m := drfSelfActionInRe.FindStringSubmatch(header); len(m) >= 2 {
+		var names []string
+		for _, sm := range drfStringLiteralRe.FindAllStringSubmatch(m[1], -1) {
+			names = append(names, sm[1])
+		}
+		if len(names) > 0 {
+			return names, true
+		}
+	}
+	return nil, false
+}
+
+// extractDefBody returns the suite of a `def ...:` whose declaration starts at
+// the head of src. It mirrors extractClassBody's boundary logic but is indent-
+// relative: the body runs until the first non-blank line whose indentation is
+// less than or equal to the `def` line's own indentation.
+func extractDefBody(src string) string {
+	lines := strings.Split(src, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	defIndent := indentWidth(lines[0])
+	var b strings.Builder
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			b.WriteString(line)
+			b.WriteByte('\n')
+			continue
+		}
+		if indentWidth(line) <= defIndent {
+			break
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// indentWidth returns the leading-whitespace width of a line, counting a tab as
+// one column (sufficient for boundary comparison — Python forbids mixing in a
+// way that would defeat this for our purposes).
+func indentWidth(line string) int {
+	n := 0
+	for _, r := range line {
+		if r == ' ' || r == '\t' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}
+
+// postureForAction returns the endpoint posture to stamp on the route backing
+// the given DRF action. It starts from the ViewSet-level posture (#3864) and,
+// when a per-action permission override exists for this action (#3933),
+// replaces the posture's permissionClasses with the action-specific list. An
+// action with no explicit entry inherits the default branch ("" key) when one
+// was resolved; absent both, the flat-union ViewSet posture is returned
+// unchanged (honest-partial).
+func postureForAction(vc drfViewSetClass, action string) drfPosture {
+	pos := vc.posture
+	if vc.actionPermissions == nil {
+		return pos
+	}
+	perms, ok := vc.actionPermissions[action]
+	if !ok {
+		// No explicit per-action entry — apply the resolved default branch if any.
+		perms, ok = vc.actionPermissions[""]
+		if !ok {
+			return pos
+		}
+	}
+	pos.permissionClasses = perms
+	return pos
+}

--- a/internal/engine/django_drf_get_permissions_test.go
+++ b/internal/engine/django_drf_get_permissions_test.go
@@ -1,0 +1,324 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestApplyDjangoDRFRoutes_GetPermissionsPerActionBranches is the #3933
+// value-asserting test: a ViewSet whose `get_permissions(self)` branches on
+// `self.action` must attach the per-action permission to the matching CRUD
+// route — POST /x (create→IsAdminUser), GET /x (list→AllowAny), and the default
+// branch (IsAuthenticated) to every other CRUD route — NOT a flat union on all.
+func TestApplyDjangoDRFRoutes_GetPermissionsPerActionBranches(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import OrderViewSet
+
+router = routers.DefaultRouter()
+router.register(r"orders", OrderViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
+
+class OrderViewSet(ModelViewSet):
+    def get_permissions(self):
+        if self.action == 'create':
+            return [IsAdminUser()]
+        elif self.action in ['list', 'retrieve']:
+            return [AllowAny()]
+        return [IsAuthenticated()]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// create → POST /orders → IsAdminUser (admin-only, distinct from union).
+	assertEndpointProp(t, got, "http:POST:/orders", "auth_required", "true")
+	assertEndpointProp(t, got, "http:POST:/orders", "middleware_names", "IsAdminUser")
+
+	// list → GET /orders → AllowAny → public (auth NOT required).
+	assertEndpointProp(t, got, "http:GET:/orders", "middleware_names", "AllowAny")
+	assertNoProp(t, got, "http:GET:/orders", "auth_required")
+
+	// retrieve → GET /orders/{pk} → AllowAny (shares the list branch).
+	assertEndpointProp(t, got, "http:GET:/orders/{pk}", "middleware_names", "AllowAny")
+	assertNoProp(t, got, "http:GET:/orders/{pk}", "auth_required")
+
+	// update / partial_update / destroy fall through to the default → IsAuthenticated.
+	for _, id := range []string{
+		"http:PUT:/orders/{pk}",
+		"http:PATCH:/orders/{pk}",
+		"http:DELETE:/orders/{pk}",
+	} {
+		assertEndpointProp(t, got, id, "middleware_names", "IsAuthenticated")
+		assertEndpointProp(t, got, id, "auth_required", "true")
+	}
+}
+
+// TestApplyDjangoDRFRoutes_GetPermissionsActionRoute verifies an @action with no
+// permission_classes kwarg picks up its per-action get_permissions branch on
+// THAT action's route (the matching @action route), distinct from CRUD routes.
+func TestApplyDjangoDRFRoutes_GetPermissionsActionRoute(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ReportViewSet
+
+router = routers.DefaultRouter()
+router.register(r"reports", ReportViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
+
+class ReportViewSet(ModelViewSet):
+    @action(detail=False, methods=["get"], url_path="summary")
+    def summary(self, request):
+        pass
+
+    def get_permissions(self):
+        if self.action == 'summary':
+            return [AllowAny()]
+        return [IsAuthenticated()]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// The @action route 'summary' picks up its own get_permissions branch.
+	assertEndpointProp(t, got, "http:GET:/reports/summary", "middleware_names", "AllowAny")
+	assertNoProp(t, got, "http:GET:/reports/summary", "auth_required")
+
+	// A regular CRUD route gets the default branch.
+	assertEndpointProp(t, got, "http:GET:/reports", "middleware_names", "IsAuthenticated")
+	assertEndpointProp(t, got, "http:GET:/reports", "auth_required", "true")
+}
+
+// TestApplyDjangoDRFRoutes_PermissionClassesByActionDict verifies the
+// `permission_classes_by_action = {...}` DRF idiom attaches per-action perms.
+func TestApplyDjangoDRFRoutes_PermissionClassesByActionDict(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ItemViewSet
+
+router = routers.DefaultRouter()
+router.register(r"items", ItemViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
+
+class ItemViewSet(ModelViewSet):
+    permission_classes_by_action = {
+        'create': [IsAdminUser],
+        'list': [AllowAny],
+        'default': [IsAuthenticated],
+    }
+
+    def get_permissions(self):
+        try:
+            return [p() for p in self.permission_classes_by_action[self.action]]
+        except KeyError:
+            return [p() for p in self.permission_classes_by_action['default']]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	assertEndpointProp(t, got, "http:POST:/items", "middleware_names", "IsAdminUser")
+	assertEndpointProp(t, got, "http:POST:/items", "auth_required", "true")
+
+	assertEndpointProp(t, got, "http:GET:/items", "middleware_names", "AllowAny")
+	assertNoProp(t, got, "http:GET:/items", "auth_required")
+
+	// retrieve/update/etc. → default IsAuthenticated.
+	assertEndpointProp(t, got, "http:GET:/items/{pk}", "middleware_names", "IsAuthenticated")
+	assertEndpointProp(t, got, "http:DELETE:/items/{pk}", "middleware_names", "IsAuthenticated")
+}
+
+// TestApplyDjangoDRFRoutes_ActionKwargBeatsGetPermissions verifies precedence:
+// an explicit `permission_classes=[...]` on the @action decorator wins over a
+// per-action get_permissions branch for the same action.
+func TestApplyDjangoDRFRoutes_ActionKwargBeatsGetPermissions(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import DocViewSet
+
+router = routers.DefaultRouter()
+router.register(r"docs", DocViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
+
+class DocViewSet(ModelViewSet):
+    @action(detail=False, methods=["get"], url_path="export", permission_classes=[IsAdminUser])
+    def export(self, request):
+        pass
+
+    def get_permissions(self):
+        if self.action == 'export':
+            return [AllowAny()]
+        return [IsAuthenticated()]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// The decorator kwarg IsAdminUser wins, not the get_permissions AllowAny.
+	assertEndpointProp(t, got, "http:GET:/docs/export", "middleware_names", "IsAdminUser")
+	assertEndpointProp(t, got, "http:GET:/docs/export", "auth_required", "true")
+}
+
+// TestApplyDjangoDRFRoutes_DynamicActionConditionFallsBackToUnion is the
+// negative / honest-partial test: a get_permissions whose conditions are NOT
+// statically resolvable self.action branches falls back to the flat-union
+// class-level permission_classes for every route.
+func TestApplyDjangoDRFRoutes_DynamicActionConditionFallsBackToUnion(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import DynViewSet
+
+router = routers.DefaultRouter()
+router.register(r"dyn", DynViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+
+class DynViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticated]
+
+    def get_permissions(self):
+        if self.request.user.is_staff:
+            return [IsAdminUser()]
+        return super().get_permissions()
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// No resolvable self.action branch → every route keeps the flat union
+	// (class-level permission_classes = IsAuthenticated).
+	for _, id := range []string{
+		"http:GET:/dyn",
+		"http:POST:/dyn",
+		"http:GET:/dyn/{pk}",
+		"http:DELETE:/dyn/{pk}",
+	} {
+		assertEndpointProp(t, got, id, "middleware_names", "IsAuthenticated")
+		assertEndpointProp(t, got, id, "auth_required", "true")
+	}
+}
+
+// TestParseDRFActionPermissions covers the parser directly for both idioms and
+// the dynamic-condition skip.
+func TestParseDRFActionPermissions(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want map[string][]string
+	}{
+		{
+			name: "get_permissions branches",
+			body: `
+    def get_permissions(self):
+        if self.action == 'create':
+            return [IsAdminUser()]
+        elif self.action in ['list', 'retrieve']:
+            return [AllowAny()]
+        return [IsAuthenticated()]
+`,
+			want: map[string][]string{
+				"create":   {"IsAdminUser"},
+				"list":     {"AllowAny"},
+				"retrieve": {"AllowAny"},
+				"":         {"IsAuthenticated"},
+			},
+		},
+		{
+			name: "dict idiom",
+			body: `
+    permission_classes_by_action = {
+        'create': [IsAdminUser],
+        'list': [AllowAny],
+        'default': [IsAuthenticated],
+    }
+`,
+			want: map[string][]string{
+				"create": {"IsAdminUser"},
+				"list":   {"AllowAny"},
+				"":       {"IsAuthenticated"},
+			},
+		},
+		{
+			name: "dotted permission refs",
+			body: `
+    def get_permissions(self):
+        if self.action == 'destroy':
+            return [permissions.IsAdminUser()]
+        return [permissions.IsAuthenticated()]
+`,
+			want: map[string][]string{
+				"destroy": {"IsAdminUser"},
+				"":        {"IsAuthenticated"},
+			},
+		},
+		{
+			name: "dynamic condition skipped",
+			body: `
+    def get_permissions(self):
+        if self.request.user.is_staff:
+            return [IsAdminUser()]
+        return super().get_permissions()
+`,
+			// Only the unguarded default return resolves; the dynamic if-branch
+			// is skipped, and the trailing super() call is not a list literal.
+			want: nil,
+		},
+		{
+			name: "no override",
+			body: `
+    permission_classes = [IsAuthenticated]
+    queryset = None
+`,
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDRFActionPermissions(tc.body)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseDRFActionPermissions() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPostureForAction verifies the per-action override layering over the
+// ViewSet posture, including the default-branch fallthrough and the
+// no-override passthrough.
+func TestPostureForAction(t *testing.T) {
+	vc := drfViewSetClass{
+		posture: drfPosture{permissionClasses: []string{"IsAuthenticated"}},
+		actionPermissions: map[string][]string{
+			"create": {"IsAdminUser"},
+			"":       {"IsAuthenticated"},
+		},
+	}
+	if got := postureForAction(vc, "create").permissionClasses; !reflect.DeepEqual(got, []string{"IsAdminUser"}) {
+		t.Errorf("create perms = %v, want [IsAdminUser]", got)
+	}
+	if got := postureForAction(vc, "list").permissionClasses; !reflect.DeepEqual(got, []string{"IsAuthenticated"}) {
+		t.Errorf("list perms (default) = %v, want [IsAuthenticated]", got)
+	}
+
+	// No actionPermissions at all → posture returned unchanged.
+	bare := drfViewSetClass{posture: drfPosture{permissionClasses: []string{"IsAuthenticated"}}}
+	if got := postureForAction(bare, "create").permissionClasses; !reflect.DeepEqual(got, []string{"IsAuthenticated"}) {
+		t.Errorf("bare passthrough = %v, want [IsAuthenticated]", got)
+	}
+}


### PR DESCRIPTION
## Summary

Build deploy-7 #3933 (epic #3929) — the rewrite agent's #1 auth ask (#288).

DRF ViewSets that override `get_permissions(self)` to return different
`permission_classes` per `self.action` previously showed only a flat union
(e.g. `IsAuthenticated`) on every router-expanded route. This PR resolves the
per-action branches and attaches the right permission to the right route.

### Root cause
The DRF expansion (`parseDRFPosture`) stamped only the flat class-level
`permission_classes` union onto every CRUD/@action route. `get_permissions`
bodies were never parsed for `self.action` branching, so POST /orders
(create → `IsAdminUser`) and GET /orders (list → `AllowAny`) both showed the
same union — wrong on both the over- and under-protective sides.

### What changed
New `internal/engine/django_drf_get_permissions.go` parses two canonical DRF
idioms into a per-action permission map, threaded into `emitOneCRUDFamily` /
`emitActionRoutes` via `postureForAction`:

- **`get_permissions(self)` branching** on `self.action == '<lit>'` /
  `self.action in [<lits>]`; the unguarded / `else` `return [...]` is the
  default branch (key `""`, applied to any action not otherwise listed).
- **`permission_classes_by_action = {...}` dict** idiom (with a `default` key).

The per-action list overrides the flat posture's `permission_classes` for the
matching CRUD or @action route only. **Precedence:** an explicit
`permission_classes=[...]` kwarg on an @action decorator still wins outright.

### Honest-partial
A branch whose condition is not a statically resolvable `self.action`
equality/membership test (e.g. `if self.request.user.is_staff:`, computed
action sets) is skipped — those routes fall back to the flat-union posture
(pre-change behaviour). Asserted by a negative test.

### Per-action perms asserted (value-asserting, not len>0)
For `get_permissions` with `create→[IsAdminUser]`, `list/retrieve→[AllowAny]`,
default `[IsAuthenticated]`:
- `POST /orders` → `middleware_names=IsAdminUser`, `auth_required=true`
- `GET /orders` (list) → `middleware_names=AllowAny`, **no** `auth_required`
- `GET /orders/{pk}` (retrieve) → `AllowAny`, **no** `auth_required`
- `PUT|PATCH|DELETE /orders/{pk}` → `IsAuthenticated`, `auth_required=true`
- @action `summary` with its own branch → that route gets `AllowAny`
- dict idiom → same per-action attachment
- @action `permission_classes=[IsAdminUser]` kwarg beats a `get_permissions`
  `AllowAny` branch for the same action
- dynamic condition → flat-union fallback (negative)

### Validation
- `go test` targeted (engine / custom/python / extractors/python / types /
  tools/coverage) green; `go test ./internal/types/` green
- `coverage validate` exit 0 (0 errors); `coverage fmt --check` canonical;
  `coverage gen` no drift
- `gofmt -l` empty; `go vet ./internal/engine/` clean

### Deploy
**DEPLOY-DEFERRED** — needs a daemon rebuild + reindex to surface the
per-action posture on the live graph.

### Cross-language note
Dynamic per-action auth resolution generalises to other frameworks' conditional
guards (Spring method-security expressions, Express per-route middleware
branches) — tracked separately.

Closes #3933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
