### PR TITLE
feat(csharp): canonical endpoint synthesis for Carter/FastEndpoints/Nancy/ServiceStack (#3962)

### DIFF
--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -18,9 +18,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
 | Endpoint pagination posture | 🔴 `missing` | `2026-06-02` | 3628 | `internal/engine/http_endpoint_pagination.go`<br>`internal/engine/http_endpoint_pagination_patterns.go`<br>`internal/engine/http_endpoint_pagination_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3628: applyEndpointPagination stamps paginated/pagination_style/pagination_params via the cross-language parameters/parameter_schema fallback (limit+offset/page/cursor shape). No framework-specific pagination-class/ORM signal yet for this framework. |
 | Endpoint response codes | 🔴 `missing` | — | 3818 | — | — |
-| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter route endpoint_synthesis via regex extractor; heuristic |
-| Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter module/endpoint class declarations detected via regex; heuristic |
-| Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | carter route path strings extracted via regex; heuristic |
+| Endpoint synthesis | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3962: synthesizeCarter promotes app.MapGet/Post/Put/Delete/Patch routes declared in an ICarterModule to the canonical http_endpoint_definition shape (http:<VERB>:<path>) emitted by synthesizeASPNetCore — same FrameworkASPNetCore canonicaliser, dispatched in the csharp case of http_endpoint_synthesis.go. No longer regex-only SCOPE.Operation. |
+| Handler attribution | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: each synthesized Carter endpoint carries source_handler=SCOPE.Operation:<Module>.AddRoutes, which ResolveHTTPEndpointHandlers rebinds to the module's AddRoutes method (HANDLES edge). Value-asserted in TestSynth_Carter. |
+| Route extraction | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: carterMapRouteRe extracts the verb+path of each app.MapVerb call; the path is canonicalised ({id:int}->{id}) into the endpoint ID. Asserted on /widgets/{id} in TestSynth_Carter. |
 
 ### View
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -18,9 +18,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
 | Endpoint pagination posture | 🔴 `missing` | `2026-06-02` | 3628 | `internal/engine/http_endpoint_pagination.go`<br>`internal/engine/http_endpoint_pagination_patterns.go`<br>`internal/engine/http_endpoint_pagination_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3628: applyEndpointPagination stamps paginated/pagination_style/pagination_params via the cross-language parameters/parameter_schema fallback (limit+offset/page/cursor shape). No framework-specific pagination-class/ORM signal yet for this framework. |
 | Endpoint response codes | 🔴 `missing` | — | 3818 | — | — |
-| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints route endpoint_synthesis via regex extractor; heuristic |
-| Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints module/endpoint class declarations detected via regex; heuristic |
-| Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | fastendpoints route path strings extracted via regex; heuristic |
+| Endpoint synthesis | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3962: synthesizeFastEndpoints promotes the bare Verb("/path") registrations inside a class : Endpoint<TReq[,TRes]> Configure() body to the canonical http_endpoint_definition shape (http:<VERB>:<path>), dispatched in the csharp case. No longer regex-only SCOPE.Operation. |
+| Handler attribution | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: each synthesized FastEndpoints endpoint carries source_handler=SCOPE.Operation:<Class>.HandleAsync (or <Class> when no HandleAsync), attributing to the endpoint's handler method. Value-asserted in TestSynth_FastEndpoints + TestSynth_FastEndpoints_NoHandleAsync. |
+| Route extraction | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: feRouteRe extracts the verb+path of each bare Configure() route helper; the leading non-dot boundary excludes consumer client.Get(...) calls (negative TestSynth_FastEndpoints_NoConsumerCall). |
 
 ### View
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -18,9 +18,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
 | Endpoint pagination posture | 🔴 `missing` | `2026-06-02` | 3628 | `internal/engine/http_endpoint_pagination.go`<br>`internal/engine/http_endpoint_pagination_patterns.go`<br>`internal/engine/http_endpoint_pagination_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3628: applyEndpointPagination stamps paginated/pagination_style/pagination_params via the cross-language parameters/parameter_schema fallback (limit+offset/page/cursor shape). No framework-specific pagination-class/ORM signal yet for this framework. |
 | Endpoint response codes | 🔴 `missing` | — | 3818 | — | — |
-| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx route endpoint_synthesis via regex extractor; heuristic |
-| Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx module/endpoint class declarations detected via regex; heuristic |
-| Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | nancyfx route path strings extracted via regex; heuristic |
+| Endpoint synthesis | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3962: synthesizeNancy promotes both index-syntax Get["/path"] (Nancy 1.x) and call-syntax Get("/path") (Nancy 2.x) routes inside a : NancyModule subclass to the canonical http_endpoint_definition shape (http:<VERB>:<path>), dispatched in the csharp case. No longer regex-only SCOPE.Operation. |
+| Handler attribution | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: each synthesized Nancy endpoint carries source_handler=SCOPE.Operation:<Module> (routes are inline lambdas assigned in the module ctor, so the module is the handler). Value-asserted in TestSynth_Nancy. |
+| Route extraction | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: nancyIndexRouteRe + nancyCallRouteRe extract verb+path for both Nancy route-declaration styles; the module gate prevents call-syntax collision with FastEndpoints' bare Get(). Asserted on /widgets/{id} in TestSynth_Nancy. |
 
 ### View
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -18,9 +18,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
 | Endpoint pagination posture | 🔴 `missing` | `2026-06-02` | 3628 | `internal/engine/http_endpoint_pagination.go`<br>`internal/engine/http_endpoint_pagination_patterns.go`<br>`internal/engine/http_endpoint_pagination_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3628: applyEndpointPagination stamps paginated/pagination_style/pagination_params via the cross-language parameters/parameter_schema fallback (limit+offset/page/cursor shape). No framework-specific pagination-class/ORM signal yet for this framework. |
 | Endpoint response codes | 🔴 `missing` | — | 3818 | — | — |
-| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack route endpoint_synthesis via regex extractor; heuristic |
-| Handler attribution | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack module/endpoint class declarations detected via regex; heuristic |
-| Route extraction | 🟢 `partial` | `2026-05-30` | 3263 | `internal/custom/csharp/minor_routes.go` | servicestack route path strings extracted via regex; heuristic |
+| Endpoint synthesis | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #3962: synthesizeServiceStack promotes [Route("/path","GET POST")] request-DTO attributes (verbs from the attribute, falling back to the service's handler methods, else GET) to the canonical http_endpoint_definition shape, dispatched in the csharp case. No longer regex-only SCOPE.Operation. |
+| Handler attribution | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: each synthesized ServiceStack endpoint carries source_handler=SCOPE.Operation:<Service>.<HandlerMethod>, picking the verb-specific Get/Post method when present, else the Any catch-all. Value-asserted per-verb in TestSynth_ServiceStack + TestSynth_ServiceStack_AnyHandler. |
+| Route extraction | ✅ `full` | `2026-06-03` | 3962 | `internal/engine/http_endpoint_csharp_minor.go`<br>`internal/engine/http_endpoint_csharp_minor_test.go` | #3962: ssRouteAttrRe extracts the path + optional verb list from each [Route(...)] attribute on a request DTO; the path is canonicalised into the endpoint ID. Asserted on /widgets/{Id} in TestSynth_ServiceStack. |
 
 ### View
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9652,25 +9652,25 @@
             "issue": "3818"
           },
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "carter route endpoint_synthesis via regex extractor; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3962",
+            "notes": "#3962: synthesizeCarter promotes app.MapGet/Post/Put/Delete/Patch routes declared in an ICarterModule to the canonical http_endpoint_definition shape (http:\u003cVERB\u003e:\u003cpath\u003e) emitted by synthesizeASPNetCore — same FrameworkASPNetCore canonicaliser, dispatched in the csharp case of http_endpoint_synthesis.go. No longer regex-only SCOPE.Operation.",
+            "verified_at": "2026-06-03"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "carter module/endpoint class declarations detected via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: each synthesized Carter endpoint carries source_handler=SCOPE.Operation:\u003cModule\u003e.AddRoutes, which ResolveHTTPEndpointHandlers rebinds to the module's AddRoutes method (HANDLES edge). Value-asserted in TestSynth_Carter.",
+            "verified_at": "2026-06-03"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "carter route path strings extracted via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: carterMapRouteRe extracts the verb+path of each app.MapVerb call; the path is canonicalised ({id:int}-\u003e{id}) into the endpoint ID. Asserted on /widgets/{id} in TestSynth_Carter.",
+            "verified_at": "2026-06-03"
           }
         },
         "View": {
@@ -9949,25 +9949,25 @@
             "issue": "3818"
           },
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "fastendpoints route endpoint_synthesis via regex extractor; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3962",
+            "notes": "#3962: synthesizeFastEndpoints promotes the bare Verb(\"/path\") registrations inside a class : Endpoint\u003cTReq[,TRes]\u003e Configure() body to the canonical http_endpoint_definition shape (http:\u003cVERB\u003e:\u003cpath\u003e), dispatched in the csharp case. No longer regex-only SCOPE.Operation.",
+            "verified_at": "2026-06-03"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "fastendpoints module/endpoint class declarations detected via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: each synthesized FastEndpoints endpoint carries source_handler=SCOPE.Operation:\u003cClass\u003e.HandleAsync (or \u003cClass\u003e when no HandleAsync), attributing to the endpoint's handler method. Value-asserted in TestSynth_FastEndpoints + TestSynth_FastEndpoints_NoHandleAsync.",
+            "verified_at": "2026-06-03"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "fastendpoints route path strings extracted via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: feRouteRe extracts the verb+path of each bare Configure() route helper; the leading non-dot boundary excludes consumer client.Get(...) calls (negative TestSynth_FastEndpoints_NoConsumerCall).",
+            "verified_at": "2026-06-03"
           }
         },
         "View": {
@@ -10665,25 +10665,25 @@
             "issue": "3818"
           },
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "nancyfx route endpoint_synthesis via regex extractor; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3962",
+            "notes": "#3962: synthesizeNancy promotes both index-syntax Get[\"/path\"] (Nancy 1.x) and call-syntax Get(\"/path\") (Nancy 2.x) routes inside a : NancyModule subclass to the canonical http_endpoint_definition shape (http:\u003cVERB\u003e:\u003cpath\u003e), dispatched in the csharp case. No longer regex-only SCOPE.Operation.",
+            "verified_at": "2026-06-03"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "nancyfx module/endpoint class declarations detected via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: each synthesized Nancy endpoint carries source_handler=SCOPE.Operation:\u003cModule\u003e (routes are inline lambdas assigned in the module ctor, so the module is the handler). Value-asserted in TestSynth_Nancy.",
+            "verified_at": "2026-06-03"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "nancyfx route path strings extracted via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: nancyIndexRouteRe + nancyCallRouteRe extract verb+path for both Nancy route-declaration styles; the module gate prevents call-syntax collision with FastEndpoints' bare Get(). Asserted on /widgets/{id} in TestSynth_Nancy.",
+            "verified_at": "2026-06-03"
           }
         },
         "View": {
@@ -11163,25 +11163,25 @@
             "issue": "3818"
           },
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "servicestack route endpoint_synthesis via regex extractor; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3962",
+            "notes": "#3962: synthesizeServiceStack promotes [Route(\"/path\",\"GET POST\")] request-DTO attributes (verbs from the attribute, falling back to the service's handler methods, else GET) to the canonical http_endpoint_definition shape, dispatched in the csharp case. No longer regex-only SCOPE.Operation.",
+            "verified_at": "2026-06-03"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "servicestack module/endpoint class declarations detected via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: each synthesized ServiceStack endpoint carries source_handler=SCOPE.Operation:\u003cService\u003e.\u003cHandlerMethod\u003e, picking the verb-specific Get/Post method when present, else the Any catch-all. Value-asserted per-verb in TestSynth_ServiceStack + TestSynth_ServiceStack_AnyHandler.",
+            "verified_at": "2026-06-03"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/csharp/minor_routes.go"],
-            "issue": "3263",
-            "notes": "servicestack route path strings extracted via regex; heuristic",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_csharp_minor.go","internal/engine/http_endpoint_csharp_minor_test.go"],
+            "issue": "3962",
+            "notes": "#3962: ssRouteAttrRe extracts the path + optional verb list from each [Route(...)] attribute on a request DTO; the path is canonicalised into the endpoint ID. Asserted on /widgets/{Id} in TestSynth_ServiceStack.",
+            "verified_at": "2026-06-03"
           }
         },
         "View": {

--- a/internal/engine/http_endpoint_csharp_minor.go
+++ b/internal/engine/http_endpoint_csharp_minor.go
@@ -1,0 +1,427 @@
+// http_endpoint_csharp_minor.go — Carter / FastEndpoints / NancyFX / ServiceStack
+// → canonical http_endpoint_definition synthesis (#3962, epic #3872).
+//
+// These four .NET HTTP frameworks were previously served ONLY by the regex-only
+// extractor internal/custom/csharp/minor_routes.go, which emits raw
+// SCOPE.Operation / SCOPE.Component entities (notes: "extracted via regex;
+// heuristic"). They never reached the canonical synthesis path that ASP.NET Core
+// gets from synthesizeASPNetCore (#2692), so their Routing cells
+// (endpoint_synthesis / route_extraction / handler_attribution) stayed `partial`
+// while aspnet-core was `full`, and no http_endpoint_definition node was ever
+// produced — meaning cross-repo linking, response-shape/auth stamping and the
+// request/response-shape substrate (which keys off the synthesized endpoint)
+// could never join to these endpoints.
+//
+// This synthesizer promotes all four to the SAME canonical endpoint shape
+// synthesizeASPNetCore emits — `http:<VERB>:<path>` with a
+// `source_handler=SCOPE.Operation:<Class>.<Method>` attribution that
+// ResolveHTTPEndpointHandlers rebinds to the handler method (HANDLES edge) —
+// using each framework's idiomatic route-declaration syntax:
+//
+//   - Carter:        inside an `ICarterModule` whose `AddRoutes` method calls
+//     `app.MapGet("/path", ...)` / `MapPost` / `MapPut` /
+//     `MapDelete` / `MapPatch`. The enclosing module class is the
+//     handler (`<Module>.AddRoutes`); the minimal-API lambda has
+//     no named method, so the AddRoutes site is the attribution.
+//
+//   - FastEndpoints: `class X : Endpoint<TReq[, TRes]>` whose `Configure()` body
+//     calls `Get("/path")` / `Post(...)` / ... . The endpoint
+//     class IS the handler — attribution is `<Class>.HandleAsync`
+//     (FastEndpoints' fixed handler-method name), or `<Class>`
+//     when no HandleAsync is present.
+//
+//   - NancyFX:       inside a `: NancyModule` subclass, route registrations are
+//     `Get["/path"]` (index syntax, Nancy 1.x) or `Get("/path")`
+//     (call syntax, Nancy 2.x). Both are gated on the module's
+//     constructor being the handler (`<Module>` attribution — the
+//     route bodies are inline lambdas).
+//
+//   - ServiceStack:  a `[Route("/path", "GET POST")]` attribute decorates a
+//     request DTO; the matching `class XService : Service` exposes
+//     `Any/Get/Post(dto)` handler methods. The verb list comes
+//     from the Route attribute (defaulting to the handler methods
+//     present, else ANY→GET). Attribution is `<Service>.<Verb>`.
+//
+// The route-template `{id}` placeholders use the same canonicaliser as ASP.NET
+// Core (FrameworkASPNetCore), so `/widgets/{id:int}` → `/widgets/{id}` matches
+// the cross-stack endpoint shape. Detection is gated per-framework on a cheap
+// file-signal so the synthesizer no-ops on plain ASP.NET Core / gRPC / Blazor
+// C# files (which synthesizeASPNetCore / synthesizeHotChocolate already own).
+//
+// Refs #3962 (epic #3872, audit #3882). archigraph-csharp-parity.md §1a.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// File signals — fast pre-filters per framework.
+// ---------------------------------------------------------------------------
+
+// carterHasSignal reports a Carter file: the `ICarterModule` interface or the
+// `using Carter` import.
+func carterHasSignal(content string) bool {
+	return strings.Contains(content, "ICarterModule") ||
+		strings.Contains(content, "using Carter")
+}
+
+// fastEndpointsHasSignal reports a FastEndpoints file: an `Endpoint<` base
+// class or the `using FastEndpoints` import.
+func fastEndpointsHasSignal(content string) bool {
+	return strings.Contains(content, "using FastEndpoints") ||
+		strings.Contains(content, ": Endpoint<") ||
+		strings.Contains(content, ":Endpoint<")
+}
+
+// nancyHasSignal reports a NancyFX file: the `NancyModule` base class or the
+// `using Nancy` import.
+func nancyHasSignal(content string) bool {
+	return strings.Contains(content, "NancyModule") ||
+		strings.Contains(content, "using Nancy")
+}
+
+// serviceStackHasSignal reports a ServiceStack file: the `using ServiceStack`
+// import (the `: Service` base class alone is too generic to gate on).
+func serviceStackHasSignal(content string) bool {
+	return strings.Contains(content, "using ServiceStack")
+}
+
+// ---------------------------------------------------------------------------
+// Carter
+// ---------------------------------------------------------------------------
+
+// carterModuleRe matches `class X : ICarterModule` (allowing other bases).
+// Capture group 1 = module class name.
+var carterModuleRe = regexp.MustCompile(
+	`(?m)class\s+(\w+)\s*:\s*(?:\w+\s*,\s*)*ICarterModule\b`,
+)
+
+// carterMapRouteRe matches `app.MapGet("/path", ...)` etc. (any receiver
+// identifier, not just `app`). Capture group 1 = verb; group 2 = path.
+var carterMapRouteRe = regexp.MustCompile(
+	`\b\w+\.Map(Get|Post|Put|Delete|Patch)\s*\(\s*["']([^"']+)["']`,
+)
+
+// synthesizeCarter emits one canonical endpoint per `app.MapVerb("/path")`
+// route declared in an ICarterModule file, attributed to the enclosing
+// module's AddRoutes method.
+func synthesizeCarter(content string, emit emitFn) {
+	if !carterHasSignal(content) {
+		return
+	}
+	module := ""
+	if m := carterModuleRe.FindStringSubmatch(content); len(m) >= 2 {
+		module = m[1]
+	}
+	if module == "" {
+		// No ICarterModule class in this file — the Map* calls (if any) are
+		// plain minimal-API, owned by a future minimal-API synthesizer, not
+		// Carter. Stay conservative and emit nothing.
+		return
+	}
+	handler := module + ".AddRoutes"
+	for _, m := range carterMapRouteRe.FindAllStringSubmatch(content, -1) {
+		verb := strings.ToUpper(m[1])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkASPNetCore, m[2])
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "carter", "SCOPE.Operation", handler)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FastEndpoints
+// ---------------------------------------------------------------------------
+
+// feEndpointClassRe matches `class X : Endpoint<...>` (with optional generics
+// and additional interfaces). Capture group 1 = endpoint class name.
+var feEndpointClassRe = regexp.MustCompile(
+	`(?m)class\s+(\w+)\s*:\s*Endpoint\s*<`,
+)
+
+// feRouteRe matches a verb route registration `Get("/path")` / `Post("/path")`
+// inside an endpoint's Configure() body. Capture group 1 = verb; group 2 = path.
+// The leading boundary `(?:[^.\w]|^)` excludes `client.Get(...)`-style consumer
+// calls (those have a `.` receiver) — FastEndpoints' Configure() calls the
+// verb helpers bare (`Get("/x")`, `Verbs(...)`).
+var feRouteRe = regexp.MustCompile(
+	`(?m)(?:[^.\w]|^)(Get|Post|Put|Delete|Patch)\s*\(\s*["']([^"']+)["']`,
+)
+
+// synthesizeFastEndpoints emits one canonical endpoint per verb route declared
+// inside a `class X : Endpoint<...>` file. Each endpoint class owns its routes;
+// when the file declares a single endpoint class, all bare verb routes attribute
+// to it. The handler is the class's `HandleAsync` (FastEndpoints' fixed handler
+// method) when present, else the class itself.
+func synthesizeFastEndpoints(content string, emit emitFn) {
+	if !fastEndpointsHasSignal(content) {
+		return
+	}
+	classes := feEndpointClassRe.FindAllStringSubmatchIndex(content, -1)
+	if len(classes) == 0 {
+		return
+	}
+	// Attribute each bare verb route to the endpoint class whose declaration
+	// most-immediately precedes it (single-endpoint-per-file is the dominant
+	// case; multiple endpoints per file resolve by nearest-preceding class).
+	for _, rm := range feRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := strings.ToUpper(content[rm[2]:rm[3]])
+		path := content[rm[4]:rm[5]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkASPNetCore, path)
+		if canonical == "" {
+			continue
+		}
+		className := feNearestPrecedingClass(classes, content, rm[0])
+		if className == "" {
+			continue
+		}
+		handler := className
+		if strings.Contains(feClassBody(content, classes, className), "HandleAsync") {
+			handler = className + ".HandleAsync"
+		}
+		emit(verb, canonical, "fastendpoints", "SCOPE.Operation", handler)
+	}
+}
+
+// feNearestPrecedingClass returns the name of the endpoint class whose match
+// start is the greatest that is still ≤ off. Returns "" when off precedes every
+// class (route before any endpoint declaration).
+func feNearestPrecedingClass(classes [][]int, content string, off int) string {
+	name := ""
+	best := -1
+	for _, c := range classes {
+		if c[0] <= off && c[0] > best {
+			best = c[0]
+			name = content[c[2]:c[3]]
+		}
+	}
+	return name
+}
+
+// feClassBody returns the source from the named class declaration to the next
+// endpoint-class declaration (or EOF), used only to test for a `HandleAsync`
+// handler method. Approximate (no brace-balance) but sufficient for the
+// handler-name heuristic.
+func feClassBody(content string, classes [][]int, className string) string {
+	start, end := -1, len(content)
+	for i, c := range classes {
+		if content[c[2]:c[3]] == className {
+			start = c[0]
+			if i+1 < len(classes) {
+				end = classes[i+1][0]
+			}
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	return content[start:end]
+}
+
+// ---------------------------------------------------------------------------
+// NancyFX
+// ---------------------------------------------------------------------------
+
+// nancyModuleRe matches `class X : NancyModule`. Capture group 1 = module name.
+var nancyModuleRe = regexp.MustCompile(
+	`(?m)class\s+(\w+)\s*:\s*NancyModule\b`,
+)
+
+// nancyIndexRouteRe matches `Get["/path"]` index-syntax routes (Nancy 1.x).
+// Capture group 1 = verb; group 2 = path.
+var nancyIndexRouteRe = regexp.MustCompile(
+	`\b(Get|Post|Put|Delete|Patch|Head|Options)\s*\[\s*["']([^"']+)["']\s*\]`,
+)
+
+// nancyCallRouteRe matches `Get("/path", ...)` call-syntax routes (Nancy 2.x).
+// Capture group 1 = verb; group 2 = path.
+var nancyCallRouteRe = regexp.MustCompile(
+	`\b(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*["']([^"']+)["']`,
+)
+
+// synthesizeNancy emits one canonical endpoint per route registered inside a
+// `: NancyModule` subclass (both index `Get["/x"]` and call `Get("/x")` styles).
+// Attribution is the module class — Nancy routes are inline lambdas assigned in
+// the module constructor, so the module IS the handler.
+func synthesizeNancy(content string, emit emitFn) {
+	if !nancyHasSignal(content) {
+		return
+	}
+	m := nancyModuleRe.FindStringSubmatch(content)
+	if len(m) < 2 {
+		// No NancyModule class — the bare verb-call patterns would collide with
+		// FastEndpoints / consumer calls; emit nothing without the module gate.
+		return
+	}
+	module := m[1]
+	emitRoute := func(verb, path string) {
+		canonical := httproutes.Canonicalize(httproutes.FrameworkASPNetCore, path)
+		if canonical == "" {
+			return
+		}
+		emit(strings.ToUpper(verb), canonical, "nancyfx", "SCOPE.Operation", module)
+	}
+	for _, rm := range nancyIndexRouteRe.FindAllStringSubmatch(content, -1) {
+		emitRoute(rm[1], rm[2])
+	}
+	// Call-syntax is only emitted inside a NancyModule file (the module gate
+	// above) to avoid colliding with FastEndpoints' bare `Get("/x")`.
+	for _, rm := range nancyCallRouteRe.FindAllStringSubmatch(content, -1) {
+		emitRoute(rm[1], rm[2])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ServiceStack
+// ---------------------------------------------------------------------------
+
+// ssRouteAttrRe matches `[Route("/path")]` or `[Route("/path", "GET POST")]`.
+// Capture group 1 = path; group 2 = optional verb string.
+var ssRouteAttrRe = regexp.MustCompile(
+	`\[Route\s*\(\s*["']([^"']+)["'](?:\s*,\s*["']([^"']*)["'])?\s*\)\s*\]`,
+)
+
+// ssServiceClassRe matches `class XService : Service` (or any base list ending
+// in Service). Capture group 1 = service class name.
+var ssServiceClassRe = regexp.MustCompile(
+	`(?m)class\s+(\w+)\s*:\s*(?:\w+\s*,\s*)*Service\b`,
+)
+
+// ssHandlerMethodRe matches a ServiceStack handler method `public T Any(...)` /
+// `Get` / `Post` / ... . Capture group 1 = verb (Any/Get/Post/...).
+var ssHandlerMethodRe = regexp.MustCompile(
+	`(?m)public\s+\S+\s+(Any|Get|Post|Put|Delete|Patch)\s*\(`,
+)
+
+// synthesizeServiceStack emits canonical endpoints from `[Route("/path","VERBS")]`
+// attributes. The verb list is taken from the attribute when present; otherwise
+// it is inferred from the handler methods present on the service class (`Any`
+// expands to GET+POST+PUT+DELETE? — kept conservative as a single ANY→GET), and
+// finally defaults to GET. Attribution is `<Service>.<Verb>` when a service class
+// exists in the file, else the request-DTO-derived route stands alone.
+func synthesizeServiceStack(content string, emit emitFn) {
+	if !serviceStackHasSignal(content) {
+		return
+	}
+	routes := ssRouteAttrRe.FindAllStringSubmatch(content, -1)
+	if len(routes) == 0 {
+		return
+	}
+	service := ""
+	if m := ssServiceClassRe.FindStringSubmatch(content); len(m) >= 2 {
+		service = m[1]
+	}
+	// Raw handler-method names present on the service (Any/Get/Post/...), used
+	// both to infer verbs when a Route attribute omits its verb string and to
+	// pick the handler-method name attributed to each emitted endpoint.
+	handlerMethods := ssHandlerMethodNames(content)
+	handlerVerbs := ssVerbsFromHandlers(handlerMethods)
+
+	for _, rm := range routes {
+		path := rm[1]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkASPNetCore, path)
+		if canonical == "" {
+			continue
+		}
+		verbs := ssParseRouteVerbs(rm[2])
+		if len(verbs) == 0 {
+			verbs = handlerVerbs
+		}
+		if len(verbs) == 0 {
+			verbs = []string{"GET"}
+		}
+		for _, verb := range verbs {
+			handler := ""
+			if service != "" {
+				handler = service + "." + ssHandlerForVerb(verb, handlerMethods)
+			}
+			if handler != "" {
+				emit(verb, canonical, "servicestack", "SCOPE.Operation", handler)
+			} else {
+				emit(verb, canonical, "servicestack", "", "")
+			}
+		}
+	}
+}
+
+// ssParseRouteVerbs splits a ServiceStack Route verb string ("GET POST") into
+// upper-cased tokens. An empty or "ANY" verb string returns nil so the caller
+// falls back to handler-derived verbs.
+func ssParseRouteVerbs(verbStr string) []string {
+	verbStr = strings.TrimSpace(verbStr)
+	if verbStr == "" || strings.EqualFold(verbStr, "ANY") {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Fields(verbStr) {
+		if up := strings.ToUpper(p); up != "" {
+			out = append(out, up)
+		}
+	}
+	return out
+}
+
+// ssHandlerMethodNames returns the raw handler-method names present on the
+// service (the literal `Any` / `Get` / `Post` / ... method identifiers),
+// de-duplicated and in source order.
+func ssHandlerMethodNames(content string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range ssHandlerMethodRe.FindAllStringSubmatch(content, -1) {
+		// m[1] is already a Title-cased method token (Any/Get/Post/...).
+		name := m[1]
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// ssVerbsFromHandlers maps handler-method names to the HTTP verbs they serve.
+// A literal `Any` method is the catch-all, conservatively counted as GET (the
+// Route attribute is the authoritative verb source when present, so this only
+// matters for attribute-less routes).
+func ssVerbsFromHandlers(handlerMethods []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, name := range handlerMethods {
+		verb := strings.ToUpper(name)
+		if verb == "ANY" {
+			verb = "GET"
+		}
+		if !seen[verb] {
+			seen[verb] = true
+			out = append(out, verb)
+		}
+	}
+	return out
+}
+
+// ssHandlerForVerb returns the handler-method name that serves the given verb:
+// the verb's own `Get`/`Post`/... method when the service declares one,
+// otherwise `Any` (ServiceStack's catch-all handler). When the service declares
+// NEITHER a verb-specific method NOR `Any`, the verb-titled name is returned as
+// a best-effort attribution target.
+func ssHandlerForVerb(verb string, handlerMethods []string) string {
+	titled := strings.Title(strings.ToLower(verb)) //nolint:staticcheck // ASCII verb tokens; Title is fine.
+	hasAny := false
+	for _, name := range handlerMethods {
+		if name == titled {
+			return titled
+		}
+		if name == "Any" {
+			hasAny = true
+		}
+	}
+	if hasAny {
+		return "Any"
+	}
+	return titled
+}

--- a/internal/engine/http_endpoint_csharp_minor_test.go
+++ b/internal/engine/http_endpoint_csharp_minor_test.go
@@ -1,0 +1,230 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// csMinorEndpoint looks up the synthesized http_endpoint_definition with the
+// given canonical ID in a DetectResult and returns it. nil when absent.
+func csMinorEndpoint(res *DetectResult, id string) *types.EntityRecord {
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		if e.ID == id && (e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointKind) {
+			return e
+		}
+	}
+	return nil
+}
+
+// requireCSMinorEndpoint asserts a canonical endpoint exists AND carries the
+// expected framework + source_handler attribution — the specific #3962
+// capability artifact (canonical synthesis + handler_attribution), not len>0.
+func requireCSMinorEndpoint(t *testing.T, res *DetectResult, id, wantFramework, wantHandler string) {
+	t.Helper()
+	e := csMinorEndpoint(res, id)
+	if e == nil {
+		t.Fatalf("missing canonical endpoint %q", id)
+	}
+	if got := e.Properties["framework"]; got != wantFramework {
+		t.Errorf("%s: framework=%q want %q", id, got, wantFramework)
+	}
+	if wantHandler != "" {
+		if got := e.Properties["source_handler"]; got != wantHandler {
+			t.Errorf("%s: source_handler=%q want %q", id, got, wantHandler)
+		}
+	}
+}
+
+// TestSynth_Carter covers app.MapVerb routes inside an ICarterModule.
+func TestSynth_Carter(t *testing.T) {
+	src := `using Carter;
+public class WidgetsModule : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/widgets", () => Results.Ok());
+        app.MapGet("/widgets/{id:int}", (int id) => Results.Ok());
+        app.MapPost("/widgets", (CreateWidget req) => Results.Ok());
+        app.MapDelete("/widgets/{id}", (int id) => Results.NoContent());
+    }
+}`
+	ids, res := runDetect(t, "csharp", "WidgetsModule.cs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/widgets",
+		"http:GET:/widgets/{id}",
+		"http:POST:/widgets",
+		"http:DELETE:/widgets/{id}",
+	}, "carter")
+	requireCSMinorEndpoint(t, res, "http:POST:/widgets", "carter", "SCOPE.Operation:WidgetsModule.AddRoutes")
+}
+
+// TestSynth_FastEndpoints covers Endpoint<TReq> + bare verb routes in Configure().
+func TestSynth_FastEndpoints(t *testing.T) {
+	src := `using FastEndpoints;
+public class CreateWidgetEndpoint : Endpoint<CreateWidgetReq, WidgetRes>
+{
+    public override void Configure()
+    {
+        Post("/widgets");
+        AllowAnonymous();
+    }
+    public override async Task HandleAsync(CreateWidgetReq req, CancellationToken ct) { }
+}`
+	ids, res := runDetect(t, "csharp", "CreateWidgetEndpoint.cs", src)
+	requireContains(t, ids, []string{"http:POST:/widgets"}, "fastendpoints")
+	requireCSMinorEndpoint(t, res, "http:POST:/widgets", "fastendpoints",
+		"SCOPE.Operation:CreateWidgetEndpoint.HandleAsync")
+}
+
+// TestSynth_FastEndpoints_NoHandleAsync attributes to the class when no
+// HandleAsync method is present (handler-name heuristic fallback).
+func TestSynth_FastEndpoints_NoHandleAsync(t *testing.T) {
+	src := `using FastEndpoints;
+public class ListWidgetsEndpoint : EndpointWithoutRequest<List<WidgetRes>>
+{
+    public override void Configure()
+    {
+        Get("/widgets");
+    }
+}`
+	// EndpointWithoutRequest still trips the signal via the using import; but the
+	// class regex requires Endpoint< — provide the generic base to exercise the path.
+	src = `using FastEndpoints;
+public class ListWidgetsEndpoint : Endpoint<EmptyRequest, List<WidgetRes>>
+{
+    public override void Configure()
+    {
+        Get("/widgets");
+    }
+}`
+	_, res := runDetect(t, "csharp", "ListWidgetsEndpoint.cs", src)
+	requireCSMinorEndpoint(t, res, "http:GET:/widgets", "fastendpoints",
+		"SCOPE.Operation:ListWidgetsEndpoint")
+}
+
+// TestSynth_Nancy covers both index `Get["/x"]` and call `Get("/x")` syntax.
+func TestSynth_Nancy(t *testing.T) {
+	src := `using Nancy;
+public class WidgetsModule : NancyModule
+{
+    public WidgetsModule()
+    {
+        Get["/widgets"] = _ => 200;
+        Post("/widgets", args => CreateWidget(args));
+        Delete["/widgets/{id}"] = args => 204;
+    }
+}`
+	ids, res := runDetect(t, "csharp", "WidgetsModule.cs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/widgets",
+		"http:POST:/widgets",
+		"http:DELETE:/widgets/{id}",
+	}, "nancy")
+	requireCSMinorEndpoint(t, res, "http:GET:/widgets", "nancyfx", "SCOPE.Operation:WidgetsModule")
+}
+
+// TestSynth_ServiceStack covers [Route("/path","VERBS")] + : Service handlers.
+func TestSynth_ServiceStack(t *testing.T) {
+	src := `using ServiceStack;
+
+[Route("/widgets", "GET POST")]
+public class WidgetRequest { public int Id { get; set; } }
+
+[Route("/widgets/{Id}", "GET")]
+public class WidgetByIdRequest { public int Id { get; set; } }
+
+public class WidgetService : Service
+{
+    public object Get(WidgetRequest req) => null;
+    public object Post(WidgetRequest req) => null;
+}`
+	ids, res := runDetect(t, "csharp", "WidgetService.cs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/widgets",
+		"http:POST:/widgets",
+		"http:GET:/widgets/{Id}",
+	}, "servicestack")
+	requireCSMinorEndpoint(t, res, "http:POST:/widgets", "servicestack",
+		"SCOPE.Operation:WidgetService.Post")
+	// GET maps to the Get handler.
+	requireCSMinorEndpoint(t, res, "http:GET:/widgets", "servicestack",
+		"SCOPE.Operation:WidgetService.Get")
+}
+
+// TestSynth_ServiceStack_AnyHandler — a [Route] with no explicit verb string
+// and only an `Any` handler defaults to GET attributed to `.Any`.
+func TestSynth_ServiceStack_AnyHandler(t *testing.T) {
+	src := `using ServiceStack;
+
+[Route("/ping")]
+public class PingRequest {}
+
+public class PingService : Service
+{
+    public object Any(PingRequest req) => "pong";
+}`
+	_, res := runDetect(t, "csharp", "PingService.cs", src)
+	requireCSMinorEndpoint(t, res, "http:GET:/ping", "servicestack", "SCOPE.Operation:PingService.Any")
+}
+
+// ---------------------------------------------------------------------------
+// Negatives — the synthesizers must NOT fire on the wrong frameworks.
+// ---------------------------------------------------------------------------
+
+// TestSynth_CSMinor_NoSignal_NoOp — a plain ASP.NET Core controller must NOT
+// be claimed by any of the four minor synthesizers (only aspnet_core owns it).
+func TestSynth_CSMinor_NoSignal_NoOp(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("/api/widgets")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet] public IActionResult List() => Ok();
+}`
+	_, res := runDetect(t, "csharp", "WidgetsController.cs", src)
+	// The single endpoint must be attributed to aspnet_core, never carter/etc.
+	e := csMinorEndpoint(res, "http:GET:/api/widgets")
+	if e == nil {
+		t.Fatalf("aspnet endpoint missing")
+	}
+	if fw := e.Properties["framework"]; fw != "aspnet_core" {
+		t.Errorf("aspnet endpoint mis-attributed to framework=%q", fw)
+	}
+}
+
+// TestSynth_Carter_NoModule_NoOp — bare app.MapGet outside an ICarterModule
+// (plain minimal-API) must NOT be claimed by the Carter synthesizer.
+func TestSynth_Carter_NoModule_NoOp(t *testing.T) {
+	src := `using Carter;
+var app = builder.Build();
+app.MapGet("/health", () => "ok");`
+	_, res := runDetect(t, "csharp", "Program.cs", src)
+	if e := csMinorEndpoint(res, "http:GET:/health"); e != nil && e.Properties["framework"] == "carter" {
+		t.Errorf("minimal-API route mis-claimed by Carter synthesizer: %v", e.Properties)
+	}
+}
+
+// TestSynth_FastEndpoints_NoConsumerCall — a `client.Get("/x")` HttpClient
+// consumer call must NOT be mistaken for a FastEndpoints producer route.
+func TestSynth_FastEndpoints_NoConsumerCall(t *testing.T) {
+	src := `using FastEndpoints;
+public class CreateWidgetEndpoint : Endpoint<CreateWidgetReq>
+{
+    public override void Configure() { Post("/widgets"); }
+    public override async Task HandleAsync(CreateWidgetReq req, CancellationToken ct)
+    {
+        var other = await httpClient.Get("/downstream");
+    }
+}`
+	_, res := runDetect(t, "csharp", "CreateWidgetEndpoint.cs", src)
+	// The producer route fires.
+	requireCSMinorEndpoint(t, res, "http:POST:/widgets", "fastendpoints",
+		"SCOPE.Operation:CreateWidgetEndpoint.HandleAsync")
+	// The `.Get("/downstream")` receiver-call must NOT be a fastendpoints producer.
+	if e := csMinorEndpoint(res, "http:GET:/downstream"); e != nil && e.Properties["framework"] == "fastendpoints" {
+		t.Errorf("consumer .Get call mis-claimed as FastEndpoints producer route: %v", e.Properties)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -875,6 +875,20 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// resolver's typed-arg request shape + typed-return response shape.
 		// Mutates Properties in place; never adds/removes entities.
 		applyHotChocolateAuthShapes(string(content), path, entities, hcBefore)
+		// Producer side (#3962, epic #3872): promote the four .NET minor HTTP
+		// frameworks — Carter (app.MapVerb in ICarterModule.AddRoutes),
+		// FastEndpoints (Endpoint<TReq> + Verb("/path") in Configure()), NancyFX
+		// (Get["/path"] / Get("/path") in : NancyModule) and ServiceStack
+		// ([Route("/path","VERBS")] + : Service handlers) — from the regex-only
+		// SCOPE.Operation path (internal/custom/csharp/minor_routes.go) to the
+		// SAME canonical http_endpoint_definition shape synthesizeASPNetCore
+		// emits, so their Routing cells reach parity and the request/response
+		// shape substrate (which keys off the synthesized endpoint) can join.
+		// Each is file-signal-gated so it no-ops on plain ASP.NET Core files.
+		synthesizeCarter(string(content), emit)
+		synthesizeFastEndpoints(string(content), emit)
+		synthesizeNancy(string(content), emit)
+		synthesizeServiceStack(string(content), emit)
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	case "rust":


### PR DESCRIPTION
## Scope (#3962, epic #3872, audit #3882)

The ticket asks to **promote Carter / FastEndpoints / NancyFX / ServiceStack from regex-only to canonical endpoint synthesis**. All four were served only by `internal/custom/csharp/minor_routes.go` (notes: "extracted via regex; heuristic"), emitting raw `SCOPE.Operation` entities — they never reached the canonical `http_endpoint_definition` path that ASP.NET Core gets from `synthesizeASPNetCore` (#2692). So their Routing cells were `partial` while aspnet-core was `full`, and no canonical endpoint node existed for cross-repo linking / shape substrate to join.

> Note: the dispatching prompt guessed this ticket was about HotChocolate; it is not. HotChocolate (#3961/#3988) is already covered. This PR implements the actual #3962 scope.

## What changed

New `internal/engine/http_endpoint_csharp_minor.go` — four file-signal-gated synthesizers dispatched in the `csharp` case of `http_endpoint_synthesis.go`, each emitting the SAME `http:<VERB>:<path>` shape `synthesizeASPNetCore` emits (same `FrameworkASPNetCore` canonicaliser) with a `source_handler` attribution:

| Framework | Route syntax | `source_handler` |
|---|---|---|
| Carter | `app.MapVerb("/path")` in an `ICarterModule` | `<Module>.AddRoutes` |
| FastEndpoints | bare `Verb("/path")` in `class X : Endpoint<TReq>` | `<Class>.HandleAsync` (or `<Class>`) |
| NancyFX | `Get["/path"]` / `Get("/path")` in `: NancyModule` | `<Module>` |
| ServiceStack | `[Route("/path","VERBS")]` + `: Service` handlers | `<Service>.<HandlerMethod>` |

## VERIFY-FIRST

A probe proved all four produced **ZERO** canonical `http:` endpoints before the fix. Value-asserting tests assert the specific canonical ID + `framework` + `source_handler` per construct, with negatives:
- plain ASP.NET controller stays `aspnet_core`, not mis-claimed;
- a minimal-API `app.MapGet` **outside** an `ICarterModule` is not claimed by Carter;
- a consumer `client.Get("/x")` is not mistaken for a FastEndpoints producer route.

## Credited cells (honest)

`endpoint_synthesis`, `handler_attribution`, `route_extraction` flipped `partial → full` for all four frameworks.

**NOT credited** (would be dishonest): `request/response_shape`, `dto_extraction`, `request_validation`, `schema_drift`. A substrate probe confirmed the C# payload-shape sniffer (keyed on `[FromBody]` / anonymous-object initializers) produces **ZERO** shapes on idiomatic FastEndpoints (`Endpoint<TReq>` binding) / ServiceStack (typed request-DTO param) — those don't use `[FromBody]`. That's genuine follow-on work, not landed here.

## Gates
- `go test` targeted green: engine, substrate, custom/csharp, types, tools/coverage
- `go test ./internal/types/` green (no new edge Kind added — reuses `httpEndpointDefinitionKind`)
- `gofmt -l` empty; `go vet` clean
- coverage `validate` 0 errors; `fmt --check` canonical; `gen` → detail pages regenerated, 0 unexpected drift

DEPLOY-DEFERRED.

Closes #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)