### PR TITLE
fix(mcp): impact_radius reliability — graceful handling of input-driven errors (#3925)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -676,10 +676,105 @@ func impactRiskScore(e *graph.Entity, inDegree int) float64 {
 	return score
 }
 
+// impactRadiusMaxResults bounds the affected-set returned for a single
+// impact_radius call. A pathological high-degree node (e.g. a base class or a
+// utility imported everywhere) can have thousands of transitive dependents; we
+// keep the top-ranked slice and emit an honest truncation marker rather than
+// returning an unbounded payload. The cap is generous so normal nodes are never
+// truncated.
+const impactRadiusMaxResults = 500
+
+// impactCandidate is a disambiguation entry returned when entity_id resolves to
+// more than one entity by name. It carries enough to let the caller re-issue
+// the request against a precise ID.
+type impactCandidate struct {
+	EntityID   string `json:"entity_id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Repo       string `json:"repo"`
+	SourceFile string `json:"source_file,omitempty"`
+}
+
+// impactResolution is the outcome of resolving the entity_id argument against
+// the loaded group. Exactly one of {repo+localID set, candidates non-empty,
+// neither (not found)} holds.
+type impactResolution struct {
+	repo       *LoadedRepo // resolved repo when a unique entity was found
+	localID    string      // resolved local (un-prefixed) entity ID
+	candidates []impactCandidate
+}
+
+// resolveImpactTarget resolves the entity_id argument to a concrete entity.
+//
+// Resolution order, designed to convert the dominant error class (agents
+// passing a name, a stale ID, or an ambiguous symbol) into graceful results:
+//  1. Exact local-ID match in any in-scope repo → unique resolution.
+//  2. Else exact Name (or QualifiedName) match across in-scope repos:
+//     - exactly one → unique resolution (the entity_id was a name, not an ID).
+//     - more than one → return candidates for disambiguation.
+//  3. Else nothing matched → empty resolution (caller emits a graceful
+//     not-found result, NOT an error).
+//
+// `target` is the un-prefixed probe (local part of a repo:ID, or the raw
+// entity_id). `repos` is the already repo-hint-filtered candidate set.
+func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
+	// Pass 1: exact ID match (the happy path — unchanged semantics).
+	for _, r := range repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		if _, ok := r.getByID()[target]; ok {
+			return impactResolution{repo: r, localID: target}
+		}
+	}
+
+	// Pass 2: exact Name / QualifiedName match. Collect every match so we can
+	// distinguish "unique by name" from "ambiguous".
+	var byName []impactCandidate
+	type hit struct {
+		repo *LoadedRepo
+		id   string
+	}
+	var hits []hit
+	for _, r := range repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Name == target || e.QualifiedName == target {
+				hits = append(hits, hit{repo: r, id: e.ID})
+				byName = append(byName, impactCandidate{
+					EntityID:   prefixedID(r.Repo, e.ID),
+					Name:       e.Name,
+					Kind:       stripScopePrefix(e.Kind),
+					Repo:       r.Repo,
+					SourceFile: e.SourceFile,
+				})
+			}
+		}
+	}
+	switch {
+	case len(hits) == 1:
+		return impactResolution{repo: hits[0].repo, localID: hits[0].id}
+	case len(hits) > 1:
+		return impactResolution{candidates: byName}
+	}
+
+	// Pass 3: nothing matched.
+	return impactResolution{}
+}
+
 // handleImpactRadius returns all entities that would be affected if the given
 // entity changes — a "change blast radius" analysis. Each result carries a
 // risk_score [0,1] indicating how dangerous that particular affected entity
 // is. Results are sorted by risk_score descending so agents can prioritise.
+//
+// Reliability (#3925): the dominant error class was input-driven — a missing
+// entity, a name passed where an ID was expected, or an ambiguous symbol all
+// returned a hard tool error. These are now converted into well-formed results:
+// a graceful empty set with a `reason` for not-found, a `candidates` list for
+// ambiguity, and an honest `truncated` marker for very high-degree nodes.
 func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	entityID, err := req.RequireString("entity_id")
 	if err != nil {
@@ -705,6 +800,40 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 		}
 	}
 
+	probe := local
+	if probe == "" {
+		probe = entityID
+	}
+	resolution := resolveImpactTarget(repos, probe)
+	// Ambiguous: entity_id matched multiple entities by name. Return candidates
+	// for disambiguation instead of erroring (#3925).
+	if len(resolution.candidates) > 0 {
+		return jsonResult(map[string]any{
+			"entity_id":  entityID,
+			"resolved":   false,
+			"ambiguous":  true,
+			"candidates": resolution.candidates,
+			"affected":   []any{},
+			"count":      0,
+			"reason": fmt.Sprintf("entity_id %q is ambiguous: %d entities share this name. "+
+				"Re-run with one of the precise entity_id values in `candidates`.",
+				entityID, len(resolution.candidates)),
+		}), nil
+	}
+	// Not found: no entity matched by ID or name. Return a graceful empty
+	// result with a reason instead of erroring (#3925).
+	if resolution.repo == nil {
+		return jsonResult(map[string]any{
+			"entity_id": entityID,
+			"resolved":  false,
+			"affected":  []any{},
+			"count":     0,
+			"reason": fmt.Sprintf("no entity matched %q by ID or name in the loaded graph. "+
+				"Use archigraph_find or archigraph_search_entities to locate the entity, "+
+				"then pass its exact entity_id.", entityID),
+		}), nil
+	}
+
 	type affected struct {
 		EntityID   string  `json:"entity_id"`
 		Name       string  `json:"name"`
@@ -716,114 +845,126 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 		RiskReason string  `json:"risk_reason,omitempty"`
 	}
 
-	for _, r := range repos {
-		if r.Doc == nil {
-			continue
-		}
-		target := local
-		if target == "" {
-			target = entityID
-		}
-		byID := r.getByID()
-		if _, ok := byID[target]; !ok {
-			continue
-		}
+	// Unique resolution: compute the impact set on the resolved repo + target.
+	r := resolution.repo
+	target := resolution.localID
+	byID := r.getByID()
 
-		// Precompute in-degree for risk scoring, broken down by caller kind.
-		// namedCallerMap counts inbound edges whose source is a named operation
-		// (Function, Method, Class, Component, Operation, etc.).
-		// moduleCallerMap counts inbound edges whose source is a file/module
-		// container node (SCOPE.Component, SCOPE.Module, File, Module, etc.).
-		// totalDegreeMap is the simple sum of all inbound edges (used for scoring).
-		namedCallerMap := map[string]int{}
-		moduleCallerMap := map[string]int{}
-		totalDegreeMap := map[string]int{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
-			totalDegreeMap[rel.ToID]++
-			if src := byID[rel.FromID]; src != nil {
-				if isModuleFileEntity(src) {
-					moduleCallerMap[rel.ToID]++
-				} else {
-					namedCallerMap[rel.ToID]++
-				}
+	// Precompute in-degree for risk scoring, broken down by caller kind.
+	// namedCallerMap counts inbound edges whose source is a named operation
+	// (Function, Method, Class, Component, Operation, etc.).
+	// moduleCallerMap counts inbound edges whose source is a file/module
+	// container node (SCOPE.Component, SCOPE.Module, File, Module, etc.).
+	// totalDegreeMap is the simple sum of all inbound edges (used for scoring).
+	namedCallerMap := map[string]int{}
+	moduleCallerMap := map[string]int{}
+	totalDegreeMap := map[string]int{}
+	for i := range r.Doc.Relationships {
+		rel := &r.Doc.Relationships[i]
+		totalDegreeMap[rel.ToID]++
+		if src := byID[rel.FromID]; src != nil {
+			if isModuleFileEntity(src) {
+				moduleCallerMap[rel.ToID]++
 			} else {
-				// Source not in byID — treat as named to avoid under-counting.
 				namedCallerMap[rel.ToID]++
 			}
+		} else {
+			// Source not in byID — treat as named to avoid under-counting.
+			namedCallerMap[rel.ToID]++
 		}
-
-		// Impact radius = entities that transitively depend on `target`.
-		// We walk the INBOUND graph from target: callers of callers.
-		adj := r.getAdjacency()
-		visited := map[string]int{target: 0}
-		frontier := []string{target}
-		for d := 0; d < hops; d++ {
-			next := []string{}
-			for _, n := range frontier {
-				for _, e := range adj.in[n] {
-					if _, seen := visited[e.target]; seen {
-						continue
-					}
-					visited[e.target] = d + 1
-					next = append(next, e.target)
-				}
-			}
-			frontier = next
-			if len(frontier) == 0 {
-				break
-			}
-		}
-
-		results := []affected{}
-		for id, d := range visited {
-			if id == target {
-				continue
-			}
-			e := byID[id]
-			if e == nil {
-				continue
-			}
-			risk := impactRiskScore(e, totalDegreeMap[id])
-			reason := buildRiskReason(e, namedCallerMap[id], moduleCallerMap[id], totalDegreeMap[id])
-			results = append(results, affected{
-				EntityID:   prefixedID(r.Repo, e.ID),
-				Name:       e.Name,
-				Kind:       stripScopePrefix(e.Kind),
-				Repo:       r.Repo,
-				SourceFile: e.SourceFile,
-				HopCount:   d,
-				RiskScore:  risk,
-				RiskReason: reason,
-			})
-		}
-		// Sort by risk descending, then hop ascending, then name.
-		sort.Slice(results, func(i, j int) bool {
-			if results[i].RiskScore != results[j].RiskScore {
-				return results[i].RiskScore > results[j].RiskScore
-			}
-			if results[i].HopCount != results[j].HopCount {
-				return results[i].HopCount < results[j].HopCount
-			}
-			return results[i].Name < results[j].Name
-		})
-
-		root := byID[target]
-		rootName := target
-		if root != nil {
-			rootName = root.Name
-		}
-		return jsonResult(map[string]any{
-			"entity_id":   prefixedID(r.Repo, target),
-			"entity_name": rootName,
-			"repo":        r.Repo,
-			"hops":        hops,
-			"affected":    results,
-			"count":       len(results),
-			"tip":         "risk_score 0.0–1.0: higher means the affected entity is more sensitive to breakage from changes in the root entity.",
-		}), nil
 	}
-	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+
+	// Impact radius = entities that transitively depend on `target`.
+	// We walk the INBOUND graph from target: callers of callers. The walk is
+	// bounded by `hops` (≤6) and the visited set, so it terminates on any
+	// graph; high-degree nodes are handled by the result cap below.
+	adj := r.getAdjacency()
+	visited := map[string]int{target: 0}
+	frontier := []string{target}
+	for d := 0; d < hops; d++ {
+		next := []string{}
+		for _, n := range frontier {
+			for _, e := range adj.in[n] {
+				if _, seen := visited[e.target]; seen {
+					continue
+				}
+				visited[e.target] = d + 1
+				next = append(next, e.target)
+			}
+		}
+		frontier = next
+		if len(frontier) == 0 {
+			break
+		}
+	}
+
+	results := []affected{}
+	for id, d := range visited {
+		if id == target {
+			continue
+		}
+		e := byID[id]
+		if e == nil {
+			continue
+		}
+		risk := impactRiskScore(e, totalDegreeMap[id])
+		reason := buildRiskReason(e, namedCallerMap[id], moduleCallerMap[id], totalDegreeMap[id])
+		results = append(results, affected{
+			EntityID:   prefixedID(r.Repo, e.ID),
+			Name:       e.Name,
+			Kind:       stripScopePrefix(e.Kind),
+			Repo:       r.Repo,
+			SourceFile: e.SourceFile,
+			HopCount:   d,
+			RiskScore:  risk,
+			RiskReason: reason,
+		})
+	}
+	// Sort by risk descending, then hop ascending, then name.
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].RiskScore != results[j].RiskScore {
+			return results[i].RiskScore > results[j].RiskScore
+		}
+		if results[i].HopCount != results[j].HopCount {
+			return results[i].HopCount < results[j].HopCount
+		}
+		return results[i].Name < results[j].Name
+	})
+
+	// Bound the payload for pathological high-degree nodes. We keep the
+	// top-ranked slice (highest risk first) and emit an honest truncation
+	// marker rather than returning an unbounded result (#3925).
+	totalAffected := len(results)
+	truncated := false
+	if len(results) > impactRadiusMaxResults {
+		results = results[:impactRadiusMaxResults]
+		truncated = true
+	}
+
+	root := byID[target]
+	rootName := target
+	if root != nil {
+		rootName = root.Name
+	}
+	out := map[string]any{
+		"entity_id":   prefixedID(r.Repo, target),
+		"entity_name": rootName,
+		"repo":        r.Repo,
+		"hops":        hops,
+		"resolved":    true,
+		"affected":    results,
+		"count":       len(results),
+		"tip":         "risk_score 0.0–1.0: higher means the affected entity is more sensitive to breakage from changes in the root entity.",
+	}
+	if truncated {
+		out["truncated"] = true
+		out["total_affected"] = totalAffected
+		out["truncation_note"] = fmt.Sprintf(
+			"high-degree node: %d entities are affected; returning the top %d by risk_score. "+
+				"Narrow with a smaller `hops` or inspect specific neighbors.",
+			totalAffected, impactRadiusMaxResults)
+	}
+	return jsonResult(out), nil
 }
 
 // buildRiskReason produces a short human-readable reason string for the risk score.

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -723,6 +723,175 @@ func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// TestImpactRadius reliability (#3925): input-driven errors → graceful results
+// ---------------------------------------------------------------------------
+
+// TestImpactRadius_MissingEntity_GracefulNotError verifies #3925: a missing
+// entity_id returns a well-formed empty result with a reason, NOT a tool error.
+func TestImpactRadius_MissingEntity_GracefulNotError(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServer(t, doc)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"entity_id": "ent-does-not-exist",
+		"hops":      float64(2),
+	}
+	res, err := srv.handleImpactRadius(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	// The whole point of the fix: this must NOT be a tool error.
+	if res.IsError {
+		t.Fatalf("missing entity must NOT be a tool error; got error result: %v", res.Content)
+	}
+	out := decodeFlowResult(t, res)
+	if out["resolved"] != false {
+		t.Errorf("expected resolved=false, got %v", out["resolved"])
+	}
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) != 0 {
+		t.Errorf("expected empty affected array, got %v", out["affected"])
+	}
+	if c, _ := out["count"].(float64); c != 0 {
+		t.Errorf("expected count=0, got %v", out["count"])
+	}
+	reason, _ := out["reason"].(string)
+	if reason == "" {
+		t.Error("expected a non-empty reason explaining why nothing was found")
+	}
+}
+
+// TestImpactRadius_NameInsteadOfID_Resolves verifies #3925: when the caller
+// passes an entity *name* (not its graph ID), and that name is unique, the
+// handler resolves it to the real entity and returns the correct impact set —
+// no error.
+func TestImpactRadius_NameInsteadOfID_Resolves(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServer(t, doc)
+
+	// "FuncB" is a Name, not an ID (the ID is "ent-b"). Changing FuncB affects
+	// FuncA (its caller). Resolution by name must find ent-b and return FuncA.
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "FuncB",
+		"hops":      float64(1),
+	})
+	if out["resolved"] != true {
+		t.Errorf("expected resolved=true after name resolution, got %v", out["resolved"])
+	}
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) == 0 {
+		t.Fatalf("expected at least 1 affected entity, got %v", out["affected"])
+	}
+	first := affected[0].(map[string]any)
+	if first["name"] != "FuncA" {
+		t.Errorf("expected FuncA as affected caller of FuncB, got %v", first["name"])
+	}
+}
+
+// TestImpactRadius_AmbiguousName_ReturnsCandidates verifies #3925: when an
+// entity_id matches multiple entities by name, the handler returns a
+// disambiguation candidates list (no error).
+func TestImpactRadius_AmbiguousName_ReturnsCandidates(t *testing.T) {
+	// Two distinct entities share the name "process".
+	doc := minDoc(
+		[]graph.Entity{
+			{ID: "ent-1", Name: "process", Kind: "Function", SourceFile: "a.go"},
+			{ID: "ent-2", Name: "process", Kind: "Method", SourceFile: "b.go"},
+			{ID: "ent-caller", Name: "main", Kind: "Function", SourceFile: "main.go"},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-caller", ToID: "ent-1", Kind: "CALLS"},
+		},
+	)
+	srv := newTestServer(t, doc)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"entity_id": "process", "hops": float64(1)}
+	res, err := srv.handleImpactRadius(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("ambiguous name must NOT be a tool error; got: %v", res.Content)
+	}
+	out := decodeFlowResult(t, res)
+	if out["ambiguous"] != true {
+		t.Errorf("expected ambiguous=true, got %v", out["ambiguous"])
+	}
+	cands, ok := out["candidates"].([]any)
+	if !ok || len(cands) != 2 {
+		t.Fatalf("expected 2 candidates, got %v", out["candidates"])
+	}
+	// Each candidate must carry a precise entity_id the caller can re-issue.
+	for _, c := range cands {
+		m := c.(map[string]any)
+		if m["entity_id"] == "" || m["entity_id"] == nil {
+			t.Errorf("candidate missing entity_id: %v", m)
+		}
+	}
+}
+
+// TestImpactRadius_HighDegree_TruncatesHonestly verifies #3925: a node with
+// more dependents than the cap returns a bounded result with an honest
+// truncation marker (no error, no unbounded payload).
+func TestImpactRadius_HighDegree_TruncatesHonestly(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "ent-hub", Name: "hub", Kind: "Function", SourceFile: "hub.go"},
+	}
+	var rels []graph.Relationship
+	// Far more callers than impactRadiusMaxResults.
+	n := impactRadiusMaxResults + 50
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("caller-%d", i)
+		entities = append(entities, graph.Entity{
+			ID: id, Name: fmt.Sprintf("caller%d", i), Kind: "Function", SourceFile: "callers.go",
+		})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "ent-hub", Kind: "CALLS"})
+	}
+	srv := newTestServer(t, minDoc(entities, rels))
+
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-hub",
+		"hops":      float64(1),
+	})
+	if out["resolved"] != true {
+		t.Errorf("expected resolved=true, got %v", out["resolved"])
+	}
+	affected, ok := out["affected"].([]any)
+	if !ok {
+		t.Fatalf("expected affected array, got %T", out["affected"])
+	}
+	if len(affected) != impactRadiusMaxResults {
+		t.Errorf("expected affected capped at %d, got %d", impactRadiusMaxResults, len(affected))
+	}
+	if out["truncated"] != true {
+		t.Errorf("expected truncated=true for high-degree node, got %v", out["truncated"])
+	}
+	total, _ := out["total_affected"].(float64)
+	if int(total) != n {
+		t.Errorf("expected total_affected=%d, got %v", n, out["total_affected"])
+	}
+	if note, _ := out["truncation_note"].(string); note == "" {
+		t.Error("expected a non-empty truncation_note")
+	}
+}
+
+// decodeFlowResult unmarshals a (possibly non-error) tool result into a map.
+func decodeFlowResult(t *testing.T, res *mcpapi.CallToolResult) map[string]any {
+	t.Helper()
+	text := extractResultText(t, res)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("result is not JSON: %v\n%s", err, text)
+	}
+	return out
+}
+
 // buildMixedCallerDoc builds a doc for #2644 testing.
 //
 // Graph shape (impact_radius walks INBOUND edges from the queried entity):


### PR DESCRIPTION
## Closes #3925

### Error class found
`archigraph_impact_radius` had a ~47% error rate (21/45 on 2026-05-31; 5/12 and 3/4 in other sessions). Root cause is **input-driven**, not a panic or timeout:

`handleImpactRadius` resolved `entity_id` by **exact graph ID only** (`r.getByID()[target]`). When no in-scope repo had that exact ID, it fell through to:

```go
return mcpapi.NewToolResultError("entity not found: " + entityID), nil
```

So every call where an agent passed a **symbol name** (not the opaque ID), a **stale/renamed ID**, or an **ambiguous symbol** returned a hard tool error. The BFS itself is already bounded by `hops` (≤6) + the visited set, so timeouts/panics were not the driver — bad-input → error was.

### The fix (QUALITY-FIRST: convert errors into well-formed results)
New `resolveImpactTarget()` resolution ladder, then graceful result shaping:

| Input | Before | After |
|---|---|---|
| exact ID (valid) | impact set | impact set (**unchanged**, resolution pass 1) |
| symbol **name**, unique | `error: entity not found` | resolves by `Name`/`QualifiedName` → correct impact set (`resolved:true`) |
| **ambiguous** name | `error: entity not found` | `resolved:false, ambiguous:true, candidates:[…]` with precise `entity_id`s to re-issue |
| **not found** | `error: entity not found` | `resolved:false, affected:[], count:0, reason:"…use archigraph_find…"` |
| **high-degree** node | unbounded payload | top `500` by risk + `truncated:true, total_affected, truncation_note` |

### Tests (value-asserting, not `len>0`)
- missing entity → asserts **not** `IsError` + empty `affected` + non-empty `reason`
- name-instead-of-ID → resolves to the real entity, correct caller in impact set
- ambiguous name → returns 2 candidates each carrying a precise `entity_id`
- high-degree → `affected` capped, `truncated:true`, `total_affected` correct
- existing valid-case tests (exact ID) unchanged and green

`go test ./internal/mcp/... ./internal/types/` green; `gofmt -l` empty; `go vet` clean; `coverage validate` 0 errors; registry canonical.

### Expected impact
The ~47% error rate was almost entirely these three input shapes. Converting them into well-formed results should drop the error rate toward **~0** (only genuine bad-arg cases like a missing required `entity_id` remain hard errors). Callers now get actionable disambiguation/empty results instead of failures.

**DEPLOY-DEFERRED**: ships on the next coordinated live-daemon rebuild/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)