### PR TITLE
feat(mro): cross-language inheritance/promotion resolution (T7 #3839)

### DIFF
--- a/internal/extractors/cross/hierarchy/extractor.go
+++ b/internal/extractors/cross/hierarchy/extractor.go
@@ -337,7 +337,10 @@ func extractJTCSharp(source, filePath, language string, res *result) {
 					},
 					QualityScore: 0.9,
 				})
-				res.addRel(clsID, parentID, "EXTENDS", map[string]string{"language": language})
+				res.addRel(clsID, parentID, "EXTENDS", map[string]string{
+					"language":  language,
+					"base_name": parentName,
+				})
 				res.extendsFound++
 			}
 		}
@@ -361,7 +364,10 @@ func extractJTCSharp(source, filePath, language string, res *result) {
 					},
 					QualityScore: 0.9,
 				})
-				res.addRel(clsID, ifID, "IMPLEMENTS", map[string]string{"language": language})
+				res.addRel(clsID, ifID, "IMPLEMENTS", map[string]string{
+					"language":  language,
+					"base_name": ifaceName,
+				})
 				res.implementsFound++
 			}
 		}
@@ -410,7 +416,10 @@ func extractJTCInterface(source, filePath, language string, res *result) {
 				continue
 			}
 			parentID := ifaceRef(parentName, language)
-			res.addRel(ifaceID, parentID, "EXTENDS", map[string]string{"language": language})
+			res.addRel(ifaceID, parentID, "EXTENDS", map[string]string{
+				"language":  language,
+				"base_name": parentName,
+			})
 			res.extendsFound++
 		}
 	}
@@ -483,7 +492,10 @@ func extractPython(source, filePath string, res *result) {
 					},
 					QualityScore: 0.9,
 				})
-				res.addRel(clsID, ifID, "IMPLEMENTS", map[string]string{"language": "python"})
+				res.addRel(clsID, ifID, "IMPLEMENTS", map[string]string{
+					"language":  "python",
+					"base_name": clean,
+				})
 				res.implementsFound++
 			} else {
 				// Issue #74: do NOT synthesise a placeholder entity for the
@@ -499,7 +511,10 @@ func extractPython(source, filePath string, res *result) {
 				// rewrite still-unresolved endpoints to "ext:<name>"
 				// placeholders with Kind="SCOPE.External".
 				parentID := classRef(filePath, clean, "python")
-				res.addRel(clsID, parentID, "EXTENDS", map[string]string{"language": "python"})
+				res.addRel(clsID, parentID, "EXTENDS", map[string]string{
+					"language":  "python",
+					"base_name": clean,
+				})
 				res.extendsFound++
 			}
 		}
@@ -536,7 +551,10 @@ func extractRuby(source, filePath string, res *result) {
 			},
 			QualityScore: 0.9,
 		})
-		res.addRel(clsID, parentID, "EXTENDS", map[string]string{"language": "ruby"})
+		res.addRel(clsID, parentID, "EXTENDS", map[string]string{
+			"language":  "ruby",
+			"base_name": parentName,
+		})
 		res.extendsFound++
 	}
 }
@@ -582,7 +600,7 @@ func extractGo(source, filePath string, res *result) {
 				QualityScore: 0.9,
 			})
 			res.addRel(clsID, parentID, "EXTENDS",
-				map[string]string{"language": "go", "kind": "embedded_struct"})
+				map[string]string{"language": "go", "kind": "embedded_struct", "base_name": emb})
 			res.extendsFound++
 		}
 	}
@@ -619,7 +637,7 @@ func extractRust(source, filePath string, res *result) {
 			QualityScore: 0.9,
 		})
 		res.addRel(structID, traitID, "IMPLEMENTS",
-			map[string]string{"language": "rust", "kind": "trait_impl"})
+			map[string]string{"language": "rust", "kind": "trait_impl", "base_name": traitName})
 		res.implementsFound++
 	}
 }
@@ -677,7 +695,7 @@ func extractElixir(source, filePath string, res *result) {
 			QualityScore: 0.9,
 		})
 		res.addRel(modID, behID, "IMPLEMENTS",
-			map[string]string{"language": "elixir", "kind": "behaviour"})
+			map[string]string{"language": "elixir", "kind": "behaviour", "base_name": behaviourName})
 		res.implementsFound++
 	}
 }

--- a/internal/extractors/cross/hierarchy/extractor_test.go
+++ b/internal/extractors/cross/hierarchy/extractor_test.go
@@ -179,6 +179,55 @@ func TestPython_DeclaredParentStillResolvable(t *testing.T) {
 	}
 }
 
