### PR TITLE
feat(ruby/sequel): credit Sequel transaction boundaries + dataset write effects

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -137,7 +137,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/11 | |
 | [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 6/9 | |
 | [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/11 | |
-| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/11 | |
+| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 9/11 | |
 | [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/5 | |
 | [ruby](../by-language/ruby.md) | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -60,7 +60,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 8/11 | |
 | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟡 6/9 | |
 | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟡 8/11 | |
-| [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 8/11 | |
+| [Sequel](../detail/lang.ruby.orm.sequel.md) | 🟡 9/11 | |
 | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |
 | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/5 | |
 | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/4 | |

--- a/docs/coverage/detail/lang.ruby.orm.sequel.md
+++ b/docs/coverage/detail/lang.ruby.orm.sequel.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-06-02` | 3950 | `internal/engine/rules/ruby/orms/sequel.yaml`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 
 ### Migrations
 
@@ -45,7 +45,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
+| Transaction function stamping | ✅ `full` | `2026-06-02` | 3950 | `internal/extractors/ruby/ruby.go`<br>`internal/txscope/txscope.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -63555,8 +63555,9 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/rules/ruby/orms/sequel.yaml","internal/substrate/effect_sinks_ruby.go"],
+            "issue": "3950",
+            "verified_at": "2026-06-02"
           }
         },
         "Migrations": {
@@ -63572,8 +63573,10 @@
         },
         "Transactions": {
           "transaction_function_stamping": {
-            "status": "missing",
-            "issue": "3628-transaction-function-stamping"
+            "status": "full",
+            "cites": ["internal/extractors/ruby/ruby.go","internal/txscope/txscope.go"],
+            "issue": "3950",
+            "verified_at": "2026-06-02"
           }
         }
       }

--- a/internal/substrate/effect_sinks_ruby.go
+++ b/internal/substrate/effect_sinks_ruby.go
@@ -13,7 +13,9 @@
 //     .update_all / .destroy / .destroy_all / .delete /
 //     .delete_all / .save / .save! / .insert / .insert_all /
 //     .upsert / .upsert_all`, raw `connection.execute(
-//     "INSERT|UPDATE|DELETE ...")`
+//     "INSERT|UPDATE|DELETE ...")`, and Sequel dataset writes
+//     `DB[:table]…insert/update/delete/multi_insert/import/
+//     truncate` (table named in the sink, e.g. sequel.write(users))
 //   - fs_read   : File.read / .open (default "r"), File.readlines, IO.read,
 //     Dir.entries / .glob / .[], Pathname#read
 //   - fs_write  : File.write / .open with "w"/"a"/"x"/binary modes,
@@ -72,6 +74,26 @@ var rubyCursorWriteRe = regexp.MustCompile(
 	`\.\s*execute\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
 )
 
+// rubySequelDatasetWriteRe matches Sequel dataset writes anchored on the
+// `DB[:table]` dataset literal so the table name is recoverable (#3950):
+//
+//	DB[:users].insert(name: 'x')
+//	DB[:users].where(id: 1).update(name: 'x')
+//	DB[:logs].where(stale: true).delete
+//	DB[:users].multi_insert(rows)  /  .import(cols, rows)  /  .update_all(...)
+//
+// Capture group 1 is the table symbol/string so the sink can name the table.
+// The terminal write verb may be separated from the dataset by an arbitrary
+// chain of read-only refinements (.where/.exclude/.filter/.join/...), matched
+// permissively as `[^\n;]*?` up to the write verb. Only mutating verbs are
+// listed, so a pure read chain (e.g. `DB[:users].where(id: 1).all`) does NOT
+// match — preserving the read/write split.
+var rubySequelDatasetWriteRe = regexp.MustCompile(
+	`\bDB\s*\[\s*:?["']?(\w+)["']?\s*\]` + // DB[:users] / DB['users']
+		`[^\n;]*?` + // optional read-only refinement chain
+		`\.\s*(?:insert|multi_insert|import|update|update_all|delete|truncate|insert_ignore)\b`,
+)
+
 // rubyFSReadRe matches read-only filesystem primitives.
 var rubyFSReadRe = regexp.MustCompile(
 	`\bFile\s*\.\s*(?:read|readlines|open\s*\(\s*[^,)]+\s*\)|foreach)\b` +
@@ -115,6 +137,7 @@ func sniffEffectsRuby(content string) []EffectMatch {
 	out = appendRubyMatches(out, content, headers, rubyCursorSelectRe, EffectDBRead, "connection.execute(SELECT)", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyDBWriteRe, EffectDBWrite, "activerecord.write", 0.85)
 	out = appendRubyMatches(out, content, headers, rubyCursorWriteRe, EffectDBWrite, "connection.execute(WRITE)", 1.0)
+	out = appendRubySequelDatasetWrites(out, content, headers)
 	out = appendRubyMatches(out, content, headers, rubyFSReadRe, EffectFSRead, "File.read/IO.read", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyFSWriteRe, EffectFSWrite, "File.write/FileUtils", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyProcessRe, EffectFSWrite, "Process.spawn/system", 0.9)
@@ -143,6 +166,30 @@ func appendRubyMatches(out []EffectMatch, content string, headers []funcHeader, 
 			Effect:     eff,
 			Sink:       sink,
 			Confidence: conf,
+		})
+	}
+	return out
+}
+
+// appendRubySequelDatasetWrites stamps a db_write EffectMatch for each Sequel
+// dataset write (`DB[:table]…insert/update/delete`), naming the table in the
+// sink tag (#3950) — e.g. `sequel.write(users)`. Full confidence: the
+// `DB[:table]` dataset literal makes the write unambiguous (unlike the generic
+// `.update`/`.save` heuristic which can fire on an unknown receiver).
+func appendRubySequelDatasetWrites(out []EffectMatch, content string, headers []funcHeader) []EffectMatch {
+	for _, m := range rubySequelDatasetWriteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		table := content[m[2]:m[3]]
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     EffectDBWrite,
+			Sink:       "sequel.write(" + table + ")",
+			Confidence: 1.0,
 		})
 	}
 	return out

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -440,6 +440,72 @@ end
 	mustHave(t, byEffect, EffectMutation, "assign")
 }
 
