### PR TITLE
feat(mcp): bridge get_source/neighbors from inherited http_endpoint to defining mixin (#3973)

### DIFF
--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -115,6 +115,18 @@ func resolveMember(lr *LoadedRepo, e *graph.Entity) memberResolution {
 		return memberResolution{Provenance: provUnresolved, Note: "no repo/entity"}
 	}
 
+	// #3973 — endpoint→mixin bridge. The rewrite agent navigates via the
+	// ENDPOINT (a router-expanded http_endpoint), not the inherited-method
+	// stub. An inherited endpoint never reaches classifyMember (it is not a DRF
+	// synthetic op nor a dotted-name method), so get_source/neighbors on it
+	// never hopped to the defining mixin. The endpoint already carries the
+	// resolution it needs (provenance:inherited + defining_class + the
+	// ViewSet-qualified drf_view_method), so resolve it directly without an
+	// EXTENDS walk (the endpoint owns no EXTENDS edges of its own).
+	if res, ok := resolveInheritedEndpoint(lr, e); ok {
+		return res
+	}
+
 	member, owningName, isBodyless := classifyMember(e)
 	if member == "" || owningName == "" {
 		// Not a recognisable inherited member — treat as explicit (caller keeps
@@ -208,6 +220,111 @@ func resolveMember(lr *LoadedRepo, e *graph.Entity) memberResolution {
 		OwningClass: owningName,
 		Note:        note,
 	}
+}
+
+// isInheritedEndpointEntity reports whether e is a router-expanded
+// http_endpoint that the engine tagged as inheriting its handler verb from a
+// base/mixin (provenance:inherited, #3831). These carry defining_class + the
+// ViewSet-qualified drf_view_method but no body and no EXTENDS edges of their
+// own — the inheritance fact lives entirely in their properties.
+func isInheritedEndpointEntity(e *graph.Entity) bool {
+	if e == nil || e.Properties == nil {
+		return false
+	}
+	if !isEndpointEntity(e) {
+		return false
+	}
+	return e.Properties["provenance"] == drfRouteProvInherited
+}
+
+// isEndpointEntity reports whether e is an http_endpoint route entity,
+// tolerating the scope-prefixed and bare spellings the index uses plus the
+// DRF router-expansion pattern tag.
+func isEndpointEntity(e *graph.Entity) bool {
+	if isHTTPEndpointKind(e.Kind) {
+		return true
+	}
+	return e.Properties != nil && e.Properties["pattern_type"] == "drf_router_expanded"
+}
+
+// drfRouteProvInherited mirrors the engine's drfProvInherited route-provenance
+// tag value (internal/engine/django_drf_actions.go). Duplicated here as a
+// const so the MCP read path recognises an inherited endpoint without a
+// cross-package import of an engine-internal symbol.
+const drfRouteProvInherited = "inherited"
+
+// resolveInheritedEndpoint bridges an inherited http_endpoint to the contract /
+// body of the mixin verb that backs it (#3973). Unlike a method stub, the
+// endpoint carries the resolution explicitly:
+//   - defining_class:  the implementing mixin (FQN or bare leaf, e.g.
+//     "rest_framework.mixins.ListModelMixin" / "ListModelMixin").
+//   - drf_view_method: the ViewSet-qualified handler ("UserProfileViewSet.list")
+//     or, for an ANY catch-all, just the ViewSet name.
+//
+// Resolution, mirroring resolveMember's EXTENDS-walk outcomes:
+//   - in-repo defining class that declares the verb with a body -> resolve to
+//     that entity (provInheritedInRepo), get_source returns the base body.
+//   - external mixin known to the pack -> provInheritedExternal with the pack
+//     contract, get_source synthesizes the contract stub.
+//   - honest-partial: defining_class missing/unknown OR member underivable ->
+//     (zero, false) so resolveMember falls through to the normal path (which,
+//     for an endpoint, is provExplicit — its own real body unchanged).
+//
+// The second return is false when e is NOT an inherited endpoint, so the
+// negative case (explicit endpoint) is untouched.
+func resolveInheritedEndpoint(lr *LoadedRepo, e *graph.Entity) (memberResolution, bool) {
+	if !isInheritedEndpointEntity(e) {
+		return memberResolution{}, false
+	}
+	defining := e.Properties["defining_class"]
+	viewMethod := e.Properties["drf_view_method"]
+	if defining == "" || viewMethod == "" {
+		// honest-partial: tagged inherited but no defining class / no handler
+		// to attribute. Fall through — never fabricate.
+		return memberResolution{}, false
+	}
+	// drf_view_method is "ViewSet.verb" for a verb route; an ANY catch-all
+	// records just the ViewSet with no verb. Without a verb we cannot name a
+	// member contract — fall through honestly.
+	member := leafAfterDot(viewMethod)
+	owning := prefixBeforeDot(viewMethod)
+	if owning == "" || member == "" || member == viewMethod {
+		return memberResolution{}, false
+	}
+
+	// (a) in-repo defining class that declares the verb with a real body.
+	if def := findClassEntity(lr, defining); def != nil {
+		if m := classDeclaredMember(lr, def, member); m != nil {
+			return memberResolution{
+				Provenance:     provInheritedInRepo,
+				Member:         member,
+				OwningClass:    owning,
+				DefiningClass:  defining,
+				DefiningEntity: m,
+			}, true
+		}
+	}
+
+	// (b) external mixin known to the baseknowledge pack.
+	reg := baseknowledge.Default()
+	if m, ok := reg.Member(defining, member); ok {
+		contract := m
+		dc := contract.DefiningClass
+		if dc == "" {
+			dc = canonicalBaseFQN(reg, defining)
+		}
+		return memberResolution{
+			Provenance:    provInheritedExternal,
+			Member:        member,
+			OwningClass:   owning,
+			DefiningClass: dc,
+			Contract:      &contract,
+		}, true
+	}
+
+	// honest-partial: tagged inherited with a defining class neither indexed
+	// nor in the pack. Fall through to the normal path rather than fabricate.
+	return memberResolution{}, false
 }
 
 // classifyMember extracts (memberName, owningClassName, isBodylessSynthetic)

--- a/internal/mcp/mro_endpoint_3973_test.go
+++ b/internal/mcp/mro_endpoint_3973_test.go
@@ -1,0 +1,308 @@
+package mcp
+
+// mro_endpoint_3973_test.go — value-asserting coverage for the
+// endpoint→mixin MRO bridge (#3973, epic #3968).
+//
+// T3 (#3915) + T4 (#3946) made get_source / neighbors MRO-aware on the
+// inherited-method STUB. But the rewrite agent navigates via the ENDPOINT
+// (a router-expanded http_endpoint) and the ViewSet — where the stub path
+// never triggered: an http_endpoint is neither a DRF synthetic op nor a
+// dotted-name method, so classifyMember rejected it and get_source on the
+// endpoint returned the subclass file-top (imports), not the mixin body.
+//
+// The inherited endpoint already carries the resolution explicitly
+// (provenance:inherited + defining_class + drf_view_method), so these tests
+// assert the RESOLUTION, not len>0:
+//
+//  1. get_source on an inherited http_endpoint (defining_class=external mixin)
+//     returns the ListModelMixin contract, NOT the subclass file-top.
+//  2. inspect on the same endpoint surfaces inheritance{defining_class,
+//     resolved, external}.
+//  3. neighbors(out) on the inherited endpoint surfaces the INHERITS hop to the
+//     defining mixin contract.
+//  4. get_source on an inherited endpoint whose defining class IS indexed in the
+//     repo returns the BASE's real body.
+//  5. NEGATIVE: an explicit (non-inherited) endpoint get_source returns its own
+//     real body, unchanged — no mixin redirect.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// inheritedEndpointDoc builds a graph with a UserProfileViewSet and a
+// router-expanded GET list endpoint whose `list` verb is INHERITED from the
+// external rest_framework.mixins.ListModelMixin — exactly what the DRF engine
+// stamps (provenance:inherited + defining_class + drf_view_method, #3831).
+func inheritedEndpointDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "vs", Name: "UserProfileViewSet", QualifiedName: "UserProfileViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "user_viewset.py", StartLine: 12, EndLine: 18, Language: "python",
+			},
+			// Router-expanded inherited endpoint. SourceFile points at the
+			// ViewSet file; StartLine is the class def line (the engine's
+			// fallback for an inherited verb with no body in this file). If
+			// get_source returned THIS span it would emit the subclass file-top
+			// (imports), not the mixin body — that is the bug under test.
+			{
+				ID:         "ep_list",
+				Name:       "GET /api/v1/user-profile/",
+				Kind:       "http_endpoint",
+				SourceFile: "user_viewset.py", StartLine: 1, EndLine: 1,
+				Language: "python",
+				Properties: map[string]string{
+					"verb":            "GET",
+					"path":            "/api/v1/user-profile/",
+					"framework":       "django",
+					"pattern_type":    "drf_router_expanded",
+					"provenance":      "inherited",
+					"defining_class":  "rest_framework.mixins.ListModelMixin",
+					"drf_view_method": "UserProfileViewSet.list",
+				},
+			},
+			{ID: "ext_modelviewset", Name: "ModelViewSet", Kind: "SCOPE.External", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID: "e1", FromID: "vs", ToID: "ext_modelviewset", Kind: "EXTENDS",
+				Properties: map[string]string{
+					"language":  "python",
+					"base_name": "rest_framework.viewsets.ModelViewSet",
+				},
+			},
+		},
+	}
+}
+
+// TestGetSource_InheritedEndpoint_ResolvesToMixinContract — #3973 case 1.
+func TestGetSource_InheritedEndpoint_ResolvesToMixinContract(t *testing.T) {
+	srv := newTestServer(t, inheritedEndpointDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "ep_list"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	// MUST identify the defining mixin, not the subclass file.
+	if !strings.Contains(text, "ListModelMixin") {
+		t.Errorf("expected defining class ListModelMixin in output, got:\n%s", text)
+	}
+	// MUST carry the pack's default status 200 for list.
+	if !strings.Contains(text, "default_status: 200") {
+		t.Errorf("expected default_status: 200 from pack, got:\n%s", text)
+	}
+	// MUST be explicit that the body is NOT the subclass source.
+	if !strings.Contains(text, "NOT subclass source") {
+		t.Errorf("expected explicit not-subclass marker, got:\n%s", text)
+	}
+	// MUST NOT pretend to read the subclass file (the file-top imports bug).
+	if strings.Contains(text, "user_viewset.py") {
+		t.Errorf("output must not reference the subclass file user_viewset.py:\n%s", text)
+	}
+}
+
+// TestInspect_InheritedEndpoint_SurfacesDefiningClass — #3973 case 2.
+func TestInspect_InheritedEndpoint_SurfacesDefiningClass(t *testing.T) {
+	srv := newTestServer(t, inheritedEndpointDoc())
+	out := callInspect(t, srv, "ep_list")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section, got keys: %v", mapKeys(out))
+	}
+	if inh["inherited"] != true {
+		t.Errorf("expected inherited=true, got %v", inh["inherited"])
+	}
+	if inh["resolved"] != true {
+		t.Errorf("expected resolved=true, got %v", inh["resolved"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "ListModelMixin") {
+		t.Errorf("expected defining_class ListModelMixin, got %q", dc)
+	}
+	if inh["external"] != true {
+		t.Errorf("expected external=true, got %v", inh["external"])
+	}
+	if mem, _ := inh["member"].(string); mem != "list" {
+		t.Errorf("expected member=list, got %q", mem)
+	}
+}
+
+// TestNeighbors_InheritedEndpoint_SurfacesInheritsToMixin — #3973 case 3. The
+// inherited endpoint must expose the INHERITS hop to the defining mixin
+// contract via neighbors(out), so the rewrite agent navigating from the
+// ENDPOINT sees the INHERITS relationship (not just the method stub).
+func TestNeighbors_InheritedEndpoint_SurfacesInheritsToMixin(t *testing.T) {
+	srv := newTestServer(t, inheritedEndpointDoc())
+	out := callNeighbors3834(t, srv, "ep_list", "out")
+	names := calleeNames3834(t, out)
+
+	found := false
+	for _, n := range names {
+		if strings.Contains(n, "ListModelMixin") && strings.Contains(n, "list") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected neighbors(out) on inherited endpoint to surface the ListModelMixin.list INHERITS hop, got: %v", names)
+	}
+	// The hop must be flagged via_inherits and be a LEAF (external contract, no
+	// fabricated callees).
+	if !calleeFlaggedInherits(out, "rest_framework.mixins.ListModelMixin.list") {
+		t.Errorf("expected the mixin contract flagged via_inherits=true, got: %v", out["callees"])
+	}
+	if len(names) != 1 {
+		t.Errorf("external contract must be a leaf with no fabricated callees; got %d: %v", len(names), names)
+	}
+}
+
+// inRepoInheritedEndpointDoc builds a graph whose inherited endpoint's defining
+// class is declared IN the indexed repo (a project-local base ViewSet) with a
+// real `list` body — get_source on the endpoint must return that base body.
+func inRepoInheritedEndpointDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "base", Name: "BaseListViewSet", QualifiedName: "BaseListViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "base.py",
+				StartLine: 1, EndLine: 4, Language: "python"},
+			{ID: "base_list", Name: "BaseListViewSet.list", QualifiedName: "BaseListViewSet.list",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.py",
+				StartLine: 2, EndLine: 4, Language: "python",
+				Signature: "def list(self, request)"},
+			{ID: "vs", Name: "ReportViewSet", QualifiedName: "ReportViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "views.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			{ID: "ep_list", Name: "GET /reports/", Kind: "http_endpoint",
+				SourceFile: "views.py", StartLine: 1, EndLine: 1, Language: "python",
+				Properties: map[string]string{
+					"verb":            "GET",
+					"path":            "/reports/",
+					"framework":       "django",
+					"pattern_type":    "drf_router_expanded",
+					"provenance":      "inherited",
+					"defining_class":  "BaseListViewSet",
+					"drf_view_method": "ReportViewSet.list",
+				}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "vs", ToID: "base", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "BaseListViewSet"}},
+		},
+	}
+}
+
+// TestGetSource_InheritedEndpoint_InRepoBase_ReturnsBaseBody — #3973 case 4.
+func TestGetSource_InheritedEndpoint_InRepoBase_ReturnsBaseBody(t *testing.T) {
+	dir := t.TempDir()
+	baseSrc := "" +
+		"class BaseListViewSet:\n" +
+		"    def list(self, request):\n" +
+		"        return Response(self.get_queryset())  # BASE_LIST_MARKER\n"
+	if err := os.WriteFile(filepath.Join(dir, "base.py"), []byte(baseSrc), 0o644); err != nil {
+		t.Fatalf("write base.py: %v", err)
+	}
+	srv := newTestServer(t, inRepoInheritedEndpointDoc())
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "ep_list"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	if !strings.Contains(text, "BASE_LIST_MARKER") {
+		t.Errorf("expected base body (BASE_LIST_MARKER) via endpoint→base resolution, got:\n%s", text)
+	}
+	if !strings.Contains(text, "INHERITED") || !strings.Contains(text, "BaseListViewSet") {
+		t.Errorf("expected inherited-from-BaseListViewSet header, got:\n%s", text)
+	}
+}
+
+// explicitEndpointDoc builds a router-expanded endpoint whose `list` verb is
+// OVERRIDDEN in the ViewSet body (provenance:explicit). get_source must return
+// its own real body — the bridge must NOT redirect it.
+func explicitEndpointDoc(t *testing.T, dir string) *graph.Document {
+	t.Helper()
+	src := "" +
+		"class AuditViewSet(ModelViewSet):\n" +
+		"    def list(self, request):\n" +
+		"        return Response([])  # EXPLICIT_LIST_MARKER\n"
+	if err := os.WriteFile(filepath.Join(dir, "audit.py"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write audit.py: %v", err)
+	}
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "vs", Name: "AuditViewSet", QualifiedName: "AuditViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "audit.py",
+				StartLine: 1, EndLine: 3, Language: "python"},
+			// Explicit endpoint: real body at lines 2-3, provenance=explicit.
+			{ID: "ep_list", Name: "GET /audit/", Kind: "http_endpoint",
+				SourceFile: "audit.py", StartLine: 2, EndLine: 3, Language: "python",
+				Properties: map[string]string{
+					"verb":            "GET",
+					"path":            "/audit/",
+					"framework":       "django",
+					"pattern_type":    "drf_router_expanded",
+					"provenance":      "explicit",
+					"defining_class":  "AuditViewSet",
+					"drf_view_method": "AuditViewSet.list",
+				}},
+		},
+	}
+}
+
+// TestGetSource_ExplicitEndpoint_ReturnsOwnBody — #3973 case 5 (NEGATIVE).
+func TestGetSource_ExplicitEndpoint_ReturnsOwnBody(t *testing.T) {
+	dir := t.TempDir()
+	srv := newTestServer(t, explicitEndpointDoc(t, dir))
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "ep_list"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	// Must return the endpoint's own real body, NOT a mixin contract.
+	if !strings.Contains(text, "EXPLICIT_LIST_MARKER") {
+		t.Errorf("expected the explicit endpoint's own body (EXPLICIT_LIST_MARKER), got:\n%s", text)
+	}
+	if strings.Contains(text, "NOT subclass source") || strings.Contains(text, "ListModelMixin") {
+		t.Errorf("explicit endpoint must NOT be redirected to a mixin contract:\n%s", text)
+	}
+}
+
+// TestNeighbors_ExplicitEndpoint_NoInheritsHop — #3973 case 5b (NEGATIVE). An
+// explicit endpoint must NOT project a synthetic INHERITS edge.
+func TestNeighbors_ExplicitEndpoint_NoInheritsHop(t *testing.T) {
+	dir := t.TempDir()
+	srv := newTestServer(t, explicitEndpointDoc(t, dir))
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	r := srv.State.groups["test"].Repos["repo1"]
+	if edges := mroOutboundEdges(r, "ep_list"); len(edges) != 0 {
+		t.Errorf("explicit endpoint must project NO INHERITS edge, got: %v", edges)
+	}
+}