+// TestExtends_CarriesBaseName is the #3839 regression: every EXTENDS /
+// IMPLEMENTS edge must carry a `base_name` property with the base FQN as
+// written, so the MRO walk and the cbv_inherited_methods consumer can resolve
+// the defining class across files/modules without re-parsing the ToID.
+func TestExtends_CarriesBaseName(t *testing.T) {
+	cases := []struct {
+		name, lang, path, src, wantKind, wantBase string
+	}{
+		{
+			name: "python_extends_dotted", lang: "python", path: "app/views.py",
+			src:      "class RoleViewSet(viewsets.ModelViewSet):\n    pass\n",
+			wantKind: "EXTENDS", wantBase: "viewsets.ModelViewSet",
+		},
+		{
+			name: "java_implements", lang: "java", path: "Impl.java",
+			src:      "class Impl implements Runnable {\n}\n",
+			wantKind: "IMPLEMENTS", wantBase: "Runnable",
+		},
+		{
+			name: "go_embedding", lang: "go", path: "service.go",
+			src:      "type Service struct {\n\t*BaseService\n}\n",
+			wantKind: "EXTENDS", wantBase: "BaseService",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runExtract(t, tc.lang, tc.path, tc.src)
+			var found bool
+			for _, e := range got {
+				for _, rel := range e.Relationships {
+					if rel.Kind != tc.wantKind {
+						continue
+					}
+					bn := rel.Properties["base_name"]
+					if bn == "" {
+						t.Errorf("%s edge missing base_name property", tc.wantKind)
+					}
+					if bn == tc.wantBase {
+						found = true
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected %s edge with base_name=%q, got entities=%v", tc.wantKind, tc.wantBase, entityNames(got))
+			}
+		})
+	}
+}
+
 // TestJava_InterfaceExtendsEmitsEdge is the regression for issue #612: a Java
 // `interface Foo extends Bar<T>, Baz` declaration must emit an EXTENDS edge
 // from Foo to each parent interface, with generic type arguments stripped.

--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -361,22 +361,39 @@ func hasRealBody(e *graph.Entity) bool {
 	return e.StartLine > 0 && e.EndLine >= e.StartLine
 }
 
-// baseRef is a resolved EXTENDS target: the written base name plus, when the
-// base is declared in the indexed repo, the in-repo entity.
+// baseRef is a resolved inheritance target: the written base name plus, when
+// the base is declared in the indexed repo, the in-repo entity. `viaImplements`
+// records that the edge was an IMPLEMENTS (interface / trait) rather than an
+// EXTENDS — used for interface-default-method resolution (#3839).
 type baseRef struct {
-	name   string        // base class name as written / FQN if available
-	entity *graph.Entity // non-nil when the base is an indexed class
+	name          string        // base class name as written / FQN if available
+	entity        *graph.Entity // non-nil when the base is an indexed class
+	viaImplements bool          // true when reached via IMPLEMENTS (interface default)
 }
 
-// extendsBases returns the EXTENDS bases of class entity c, in edge order. The
-// base name prefers the edge's base_name property (the dotted FQN, PR A1) and
-// falls back to the ToID leaf / target entity name.
+// extendsBases returns the inheritance bases of class entity c, in edge order.
+//
+// It walks BOTH the EXTENDS edges (superclass / Go struct embedding) AND the
+// IMPLEMENTS edges (interface / trait), so the MRO resolver can promote:
+//   - a Go struct's embedded-type methods (EXTENDS kind=embedded_struct, #3839),
+//   - a Java/Kotlin class's inherited interface DEFAULT methods (IMPLEMENTS to an
+//     interface whose method carries a real body, #3839).
+//
+// Following IMPLEMENTS is safe because the actual member resolution
+// (classDeclaredMember) requires the base member to have a REAL BODY: an
+// abstract interface method (no body, the common case) simply won't match, so
+// only genuine default-method bodies resolve. An external/abstract interface
+// with no indexed body falls through to the honest-unresolved path — never
+// fabricated.
+//
+// The base name prefers the edge's base_name property (the dotted FQN, PR A1)
+// and falls back to the ToID leaf / target entity name.
 func extendsBases(lr *LoadedRepo, c *graph.Entity) []baseRef {
 	adj := lr.getAdjacency()
 	rels := lr.Doc.Relationships
 	var out []baseRef
 	for _, ed := range adj.Outgoing(c.ID) {
-		if ed.kind != "EXTENDS" {
+		if ed.kind != "EXTENDS" && ed.kind != "IMPLEMENTS" {
 			continue
 		}
 		name := ""
@@ -393,7 +410,7 @@ func extendsBases(lr *LoadedRepo, c *graph.Entity) []baseRef {
 				name = leafAfterColon(ed.target)
 			}
 		}
-		out = append(out, baseRef{name: name, entity: target})
+		out = append(out, baseRef{name: name, entity: target, viaImplements: ed.kind == "IMPLEMENTS"})
 	}
 	return out
 }
@@ -442,13 +459,23 @@ func classDeclaredMember(lr *LoadedRepo, cls *graph.Entity, member string) *grap
 		candidates = append(candidates, cls.QualifiedName+"."+member)
 	}
 	for _, qn := range candidates {
+		// The qualified-name key "Owner.member" already pins the member to its
+		// owning class, so we do NOT require the member to live in the same file
+		// as the (sub)class entity we walked from. This is load-bearing for
+		// cross-file inheritance: a Go struct embedding `*BaseService` declared
+		// in another file, or a Java class implementing an interface whose
+		// default method body lives in the interface's own file, must still
+		// resolve to that out-of-file body (#3839).
 		if e := lr.LabelIndex.ByQName[strings.ToLower(qn)]; e != nil &&
-			isMemberEntity(e) && hasRealBody(e) && e.SourceFile == cls.SourceFile {
+			isMemberEntity(e) && hasRealBody(e) {
 			return e
 		}
 	}
 	// Fall back to a same-file scan: a member whose leaf matches and whose
-	// owning prefix is the class (handles QName-shape variation).
+	// owning prefix is the class (handles QName-shape variation). This path
+	// stays file-scoped because it matches on a bare leaf+prefix (no globally
+	// unique key), so a cross-file scan could pull an unrelated same-named
+	// method; the ByQName path above already covers the cross-file case.
 	for i := range lr.Doc.Entities {
 		e := &lr.Doc.Entities[i]
 		if e.SourceFile != cls.SourceFile || !isMemberEntity(e) || !hasRealBody(e) {

--- a/internal/mcp/mro_crosslang_3839_test.go
+++ b/internal/mcp/mro_crosslang_3839_test.go
@@ -1,0 +1,258 @@
+package mcp
+
+// mro_crosslang_3839_test.go — value-asserting coverage for cross-language
+// inheritance / member-promotion resolution (#3839, epic #3829 MRO T7).
+//
+// These generalise the DRF MRO work (T1–T6) to the LANGUAGE level. They assert
+// the promoted/inherited member resolves to its DEFINING BODY (not len>0):
+//
+//  1. Go struct embedding — `type Service struct { *BaseService }` and a
+//     bodyless `Service.Process` stub resolves (method PROMOTION) to
+//     BaseService.Process's real body via the EXTENDS(embedded_struct) walk,
+//     CROSS-FILE (base lives in base.go). neighbors(out) reaches the base's
+//     real callee.
+//  2. Java interface default methods — `class Impl implements Iface` where the
+//     interface declares `default void foo(){...}` (a real body): impl.foo
+//     resolves to Iface.foo via the IMPLEMENTS walk, cross-file.
+//  3. EXTENDS base_name resolves CROSS-FILE: a subclass in one file inherits a
+//     base member whose body is in another file; the dotted base_name on the
+//     EXTENDS edge drives the walk to the right defining class.
+//  4. NEGATIVE: a Java class implementing an EXTERNAL interface with no indexed
+//     body and no pack entry resolves honest-unresolved — never fabricated.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// goEmbeddingDoc models `type Service struct { *BaseService }` where
+// BaseService.Process has a real body in a DIFFERENT file (base.go) and calls a
+// helper. Service.Process is a bodyless promoted stub the child never declares.
+func goEmbeddingDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "base", Name: "BaseService", QualifiedName: "BaseService",
+				Kind: "SCOPE.Component", Subtype: "struct", SourceFile: "base.go",
+				StartLine: 1, EndLine: 6, Language: "go"},
+			{ID: "base_process", Name: "BaseService.Process", QualifiedName: "BaseService.Process",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.go",
+				StartLine: 3, EndLine: 6, Language: "go"},
+			{ID: "base_helper", Name: "BaseService.validate", QualifiedName: "BaseService.validate",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "base.go",
+				StartLine: 8, EndLine: 9, Language: "go"},
+			// The embedding struct, in a different file.
+			{ID: "svc", Name: "Service", QualifiedName: "Service",
+				Kind: "SCOPE.Component", Subtype: "struct", SourceFile: "service.go",
+				StartLine: 1, EndLine: 3, Language: "go"},
+			// Bodyless PROMOTED method stub on Service (no body, no CALLS edges).
+			{ID: "svc_process", Name: "Service.Process", QualifiedName: "Service.Process",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "service.go",
+				StartLine: 0, EndLine: 0, Language: "go",
+				Signature: "func (s *Service) Process()"},
+		},
+		Relationships: []graph.Relationship{
+			// Go embedding -> EXTENDS(kind=embedded_struct) with base_name.
+			{ID: "e1", FromID: "svc", ToID: "base", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "go", "kind": "embedded_struct", "base_name": "BaseService"}},
+			// The base method calls validate — the real promoted-through edge.
+			{ID: "e2", FromID: "base_process", ToID: "base_helper", Kind: "CALLS",
+				Properties: map[string]string{"language": "go"}},
+		},
+	}
+}
+
+// TestGoEmbedding_PromotedMethod_ResolvesToBaseBody — #3839 case 1 (inspect).
+// Service.Process is promoted from the embedded *BaseService; inspect must
+// resolve it to BaseService.Process (the defining body), cross-file.
+func TestGoEmbedding_PromotedMethod_ResolvesToBaseBody(t *testing.T) {
+	srv := newTestServer(t, goEmbeddingDoc())
+	out := callInspect(t, srv, "svc_process")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for promoted Go method, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected resolved=true for Go method promotion, got %v (note=%v)", inh["resolved"], inh["note"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "BaseService") {
+		t.Errorf("expected defining_class BaseService, got %q", dc)
+	}
+	if rf, _ := inh["resolved_from"].(string); rf != "extends_in_repo" {
+		t.Errorf("expected resolved_from extends_in_repo (in-repo embedded base), got %q", rf)
+	}
+	// Must point at the BASE file, proving cross-file resolution.
+	if df, _ := inh["defining_file"].(string); df != "base.go" {
+		t.Errorf("expected defining_file base.go (cross-file promotion), got %q", df)
+	}
+}
+
+// TestGoEmbedding_PromotedMethod_TraversalReachesBaseCallee — #3839 case 1
+// (neighbors). The promoted stub has no CALLS edges; neighbors(out) must hop
+// via INHERITS to BaseService.Process and surface its real callee
+// BaseService.validate.
+func TestGoEmbedding_PromotedMethod_TraversalReachesBaseCallee(t *testing.T) {
+	srv := newTestServer(t, goEmbeddingDoc())
+	out := callNeighbors3834(t, srv, "svc_process", "out")
+	names := calleeNames3834(t, out)
+	if !containsString(names, "BaseService.Process") {
+		t.Fatalf("expected promoted stub to reach defining BaseService.Process via INHERITS, got: %v", names)
+	}
+	if !containsString(names, "BaseService.validate") {
+		t.Errorf("expected to reach base callee BaseService.validate THROUGH the promoted body, got: %v", names)
+	}
+}
+
+// javaInterfaceDefaultDoc models `class Impl implements Iface` where Iface
+// declares a `default void foo()` with a real body in Iface.java (a DIFFERENT
+// file). Impl.foo is a bodyless inherited stub.
+func javaInterfaceDefaultDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "iface", Name: "Iface", QualifiedName: "Iface",
+				Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "Iface.java",
+				StartLine: 1, EndLine: 6, Language: "java"},
+			// The interface DEFAULT method — has a real body.
+			{ID: "iface_foo", Name: "Iface.foo", QualifiedName: "Iface.foo",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Iface.java",
+				StartLine: 2, EndLine: 5, Language: "java"},
+			{ID: "iface_log", Name: "Iface.log", QualifiedName: "Iface.log",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Iface.java",
+				StartLine: 7, EndLine: 8, Language: "java"},
+			{ID: "impl", Name: "Impl", QualifiedName: "Impl",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "Impl.java",
+				StartLine: 1, EndLine: 3, Language: "java"},
+			// Bodyless inherited stub — Impl does not redeclare foo.
+			{ID: "impl_foo", Name: "Impl.foo", QualifiedName: "Impl.foo",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Impl.java",
+				StartLine: 0, EndLine: 0, Language: "java",
+				Signature: "void foo()"},
+		},
+		Relationships: []graph.Relationship{
+			// class Impl implements Iface -> IMPLEMENTS, carrying base_name.
+			{ID: "e1", FromID: "impl", ToID: "iface", Kind: "IMPLEMENTS",
+				Properties: map[string]string{"language": "java", "base_name": "Iface"}},
+			// The default method calls log — the real edge to follow through.
+			{ID: "e2", FromID: "iface_foo", ToID: "iface_log", Kind: "CALLS",
+				Properties: map[string]string{"language": "java"}},
+		},
+	}
+}
+
+// TestJavaInterfaceDefault_ResolvesToInterfaceBody — #3839 case 2 (inspect).
+// impl.foo is inherited from the interface DEFAULT method; inspect must resolve
+// it to Iface.foo via the IMPLEMENTS walk, cross-file.
+func TestJavaInterfaceDefault_ResolvesToInterfaceBody(t *testing.T) {
+	srv := newTestServer(t, javaInterfaceDefaultDoc())
+	out := callInspect(t, srv, "impl_foo")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for interface-default method, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected resolved=true for interface default method, got %v (note=%v)", inh["resolved"], inh["note"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "Iface") {
+		t.Errorf("expected defining_class Iface, got %q", dc)
+	}
+	if df, _ := inh["defining_file"].(string); df != "Iface.java" {
+		t.Errorf("expected defining_file Iface.java (default method in interface file), got %q", df)
+	}
+}
+
+// TestJavaInterfaceDefault_TraversalReachesInterfaceCallee — #3839 case 2
+// (neighbors). The inherited stub hops via INHERITS to Iface.foo and surfaces
+// its real callee Iface.log.
+func TestJavaInterfaceDefault_TraversalReachesInterfaceCallee(t *testing.T) {
+	srv := newTestServer(t, javaInterfaceDefaultDoc())
+	out := callNeighbors3834(t, srv, "impl_foo", "out")
+	names := calleeNames3834(t, out)
+	if !containsString(names, "Iface.foo") {
+		t.Fatalf("expected inherited stub to reach defining Iface.foo via INHERITS, got: %v", names)
+	}
+	if !containsString(names, "Iface.log") {
+		t.Errorf("expected to reach interface callee Iface.log THROUGH the default body, got: %v", names)
+	}
+}
+
+// TestExtendsBaseName_CrossFileResolution — #3839 case 3. A subclass inherits a
+// base member whose body lives in another file; the dotted base_name on the
+// EXTENDS edge drives the walk to the defining class cross-file.
+func TestExtendsBaseName_CrossFileResolution(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "base", Name: "Repository", QualifiedName: "app.data.Repository",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "data/repository.py",
+				StartLine: 1, EndLine: 4, Language: "python"},
+			{ID: "base_save", Name: "Repository.save", QualifiedName: "app.data.Repository.save",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "data/repository.py",
+				StartLine: 2, EndLine: 4, Language: "python"},
+			{ID: "child", Name: "UserRepository", QualifiedName: "app.users.UserRepository",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "users/repo.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			{ID: "child_save", Name: "UserRepository.save", QualifiedName: "app.users.UserRepository.save",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "users/repo.py",
+				StartLine: 0, EndLine: 0, Language: "python",
+				Signature: "def save(self, obj)"},
+		},
+		Relationships: []graph.Relationship{
+			// base_name is the dotted FQN — must drive cross-file resolution.
+			{ID: "e1", FromID: "child", ToID: "base", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "app.data.Repository"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "child_save")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected cross-file EXTENDS resolution, got resolved=%v note=%v", inh["resolved"], inh["note"])
+	}
+	if df, _ := inh["defining_file"].(string); df != "data/repository.py" {
+		t.Errorf("expected defining_file data/repository.py (cross-file), got %q", df)
+	}
+}
+
+// TestJavaInterfaceDefault_ExternalAbstract_HonestUnresolved — #3839 case 4
+// (negative). A class implementing an EXTERNAL interface with no indexed body
+// and no pack entry must surface honest-unresolved — no fabricated body.
+func TestJavaInterfaceDefault_ExternalAbstract_HonestUnresolved(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "impl", Name: "Handler", QualifiedName: "Handler",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "Handler.java",
+				StartLine: 1, EndLine: 3, Language: "java"},
+			// Inherited stub whose interface is external/abstract (no indexed body).
+			{ID: "impl_run", Name: "Handler.run", QualifiedName: "Handler.run",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Handler.java",
+				StartLine: 0, EndLine: 0, Language: "java", Signature: "void run()"},
+			{ID: "ext", Name: "Runnable", Kind: "SCOPE.External", Language: "java"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "impl", ToID: "ext", Kind: "IMPLEMENTS",
+				Properties: map[string]string{"language": "java", "base_name": "java.lang.Runnable"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "impl_run")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for unresolved member, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != false {
+		t.Errorf("expected resolved=false for external abstract interface, got %v", inh["resolved"])
+	}
+	if _, hasDC := inh["defining_class"]; hasDC {
+		t.Errorf("unresolved member must NOT carry a defining_class, got %v", inh["defining_class"])
+	}
+	if note, _ := inh["note"].(string); note == "" {
+		t.Errorf("expected an honest-unresolved note, got empty")
+	}
+	// No synthetic INHERITS edge for the unresolved member.
+	if edges := mroOutboundEdges(srv.State.groups["test"].Repos["repo1"], "impl_run"); len(edges) != 0 {
+		t.Errorf("expected no synthetic INHERITS edge for unresolved member, got: %+v", edges)
+	}
+}


