### PR TITLE
feat(drf): per-action page-key identity in get_permissions (#3972)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -240,6 +240,14 @@ type drfViewSetClass struct {
 	// resolvable per-action override exists — the route falls back to the flat
 	// union posture (honest-partial).
 	actionPermissions map[string][]string
+	// actionPermissionPages maps a DRF action name (same keying as
+	// actionPermissions, with "" as the default branch) to the fine-grained
+	// page-key identities resolved for that action — the constant keys of a
+	// `PERMISSION_PAGES["<KEY>"]` argument passed to a custom page/action guard
+	// in the `get_permissions(self)` branch for that action (#3972). When
+	// present, the route surfaces these as `auth_permissions`. nil / a missing
+	// action means no resolvable page-key (honest-partial).
+	actionPermissionPages map[string][]string
 	// resolved reports whether the ViewSet class was actually located and
 	// parsed on disk (parseViewSetClass found the `class <name>(...)`
 	// declaration). When false, the caller fell back to modelViewSetMethods()
@@ -351,6 +359,16 @@ type drfPosture struct {
 	permissionClasses     []string
 	authenticationClasses []string
 	throttleClasses       []string
+	// permissionPages carries the fine-grained page-key identities that a
+	// per-action permission resolution surfaced — the constant keys of a
+	// `PERMISSION_PAGES["<KEY>"]` argument passed to a custom permission guard
+	// (e.g. `CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])`),
+	// captured as ["JURISDICTIONS"] (#3972). These are the real per-action
+	// authorisation identity for custom page/action guards; the DRF expansion
+	// pass stamps them as the route's `auth_permissions` so archigraph_auth_coverage
+	// can answer "what page-permission does this route require?". Empty when no
+	// page-key argument was resolvable (honest-partial — never fabricated).
+	permissionPages []string
 }
 
 // empty reports whether the posture declares nothing at all.
@@ -1476,6 +1494,18 @@ func stampDRFEndpointPosture(props map[string]string, posture drfPosture) {
 		props["auth_required"] = "true"
 	}
 
+	// #3972 — fine-grained per-action page-key identity. When a per-action
+	// permission resolution captured a `PERMISSION_PAGES["<KEY>"]` argument to a
+	// custom page/action guard (e.g. CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])),
+	// surface those constant keys as `auth_permissions` — the established
+	// cross-language fine-grained-permission property (http_endpoint_jsts_auth.go)
+	// so archigraph_auth_coverage answers "what page-permission does this route
+	// require?". A custom guard with a page-key always requires auth.
+	if len(posture.permissionPages) > 0 {
+		props["auth_permissions"] = strings.Join(uniqueSorted(posture.permissionPages), ",")
+		props["auth_required"] = "true"
+	}
+
 	// Throttle classes ⇒ the route is rate-limited.
 	if len(posture.throttleClasses) > 0 {
 		props["rate_limited"] = "true"
@@ -1683,7 +1713,7 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	// permission to the right route (e.g. POST /x → IsAdminUser, GET /x → AllowAny)
 	// instead of the flat union parseDRFPosture stamps. Dynamic / non-literal
 	// conditions are left unresolved (honest-partial → flat-union fallback).
-	out.actionPermissions = parseDRFActionPermissions(classBody)
+	out.actionPermissions, out.actionPermissionPages = parseDRFActionPermissions(classBody)
 	// classBody starts at classBodyStart in src; pass that offset so
 	// extractActions can compute absolute (src-relative) line numbers for
 	// each @action's `def NAME(` line (#2677).

--- a/internal/engine/django_drf_get_permissions.go
+++ b/internal/engine/django_drf_get_permissions.go
@@ -66,12 +66,6 @@ var drfSelfActionEqRe = regexp.MustCompile(`self\.action\s*==\s*["']([^"']+)["']
 // set) condition. Group 1 is the raw bracketed body of action-name literals.
 var drfSelfActionInRe = regexp.MustCompile(`self\.action\s+in\s+[\[(\{]([^\])\}]*)[\])\}]`)
 
-// drfReturnPermsRe matches a `return [ ... ]` (list/tuple) statement and
-// captures the bracketed body so the permission class symbols can be pulled out
-// with drfClassNames. The leading `return` keeps it from matching arbitrary
-// list literals.
-var drfReturnPermsRe = regexp.MustCompile(`return\s+[\[(]([^\])]*)[\])]`)
-
 // drfPermissionsByActionDictRe locates a `permission_classes_by_action = { ... }`
 // (or `_perms_by_action` style) dict assignment and captures the brace body.
 // (?s) lets the dict span multiple lines. The first `}` closes it — DRF maps are
@@ -88,6 +82,130 @@ var drfDictEntryRe = regexp.MustCompile(`["']([^"']+)["']\s*:\s*[\[(]([^\])]*)[\
 // `self.action in [...]` body.
 var drfStringLiteralRe = regexp.MustCompile(`["']([^"']+)["']`)
 
+// drfReturnPermsComprehensionRe matches the comprehension return that closes the
+// assign-then-return idiom: `return [ <call>(...) for <var> in permission_classes ]`.
+// We only need to recognise that the method returns the assigned `permission_classes`
+// local so the per-branch assignments are the real result (no captured groups
+// beyond detection).
+var drfReturnPermsComprehensionRe = regexp.MustCompile(`return\s+[\[(].*\bfor\b.*\bin\b.*\bpermission_classes\b`)
+
+// drfPermissionPagesKeyRe matches a `PERMISSION_PAGES["<KEY>"]` (or single-quoted)
+// constant-dict subscript — the fine-grained page-key argument of a custom
+// page/action permission guard. Group 1 is the constant KEY (e.g. JURISDICTIONS),
+// which is the stable per-action authorisation identity surfaced as
+// `auth_permissions` (#3972). A dynamic / computed subscript does not match —
+// honest-partial.
+var drfPermissionPagesKeyRe = regexp.MustCompile(`PERMISSION_PAGES\s*\[\s*["']([^"']+)["']\s*\]`)
+
+// drfBalancedListBody returns the body of the FIRST `[...]` list literal in src,
+// with the outer brackets stripped, tracking nested ()/[]/{} so a permission
+// entry that is itself a call with a subscript argument — e.g.
+// `CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])` — is captured
+// WHOLE rather than truncated at the first inner `]`/`)` (the limitation of the
+// flat `[^\])]` regexes). Only a square-bracket list is matched: a `return
+// super().get_permissions()` or a bare call must NOT be mistaken for a permission
+// list (it would otherwise bind an empty default branch). Returns ("", false)
+// when no `[...]` list literal is found.
+func drfBalancedListBody(src string) (string, bool) {
+	open := strings.IndexByte(src, '[')
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '[', '(', '{':
+			depth++
+		case ']', ')', '}':
+			depth--
+			if depth == 0 {
+				return src[open+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// drfSplitTopLevel splits a list body on top-level commas only — commas inside
+// nested ()/[]/{} (a permission entry's call arguments / subscript) are not
+// split points. Each returned segment is one permission-list entry.
+func drfSplitTopLevel(body string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '[', '(', '{':
+			depth++
+		case ']', ')', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start <= len(body) {
+		out = append(out, body[start:])
+	}
+	return out
+}
+
+// drfPermissionItemClass returns the permission-class symbol of one list entry,
+// i.e. the leading dotted identifier BEFORE any `(` instantiation, dropping the
+// call arguments. `IsAuthenticated` → "IsAuthenticated";
+// `CustomPagePermissionCheck(PERMISSION_PAGES["X"])` → "CustomPagePermissionCheck";
+// `permissions.IsAdminUser` → "permissions.IsAdminUser" (finalDottedSegments
+// later reduces it). Returns "" for an empty / non-identifier entry.
+func drfPermissionItemClass(entry string) string {
+	entry = strings.TrimSpace(entry)
+	if paren := strings.IndexByte(entry, '('); paren >= 0 {
+		entry = entry[:paren]
+	}
+	entry = strings.TrimSpace(entry)
+	m := drfLeadingIdentRe.FindString(entry)
+	return m
+}
+
+// drfLeadingIdentRe matches a bare/dotted Python identifier at the START of a
+// permission-list entry.
+var drfLeadingIdentRe = regexp.MustCompile(`^[A-Za-z_][\w.]*`)
+
+// drfPermissionClasses extracts the per-entry permission-class symbols (final
+// dotted segment) from a list body, splitting on top-level commas so each
+// entry's call arguments (e.g. a PERMISSION_PAGES[...] page-key subscript) do
+// NOT leak in as spurious class names. This replaces the flat
+// `finalDottedSegments(drfClassNames(...))` path inside get_permissions parsing,
+// which over-captured `PERMISSION_PAGES` and the page-key string as classes.
+func drfPermissionClasses(listBody string) []string {
+	var out []string
+	for _, entry := range drfSplitTopLevel(listBody) {
+		if cls := drfPermissionItemClass(entry); cls != "" {
+			out = append(out, finalDottedSegment(cls))
+		}
+	}
+	return out
+}
+
+// drfPageKeysIn extracts the ordered, de-duplicated set of PERMISSION_PAGES["KEY"]
+// constant keys referenced in a permission-list body (e.g. the `[...]` of a
+// `permission_classes = [...]` assignment or a `return [...]`). Returns nil when
+// no static page-key subscript is present (honest-partial).
+func drfPageKeysIn(body string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range drfPermissionPagesKeyRe.FindAllStringSubmatch(body, -1) {
+		key := m[1]
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	return out
+}
+
 // parseDRFActionPermissions resolves a per-action permission map from a ViewSet
 // class body, handling both the get_permissions(self) self.action-branch idiom
 // and the permission_classes_by_action dict idiom. Returns nil when neither is
@@ -98,15 +216,16 @@ var drfStringLiteralRe = regexp.MustCompile(`["']([^"']+)["']`)
 // names); the value is the ordered list of permission-class leaf symbols. A key
 // of "" carries the default branch that applies to any action not otherwise
 // listed.
-func parseDRFActionPermissions(classBody string) map[string][]string {
+func parseDRFActionPermissions(classBody string) (perms map[string][]string, pages map[string][]string) {
 	out := map[string][]string{}
+	pageOut := map[string][]string{}
 
 	// Idiom (2): permission_classes_by_action dict. Parsed first so an explicit
 	// get_permissions self.action branch (idiom 1) can refine / override it.
 	if m := drfPermissionsByActionDictRe.FindStringSubmatch(classBody); len(m) >= 2 {
 		for _, e := range drfDictEntryRe.FindAllStringSubmatch(m[1], -1) {
 			action := e[1]
-			perms := finalDottedSegments(drfClassNames(e[2]))
+			perms := drfPermissionClasses(e[2])
 			key := action
 			if action == "default" {
 				key = ""
@@ -114,16 +233,22 @@ func parseDRFActionPermissions(classBody string) map[string][]string {
 			// Always record the key (even when perms is empty, e.g. `[]` = open)
 			// so the route is recognised as explicitly resolved.
 			out[key] = perms
+			if pk := drfPageKeysIn(e[2]); len(pk) > 0 {
+				pageOut[key] = pk
+			}
 		}
 	}
 
 	// Idiom (1): get_permissions(self) branching on self.action.
-	mergeGetPermissionsBranches(classBody, out)
+	mergeGetPermissionsBranches(classBody, out, pageOut)
 
 	if len(out) == 0 {
-		return nil
+		out = nil
 	}
-	return out
+	if len(pageOut) == 0 {
+		pageOut = nil
+	}
+	return out, pageOut
 }
 
 // mergeGetPermissionsBranches parses the body of `def get_permissions(self):`
@@ -137,7 +262,7 @@ func parseDRFActionPermissions(classBody string) map[string][]string {
 // is NOT guarded by a self.action condition (the method-level fallthrough or an
 // `else:`) binds to the default key "". Non-resolvable conditions
 // (`if self.request...`, computed sets) are skipped — honest-partial.
-func mergeGetPermissionsBranches(classBody string, out map[string][]string) {
+func mergeGetPermissionsBranches(classBody string, out map[string][]string, pageOut map[string][]string) {
 	loc := drfGetPermissionsDefRe.FindStringIndex(classBody)
 	if loc == nil {
 		return
@@ -151,25 +276,36 @@ func mergeGetPermissionsBranches(classBody string, out map[string][]string) {
 	}
 
 	lines := strings.Split(body, "\n")
-	// pendingActions holds the action names that the *next* `return [...]` should
-	// bind to. Empty slice + pendingDefault=false means "no guard seen yet" — a
-	// return found in that state is the method-level default.
+	// pendingActions holds the action names that the *next* result line (a
+	// `return [...]` literal OR a `permission_classes = [...]` assignment in the
+	// assign-then-return-comprehension idiom) should bind to. An empty slice with
+	// pendingResolvable=true means "no guard / default branch" — a result found in
+	// that state is the method-level default.
 	var pendingActions []string
 	pendingResolvable := true // whether the current guard was statically resolvable
 
-	bindReturn := func(perms []string) {
-		if len(pendingActions) == 0 {
-			// Unguarded return → default branch.
-			if pendingResolvable {
-				if _, exists := out[""]; !exists {
-					out[""] = perms
-				}
+	// bindResult binds a resolved permission-class list (and any page-keys) to the
+	// pending guard's action(s), or to the default key "" when unguarded. First
+	// binding wins (matches the existing precedence: an earlier branch is not
+	// overwritten by a later default).
+	bindResult := func(perms, pages []string) {
+		targets := pendingActions
+		if len(targets) == 0 {
+			// Unguarded / default branch — only bind when the (absent) guard was
+			// resolvable (a dynamic guard sets pendingResolvable=false and is skipped).
+			if !pendingResolvable {
+				return
 			}
-			return
+			targets = []string{""}
 		}
-		for _, a := range pendingActions {
+		for _, a := range targets {
 			if _, exists := out[a]; !exists {
 				out[a] = perms
+			}
+			if len(pages) > 0 {
+				if _, exists := pageOut[a]; !exists {
+					pageOut[a] = pages
+				}
 			}
 		}
 	}
@@ -188,10 +324,35 @@ func mergeGetPermissionsBranches(classBody string, out map[string][]string) {
 			// else binds to the default key.
 			pendingActions = nil
 			pendingResolvable = true
+		case strings.HasPrefix(trimmed, "permission_classes"):
+			// Assign-then-return-comprehension idiom: each branch assigns the local
+			// `permission_classes = [...]`, and the method ends with
+			// `return [p() for p in permission_classes]`. The assignment IS the
+			// branch result (#3972). Bind it like a return literal.
+			if eq := strings.IndexByte(line, '='); eq >= 0 {
+				if listBody, ok := drfBalancedListBody(line[eq+1:]); ok {
+					bindResult(drfPermissionClasses(listBody), drfPageKeysIn(listBody))
+				}
+			}
+			// Reset the guard so a stray subsequent unguarded assignment is not
+			// mis-bound; the closing comprehension return is ignored below.
+			pendingActions = nil
+			pendingResolvable = true
 		case strings.HasPrefix(trimmed, "return "):
-			if rm := drfReturnPermsRe.FindStringSubmatch(trimmed); len(rm) >= 2 {
-				perms := finalDottedSegments(drfClassNames(rm[1]))
-				bindReturn(perms)
+			// The closing comprehension `return [p() for p in permission_classes]`
+			// of the assign-then-return idiom is NOT a per-branch literal — skip it
+			// so it is not mis-bound as the default branch (its perms came from the
+			// assignments above).
+			if drfReturnPermsComprehensionRe.MatchString(trimmed) {
+				pendingActions = nil
+				pendingResolvable = true
+				break
+			}
+			// Direct `return [<perms>]` literal (the #3933 idiom). Balanced
+			// extraction so a permission entry instantiated with a nested
+			// subscript/call argument is captured whole (#3972).
+			if listBody, ok := drfBalancedListBody(trimmed); ok {
+				bindResult(drfPermissionClasses(listBody), drfPageKeysIn(listBody))
 			}
 			// A return that is not a list literal (e.g. a dict-lookup
 			// comprehension) is left unresolved here — the dict idiom (parsed
@@ -276,6 +437,15 @@ func indentWidth(line string) int {
 // unchanged (honest-partial).
 func postureForAction(vc drfViewSetClass, action string) drfPosture {
 	pos := vc.posture
+	// #3972 — resolve the per-action page-key identity independently of the
+	// permission-class list. Both share the same action→default("") keying. An
+	// action with an explicit per-action page-key entry uses it; otherwise it
+	// inherits the default branch's page-keys (if any). Absent both, no page-key
+	// is stamped (honest-partial). Resolved even when actionPermissions is nil
+	// is impossible (they are produced together), but the lookups are guarded.
+	if pages, ok := actionLookup(vc.actionPermissionPages, action); ok {
+		pos.permissionPages = pages
+	}
 	if vc.actionPermissions == nil {
 		return pos
 	}
@@ -289,4 +459,21 @@ func postureForAction(vc drfViewSetClass, action string) drfPosture {
 	}
 	pos.permissionClasses = perms
 	return pos
+}
+
+// actionLookup resolves a per-action value from a map keyed by action name with
+// "" as the default branch: an explicit entry for action wins, else the default
+// ("") entry, else (nil, false). Mirrors the precedence postureForAction applies
+// to actionPermissions so the page-key map tracks the same per-action shape.
+func actionLookup(m map[string][]string, action string) ([]string, bool) {
+	if m == nil {
+		return nil, false
+	}
+	if v, ok := m[action]; ok {
+		return v, true
+	}
+	if v, ok := m[""]; ok {
+		return v, true
+	}
+	return nil, false
 }

--- a/internal/engine/django_drf_get_permissions_test.go
+++ b/internal/engine/django_drf_get_permissions_test.go
@@ -290,7 +290,7 @@ func TestParseDRFActionPermissions(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseDRFActionPermissions(tc.body)
+			got, _ := parseDRFActionPermissions(tc.body)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("parseDRFActionPermissions() = %#v, want %#v", got, tc.want)
 			}
@@ -321,4 +321,160 @@ func TestPostureForAction(t *testing.T) {
 	if got := postureForAction(bare, "create").permissionClasses; !reflect.DeepEqual(got, []string{"IsAuthenticated"}) {
 		t.Errorf("bare passthrough = %v, want [IsAuthenticated]", got)
 	}
+}
+
+// TestPostureForAction_PermissionPages verifies the #3972 per-action page-key
+// identity layers onto the posture with the same explicit→default("")
+// precedence as the permission-class list.
+func TestPostureForAction_PermissionPages(t *testing.T) {
+	vc := drfViewSetClass{
+		posture: drfPosture{permissionClasses: []string{"IsAuthenticated"}},
+		actionPermissions: map[string][]string{
+			"get_jurisdictions_by_group": {"IsAuthenticated", "CustomPagePermissionCheck"},
+			"":                           {"IsAuthenticated", "CustomActionPermissionCheck"},
+		},
+		actionPermissionPages: map[string][]string{
+			"get_jurisdictions_by_group": {"JURISDICTIONS"},
+		},
+	}
+	if got := postureForAction(vc, "get_jurisdictions_by_group").permissionPages; !reflect.DeepEqual(got, []string{"JURISDICTIONS"}) {
+		t.Errorf("jurisdictions page-keys = %v, want [JURISDICTIONS]", got)
+	}
+	// An action with no explicit page-key entry and no default ("") page-key →
+	// no page-key stamped (honest-partial).
+	if got := postureForAction(vc, "some_other_action").permissionPages; len(got) != 0 {
+		t.Errorf("default action page-keys = %v, want empty", got)
+	}
+}
+
+// TestParseDRFActionPermissions_AssignThenReturnComprehension is the #3972
+// value-asserting direct-parser test on the REAL upvate GroupViewSet shape:
+// each branch ASSIGNS `permission_classes = [...]` (not `return [...]`) and the
+// method ends with `return [p() for p in permission_classes]` — the assigned
+// list must bind per branch, the PERMISSION_PAGES["<KEY>"] argument must surface
+// as the per-action page-key, and a branch without a page-key (CustomActionPermissionCheck
+// default) must NOT fabricate one.
+func TestParseDRFActionPermissions_AssignThenReturnComprehension(t *testing.T) {
+	body := `
+    def get_permissions(self):
+        if self.action in ["groups_list", "get_group_type"]:
+            permission_classes = [IsAuthenticated]
+        elif self.action in ["update_group_jurisdiction_config", "get_jurisdictions_by_group"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])]
+        elif self.action in ["filter"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["CONTRACT_PROPOSALS"])]
+        else:
+            permission_classes = [IsAuthenticated, CustomActionPermissionCheck]
+        return [permission() for permission in permission_classes]
+`
+	perms, pages := parseDRFActionPermissions(body)
+
+	// Permission-class lists bind per branch (assignment, not return literal).
+	wantPerms := map[string][]string{
+		"groups_list":                      {"IsAuthenticated"},
+		"get_group_type":                   {"IsAuthenticated"},
+		"update_group_jurisdiction_config": {"IsAuthenticated", "CustomPagePermissionCheck"},
+		"get_jurisdictions_by_group":       {"IsAuthenticated", "CustomPagePermissionCheck"},
+		"filter":                           {"IsAuthenticated", "CustomPagePermissionCheck"},
+		"":                                 {"IsAuthenticated", "CustomActionPermissionCheck"},
+	}
+	if !reflect.DeepEqual(perms, wantPerms) {
+		t.Errorf("perms = %#v\nwant %#v", perms, wantPerms)
+	}
+
+	// Page-keys: the JURISDICTIONS branch surfaces JURISDICTIONS on BOTH its
+	// actions; the filter branch surfaces CONTRACT_PROPOSALS — DISTINCT per
+	// action. The plain-IsAuthenticated and CustomActionPermissionCheck branches
+	// have no page-key (honest-partial — absent, not fabricated).
+	wantPages := map[string][]string{
+		"update_group_jurisdiction_config": {"JURISDICTIONS"},
+		"get_jurisdictions_by_group":       {"JURISDICTIONS"},
+		"filter":                           {"CONTRACT_PROPOSALS"},
+	}
+	if !reflect.DeepEqual(pages, wantPages) {
+		t.Errorf("pages = %#v\nwant %#v", pages, wantPages)
+	}
+}
+
+// TestParseDRFActionPermissions_DynamicPageKeyHonestPartial is the #3972
+// negative test: a PERMISSION_PAGES subscript whose key is a VARIABLE (not a
+// string literal) is not statically resolvable, so no page-key is captured
+// (honest-partial) — but the permission-class list still binds.
+func TestParseDRFActionPermissions_DynamicPageKeyHonestPartial(t *testing.T) {
+	body := `
+    def get_permissions(self):
+        if self.action in ["dynamic"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES[self.page_key])]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]
+`
+	perms, pages := parseDRFActionPermissions(body)
+	if got := perms["dynamic"]; !reflect.DeepEqual(got, []string{"IsAuthenticated", "CustomPagePermissionCheck"}) {
+		t.Errorf("dynamic perms = %v, want [IsAuthenticated CustomPagePermissionCheck]", got)
+	}
+	// Dynamic (variable) subscript → no page-key resolved anywhere.
+	if len(pages) != 0 {
+		t.Errorf("pages = %#v, want empty (dynamic key honest-partial)", pages)
+	}
+}
+
+// TestApplyDjangoDRFRoutes_PageKeyPerActionRoute is the #3972 end-to-end
+// value-asserting test on the real GroupViewSet idiom: @action routes whose
+// get_permissions branch assigns CustomPagePermissionCheck(PERMISSION_PAGES["<KEY>"])
+// surface the page-key as `auth_permissions` on THAT action's route — distinct
+// per action — while a branch with no page-key does not.
+func TestApplyDjangoDRFRoutes_PageKeyPerActionRoute(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import GroupViewSet
+
+router = routers.DefaultRouter()
+router.register(r"groups", GroupViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from core.helper.permissions import CustomPagePermissionCheck, CustomActionPermissionCheck
+from upvate_core.settings import PERMISSION_PAGES
+
+class GroupViewSet(ModelViewSet):
+    @action(detail=False, methods=["get"], url_path="jurisdictions")
+    def get_jurisdictions_by_group(self, request):
+        pass
+
+    @action(detail=False, methods=["get"], url_path="proposals")
+    def filter(self, request):
+        pass
+
+    @action(detail=False, methods=["get"], url_path="types")
+    def get_group_type(self, request):
+        pass
+
+    def get_permissions(self):
+        if self.action in ["get_group_type"]:
+            permission_classes = [IsAuthenticated]
+        elif self.action in ["get_jurisdictions_by_group"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])]
+        elif self.action in ["filter"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["CONTRACT_PROPOSALS"])]
+        else:
+            permission_classes = [IsAuthenticated, CustomActionPermissionCheck]
+        return [permission() for permission in permission_classes]
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// get_jurisdictions_by_group → JURISDICTIONS page-key on its route.
+	assertEndpointProp(t, got, "http:GET:/groups/jurisdictions", "auth_permissions", "JURISDICTIONS")
+	assertEndpointProp(t, got, "http:GET:/groups/jurisdictions", "auth_required", "true")
+
+	// filter → CONTRACT_PROPOSALS — DISTINCT from the jurisdictions route.
+	assertEndpointProp(t, got, "http:GET:/groups/proposals", "auth_permissions", "CONTRACT_PROPOSALS")
+	assertEndpointProp(t, got, "http:GET:/groups/proposals", "auth_required", "true")
+
+	// get_group_type → plain IsAuthenticated branch → NO page-key surfaced.
+	assertNoProp(t, got, "http:GET:/groups/types", "auth_permissions")
 }


### PR DESCRIPTION
## Closes #3972 (epic #3968, deploy-8)

Builds on #3941/#3933 (per-action DRF permission resolution). That work required a literal `return [...]` per branch and discarded permission-guard **arguments**. The real upvate `GroupViewSet.get_permissions` uses a different shape that bound nothing and dropped the page-key identity:

```python
def get_permissions(self):
    if self.action in ["update_group_jurisdiction_config", "get_jurisdictions_by_group"]:
        permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])]
    elif self.action in ["filter"]:
        permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["CONTRACT_PROPOSALS"])]
    else:
        permission_classes = [IsAuthenticated, CustomActionPermissionCheck]
    return [permission() for permission in permission_classes]
```

Each branch **assigns** `permission_classes = [...]` then returns a **comprehension** → no branch bound → flat placeholder. And the `PERMISSION_PAGES["JURISDICTIONS"]` key — the real per-action authorisation identity — was discarded.

## Fixes (engine get_permissions pass)

1. **Assign-then-return-comprehension idiom** — a per-branch `permission_classes = [...]` assignment now binds as that branch's result; the closing `return [... for ... in permission_classes]` comprehension is recognised and **not** mis-bound as the default branch.
2. **Page-key identity** — a `PERMISSION_PAGES["<KEY>"]` constant subscript argument to a custom page/action guard is captured per action and surfaced as the route's `auth_permissions` (the established cross-language fine-grained-permission property), **distinct per action**. Dynamic/variable subscript → honest-partial (no page-key; perms still bind).

Balanced-bracket list extraction replaces the flat `[^\])]` regexes inside get_permissions parsing so a permission entry instantiated with a nested subscript/call argument is captured whole rather than truncated, and per-entry class extraction stops `PERMISSION_PAGES`/the key string leaking in as spurious permission-class names.

## Tests (value-asserting, on the real GroupViewSet shape)
- `TestApplyDjangoDRFRoutes_PageKeyPerActionRoute` — `GET /groups/jurisdictions` → `auth_permissions=JURISDICTIONS`; `GET /groups/proposals` → `auth_permissions=CONTRACT_PROPOSALS` (distinct per action); a plain-`IsAuthenticated` branch route → no page-key.
- `TestParseDRFActionPermissions_AssignThenReturnComprehension` — per-branch perms + page-keys, JURISDICTIONS on both its actions, CONTRACT_PROPOSALS on `filter`, none on the `CustomActionPermissionCheck` default.
- `TestParseDRFActionPermissions_DynamicPageKeyHonestPartial` — variable subscript → perms bind, no page-key (honest fallback).
- `TestPostureForAction_PermissionPages` — explicit→default("") page-key precedence.

`go test ./internal/engine/ ./internal/custom/python/ ./internal/extractors/python/ ./internal/types/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

## Cross-language note
The per-action custom-guard page-key identity generalises: any framework whose route guard carries a fine-grained constant key (page/resource/scope) can surface it as `auth_permissions` per action via the same capture-the-constant-argument approach.

## DEPLOY-DEFERRED
Requires a daemon rebuild + reindex of upvate to populate `auth_permissions` on the GroupViewSet action routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)