### PR TITLE
feat(java-graphql): request/response shapes + fix nested-paren @PreAuthorize endpoint drop

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -153,11 +153,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 4/19 | |
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 5/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 3/10 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 14/19 | |
-| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/24 | 🔴 0/19 | |
+| [java](../by-language/java.md) | [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 3/24 | 🟡 1/19 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 4/19 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 6/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟡 18/21 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟡 14/19 | |
-| [java](../by-language/java.md) | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/24 | 🔴 0/19 | |
+| [java](../by-language/java.md) | [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 3/24 | 🟡 1/19 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 5/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 3/10 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/6 | |
 | [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/19 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -36,11 +36,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 4/19 | |
 | [Javalin](../detail/lang.java.framework.javalin.md) | 🟡 5/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 3/10 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 14/19 | |
-| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/24 | 🔴 0/19 | |
+| [Netflix DGS](../detail/lang.java.framework.dgs.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 3/24 | 🟡 1/19 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 4/19 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 6/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟡 18/21 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 6/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟡 14/19 | |
-| [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 1/24 | 🔴 0/19 | |
+| [Spring for GraphQL](../detail/lang.java.framework.spring-graphql.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 3/24 | 🟡 1/19 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟡 5/6 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟡 3/10 | |
 
 

--- a/docs/coverage/detail/lang.java.framework.dgs.md
+++ b/docs/coverage/detail/lang.java.framework.dgs.md
@@ -32,13 +32,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/spring_graphql.go` | #3862: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). DGS mapping regexes now tolerate an interleaved security annotation. Value-asserting tests: @Secured("ROLE_ADMIN") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent. |
+| Auth coverage | 🟢 `partial` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3862) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/spring_graphql.go` | #3862/#3995: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). #3995 BUGFIX: the interleaved-annotation tolerance now uses annArgsRe (one-level nested-paren tolerant) so a SpEL @PreAuthorize("hasRole('ADMIN')") interleaved AFTER the @Dgs mapping annotation no longer drops the whole endpoint (the old \([^)]*\) stopped at the first inner ')'). Value-asserting tests: @Secured("ROLE_ADMIN") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: DTO-typed @InputArgument/@Argument resolver params and unwrapped return types register scope:schema:spring_dto SCOPE.Schema entities (kind=dto, framework=graphql). PARTIAL: type-name-only; DTO class member fields recovered only when in-file (cross-file is Phase 4, same limit as the Spring MVC sniffer). Asserted in spring_graphql_test.go. |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
@@ -121,9 +121,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: each DTO-typed @InputArgument/@Argument resolver param emits ACCEPTS_INPUT endpoint→DTO (scope:schema:spring_dto), the GraphQL analogue of Spring MVC @RequestBody. Scalar args (Long/String/int) skipped via gqlShapeBaseType+srrSkipTypes. PARTIAL: signature-DTO-typed args only; inline field-selection sets and cross-file DTO member fields not recovered. Asserted in spring_graphql_test.go (ACCEPTS_INPUT createUser→NewUser / addUser→NewUser; scalar id is NOT an input). |
 | Request sink dataflow | 🔴 `missing` | — | 3958 | — | No dataflow sniffer covers this framework's request-binding forms yet. The Java sniffer (internal/substrate/dataflow_java.go, #3958) targets Spring MVC/WebFlux @RequestBody/@RequestParam/@PathVariable; Kotlin/Scala have no sniffer at all (no "kotlin"/"scala" slug registered). request_sink_dataflow remains a follow-up for these JVM frameworks. |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: the unwrapped resolver return type (List<User>/Mono<User>/Flux<Event> → User/Event, via the shared Spring MVC unwrapReturnType) emits RETURNS endpoint→DTO (scope:schema:spring_dto). PARTIAL: type-name-only response DTO; in-file member fields only. Asserted in spring_graphql_test.go (RETURNS createUser→User, users→User unwrapped). |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.java.framework.spring-graphql.md
+++ b/docs/coverage/detail/lang.java.framework.spring-graphql.md
@@ -32,13 +32,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Auth coverage | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/framework_auth.go`<br>`internal/custom/java/framework_auth_test.go`<br>`internal/custom/java/spring_graphql.go` | #3862/#3995: spring_graphql.go stamps the flat Spring-compatible auth contract on each synthesized GRAPHQL resolver endpoint. @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @QueryMapping/@MutationMapping/@SchemaMapping resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ split like Spring MVC). #3995 BUGFIX: the interleaved-annotation tolerance now uses annArgsRe (one-level nested-paren tolerant) so a SpEL @PreAuthorize("hasRole('ADMIN')") interleaved between the mapping annotation and the method no longer drops the whole endpoint (old \([^)]*\) stopped at the first inner ')'). PARTIAL: same matcher set as Spring MVC; custom GraphQL interceptors / instrumentation-based auth not read. Value-asserting test TestSpringGraphQLAuth_PreAuthorizeNestedParen_Issue3873: @QueryMapping @PreAuthorize(hasRole(ADMIN)) → auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole(MANAGER) and hasAuthority(SCOPE_write)) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → no auth_required. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: DTO-typed @InputArgument/@Argument resolver params and unwrapped return types register scope:schema:spring_dto SCOPE.Schema entities (kind=dto, framework=graphql). PARTIAL: type-name-only; DTO class member fields recovered only when in-file (cross-file is Phase 4, same limit as the Spring MVC sniffer). Asserted in spring_graphql_test.go. |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
@@ -121,9 +121,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: each DTO-typed @InputArgument/@Argument resolver param emits ACCEPTS_INPUT endpoint→DTO (scope:schema:spring_dto), the GraphQL analogue of Spring MVC @RequestBody. Scalar args (Long/String/int) skipped via gqlShapeBaseType+srrSkipTypes. PARTIAL: signature-DTO-typed args only; inline field-selection sets and cross-file DTO member fields not recovered. Asserted in spring_graphql_test.go (ACCEPTS_INPUT createUser→NewUser / addUser→NewUser; scalar id is NOT an input). |
 | Request sink dataflow | 🔴 `missing` | — | 3958 | — | No dataflow sniffer covers this framework's request-binding forms yet. The Java sniffer (internal/substrate/dataflow_java.go, #3958) targets Spring MVC/WebFlux @RequestBody/@RequestParam/@PathVariable; Kotlin/Scala have no sniffer at all (no "kotlin"/"scala" slug registered). request_sink_dataflow remains a follow-up for these JVM frameworks. |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3995) | `internal/custom/java/spring_graphql.go`<br>`internal/custom/java/spring_graphql_test.go` | #3995: the unwrapped resolver return type (List<User>/Mono<User>/Flux<Event> → User/Event, via the shared Spring MVC unwrapReturnType) emits RETURNS endpoint→DTO (scope:schema:spring_dto). PARTIAL: type-name-only response DTO; in-file member fields only. Asserted in spring_graphql_test.go (RETURNS createUser→User, users→User unwrapped). |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -26,7 +26,7 @@ one is a separate detail page.
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 3 full, 1 partial, 45 missing |
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 6 partial, 39 missing |
-| [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 1 partial, 50 missing |
+| [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 5 partial, 46 missing |
 | [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 1 missing, 1 n/a |
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 4 full, 51 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -24189,14 +24189,17 @@
             "status": "partial",
             "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/spring_graphql.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/3862",
-            "notes": "#3862: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). DGS mapping regexes now tolerate an interleaved security annotation. Value-asserting tests: @Secured(\"ROLE_ADMIN\") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent.",
+            "notes": "#3862/#3995: spring_graphql.go stamps the flat Spring-compatible auth contract on the synthesized GRAPHQL resolver endpoints (Spring Security under DGS). @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @DgsQuery/@DgsMutation resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ prefixes split like Spring MVC). #3995 BUGFIX: the interleaved-annotation tolerance now uses annArgsRe (one-level nested-paren tolerant) so a SpEL @PreAuthorize(\"hasRole('ADMIN')\") interleaved AFTER the @Dgs mapping annotation no longer drops the whole endpoint (the old \\([^)]*\\) stopped at the first inner ')'). Value-asserting tests: @Secured(\"ROLE_ADMIN\") on @DgsQuery allUsers → /graphql/Query/allUsers auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole('MANAGER') and hasAuthority('SCOPE_write')) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → auth_required absent.",
             "verified_at": "2026-06-02"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: DTO-typed @InputArgument/@Argument resolver params and unwrapped return types register scope:schema:spring_dto SCOPE.Schema entities (kind=dto, framework=graphql). PARTIAL: type-name-only; DTO class member fields recovered only when in-file (cross-file is Phase 4, same limit as the Spring MVC sniffer). Asserted in spring_graphql_test.go.",
+            "verified_at": "2026-06-03"
           },
           "request_validation": {
             "status": "missing",
@@ -24370,8 +24373,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: each DTO-typed @InputArgument/@Argument resolver param emits ACCEPTS_INPUT endpoint→DTO (scope:schema:spring_dto), the GraphQL analogue of Spring MVC @RequestBody. Scalar args (Long/String/int) skipped via gqlShapeBaseType+srrSkipTypes. PARTIAL: signature-DTO-typed args only; inline field-selection sets and cross-file DTO member fields not recovered. Asserted in spring_graphql_test.go (ACCEPTS_INPUT createUser→NewUser / addUser→NewUser; scalar id is NOT an input).",
+            "verified_at": "2026-06-03"
           },
           "request_sink_dataflow": {
             "status": "missing",
@@ -24379,8 +24385,11 @@
             "notes": "No dataflow sniffer covers this framework's request-binding forms yet. The Java sniffer (internal/substrate/dataflow_java.go, #3958) targets Spring MVC/WebFlux @RequestBody/@RequestParam/@PathVariable; Kotlin/Scala have no sniffer at all (no \"kotlin\"/\"scala\" slug registered). request_sink_dataflow remains a follow-up for these JVM frameworks."
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: the unwrapped resolver return type (List\u003cUser\u003e/Mono\u003cUser\u003e/Flux\u003cEvent\u003e → User/Event, via the shared Spring MVC unwrapReturnType) emits RETURNS endpoint→DTO (scope:schema:spring_dto). PARTIAL: type-name-only response DTO; in-file member fields only. Asserted in spring_graphql_test.go (RETURNS createUser→User, users→User unwrapped).",
+            "verified_at": "2026-06-03"
           },
           "sanitizer_recognition": {
             "status": "missing",
@@ -28366,14 +28375,20 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/framework_auth.go","internal/custom/java/framework_auth_test.go","internal/custom/java/spring_graphql.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3862/#3995: spring_graphql.go stamps the flat Spring-compatible auth contract on each synthesized GRAPHQL resolver endpoint. @Secured/@PreAuthorize/@RolesAllowed/@PermitAll on a @QueryMapping/@MutationMapping/@SchemaMapping resolver → auth_required + auth_roles/auth_scopes/auth_permissions (ROLE_/SCOPE_ split like Spring MVC). #3995 BUGFIX: the interleaved-annotation tolerance now uses annArgsRe (one-level nested-paren tolerant) so a SpEL @PreAuthorize(\"hasRole('ADMIN')\") interleaved between the mapping annotation and the method no longer drops the whole endpoint (old \\([^)]*\\) stopped at the first inner ')'). PARTIAL: same matcher set as Spring MVC; custom GraphQL interceptors / instrumentation-based auth not read. Value-asserting test TestSpringGraphQLAuth_PreAuthorizeNestedParen_Issue3873: @QueryMapping @PreAuthorize(hasRole(ADMIN)) → auth_required=true auth_roles=ADMIN; @PreAuthorize(hasRole(MANAGER) and hasAuthority(SCOPE_write)) → auth_roles=MANAGER auth_scopes=write; unannotated resolver → no auth_required.",
+            "verified_at": "2026-06-03"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: DTO-typed @InputArgument/@Argument resolver params and unwrapped return types register scope:schema:spring_dto SCOPE.Schema entities (kind=dto, framework=graphql). PARTIAL: type-name-only; DTO class member fields recovered only when in-file (cross-file is Phase 4, same limit as the Spring MVC sniffer). Asserted in spring_graphql_test.go.",
+            "verified_at": "2026-06-03"
           },
           "request_validation": {
             "status": "missing",
@@ -28547,8 +28562,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: each DTO-typed @InputArgument/@Argument resolver param emits ACCEPTS_INPUT endpoint→DTO (scope:schema:spring_dto), the GraphQL analogue of Spring MVC @RequestBody. Scalar args (Long/String/int) skipped via gqlShapeBaseType+srrSkipTypes. PARTIAL: signature-DTO-typed args only; inline field-selection sets and cross-file DTO member fields not recovered. Asserted in spring_graphql_test.go (ACCEPTS_INPUT createUser→NewUser / addUser→NewUser; scalar id is NOT an input).",
+            "verified_at": "2026-06-03"
           },
           "request_sink_dataflow": {
             "status": "missing",
@@ -28556,8 +28574,11 @@
             "notes": "No dataflow sniffer covers this framework's request-binding forms yet. The Java sniffer (internal/substrate/dataflow_java.go, #3958) targets Spring MVC/WebFlux @RequestBody/@RequestParam/@PathVariable; Kotlin/Scala have no sniffer at all (no \"kotlin\"/\"scala\" slug registered). request_sink_dataflow remains a follow-up for these JVM frameworks."
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_graphql.go","internal/custom/java/spring_graphql_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3995",
+            "notes": "#3995: the unwrapped resolver return type (List\u003cUser\u003e/Mono\u003cUser\u003e/Flux\u003cEvent\u003e → User/Event, via the shared Spring MVC unwrapReturnType) emits RETURNS endpoint→DTO (scope:schema:spring_dto). PARTIAL: type-name-only response DTO; in-file member fields only. Asserted in spring_graphql_test.go (RETURNS createUser→User, users→User unwrapped).",
+            "verified_at": "2026-06-03"
           },
           "sanitizer_recognition": {
             "status": "missing",

--- a/internal/custom/java/spring_graphql.go
+++ b/internal/custom/java/spring_graphql.go
@@ -83,6 +83,16 @@ var springGraphQLFrameworks = map[string]bool{
 	"spring_boot": true,
 }
 
+// annArgsRe matches an annotation argument list `(...)` that may contain ONE
+// level of nested parens — e.g. `@PreAuthorize("hasRole('ADMIN')")` or
+// `@PreAuthorize("hasRole('A') and hasAuthority('B')")`. The previous
+// `\([^)]*\)` form stopped at the first inner `)` and so silently dropped the
+// WHOLE resolver endpoint whenever a SpEL `@PreAuthorize` was interleaved
+// between the mapping annotation and the method (#3862 only tested @Secured /
+// pre-method @PreAuthorize, which avoided the nested-paren case). Used by every
+// Spring/DGS mapping regex below so endpoint synthesis survives a SpEL guard.
+const annArgsRe = `\((?:[^()]|\([^()]*\))*\)`
+
 var (
 	// Spring for GraphQL mapping annotations whose operation is fixed by the
 	// annotation name. Capture group 1 = annotation simple name, group 2 = the
@@ -94,8 +104,8 @@ var (
 	//   @MutationMapping(name = "createUser") User create(@Argument In in) {
 	//   @SubscriptionMapping Flux<Event> events() {
 	reSpringGQLMapping = regexp.MustCompile(
-		`(?s)@(QueryMapping|MutationMapping|SubscriptionMapping)\b\s*(\([^)]*\))?\s*` +
-			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+		`(?s)@(QueryMapping|MutationMapping|SubscriptionMapping)\b\s*(` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
@@ -103,8 +113,8 @@ var (
 	// operation comes from typeName and field from field. Group 1 = arg list,
 	// group 2 = method name (used as the field fallback when field= absent).
 	reSpringSchemaMapping = regexp.MustCompile(
-		`(?s)@SchemaMapping\b\s*(\([^)]*\))?\s*` +
-			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+		`(?s)@SchemaMapping\b\s*(` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
@@ -113,15 +123,15 @@ var (
 	// (@Secured / @PreAuthorize / @RolesAllowed) interleaved between the DGS
 	// mapping annotation and the resolver method (#3862).
 	reDgsShorthand = regexp.MustCompile(
-		`(?s)@(DgsQuery|DgsMutation|DgsSubscription)\b\s*(\([^)]*\))?\s*` +
-			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+		`(?s)@(DgsQuery|DgsMutation|DgsSubscription)\b\s*(` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
 	// Netflix DGS general @DgsData(parentType="Query", field="x").
 	reDgsData = regexp.MustCompile(
-		`(?s)@DgsData\b\s*(\([^)]*\))?\s*` +
-			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+		`(?s)@DgsData\b\s*(` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
 			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
 			`(?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?\s+(\w+)\s*\(`,
 	)
@@ -132,6 +142,77 @@ var (
 	reGQLArgTypeName   = regexp.MustCompile(`\btypeName\s*=\s*"([^"]*)"`)
 	reGQLArgParentType = regexp.MustCompile(`\bparentType\s*=\s*"([^"]*)"`)
 )
+
+// Request/response shape extraction (#3873). A GraphQL resolver's typed input
+// args and return type are its request/response shapes — the GraphQL analogue
+// of Spring MVC's @RequestBody / return type that spring_request_response.go
+// already credits. We emit:
+//
+//   - ACCEPTS_INPUT  endpoint → DTO schema, for each @Argument / @InputArgument
+//     parameter whose type is a non-scalar input object (an input DTO). Scalar
+//     args (Long id, String q) are NOT shape DTOs — they are skipped, matching
+//     the Spring MVC sniffer's srrSkipTypes filter.
+//   - RETURNS         endpoint → DTO schema, for the unwrapped resolver return
+//     type (List<User>/Mono<User>/Flux<Event> → User/Event), reusing the exact
+//     unwrapReturnType helper Spring MVC uses.
+//
+// HONEST LIMIT (partial): shapes resolve from the resolver method SIGNATURE
+// (DTO-typed @Argument params + return type). Inline field-selection sets are
+// not recovered, and a DTO declared in another file contributes only its type
+// name (no member fields) — identical to the Spring MVC single-file limit.
+var (
+	// gqlMethodSigRe captures a resolver method's return type (group 1), name
+	// (group 2) and parameter block (group 3) starting at the mapping
+	// annotation. The leading annotation run (mapping + any interleaved
+	// security annotation) is skipped via annArgsRe-aware tolerance.
+	gqlMethodSigRe = regexp.MustCompile(
+		`(?s)@(?:Query|Mutation|Subscription)Mapping\b\s*(?:` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
+			`((?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?)\s+(\w+)\s*\(([^)]*)\)`)
+	gqlDgsMethodSigRe = regexp.MustCompile(
+		`(?s)@Dgs(?:Query|Mutation|Subscription|Data)\b\s*(?:` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
+			`((?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?)\s+(\w+)\s*\(([^)]*)\)`)
+	gqlSchemaMethodSigRe = regexp.MustCompile(
+		`(?s)@SchemaMapping\b\s*(?:` + annArgsRe + `)?\s*` +
+			`(?:@\w+(?:` + annArgsRe + `)?\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?` +
+			`((?:<[^>]*>\s*)?[\w.$<>\[\], ?]+?)\s+(\w+)\s*\(([^)]*)\)`)
+	// gqlArgParamRe matches a single `@Argument [Type] name` or
+	// `@InputArgument [Type] name` resolver parameter. Group 1 = the type name
+	// (base, possibly generic). Inner annotations (@Valid, @Argument(name=...))
+	// are tolerated before the type.
+	gqlArgParamRe = regexp.MustCompile(
+		`@(?:Argument|InputArgument)\b(?:\s*\([^)]*\))?\s*(?:@\w+(?:\([^)]*\))?\s*)*` +
+			`([A-Za-z_$][\w$.]*(?:\s*<[^>]*>)?)\s+[A-Za-z_$][\w$]*`)
+)
+
+// gqlShapeBaseType strips a generic wrapper (List<X>, Optional<X>, Mono<X>,
+// Flux<X>, Set<X>) down to its element base type, returning the base type name
+// (or "" if the type bottoms out at a scalar/skip type). Reuses srrSkipTypes
+// (the Spring MVC scalar/container skip set) for parity.
+func gqlShapeBaseType(raw string) string {
+	raw = strings.TrimSpace(raw)
+	// Peel one or two generic layers (List<Mono<User>> is pathological but
+	// unwrapReturnType handles return types; for args one peel suffices).
+	for range 2 {
+		if m := srrBaseGenericRE.FindStringSubmatch(raw); m != nil {
+			base, inner := m[1], m[2]
+			if srrSkipTypes[base] && inner != "" {
+				raw = strings.TrimSpace(inner)
+				continue
+			}
+			if srrSkipTypes[base] {
+				return ""
+			}
+			return base
+		}
+		break
+	}
+	return ""
+}
 
 // springGQLOperationForMapping maps a Spring/DGS shorthand annotation name to
 // its GraphQL root operation. Returns "" for an unrecognised name.
@@ -374,7 +455,21 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 	// emit records one resolver method as a canonical GRAPHQL endpoint plus a
 	// resolver-method entity and a HANDLES edge between them. `framework` is the
 	// record-citing framework label ("spring-graphql" or "dgs").
-	emit := func(operation, field, methodName, framework, provenance string, offset int) {
+	// ensureGQLDTO registers a request/response DTO schema entity (one per type
+	// per file) so ACCEPTS_INPUT/RETURNS edges have a stable target, mirroring
+	// the Spring MVC ensureDTO contract (scope:schema:spring_dto:...).
+	ensureGQLDTO := func(dtoName string, lineNo int) string {
+		ref := "scope:schema:spring_dto:" + fp + ":" + dtoName
+		addEntity(&result, seenEnt, SecondaryEntity{
+			Name: dtoName, Kind: "SCOPE.Schema", SourceFile: fp,
+			LineStart: lineNo, LineEnd: lineNo,
+			Provenance: "INFERRED_FROM_SPRING_GRAPHQL_SHAPE", Ref: ref,
+			Properties: map[string]any{"kind": "dto", "framework": "graphql"},
+		})
+		return ref
+	}
+
+	emit := func(operation, field, methodName, framework, provenance string, offset int, returnType, paramsBlock string) {
 		if operation == "" || field == "" {
 			return
 		}
@@ -448,6 +543,55 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 				"match_source":  "graphql_resolver_annotation",
 			},
 		})
+
+		// Request shape (#3873): each DTO-typed @Argument/@InputArgument param
+		// is an ACCEPTS_INPUT to its input DTO. Scalar args (Long/String/int)
+		// are not shapes and are skipped via gqlShapeBaseType/srrSkipTypes.
+		for _, pm := range gqlArgParamRe.FindAllStringSubmatch(paramsBlock, -1) {
+			dto := gqlShapeBaseType(pm[1])
+			if dto == "" {
+				continue
+			}
+			dtoRef := ensureGQLDTO(dto, lineNo)
+			addRel(&result, seenRel, Relationship{
+				SourceRef:        endpointRef,
+				TargetRef:        dtoRef,
+				RelationshipType: "ACCEPTS_INPUT",
+				Properties: map[string]string{
+					"framework":    framework,
+					"dto_type":     dto,
+					"match_source": "graphql_argument",
+				},
+			})
+		}
+
+		// Response shape (#3873): the unwrapped resolver return type
+		// (List<User>/Mono<User>/Flux<Event> → User/Event) is a RETURNS to its
+		// output DTO. Reuses the exact Spring MVC unwrapReturnType helper.
+		if dto := unwrapReturnType(strings.TrimSpace(returnType)); dto != "" {
+			dtoRef := ensureGQLDTO(dto, lineNo)
+			addRel(&result, seenRel, Relationship{
+				SourceRef:        endpointRef,
+				TargetRef:        dtoRef,
+				RelationshipType: "RETURNS",
+				Properties: map[string]string{
+					"framework":       framework,
+					"dto_type":        dto,
+					"return_type_raw": strings.TrimSpace(returnType),
+					"match_source":    "graphql_return_type",
+				},
+			})
+		}
+	}
+
+	// sigAt extracts (returnType, paramsBlock) for the resolver whose mapping
+	// annotation begins at off, applying sigRe to a window from off. Returns
+	// ("","") when the signature does not re-match (shapes are then skipped).
+	sigAt := func(sigRe *regexp.Regexp, off int) (string, string) {
+		if sm := sigRe.FindStringSubmatch(src[off:]); sm != nil {
+			return sm[1], sm[3]
+		}
+		return "", ""
 	}
 
 	// 1. Spring for GraphQL shorthand mappings (@QueryMapping etc.).
@@ -463,8 +607,9 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 		if n := firstArg(reGQLArgName, args); n != "" {
 			field = n
 		}
+		rt, pb := sigAt(gqlMethodSigRe, m[0])
 		emit(operation, field, methodName, "spring-graphql",
-			"INFERRED_FROM_SPRING_GRAPHQL_MAPPING", m[0])
+			"INFERRED_FROM_SPRING_GRAPHQL_MAPPING", m[0], rt, pb)
 	}
 
 	// 2. Spring for GraphQL @SchemaMapping(typeName=..., field=...).