### PR DESCRIPTION
Closes #3839 (epic #3829, MRO T7). Generalises the DRF MRO work (T1–T6) to the **language level** so inherited / promoted members resolve everywhere, not just for DRF.

## What changed

### (a) EXTENDS / IMPLEMENTS `base_name` FQN
The hierarchy extractor (`internal/extractors/cross/hierarchy/extractor.go`) now stamps `base_name` — the base as written, dotted FQN when available — on **every** EXTENDS and IMPLEMENTS edge, across all languages (JTC family, Python, Ruby, Go, Rust, Elixir, interface-extends). The MRO walk (`extendsBases`) and the `cbv_inherited_methods` consumer already *expected* this property (`r.Properties["base_name"]`) but it was never written. Filling that contract lets the walk resolve a defining class across files/modules instead of re-parsing the ToID leaf.

### (b) Go struct-embedding method promotion
`extendsBases` already followed EXTENDS (Go embedding is `EXTENDS kind=embedded_struct`), but `classDeclaredMember` required the defining body to live in the **same file** as the subclass — blocking promotion when the embedded type is declared elsewhere. The qualified-name key `"Owner.member"` already pins the member to its owner, so the same-file constraint is dropped on the ByQName path (the bare leaf+prefix fallback stays file-scoped to avoid false positives). A bodyless `Service.Process` now resolves (PROMOTION) to the embedded `*BaseService.Process` body cross-file.

