### PR TITLE
feat(csharp): credit HotChocolate GraphQL auth + request/response shapes (#3961)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -29,7 +29,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
-| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
+| [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/13 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
 | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 9/11 | |
-| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🔴 0/13 | |
+| [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/13 | |
 | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 

--- a/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
+++ b/docs/coverage/detail/lang.csharp.framework.hotchocolate.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Auth coverage | ✅ `full` | `2026-06-02` | 3961 | `internal/custom/csharp/auth.go`<br>`internal/engine/http_endpoint_hotchocolate_auth.go`<br>`internal/engine/http_endpoint_hotchocolate_auth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/mcp/auth_coverage.go` | #3961: applyHotChocolateAuthShapes stamps [Authorize]/[Authorize(Roles=...)]/[Authorize(Policy=...)]/[AllowAnonymous] from each HotChocolate resolver method (and inherited type-level [Authorize]) onto its http:GRAPHQL: endpoint via the shared stampAuthPolicy contract — auth_required + auth_roles + auth_permissions + auth_policy, plus signal-1 auth_decorator so archigraph_auth_coverage fires. [AllowAnonymous] overrides class-level Authorize to explicit-public. Value-asserting tests assert the verdict on the specific resolver endpoint + negative (undecorated/no-signal) cases. |
 
 ### Validation
 
@@ -110,9 +110,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-06-02` | 3961 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go`<br>`internal/substrate/payload_shapes_hotchocolate_test.go` | #3961: sniffHotChocolateResolverShapes surfaces each HotChocolate resolver method's typed argument list as a producer REQUEST shape (DTO-typed args expanded to the DTO's fields; scalar args one field each; ambient framework params like CancellationToken/IResolverContext skipped) and its typed return as a producer RESPONSE shape (Task<>/IEnumerable<>/List<>/nullable wrappers unwrapped to the leaf DTO), flowing through the standard payload-drift join. Gated on a HotChocolate file-signal. Partial: DTO-field + scalar-arg expansion only — no inline-literal resolver-body resolution or cross-file DTO import. |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-06-02` | 3961 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go`<br>`internal/substrate/payload_shapes_hotchocolate_test.go` | #3961: sniffHotChocolateResolverShapes surfaces each HotChocolate resolver method's typed argument list as a producer REQUEST shape (DTO-typed args expanded to the DTO's fields; scalar args one field each; ambient framework params like CancellationToken/IResolverContext skipped) and its typed return as a producer RESPONSE shape (Task<>/IEnumerable<>/List<>/nullable wrappers unwrapped to the leaf DTO), flowing through the standard payload-drift join. Gated on a HotChocolate file-signal. Partial: DTO-field + scalar-arg expansion only — no inline-literal resolver-body resolution or cross-file DTO import. |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -23,7 +23,7 @@ one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
-| [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 3 full, 1 partial, 45 missing |
+| [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 4 full, 3 partial, 42 missing |
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 6 partial, 39 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 1 partial, 50 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10418,8 +10418,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/csharp/auth.go","internal/engine/http_endpoint_hotchocolate_auth.go","internal/engine/http_endpoint_hotchocolate_auth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/mcp/auth_coverage.go"],
+            "issue": "3961",
+            "notes": "#3961: applyHotChocolateAuthShapes stamps [Authorize]/[Authorize(Roles=...)]/[Authorize(Policy=...)]/[AllowAnonymous] from each HotChocolate resolver method (and inherited type-level [Authorize]) onto its http:GRAPHQL: endpoint via the shared stampAuthPolicy contract — auth_required + auth_roles + auth_permissions + auth_policy, plus signal-1 auth_decorator so archigraph_auth_coverage fires. [AllowAnonymous] overrides class-level Authorize to explicit-public. Value-asserting tests assert the verdict on the specific resolver endpoint + negative (undecorated/no-signal) cases.",
+            "verified_at": "2026-06-02"
           }
         },
         "Validation": {
@@ -10573,16 +10576,22 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go","internal/substrate/payload_shapes_hotchocolate_test.go"],
+            "issue": "3961",
+            "notes": "#3961: sniffHotChocolateResolverShapes surfaces each HotChocolate resolver method's typed argument list as a producer REQUEST shape (DTO-typed args expanded to the DTO's fields; scalar args one field each; ambient framework params like CancellationToken/IResolverContext skipped) and its typed return as a producer RESPONSE shape (Task\u003c\u003e/IEnumerable\u003c\u003e/List\u003c\u003e/nullable wrappers unwrapped to the leaf DTO), flowing through the standard payload-drift join. Gated on a HotChocolate file-signal. Partial: DTO-field + scalar-arg expansion only — no inline-literal resolver-body resolution or cross-file DTO import.",
+            "verified_at": "2026-06-02"
           },
           "request_sink_dataflow": {
             "status": "missing",
             "issue": "3740"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go","internal/substrate/payload_shapes_hotchocolate_test.go"],
+            "issue": "3961",
+            "notes": "#3961: sniffHotChocolateResolverShapes surfaces each HotChocolate resolver method's typed argument list as a producer REQUEST shape (DTO-typed args expanded to the DTO's fields; scalar args one field each; ambient framework params like CancellationToken/IResolverContext skipped) and its typed return as a producer RESPONSE shape (Task\u003c\u003e/IEnumerable\u003c\u003e/List\u003c\u003e/nullable wrappers unwrapped to the leaf DTO), flowing through the standard payload-drift join. Gated on a HotChocolate file-signal. Partial: DTO-field + scalar-arg expansion only — no inline-literal resolver-body resolution or cross-file DTO import.",
+            "verified_at": "2026-06-02"
           },
           "sanitizer_recognition": {
             "status": "missing",

--- a/internal/engine/http_endpoint_hotchocolate_auth.go
+++ b/internal/engine/http_endpoint_hotchocolate_auth.go
@@ -1,0 +1,246 @@
+// http_endpoint_hotchocolate_auth.go — HotChocolate (C#) GraphQL resolver
+// authorization + request/response payload-shape attribution (#3961, epic #3872).
+//
+// synthesizeHotChocolate (http_endpoint_hotchocolate.go) emits one
+// `http:GRAPHQL:/graphql/<Root>/<field>` synthetic per public resolver method
+// with `source_handler=SCOPE.Operation:<Class>.<Method>`. That pass deliberately
+// records only the endpoint identity + handler binding. This pass is the
+// second, property-stamping half:
+//
+//   - AUTH: HotChocolate resolvers use the SAME `[Authorize]` /
+//     `[Authorize(Roles="x")]` / `[Authorize(Policy="x")]` / `[AllowAnonymous]`
+//     attributes ASP.NET Core uses (internal/custom/csharp/auth.go matches the
+//     identical attribute set). A resolver method (or its enclosing resolver
+//     class) carrying `[Authorize]` is auth-protected; the matched policy is
+//     stamped onto its endpoint via the shared stampAuthPolicy contract so the
+//     MCP archigraph_auth_coverage tool's signal-1 property check fires
+//     (auth_decorator) AND auth_required/auth_roles/auth_policy carry the
+//     fine-grained verdict. `[AllowAnonymous]` proves the resolver is public.
+//
+//   - SHAPES: each resolver's typed C# argument list contributes a producer
+//     REQUEST shape and its typed return contributes a producer RESPONSE shape,
+//     surfaced through the existing C# payload-shape sniffer
+//     (internal/substrate/payload_shapes_csharp.go) — see sniffHotChocolate*
+//     there. This file owns AUTH only; shapes live in the substrate sniffer so
+//     they flow through the standard payload-drift join.
+//
+// The pass mutates Properties in place and never adds or removes entities, so it
+// cannot regress the synthesis pass. It is gated on the same HotChocolate
+// file-signal as the synthesizer (no endpoints → no work).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// The hcAuthorize* regexes match a HotChocolate/ASP.NET `[Authorize]` attribute
+// in its bare, role, policy, or positional-policy forms — the exact set the C#
+// auth extractor (internal/custom/csharp/auth.go) recognises. Used to classify
+// an attribute block sitting above a resolver method or class.
+//
+//	[Authorize]                         → protected, no roles/policy
+//	[Authorize(Roles="Admin,Owner")]    → protected, roles
+//	[Authorize(Policy="CanRead")]       → protected, policy
+//	[Authorize("CanRead")]              → protected, positional policy
+//	[AllowAnonymous]                    → explicit public (overrides Authorize)
+var (
+	hcAuthorizeRolesRe = regexp.MustCompile(
+		`\[\s*Authorize\s*\(\s*Roles\s*=\s*"([^"]+)"`)
+	hcAuthorizePolicyRe = regexp.MustCompile(
+		`\[\s*Authorize\s*\(\s*Policy\s*=\s*"([^"]+)"`)
+	hcAuthorizePositionalRe = regexp.MustCompile(
+		`\[\s*Authorize\s*\(\s*"([^"]+)"\s*\)`)
+	hcAuthorizeAnyRe   = regexp.MustCompile(`\[\s*Authorize\b`)
+	hcAllowAnonymousRe = regexp.MustCompile(`\[\s*AllowAnonymous\s*\]`)
+)
+
+// hcAuthVerdict is the resolved authorization posture for one resolver,
+// combining the method-level attribute (highest precedence) with the enclosing
+// class-level attribute (fallback).
+type hcAuthVerdict struct {
+	decided  bool     // an explicit [Authorize]/[AllowAnonymous] was found
+	required bool     // true → [Authorize]; false → [AllowAnonymous]
+	roles    []string // from [Authorize(Roles="a,b")]
+	policy   string   // from [Authorize(Policy="x")] or [Authorize("x")]
+}
+
+// classifyHCAuthBlock classifies an attribute block (the text immediately
+// preceding a `class` or method declaration) into a verdict. `[AllowAnonymous]`
+// wins over `[Authorize]` when both appear (explicit opt-out).
+func classifyHCAuthBlock(block string) hcAuthVerdict {
+	if block == "" {
+		return hcAuthVerdict{}
+	}
+	if hcAllowAnonymousRe.MatchString(block) {
+		return hcAuthVerdict{decided: true, required: false}
+	}
+	if !hcAuthorizeAnyRe.MatchString(block) {
+		return hcAuthVerdict{}
+	}
+	v := hcAuthVerdict{decided: true, required: true}
+	if m := hcAuthorizeRolesRe.FindStringSubmatch(block); m != nil {
+		for _, r := range strings.Split(m[1], ",") {
+			if r = strings.TrimSpace(r); r != "" {
+				v.roles = append(v.roles, r)
+			}
+		}
+	}
+	if m := hcAuthorizePolicyRe.FindStringSubmatch(block); m != nil {
+		v.policy = m[1]
+	} else if m := hcAuthorizePositionalRe.FindStringSubmatch(block); m != nil {
+		v.policy = m[1]
+	}
+	return v
+}
+
+// hcMethodAuth maps a `<Class>.<Method>` key (matching the synthesizer's
+// source_handler operation) to its resolved auth verdict.
+func buildHCMethodAuth(content string) map[string]hcAuthVerdict {
+	out := map[string]hcAuthVerdict{}
+	// Walk each resolver class (any class with a body); within it, record the
+	// class-level verdict and each public method's method-level verdict.
+	for _, cm := range hcPlainClassRe.FindAllStringSubmatchIndex(content, -1) {
+		className := content[cm[2]:cm[3]]
+		classBlock := hcAttrBlockBefore(content, cm[0])
+		classVerdict := classifyHCAuthBlock(classBlock)
+		body := hcClassBody(content, cm[1])
+		if body == "" {
+			continue
+		}
+		// Locate each public resolver method inside the class body and read the
+		// attribute block immediately preceding it.
+		for _, mm := range hcResolverMethodRe.FindAllStringSubmatchIndex(body, -1) {
+			method := body[mm[2]:mm[3]]
+			if method == className {
+				continue // constructor
+			}
+			// hcResolverMethodRe consumes the method's own leading `[...]`
+			// attribute block (the `(?:\[...\]\s*)*` prefix), so the method-level
+			// attributes live INSIDE the match (body[mm[0]:nameStart]). Read them
+			// from there; fall back to a backward scan for any attributes the
+			// bounded prefix did not reach (multi-line role/policy args).
+			methodBlock := body[mm[0]:mm[2]]
+			if before := hcAttrBlockBefore(body, mm[0]); before != "" {
+				methodBlock = before + methodBlock
+			}
+			v := classifyHCAuthBlock(methodBlock)
+			if !v.decided {
+				// Inherit the enclosing class verdict (HotChocolate honours a
+				// type-level [Authorize] for every field on the type).
+				v = classVerdict
+			}
+			if v.decided {
+				out[className+"."+method] = v
+			}
+		}
+	}
+	return out
+}
+
+// hcAttrBlockBefore returns the contiguous run of `[...]` attribute lines (and
+// intervening blank/comment-free whitespace) immediately preceding byte offset
+// `at`. Stops at the previous non-attribute, non-whitespace line (e.g. the prior
+// `}` or statement), so a method's block never bleeds into an earlier method.
+func hcAttrBlockBefore(content string, at int) string {
+	// Walk backwards over lines; collect a trailing run that is entirely
+	// attribute(s) or whitespace.
+	start := at
+	for start > 0 {
+		// Find start of the line preceding `start`.
+		lineEnd := start
+		lineStart := strings.LastIndexByte(content[:lineEnd], '\n')
+		if lineStart < 0 {
+			lineStart = 0
+		} else {
+			lineStart++
+		}
+		line := strings.TrimSpace(content[lineStart:lineEnd])
+		if line == "" {
+			// blank line — keep scanning upward
+			if lineStart == 0 {
+				break
+			}
+			start = lineStart - 1
+			continue
+		}
+		// An attribute line both starts with `[` and ends with `]`.
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			start = lineStart
+			if lineStart == 0 {
+				break
+			}
+			start = lineStart - 1
+			continue
+		}
+		break
+	}
+	if start < 0 {
+		start = 0
+	}
+	return content[start:at]
+}
+
+// applyHotChocolateAuthShapes stamps the resolved [Authorize] policy onto every
+// HotChocolate GRAPHQL endpoint emitted for this file (indices >= before). It is
+// a no-op when the file carries no HotChocolate signal or emitted no endpoints.
+func applyHotChocolateAuthShapes(content, path string, entities []types.EntityRecord, before int) {
+	if before >= len(entities) || !hotChocolateHasSignal(content) {
+		return
+	}
+	methodAuth := buildHCMethodAuth(content)
+	if len(methodAuth) == 0 {
+		return
+	}
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		if e.Properties["framework"] != "hotchocolate" {
+			continue
+		}
+		// source_handler = "SCOPE.Operation:<Class>.<Method>"
+		sh := e.Properties["source_handler"]
+		op := sh
+		if c := strings.LastIndexByte(sh, ':'); c >= 0 {
+			op = sh[c+1:]
+		}
+		v, ok := methodAuth[op]
+		if !ok {
+			continue
+		}
+		stampHCAuth(e.Properties, v)
+	}
+}
+
+// stampHCAuth writes the verdict onto an endpoint's Properties using the shared
+// auth contract (stampAuthPolicy) plus the signal-1 `auth_decorator` key so the
+// MCP archigraph_auth_coverage cheap property check fires. `[AllowAnonymous]`
+// stamps auth_required=false (explicit public) without a guard symbol.
+func stampHCAuth(props map[string]string, v hcAuthVerdict) {
+	if !v.decided {
+		return
+	}
+	policy := AuthPolicy{
+		Method:     "annotation",
+		Required:   v.required,
+		Roles:      v.roles,
+		Confidence: "high",
+		SourceChain: []AuthSignal{{
+			Kind: "annotation",
+			Text: "[Authorize]",
+		}},
+	}
+	if v.policy != "" {
+		policy.Permissions = []string{v.policy}
+	}
+	stampAuthPolicy(props, policy)
+	if v.required {
+		// signal-1 key for the MCP auth_coverage property check: an attribute-
+		// based guard, mirroring how decorator/attribute frameworks surface auth.
+		props["auth_decorator"] = "Authorize"
+	}
+}

--- a/internal/engine/http_endpoint_hotchocolate_auth_test.go
+++ b/internal/engine/http_endpoint_hotchocolate_auth_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// assertEndpointPropEmpty asserts the synthetic endpoint `wantID` does NOT
+// carry a non-empty Properties[key].
+func assertEndpointPropEmpty(t *testing.T, records []types.EntityRecord, wantID, key string) {
+	t.Helper()
+	for _, e := range records {
+		if e.ID != wantID {
+			continue
+		}
+		if got := e.Properties[key]; got != "" {
+			t.Errorf("%s: %s=%q, want empty", wantID, key, got)
+		}
+		return
+	}
+	t.Errorf("missing synthetic endpoint %q", wantID)
+}
+
+// TestHotChocolate_MethodLevelAuthorize asserts that a HotChocolate resolver
+// method decorated with [Authorize] / [Authorize(Roles=...)] /
+// [Authorize(Policy=...)] has the auth verdict stamped on its GRAPHQL endpoint
+// (auth_required + signal-1 auth_decorator + roles/permissions), while an
+// undecorated resolver in the same class stays unauthenticated (#3961).
+func TestHotChocolate_MethodLevelAuthorize(t *testing.T) {
+	src := `
+using HotChocolate;
+using HotChocolate.Types;
+using Microsoft.AspNetCore.Authorization;
+
+[QueryType]
+public class Query
+{
+    [Authorize]
+    public User GetUser(int id) => _repo.Find(id);
+
+    [Authorize(Roles="Admin,Owner")]
+    public User GetAdmin(int id) => _repo.Find(id);
+
+    [Authorize(Policy="CanReadReports")]
+    public Report GetReport(int id) => _repo.Report(id);
+
+    public User GetPublic(int id) => _repo.Find(id);
+}
+`
+	_, res := runDetect(t, "csharp", "GraphQL/Query.cs", src)
+
+	// [Authorize] → protected, signal-1 auth_decorator fires.
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_required", "true")
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_decorator", "Authorize")
+
+	// [Authorize(Roles="Admin,Owner")] → auth_roles.
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/admin", "auth_required", "true")
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/admin", "auth_roles", "Admin,Owner")
+
+	// [Authorize(Policy="CanReadReports")] → auth_permissions.
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/report", "auth_required", "true")
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/report", "auth_permissions", "CanReadReports")
+
+	// Undecorated resolver → NO auth stamped (negative).
+	assertEndpointPropEmpty(t, res.Entities, "http:GRAPHQL:/graphql/Query/public", "auth_required")
+	assertEndpointPropEmpty(t, res.Entities, "http:GRAPHQL:/graphql/Query/public", "auth_decorator")
+}
+
+// TestHotChocolate_ClassLevelAuthorize asserts a type-level [Authorize] on the
+// resolver class protects every field, and a method-level [AllowAnonymous]
+// overrides it to public (explicit auth_required=false).
+func TestHotChocolate_ClassLevelAuthorize(t *testing.T) {
+	src := `
+using HotChocolate.Types;
+using Microsoft.AspNetCore.Authorization;
+
+[QueryType]
+[Authorize]
+public class Query
+{
+    public User GetUser(int id) => _repo.Find(id);
+
+    [AllowAnonymous]
+    public Health GetHealth() => Health.Ok();
+}
+`
+	_, res := runDetect(t, "csharp", "GraphQL/Secured.cs", src)
+
+	// Inherits the class-level [Authorize].
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_required", "true")
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_decorator", "Authorize")
+
+	// [AllowAnonymous] overrides the class-level protection → explicit public.
+	assertEndpointProp(t, res.Entities, "http:GRAPHQL:/graphql/Query/health", "auth_required", "false")
+	assertEndpointPropEmpty(t, res.Entities, "http:GRAPHQL:/graphql/Query/health", "auth_decorator")
+}
+
+// TestHotChocolate_NoAuthNoStamp asserts a HotChocolate file with NO authorize
+// attributes leaves every endpoint unauthenticated (no false positives).
+func TestHotChocolate_NoAuthNoStamp(t *testing.T) {
+	src := `
+using HotChocolate.Types;
+
+[QueryType]
+public class Query
+{
+    public User GetUser(int id) => _repo.Find(id);
+}
+`
+	_, res := runDetect(t, "csharp", "GraphQL/Open.cs", src)
+	assertEndpointPropEmpty(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_required")
+	assertEndpointPropEmpty(t, res.Entities, "http:GRAPHQL:/graphql/Query/user", "auth_decorator")
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -867,7 +867,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// the SAME canonical shape the JS / Python / Go / Elixir GraphQL
 		// servers emit — with a HANDLES edge to each C# resolver method.
 		// Gated on a HotChocolate file-signal so it no-ops on other C# files.
+		hcBefore := len(entities)
 		synthesizeHotChocolate(string(content), emit)
+		// Producer side (#3961): stamp [Authorize] / [Authorize(Roles=...)] /
+		// [Authorize(Policy=...)] / [AllowAnonymous] from each HotChocolate
+		// resolver method onto its just-emitted GRAPHQL endpoint, plus the
+		// resolver's typed-arg request shape + typed-return response shape.
+		// Mutates Properties in place; never adds/removes entities.
+		applyHotChocolateAuthShapes(string(content), path, entities, hcBefore)
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	case "rust":

--- a/internal/substrate/payload_shapes_csharp.go
+++ b/internal/substrate/payload_shapes_csharp.go
@@ -154,7 +154,165 @@ func sniffPayloadShapesCSharp(content string) []PayloadShape {
 		})
 	}
 
+	// Producer-side: HotChocolate GraphQL resolver methods (#3961). A resolver's
+	// typed argument list is the request shape; its typed return is the response
+	// shape. Gated on a HotChocolate file-signal so plain ASP.NET methods don't
+	// double-emit.
+	out = append(out, sniffHotChocolateResolverShapes(content, classFields)...)
+
 	return out
+}
+
+// hcShapeSignalRe detects a HotChocolate GraphQL server in the file (import or
+// fluent server registration), mirroring hotChocolateHasSignal in the engine.
+var hcShapeSignalRe = regexp.MustCompile(`HotChocolate|\.AddGraphQLServer\s*\(`)
+
+// hcResolverSigRe matches a public HotChocolate resolver method declaration,
+// capturing the return type, method name, and the parenthesised argument list.
+//
+//	public User GetUser(GetUserInput input) => ...
+//	public async Task<User> GetUser(int id, CancellationToken ct) { ... }
+//
+// Group 1 = return type chunk; group 2 = method name; group 3 = arg list body.
+var hcResolverSigRe = regexp.MustCompile(
+	`(?m)^\s*(?:\[[^\]\r\n]+\]\s*)*\s*public\s+` +
+		`(?:static\s+|virtual\s+|override\s+|async\s+|sealed\s+)*` +
+		`([\w<>\[\],.\s?]+?)\s+([A-Za-z_]\w*)\s*\(([^)]*)\)`,
+)
+
+// hcAmbientArgTypes are framework-injected resolver parameters that are NOT part
+// of the GraphQL request shape (HotChocolate service/context injection). Matched
+// on the leaf type name, case-insensitively.
+var hcAmbientArgTypes = map[string]bool{
+	"cancellationtoken":    true,
+	"iresolvercontext":     true,
+	"claimsprincipal":      true,
+	"httpcontext":          true,
+	"ihttpcontextaccessor": true,
+}
+
+// sniffHotChocolateResolverShapes emits one producer request shape (from the
+// typed argument list) and one producer response shape (from the return type)
+// per HotChocolate resolver method. A request field whose static type resolves
+// to a DTO class in this file expands to that DTO's fields; a scalar argument
+// contributes a single field named after the parameter. The response shape is
+// the return type's DTO fields (after stripping Task<>/IEnumerable<>/nullable
+// wrappers).
+func sniffHotChocolateResolverShapes(content string, classFields map[string][]PayloadField) []PayloadShape {
+	if !hcShapeSignalRe.MatchString(content) {
+		return nil
+	}
+	var out []PayloadShape
+	for _, m := range hcResolverSigRe.FindAllStringSubmatchIndex(content, -1) {
+		retType := strings.TrimSpace(content[m[2]:m[3]])
+		method := content[m[4]:m[5]]
+		argList := content[m[6]:m[7]]
+		line := lineOfOffset(content, m[0])
+
+		// Skip non-resolver return types: void / constructors have no return
+		// type captured by the regex (it requires `<ret> <name>`), but guard
+		// against `void` explicitly.
+		if retType == "" || retType == "void" {
+			continue
+		}
+
+		// Request shape from the typed argument list.
+		if reqFields := hcRequestFields(argList, classFields); len(reqFields) > 0 {
+			out = append(out, PayloadShape{
+				Function:   method,
+				Line:       line,
+				Direction:  PayloadDirectionRequest,
+				Side:       PayloadSideProducer,
+				Fields:     DedupFields(reqFields),
+				Confidence: 0.85,
+			})
+		}
+
+		// Response shape from the (unwrapped) return type's DTO fields.
+		retLeaf := hcUnwrapType(retType)
+		if fields := classFields[retLeaf]; len(fields) > 0 {
+			out = append(out, PayloadShape{
+				Function:   method,
+				Line:       line,
+				Direction:  PayloadDirectionResponse,
+				Side:       PayloadSideProducer,
+				Fields:     fields,
+				Confidence: 0.85,
+			})
+		}
+	}
+	return out
+}
+
+// hcRequestFields builds the request-shape fields from a resolver argument list.
+// A DTO-typed argument (type resolves to a class in the file) expands to that
+// DTO's fields; a scalar/unknown argument contributes one field named after the
+// parameter. Framework-injected ambient parameters are skipped.
+func hcRequestFields(argList string, classFields map[string][]PayloadField) []PayloadField {
+	var fields []PayloadField
+	for _, raw := range splitTopLevel(argList) {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue
+		}
+		// Drop a leading parameter attribute (e.g. `[Service] X x`).
+		for strings.HasPrefix(p, "[") {
+			if j := strings.IndexByte(p, ']'); j >= 0 {
+				p = strings.TrimSpace(p[j+1:])
+			} else {
+				break
+			}
+		}
+		// Drop a default-value suffix (`int id = 0`).
+		if eq := strings.IndexByte(p, '='); eq >= 0 {
+			p = strings.TrimSpace(p[:eq])
+		}
+		// `Type Name` — split on last whitespace.
+		i := strings.LastIndexAny(p, " \t")
+		if i <= 0 {
+			continue
+		}
+		typ := strings.TrimSpace(p[:i])
+		name := strings.TrimSpace(p[i+1:])
+		if !isPlainIdent(name) {
+			continue
+		}
+		leaf := hcUnwrapType(typ)
+		if hcAmbientArgTypes[strings.ToLower(leaf)] {
+			continue
+		}
+		if dtoFields := classFields[leaf]; len(dtoFields) > 0 {
+			fields = append(fields, dtoFields...)
+			continue
+		}
+		optional := strings.HasSuffix(typ, "?")
+		fields = append(fields, PayloadField{Name: name, Type: typ, Optional: optional})
+	}
+	return fields
+}
+
+// hcUnwrapType reduces a resolver type to its leaf DTO name by stripping common
+// async / collection / nullable wrappers: `Task<User>` → `User`,
+// `IEnumerable<User?>` → `User`, `List<User>` → `User`, `User?` → `User`.
+// Namespace qualification is dropped (`Types.User` → `User`).
+func hcUnwrapType(t string) string {
+	t = strings.TrimSpace(t)
+	// Peel one or more generic wrappers down to the innermost argument.
+	for {
+		lt := strings.IndexByte(t, '<')
+		gt := strings.LastIndexByte(t, '>')
+		if lt < 0 || gt < 0 || gt < lt {
+			break
+		}
+		t = strings.TrimSpace(t[lt+1 : gt])
+	}
+	t = strings.TrimSuffix(t, "?")
+	t = strings.TrimSuffix(t, "[]")
+	t = strings.TrimSpace(t)
+	if i := strings.LastIndexByte(t, '.'); i >= 0 {
+		t = t[i+1:]
+	}
+	return t
 }
 
 // scanCSharpClassFields walks the file once and returns a map of

