### PR TITLE
fix(jsts): NestJS controller DI edges survive same-id dedup (#3970)

### DIFF
--- a/cmd/archigraph/nestjs_shadow_fold_test.go
+++ b/cmd/archigraph/nestjs_shadow_fold_test.go
@@ -129,6 +129,83 @@ func TestClassShadowFold_ServiceKind_NoDanglingEdges(t *testing.T) {
 	}
 }
 
+// TestNestJSControllerDIEdgeSurvivesDedup is the deploy-8 (#3970) regression:
+// a NestJS @Controller class with a constructor-injected service. The custom
+// NestJS extractor emits a SCOPE.Component/controller entity carrying the
+// inbound INJECTED_INTO edge (NotificationService → NotificationController),
+// while the generic AST extractor emits a co-located SCOPE.Component/class node
+// for the SAME (Kind, Name, SourceFile) — i.e. the SAME entity ID — WITHOUT the
+// edge.
+//
+// The fold pass must designate the edge-bearing specialized entity as the
+// survivor (or re-home its edges onto the survivor) so the INJECTED_INTO edge
+// is REACHABLE on the surviving controller node — not clobbered by the edge-less
+// AST duplicate during same-ID assembly. We assert the SPECIFIC edge survives:
+// an INJECTED_INTO whose ToID is the controller's hex id and whose FromID is the
+// service's hex id (the exact edge inspect.di_edges would surface on the
+// controller). A len>0 check would be too weak — we pin the precise endpoints.
+func TestNestJSControllerDIEdgeSurvivesDedup(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/nestjs_app", "nestjs_app", nil)
+	if len(doc.Entities) == 0 {
+		t.Fatal("nestjs_app: no entities extracted")
+	}
+
+	// Resolve the single class-declaration node for each class symbol (excluding
+	// file/import/module sentinels) and capture its hex id.
+	classNodeID := func(name string) string {
+		t.Helper()
+		var ids []string
+		for _, e := range doc.Entities {
+			if e.Name != name {
+				continue
+			}
+			if e.Subtype == "file" || e.Subtype == "import" || e.Subtype == "module" {
+				continue
+			}
+			ids = append(ids, e.ID)
+		}
+		if len(ids) != 1 {
+			t.Fatalf("%s: expected exactly 1 class-declaration node after fold, got %d (ids=%v)",
+				name, len(ids), ids)
+		}
+		return ids[0]
+	}
+
+	controllerID := classNodeID("NotificationController")
+	serviceID := classNodeID("NotificationService")
+
+	// The deploy-8 failure: the controller carries ZERO di_edges. Assert the
+	// EXACT inbound INJECTED_INTO edge survives, reachable on the controller.
+	found := false
+	for _, r := range doc.Relationships {
+		if r.Kind == "INJECTED_INTO" && r.ToID == controllerID && r.FromID == serviceID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected NotificationService INJECTED_INTO NotificationController to survive same-id dedup "+
+			"(controllerID=%s serviceID=%s); the edge-bearing controller entity was clobbered by the edge-less AST duplicate",
+			controllerID, serviceID)
+	}
+
+	// Regression guard: the service→service DI edge (ChannelRegistry INJECTED_INTO
+	// NotificationService) must still resolve — @Injectable was never the bug, but
+	// the fix must not regress it.
+	registryID := classNodeID("ChannelRegistry")
+	svcFound := false
+	for _, r := range doc.Relationships {
+		if r.Kind == "INJECTED_INTO" && r.ToID == serviceID && r.FromID == registryID {
+			svcFound = true
+			break
+		}
+	}
+	if !svcFound {
+		t.Errorf("regression: expected ChannelRegistry INJECTED_INTO NotificationService to survive "+
+			"(serviceID=%s registryID=%s)", serviceID, registryID)
+	}
+}
+
 // entitySummary is a compact representation of an entity for test diagnostics.
 type entitySummary struct {
 	Kind    string

--- a/cmd/archigraph/testdata/nestjs_app/src/notification.controller.ts
+++ b/cmd/archigraph/testdata/nestjs_app/src/notification.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+
+/**
+ * NotificationController exposes the broadcast surface over HTTP. It injects
+ * NotificationService via constructor DI — the deploy-8 (#3970) case: the
+ * NestJS custom extractor emits a SCOPE.Component/controller carrying the
+ * INJECTED_INTO edge, while the generic AST extractor emits a co-located
+ * SCOPE.Component/class node WITHOUT the edge. After same-ID dedup the
+ * edge-bearing controller entity must survive so NotificationService
+ * INJECTED_INTO NotificationController is reachable.
+ */
+@Controller('notifications')
+export class NotificationController {
+  constructor(private readonly notifications: NotificationService) {}
+
+  @Get(':channelId')
+  list(@Param('channelId') channelId: string): string {
+    return channelId;
+  }
+}

--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -41,14 +41,59 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// angularClassDecorators maps a recognised Angular decorator identifier to the
-// SCOPE.Component subtype emitted for the decorated class.
+// angularClassDecorators maps a recognised class decorator identifier to the
+// SCOPE.Component subtype emitted for the decorated class. The map name is
+// historical (#2854 was Angular-only); it now also carries the NestJS
+// constructor-DI decorators so the base AST extractor routes those classes
+// through handleAngularClass — which emits the provider→consumer INJECTED_INTO
+// edges from the constructor parameter list.
+//
+// Why the NestJS controller/resolver/gateway decorators belong here (#3970):
+// @Injectable was already recognised, so NestJS *service* classes went through
+// the DI-aware path and kept their INJECTED_INTO edges. @Controller / @Resolver
+// / @WebSocketGateway were NOT, so a NestJS controller fell through to the
+// generic class path and emitted an edge-LESS SCOPE.Component/class node. That
+// node shares an entity ID (Kind+Name+SourceFile) with the NestJS custom
+// extractor's edge-bearing controller entity, and the edge-less AST node won the
+// same-id assembly dedup (first-writer-wins), dropping the controller's
+// INJECTED_INTO edges. Routing @Controller/@Resolver/@WebSocketGateway through
+// handleAngularClass makes the surviving AST node ALSO carry the INJECTED_INTO
+// edges, so they are reachable on the controller via inspect.di_edges
+// regardless of which same-id node wins. The constructor-injection scan
+// (angularConstructorInjections) is framework-agnostic, so it captures the
+// `constructor(private readonly svc: DevicesService)` providers identically.
 var angularClassDecorators = map[string]string{
 	"Component":  "angular_component",
 	"Directive":  "angular_directive",
 	"Injectable": "angular_service",
 	"Pipe":       "angular_pipe",
 	"NgModule":   "angular_module",
+	// NestJS constructor-DI decorators (#3970). Subtypes match the
+	// classLikeComponentSubtypes fold-source allowlist (controller/resolver/
+	// gateway) so the node folds/dedups cleanly with the custom extractor's
+	// same-named entity.
+	"Controller":       "controller",
+	"Resolver":         "resolver",
+	"WebSocketGateway": "gateway",
+}
+
+// nestClassDecorators is the subset of angularClassDecorators that belongs to
+// NestJS rather than Angular (#3970). It is used only to stamp the correct
+// `framework` property/edge label on the emitted entity — the structural
+// handling (subtype emission + constructor-DI INJECTED_INTO edges) is shared.
+var nestClassDecorators = map[string]bool{
+	"Controller":       true,
+	"Resolver":         true,
+	"WebSocketGateway": true,
+}
+
+// frameworkForDecorator returns the framework label for a recognised class
+// decorator: "nestjs" for the NestJS DI decorators, else "angular".
+func frameworkForDecorator(decorator string) string {
+	if nestClassDecorators[decorator] {
+		return "nestjs"
+	}
+	return "angular"
 }
 
 // reAngularPascalTag matches PascalCase / kebab custom-element tags in an inline
@@ -122,8 +167,9 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 		return false
 	}
 