+// TestSniffEffectsRuby_SequelDatasetWrites asserts Sequel dataset writes
+// surface as db_write effects naming the target table, and that a pure
+// dataset read does NOT (#3950).
+func TestSniffEffectsRuby_SequelDatasetWrites(t *testing.T) {
+	const src = `
+class AccountRepo
+  def insert_user
+    DB[:users].insert(name: 'x')
+  end
+
+  def rename_user
+    DB[:users].where(id: 1).update(name: 'x')
+  end
+
+  def purge_logs
+    DB[:logs].where(stale: true).delete
+  end
+
+  def list_users
+    DB[:users].where(id: 1).all
+  end
+end
+`
+	got := sniffEffectsRuby(src)
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectDBWrite, "insert_user")
+	mustHave(t, byEffect, EffectDBWrite, "rename_user")
+	mustHave(t, byEffect, EffectDBWrite, "purge_logs")
+
+	// The pure read `DB[:users]...all` in list_users must NOT carry db_write.
+	if byEffect[EffectDBWrite]["list_users"] {
+		t.Errorf("pure Sequel read in list_users must not be db_write")
+	}
+
+	// Assert the table name is recoverable in the sink tag.
+	wantSinks := map[string]string{
+		"insert_user": "sequel.write(users)",
+		"rename_user": "sequel.write(users)",
+		"purge_logs":  "sequel.write(logs)",
+	}
+	for fn, want := range wantSinks {
+		found := false
+		for _, m := range got {
+			if m.Function == fn && m.Effect == EffectDBWrite && m.Sink == want {
+				found = true
+				if m.Confidence != 1.0 {
+					t.Errorf("%s: sequel dataset write should be full confidence, got %.2f", fn, m.Confidence)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected db_write sink %q naming the table; got matches %+v", fn, want, sequelSinks(got, fn))
+		}
+	}
+}
+
+func sequelSinks(ms []EffectMatch, fn string) []string {
+	var out []string
+	for _, m := range ms {
+		if m.Function == fn && m.Effect == EffectDBWrite {
+			out = append(out, m.Sink)
+		}
+	}
+	return out
+}
+
 func TestSniffEffectsPHP_PrimitiveCoverage(t *testing.T) {
 	const src = `<?php
 class UserService {

--- a/internal/txscope/txscope.go
+++ b/internal/txscope/txscope.go
@@ -144,10 +144,42 @@ var (
 	// self.class, ApplicationRecord). The trailing `do`/`{` distinguishes a
 	// transaction BLOCK from an unrelated `foo.transaction` attribute read.
 	rubyTransactionRE = regexp.MustCompile(`(?:\b[A-Z]\w*(?:::\w+)*|\bself\b)\s*\.\s*transaction\b\s*(?:\(\s*[^)]*\)\s*)?(?:do\b|\{)`)
+
+	// Sequel transaction boundaries (#3950). Sequel opens a transaction on a
+	// DATABASE-HANDLE receiver — conventionally the `DB` constant, but the
+	// handle is just as often held in a local var (`db`), an ivar (`@db`), or
+	// a dataset (`DB[:users].transaction do`). The trailing `do`/`{`
+	// distinguishes a transaction BLOCK from an attribute read. We accept:
+	//   * the canonical `DB` constant   : `DB.transaction do`
+	//   * a `Sequel.…`/`Sequel::…` path : `Sequel::DATABASES.first.transaction do`
+	//   * a dataset receiver            : `DB[:users].transaction do`
+	//   * a lowercase / ivar handle     : `db.transaction do`, `@db.transaction do`
+	// The lowercase/ivar arm is the genuine gap the Rails regex (constant-only
+	// receiver) cannot reach.
+	rubySequelTxRE = regexp.MustCompile(
+		`(?:\bDB\b(?:\s*\[\s*:?\w+\s*\])?` + // DB / DB[:users]
+			`|\bSequel(?:::\w+)*(?:\s*\.\s*\w+)*` + // Sequel::DATABASES.first
+			`|\b(?:@{1,2})?[a-z_]\w*(?:\s*\[\s*:?\w+\s*\])?)` + // db / @db / dset / db[:users]
+			`\s*\.\s*transaction\b\s*(?:\(\s*[^)]*\)\s*)?(?:do\b|\{)`,
+	)
+	// A Sequel database handle / dataset must be plausibly present for the
+	// lowercase-receiver arm to fire, to avoid stamping an unrelated
+	// `payments.transaction do` block in a non-Sequel codebase. The DB
+	// constant, a `DB[:` dataset, a `Sequel.` reference, or a `.dataset`
+	// builder anywhere in the body is sufficient evidence.
+	rubySequelEvidenceRE = regexp.MustCompile(`\bDB\b|\bSequel\b|\.\s*dataset\b|\[\s*:\w+\s*\]`)
 )
 
-// DetectRuby returns the transaction stamp for a Ruby method body.
+// DetectRuby returns the transaction stamp for a Ruby method body. Sequel
+// (#3950) is recognised ahead of the generic Rails check so the canonical
+// `DB.transaction do` boundary is credited as sequel_transaction rather than
+// mislabelled rails_transaction; the lowercase/ivar handle form (which the
+// constant-only Rails regex misses entirely) is also covered when Sequel
+// evidence is present in the body.
 func DetectRuby(src string) Stamp {
+	if rubySequelTxRE.MatchString(src) && rubySequelEvidenceRE.MatchString(src) {
+		return Stamp{Transactional: true, Source: "sequel_transaction"}
+	}
 	if rubyTransactionRE.MatchString(src) {
 		return Stamp{Transactional: true, Source: "rails_transaction"}
 	}

--- a/internal/txscope/txscope_test.go
+++ b/internal/txscope/txscope_test.go
@@ -134,6 +134,63 @@ func TestDetectRuby_NegativeNonDBTransaction(t *testing.T) {
 	}
 }
 
+func TestDetectRuby_SequelDBTransaction(t *testing.T) {
+	// Sequel's canonical `DB.transaction do` boundary must be credited as
+	// sequel_transaction (not mislabelled rails_transaction). #3950.
+	src := `
+  def transfer
+    DB.transaction do
+      DB[:accounts].where(id: 1).update(balance: 0)
+      DB[:ledger].insert(amount: 5)
+    end
+  end`
+	s := DetectRuby(src)
+	if !s.Transactional || s.Source != "sequel_transaction" {
+		t.Fatalf("DB.transaction do should stamp sequel_transaction, got %+v", s)
+	}
+}
+
+func TestDetectRuby_SequelDatasetTransaction(t *testing.T) {
+	// A dataset receiver `DB[:users].transaction do` is a Sequel boundary.
+	s := DetectRuby("def go\n  DB[:users].transaction do\n    DB[:users].insert(a: 1)\n  end\nend")
+	if !s.Transactional || s.Source != "sequel_transaction" {
+		t.Fatalf("DB[:users].transaction should stamp sequel_transaction, got %+v", s)
+	}
+}
+
+func TestDetectRuby_SequelLowercaseHandleTransaction(t *testing.T) {
+	// The genuine gap: a lowercase / ivar connection handle that the
+	// constant-only Rails regex cannot reach, gated on Sequel evidence.
+	src := `
+  def pay
+    db = Sequel.connect(ENV['DB_URL'])
+    db.transaction do
+      db[:users].update(name: 'x')
+    end
+  end`
+	s := DetectRuby(src)
+	if !s.Transactional || s.Source != "sequel_transaction" {
+		t.Fatalf("db.transaction with Sequel evidence should stamp sequel_transaction, got %+v", s)
+	}
+}
+
+func TestDetectRuby_SequelNegativeNoEvidence(t *testing.T) {
+	// A lowercase `payments.transaction do` with NO Sequel evidence anywhere
+	// in the body must NOT be stamped — avoids false positives in non-Sequel
+	// codebases.
+	if s := DetectRuby("def pay\n  payments.transaction do\n    charge!\n  end\nend"); s.Transactional {
+		t.Fatalf("lowercase transaction without Sequel evidence must not stamp: %+v", s)
+	}
+}
+
+func TestDetectRuby_RailsStillRailsDespiteLowercaseGap(t *testing.T) {
+	// Rails receiver (uppercase, no DB/Sequel evidence) must stay rails_transaction.
+	s := DetectRuby("def pay\n  User.transaction do\n    user.save!\n  end\nend")
+	if !s.Transactional || s.Source != "rails_transaction" {
+		t.Fatalf("Rails User.transaction must remain rails_transaction, got %+v", s)
+	}
+}
+
 func TestDetectJSTS_SequelizeTransaction(t *testing.T) {
 	src := `async function transfer() {
     await sequelize.transaction(async (t) => {

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -16664,6 +16664,27 @@ records:
             - file: internal/custom/ruby/activerecord_test.go
           issues_implemented: ["3282"]
           verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # #3950: Sequel dataset writes `DB[:table]…insert/update/delete/
+          # multi_insert/import/truncate` surface as db_write effect-sinks that
+          # NAME the target table in the sink tag (e.g. sequel.write(users)),
+          # giving write-effect attribution at the table level. The DB[:table]
+          # dataset literal makes the write unambiguous (full confidence); a
+          # pure dataset read `DB[:users]…all` does NOT produce a db_write.
+          # Model/instance writes (Model.create, .save/.update/.destroy) reuse
+          # the shared ActiveRecord write-verb sniffer. Partial: the table is
+          # named only for the DB[:table] dataset form, not for model-class or
+          # instance-handle writes where the table is not lexically recoverable.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_ruby.go
+              functions: [sniffEffectsRuby, appendRubySequelDatasetWrites]
+          tests:
+            - file: internal/substrate/effects_test.go
+              functions: [TestSniffEffectsRuby_SequelDatasetWrites]
+          issues_implemented: ["3950"]
+          verified_at: "2026-06-03"
       Migrations:
         migration_parsing:
           status: partial
@@ -16674,6 +16695,31 @@ records:
             - file: internal/custom/ruby/activerecord_test.go
           issues_implemented: ["3282"]
           verified_at: "2026-05-30"
+      Transactions:
+        transaction_function_stamping:
+          # #3950: Sequel `DB.transaction do … end` boundaries stamp
+          # transactional=true + tx_source=sequel_transaction DIRECTLY on the
+          # enclosing method entity (shared internal/txscope detector, wired via
+          # the Ruby extractor's stampRubyTx). Recognised forms: the canonical
+          # DB constant (DB.transaction do), a dataset receiver
+          # (DB[:users].transaction do), and lowercase/ivar connection handles
+          # (db.transaction / @db.transaction) gated on Sequel evidence in the
+          # body — the lowercase form is the gap the constant-only Rails regex
+          # could not reach. Rails receivers stay tx_source=rails_transaction.
+          # Full: all canonical Sequel boundary forms fire with a named tx_source
+          # and a negative guard (no Sequel evidence -> no stamp). No transitive
+          # propagation (honesty boundary).
+          status: full
+          symbols:
+            - file: internal/txscope/txscope.go
+              functions: [DetectRuby]
+            - file: internal/extractors/ruby/ruby.go
+              functions: [stampRubyTx]
+          tests:
+            - file: internal/txscope/txscope_test.go
+              functions: [TestDetectRuby_SequelDBTransaction, TestDetectRuby_SequelDatasetTransaction, TestDetectRuby_SequelLowercaseHandleTransaction, TestDetectRuby_SequelNegativeNoEvidence]
+          issues_implemented: ["3950"]
+          verified_at: "2026-06-03"
 
   lang.ruby.orm.datamapper:
     capabilities:


### PR DESCRIPTION
## Summary
Sequel ORM transaction boundaries and write effects were under-credited (epic #3872). This generalises the ActiveRecord transaction + write-effect treatment to Sequel.

**Transaction boundaries** (`internal/txscope/txscope.go`, `DetectRuby`):
- The canonical `DB.transaction do … end` boundary was already detected but **mislabelled** `rails_transaction`; it is now credited `sequel_transaction`.
- Lowercase / ivar connection handles (`db.transaction do`, `@db.transaction do`) and dataset receivers (`DB[:users].transaction do`) were **not detected at all** by the constant-only Rails regex — now covered, gated on Sequel evidence in the body.
- Rails receivers stay `rails_transaction`; a lowercase block with no Sequel evidence is **not** stamped (negative guard). No transitive propagation (honesty boundary).

**Write effects** (`internal/substrate/effect_sinks_ruby.go`):
- New Sequel dataset-write sniffer anchored on `DB[:table]` emits a `db_write` effect that **names the table** in the sink tag (e.g. `sequel.write(users)`) at full confidence for `insert/update/delete/multi_insert/import/truncate`.
- A pure dataset read (`DB[:users].where(id: 1).all`) produces **no** `db_write`.
- Model/instance writes (`Model.create`, `.save/.update/.destroy`) continue to reuse the shared ActiveRecord write-verb sniffer.

**Coverage** (`lang.ruby.orm.sequel`): `transaction_function_stamping` missing→**full**; `query_attribution` re-cited to the effect-sink code (kept **partial** — the table is named only for the `DB[:table]` dataset form, not for model-class/instance-handle writes). Coverage docs regenerated.

### Reuse vs Sequel-specific
- Transaction detection **reuses** the shared `internal/txscope` path (added a Sequel arm to `DetectRuby`, wired through the existing `stampRubyTx`).
- Write-effect table-naming is **Sequel-specific** (new `appendRubySequelDatasetWrites`) layered on the shared Ruby effect-sink sniffer; the generic write verbs continue to fire via the shared ActiveRecord regex.

## Verification
- VALUE-ASSERTING tests: `sequel_transaction` source for all 3 boundary forms + negatives; `sequel.write(<table>)` named sinks for insert/update/delete + negative on the pure read.
- `go test ./internal/txscope/ ./internal/substrate/ ./internal/types/ ./internal/extractors/ruby/ ./tools/coverage/` green.
- `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

Closes #3950

DEPLOY-DEFERRED — substrate/txscope detector changes require a daemon rebuild + reindex to take effect; not deployed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)