### PR TITLE
resolve: scope-local synthetic stubs don't cross-resolve into spec nodes (#3936)

### DIFF
--- a/internal/resolve/discriminator_scope_3936_test.go
+++ b/internal/resolve/discriminator_scope_3936_test.go
@@ -1,0 +1,124 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #3936 — a scope-local synthetic DISCRIMINATES_ON stub ("var:order",
+// emitted by the pymongo/JS discriminator extractors for a local sort-key /
+// compared variable) MUST NOT cross-resolve into a same-named global entity
+// of an UNRELATED kind. The canonical false edge: a pymongo aggregation
+// builder's `var:order` sort key binding to an OpenAPI `order` query-param
+// node from open-api/buildings.yml — a bare-leaf-name collision across the
+// code↔spec boundary.
+//
+// These tests assert the false edge is GONE (the var: stub stays verbatim /
+// unresolved, no cross-boundary edge) AND that a legitimate DISCRIMINATES_ON
+// to a real same-scope discriminator field still resolves.
+
+// openAPIParam models the spec-side `order` query-param node that lives in
+// open-api/buildings.yml: an entity of a different kind than any local
+// variable, indexed under the global byName index by its bare leaf name.
+func openAPIParam(id, name string) types.EntityRecord {
+	return types.EntityRecord{
+		ID:         id,
+		Kind:       "SCOPE.Component",
+		Name:       name,
+		SourceFile: "open-api/buildings.yml",
+	}
+}
+
+// TestDiscriminator_VarStub_DoesNotBindToOpenAPIParam is the #3936 regression:
+// the ONLY global entity named "order" is the OpenAPI param node. A
+// DISCRIMINATES_ON edge whose ToID is the scope-local synthetic "var:order"
+// must stay unresolved — it must NOT bind to that spec node.
+func TestDiscriminator_VarStub_DoesNotBindToOpenAPIParam(t *testing.T) {
+	entities := []types.EntityRecord{
+		// the spec-side OpenAPI `order` query param (the false-edge target)
+		openAPIParam("0123456789abcdef", "order"),
+		// the pymongo aggregation builder that emits the discriminator edge
+		entAt("fedcba9876543210", "SCOPE.Operation", "build_pipeline", "app/agg.py"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{{
+		FromID: "fedcba9876543210",
+		ToID:   "var:order",
+		Kind:   "DISCRIMINATES_ON",
+	}}
+	stats := References(rels, idx)
+
+	// The false edge must be GONE: the var: stub is preserved verbatim, NOT
+	// rewritten to the OpenAPI param's hex ID.
+	if rels[0].ToID == "0123456789abcdef" {
+		t.Fatalf("FALSE EDGE: var:order cross-resolved to the OpenAPI `order` param node")
+	}
+	if rels[0].ToID != "var:order" {
+		t.Fatalf("var:order should stay verbatim/unresolved, got %q", rels[0].ToID)
+	}
+	if stats.Rewritten != 0 {
+		t.Fatalf("expected 0 rewrites for a scope-local var stub, got %d", stats.Rewritten)
+	}
+}
+
+// TestDiscriminator_VarStub_ClassifiedDynamic asserts the unresolved var:
+// stub lands in DispositionDynamic (scope-local by design), NOT a bug bucket.
+func TestDiscriminator_VarStub_ClassifiedDynamic(t *testing.T) {
+	entities := []types.EntityRecord{openAPIParam("0123456789abcdef", "order")}
+	idx := BuildIndex(entities)
+	d := idx.classifyDispositionLang("var:order", "var:order", "python", nil)
+	if d != DispositionDynamic {
+		t.Fatalf("var:order disposition = %v, want DispositionDynamic", d)
+	}
+}
+
+// TestDiscriminator_VarStub_LookupGuards asserts both resolver entry points
+// (Lookup and LookupStatusHint) refuse to cross-resolve a var: stub even when
+// a same-named global entity exists.
+func TestDiscriminator_VarStub_LookupGuards(t *testing.T) {
+	entities := []types.EntityRecord{openAPIParam("0123456789abcdef", "order")}
+	idx := BuildIndex(entities)
+
+	if id, ok := idx.Lookup("var:order"); ok {
+		t.Fatalf("Lookup(var:order) cross-resolved to %q, want miss", id)
+	}
+	if id, st := idx.LookupStatusHint("var:order", "DISCRIMINATES_ON"); st == statusRewritten {
+		t.Fatalf("LookupStatusHint(var:order) rewrote to %q, want non-rewritten", id)
+	}
+}
+
+// TestDiscriminator_LegitimateFieldEdge_StillResolves asserts the TRUE edge
+// survives: a DISCRIMINATES_ON edge that legitimately targets a real
+// same-scope discriminator field (addressed by a concrete structural ref, the
+// shape the resolver IS meant to bind) still resolves to that field's entity.
+// The var: guard only short-circuits the scope-local synthetic shape; it must
+// not touch concrete structural refs.
+func TestDiscriminator_LegitimateFieldEdge_StillResolves(t *testing.T) {
+	// A real discriminator field entity defined in the same file as the
+	// operation that branches on it. Addressed by a Format A structural ref.
+	field := types.EntityRecord{
+		ID:         "aaaaaaaaaaaaaaaa",
+		Kind:       "SCOPE.Operation",
+		Name:       "status",
+		SourceFile: "app/models.py",
+	}
+	// An unrelated global entity also named "status" to prove the resolution
+	// is scope/structural, not a lucky bare-name hit.
+	other := openAPIParam("bbbbbbbbbbbbbbbb", "status")
+	idx := BuildIndex([]types.EntityRecord{field, other})
+
+	rels := []types.RelationshipRecord{{
+		FromID: "cccccccccccccccc",
+		ToID:   "scope:operation:method:python:app/models.py:status",
+		Kind:   "DISCRIMINATES_ON",
+	}}
+	stats := References(rels, idx)
+
+	if rels[0].ToID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("TRUE EDGE LOST: legitimate same-scope discriminator field did not resolve, got %q", rels[0].ToID)
+	}
+	if stats.Rewritten != 1 {
+		t.Fatalf("expected 1 rewrite for the legitimate field edge, got %d", stats.Rewritten)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -40,6 +40,18 @@ const (
 	// stubPrefixExternal marks an external-package placeholder
 	// emitted by the external synthesiser (e.g. "ext:django").
 	stubPrefixExternal = "ext:"
+	// stubPrefixVar marks a scope-local synthetic stub naming a local
+	// variable / sort key / discriminator field by its BARE leaf name
+	// (e.g. "var:order"). Emitted by the Python / JS discriminator
+	// extractors for DISCRIMINATES_ON edges (#2666): the ToID encodes the
+	// compared local-variable name purely so inspect/find can surface the
+	// line-precise hit — it is NOT a cross-file reference and has no global
+	// target entity. The leaf name routinely collides with an unrelated
+	// global entity of a different kind (the canonical #3936 bug: a pymongo
+	// sort key `var:order` mis-binding to an OpenAPI `order` query param).
+	// Such stubs MUST stay scope-local and NEVER cross-resolve through the
+	// global byKind / byName indexes. See isScopeLocalSyntheticStub.
+	stubPrefixVar = "var:"
 	// scopeKindPrefix is the optional family prefix on entity kinds
 	// emitted by Pass 3 cross-language extractors (e.g. "SCOPE.View").
 	scopeKindPrefix = "SCOPE."
@@ -1245,6 +1257,12 @@ func (idx Index) Lookup(stub string) (string, bool) {
 	if stub == "" {
 		return "", false
 	}
+	// #3936 — scope-local synthetic stubs ("var:<name>") never cross-resolve
+	// into a same-named global node. Mirror the LookupStatusHint guard so the
+	// kind-agnostic Lookup entry point is equally scope-safe.
+	if isScopeLocalSyntheticStub(stub) {
+		return "", false
+	}
 	// Direct QualifiedName hit short-circuits the kind/name paths
 	// (issue #100). Blank-string sentinel = ambiguous → treat as miss.
 	if qid, ok := idx.byQualifiedName[stub]; ok {
@@ -1290,6 +1308,19 @@ func (idx Index) LookupStatus(stub string) (id string, status int) {
 // When passed "" the function behaves exactly like LookupStatus.
 func (idx Index) LookupStatusHint(stub, relKind string) (id string, status int) {
 	if stub == "" {
+		return "", statusUnmatched
+	}
+
+	// #3936 — scope-local synthetic stubs (e.g. "var:order" discriminator /
+	// sort-key markers) name a local variable by its bare leaf inside the
+	// emitting scope. They have no global target entity and MUST NOT
+	// cross-resolve into a same-named-but-unrelated global node (the false
+	// edge being a pymongo `var:order` binding to an OpenAPI `order` param).
+	// Short-circuit BEFORE the QualifiedName / structural / kind / name tiers
+	// so the bare leaf is never matched against byName. Left as statusUnmatched
+	// → rewriteOne keeps the verbatim stub; classifyDispositionLang routes it
+	// to DispositionDynamic.
+	if isScopeLocalSyntheticStub(stub) {
 		return "", statusUnmatched
 	}
 
@@ -2122,6 +2153,32 @@ var sourceFileExtensions = []string{
 // Kept: short-form stubs whose target genuinely cannot resolve to a
 // single entity at link time (runtime-built URLs for http callers,
 // unresolved local imports, file/coverage wrappers).
+// isScopeLocalSyntheticStub reports whether s is a scope-local synthetic
+// stub — a placeholder whose ToID encodes a BARE local-variable / sort-key /
+// discriminator-field name (e.g. "var:order") that is meaningful ONLY inside
+// the emitting function's scope. These stubs exist so inspect/find can show a
+// line-precise hit; they are NOT cross-file references and have NO global
+// target entity.
+//
+// #3936: the generic resolver previously split such a stub on the first ':'
+// (kind="var", name="order"), missed byKind["var"], and fell through to the
+// global byName index — where the bare leaf name "order" bound to a totally
+// unrelated entity of a different kind (an OpenAPI `order` query param from
+// open-api/buildings.yml). That is a false edge across the code↔spec
+// boundary born of a bare-name collision; the resolver was neither scope- nor
+// type-aware for this synthetic shape.
+//
+// Recognising the stub here lets LookupStatusHint short-circuit it to
+// statusUnmatched (leave the stub verbatim) BEFORE the byKind / byName tiers
+// run, and lets classifyDispositionLang route it to DispositionDynamic rather
+// than a bug bucket. The guard is intentionally prefix-based so it generalises
+// to any future scope-local synthetic prefix without re-plumbing the resolver:
+// add the prefix to this function and both the cross-resolve guard and the
+// disposition classification follow automatically.
+func isScopeLocalSyntheticStub(s string) bool {
+	return strings.HasPrefix(s, stubPrefixVar)
+}
+
 func isHeuristicScopeStub(s string) bool {
 	if !strings.HasPrefix(s, stubPrefixScope) {
 		return false
@@ -2810,6 +2867,13 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	// edges aren't resolvable by static name lookup. They keep the v1.0
 	// bug-rate metric honest while leaving the edges visible in graph.json.
 	if isHeuristicScopeStub(originalStub) {
+		return DispositionDynamic
+	}
+	// #3936 — scope-local synthetic stubs ("var:<name>" discriminator / sort-
+	// key markers) are intentionally left unresolved: they name a local
+	// variable inside the emitting scope, not a global entity. Route to
+	// Dynamic so they neither inflate the bug-rate nor falsely cross-resolve.
+	if isScopeLocalSyntheticStub(originalStub) {
 		return DispositionDynamic
 	}
 	// Issue #507 — Python SQL-driver dataaccess refs of the form


### PR DESCRIPTION
## Summary
Closes #3936 (deploy-7 #3936, epic #3929).

The rewrite agent flagged a false edge: a pymongo aggregation builder's `DISCRIMINATES_ON → "order"` wrongly resolved to an OpenAPI `order` query-param node (`open-api/buildings.yml`) — a bare-local-var name collision across the code↔spec boundary.

## Root cause
The discriminator extractors (#2666, python + JS) emit DISCRIMINATES_ON edges with a **scope-local synthetic** ToID: `var:<name>` (e.g. `var:order`), where `<name>` is the bare leaf name of the compared local variable / sort key. It exists purely so `inspect`/`find` can surface a line-precise hit; it is NOT a cross-file reference and has no global target entity.

The generic resolver:
1. split `var:order` on the first `:` → kind=`var`, name=`order`
2. missed `byKind["var"]`
3. fell through to the **global `byName` index**, where `order` was the unique OpenAPI param node → false cross-boundary edge.

The #3940 `hintKinds` addition (DISCRIMINATES_ON → operationKindFamily) does **not** fix this: `byName["order"]` hits directly because the spec node is the *unique* `order`, so the ambiguous-bare-name hint branch is never reached. The `var:` stub bypasses hintKinds entirely.

## Fix (scope-aware, generalised)
Recognise scope-local synthetic stubs (`isScopeLocalSyntheticStub`, prefix-based on `var:`) and refuse to cross-resolve them through the global `byKind`/`byName` indexes:
- guarded at **both** resolver entry points (`Lookup`, `LookupStatusHint`) — the bare leaf is never matched globally;
- `classifyDispositionLang` routes the now-unresolved stub to `DispositionDynamic` (scope-local by design) instead of `bug-resolver`.

The guard is **prefix-based**, so it generalises to any future scope-local synthetic prefix without re-plumbing the resolver — add the prefix to one helper and both the cross-resolve guard and the disposition classification follow.

Legitimate DISCRIMINATES_ON edges targeting a real same-scope discriminator field via a concrete **structural ref** (`scope:operation:...:status`) are unaffected and still resolve.

## Tests (value-asserting, not len>0)
- `var:order` does **not** bind to the same-named OpenAPI param — false edge GONE, stub stays verbatim, 0 rewrites, classified `Dynamic`.
- both `Lookup` and `LookupStatusHint` refuse to cross-resolve the `var:` stub even with a same-named global entity present.
- a **legitimate** same-scope structural-ref discriminator field STILL resolves (true edge preserved) even with an unrelated same-named global entity in the index.

Verified the suite fails on the exact false edge (cross-resolve + `bug-resolver` classification) when the guard is neutered, and passes with it.

## Gates
`go test ./internal/resolve/... ./internal/types/ ./internal/links/...` green; coverage `validate` 0 errors + `fmt` canonical; `gofmt -l` empty; `go vet` clean.

## DEPLOY-DEFERRED
Requires a reindex to re-run the resolver over emitted edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)