@@ -484,8 +629,9 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 		if f := firstArg(reGQLArgField, args); f != "" {
 			field = f
 		}
+		rt, pb := sigAt(gqlSchemaMethodSigRe, m[0])
 		emit(operation, field, methodName, "spring-graphql",
-			"INFERRED_FROM_SPRING_GRAPHQL_SCHEMA_MAPPING", m[0])
+			"INFERRED_FROM_SPRING_GRAPHQL_SCHEMA_MAPPING", m[0], rt, pb)
 	}
 
 	// 3. Netflix DGS shorthand (@DgsQuery / @DgsMutation / @DgsSubscription).
@@ -501,8 +647,9 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 		if f := firstArg(reGQLArgField, args); f != "" {
 			field = f
 		}
+		rt, pb := sigAt(gqlDgsMethodSigRe, m[0])
 		emit(operation, field, methodName, "dgs",
-			"INFERRED_FROM_DGS_MAPPING", m[0])
+			"INFERRED_FROM_DGS_MAPPING", m[0], rt, pb)
 	}
 
 	// 4. Netflix DGS general @DgsData(parentType=..., field=...).
@@ -520,8 +667,9 @@ func ExtractSpringGraphQL(ctx PatternContext) PatternResult {
 		if f := firstArg(reGQLArgField, args); f != "" {
 			field = f
 		}
+		rt, pb := sigAt(gqlDgsMethodSigRe, m[0])
 		emit(operation, field, methodName, "dgs",
-			"INFERRED_FROM_DGS_DATA", m[0])
+			"INFERRED_FROM_DGS_DATA", m[0], rt, pb)
 	}
 
 	return result

