### PR TITLE
MRO-aware neighbors/def_use/trace + INHERITS edge (#3834)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -201,6 +201,10 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		SourceFile string `json:"file,omitempty"`
 		StartLine  int    `json:"line,omitempty"`
 		HopCount   int    `json:"hop_count"`
+		// ViaInherits marks a caller reached by a reverse-INHERITS hop (#3834):
+		// an inheriting subclass stub that exposes this (base) member's
+		// behaviour, not a direct CALLS-site of it.
+		ViaInherits bool `json:"via_inherits,omitempty"`
 		// isTest is excluded from the wire shape (json:"-") — it is an internal
 		// ranking/accounting signal only. #3648: production callers outrank test
 		// callers so they survive the token-budget cap, and the truncation note
@@ -254,6 +258,19 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 					discoveredVia[e.target] = e.kind
 					next = append(next, e.target)
 				}
+				// #3834 (MRO T4): reverse-INHERITS. When `n` is a DEFINING base
+				// member, the subclasses that inherit it (their bodyless stubs)
+				// are legitimate callers — they expose `n`'s behaviour under
+				// their own class. Surface them so neighbors(in) on a base method
+				// reaches the inheriting subclasses.
+				for _, stub := range mroInboundEdges(r, n) {
+					if _, seen := visited[stub]; seen {
+						continue
+					}
+					visited[stub] = d + 1
+					discoveredVia[stub] = inheritsEdgeKind
+					next = append(next, stub)
+				}
 			}
 			frontier = next
 			if len(frontier) == 0 {
@@ -268,6 +285,10 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			}
 			dk := discoveredVia[id]
 			isFileRefEdge := dk == "REFERENCES" || dk == "IMPORTS"
+			// #3834: a reverse-INHERITS caller is a (bodyless) inheriting stub.
+			// It is a legitimate caller of the base member, so it must survive
+			// the shadow/container noise filter exactly like a file-ref edge.
+			isInheritsEdge := dk == inheritsEdgeKind
 			e := byID[id]
 			if e == nil {
 				// #2015: previously a nil byID lookup silently dropped the
@@ -312,7 +333,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			// REFERENCES or IMPORTS the source is a real referencer — keep it.
 			switch classifyNoise(e) {
 			case noiseShadow:
-				if !isFileRefEdge {
+				if !isFileRefEdge && !isInheritsEdge {
 					continue
 				}
 			case noiseContainer:
@@ -327,6 +348,9 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 				StartLine:  e.StartLine,
 				HopCount:   d,
 				isTest:     isTestFileMCP(e.SourceFile),
+			}
+			if isInheritsEdge {
+				c.ViaInherits = true
 			}
 			if verbose {
 				c.Kind = stripScopePrefix(e.Kind)
@@ -501,6 +525,10 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		SourceFile string `json:"file,omitempty"`
 		StartLine  int    `json:"line,omitempty"`
 		HopCount   int    `json:"hop_count"`
+		// ViaInherits marks a callee reached by hopping through an inherited
+		// member's INHERITS edge (#3834) — i.e. the node is a defining base/
+		// mixin member, not a direct CALLS target of the queried entity.
+		ViaInherits bool `json:"via_inherits,omitempty"`
 		// isTest: internal ranking/accounting signal only (json:"-"). #3648.
 		isTest bool `json:"-"`
 	}
@@ -519,8 +547,18 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		}
 
 		// BFS over outbound-only adjacency.
+		//
+		// #3834 (MRO T4): when the walk reaches an inherited-member STUB (empty
+		// CALLS edges — the body lives on a base/mixin), splice a synthetic
+		// INHERITS hop to the DEFINING member so callees reach the real base
+		// implementation instead of dead-ending at the bodyless node.
+		// mroExternal records synthetic external-contract nodes (DRF mixin) so
+		// they render without a backing indexed entity; mroVia marks the
+		// INHERITS-discovered ids so the wire shape can label the hop.
 		adj := r.getAdjacency()
 		visited := map[string]int{target: 0}
+		mroExternal := map[string]*graph.Entity{}
+		mroVia := map[string]bool{}
 		frontier := []string{target}
 		for d := 0; d < depth; d++ {
 			next := []string{}
@@ -531,6 +569,21 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 					}
 					visited[e.target] = d + 1
 					next = append(next, e.target)
+				}
+				for _, me := range mroOutboundEdges(r, n) {
+					if _, seen := visited[me.Target]; seen {
+						continue
+					}
+					visited[me.Target] = d + 1
+					mroVia[me.Target] = true
+					if me.External && me.Contract != nil {
+						mroExternal[me.Target] = me.Contract
+					}
+					// An external contract is a leaf — no fabricated callees;
+					// continue the walk only from in-repo defining members.
+					if !me.External {
+						next = append(next, me.Target)
+					}
 				}
 			}
 			frontier = next
