### PR TITLE
feat(mcp): archigraph_effective_contract per-verb ViewSet contract (#3836)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -132,6 +132,7 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_subgraph`](#archigraph_subgraph) | Nodes+edges (format=raw) or Markdown summary (format=markdown) within N hops. |
 | [`archigraph_find_paths`](#archigraph_find_paths) | Shortest path between two entities. |
 | [`archigraph_endpoints`](#archigraph_endpoints) | HTTP endpoint surface (action: definitions\|calls\|stats). |
+| [`archigraph_effective_contract`](#archigraph_effective_contract) | Per-verb effective contract of a ViewSet/controller (kind, status, error_statuses, serializer, pagination, permissions). |
 | `archigraph_neighbors` | Graph neighbors of `entity_id` (`direction=in\|out\|both`, default `both`). **Unifies `find_callers` + `find_callees` (#1753).** |
 | [`archigraph_find_callers`](#archigraph_find_callers) | **Deprecated alias** of `archigraph_neighbors(direction=in)`. Removed next release. |
 | [`archigraph_find_callees`](#archigraph_find_callees) | **Deprecated alias** of `archigraph_neighbors(direction=out)`. Removed next release. |
@@ -1221,6 +1222,76 @@ When `migrated: false`, `note` contains a migration reminder.
 
 When `token_budget` is exceeded the response carries a `truncation_note` explaining
 how many items were omitted and how to get more. Use `limit=N` for simple pagination.
+
+---
+
+### `archigraph_effective_contract`
+
+> Added in #3836 (epic #3829, MRO T6). Per-verb **effective contract** of a
+> ViewSet / controller. Thin serving/grouping layer over the T5 (#3964)
+> computation — the `effective_*` properties the DRF expansion pass stamps onto
+> every router-expanded route, lifted into a structured per-verb record.
+
+Given a ViewSet/controller entity (or a single route/endpoint), returns that
+ViewSet's router-expanded routes' per-verb effective contracts, grouped by the
+owning ViewSet. This is the single artifact that answers "what is the full
+contract of every verb on this ViewSet?" in one call — preventing the #278
+defect class (an **inherited** `create` surfacing `kind:inherited`,
+`source_class:CreateModelMixin`, `default_status:201`, `error_statuses:[400]`
+even though the ViewSet body is empty).
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `entity_id` | string | yes | — | ViewSet/controller entity ID, qualified name, or label — or a single route/endpoint, which resolves to its owning ViewSet. |
+| `qualified_name` | string | no | — | Alternative to `entity_id`. |
+| `repo_filter` | string[] | no | `[]` | Common arg. |
+| `group`, `cwd`, `ref` | string | no | — | Common args. |
+
+**Resolution.** The target is resolved by (1) a router-expanded route → its
+owning ViewSet; (2) a class/component entity → its leaf name; (3) no entity
+match → the raw string's leaf, so a bare ViewSet name still works when only the
+routes carry it.
+
+**Output** — JSON object:
+
+```json
+{
+  "target": "RoleViewSet",
+  "groups": [
+    {
+      "class": "RoleViewSet",
+      "framework": "django",
+      "repo": "backend",
+      "handlers": [
+        { "verb": "POST", "path": "/api/v1/roles", "handler": "RoleViewSet.create",
+          "kind": "inherited", "source_class": "CreateModelMixin",
+          "default_status": 201, "error_statuses": [400],
+          "serializer": "RoleSerializer", "permissions": ["IsAuthenticated"],
+          "auth_required": true },
+        { "verb": "GET", "path": "/api/v1/roles", "handler": "RoleViewSet.list",
+          "kind": "explicit", "source_class": "RoleViewSet",
+          "default_status": 200, "pagination": true, "serializer": "RoleSerializer" },
+        { "verb": "POST", "path": "/api/v1/roles/{pk}/approve", "handler": "RoleViewSet.approve",
+          "kind": "action", "source_class": "RoleViewSet", "serializer": "RoleSerializer" }
+      ]
+    }
+  ]
+}
+```
+
+**Handler fields** (per verb): `verb`, `path`, `handler`, `kind`
+(`explicit` \| `inherited` \| `action`), `source_class`, `default_status`,
+`error_statuses`, `serializer`, `pagination`, `permissions`, `auth_required`,
+`behaviour`.
+
+**Honest-partial.** A verb whose backing route carries no resolvable contract
+field simply omits that field (`default_status` 0, empty `error_statuses`) — it
+is never fabricated. A ViewSet with no router-expanded routes returns an empty
+`groups` list with a `note` (the contract is stamped by the T5 #3964 DRF
+expansion pass — an index predating that stamping requires a **reindex** to
+populate it).
 
 ---
 

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -1,0 +1,195 @@
+package mcp
+
+// effective_contract_tool.go — archigraph_effective_contract MCP tool (epic
+// #3829, ticket #3836 — T6).
+//
+// This is the thin SERVING / GROUPING layer over T5's computation
+// (effective_contract.go projectEffectiveContract + the engine-stamped
+// effective_* props). Given a ViewSet/controller (or a single route/endpoint),
+// it gathers that ViewSet's router-expanded routes, projects each into the
+// structured per-verb contract, and groups them under the owning ViewSet:
+//
+//	{ class, framework, handlers: [ {verb, path, kind, source_class,
+//	  default_status, error_statuses, serializer, pagination, permissions,
+//	  auth_required, behaviour, handler}, ... ] }
+//
+// It is the single artifact that lets the rewrite agent answer "what is the
+// full contract of every verb on this ViewSet?" in one call — preventing the
+// #278 defect class (an INHERITED create surfacing kind:inherited,
+// source_class:CreateModelMixin, default_status:201, error_statuses:[400] even
+// though the ViewSet body is empty).
+//
+// HONEST-PARTIAL: a verb whose backing route carries no resolvable contract
+// field simply omits that field (projectEffectiveContract leaves it zero/empty)
+// — nothing is fabricated. A ViewSet with no router-expanded routes in the
+// index returns an empty handlers list with a note, not an error.
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// effectiveContractGroup is the per-ViewSet wire shape returned by
+// archigraph_effective_contract: the owning class, its framework, and the
+// per-verb effective contracts of its router-expanded routes.
+type effectiveContractGroup struct {
+	// Class is the owning ViewSet/controller leaf name (the grouping key).
+	Class string `json:"class"`
+	// Framework is the route framework ("django" for DRF), when known.
+	Framework string `json:"framework,omitempty"`
+	// Repo is the repo the routes were found in, for cross-repo locating.
+	Repo string `json:"repo,omitempty"`
+	// Handlers are the per-verb effective contracts, sorted by path then verb.
+	Handlers []effectiveContract `json:"handlers"`
+}
+
+// effectiveContractResult is the top-level envelope. Groups is one entry per
+// owning ViewSet (usually one, but a route/endpoint input could match across
+// repos). Note carries the honest-partial / empty-result explanation.
+type effectiveContractResult struct {
+	Target string                   `json:"target"`
+	Groups []effectiveContractGroup `json:"groups"`
+	Note   string                   `json:"note,omitempty"`
+}
+
+// viewSetNameForRoute returns the owning ViewSet leaf name a router-expanded
+// route belongs to, derived from its drf_view_method prop ("ViewSet.method" for
+// a verb route, or just "ViewSet" for the ANY catch-all). Empty when the route
+// carries no ViewSet attribution.
+func viewSetNameForRoute(e *graph.Entity) string {
+	dvm := e.Properties["drf_view_method"]
+	if dvm == "" {
+		return ""
+	}
+	if owning := prefixBeforeDot(dvm); owning != "" {
+		return leafAfterDot(owning)
+	}
+	// No dot: the ANY catch-all records just the ViewSet name.
+	return leafAfterDot(dvm)
+}
+
+// resolveEffectiveContractTarget determines the ViewSet leaf name to group by
+// from the request's entity_id / qualified_name. Resolution order:
+//
+//  1. The arg matches a router-expanded route entity → derive its ViewSet.
+//  2. The arg matches a class/component entity → use its leaf name.
+//  3. The arg matches no entity → treat the raw string's leaf as the ViewSet
+//     name (lets callers pass a bare class name that isn't itself indexed as a
+//     standalone entity, e.g. when only the routes carry it).
+//
+// Returns the lower-cased ViewSet leaf to match routes against, plus the
+// resolved entity (may be nil for case 3).
+func resolveEffectiveContractTarget(lg *LoadedGroup, arg string) (string, *graph.Entity) {
+	for _, r := range reposToConsider(lg, nil) {
+		if r.LabelIndex == nil {
+			continue
+		}
+		for _, e := range r.LabelIndex.LookupAll(arg) {
+			if isRouterExpandedRoute(e) {
+				if vs := viewSetNameForRoute(e); vs != "" {
+					return strings.ToLower(vs), e
+				}
+			}
+			if isClassEntity(e) {
+				return strings.ToLower(leafAfterDot(e.Name)), e
+			}
+		}
+	}
+	// Case 3: no entity matched — fall back to the raw leaf.
+	return strings.ToLower(leafAfterDot(arg)), nil
+}
+
+// handleEffectiveContract serves archigraph_effective_contract. It resolves the
+// target ViewSet, gathers its router-expanded routes across the group, projects
+// each into a per-verb effective contract, and groups them by owning ViewSet.
+func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	target := argString(req, "entity_id", "")
+	if target == "" {
+		target = argString(req, "qualified_name", "")
+	}
+	if target == "" {
+		return mcpapi.NewToolResultError("entity_id (or qualified_name) is required"), nil
+	}
+
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+
+	wantVS, _ := resolveEffectiveContractTarget(lg, target)
+
+	// Gather, per (repo, ViewSet), the projected per-verb contracts of every
+	// router-expanded route owned by the target ViewSet. Keyed by repo so a
+	// same-named ViewSet in two repos stays distinct.
+	type groupKey struct{ repo, class string }
+	groups := map[groupKey]*effectiveContractGroup{}
+	var order []groupKey
+
+	for _, r := range reposToConsider(lg, nil) {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isRouterExpandedRoute(e) {
+				continue
+			}
+			vs := viewSetNameForRoute(e)
+			if vs == "" || strings.ToLower(vs) != wantVS {
+				continue
+			}
+			c, ok := projectEffectiveContract(e)
+			if !ok {
+				continue
+			}
+			key := groupKey{repo: r.Repo, class: vs}
+			g, exists := groups[key]
+			if !exists {
+				g = &effectiveContractGroup{
+					Class:     vs,
+					Framework: e.Properties["framework"],
+					Repo:      r.Repo,
+				}
+				groups[key] = g
+				order = append(order, key)
+			}
+			g.Handlers = append(g.Handlers, c)
+		}
+	}
+
+	out := effectiveContractResult{Target: target}
+	// Deterministic group order: repo, then class.
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].repo != order[j].repo {
+			return order[i].repo < order[j].repo
+		}
+		return order[i].class < order[j].class
+	})
+	for _, key := range order {
+		g := groups[key]
+		sortEffectiveContracts(g.Handlers)
+		out.Groups = append(out.Groups, *g)
+	}
+
+	if len(out.Groups) == 0 {
+		out.Note = "no router-expanded routes found for this ViewSet. " +
+			"The effective contract is stamped by the DRF expansion pass (T5 #3964); " +
+			"if the index predates that stamping a reindex is required to populate it."
+	}
+	return jsonResult(out), nil
+}
+
+// sortEffectiveContracts orders per-verb contracts deterministically by path
+// then verb so the output is stable across calls.
+func sortEffectiveContracts(cs []effectiveContract) {
+	sort.Slice(cs, func(i, j int) bool {
+		if cs[i].Path != cs[j].Path {
+			return cs[i].Path < cs[j].Path
+		}
+		return cs[i].Verb < cs[j].Verb
+	})
+}

--- a/internal/mcp/effective_contract_tool_test.go
+++ b/internal/mcp/effective_contract_tool_test.go
@@ -1,0 +1,247 @@
+package mcp
+
+// effective_contract_tool_test.go — value-asserting coverage for the
+// archigraph_effective_contract MCP tool (#3836, epic #3829 MRO T6).
+//
+// These assert the STRUCTURED per-verb contract grouped under the ViewSet, not
+// len>0:
+//
+//  1. effective_contract on a ModelViewSet groups its router-expanded routes
+//     into per-verb contracts: inherited create {kind:inherited,
+//     source_class:CreateModelMixin, default_status:201, error_statuses:[400]},
+//     explicit list {kind:explicit, status 200, pagination}, @action approve
+//     {kind:action, no fabricated status}.
+//  2. Targeting a single route resolves to the SAME ViewSet group.
+//  3. Honest-partial: a verb whose route omitted the pack fields surfaces the
+//     resolvable fields and omits the unknown ones (status 0, no error_statuses).
+//  4. NEGATIVE: a ViewSet with no router-expanded routes returns an empty group
+//     set with the reindex note — not an error, not fabricated handlers.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// roleViewSetDoc builds a DRF ModelViewSet (RoleViewSet) plus the four
+// router-expanded route entities the engine would stamp for it: an INHERITED
+// create (POST, 201 + [400], CreateModelMixin), an EXPLICIT list (GET, 200,
+// paginated), an @action approve (POST, no curated status), and an
+// honest-partial verb (GET retrieve on an unknown base — no pack fields).
+func roleViewSetDoc() *graph.Document {
+	route := func(id string, props map[string]string) graph.Entity {
+		p := map[string]string{"pattern_type": "drf_router_expanded", "framework": "django"}
+		for k, v := range props {
+			p[k] = v
+		}
+		return graph.Entity{ID: id, Name: id, Kind: "http_endpoint", Language: "python", Properties: p}
+	}
+	return &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "roleviewset", Name: "RoleViewSet", QualifiedName: "core.views.RoleViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/views.py",
+				StartLine: 1, EndLine: 3, Language: "python"},
+			// INHERITED create — the #278 case.
+			route("http:create", map[string]string{
+				"verb": "POST", "path": "/api/v1/roles",
+				"drf_view_method":          "RoleViewSet.create",
+				"provenance":               "inherited",
+				"effective_kind":           "inherited",
+				"effective_source_class":   "CreateModelMixin",
+				"effective_status":         "201",
+				"effective_error_statuses": "400",
+				"serializer_class":         "RoleSerializer",
+				"middleware_names":         "IsAuthenticated",
+				"auth_required":            "true",
+			}),
+			// EXPLICIT list, paginated.
+			route("http:list", map[string]string{
+				"verb": "GET", "path": "/api/v1/roles",
+				"drf_view_method":        "RoleViewSet.list",
+				"provenance":             "explicit",
+				"effective_kind":         "explicit",
+				"effective_source_class": "RoleViewSet",
+				"effective_status":       "200",
+				"effective_pagination":   "true",
+				"serializer_class":       "RoleSerializer",
+			}),
+			// @action approve — no fabricated status.
+			route("http:approve", map[string]string{
+				"verb": "POST", "path": "/api/v1/roles/{pk}/approve",
+				"drf_view_method":        "RoleViewSet.approve",
+				"provenance":             "action",
+				"effective_kind":         "action",
+				"effective_source_class": "RoleViewSet",
+				"serializer_class":       "RoleSerializer",
+			}),
+			// Honest-partial retrieve — unknown base, no pack fields.
+			route("http:retrieve", map[string]string{
+				"verb": "GET", "path": "/api/v1/roles/{pk}",
+				"drf_view_method":        "RoleViewSet.retrieve",
+				"effective_kind":         "explicit",
+				"effective_source_class": "RoleViewSet",
+			}),
+			// A DIFFERENT ViewSet's route — must NOT leak into the RoleViewSet group.
+			route("http:other", map[string]string{
+				"verb": "GET", "path": "/api/v1/widgets",
+				"drf_view_method":        "WidgetViewSet.list",
+				"effective_kind":         "explicit",
+				"effective_source_class": "WidgetViewSet",
+			}),
+		},
+	}
+}
+
+// callEffectiveContract invokes the tool and returns the decoded result.
+func callEffectiveContract(t *testing.T, srv *Server, entityID string) effectiveContractResult {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": entityID}
+	res, err := srv.handleEffectiveContract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleEffectiveContract error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleEffectiveContract returned IsError: %s", resultText(res))
+	}
+	var out effectiveContractResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal result: %v\n%s", err, resultText(res))
+	}
+	return out
+}
+
+// handlerByVerbPath finds the per-verb contract for the given verb+path in a
+// group, or fails the test.
+func handlerByVerbPath(t *testing.T, g effectiveContractGroup, verb, path string) effectiveContract {
+	t.Helper()
+	for _, h := range g.Handlers {
+		if h.Verb == verb && h.Path == path {
+			return h
+		}
+	}
+	t.Fatalf("no handler %s %s in group %s; handlers=%+v", verb, path, g.Class, g.Handlers)
+	return effectiveContract{}
+}
+
+// TestEffectiveContract_ModelViewSet_PerVerbShape asserts the grouped per-verb
+// contract for RoleViewSet: inherited create, explicit list, @action approve,
+// honest-partial retrieve — and that WidgetViewSet's route does not leak in.
+func TestEffectiveContract_ModelViewSet_PerVerbShape(t *testing.T) {
+	srv := newTestServer(t, roleViewSetDoc())
+	out := callEffectiveContract(t, srv, "RoleViewSet")
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected exactly 1 group (RoleViewSet), got %d: %+v", len(out.Groups), out.Groups)
+	}
+	g := out.Groups[0]
+	if g.Class != "RoleViewSet" {
+		t.Errorf("group class = %q; want RoleViewSet", g.Class)
+	}
+	if g.Framework != "django" {
+		t.Errorf("framework = %q; want django", g.Framework)
+	}
+	if len(g.Handlers) != 4 {
+		t.Fatalf("expected 4 handlers (no WidgetViewSet leak), got %d: %+v", len(g.Handlers), g.Handlers)
+	}
+
+	// INHERITED create — the #278 contract.
+	create := handlerByVerbPath(t, g, "POST", "/api/v1/roles")
+	if create.Kind != "inherited" {
+		t.Errorf("create kind = %q; want inherited", create.Kind)
+	}
+	if create.SourceClass != "CreateModelMixin" {
+		t.Errorf("create source_class = %q; want CreateModelMixin", create.SourceClass)
+	}
+	if create.DefaultStatus != 201 {
+		t.Errorf("create default_status = %d; want 201", create.DefaultStatus)
+	}
+	if len(create.ErrorStatuses) != 1 || create.ErrorStatuses[0] != 400 {
+		t.Errorf("create error_statuses = %v; want [400] (#278)", create.ErrorStatuses)
+	}
+	if create.Serializer != "RoleSerializer" {
+		t.Errorf("create serializer = %q; want RoleSerializer", create.Serializer)
+	}
+	if len(create.Permissions) != 1 || create.Permissions[0] != "IsAuthenticated" {
+		t.Errorf("create permissions = %v; want [IsAuthenticated]", create.Permissions)
+	}
+	if !create.AuthRequired {
+		t.Error("create auth_required = false; want true")
+	}
+
+	// EXPLICIT list — status from body, paginated.
+	list := handlerByVerbPath(t, g, "GET", "/api/v1/roles")
+	if list.Kind != "explicit" {
+		t.Errorf("list kind = %q; want explicit", list.Kind)
+	}
+	if list.DefaultStatus != 200 {
+		t.Errorf("list default_status = %d; want 200", list.DefaultStatus)
+	}
+	if !list.Pagination {
+		t.Error("list pagination = false; want true")
+	}
+
+	// @action approve — no fabricated status.
+	approve := handlerByVerbPath(t, g, "POST", "/api/v1/roles/{pk}/approve")
+	if approve.Kind != "action" {
+		t.Errorf("approve kind = %q; want action", approve.Kind)
+	}
+	if approve.DefaultStatus != 0 {
+		t.Errorf("approve default_status = %d; want 0 (no fabricated status for @action)", approve.DefaultStatus)
+	}
+
+	// HONEST-PARTIAL retrieve — resolvable kind present, status omitted.
+	retrieve := handlerByVerbPath(t, g, "GET", "/api/v1/roles/{pk}")
+	if retrieve.Kind != "explicit" {
+		t.Errorf("retrieve kind = %q; want explicit", retrieve.Kind)
+	}
+	if retrieve.DefaultStatus != 0 {
+		t.Errorf("retrieve default_status = %d; want 0 (honest-partial omit)", retrieve.DefaultStatus)
+	}
+	if len(retrieve.ErrorStatuses) != 0 {
+		t.Errorf("retrieve error_statuses = %v; want empty (honest-partial omit)", retrieve.ErrorStatuses)
+	}
+}
+
+// TestEffectiveContract_TargetByRoute resolves a SINGLE route entity to its
+// owning ViewSet group — the same RoleViewSet contract.
+func TestEffectiveContract_TargetByRoute(t *testing.T) {
+	srv := newTestServer(t, roleViewSetDoc())
+	out := callEffectiveContract(t, srv, "http:create")
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected 1 group resolved from a route, got %d", len(out.Groups))
+	}
+	if out.Groups[0].Class != "RoleViewSet" {
+		t.Errorf("route resolved to class %q; want RoleViewSet", out.Groups[0].Class)
+	}
+	if len(out.Groups[0].Handlers) != 4 {
+		t.Errorf("expected the full 4-verb RoleViewSet contract from a route target, got %d", len(out.Groups[0].Handlers))
+	}
+}
+
+// TestEffectiveContract_NoRoutes returns an empty group set with the reindex
+// note — not an error, not fabricated handlers.
+func TestEffectiveContract_NoRoutes(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "lonely", Name: "LonelyViewSet", QualifiedName: "core.LonelyViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/views.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callEffectiveContract(t, srv, "LonelyViewSet")
+
+	if len(out.Groups) != 0 {
+		t.Fatalf("expected no groups for a ViewSet with no routes, got %d", len(out.Groups))
+	}
+	if out.Note == "" {
+		t.Error("expected an honest reindex note when no router-expanded routes are found")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -792,6 +792,24 @@ func (s *Server) registerTools() {
 		// #2769 Phase 1C: min_confidence accepted via #1639 token-ceiling pattern.
 	), s.wrap("archigraph_endpoints", s.handleEndpoints))
 
+	// archigraph_effective_contract — per-verb EFFECTIVE CONTRACT of a ViewSet /
+	// controller (epic #3829, T6 #3836). Given a ViewSet/controller (or a single
+	// route/endpoint), returns its router-expanded routes' per-verb contracts
+	// grouped by the owning ViewSet: {verb, path, kind (explicit|inherited|
+	// action), source_class, default_status, error_statuses, serializer,
+	// pagination, permissions, auth_required, behaviour}. Thin serving/grouping
+	// layer over T5's projectEffectiveContract (#3964). Prevents the #278 defect
+	// class (inherited create surfacing 201 + [400] though the body is empty).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_effective_contract",
+		mcpapi.WithDescription("Per-verb effective contract of a ViewSet/controller (or route)."),
+		mcpapi.WithString("entity_id", mcpapi.Required()),
+		mcpapi.WithAny("qualified_name"),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"), // PH1c: optional git ref
+	), s.wrap("archigraph_effective_contract", s.handleEffectiveContract))
+
 	// archigraph_neighbors — folds find_callers + find_callees into one tool
 	// (#1753, #1742). direction=in returns callers, out returns callees, both
 	// returns the union. find_callers / find_callees stay as deprecated aliases.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -549,6 +549,7 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_find_paths",
 		// #1281 consolidated HTTP endpoint tools (was 3 tools)
 		"archigraph_endpoints",