--- a/internal/substrate/payload_shapes_hotchocolate_test.go
+++ b/internal/substrate/payload_shapes_hotchocolate_test.go
@@ -1,0 +1,113 @@
+package substrate
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPayloadShapesHotChocolate_TypedResolver asserts that a HotChocolate
+// resolver method contributes a producer REQUEST shape from its typed argument
+// list (DTO-typed args expanded to the DTO's fields) and a producer RESPONSE
+// shape from its typed return type (#3961).
+func TestPayloadShapesHotChocolate_TypedResolver(t *testing.T) {
+	const src = `
+using HotChocolate;
+using HotChocolate.Types;
+
+public class GetUserInput {
+  public int Id { get; set; }
+  public string Tenant { get; set; }
+}
+public class User {
+  public int Id { get; set; }
+  public string Name { get; set; }
+  public string Email { get; set; }
+}
+
+[QueryType]
+public class Query
+{
+    public User GetUser(GetUserInput input) => _repo.Find(input.Id);
+}
+`
+	shapes := sniffPayloadShapesCSharp(src)
+
+	req := findShape(shapes, "GetUser", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected HotChocolate request shape for GetUser; got %+v", shapes)
+	}
+	wantReq := []string{"Id", "Tenant"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, wantReq) {
+		t.Errorf("HC request fields: want %v got %v", wantReq, got)
+	}
+
+	resp := findShape(shapes, "GetUser", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected HotChocolate response shape for GetUser; got %+v", shapes)
+	}
+	wantResp := []string{"Email", "Id", "Name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantResp) {
+		t.Errorf("HC response fields: want %v got %v", wantResp, got)
+	}
+}
+
+// TestPayloadShapesHotChocolate_ScalarArgsAndWrappedReturn asserts scalar
+// resolver arguments contribute one field each (ambient framework params
+// skipped) and a wrapped return type (Task<IEnumerable<User>>) is unwrapped to
+// the leaf DTO for the response shape.
+func TestPayloadShapesHotChocolate_ScalarArgsAndWrappedReturn(t *testing.T) {
+	const src = `
+using HotChocolate;
+
+public class User {
+  public int Id { get; set; }
+  public string Name { get; set; }
+}
+
+[QueryType]
+public class Query
+{
+    public async Task<IEnumerable<User>> GetUsers(int teamId, string filter, CancellationToken ct)
+        => await _repo.ByTeam(teamId);
+}
+`
+	shapes := sniffPayloadShapesCSharp(src)
+
+	req := findShape(shapes, "GetUsers", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected HC scalar request shape; got %+v", shapes)
+	}
+	// CancellationToken is an ambient framework param → excluded.
+	wantReq := []string{"filter", "teamId"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, wantReq) {
+		t.Errorf("HC scalar request fields: want %v got %v", wantReq, got)
+	}
+
+	resp := findShape(shapes, "GetUsers", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected HC wrapped-return response shape; got %+v", shapes)
+	}
+	wantResp := []string{"Id", "Name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantResp) {
+		t.Errorf("HC wrapped response fields: want %v got %v", wantResp, got)
+	}
+}
+
+// TestPayloadShapesHotChocolate_NoSignalNoEmit asserts the HotChocolate shape
+// sniffer is gated on a HotChocolate file-signal — a plain C# class with the
+// same method shape but NO HotChocolate import produces no HC resolver shapes.
+func TestPayloadShapesHotChocolate_NoSignalNoEmit(t *testing.T) {
+	const src = `
+public class User {
+  public int Id { get; set; }
+}
+public class Service
+{
+    public User Lookup(int id) => _repo.Find(id);
+}
+`
+	shapes := sniffPayloadShapesCSharp(src)
+	if s := findShape(shapes, "Lookup", PayloadDirectionResponse, PayloadSideProducer); s != nil {
+		t.Errorf("HC sniffer fired on a non-HotChocolate file: %+v", s)
+	}
+}