--- a/internal/custom/java/spring_graphql_test.go
+++ b/internal/custom/java/spring_graphql_test.go
@@ -266,6 +266,150 @@ func TestSpringGraphQL_GatesOffWrongFramework(t *testing.T) {
 	}
 }
 
+// Auth — nested-paren @PreAuthorize regression (#3873) -----------------------
+//
+// Before the annArgsRe fix, a SpEL @PreAuthorize interleaved between the
+// mapping annotation and the resolver method (the COMMON Spring auth form)
+// dropped the WHOLE endpoint, because the interleaved-annotation tolerance used
+// `\([^)]*\)` and stopped at the first inner `)` of hasRole('ADMIN').
+
+func TestSpringGraphQLAuth_PreAuthorizeNestedParen_Issue3873(t *testing.T) {
+	src := `package com.example;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+@Controller
+public class UserController {
+    @QueryMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public User user(@Argument Long id) { return repo.get(id); }
+
+    @PreAuthorize("hasRole('MANAGER') and hasAuthority('SCOPE_write')")
+    @MutationMapping
+    public User createUser(@Argument NewUser input) { return repo.save(input); }
+}`
+	r := ExtractSpringGraphQL(PatternContext{Source: src, Language: "java", Framework: "spring_graphql", FilePath: "UserController.java"})
+
+	// Endpoint survives the SpEL @PreAuthorize and is stamped with role ADMIN.
+	e := findGQLEndpoint(r, "GRAPHQL /graphql/Query/user")
+	if e == nil {
+		t.Fatal("endpoint dropped by interleaved @PreAuthorize (nested-paren regression)")
+	}
+	if got := propStr(e, "auth_required"); got != "true" {
+		t.Errorf("user auth_required = %q, want \"true\"", got)
+	}
+	if got := propStr(e, "auth_roles"); got != "ADMIN" {
+		t.Errorf("user auth_roles = %q, want \"ADMIN\"", got)
+	}
+
+	// @PreAuthorize BEFORE the mapping with role+authority also survives.
+	c := findGQLEndpoint(r, "GRAPHQL /graphql/Mutation/createUser")
+	if c == nil {
+		t.Fatal("createUser endpoint dropped")
+	}
+	if got := propStr(c, "auth_roles"); got != "MANAGER" {
+		t.Errorf("createUser auth_roles = %q, want \"MANAGER\"", got)
+	}
+	if got := propStr(c, "auth_scopes"); got != "write" {
+		t.Errorf("createUser auth_scopes = %q, want \"write\"", got)
+	}
+}
+
+// Request/response shapes (#3873) ---------------------------------------------
+//
+// A resolver's DTO-typed @Argument/@InputArgument params are the request shape
+// (ACCEPTS_INPUT) and the unwrapped return type is the response shape
+// (RETURNS), mirroring the Spring MVC @RequestBody / return-type contract.
+
+// gqlShapeRel reports whether result carries a rel of type relType from the
+// endpoint named endpointName to a spring_dto schema for dtoName.
+func gqlShapeRel(r PatternResult, endpointName, relType, dtoName string) bool {
+	ep := findGQLEndpoint(r, endpointName)
+	if ep == nil {
+		return false
+	}
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == relType && rel.SourceRef == ep.Ref &&
+			rel.Properties["dto_type"] == dtoName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSpringGraphQLShapes_RequestAndResponse_Issue3873(t *testing.T) {
+	src := `package com.example;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
+@Controller
+public class UserController {
+    @QueryMapping
+    public User user(@Argument Long id) { return repo.get(id); }
+
+    @MutationMapping
+    public User createUser(@Argument NewUser input) { return repo.save(input); }
+
+    @QueryMapping
+    public List<User> users() { return repo.all(); }
+}`
+	r := ExtractSpringGraphQL(PatternContext{Source: src, Language: "java", Framework: "spring_graphql", FilePath: "UserController.java"})
+
+	// Mutation request shape: @Argument NewUser input → ACCEPTS_INPUT NewUser.
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Mutation/createUser", "ACCEPTS_INPUT", "NewUser") {
+		t.Error("expected ACCEPTS_INPUT createUser -> NewUser")
+	}
+	// Mutation response shape: returns User → RETURNS User.
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Mutation/createUser", "RETURNS", "User") {
+		t.Error("expected RETURNS createUser -> User")
+	}
+	// Query response shape through List<User> → RETURNS User (unwrapped).
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Query/users", "RETURNS", "User") {
+		t.Error("expected RETURNS users -> User (List<User> unwrapped)")
+	}
+	// NEGATIVE: a scalar @Argument Long id is NOT a request DTO.
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "ACCEPTS_INPUT" &&
+			(rel.Properties["dto_type"] == "Long" || rel.Properties["dto_type"] == "id") {
+			t.Errorf("scalar @Argument should not produce ACCEPTS_INPUT, got %v", rel.Properties)
+		}
+	}
+	// user(...) takes only a scalar arg → no ACCEPTS_INPUT on its endpoint.
+	uep := findGQLEndpoint(r, "GRAPHQL /graphql/Query/user")
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "ACCEPTS_INPUT" && uep != nil && rel.SourceRef == uep.Ref {
+			t.Errorf("scalar-only resolver user should have no ACCEPTS_INPUT, got %v", rel.Properties)
+		}
+	}
+}
+
+func TestDGSShapes_InputArgumentAndReturn_Issue3873(t *testing.T) {
+	src := `package com.example;
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.DgsMutation;
+@DgsComponent
+public class UserFetcher {
+    @DgsMutation
+    public User addUser(@InputArgument NewUser in) { return svc.add(in); }
+
+    @DgsQuery
+    public List<User> users() { return svc.all(); }
+}`
+	r := ExtractSpringGraphQL(PatternContext{Source: src, Language: "java", Framework: "dgs", FilePath: "UserFetcher.java"})
+
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Mutation/addUser", "ACCEPTS_INPUT", "NewUser") {
+		t.Error("expected ACCEPTS_INPUT addUser -> NewUser (@InputArgument)")
+	}
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Mutation/addUser", "RETURNS", "User") {
+		t.Error("expected RETURNS addUser -> User")
+	}
+	if !gqlShapeRel(r, "GRAPHQL /graphql/Query/users", "RETURNS", "User") {
+		t.Error("expected RETURNS users -> User")
+	}
+}
+
 // Endpoint-shape parity: the emitted id/name MUST match the gqlgen / JS / Kotlin
 // canonical "GRAPHQL /graphql/<RootType>/<field>" exactly.
 func TestSpringGraphQL_CanonicalShapeParity(t *testing.T) {


### PR DESCRIPTION
**Closes #3995** · epic #3854 (Java/JVM Spring-parity) / meta #3872 (per-language parity audit). **DEPLOY-DEFERRED.**

The recurring GraphQL meta-pattern (HotChocolate/Pothos/graphene/gqlgen/graphql-ruby) for the JVM frameworks. VERIFY-FIRST audit of `internal/custom/java/spring_graphql.go`.

## What already fired (kept as-is)
- **Endpoint synthesis (#3615)** — `@QueryMapping/@MutationMapping/@SubscriptionMapping/@SchemaMapping` (spring-graphql) + `@DgsQuery/@DgsMutation/@DgsSubscription/@DgsData` (DGS) → canonical `http:GRAPHQL:` endpoint `/graphql/<Operation>/<field>` + HANDLES edge. `endpoint_synthesis` stays `full`.

## What was broken / missing (fixed here)

### 1. BUG — SpEL `@PreAuthorize` dropped the whole endpoint
The interleaved-annotation tolerance used `\([^)]*\)`, which stops at the first inner `)` of a SpEL expression. So a resolver with the **common** form
```java
@QueryMapping
@PreAuthorize("hasRole('ADMIN')")
public User user(@Argument Long id) { ... }
```
had its **entire GRAPHQL endpoint silently dropped** — not just auth. #3862's tests only used `@Secured` (no nested parens), so this was never caught. Same bug in DGS. Fixed with `annArgsRe` (one-level nested-paren tolerant) across all four mapping regexes.

Probe confirmed the failure first: `@Secured("ROLE_ADMIN")` → endpoint present; `@PreAuthorize("hasRole('ADMIN')")` → endpoint **absent** (now present + `auth_required=true auth_roles=ADMIN`).

### 2. Request/response shapes — not built
Now mirrors `spring_request_response.go`: DTO-typed `@Argument`/`@InputArgument` params → `ACCEPTS_INPUT` endpoint→DTO; unwrapped return type (`List<User>`/`Mono<User>`/`Flux<Event>` → `User`/`Event`, via shared `unwrapReturnType`) → `RETURNS` endpoint→DTO. Targets `scope:schema:spring_dto` entities. Scalar args (`Long`/`String`/`int`) correctly skipped via `gqlShapeBaseType`+`srrSkipTypes`.

## Honest registry credit (partial)
| cell | spring-graphql | dgs |
|---|---|---|
| auth_coverage | missing → **partial** | partial (note: nested-paren fix) |
| request_shape_extraction | missing → **partial** | missing → **partial** |
| response_shape_extraction | missing → **partial** | missing → **partial** |
| dto_extraction | missing → **partial** | missing → **partial** |

PARTIAL because shapes resolve from the resolver **signature** (DTO-typed args + return type) only — inline field-selection sets and cross-file DTO member fields are not recovered (same single-file limit as the Spring MVC sniffer).

## What my probe asserts
- `@QueryMapping @PreAuthorize("hasRole('ADMIN')") user(@Argument Long id)` → endpoint present + `auth_required=true` + `auth_roles=ADMIN` + `RETURNS User` + scalar `id` is **NOT** an `ACCEPTS_INPUT`.
- `createUser(@Argument NewUser input)` → `ACCEPTS_INPUT NewUser` + `RETURNS User`.
- DGS `@InputArgument` equivalent + `@PreAuthorize("...and hasAuthority('SCOPE_write')")` → `auth_roles=MANAGER auth_scopes=write`.
- Negatives: scalar `@Argument` produces no input; unannotated resolver stamps no auth.

## Left missing (deliberately)
- Inline GraphQL field-selection sets and cross-file DTO member fields (signature-only) → kept `partial`, not `full`.
- `graphql-java`/SPQR codegen (`@GraphQLQuery`) — not present in this repo's surface; out of scope for this PR.

## Verification
`go test ./internal/custom/java/ ./internal/engine/ ./internal/substrate/ ./internal/types/ ./tools/coverage/` green · `coverage fmt --check` canonical · `coverage validate` 0 errors · `gofmt -l` empty · `go vet` clean · docs regenerated (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)