@@ -546,6 +599,9 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 			}
 			e := byID[id]
 			if e == nil {
+				e = mroExternal[id]
+			}
+			if e == nil {
 				continue
 			}
 			c := callee{
@@ -555,6 +611,9 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 				StartLine:  e.StartLine,
 				HopCount:   d,
 				isTest:     isTestFileMCP(e.SourceFile),
+			}
+			if mroVia[id] {
+				c.ViaInherits = true
 			}
 			if verbose {
 				c.Kind = stripScopePrefix(e.Kind)

--- a/internal/mcp/mro_traverse.go
+++ b/internal/mcp/mro_traverse.go
@@ -1,0 +1,252 @@
+package mcp
+
+// mro_traverse.go — MRO-aware TRAVERSAL for archigraph_neighbors / _def_use /
+// _trace (epic #3829, ticket #3834 — MRO T4).
+//
+// Problem (the rewrite agent's G5): an inherited member STUB has an empty call
+// graph. A DRF `RoleViewSet.retrieve` synthetic, or a `ChildService.handle` the
+// child never redeclares, owns NO outbound CALLS edges — the body lives on the
+// base/mixin, not the subclass. So neighbors(out), def_use, and trace all
+// DEAD-END at the bodyless node: callees come back empty, and a shortest path
+// that arrives at the stub can never reach the real implementation.
+//
+// T3 (#3833, mro.go) already resolves the stub → its DEFINING member for
+// get_source / inspect. T4 reuses that resolver on the TRAVERSAL surfaces:
+// when a walk reaches an inherited stub, it follows an INHERITS hop to the
+// defining member's body and continues from THAT node's real edges.
+//
+//   (a) in-repo base member (provInheritedInRepo): the defining method is an
+//       indexed entity with a real body and its own CALLS edges. We splice an
+//       INHERITS edge stub→defining, so the BFS/Dijkstra continues through the
+//       defining member's actual callees. trace/def_use/neighbors reach the
+//       real base implementation.
+//
+//   (b) external mixin (provInheritedExternal): the defining body is NOT in the
+//       index — it lives in the library (DRF RetrieveModelMixin, …). HONEST-
+//       PARTIAL: we surface ONE INHERITS edge to a synthetic, deterministic
+//       contract node (id "inherits-ext:<DefiningClass>.<member>") that carries
+//       the pack contract, and mark it external. We DO NOT fabricate call edges
+//       from that node — the traversal endpoint is the contract, not invented
+//       callees.
+//
+//   (c) unresolved: no synthetic edge — honest dead-end (the existing
+//       behaviour). resolveMember already guarantees no fabrication here.
+//
+// This is a PURE READ-PATH projection. It adds NO edges to the stored graph and
+// needs no reindex to start working (DEPLOY-DEFERRED only for the daemon
+// rebuild that serves the new read path). When an indexer producer later
+// materialises a real INHERITS edge, these synthetic edges become redundant and
+// the helpers below skip stubs that already carry an explicit INHERITS edge.
+
+import (
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// inheritsEdgeKind is the member-granularity inheritance edge kind (#3834).
+const inheritsEdgeKind = string(types.RelationshipKindInherits)
+
+// externalContractIDPrefix namespaces the synthetic external-contract node IDs
+// so they never collide with real entity IDs and are recognisably synthetic.
+const externalContractIDPrefix = "inherits-ext:"
+
+// mroEdge is a synthetic outbound edge produced by the MRO projection. It
+// mirrors the shape the traversal handlers consume (target localID + kind),
+// plus enough metadata for trace/neighbors to label the hop and, for the
+// external case, to render the contract endpoint without a backing entity.
+type mroEdge struct {
+	// Target is the LOCAL (unprefixed) id of the defining member, OR — for the
+	// external case — the synthetic contract node id (externalContractIDPrefix…).
+	Target string
+	// Kind is always inheritsEdgeKind.
+	Kind string
+	// External is true for the pack-resolved contract endpoint (no in-repo body).
+	External bool
+	// DefiningClass / Member describe the resolution for labelling.
+	DefiningClass string
+	Member        string
+	// Contract is the synthetic external node's display entity (external case
+	// only); nil for the in-repo case where Target is a real indexed entity.
+	Contract *graph.Entity
+}
+
+// mroOutboundEdges returns the synthetic INHERITS edge(s) for local entity id
+// `local` in repo lr, or nil when the entity is not an inherited stub (explicit
+// body, non-member, or unresolved). At most one edge is returned today (a
+// member resolves to a single defining body via left-to-right MRO).
+//
+// The returned edge is what neighbors(out) / trace should ADD to the entity's
+// real outbound edges so traversal can hop to the defining body. The caller is
+// responsible for continuing the walk from the in-repo target's own edges (the
+// target is a normal indexed entity); the external target is a leaf contract.
+func mroOutboundEdges(lr *LoadedRepo, local string) []mroEdge {
+	if lr == nil || lr.Doc == nil {
+		return nil
+	}
+	e := lr.LabelIndex.ByID[local]
+	if e == nil {
+		return nil
+	}
+	// If the graph already carries a real INHERITS edge from this stub, the
+	// indexer materialised it — do not double-project.
+	if adj := lr.getAdjacency(); adj != nil {
+		for _, ed := range adj.out[local] {
+			if ed.kind == inheritsEdgeKind {
+				return nil
+			}
+		}
+	}
+
+	res := resolveMember(lr, e)
+	switch res.Provenance {
+	case provInheritedInRepo:
+		if res.DefiningEntity == nil || res.DefiningEntity.ID == local {
+			return nil
+		}
+		return []mroEdge{{
+			Target:        res.DefiningEntity.ID,
+			Kind:          inheritsEdgeKind,
+			External:      false,
+			DefiningClass: res.DefiningClass,
+			Member:        res.Member,
+		}}
+	case provInheritedExternal:
+		node := externalContractEntity(res)
+		return []mroEdge{{
+			Target:        node.ID,
+			Kind:          inheritsEdgeKind,
+			External:      true,
+			DefiningClass: res.DefiningClass,
+			Member:        res.Member,
+			Contract:      node,
+		}}
+	default:
+		// provExplicit / provUnresolved: honest dead-end, no synthetic edge.
+		return nil
+	}
+}
+
+// externalContractID returns the deterministic synthetic id for an external
+// pack-resolved contract endpoint.
+func externalContractID(definingClass, member string) string {
+	return externalContractIDPrefix + definingClass + "." + member
+}
+
+// externalContractEntity builds the synthetic, in-memory contract node that
+// represents an external (pack-described) defining member. It is NOT stored in
+// the graph — it exists only so neighbors/trace can name the resolution
+// endpoint. It carries no source span (StartLine 0) and the pack contract on
+// its Properties so a consumer can read the default status / behaviour.
+func externalContractEntity(res memberResolution) *graph.Entity {
+	id := externalContractID(res.DefiningClass, res.Member)
+	props := map[string]string{
+		"synthetic":      "true",
+		"external":       "true",
+		"member":         res.Member,
+		"defining_class": res.DefiningClass,
+		"resolved_from":  "baseknowledge_pack",
+	}
+	if m := res.Contract; m != nil {
+		if m.HTTPVerb != "" {
+			props["http_verb"] = m.HTTPVerb
+		}
+		if m.Behaviour != "" {
+			props["behaviour"] = m.Behaviour
+		}
+		if m.DocURL != "" {
+			props["doc_url"] = m.DocURL
+		}
+	}
+	return &graph.Entity{
+		ID:            id,
+		Name:          res.DefiningClass + "." + res.Member,
+		QualifiedName: res.DefiningClass + "." + res.Member,
+		Kind:          "SCOPE.External",
+		Subtype:       "method",
+		Language:      "",
+		Properties:    props,
+	}
+}
+
+// buildMROInbound computes the reverse-INHERITS map for repo lr: for every
+// inherited stub that resolves (in-repo) to a defining member, it records the
+// defining member's id -> the stub id. Only in-repo defining members are keyed
+// — an external pack contract has no in-repo node whose callers a user could
+// query. Built once and cached on LoadedRepo (#3834).
+func buildMROInbound(lr *LoadedRepo) map[string][]string {
+	out := map[string][]string{}
+	if lr == nil || lr.Doc == nil {
+		return out
+	}
+	for i := range lr.Doc.Entities {
+		e := &lr.Doc.Entities[i]
+		if !isMemberEntity(e) {
+			continue
+		}
+		for _, me := range mroOutboundEdges(lr, e.ID) {
+			if me.External {
+				continue
+			}
+			out[me.Target] = append(out[me.Target], e.ID)
+		}
+	}
+	return out
+}
+
+// mroInboundEdges returns the inherited-stub ids that resolve to in-repo
+// defining member `local` (the reverse-INHERITS callers). Empty when `local` is
+// not a defining base member that any indexed subclass inherits.
+func mroInboundEdges(lr *LoadedRepo, local string) []string {
+	if lr == nil {
+		return nil
+	}
+	return lr.getMROInbound()[local]
+}
+
+// defUseMRORetarget resolves an inherited-member def_use query to its in-repo
+// DEFINING member (#3834). Given the (possibly repo-prefixed) entity_id filter,
+// it locates the entity, runs the MRO walk, and — when the entity is an
+// inherited stub resolving to an in-repo base member — returns that base
+// member's LOCAL id plus the defining class name. Returns ("", "") when the
+// entity is not found, is not an inherited stub, or resolves only externally
+// (an external pack member has no in-repo def-use chains — honest dead-end).
+func defUseMRORetarget(lg *LoadedGroup, entityFilter string) (definingID, definingClass string) {
+	if lg == nil || entityFilter == "" {
+		return "", ""
+	}
+	repoHint, local := splitPrefixed(entityFilter)
+	tryRepo := func(r *LoadedRepo, id string) (string, string) {
+		if r == nil || r.Doc == nil {
+			return "", ""
+		}
+		e := r.LabelIndex.ByID[id]
+		if e == nil {
+			return "", ""
+		}
+		res := resolveMember(r, e)
+		if res.Provenance == provInheritedInRepo && res.DefiningEntity != nil {
+			return res.DefiningEntity.ID, res.DefiningClass
+		}
+		return "", ""
+	}
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok {
+			return tryRepo(r, local)
+		}
+		return "", ""
+	}
+	// Unprefixed: try each repo by raw id.
+	for _, r := range lg.Repos {
+		if id, cls := tryRepo(r, entityFilter); id != "" {
+			return id, cls
+		}
+	}
+	return "", ""
+}
+
+// isExternalContractID reports whether id is a synthetic external-contract node
+// id produced by this projection (so handlers can render it without a backing
+// indexed entity).
+func isExternalContractID(id string) bool {
+	return len(id) >= len(externalContractIDPrefix) && id[:len(externalContractIDPrefix)] == externalContractIDPrefix
+}

--- a/internal/mcp/mro_traverse_3834_test.go
+++ b/internal/mcp/mro_traverse_3834_test.go
@@ -1,0 +1,340 @@
+package mcp
+
+// mro_traverse_3834_test.go — value-asserting coverage for MRO-aware
+// neighbors / def_use / trace (#3834, epic #3829 MRO T4).
+//
+// These assert the TRAVERSAL REACHES the defining implementation, not len>0:
+//
+//  1. neighbors(out) on an in-repo inherited stub (ChildService.handle) reaches
+//     the BASE method's callees (BaseService.handle -> process) — the stub's own
+//     CALLS edges are empty, so without the INHERITS hop this dead-ends.
+//  2. trace from the inherited stub reaches the BASE method body via the
+//     INHERITS edge.
+//  3. neighbors(out) on a DRF inherited `retrieve` synthetic surfaces the
+//     external RetrieveModelMixin contract endpoint (external=true) and does NOT
+//     fabricate call edges from it.
+//  4. trace from the DRF stub resolves to the RetrieveModelMixin contract node.
+//  5. neighbors(in) on the BASE method surfaces the inheriting subclass stub
+//     (reverse-INHERITS).
+//  6. def_use on the inherited stub returns the BASE member's reaching-def
+//     chains, tagged resolved_via_inherits.
+//  7. NEGATIVE: an unresolvable inherited member produces NO synthetic edge —
+//     honest dead-end, no fabricated callees.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// inRepoBaseCallDoc extends inRepoBaseDoc's shape with a real CALLS edge from
+// the base method to a `process` helper, so neighbors(out)/trace on the
+// inherited child stub must reach `process` THROUGH the base body.
+func inRepoBaseCallDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "base", Name: "BaseService", QualifiedName: "BaseService",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "base.py",
+				StartLine: 1, EndLine: 4, Language: "python"},
+			{ID: "base_handle", Name: "BaseService.handle", QualifiedName: "BaseService.handle",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.py",
+				StartLine: 2, EndLine: 4, Language: "python"},
+			{ID: "process", Name: "BaseService.process", QualifiedName: "BaseService.process",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.py",
+				StartLine: 5, EndLine: 6, Language: "python"},
+			{ID: "child", Name: "ChildService", QualifiedName: "ChildService",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "child.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			// Bodyless inherited member on the child (no CALLS edges of its own).
+			{ID: "child_handle", Name: "ChildService.handle", QualifiedName: "ChildService.handle",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "child.py",
+				StartLine: 0, EndLine: 0, Language: "python",
+				Signature: "def handle(self, request)"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "child", ToID: "base", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "BaseService"}},
+			// The BASE method calls process — the real implementation edge.
+			{ID: "e2", FromID: "base_handle", ToID: "process", Kind: "CALLS",
+				Properties: map[string]string{"language": "python"}},
+		},
+	}
+}
+
+func callNeighbors3834(t *testing.T, srv *Server, entityID, direction string) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"group": "test", "entity_id": entityID, "direction": direction, "depth": 3,
+	}
+	res, err := srv.handleNeighbors(context.Background(), req)
+	if err != nil {
+		t.Fatalf("neighbors error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("neighbors tool error: %v", res.Content)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &out); err != nil {
+		t.Fatalf("neighbors decode: %v", err)
+	}
+	return out
+}
+
+// calleeNames extracts the "name" of every callee record in a neighbors result.
+func calleeNames3834(t *testing.T, out map[string]any) []string {
+	t.Helper()
+	raw, _ := out["callees"].([]any)
+	var names []string
+	for _, r := range raw {
+		m, _ := r.(map[string]any)
+		if n, _ := m["name"].(string); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// TestNeighbors_InRepoInheritedStub_ReachesBaseCallees — #3834 case 1. The
+// inherited stub owns NO CALLS edges; neighbors(out) must hop via INHERITS to
+// the base body and surface BaseService.process (the base's real callee).
+func TestNeighbors_InRepoInheritedStub_ReachesBaseCallees(t *testing.T) {
+	srv := newTestServer(t, inRepoBaseCallDoc())
+	out := callNeighbors3834(t, srv, "child_handle", "out")
+	names := calleeNames3834(t, out)
+
+	if !containsString(names, "BaseService.process") {
+		t.Fatalf("expected neighbors(out) on inherited stub to reach BaseService.process via INHERITS, got callees: %v", names)
+	}
+	// The defining base method itself must also be surfaced (the INHERITS hop).
+	if !containsString(names, "BaseService.handle") {
+		t.Errorf("expected the defining base member BaseService.handle in callees, got: %v", names)
+	}
+	// The hop must be flagged as via_inherits on the defining member.
+	if !calleeFlaggedInherits(out, "BaseService.handle") {
+		t.Errorf("expected BaseService.handle flagged via_inherits=true, got: %v", out["callees"])
+	}
+}
+
+// TestTrace_InRepoInheritedStub_ReachesBaseBody — #3834 case 2.
+func TestTrace_InRepoInheritedStub_ReachesBaseBody(t *testing.T) {
+	srv := newTestServer(t, inRepoBaseCallDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "source": "child_handle", "target": "process"}
+	res, err := srv.handleShortestPath(context.Background(), req)
+	if err != nil {
+		t.Fatalf("trace error: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &out); err != nil {
+		t.Fatalf("trace decode: %v", err)
+	}
+	if out["found"] != true {
+		t.Fatalf("expected a path from the inherited stub to process via INHERITS+CALLS, got: %v", out)
+	}
+	// The path must traverse the defining base method (the INHERITS hop) — not
+	// teleport. Assert base_handle is on the path.
+	path, _ := out["path"].([]any)
+	if !pathItemsContain3834(path, "base_handle") {
+		t.Errorf("expected path to traverse base_handle (the defining member), got: %v", path)
+	}
+	// And the INHERITS edge kind must appear in the edge list.
+	edges, _ := out["edges"].([]any)
+	if !pathItemsContain3834(edges, inheritsEdgeKind) {
+		t.Errorf("expected an %s edge on the resolved path, got edges: %v", inheritsEdgeKind, edges)
+	}
+}
+
+// TestNeighbors_DRFInheritedStub_ReachesExternalContract — #3834 case 3.
+func TestNeighbors_DRFInheritedStub_ReachesExternalContract(t *testing.T) {
+	srv := newTestServer(t, drfViewSetDoc())
+	out := callNeighbors3834(t, srv, "op_retrieve", "out")
+	names := calleeNames3834(t, out)
+
+	// Must surface the external RetrieveModelMixin contract endpoint.
+	found := false
+	for _, n := range names {
+		if strings.Contains(n, "RetrieveModelMixin") && strings.Contains(n, "retrieve") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected DRF inherited stub neighbors(out) to surface the RetrieveModelMixin.retrieve contract endpoint, got: %v", names)
+	}
+	// HONEST-PARTIAL: the external contract is a LEAF — it must not bring along
+	// fabricated callees. Only the single contract endpoint should appear.
+	if len(names) != 1 {
+		t.Errorf("external contract must be a leaf with no fabricated callees; got %d callees: %v", len(names), names)
+	}
+}
+
+// TestTrace_DRFInheritedStub_ResolvesToContract — #3834 case 4.
+func TestTrace_DRFInheritedStub_ResolvesToContract(t *testing.T) {
+	srv := newTestServer(t, drfViewSetDoc())
+	contractID := externalContractID("rest_framework.mixins.RetrieveModelMixin", "retrieve")
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "source": "op_retrieve", "target": contractID}
+	res, err := srv.handleShortestPath(context.Background(), req)
+	if err != nil {
+		t.Fatalf("trace error: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &out); err != nil {
+		t.Fatalf("trace decode: %v", err)
+	}
+	if out["found"] != true {
+		t.Fatalf("expected trace from DRF stub to resolve to the RetrieveModelMixin contract endpoint, got: %v", out)
+	}
+	edges, _ := out["edges"].([]any)
+	if !pathItemsContain3834(edges, inheritsEdgeKind) {
+		t.Errorf("expected the resolution edge to be %s, got: %v", inheritsEdgeKind, edges)
+	}
+}
+
+// TestNeighbors_BaseMethod_SurfacesInheritingStub — #3834 case 5 (reverse).
+func TestNeighbors_BaseMethod_SurfacesInheritingStub(t *testing.T) {
+	srv := newTestServer(t, inRepoBaseCallDoc())
+	out := callNeighbors3834(t, srv, "base_handle", "in")
+	raw, _ := out["callers"].([]any)
+	found := false
+	for _, r := range raw {
+		m, _ := r.(map[string]any)
+		if n, _ := m["name"].(string); n == "ChildService.handle" {
+			found = true
+			if m["via_inherits"] != true {
+				t.Errorf("expected ChildService.handle caller flagged via_inherits, got: %v", m)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected neighbors(in) on the base method to surface the inheriting ChildService.handle stub, got callers: %v", raw)
+	}
+}
+
+// TestDefUse_InheritedStub_ReturnsBaseChains — #3834 case 6.
+func TestDefUse_InheritedStub_ReturnsBaseChains(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Write a def-use sidecar with a chain for the BASE member only (the stub
+	// has none — it is bodyless).
+	doc := defUseSidecarDoc{
+		Version: 1, Method: "test", Total: 1,
+		Entries: []defUseSidecarEntry{{
+			Repo: "repo1", EntityID: "base_handle", Name: "BaseService.handle",
+			SourceFile: "base.py",
+			Chains:     []defUseChainSidecar{{Var: "result", DefLine: 2, UseLine: 3}},
+		}},
+	}
+	writeSidecar(t, home, "test", "def-use", doc)
+
+	srv := newTestServer(t, inRepoBaseCallDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "child_handle"}
+	res, err := srv.handleDefUse(context.Background(), req)
+	if err != nil {
+		t.Fatalf("def_use error: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &out); err != nil {
+		t.Fatalf("def_use decode: %v", err)
+	}
+	entries, _ := out["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("expected def_use on inherited stub to return the BASE member's 1 chain entry, got %d: %v", len(entries), out)
+	}
+	e0, _ := entries[0].(map[string]any)
+	if e0["resolved_via_inherits"] != true {
+		t.Errorf("expected resolved_via_inherits=true on the inherited def_use entry, got: %v", e0)
+	}
+	if name, _ := e0["name"].(string); name != "BaseService.handle" {
+		t.Errorf("expected the BASE member's chains, got name %q", name)
+	}
+	// And the chain content must be the base's (var "result").
+	if !strings.Contains(extractResultText(t, res), `"result"`) {
+		t.Errorf("expected the base member's reaching-def chain (var result), got: %s", extractResultText(t, res))
+	}
+}
+
+// TestNeighbors_UnresolvableInheritedStub_NoFabrication — #3834 case 7
+// (negative). A bodyless member whose base is neither indexed nor in the pack
+// must NOT grow a synthetic INHERITS edge — honest dead-end.
+func TestNeighbors_UnresolvableInheritedStub_NoFabrication(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "cls", Name: "MysteryView", QualifiedName: "MysteryView",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "m.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			{ID: "op", Name: "MysteryView.frobnicate", QualifiedName: "MysteryView.frobnicate",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "m.py",
+				StartLine: 0, EndLine: 0, Language: "python",
+				Signature: "def frobnicate(self)",
+				Properties: map[string]string{
+					"pattern_type":      "drf_viewset_implicit_method",
+					"viewset_class":     "MysteryView",
+					"drf_method_origin": "frobnicate",
+				}},
+			{ID: "ext", Name: "WeirdBase", Kind: "SCOPE.External", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "cls", ToID: "ext", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "some.unknown.WeirdBase"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+
+	// Direct unit assertion: no synthetic outbound edge.
+	lr := srv.State.groups["test"].Repos["repo1"]
+	if edges := mroOutboundEdges(lr, "op"); len(edges) != 0 {
+		t.Fatalf("unresolvable inherited member must produce NO synthetic INHERITS edge, got: %+v", edges)
+	}
+
+	// And neighbors(out) must report no outgoing edges (no fabricated callees).
+	out := callNeighbors3834(t, srv, "op", "out")
+	if names := calleeNames3834(t, out); len(names) != 0 {
+		t.Errorf("unresolvable inherited stub must have no fabricated callees, got: %v", names)
+	}
+}
+
+// --- test helpers ----------------------------------------------------------
+
+func pathItemsContain3834(items []any, want string) bool {
+	for _, it := range items {
+		if s, _ := it.(string); strings.Contains(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func calleeFlaggedInherits(out map[string]any, name string) bool {
+	raw, _ := out["callees"].([]any)
+	for _, r := range raw {
+		m, _ := r.(map[string]any)
+		if n, _ := m["name"].(string); n == name {
+			return m["via_inherits"] == true
+		}
+	}
+	return false
+}
+
+func writeSidecar(t *testing.T, home, group, suffix string, doc any) {
+	t.Helper()
+	dir := filepath.Join(home, ".archigraph", "groups")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sidecar dir: %v", err)
+	}
+	buf, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	path := filepath.Join(dir, group+"-links-"+suffix+".json")
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}

--- a/internal/mcp/phase3_tools.go
+++ b/internal/mcp/phase3_tools.go
@@ -249,7 +249,7 @@ type defUseSidecarDoc struct {
 }
 
 func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	groupName, _, errRes := s.resolveAndGroup(req)
+	groupName, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -259,6 +259,15 @@ func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*m
 	}
 	entityFilter := strings.TrimSpace(argString(req, "entity_id", ""))
 	limit := argInt(req, "limit", 50)
+
+	// #3834 (MRO T4): an inherited-member STUB has no body, so it owns NO
+	// def-use chains — a def_use query on it would dead-end empty. Resolve the
+	// stub to its in-repo DEFINING member and ALSO accept that member's id, so
+	// def_use on `ChildService.handle` returns the base method's reaching-def
+	// chains. mroDefiningID carries the resolved defining id (local) so matched
+	// entries can be tagged resolved_via_inherits. External (pack) members have
+	// no in-repo body and thus no def-use chains — honest dead-end, no retarget.
+	mroDefiningID, mroDefiningClass := defUseMRORetarget(lg, entityFilter)
 
 	var doc defUseSidecarDoc
 	path := sidecarPath(groupName, "def-use")
@@ -277,11 +286,15 @@ func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*m
 		if len(repoFilter) > 0 && !repoFilter[e.Repo] {
 			continue
 		}
+		matchedViaInherits := false
 		if entityFilter != "" {
 			eid := prefixedID(e.Repo, e.EntityID)
-			if eid != entityFilter && e.EntityID != entityFilter {
+			direct := eid == entityFilter || e.EntityID == entityFilter
+			viaMRO := mroDefiningID != "" && e.EntityID == mroDefiningID
+			if !direct && !viaMRO {
 				continue
 			}
+			matchedViaInherits = viaMRO && !direct
 		}
 		chains := make([]map[string]any, len(e.Chains))
 		for i, c := range e.Chains {
@@ -291,14 +304,26 @@ func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*m
 				"use_line": c.UseLine,
 			}
 		}
-		out = append(out, map[string]any{
+		entry := map[string]any{
 			"entity_id":   prefixedID(e.Repo, e.EntityID),
 			"name":        e.Name,
 			"repo":        e.Repo,
 			"source_file": e.SourceFile,
 			"chain_count": len(e.Chains),
 			"chains":      chains,
-		})
+		}
+		if matchedViaInherits {
+			// The chains belong to the base/mixin DEFINING member, surfaced
+			// because the queried entity inherits it (#3834). Mark it so the
+			// consumer knows these are the inherited member's chains, not the
+			// stub's own (the stub has none).
+			entry["resolved_via_inherits"] = true
+			entry["queried_entity_id"] = entityFilter
+			if mroDefiningClass != "" {
+				entry["defining_class"] = mroDefiningClass
+			}
+		}
+		out = append(out, entry)
 	}
 	total := len(out)
 	if limit > 0 && len(out) > limit {

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -291,11 +291,18 @@ type LoadedRepo struct {
 	byIDOnce     sync.Once
 	pagerankOnce sync.Once
 	bm25Once     sync.Once                // #3377: BM25 built lazily on first search
+	mroInOnce    sync.Once                // #3834: reverse-INHERITS map built lazily
 	adjacency    *adjacency               // in/out neighbor lists (#1656)
 	callsAdj     map[string][]string      // CALLS-only forward adjacency (#1656)
 	stepAdj      map[string][]stepEdge    // STEP_IN_PROCESS forward adjacency (#2417)
 	byID         map[string]*graph.Entity // entity ID -> entity (#1656)
 	topKPageRank []string                 // entity IDs sorted descending by PageRank (#2304)
+	// mroInbound maps a DEFINING member's local id -> the inherited-stub ids
+	// that resolve to it via the MRO walk (#3834). It is the reverse of
+	// mroOutboundEdges, used by neighbors(in) so a base method surfaces the
+	// subclasses that inherit it. In-repo defining members only (external
+	// contract endpoints have no in-repo node to query callers of).
+	mroInbound map[string][]string
 
 	semMtime time.Time
 	mtime    time.Time
@@ -326,12 +333,30 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.byIDOnce = sync.Once{}
 	lr.pagerankOnce = sync.Once{}
 	lr.bm25Once = sync.Once{}
+	lr.mroInOnce = sync.Once{}
 	lr.BM25 = nil
 	lr.adjacency = nil
 	lr.callsAdj = nil
 	lr.stepAdj = nil
 	lr.byID = nil
 	lr.topKPageRank = nil
+	lr.mroInbound = nil
+}
+
+// getMROInbound returns the reverse-INHERITS map (defining-member id ->
+// inheriting-stub ids), building it lazily on first use (#3834). It scans the
+// repo's member entities once and records, for each that resolves to an in-repo
+// defining member via the MRO walk, the defining member's id. Used by
+// neighbors(in) so a base method surfaces its inheriting subclasses as callers.
+func (lr *LoadedRepo) getMROInbound() map[string][]string {
+	// NOTE: deliberately NOT guarded by idxMu — buildMROInbound calls
+	// mroOutboundEdges -> resolveMember -> extendsBases -> getAdjacency, which
+	// itself takes idxMu (a non-reentrant Mutex). sync.Once.Do is independently
+	// safe for concurrent callers, so the Once alone gives build-at-most-once.
+	lr.mroInOnce.Do(func() {
+		lr.mroInbound = buildMROInbound(lr)
+	})
+	return lr.mroInbound
 }
 
 // getByID returns the entity-ID → *Entity map, building it on first use.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1915,6 +1915,19 @@ func (s *Server) handleShortestPath(ctx context.Context, req mcpapi.CallToolRequ
 					relIdx: -1,              // synthetic — no backing Relationship (#2305)
 				})
 			}
+			// #3834 (MRO T4): splice the inherited-member INHERITS hop so a
+			// shortest path that arrives at a bodyless inherited stub can reach
+			// the DEFINING base/mixin member (in-repo body, or the external pack
+			// contract leaf) instead of dead-ending. The defining member is a
+			// normal node whose own out-edges expand() picks up on the next pop.
+			for _, me := range mroOutboundEdges(r, local) {
+				out = append(out, edge{
+					target: prefixedID(repo, me.Target),
+					kind:   me.Kind,
+					weight: -math.Log(0.95),
+					relIdx: -1, // synthetic — no backing Relationship (#2305)
+				})
+			}
 		}
 		// cross-repo overlay — use cache-backed linksForSourceRepo (#2224)
 		// to avoid stale results after a ref switch.
@@ -1990,6 +2003,25 @@ func normalizePrefixed(lg *LoadedGroup, s string) string {
 		}
 		if e := r.LabelIndex.Lookup(s); e != nil {
 			return prefixedID(r.Repo, e.ID)
+		}
+	}
+	// #3834 (MRO T4): a synthetic external-contract id ("inherits-ext:<FQN>")
+	// is not a stored entity, so it resolves to no LabelIndex hit above. It is
+	// nonetheless a legitimate trace target — the resolution endpoint for an
+	// inherited member whose body lives in an external library. Bind it to the
+	// repo whose inherited stub projects it (the only repo that can reach it).
+	if isExternalContractID(s) {
+		for _, r := range lg.Repos {
+			if r.Doc == nil {
+				continue
+			}
+			for i := range r.Doc.Entities {
+				for _, me := range mroOutboundEdges(r, r.Doc.Entities[i].ID) {
+					if me.External && me.Target == s {
+						return prefixedID(r.Repo, s)
+					}
+				}
+			}
 		}
 	}
 	return ""

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1188,6 +1188,31 @@ const (
 	//   "dependency_kind" : runtime|dev|peer|locked|indirect (from the manifest).
 	// Emitted by internal/extractors/cross/manifest/extractor.go.
 	RelationshipKindDependsOnPackage RelationshipKind = "DEPENDS_ON_PACKAGE"
+
+	// #3834 (epic #3829, MRO T4): member-granularity inheritance edge.
+	//   INHERITS : an inherited member STUB (e.g. a bodyless DRF
+	//              `RoleViewSet.retrieve` synthetic, or a `ChildService.handle`
+	//              the child never redeclares) → the DEFINING member that owns
+	//              the real body (the in-repo base method, or — when the base is
+	//              external and the body is not indexed — a synthetic contract
+	//              node from the baseknowledge pack).
+	// This is the member-level counterpart of the class-level EXTENDS edge: it
+	// lets neighbors/def_use/trace HOP from the inherited stub (which has empty
+	// CALLS/called_by) to the defining body's call graph, so traversal reaches
+	// the real implementation instead of dead-ending at the bodyless node (the
+	// rewrite agent's G5). Edge properties:
+	//   "member"         : the inherited member's bare name (e.g. "retrieve").
+	//   "owning_class"   : the subclass that inherits the member.
+	//   "defining_class" : FQN of the class whose body defines the member
+	//                      (in-repo base name, or external pack FQN such as
+	//                      "rest_framework.mixins.RetrieveModelMixin").
+	//   "resolved_from"  : "extends_in_repo" | "baseknowledge_pack".
+	//   "external"       : "true" when the defining body is an external library
+	//                      member described only by the pack (no in-repo body).
+	// The MCP read path (internal/mcp/mro_traverse.go) projects this edge
+	// synthetically from the EXTENDS walk + pack so it works before any
+	// indexer-side emission; an indexer producer MAY later materialise it.
+	RelationshipKindInherits RelationshipKind = "INHERITS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1339,6 +1364,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindBroadcastsTo,
 		// #3628 data-model: field/param → enum value-set edge.
 		RelationshipKindTypedAs,
+		// #3834 (epic #3829) member-granularity inheritance edge:
+		RelationshipKindInherits,
 	}
 }
 


### PR DESCRIPTION
Closes #3834 (epic #3829, MRO T4).

## Problem — the rewrite agent's G5
An inherited member **STUB** owns NO CALLS edges — the body lives on the base/mixin, not the subclass. A bodyless DRF `RoleViewSet.retrieve` synthetic, or a `ChildService.handle` the child never redeclares, made `neighbors(out)`, `def_use`, and `trace` **dead-end at the bodyless node** instead of reaching the real implementation.

## Approach
Reuse T3's `resolveMember` (mro.go, #3833 — EXTENDS-walk + baseknowledge pack #3906) on the **traversal** surfaces. A pure read-path projection splices a synthetic **INHERITS** hop from an inherited stub to its DEFINING member.

- **INHERITS edge** (`internal/types/kinds.go`): member-granularity inheritance edge kind registered + `go test ./internal/types/` green.
- **`internal/mcp/mro_traverse.go`**: `mroOutboundEdges` — stub → in-repo base method (traversal continues through its real CALLS edges) OR → a deterministic synthetic external-contract **leaf** node carrying the pack contract (marked `external`, **no fabricated call edges**). `mroInbound` reverse map for `neighbors(in)`.
- **neighbors** (`flow_tools.go`): out-hop reaches base callees; in-hop surfaces inheriting subclass stubs (reverse-INHERITS, kept past the shadow noise filter). Both flag `via_inherits`.
- **trace** (`tools.go`): shortest-path `expand` splices the INHERITS hop; `normalizePrefixed` resolves the synthetic external-contract id as a target.
- **def_use** (`phase3_tools.go`): inherited stub retargets to its in-repo defining member's reaching-def chains, tagged `resolved_via_inherits`.

## Honest-partial
Unresolvable inherited member (unknown base, not in pack) → **no synthetic edge**, honest dead-end, no fabricated callees/status. Covered by a negative test.

## MRO traversal asserted (value-asserting, not len>0)
- in-repo `ChildService(BaseService)`: `neighbors(out)` reaches `BaseService.process` (base's real callee) via the INHERITS hop; `trace` path **traverses `base_handle`** and carries an `INHERITS` edge.
- DRF inherited `retrieve` stub: `neighbors(out)` / `trace` resolve to the **`RetrieveModelMixin.retrieve` external contract** endpoint (leaf, no fabricated callees).
- reverse: `neighbors(in)` on the base method surfaces the inheriting `ChildService.handle` stub.
- `def_use` on the stub returns the **base member's** chains.
- negative: unresolvable member → no synthetic edge / no callees.

## Quality gates
`go test ./internal/mcp/... ./internal/frameworks/... ./internal/types/` green; `internal/resolve` + `tools/coverage` green; coverage `validate` 0 errors; `fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## Deploy
**DEPLOY-DEFERRED** — pure read path; needs a daemon rebuild to serve. No reindex required for the projection; an indexer producer MAY later materialise the INHERITS edge (the read path skips stubs that already carry one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)