+		"archigraph_effective_contract",
 		// #1252 flow-aware traversal tools
 		"archigraph_find_callers",
 		"archigraph_find_callees",
@@ -685,8 +686,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +4 archigraph_pure_functions/_import_cycles/_def_use/_template_patterns (#2774/#2775 Phase 3 misc).
 	// +1 archigraph_feedback_event (#3204 agent-experience feedback, internal test harness).
 	// +1 archigraph_data_flows (#3867 request-input→sink DATA_FLOWS_TO projection).
-	if got := len(allRegisteredTools); got != 55 {
-		t.Errorf("expected 55 registered tools, got %d — update this count if tools are added/removed (added archigraph_data_flows #3867)", got)
+	// +1 archigraph_effective_contract (#3836 per-verb ViewSet effective contract).
+	if got := len(allRegisteredTools); got != 56 {
+		t.Errorf("expected 56 registered tools, got %d — update this count if tools are added/removed (added archigraph_effective_contract #3836)", got)
 	}
 }
 
@@ -3151,6 +3153,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_subgraph":             {"group": "g", "entity_id": "r1::a1"},
 		"archigraph_find_paths":           {"group": "g", "from": "r1::a1", "to": "r1::a4"},
 		"archigraph_endpoints":            {"group": "g", "action": "definitions"},
+		"archigraph_effective_contract":   {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_find_callers":         {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_find_callees":         {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_impact_radius":        {"group": "g", "entity_id": "r1::a2"},
@@ -3242,8 +3245,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 55 {
-		t.Errorf("expected 55 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_data_flows #3867)", len(tools))
+	if len(tools) != 56 {
+		t.Errorf("expected 56 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_effective_contract #3836)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## archigraph_effective_contract — per-verb effective contract (epic #3829, MRO T6)

Closes #3836.

Adds the **`archigraph_effective_contract`** MCP tool — the thin serving/grouping layer over T5's computation (#3964 `projectEffectiveContract` + the engine-stamped `effective_*` props from `django_drf_actions.go stampDRFEffectiveContract`).

### What it does
Given a ViewSet/controller entity (or a single route/endpoint, which resolves to its owning ViewSet), it gathers that ViewSet's router-expanded routes, projects each into the structured per-verb contract via `projectEffectiveContract`, and groups them under the owning ViewSet:

```json
{
  "target": "RoleViewSet",
  "groups": [{
    "class": "RoleViewSet", "framework": "django", "repo": "backend",
    "handlers": [
      {"verb":"POST","path":"/api/v1/roles","handler":"RoleViewSet.create",
       "kind":"inherited","source_class":"CreateModelMixin",
       "default_status":201,"error_statuses":[400],
       "serializer":"RoleSerializer","permissions":["IsAuthenticated"],"auth_required":true},
      {"verb":"GET","path":"/api/v1/roles","handler":"RoleViewSet.list",
       "kind":"explicit","source_class":"RoleViewSet","default_status":200,
       "pagination":true,"serializer":"RoleSerializer"},
      {"verb":"POST","path":"/api/v1/roles/{pk}/approve","handler":"RoleViewSet.approve",
       "kind":"action","source_class":"RoleViewSet","serializer":"RoleSerializer"}
    ]
  }]
}
```

This is the single artifact that answers "what is the full contract of every verb on this ViewSet?" in one call — preventing the **#278 defect class** (an inherited `create` surfacing `kind:inherited`, `source_class:CreateModelMixin`, `default_status:201`, `error_statuses:[400]` even though the ViewSet body is empty).

### Resolution
1. router-expanded route → its owning ViewSet; 2. class/component entity → its leaf name; 3. no entity match → the raw string's leaf (a bare ViewSet name still works when only the routes carry it).

### Honest-partial
A verb whose backing route omitted a pack field omits it (`default_status` 0, empty `error_statuses`) — never fabricated. A ViewSet with no router-expanded routes returns an empty `groups` list with a `note` (not an error).

### Changes
- New `internal/mcp/effective_contract_tool.go` (handler + grouping).
- Registered in `server.go`; tool index row + full section in `SCHEMA.md`.
- Value-asserting tests (`effective_contract_tool_test.go`): inherited/explicit/action/honest-partial per-verb shape, single-route-target resolution, no-routes reindex note, no cross-ViewSet leak.
- Tool-count bookkeeping 55→56 (both assertions), `minimalArgs`, `wantPresent`.

### Validation (sandboxed, targeted only)
- `go test ./internal/mcp/... ./internal/types/` green; `go test ./tools/coverage/` green.
- `gofmt -l internal/mcp/` clean; `go vet ./internal/mcp/...` clean.
- `coverage validate` 0 errors; `coverage fmt --check` canonical.

### DEPLOY-DEFERRED
Read-path only — needs a **daemon rebuild** to serve the new tool. The contract fields are stamped by the T5 #3964 DRF expansion pass; an index predating that stamping needs a **reindex** to populate the `effective_*` props (the tool returns the honest empty-with-note result until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)