### PR DESCRIPTION
## Summary
Build deploy-8 #3973 (epic #3968). T3 (#3915) + T4 (#3946) made get_source/inspect/neighbors MRO-aware on the inherited-method **STUB**, but the rewrite agent navigates via the **ENDPOINT** (a router-expanded `http_endpoint`) and the ViewSet — where the MRO hop never triggered.

### Root cause
`classifyMember` (T3, `internal/mcp/mro.go`) only recognises DRF synthetic ops (`pattern_type=drf_viewset_implicit_method`) and dotted-name methods. An `http_endpoint` route entity is neither → `resolveMember` returned `provExplicit` → `get_source` on an inherited endpoint returned the subclass **file-top (imports)**, not the mixin body, and `neighbors`/`inspect` surfaced no INHERITS relationship.

### Fix — endpoint→mixin bridge
`resolveMember` now bridges an inherited endpoint **first**, before `classifyMember`. An inherited endpoint already carries its resolution explicitly (`provenance:inherited` + `defining_class` + the ViewSet-qualified `drf_view_method`, from #3831/#3898), so it resolves **without an EXTENDS walk** (the endpoint owns no EXTENDS edges of its own):

- **in-repo** defining class declaring the verb with a body → `provInheritedInRepo` (get_source returns the base body; neighbors/trace hop via INHERITS);
- **external** mixin known to the baseknowledge pack → `provInheritedExternal` (get_source synthesizes the contract stub; neighbors surfaces the INHERITS edge to the mixin contract leaf);
- **honest-partial**: `defining_class` missing/unknown or member underivable (ANY catch-all) → fall through to the normal path, **never fabricate**.

Because the bridge routes through the shared `resolveMember` outcome, the existing get_source redirect, `inspectInheritance` section, and `mroOutboundEdges` INHERITS projection **all light up for the endpoint for free**.

### Resolution asserted
- `get_source(GET /api/v1/user-profile/)` (inherited `list`) → **ListModelMixin contract + `default_status: 200`**, marked "NOT subclass source", and does **not** reference `user_viewset.py`.
- `neighbors(out)` on the inherited endpoint → surfaces **INHERITS → `ListModelMixin.list`** as a `via_inherits` leaf (no fabricated callees).
- `inspect` on the endpoint → `inheritance{inherited, resolved, external, defining_class: …ListModelMixin, member: list}`.

### Tests — VALUE-ASSERTING (`internal/mcp/mro_endpoint_3973_test.go`)
1. inherited endpoint get_source → ListModelMixin contract + status 200, NOT subclass file
2. inspect surfaces the defining class
3. neighbors(out) surfaces the INHERITS hop as a leaf
4. in-repo defining class → returns the BASE body
5. **NEGATIVE**: explicit endpoint → own real body, projects NO INHERITS edge

### Gates
`go test ./internal/mcp/... ./internal/frameworks/... ./internal/types/` green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors + `fmt --check` canonical (no coverage files touched).

### DEPLOY-DEFERRED
Pure MCP read-path projection — adds **no** graph entities/edges. Needs a daemon rebuild to serve the new endpoint resolution.

Closes #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)