### PR TITLE
fix(mongo): $lookup builder joins via multi-line `from x import (...)` — closes deploy-8 item-2 parity gap

### DIFF
--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -1188,13 +1188,29 @@ func mongoAggPipelineSubArrays(stage string) []string {
 // object key (the value follows). Used to locate correlated $lookup sub-arrays.
 var mongoAggPipelineKeyRe = regexp.MustCompile(`(?:\bpipeline\b|['"]pipeline['"])\s*:`)
 
-// mongoAggPyFromImportRe matches a Python `from <module> import <names>` line,
-// capturing the module path (group 1, e.g. `.queries`, `core.services.building.queries`)
-// and the imported-names clause (group 2, e.g. `build, other` or `build as b`).
-// Parenthesised multi-line import lists are NOT followed (single-line only) —
-// honest-partial; the dominant builder-import shape is a single-line
-// `from .queries import get_inspection_devices_pipeline`.
-var mongoAggPyFromImportRe = regexp.MustCompile(`(?m)^[ \t]*from\s+([.\w]+)\s+import\s+([^\n#]+)`)
+// mongoAggPyFromImportRe matches a SINGLE-LINE Python `from <module> import
+// <names>` statement, capturing the module path (group 1, e.g. `.queries`,
+// `core.services.building.queries`) and the imported-names clause (group 2,
+// e.g. `build, other` or `build as b`). The leading `import\s+` is constrained
+// to NOT be followed by an opening paren so the multi-line parenthesised form
+// is handled by mongoAggPyFromImportParenRe instead (the two are disjoint).
+var mongoAggPyFromImportRe = regexp.MustCompile(`(?m)^[ \t]*from\s+([.\w]+)\s+import\s+([^\n(#][^\n#]*)`)
+
+// mongoAggPyFromImportParenRe matches the MULTI-LINE parenthesised import form
+//
+//	from core.services.building.queries import (
+//	    get_inspection_devices_pipeline,
+//	    get_inspection_devices_filters_pipeline,
+//	)
+//
+// capturing the module path (group 1) and the full parenthesised names clause
+// (group 2, newlines and trailing commas included — split/trimmed by the caller).
+// `(?s)` lets `.` span newlines; `[^)]*` is non-greedy enough because a Python
+// import-name list never contains a nested `)`. This is the dominant real
+// builder-import shape in upvate-core's service.py (deploy-8 item-2): without it
+// the cross-file builder name never resolves and the $lookup `from` collections
+// orphan.
+var mongoAggPyFromImportParenRe = regexp.MustCompile(`(?ms)^[ \t]*from\s+([.\w]+)\s+import\s+\(([^)]*)\)`)
 
 // newMongoAggPyCrossFileResolver builds a cross-file builder resolver bound to
 // the executor file's imports. For a builder NAME it:
@@ -1209,12 +1225,18 @@ var mongoAggPyFromImportRe = regexp.MustCompile(`(?m)^[ \t]*from\s+([.\w]+)\s+im
 // When `repoRoot` is empty (path not absolutifiable) the resolver still works if
 // `path` is itself absolute; otherwise it yields "" for every name.
 func newMongoAggPyCrossFileResolver(repoRoot, path, src string) mongoAggPyCrossFileResolver {
-	// Pre-scan imports once: NAME → module path.
+	// Pre-scan imports once: NAME → module path. Both single-line and
+	// parenthesised multi-line `from ... import (...)` forms are scanned so a
+	// builder imported via the dominant multi-line list still resolves.
 	nameToModule := map[string]string{}
-	for _, m := range mongoAggPyFromImportRe.FindAllStringSubmatch(src, -1) {
-		module := m[1]
-		for _, raw := range strings.Split(m[2], ",") {
+	addImport := func(module, clause string) {
+		for _, raw := range strings.Split(clause, ",") {
 			name := strings.TrimSpace(raw)
+			// Drop any trailing inline comment (multi-line lists may carry one
+			// per line: `name,  # keep`).
+			if i := strings.IndexByte(name, '#'); i >= 0 {
+				name = strings.TrimSpace(name[:i])
+			}
 			if name == "" || name == "*" {
 				continue
 			}
@@ -1235,6 +1257,12 @@ func newMongoAggPyCrossFileResolver(repoRoot, path, src string) mongoAggPyCrossF
 			}
 			nameToModule[name] = module + "\x00" + orig
 		}
