### PR TITLE
fix(mcp): count inbound TESTS edges in impact_radius risk scoring (#3974)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -699,8 +699,16 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 // entity. Higher means "more risky to touch". Factors:
 //   - in-degree (more callers → higher blast radius if it breaks)
 //   - is the entity a public API endpoint or topic publisher
-//   - lack of test coverage indicator (entity has "test_coverage" property)
-func impactRiskScore(e *graph.Entity, inDegree int) float64 {
+//   - lack of test coverage indicator
+//
+// Test-coverage signal (#3974): an entity is treated as covered when EITHER it
+// carries a positive "test_coverage" property OR it has ≥1 inbound TESTS edge
+// (a real test→SUT relation from test→SUT extraction, #3754/#3855). Relying on
+// the property alone falsely flagged genuinely-tested entities (e.g. AuthService
+// with inbound TESTS edges) as "no test coverage". A test-spec entity itself
+// (isTestEntity) is not production code, so the no-coverage penalty never
+// applies to it.
+func impactRiskScore(e *graph.Entity, inDegree int, hasInboundTests, isTestEntity bool) float64 {
 	score := 0.0
 
 	// In-degree contribution: log-scale, max contribution 0.5.
@@ -723,9 +731,9 @@ func impactRiskScore(e *graph.Entity, inDegree int) float64 {
 		score += 0.25
 	}
 
-	// No test coverage: increase risk.
-	cov := e.Properties["test_coverage"]
-	if cov == "" || cov == "0" || cov == "none" {
+	// No test coverage: increase risk — but only for production entities that
+	// have neither a positive coverage property nor an inbound TESTS edge.
+	if !isTestEntity && !entityHasTestCoverage(e, hasInboundTests) {
 		score += 0.25
 	}
 
@@ -733,6 +741,34 @@ func impactRiskScore(e *graph.Entity, inDegree int) float64 {
 		score = 1.0
 	}
 	return score
+}
+
+// entityHasTestCoverage reports whether an entity has genuine test linkage.
+// True when EITHER a positive "test_coverage" property is present (non-empty,
+// not "0"/"none") OR the entity has ≥1 inbound TESTS edge. Centralised so the
+// risk score and the risk_reason string stay in agreement (#3974).
+func entityHasTestCoverage(e *graph.Entity, hasInboundTests bool) bool {
+	if hasInboundTests {
+		return true
+	}
+	cov := e.Properties["test_coverage"]
+	return cov != "" && cov != "0" && cov != "none"
+}
+
+// isTestSpecEntity reports whether an entity is itself test/spec code rather
+// than production code to flag (#3974). A test-spec entity must not be labelled
+// "no test coverage": it is not a unit under test. We use the same test-file
+// convention predicate as dead-code analysis, plus an explicit Pattern/Test
+// kind check for spec-pattern nodes that may not live in a conventional path.
+func isTestSpecEntity(e *graph.Entity) bool {
+	if isTestFileMCP(e.SourceFile) {
+		return true
+	}
+	k := strings.ToLower(e.Kind)
+	if strings.Contains(k, "test") || strings.Contains(k, "spec") {
+		return true
+	}
+	return false
 }
 
 // impactRadiusMaxResults bounds the affected-set returned for a single
@@ -918,9 +954,16 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 	namedCallerMap := map[string]int{}
 	moduleCallerMap := map[string]int{}
 	totalDegreeMap := map[string]int{}
+	// inboundTestsMap counts inbound TESTS edges per entity (#3974). An entity
+	// with ≥1 inbound TESTS edge has genuine test linkage and must not be
+	// labelled "no test coverage" regardless of its test_coverage property.
+	inboundTestsMap := map[string]int{}
 	for i := range r.Doc.Relationships {
 		rel := &r.Doc.Relationships[i]
 		totalDegreeMap[rel.ToID]++
+		if rel.Kind == "TESTS" {
+			inboundTestsMap[rel.ToID]++
+		}
 		if src := byID[rel.FromID]; src != nil {
 			if isModuleFileEntity(src) {
 				moduleCallerMap[rel.ToID]++
@@ -966,8 +1009,10 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 		if e == nil {
 			continue
 		}
-		risk := impactRiskScore(e, totalDegreeMap[id])
-		reason := buildRiskReason(e, namedCallerMap[id], moduleCallerMap[id], totalDegreeMap[id])
+		hasTests := inboundTestsMap[id] > 0
+		isTestSpec := isTestSpecEntity(e)
+		risk := impactRiskScore(e, totalDegreeMap[id], hasTests, isTestSpec)
+		reason := buildRiskReason(e, namedCallerMap[id], moduleCallerMap[id], totalDegreeMap[id], hasTests, isTestSpec)
 		results = append(results, affected{
 			EntityID:   prefixedID(r.Repo, e.ID),
 			Name:       e.Name,
@@ -1032,7 +1077,12 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 // container entities (SCOPE.Component, SCOPE.Module, File, Module, etc.). total is
 // their sum. When the two counts differ we emit a qualified breakdown so consumers
 // understand how much of the in-degree is actual named callers vs structural noise.
-func buildRiskReason(e *graph.Entity, namedCallers, moduleNodes, total int) string {
+// hasInboundTests reports whether the entity has ≥1 inbound TESTS edge, and
+// isTestEntity reports whether the entity is itself test/spec code (#3974). The
+// "no test coverage" label is suppressed when the entity has genuine test
+// linkage (positive coverage property OR an inbound TESTS edge) and is never
+// emitted for a test-spec entity, which is not production code under test.
+func buildRiskReason(e *graph.Entity, namedCallers, moduleNodes, total int, hasInboundTests, isTestEntity bool) string {
 	parts := []string{}
 	if total > 5 {
 		if moduleNodes == 0 {
@@ -1049,8 +1099,10 @@ func buildRiskReason(e *graph.Entity, namedCallers, moduleNodes, total int) stri
 	} else if strings.Contains(k, "topic") || strings.Contains(k, "queue") {
 		parts = append(parts, "message channel")
 	}
-	cov := e.Properties["test_coverage"]
-	if cov == "" || cov == "0" || cov == "none" {
+	// Only flag missing test coverage for production entities with no genuine
+	// test linkage. An inbound TESTS edge or a positive coverage property means
+	// the entity IS tested; a test-spec entity is not a unit to flag (#3974).
+	if !isTestEntity && !entityHasTestCoverage(e, hasInboundTests) {
 		parts = append(parts, "no test coverage")
 	}
 	if len(parts) == 0 {

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -723,6 +723,113 @@ func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 	}
 }
 
+// TestImpactRadius_InboundTestsSuppressesNoCoverageLabel verifies #3974
+// end-to-end through the handler: two sibling callers of the root entity are
+// identical except one has an inbound TESTS edge (from a test entity) and the
+// other has none. The TESTS-covered caller must NOT carry "no test coverage" in
+// its risk_reason, while the uncovered caller still does. This asserts the
+// AuthService-class bug (genuinely-tested entity mislabelled uncovered) is fixed.
+func TestImpactRadius_InboundTestsSuppressesNoCoverageLabel(t *testing.T) {
+	entities := []graph.Entity{
+		// Root whose impact we query (changing it affects its callers).
+		{ID: "ent-core", Name: "CoreService", Kind: "Class", SourceFile: "core.go"},
+		// Covered caller: production class WITH an inbound TESTS edge.
+		{ID: "ent-auth", Name: "AuthService", Kind: "Class", SourceFile: "auth.go"},
+		// Uncovered caller: identical production class, NO TESTS edge.
+		{ID: "ent-billing", Name: "BillingService", Kind: "Class", SourceFile: "billing.go"},
+		// A test/spec entity that exercises AuthService.
+		{ID: "ent-auth-test", Name: "TestAuthService", Kind: "Function", SourceFile: "auth_test.go"},
+	}
+	rels := []graph.Relationship{
+		// Both services depend on CoreService → both are in its impact radius.
+		{FromID: "ent-auth", ToID: "ent-core", Kind: "CALLS"},
+		{FromID: "ent-billing", ToID: "ent-core", Kind: "CALLS"},
+		// AuthService has real test linkage via an inbound TESTS edge.
+		{FromID: "ent-auth-test", ToID: "ent-auth", Kind: "TESTS"},
+	}
+	doc := minDoc(entities, rels)
+	srv := newTestServer(t, doc)
+
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-core",
+		"hops":      float64(1),
+	})
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) == 0 {
+		t.Fatalf("expected affected entities, got %v", out["affected"])
+	}
+	reasons := map[string]string{}
+	scores := map[string]float64{}
+	for _, a := range affected {
+		m := a.(map[string]any)
+		name, _ := m["name"].(string)
+		reasons[name], _ = m["risk_reason"].(string)
+		scores[name], _ = m["risk_score"].(float64)
+	}
+
+	authReason, ok := reasons["AuthService"]
+	if !ok {
+		t.Fatal("AuthService not found in affected list")
+	}
+	billingReason, ok := reasons["BillingService"]
+	if !ok {
+		t.Fatal("BillingService not found in affected list")
+	}
+
+	// The covered (TESTS-linked) entity must NOT be flagged uncovered.
+	if strings.Contains(authReason, "no test coverage") {
+		t.Errorf("AuthService has an inbound TESTS edge; risk_reason must NOT say 'no test coverage', got %q", authReason)
+	}
+	// The uncovered sibling must STILL be flagged (honest — no false suppression).
+	if !strings.Contains(billingReason, "no test coverage") {
+		t.Errorf("BillingService has zero TESTS edges; risk_reason MUST say 'no test coverage', got %q", billingReason)
+	}
+	// The label change must move the score: covered scores strictly lower.
+	if scores["AuthService"] >= scores["BillingService"] {
+		t.Errorf("covered AuthService (%v) must score lower than uncovered BillingService (%v)", scores["AuthService"], scores["BillingService"])
+	}
+}
+
+// TestImpactRadius_TestSpecEntityNotMislabelled verifies #3974: when a test-spec
+// entity itself lands in an impact radius (e.g. it depends on the root), it must
+// not be mislabelled "no test coverage" — it is not production code under test.
+func TestImpactRadius_TestSpecEntityNotMislabelled(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "ent-helper", Name: "sharedHelper", Kind: "Function", SourceFile: "helper.go"},
+		// A test/spec entity that calls the helper → lands in helper's impact radius.
+		{ID: "ent-spec", Name: "helperSpec", Kind: "Function", SourceFile: "helper.spec.ts"},
+	}
+	rels := []graph.Relationship{
+		{FromID: "ent-spec", ToID: "ent-helper", Kind: "CALLS"},
+	}
+	doc := minDoc(entities, rels)
+	srv := newTestServer(t, doc)
+
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-helper",
+		"hops":      float64(1),
+	})
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) == 0 {
+		t.Fatalf("expected affected entities, got %v", out["affected"])
+	}
+	var specEntry map[string]any
+	for _, a := range affected {
+		m := a.(map[string]any)
+		if m["name"] == "helperSpec" {
+			specEntry = m
+			break
+		}
+	}
+	if specEntry == nil {
+		t.Fatal("helperSpec not found in affected list")
+	}
+	reason, _ := specEntry["risk_reason"].(string)
+	if strings.Contains(reason, "no test coverage") {
+		t.Errorf("a test-spec entity must not be labelled 'no test coverage'; got %q", reason)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestImpactRadius reliability (#3925): input-driven errors → graceful results
 // ---------------------------------------------------------------------------
@@ -1453,7 +1560,7 @@ func TestFindDeadCode_ImportedNotFlagged(t *testing.T) {
 
 func TestImpactRiskScore_HighInDegree(t *testing.T) {
 	e := &graph.Entity{Kind: "Function", Properties: map[string]string{}}
-	score := impactRiskScore(e, 50)
+	score := impactRiskScore(e, 50, false, false)
 	if score <= 0 {
 		t.Errorf("high in-degree should produce score > 0, got %v", score)
 	}
@@ -1461,7 +1568,7 @@ func TestImpactRiskScore_HighInDegree(t *testing.T) {
 
 func TestImpactRiskScore_APIBoundary(t *testing.T) {
 	e := &graph.Entity{Kind: "http_endpoint_definition", Properties: map[string]string{}}
-	score := impactRiskScore(e, 0)
+	score := impactRiskScore(e, 0, false, false)
 	if score < 0.25 {
 		t.Errorf("API boundary entity should score >= 0.25, got %v", score)
 	}
@@ -1470,10 +1577,37 @@ func TestImpactRiskScore_APIBoundary(t *testing.T) {
 func TestImpactRiskScore_WithCoverage(t *testing.T) {
 	eCovered := &graph.Entity{Kind: "Function", Properties: map[string]string{"test_coverage": "85"}}
 	eUncovered := &graph.Entity{Kind: "Function", Properties: map[string]string{}}
-	scoreCovered := impactRiskScore(eCovered, 0)
-	scoreUncovered := impactRiskScore(eUncovered, 0)
+	scoreCovered := impactRiskScore(eCovered, 0, false, false)
+	scoreUncovered := impactRiskScore(eUncovered, 0, false, false)
 	if scoreCovered >= scoreUncovered {
 		t.Errorf("covered entity (%v) should score lower than uncovered (%v)", scoreCovered, scoreUncovered)
+	}
+}
+
+// TestImpactRiskScore_InboundTestsSuppressesNoCoverage verifies #3974: an entity
+// with an inbound TESTS edge (hasInboundTests=true) but no test_coverage property
+// must score LOWER than an identical entity with neither signal, because the
+// TESTS edge is genuine test linkage and the no-coverage penalty must not apply.
+func TestImpactRiskScore_InboundTestsSuppressesNoCoverage(t *testing.T) {
+	e := &graph.Entity{Kind: "Class", Name: "AuthService", Properties: map[string]string{}}
+	withTests := impactRiskScore(e, 0, true /*hasInboundTests*/, false)
+	withoutTests := impactRiskScore(e, 0, false, false)
+	if withTests >= withoutTests {
+		t.Errorf("entity with inbound TESTS edge (%v) must score lower than one with zero TESTS (%v)", withTests, withoutTests)
+	}
+	// Concretely: no other risk factors → TESTS-covered entity scores 0.0.
+	if withTests != 0.0 {
+		t.Errorf("AuthService with inbound TESTS and no other risk should score 0.0, got %v", withTests)
+	}
+}
+
+// TestImpactRiskScore_TestSpecEntityNotFlagged verifies #3974: a test-spec entity
+// itself is not production code, so the no-coverage penalty must never apply.
+func TestImpactRiskScore_TestSpecEntityNotFlagged(t *testing.T) {
+	spec := &graph.Entity{Kind: "Function", Name: "TestLogin", SourceFile: "auth_test.go", Properties: map[string]string{}}
+	score := impactRiskScore(spec, 0, false /*no inbound TESTS*/, true /*isTestEntity*/)
+	if score != 0.0 {
+		t.Errorf("test-spec entity must not be penalised for no coverage; got %v", score)
 	}
 }
 


### PR DESCRIPTION
## Summary
The `impact_radius` risk scorer (internal/mcp/flow_tools.go) falsely flagged genuinely-tested entities as **"no test coverage"**. `impactRiskScore` and `buildRiskReason` consulted only the `test_coverage` property and ignored inbound `TESTS` edges — so an entity like **AuthService**, which has real test→SUT linkage (#3754/#3855), was scored as production-uncovered. It also could mis-score test-spec nodes as production.

## Fix
- **Inbound TESTS edges count as coverage.** `handleImpactRadius` now builds an `inboundTestsMap`; an entity with ≥1 inbound `TESTS` edge is treated as covered, so the no-coverage penalty (+0.25) and the `"no test coverage"` `risk_reason` label are both suppressed. Centralised in `entityHasTestCoverage` so the score and the reason string stay in agreement.
- **Test-spec entities aren't flagged.** `isTestSpecEntity` (test-file convention via `isTestFileMCP`, plus Test/Spec kind) marks an entity as not-production-code, so it is never labelled `"no test coverage"`.
- **Honest:** entities with truly zero TESTS and no positive coverage property still flag.

## Corrected risk labeling asserted
Value-asserting tests (not `len>0`):
- `TestImpactRadius_InboundTestsSuppressesNoCoverageLabel` — two sibling callers of a root; the one with an inbound `TESTS` edge (AuthService) drops the `"no test coverage"` label **and scores strictly lower**, while the uncovered sibling (BillingService) **keeps** it. Verified this test **fails without the fix** (reproduces the exact AuthService mislabel: reason `"no test coverage"`, score 0.35 > 0.25).
- `TestImpactRadius_TestSpecEntityNotMislabelled` — a `*.spec.ts` entity in the radius is not labelled uncovered.
- `TestImpactRiskScore_InboundTestsSuppressesNoCoverage` / `TestImpactRiskScore_TestSpecEntityNotFlagged` — unit-level.

## Validation
- `go test ./internal/mcp/ ./internal/types/` green.
- `coverage validate` 0 errors; `coverage fmt --check` canonical (no registry touched).
- `gofmt -l` empty; `go vet ./internal/mcp/` clean.

## Deploy
**DEPLOY-DEFERRED** — read-path change; requires a daemon rebuild to take effect.

Closes #3974

🤖 Generated with [Claude Code](https://claude.com/claude-code)