+	framework := frameworkForDecorator(decorator)
 	props := map[string]string{
-		"framework":          "angular",
+		"framework":          framework,
 		"angular_decorator":  decorator,
 		"angular_class_kind": subtype,
 	}
@@ -171,7 +217,7 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 				Properties: map[string]string{
 					"consumer":  className,
 					"provider":  dep,
-					"framework": "angular",
+					"framework": framework,
 				},
 			})
 		}


### PR DESCRIPTION
Closes #3970

## Problem (deploy-8 #3970)
NestJS `@Controller` classes carried **ZERO** `di_edges` despite constructor injection. `inspect` on a controller showed no inbound `INJECTED_INTO`, breaking the rewrite-parity oracle's "what provider satisfies this controller's constructor" resolution. NestJS *services* (`@Injectable`) were fine.

## Root cause (confirmed by full-indexer probe)
The base JS/TS AST extractor recognises `@Injectable` in `angularClassDecorators`, so a NestJS service routes through `handleAngularClass`, which emits the `provider → consumer` `INJECTED_INTO` edges from the constructor parameter list. `@Controller`/`@Resolver`/`@WebSocketGateway` were **not** recognised, so a controller fell through to the generic class path and emitted an **edge-less** `SCOPE.Component`/`class` node.

That generic node shares an entity ID (`Kind+Name+SourceFile`) with the NestJS custom extractor's edge-bearing `SCOPE.Component`/`controller` entity. In `buildDocument`'s final same-id assembly dedup (`if !seenEntity[id]`, first-writer-wins), the **edge-less AST node won**, dropping the controller's `INJECTED_INTO` edges. The service case survived only because `@Injectable` was already on the DI-aware AST path producing the same edge.