### PR DESCRIPTION
## Summary
HotChocolate (C# GraphQL) resolver endpoints were synthesised with the correct canonical `http:GRAPHQL:` shape (`endpoint_synthesis=full`) but the **Auth** and **request/response shape** capability cells read `missing` despite the primitives existing. This wires them honestly.

## Auth
New `internal/engine/http_endpoint_hotchocolate_auth.go` — `applyHotChocolateAuthShapes` runs as a property-stamping post-pass right after `synthesizeHotChocolate`. For each emitted `http:GRAPHQL:` endpoint it resolves the resolver method's authorization attribute (with type-level inheritance) and stamps it via the shared `stampAuthPolicy` contract:

- `[Authorize]` → `auth_required=true` + signal-1 `auth_decorator=Authorize` (so `archigraph_auth_coverage` fires)
- `[Authorize(Roles="Admin,Owner")]` → `auth_roles=Admin,Owner`
- `[Authorize(Policy="x")]` / `[Authorize("x")]` → `auth_permissions=x`
- type-level `[Authorize]` is inherited by every field
- method-level `[AllowAnonymous]` overrides class-level `[Authorize]` → explicit `auth_required=false`

Same attribute set `internal/custom/csharp/auth.go` already matches for ASP.NET. Mutates Properties in place; never adds/removes entities.

## Request / response shapes
`sniffHotChocolateResolverShapes` added to the existing C# payload-shape sniffer (`internal/substrate/payload_shapes_csharp.go`):

- typed argument list → producer **request** shape (DTO-typed args expanded to the DTO's fields; scalar args one field each; ambient framework params like `CancellationToken`/`IResolverContext` skipped)
- typed return → producer **response** shape (`Task<>`/`IEnumerable<>`/`List<>`/nullable wrappers unwrapped to the leaf DTO)

Flows through the standard payload-drift join. Gated on a HotChocolate file-signal so plain ASP.NET methods don't double-emit.

## Tests (value-asserting)
- `TestHotChocolate_MethodLevelAuthorize` — asserts `auth_required`/`auth_decorator`/`auth_roles`/`auth_permissions` on the specific resolver endpoint; undecorated resolver → no auth (negative)
- `TestHotChocolate_ClassLevelAuthorize` — type-level inheritance + `[AllowAnonymous]` override
- `TestHotChocolate_NoAuthNoStamp` — no false positives
- `TestPayloadShapesHotChocolate_TypedResolver` / `_ScalarArgsAndWrappedReturn` — asserts the exact request/response field sets; `_NoSignalNoEmit` — file-signal gate

Targeted suites green (`engine`, `substrate`, `custom/csharp`, `types`, `tools/coverage`); `go vet` clean; `gofmt -l` empty; `coverage validate` 0 errors; `coverage fmt --check` canonical. Docs regenerated.

## Coverage cells
- `auth_coverage`: missing → **full**
- `request_shape_extraction`: missing → **partial**
- `response_shape_extraction`: missing → **partial**

Closes #3961. Part of epic #3872.

**DEPLOY-DEFERRED** — requires a coordinated live-daemon rebuild + reindex; not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)