### (c) Java/Kotlin interface default methods
`extendsBases` now **also follows IMPLEMENTS edges**. Safe because member resolution requires a **real body**: an abstract interface method (no body, the common case) never matches, so only genuine `default` method bodies resolve. An external/abstract interface with no indexed body falls through to honest-unresolved.

## Honest-partial
Unresolvable base / external interface with no indexed body and no pack entry → `resolved=false` + note, **no** synthetic INHERITS edge, never a fabricated body or status.

## Cross-language member resolutions asserted (value-asserting, not len>0)
- **Go embedding**: `type Service struct { *BaseService }` + bodyless `Service.Process` → inspect resolves `defining_class=BaseService`, `defining_file=base.go` (cross-file); neighbors(out) hops via INHERITS through the promoted body to base callee `BaseService.validate`.
- **Java interface default**: `class Impl implements Iface` where `Iface.foo` is a `default` with a body → inspect resolves `defining_class=Iface`, `defining_file=Iface.java`; neighbors reaches `Iface.log` through the default body.
- **EXTENDS base_name cross-file**: subclass in one file, base member body in another, dotted `base_name` drives resolution to `defining_file=data/repository.py`.
- **Negative**: class implementing external `java.lang.Runnable` (no indexed body, no pack) → `resolved=false` + note, no synthetic edge.
- **Extractor**: `base_name` carried on EXTENDS/IMPLEMENTS for python/java/go.

## Validation
`go test` green on `./internal/extractors/cross/hierarchy/ ./internal/extractors/python/ ./internal/mcp/ ./internal/types/` + broader `./internal/extractors/...`; `go test ./internal/types/` green; `go vet` clean; `gofmt -l` empty; coverage `validate` 0 errors; registry.json canonical. No new kinds (EXTENDS/IMPLEMENTS/INHERITS pre-exist).

## DEPLOY-DEFERRED
Reindex to populate `base_name` on existing edges; the MCP resolver already falls back to the ToID leaf for not-yet-reindexed edges, so the read path is correct before a reindex and improves after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)