## Fix — approach (a), the cleaner + generalizing one here
Add `Controller`/`Resolver`/`WebSocketGateway` to `angularClassDecorators`, mapped to the `controller`/`resolver`/`gateway` subtypes already in the `classLikeComponentSubtypes` fold allowlist. The surviving AST node now **also** carries the constructor-injection edges, so the winning same-id node is edge-bearing regardless of dedup order. The injection scan (`angularConstructorInjections`) is framework-agnostic — it captures `constructor(private readonly svc: DevicesService)` identically to a service. A small `frameworkForDecorator` helper stamps `framework=nestjs` on these entities/edges instead of the misleading `angular` label.

**Why (a) over a dedup rewrite (b):** in this codebase the base AST extractor is already the DI-edge producer for NestJS via the Angular path; the controller was simply missing from the recognised-decorator set. Fixing it there means the surviving node is edge-bearing by construction (no reliance on dedup ordering or edge re-homing). It generalizes: the same recognition gap closes for resolvers and gateways, and the edge-less-AST-twin clobber is removed at the source rather than patched at merge time.

## Test (value-asserting, not `len>0`)
`TestNestJSControllerDIEdgeSurvivesDedup` runs the **full indexer** on the `nestjs_app` fixture (new `notification.controller.ts` injecting `NotificationService`) and asserts the **exact** edge survives: `NotificationService INJECTED_INTO NotificationController` with `ToID` = the controller's hex id and `FromID` = the service's hex id — the precise deploy-8 failure, reachable on the surviving controller node. It also regression-guards that the service→service edge (`ChannelRegistry INJECTED_INTO NotificationService`) still resolves. The test was confirmed RED before the fix, GREEN after.

## Validation
- `go test ./internal/extractors/javascript/ ./internal/custom/javascript/ ./internal/engine/ ./internal/types/ ./cmd/archigraph/` green (existing `TestClassShadowFold_*`, `Issue2933` Angular-dedup, `audit2678` NestJS suites all pass).
- `gofmt -l` empty; `go vet` clean.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.

## DEPLOY-DEFERRED
Requires a reindex to take effect on the live graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)