### PR TITLE
feat(csharp/di): credit M.E.DI-container sibling frameworks for the .NET DI binding graph (#3959)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -26,9 +26,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -27,9 +27,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
 | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -67,9 +67,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
-| DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
+| DI binding extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959 (epic #3872): ASP.NET Core MVC (targeted via Microsoft.AspNetCore.Mvc / Microsoft.NET.Sdk.Web) uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient<IFoo,Foo>() (Try/Keyed + typeof forms) -> IFoo BINDS Foo with lifetime; single-type-arg -> self-BINDS. Verify-first probe TestDotnetDI_Sibling_AspNetMvc asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a Controller-based file with M.E.DI registration. |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -> consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions<>/ILogger<> + primitives rejected. Probe TestDotnetDI_Sibling_AspNetMvc asserts IGreeter INJECTED_INTO the Controller class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked. |
+| DI scope resolution | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_AspNetMvc (lifetime=Scoped). |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -67,9 +67,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
-| DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
+| DI binding extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959 (epic #3872): Carter is an ASP.NET Core-hosted framework that uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient<IFoo,Foo>() (Try/Keyed + typeof forms) -> IFoo BINDS Foo with lifetime; single-type-arg -> self-BINDS. Verify-first probe TestDotnetDI_Sibling_Carter asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a ICarterModule-based file with M.E.DI registration. |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -> consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions<>/ILogger<> + primitives rejected. Probe TestDotnetDI_Sibling_Carter asserts IGreeter INJECTED_INTO the ICarterModule class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked. |
+| DI scope resolution | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_Carter (lifetime=Scoped). |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -67,9 +67,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
-| DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
+| DI binding extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959 (epic #3872): FastEndpoints is an ASP.NET Core-hosted framework that uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient<IFoo,Foo>() (Try/Keyed + typeof forms) -> IFoo BINDS Foo with lifetime; single-type-arg -> self-BINDS. Verify-first probe TestDotnetDI_Sibling_FastEndpoints asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a Endpoint-based file with M.E.DI registration. |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -> consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions<>/ILogger<> + primitives rejected. Probe TestDotnetDI_Sibling_FastEndpoints asserts IGreeter INJECTED_INTO the Endpoint class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked. |
+| DI scope resolution | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_siblings_test.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_FastEndpoints (lifetime=Scoped). |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -8823,16 +8823,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959 (epic #3872): ASP.NET Core MVC (targeted via Microsoft.AspNetCore.Mvc / Microsoft.NET.Sdk.Web) uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient\u003cIFoo,Foo\u003e() (Try/Keyed + typeof forms) -\u003e IFoo BINDS Foo with lifetime; single-type-arg -\u003e self-BINDS. Verify-first probe TestDotnetDI_Sibling_AspNetMvc asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a Controller-based file with M.E.DI registration.",
+            "verified_at": "2026-06-03"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -\u003e consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions\u003c\u003e/ILogger\u003c\u003e + primitives rejected. Probe TestDotnetDI_Sibling_AspNetMvc asserts IGreeter INJECTED_INTO the Controller class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_AspNetMvc (lifetime=Scoped).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {
@@ -9721,16 +9727,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959 (epic #3872): Carter is an ASP.NET Core-hosted framework that uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient\u003cIFoo,Foo\u003e() (Try/Keyed + typeof forms) -\u003e IFoo BINDS Foo with lifetime; single-type-arg -\u003e self-BINDS. Verify-first probe TestDotnetDI_Sibling_Carter asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a ICarterModule-based file with M.E.DI registration.",
+            "verified_at": "2026-06-03"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -\u003e consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions\u003c\u003e/ILogger\u003c\u003e + primitives rejected. Probe TestDotnetDI_Sibling_Carter asserts IGreeter INJECTED_INTO the ICarterModule class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_Carter (lifetime=Scoped).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {
@@ -10005,16 +10017,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959 (epic #3872): FastEndpoints is an ASP.NET Core-hosted framework that uses the identical Microsoft.Extensions.DependencyInjection container as ASP.NET Core, so the container-driven custom_csharp_dotnet_di extractor (#3699, NO framework gating) emits the SAME DI binding GRAPH: services.AddSingleton/AddScoped/AddTransient\u003cIFoo,Foo\u003e() (Try/Keyed + typeof forms) -\u003e IFoo BINDS Foo with lifetime; single-type-arg -\u003e self-BINDS. Verify-first probe TestDotnetDI_Sibling_FastEndpoints asserts IGreeter BINDS Greeter (lifetime=Scoped, framework=dotnet_di) fires for a Endpoint-based file with M.E.DI registration.",
+            "verified_at": "2026-06-03"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: container-driven custom_csharp_dotnet_di (#3699) emits INJECTED_INTO (service type -\u003e consumer class, via=dotnet_constructor) for any class ctor; IConfiguration/IServiceProvider/IOptions\u003c\u003e/ILogger\u003c\u003e + primitives rejected. Probe TestDotnetDI_Sibling_FastEndpoints asserts IGreeter INJECTED_INTO the Endpoint class. PARTIAL mirrors aspnet-core: the registered-as-DI gate is structural and impl/provider resolves cross-file via the resolver pass; factory-lambda registrations not linked.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_siblings_test.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3959: BINDS edges carry the M.E.DI lifetime (Singleton/Scoped/Transient) parsed from the AddXxx verb -- identical container to aspnet-core. Value-asserted in TestDotnetDI_Sibling_FastEndpoints (lifetime=Scoped).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {

--- a/internal/custom/csharp/dotnet_di_siblings_test.go
+++ b/internal/custom/csharp/dotnet_di_siblings_test.go
@@ -1,0 +1,209 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dotnet_di_siblings_test.go — VERIFY-FIRST probe for #3959.
+//
+// The .NET DI binding graph extractor (custom_csharp_dotnet_di, #3699) is
+// container-driven on Microsoft.Extensions.DependencyInjection: it gates ONLY on
+// file.Language=="csharp" and keys purely on services.AddScoped/AddSingleton/
+// AddTransient + constructor injection — there is NO framework gating. These
+// probes assert that a NON-ASP.NET-Core .NET file (Carter / FastEndpoints / etc)
+// carrying the identical M.E.DI container registration + constructor injection
+// produces the SAME BINDS + INJECTED_INTO edges as ASP.NET Core, so the sibling
+// framework DI cells are honestly creditable.
+
+// assertSiblingDIFires runs the shared M.E.DI registration + ctor-injection shape
+// through the extractor and asserts the BINDS (iface->impl, lifetime) and
+// INJECTED_INTO (service->consumer) edges fire — value-asserting, never len>0.
+func assertSiblingDIFires(t *testing.T, framework, src string) {
+	t.Helper()
+	recs := extractRecords(t, src)
+
+	// BINDS: IGreeter BINDS Greeter, lifetime=Scoped — identical to ASP.NET Core.
+	bind := findRel(recs, "BINDS", "di:IGreeter->Greeter", "impl:Greeter")
+	if bind == nil {
+		t.Fatalf("%s: expected IGreeter BINDS Greeter from M.E.DI registration", framework)
+	}
+	if bind.Properties["lifetime"] != "Scoped" {
+		t.Errorf("%s: lifetime = %q, want Scoped", framework, bind.Properties["lifetime"])
+	}
+	if bind.Properties["framework"] != "dotnet_di" {
+		t.Errorf("%s: framework prop = %q, want dotnet_di (container-driven, framework-agnostic)", framework, bind.Properties["framework"])
+	}
+
+	// INJECTED_INTO: IGreeter -> the consumer endpoint/module class.
+	inj := findRel(recs, "INJECTED_INTO", "IGreeter", "consumer:"+consumerOf(framework))
+	if inj == nil {
+		t.Fatalf("%s: expected IGreeter INJECTED_INTO %s", framework, consumerOf(framework))
+	}
+	if inj.Properties["via"] != "dotnet_constructor" {
+		t.Errorf("%s: via = %q, want dotnet_constructor", framework, inj.Properties["via"])
+	}
+}
+
+func consumerOf(framework string) string {
+	switch framework {
+	case "Carter":
+		return "GreetingModule"
+	case "FastEndpoints":
+		return "GreetEndpoint"
+	case "Blazor":
+		return "Counter"
+	case "grpc-net":
+		return "GreeterService"
+	case "aspnet-mvc":
+		return "GreetController"
+	}
+	return ""
+}
+
+func TestDotnetDI_Sibling_Carter(t *testing.T) {
+	// Carter: ICarterModule, no ASP.NET-Core controller — same M.E.DI container.
+	assertSiblingDIFires(t, "Carter", `
+using Carter;
+public class GreetingModule : ICarterModule {
+    private readonly IGreeter _greeter;
+    public GreetingModule(IGreeter greeter) { _greeter = greeter; }
+    public void AddRoutes(IEndpointRouteBuilder app) {
+        app.MapGet("/hi", () => _greeter.Hi());
+    }
+}
+public static class Reg {
+    public static void Wire(IServiceCollection services) {
+        services.AddScoped<IGreeter, Greeter>();
+    }
+}
+`)
+}
+
+func TestDotnetDI_Sibling_FastEndpoints(t *testing.T) {
+	assertSiblingDIFires(t, "FastEndpoints", `
+using FastEndpoints;
+public class GreetEndpoint : Endpoint<GreetReq, GreetRes> {
+    private readonly IGreeter _greeter;
+    public GreetEndpoint(IGreeter greeter) { _greeter = greeter; }
+    public override void Configure() { Get("/greet"); }
+}
+public static class Reg {
+    public static void Wire(IServiceCollection services) {
+        services.AddScoped<IGreeter, Greeter>();
+    }
+}
+`)
+}
+
+// NOTE on Nancy / ServiceStack: these frameworks default to a DIFFERENT IoC
+// container (NancyFX → TinyIoC, ServiceStack → Funq). The M.E.DI extractor does
+// NOT match their idiomatic registration syntax (asserted by the negative probes
+// TestDotnetDI_TinyIoC_NotCredited / TestDotnetDI_FunqContainer_NotCredited
+// below), so they are NOT credited by #3959.
+
+func TestDotnetDI_Sibling_Blazor(t *testing.T) {
+	assertSiblingDIFires(t, "Blazor", `
+using Microsoft.AspNetCore.Components;
+public partial class Counter : ComponentBase {
+    private readonly IGreeter _greeter;
+    public Counter(IGreeter greeter) { _greeter = greeter; }
+}
+public static class Reg {
+    public static void Wire(IServiceCollection services) {
+        services.AddScoped<IGreeter, Greeter>();
+    }
+}
+`)
+}
+
+func TestDotnetDI_Sibling_GrpcNet(t *testing.T) {
+	assertSiblingDIFires(t, "grpc-net", `
+using Grpc.Core;
+public class GreeterService : Greeter.GreeterBase {
+    private readonly IGreeter _greeter;
+    public GreeterService(IGreeter greeter) { _greeter = greeter; }
+}
+public static class Reg {
+    public static void Wire(IServiceCollection services) {
+        services.AddScoped<IGreeter, Greeter>();
+    }
+}
+`)
+}
+
+func TestDotnetDI_Sibling_AspNetMvc(t *testing.T) {
+	assertSiblingDIFires(t, "aspnet-mvc", `
+using Microsoft.AspNetCore.Mvc;
+public class GreetController : Controller {
+    private readonly IGreeter _greeter;
+    public GreetController(IGreeter greeter) { _greeter = greeter; }
+}
+public static class Reg {
+    public static void Wire(IServiceCollection services) {
+        services.AddScoped<IGreeter, Greeter>();
+    }
+}
+`)
+}
+
+// TestDotnetDI_Sibling_AllShareContainer documents the verify-first finding:
+// the extractor emits container records irrespective of the framework marker, so
+// the only thing that matters is that the framework uses the M.E.DI container
+// (services.AddXxx). Frameworks on a DIFFERENT container (e.g. Autofac-only with
+// builder.RegisterType, no services.AddXxx) would NOT fire here and are NOT
+// credited.
+func TestDotnetDI_DifferentContainer_NotCredited(t *testing.T) {
+	// Pure Autofac registration (ContainerBuilder.RegisterType) — NOT M.E.DI.
+	recs := extractRecords(t, `
+using Autofac;
+public class Wiring {
+    public void Build(ContainerBuilder builder) {
+        builder.RegisterType<Greeter>().As<IGreeter>();
+    }
+}
+`)
+	if findRel(recs, "BINDS", "di:IGreeter->Greeter", "impl:Greeter") != nil {
+		t.Error("Autofac RegisterType<>().As<>() must NOT be credited by the M.E.DI extractor")
+	}
+	_ = types.RelationshipKindBinds
+}
+
+// TestDotnetDI_FunqContainer_NotCredited proves ServiceStack's DEFAULT Funq
+// container registration syntax (container.Register<IGreeter>(c => new Greeter()))
+// does NOT match the M.E.DI services.AddXxx<,>() shape — so ServiceStack is NOT
+// credited on its idiomatic container.
+func TestDotnetDI_FunqContainer_NotCredited(t *testing.T) {
+	recs := extractRecords(t, `
+using Funq;
+public class AppHost : AppHostBase {
+    public override void Configure(Container container) {
+        container.Register<IGreeter>(c => new Greeter());
+        container.RegisterAs<Greeter, IGreeter>();
+    }
+}
+`)
+	if findRel(recs, "BINDS", "di:IGreeter->Greeter", "impl:Greeter") != nil {
+		t.Error("Funq container.Register/RegisterAs must NOT be credited by the M.E.DI extractor")
+	}
+}
+
+// TestDotnetDI_TinyIoC_NotCredited proves NancyFX's DEFAULT TinyIoC container
+// registration syntax (container.Register<IGreeter, Greeter>()) — note: NOT
+// services.AddXxx — does NOT match. The extractor keys on the services.Add*
+// VERB, not a bare Register<,>(); Nancy is NOT credited on its idiomatic
+// container.
+func TestDotnetDI_TinyIoC_NotCredited(t *testing.T) {
+	recs := extractRecords(t, `
+using TinyIoC;
+public class Bootstrapper : DefaultNancyBootstrapper {
+    protected override void ConfigureApplicationContainer(TinyIoCContainer container) {
+        container.Register<IGreeter, Greeter>();
+    }
+}
+`)
+	if findRel(recs, "BINDS", "di:IGreeter->Greeter", "impl:Greeter") != nil {
+		t.Error("TinyIoC container.Register<,>() must NOT be credited by the M.E.DI extractor")
+	}
+}


### PR DESCRIPTION
Closes #3959 (epic #3872).

## Verify-first finding
`internal/custom/csharp/dotnet_di.go` (the .NET DI binding-graph extractor, #3699) is **container-driven** on `Microsoft.Extensions.DependencyInjection` and gates **only** on `file.Language=="csharp"` (line 100) — there is **no framework gating**. It keys purely on `services.AddSingleton/AddScoped/AddTransient<IFoo,Foo>()` (Try/Keyed + `typeof` forms) and constructor injection. So any `.cs` file from any .NET framework using the identical M.E.DI container produces the same `BINDS` + `INJECTED_INTO` edges as ASP.NET Core, yet only `aspnet-core` was credited.

## Probe (value-asserting, never len>0)
`internal/custom/csharp/dotnet_di_siblings_test.go`:
- `IGreeter BINDS Greeter` with `lifetime=Scoped`, `framework=dotnet_di`
- `IGreeter INJECTED_INTO <consumer>` with `via=dotnet_constructor`

Positive probes (fire identically to ASP.NET Core): **Carter, FastEndpoints, ASP.NET Core MVC (aspnet-mvc), Blazor, grpc-net**.

Negative probes (different container → NOT credited):
- `TestDotnetDI_TinyIoC_NotCredited` — NancyFX default container is TinyIoC
- `TestDotnetDI_FunqContainer_NotCredited` — ServiceStack default container is Funq
- `TestDotnetDI_DifferentContainer_NotCredited` — Autofac `RegisterType().As()`

## Honest credits (mirror aspnet-core)
For the three M.E.DI-container frameworks that carry a `DI` capability category in the registry — **aspnet-mvc, carter, fastendpoints**:
- `di_binding_extraction`: missing → **full**
- `di_injection_point`: missing → **partial** (structural ctor gate; impl/provider resolves cross-file via resolver pass; factory-lambda not linked — same honest-partial as aspnet-core)
- `di_scope_resolution`: missing → **full** (lifetime carried on BINDS)

`aspnet-mvc` is the registry's ASP.NET **Core** MVC entry (`Microsoft.AspNetCore.Mvc` / `Microsoft.NET.Sdk.Web` per `asp_net_mvc.yaml`), which uses M.E.DI — despite the "(legacy)" label.

## NOT credited (verified)
- **Nancy** (TinyIoC) and **ServiceStack** (Funq) — different default container; M.E.DI extractor does not match their idiomatic registration (negative probes).
- **Blazor** (server/wasm) and **grpc-net** genuinely fire on M.E.DI, but their registry capability profiles carry **no `DI` category** (Blazor: Structure/Data Flow/Navigation; grpc-net: Schema/Codegen/Transport). Crediting them would require adding a DI category — a schema/scope change beyond this ticket. **Deferred.**

## Validation
- Targeted `go test ./internal/custom/csharp/ ./internal/engine/ ./internal/types/ ./tools/coverage/` — green
- `coverage validate` — 0 errors (pre-existing warnings only)
- `coverage fmt --check` — canonical
- `gofmt -l` — empty; `go vet` — clean
- Regenerated coverage docs (DI count 6/11 → 9/11 for the 3 frameworks)

**DEPLOY-DEFERRED**: registry/test/docs only; no daemon rebuild or reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)