+	}
+	for _, m := range mongoAggPyFromImportRe.FindAllStringSubmatch(src, -1) {
+		addImport(m[1], m[2])
+	}
+	for _, m := range mongoAggPyFromImportParenRe.FindAllStringSubmatch(src, -1) {
+		addImport(m[1], m[2])
 	}
 
 	return func(builderName string) string {

--- a/internal/engine/orm_queries_python_mongo_agg_builderjoin_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_builderjoin_test.go
@@ -1,0 +1,220 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Deploy-8 item-2 parity fix: Mongo `$lookup` → JOINS_COLLECTION for a builder
+// pipeline assembled with a list-literal init + `pipeline.append({...})` +
+// `pipeline.extend([...])`, returned cross-file and consumed by `.aggregate()`.
+//
+// REAL FAILING TARGET (reproduced here):
+//   upvate-core core/services/building/queries.py:get_inspection_devices_pipeline
+//   (builder) imported via a MULTI-LINE parenthesised `from ... import (...)` by
+//   service.py and run as `inspections_cln.aggregate(get_inspection_devices_
+//   pipeline(params))`.
+//
+// ROOT CAUSE the production resolver `newMongoAggPyCrossFileResolver` only parsed
+// SINGLE-LINE imports, so the multi-line list never mapped the builder name →
+// module; the builder stayed unresolved and every `$lookup.from` orphaned
+// (depth-2 subgraph grep for JOINS_COLLECTION = 0). See TestMongoAggPy_Builder
+// JoinFix_OnDisk_MultilineImport which reproduces the empty-rels orphan against
+// the production factory.
+
+// mongoAggBuilderJoinQueries is the queries.py builder body shared by the
+// fixtures below: list-literal init carrying a correlated nested-pipeline
+// $lookup, an append of a NON-lookup $match, and an extend carrying a $lookup.
+const mongoAggBuilderJoinQueries = `
+from pymongo import ASCENDING, DESCENDING
+
+def get_inspection_devices_pipeline(params):
+    pipeline = [
+        {"$lookup": {"from": "inspections", "localField": "inspection_id", "foreignField": "_id", "as": "insp"}},
+        {"$lookup": {"from": "m_contracts", "let": {"cid": "$contractId"}, "pipeline": [
+            {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$cid"]}}},
+            {"$lookup": {"from": "m_devices", "localField": "device_id", "foreignField": "_id", "as": "dev"}},
+        ], "as": "contract"}},
+    ]
+    if params.get("statuses"):
+        pipeline.append({"$match": {"status": {"$in": params["statuses"]}}})
+    pipeline.extend([
+        {"$lookup": {"from": "inspections_history", "localField": "_id", "foreignField": "parent_id", "as": "history"}},
+    ])
+    return pipeline
+`
+
+// assertBuilderJoinTargets asserts the four NAMED JOINS_COLLECTION edges the real
+// target produces — to the SPECIFIC `from:` collections, not len>0:
+//
+//	inspections          — init list-literal $lookup
+//	m_contracts          — init correlated $lookup (outer)
+//	m_devices            — nested sub-pipeline $lookup (inner, correlated)
+//	inspections_history  — extend([...]) $lookup
+func assertBuilderJoinTargets(t *testing.T, rels []types.RelationshipRecord) {
+	t.Helper()
+	want := []string{"inspections", "m_contracts", "m_devices", "inspections_history"}
+	for _, raw := range want {
+		coll := capitalisedSingular(raw)
+		if pyFindJoinTo(rels, coll) == nil {
+			t.Fatalf("MISSING JOINS_COLLECTION to Class:%s (raw %q); rels=%+v", coll, raw, rels)
+		}
+	}
+	if len(rels) != len(want) {
+		t.Fatalf("expected exactly %d join edges, got %d: %+v", len(want), len(rels), rels)
+	}
+	// FromID must anchor on the aggregating collection (inspections), proving the
+	// cross-file receiver resolved — not the builder var or an orphan source.
+	for _, raw := range want {
+		j := pyFindJoinTo(rels, capitalisedSingular(raw))
+		if j.FromID != "Class:"+capitalisedSingular("inspections") {
+			t.Errorf("join to %s FromID = %q, want Class:%s (aggregating coll)",
+				raw, j.FromID, capitalisedSingular("inspections"))
+		}
+	}
+}
+
+// scanWithOnDiskQueries writes the shared queries.py + a service.py with the
+// given import line, runs the PRODUCTION cross-file resolver, and returns the
+// emitted join edges.
+func scanWithOnDiskQueries(t *testing.T, importStmt string) []types.RelationshipRecord {
+	t.Helper()
+	repo := t.TempDir()
+	pkg := filepath.Join(repo, "core", "services", "building")
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "queries.py"),
+		[]byte(mongoAggBuilderJoinQueries), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	servicePath := filepath.Join("core", "services", "building", "service.py")
+	serviceSrc := `
+import pymongo
+from core.helper.mongo_helper import MongoDBConnection
+from core.mongodb_collections import INSPECTIONS
+` + importStmt + `
+
+def get_inspection_devices(params):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    return inspections_cln.aggregate(get_inspection_devices_pipeline(params)).next()
+`
+	resolver := newMongoAggPyCrossFileResolver(repo, servicePath, serviceSrc)
+	funcs := indexEnclosingFunctions("python", serviceSrc)
+	var rels []types.RelationshipRecord
+	scanPythonMongoAggregation(serviceSrc, funcs, servicePath, "python", resolver,
+		func(e types.EntityRecord) {},
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+	return rels
+}
+
+// (a)+(b)+(c): in-memory cross-file resolver — append-assembled, extend-assembled,
+// and nested/correlated pipeline-form $lookup all resolve from the builder body.
+func TestMongoAggPy_BuilderJoinFix_AppendExtendNested(t *testing.T) {
+	service := `
+import pymongo
+from core.helper.mongo_helper import MongoDBConnection
+from core.mongodb_collections import INSPECTIONS
+from core.services.building.queries import (
+    get_inspection_devices_pipeline,
+    get_inspection_devices_filters_pipeline,
+)
+
+def get_inspection_devices(params):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    return inspections_cln.aggregate(get_inspection_devices_pipeline(params)).next()
+`
+	_, rels := runMongoAggPyXFile(t, service,
+		map[string]string{"get_inspection_devices_pipeline": mongoAggBuilderJoinQueries})
+	assertBuilderJoinTargets(t, rels)
+}
+
+// THE ORPHAN REPRODUCER + FIX: production on-disk resolver with the EXACT
+// multi-line parenthesised import shape from service.py. Before the fix this
+// yielded ZERO join edges (the builder name never mapped to its module).
+func TestMongoAggPy_BuilderJoinFix_OnDisk_MultilineImport(t *testing.T) {
+	rels := scanWithOnDiskQueries(t, `from core.services.building.queries import (
+    get_inspection_devices_pipeline,
+    get_inspection_devices_filters_pipeline,
+)`)
+	assertBuilderJoinTargets(t, rels)
+}
+
+// SINGLE-LINE parenthesised import on ONE line (`from x import (a, b)`) must also
+// resolve — the new paren regex owns this shape (the single-line regex now
+// excludes a leading `(`). Guards the disjointness of the two import matchers.
+func TestMongoAggPy_BuilderJoinFix_SingleLineParenImport(t *testing.T) {
+	rels := scanWithOnDiskQueries(t,
+		`from core.services.building.queries import (get_inspection_devices_pipeline, other_fn)`)
+	assertBuilderJoinTargets(t, rels)
+}
+
+// SINGLE-LINE non-paren import still resolves (regression guard for the tightened
+// single-line regex `[^\n(#]...`).
+func TestMongoAggPy_BuilderJoinFix_SingleLinePlainImport(t *testing.T) {
+	rels := scanWithOnDiskQueries(t,
+		`from core.services.building.queries import get_inspection_devices_pipeline`)
+	assertBuilderJoinTargets(t, rels)
+}
+
+// (d) NEGATIVE — a builder whose appended/extended stages are ONLY $match /
+// $project (no $lookup) must emit NO JOINS_COLLECTION. We never fabricate a join.
+func TestMongoAggPy_BuilderJoinFix_Negative_NoLookupStages(t *testing.T) {
+	service := `
+import pymongo
+from core.services.building.queries import (
+    build_match_only,
+    other_fn,
+)
+
+def run(db):
+    return db.inspections.aggregate(build_match_only(db))
+`
+	queries := `
+def build_match_only(db):
+    pipeline = [{"$match": {"active": True}}]
+    pipeline.append({"$project": {"_id": 1, "name": 1}})
+    pipeline.extend([{"$sort": {"name": 1}}])
+    return pipeline
+`
+	_, rels := runMongoAggPyXFile(t, service, map[string]string{"build_match_only": queries})
+	if len(rels) != 0 {
+		t.Fatalf("a lookup-free builder must emit no JOINS_COLLECTION; got %d: %+v", len(rels), rels)
+	}
+}
+
+// (d) NEGATIVE — an appended/extended $lookup whose `from:` is a NON-LITERAL
+// variable (not a quoted string) must NOT fabricate a collection name. Only the
+// literal-from extend stage produces an edge; the variable-from append does not.
+func TestMongoAggPy_BuilderJoinFix_Negative_DynamicFrom(t *testing.T) {
+	service := `
+import pymongo
+from core.services.building.queries import (
+    build_dynamic,
+    other_fn,
+)
+
+def run(db):
+    return db.inspections.aggregate(build_dynamic(db, "m_users"))
+`
+	queries := `
+def build_dynamic(db, target):
+    pipeline = []
+    pipeline.append({"$lookup": {"from": target, "localField": "uid", "foreignField": "_id", "as": "u"}})
+    pipeline.extend([{"$lookup": {"from": "m_clients", "localField": "cid", "foreignField": "_id", "as": "c"}}])
+    return pipeline
+`
+	_, rels := runMongoAggPyXFile(t, service, map[string]string{"build_dynamic": queries})
+	// Only the literal `m_clients` from the extend resolves; the variable `target`
+	// from the append must NOT produce a (fabricated) join.
+	if pyFindJoinTo(rels, capitalisedSingular("m_clients")) == nil {
+		t.Fatalf("expected literal JOINS_COLLECTION to Class:M_client; rels=%+v", rels)
+	}
+	if len(rels) != 1 {
+		t.Fatalf("dynamic `from` var must not emit an edge; want exactly 1 join, got %d: %+v", len(rels), rels)
+	}
+}


### PR DESCRIPTION
Closes the deploy-8 item-2 Mongo-join parity gap.

The rewrite-agent REFUTED deploy-8 item 2: Mongo `$lookup` DataAccess nodes were ORPHANS — the `from:` collections never linked for builder pipelines assembled via `pipeline.append({...})` / `pipeline.extend([...])`. #3937 (append/extend scan) and #3976 (cross-file builder-import + nested-`$lookup` recursion) did not land for the **real** target.

## Real failing target (reproduced orphan-first)
`upvate-core` `core/services/building/queries.py:get_inspection_devices_pipeline` — a builder that inits `pipeline = [ ... ]` (with a correlated nested-`$lookup`), then `pipeline.append(...)` / `pipeline.extend([...])`, `return pipeline`; consumed cross-file in `service.py` as `inspections_cln.aggregate(get_inspection_devices_pipeline(params))`. deploy-8 depth-2 subgraph grep for `JOINS_COLLECTION` = 0.

## Root cause
The append/extend/nested engine logic is **correct** (an in-memory probe passes). The orphan is in the **import parser**: `newMongoAggPyCrossFileResolver` / `mongoAggPyFromImportRe` only matched **single-line** imports. The real `service.py` imports the builder via a **multi-line parenthesised** list:

```python
from core.services.building.queries import (
    get_inspection_devices_pipeline,
    get_inspection_devices_filters_pipeline,
)
```

→ the builder name never mapped to its module → builder unresolved → every `$lookup.from` orphaned.

**Reproduced first:** an on-disk probe driving the production resolver factory with the exact multi-line import yields `rels = []` (zero edges) before the fix; passes after.

## Fix
- add `mongoAggPyFromImportParenRe` for the parenthesised multi-line form,
- tighten the single-line regex to exclude a leading `(` (the two matchers are now disjoint),
- share a name-extraction helper that strips per-line inline comments.

## Probe asserts JOINS_COLLECTION to the SPECIFIC named collections
`inspections` (init literal), `m_contracts` (init correlated outer), `m_devices` (nested sub-pipeline inner), `inspections_history` (extend) — with `FromID = Class:Inspection` (the aggregating collection), exactly 4 edges, not `len>0`.

## Tests (value-asserting)
- (a) append-assembled, (b) extend-assembled, (c) correlated nested-pipeline `$lookup`
- single-line plain / single-line paren / multi-line paren import shapes (disjointness guard)
- NEGATIVE: lookup-free builder (`$match`/`$project`/`$sort`) → no JOINS_COLLECTION; dynamic non-literal `from` var → no fabricated collection (only the literal sibling resolves)

## Gates
`go test` engine/types/resolve/coverage green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors; `fmt --check` canonical. No pymongo-`$lookup` coverage cell exists to flip (this is an extraction-quality fix to an already-shipped capability).

**DEPLOY-DEFERRED:** needs a reindex of upvate-core to populate the edges in the live graph.

Closes #3993

🤖 Generated with [Claude Code](https://claude.com/claude-code)