### PR TITLE
feat(mro): Ruby mixins + PHP traits → defining body (T8 #3840)

### DIFF
--- a/internal/extractors/cross/hierarchy/extractor.go
+++ b/internal/extractors/cross/hierarchy/extractor.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -107,6 +108,34 @@ var pyInterfaceBases = map[string]bool{
 
 // Ruby: class Foo < Bar
 var rubyClassRE = regexp.MustCompile(`(?m)^class\s+(\w+)\s*<\s*([\w:]+)`)
+
+// Ruby: opening of a class OR module declaration (with or without a superclass).
+// Captures the keyword (class|module) and the declared name so the mixin pass
+// can attribute an `include`/`prepend`/`extend` to the lexically enclosing
+// class/module. Anchored at column 0 OR after leading indentation so nested
+// declarations are still recognised.
+var rubyClassOrModuleRE = regexp.MustCompile(`(?m)^[ \t]*(class|module)\s+(\w+)`)
+
+// Ruby: `end` keyword on its own line — used to track the lexical scope stack
+// so `include` is attributed to the innermost open class/module.
+var rubyEndRE = regexp.MustCompile(`(?m)^[ \t]*end\b`)
+
+// Ruby mixin: `include M`, `prepend M`, `extend M`. The op group selects the
+// precedence (#3840): prepend wins over the class's own method, include/extend
+// lose to it. Captures a single constant path (Foo or Foo::Bar). Multiple
+// modules on one line (`include A, B`) are split downstream.
+var rubyMixinRE = regexp.MustCompile(`(?m)^[ \t]*(include|prepend|extend)\s+([\w:][\w:,\s]*?)[ \t]*$`)
+
+// PHP trait usage inside a class/trait body: `use Audit;`, `use A, B;`,
+// `use Audit { foo as bar; }` (#3840). The leading delimiter ensures we don't
+// match a substring; the names group captures one or more comma-separated trait
+// names (FQ or leaf). A trailing `{ ... }` adaptation block or `;` terminates.
+// Distinguished from a top-level namespace import (`use Foo\Bar;`) by being
+// matched only within class/trait brace scope (see extractPHPTraits).
+var phpTraitUseRE = regexp.MustCompile(`(?m)(?:^|[\s;{])use\s+([\\\w][\\\w,\s]*?)\s*(?:\{|;)`)
+
+// PHP class OR trait declaration opener (name only) — anchors trait-use scope.
+var phpClassOpenRE = regexp.MustCompile(`(?:^|[\s;{])(?:abstract\s+|final\s+)?(?:class|trait)\s+(\w+)`)
 
 // Go embedded struct:
 // type Foo struct { ... Bar ... *Baz ... }
@@ -557,6 +586,219 @@ func extractRuby(source, filePath string, res *result) {
 		})
 		res.extendsFound++
 	}
+
+	extractRubyMixins(source, filePath, res)
+}
+
+// extractRubyMixins emits an IMPLEMENTS edge for every `include`/`prepend`/
+// `extend M` mixin, from the lexically-enclosing class/module to the mixed-in
+// module (#3840, epic #3829 MRO T8). It models the SAME member-promotion
+// semantics as Java interface defaults: the MCP MRO walk (extendsBases) already
+// follows IMPLEMENTS and only resolves a member when the module declares it
+// with a REAL body, so an external/unindexed module falls through to
+// honest-unresolved (no fabrication).
+//
+// We reuse IMPLEMENTS (not a new edge kind) — same choice Rust trait_impl makes
+// — and tag the edge `kind=ruby_mixin` + `mixin_op` so the precedence is
+// recoverable. Resolution is name-based (base_name = the module's leaf
+// constant), matching how Ruby methods are keyed (Module.member) downstream.
+//
+// Scope attribution: Ruby has no braces, so we track a lexical stack by scanning
+// class/module openers and `end` closers in source order; a mixin is attributed
+// to the innermost open class/module. A mixin at file top-level (no enclosing
+// class) is skipped — there is nothing to attach the promoted member to.
+func extractRubyMixins(source, filePath string, res *result) {
+	type tok struct {
+		pos  int
+		kind string // "open" | "end" | "include" | "prepend" | "extend"
+		name string // class/module name for "open"; module list for a mixin
+	}
+	var toks []tok
+	for _, im := range rubyClassOrModuleRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
+		toks = append(toks, tok{pos: im[0], kind: "open", name: m[2]})
+	}
+	for _, im := range rubyEndRE.FindAllStringIndex(source, -1) {
+		toks = append(toks, tok{pos: im[0], kind: "end"})
+	}
+	for _, im := range rubyMixinRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
+		toks = append(toks, tok{pos: im[0], kind: m[1], name: m[2]})
+	}
+	// Source order is the lexical order for the stack machine.
+	sort.SliceStable(toks, func(i, j int) bool { return toks[i].pos < toks[j].pos })
+
+	var stack []string // enclosing class/module names, innermost last
+	for _, tk := range toks {
+		switch tk.kind {
+		case "open":
+			stack = append(stack, tk.name)
+		case "end":
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		default: // include | prepend | extend
+			if len(stack) == 0 {
+				// Top-level mixin — no enclosing class to attach to. Skip rather
+				// than fabricate an owner.
+				continue
+			}
+			owner := stack[len(stack)-1]
+			clsID := classRef(filePath, owner, "ruby")
+			for _, modRaw := range strings.Split(tk.name, ",") {
+				modName := strings.TrimSpace(modRaw)
+				if modName == "" || modName == "self" {
+					// `extend self` / `include self` is a self-mixin, not a
+					// cross-module member promotion — nothing to resolve.
+					continue
+				}
+				modLeaf := rubyConstLeaf(modName)
+				modID := ifaceRef(modLeaf, "ruby")
+				res.addEntity(types.EntityRecord{
+					Name: modLeaf, Kind: "SCOPE.Component", Subtype: "module",
+					SourceFile: filePath, Language: "ruby",
+					Properties: map[string]string{
+						"role": "module", "ref": modID,
+						"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
+					},
+					QualityScore: 0.9,
+				})
+				res.addRel(clsID, modID, "IMPLEMENTS", map[string]string{
+					"language":  "ruby",
+					"kind":      "ruby_mixin",
+					"mixin_op":  tk.kind,
+					"base_name": modLeaf,
+				})
+				res.implementsFound++
+			}
+		}
+	}
+}
+
+// rubyConstLeaf returns the trailing constant of a `Foo::Bar::Baz` path. Ruby
+// methods are keyed by their bare module/class leaf downstream, so the
+// base_name must be the leaf for the MRO walk to match Module.member.
+func rubyConstLeaf(s string) string {
+	if i := strings.LastIndex(s, "::"); i >= 0 {
+		return s[i+2:]
+	}
+	return s
+}
+
+// extractPHPTraits emits an IMPLEMENTS edge for every `use Trait;` statement
+// inside a class/trait body, from the enclosing class to the used trait (#3840,
+// epic #3829 MRO T8). Same member-promotion model as the Ruby mixin / Java
+// interface-default path: the MCP MRO walk follows IMPLEMENTS and only resolves
+// a member when the trait declares it with a REAL body (the PHP extractor emits
+// trait methods as Trait.method), so an external/unindexed trait falls through
+// to honest-unresolved — never fabricated.
+//
+// Reuses IMPLEMENTS (no new edge kind) tagged kind=php_trait. The challenge is
+// disambiguating a TRAIT use from a top-level namespace import (`use Foo\Bar;`),
+// which shares the `use` keyword: a trait use lives INSIDE a class/trait brace
+// scope, an import lives at file/namespace scope. We track brace depth and the
+// innermost enclosing class to attribute the trait correctly; a `use` at depth 0
+// is an import and is ignored here (the PHP extractor already emits it as
+// IMPORTS).
+func extractPHPTraits(source, filePath string, res *result) {
+	type frame struct {
+		name  string
+		depth int // brace depth at which this class's body opened
+	}
+	var stack []frame
+
+	type opener struct {
+		pos  int
+		name string
+	}
+	var openers []opener
+	for _, im := range phpClassOpenRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 2)
+		openers = append(openers, opener{pos: im[0], name: m[1]})
+	}
+	oi := 0
+
+	type useTok struct {
+		pos   int
+		names string
+	}
+	var uses []useTok
+	for _, im := range phpTraitUseRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 2)
+		uses = append(uses, useTok{pos: im[0], names: m[1]})
+	}
+	ui := 0
+
+	depth := 0
+	pendingClass := "" // class name awaiting its opening brace
+	for pos := 0; pos < len(source); pos++ {
+		for oi < len(openers) && openers[oi].pos <= pos {
+			pendingClass = openers[oi].name
+			oi++
+		}
+		ch := source[pos]
+		switch ch {
+		case '{':
+			depth++
+			if pendingClass != "" {
+				stack = append(stack, frame{name: pendingClass, depth: depth})
+				pendingClass = ""
+			}
+		case '}':
+			if len(stack) > 0 && stack[len(stack)-1].depth == depth {
+				stack = stack[:len(stack)-1]
+			}
+			if depth > 0 {
+				depth--
+			}
+		}
+		for ui < len(uses) && uses[ui].pos <= pos {
+			u := uses[ui]
+			ui++
+			if len(stack) == 0 {
+				continue // top-level import, not a trait use
+			}
+			owner := stack[len(stack)-1].name
+			clsID := classRef(filePath, owner, "php")
+			for _, traitRaw := range strings.Split(u.names, ",") {
+				traitName := strings.TrimSpace(traitRaw)
+				if traitName == "" {
+					continue
+				}
+				if traitName == "function" || traitName == "const" {
+					continue
+				}
+				traitLeaf := phpTraitLeaf(traitName)
+				traitID := ifaceRef(traitLeaf, "php")
+				res.addEntity(types.EntityRecord{
+					Name: traitLeaf, Kind: "SCOPE.Component", Subtype: "trait",
+					SourceFile: filePath, Language: "php",
+					Properties: map[string]string{
+						"role": "trait", "ref": traitID,
+						"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
+					},
+					QualityScore: 0.9,
+				})
+				res.addRel(clsID, traitID, "IMPLEMENTS", map[string]string{
+					"language":  "php",
+					"kind":      "php_trait",
+					"base_name": traitLeaf,
+				})
+				res.implementsFound++
+			}
+		}
+	}
+}
+
+// phpTraitLeaf returns the trailing segment of a `Foo\Bar\Audit` trait path.
+// PHP trait methods are keyed by the bare trait leaf downstream (Trait.method),
+// so the base_name must be the leaf for the MRO walk to match.
+func phpTraitLeaf(s string) string {
+	s = strings.TrimPrefix(s, "\\")
+	if i := strings.LastIndex(s, "\\"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 func extractGo(source, filePath string, res *result) {
@@ -805,6 +1047,11 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	case "java", "typescript", "javascript", "csharp", "kotlin", "scala", "dart", "php":
 		extractJTCSharp(source, file.Path, lang, res)
 		extractJTCInterface(source, file.Path, lang, res)
+		if lang == "php" {
+			// PHP traits (`class C { use T; }`) — member promotion via IMPLEMENTS
+			// (#3840). Only PHP has the trait-use syntax in this family.
+			extractPHPTraits(source, file.Path, res)
+		}
 	case "python":
 		// Issue #2603 — Django migration files are pruned by default.  The
 		// Python extractor already returns early for these files, but this

--- a/internal/extractors/cross/hierarchy/mixin_trait_3840_test.go
+++ b/internal/extractors/cross/hierarchy/mixin_trait_3840_test.go
@@ -1,0 +1,172 @@
+package hierarchy
+
+// mixin_trait_3840_test.go — Ruby mixin (`include`/`prepend`/`extend`) and PHP
+// trait (`use`) hierarchy-edge extraction (#3840, epic #3829 MRO T8).
+//
+// These assert the hierarchy extractor emits an IMPLEMENTS edge from the
+// enclosing class to the mixed-in module / used trait, carrying the
+// distinguishing kind + base_name the MCP MRO walk consumes. They are
+// value-asserting: they pin the FROM/TO names, the edge kind property, and the
+// mixin op (precedence) — not just "an edge exists".
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findImplements returns the first IMPLEMENTS edge whose base_name matches.
+func findImplements(recs []types.EntityRecord, baseName string) *types.RelationshipRecord {
+	for ri := range recs {
+		for rj := range recs[ri].Relationships {
+			r := &recs[ri].Relationships[rj]
+			if r.Kind == "IMPLEMENTS" && r.Properties["base_name"] == baseName {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// TestRubyInclude_EmitsImplementsToModule — `class User; include Greet; end`
+// emits IMPLEMENTS User -> Greet tagged ruby_mixin / include.
+func TestRubyInclude_EmitsImplementsToModule(t *testing.T) {
+	src := "module Greet\n  def hello\n  end\nend\n\nclass User\n  include Greet\nend\n"
+	got := runExtract(t, "ruby", "app/models/user.rb", src)
+
+	edge := findImplements(got, "Greet")
+	if edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge to Greet, got entities=%v", entityNames(got))
+	}
+	if edge.Properties["kind"] != "ruby_mixin" {
+		t.Errorf("kind=%q, want ruby_mixin", edge.Properties["kind"])
+	}
+	if edge.Properties["mixin_op"] != "include" {
+		t.Errorf("mixin_op=%q, want include", edge.Properties["mixin_op"])
+	}
+	if edge.FromID != classRef("app/models/user.rb", "User", "ruby") {
+		t.Errorf("FromID=%q, want User class ref", edge.FromID)
+	}
+	if edge.ToID != ifaceRef("Greet", "ruby") {
+		t.Errorf("ToID=%q, want Greet iface ref", edge.ToID)
+	}
+}
+
+// TestRubyPrepend_RecordsPrependOp — prepend precedence is recoverable from the
+// mixin_op property (prepend wins over the class's own method).
+func TestRubyPrepend_RecordsPrependOp(t *testing.T) {
+	src := "class User\n  prepend Loud\nend\n"
+	got := runExtract(t, "ruby", "user.rb", src)
+	edge := findImplements(got, "Loud")
+	if edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge to Loud")
+	}
+	if edge.Properties["mixin_op"] != "prepend" {
+		t.Errorf("mixin_op=%q, want prepend", edge.Properties["mixin_op"])
+	}
+}
+
+// TestRubyExtend_RecordsExtendOp — `extend M` is a singleton-class mixin; still
+// a member-promotion edge.
+func TestRubyExtend_RecordsExtendOp(t *testing.T) {
+	src := "class User\n  extend ClassMethods\nend\n"
+	got := runExtract(t, "ruby", "user.rb", src)
+	edge := findImplements(got, "ClassMethods")
+	if edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge to ClassMethods")
+	}
+	if edge.Properties["mixin_op"] != "extend" {
+		t.Errorf("mixin_op=%q, want extend", edge.Properties["mixin_op"])
+	}
+}
+
+// TestRubyMixin_NamespacedModule_UsesLeaf — `include Foo::Bar` resolves to the
+// leaf constant Bar (Ruby methods are keyed by their bare module leaf).
+func TestRubyMixin_NamespacedModule_UsesLeaf(t *testing.T) {
+	src := "class User\n  include Concerns::Auditable\nend\n"
+	got := runExtract(t, "ruby", "user.rb", src)
+	if edge := findImplements(got, "Auditable"); edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge with base_name=Auditable (leaf of Concerns::Auditable), got entities=%v", entityNames(got))
+	}
+}
+
+// TestRubyMixin_Nested_AttributedToInnermost — a mixin inside a nested class is
+// attributed to the innermost open class, not the outer module.
+func TestRubyMixin_Nested_AttributedToInnermost(t *testing.T) {
+	src := "module Outer\n  class Inner\n    include Greet\n  end\nend\n"
+	got := runExtract(t, "ruby", "n.rb", src)
+	edge := findImplements(got, "Greet")
+	if edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge to Greet")
+	}
+	if edge.FromID != classRef("n.rb", "Inner", "ruby") {
+		t.Errorf("FromID=%q, want Inner (innermost), not Outer", edge.FromID)
+	}
+}
+
+// TestRubyMixin_TopLevel_NoEdge — a mixin with no enclosing class produces no
+// edge (nothing to attach the promoted member to). Honest, no fabrication.
+func TestRubyMixin_TopLevel_NoEdge(t *testing.T) {
+	src := "include Kernel\n"
+	got := runExtract(t, "ruby", "top.rb", src)
+	if edge := findImplements(got, "Kernel"); edge != nil {
+		t.Errorf("top-level mixin should emit no IMPLEMENTS edge, got %+v", edge)
+	}
+}
+
+// TestPHPTrait_EmitsImplementsToTrait — `class Order { use Audit; }` emits
+// IMPLEMENTS Order -> Audit tagged php_trait.
+func TestPHPTrait_EmitsImplementsToTrait(t *testing.T) {
+	src := "<?php\ntrait Audit {\n  public function log() {}\n}\nclass Order {\n  use Audit;\n}\n"
+	got := runExtract(t, "php", "src/Order.php", src)
+
+	edge := findImplements(got, "Audit")
+	if edge == nil {
+		t.Fatalf("expected IMPLEMENTS edge to Audit, got entities=%v", entityNames(got))
+	}
+	if edge.Properties["kind"] != "php_trait" {
+		t.Errorf("kind=%q, want php_trait", edge.Properties["kind"])
+	}
+	if edge.FromID != classRef("src/Order.php", "Order", "php") {
+		t.Errorf("FromID=%q, want Order class ref", edge.FromID)
+	}
+	if edge.ToID != ifaceRef("Audit", "php") {
+		t.Errorf("ToID=%q, want Audit iface ref", edge.ToID)
+	}
+}
+
+// TestPHPTrait_MultipleAndNamespaced — `use A, B;` emits two edges; a
+// namespaced trait resolves to its leaf.
+func TestPHPTrait_MultipleAndNamespaced(t *testing.T) {
+	src := "<?php\nclass Order {\n  use Audit, App\\Traits\\Timestamps;\n}\n"
+	got := runExtract(t, "php", "Order.php", src)
+	if findImplements(got, "Audit") == nil {
+		t.Errorf("expected IMPLEMENTS to Audit")
+	}
+	if findImplements(got, "Timestamps") == nil {
+		t.Errorf("expected IMPLEMENTS to Timestamps (leaf of App\\Traits\\Timestamps)")
+	}
+}
+
+// TestPHPTrait_TopLevelImportNotTrait — a namespace import `use Foo\Bar;` at
+// file scope (NOT inside a class) must NOT become a trait IMPLEMENTS edge.
+func TestPHPTrait_TopLevelImportNotTrait(t *testing.T) {
+	src := "<?php\nnamespace App;\nuse Foo\\Bar;\nuse Psr\\Log\\LoggerInterface;\nclass Svc extends Base {\n}\n"
+	got := runExtract(t, "php", "Svc.php", src)
+	if edge := findImplements(got, "Bar"); edge != nil && edge.Properties["kind"] == "php_trait" {
+		t.Errorf("top-level import use Foo\\Bar must not be a php_trait edge, got %+v", edge)
+	}
+	if edge := findImplements(got, "LoggerInterface"); edge != nil && edge.Properties["kind"] == "php_trait" {
+		t.Errorf("top-level import must not be a php_trait edge, got %+v", edge)
+	}
+}
+
+// TestPHPTrait_WithAdaptationBlock — `use Audit { foo as bar; }` still emits the
+// trait edge (the adaptation block terminates the name list at `{`).
+func TestPHPTrait_WithAdaptationBlock(t *testing.T) {
+	src := "<?php\nclass Order {\n  use Audit { log as auditLog; }\n}\n"
+	got := runExtract(t, "php", "Order.php", src)
+	if findImplements(got, "Audit") == nil {
+		t.Fatalf("expected IMPLEMENTS to Audit even with adaptation block")
+	}
+}

--- a/internal/mcp/mro_mixin_trait_3840_test.go
+++ b/internal/mcp/mro_mixin_trait_3840_test.go
@@ -1,0 +1,244 @@
+package mcp
+
+// mro_mixin_trait_3840_test.go — value-asserting coverage for Ruby mixin
+// (`include`/`prepend`/`extend`) and PHP trait (`use`) member resolution
+// (#3840, epic #3829 MRO T8).
+//
+// T7 (#3987) generalised the MRO walk to follow IMPLEMENTS with a base_name FQN
+// and resolve a member to its DEFINING BODY cross-file, requiring a REAL body
+// (safe-by-construction). T8 emits Ruby-mixin / PHP-trait edges as IMPLEMENTS
+// (kind=ruby_mixin / php_trait), so the SAME walk promotes a module/trait
+// method into the including class. These tests model the post-index graph and
+// assert the inherited stub resolves to the SPECIFIC module/trait body in the
+// OTHER file — not len>0.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// rubyMixinDoc models `module Greet; def hello; ...; end; end` in greet.rb and
+// `class User; include Greet; end` in user.rb, where User.hello is a bodyless
+// inherited stub (User never declares hello). Greet.hello calls a helper, the
+// real promoted-through edge.
+func rubyMixinDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "mod", Name: "Greet", QualifiedName: "Greet",
+				Kind: "SCOPE.Component", Subtype: "module", SourceFile: "greet.rb",
+				StartLine: 1, EndLine: 5, Language: "ruby"},
+			{ID: "mod_hello", Name: "Greet.hello", QualifiedName: "Greet.hello",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "greet.rb",
+				StartLine: 2, EndLine: 4, Language: "ruby"},
+			{ID: "mod_fmt", Name: "Greet.format", QualifiedName: "Greet.format",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "greet.rb",
+				StartLine: 6, EndLine: 7, Language: "ruby"},
+			{ID: "cls", Name: "User", QualifiedName: "User",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "user.rb",
+				StartLine: 1, EndLine: 3, Language: "ruby"},
+			// Bodyless inherited stub: User mixes in Greet#hello.
+			{ID: "cls_hello", Name: "User.hello", QualifiedName: "User.hello",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "user.rb",
+				StartLine: 0, EndLine: 0, Language: "ruby", Signature: "def hello"},
+		},
+		Relationships: []graph.Relationship{
+			// include Greet -> IMPLEMENTS(kind=ruby_mixin) with base_name.
+			{ID: "e1", FromID: "cls", ToID: "mod", Kind: "IMPLEMENTS",
+				Properties: map[string]string{"language": "ruby", "kind": "ruby_mixin", "mixin_op": "include", "base_name": "Greet"}},
+			// The module method calls format — the real edge to follow through.
+			{ID: "e2", FromID: "mod_hello", ToID: "mod_fmt", Kind: "CALLS",
+				Properties: map[string]string{"language": "ruby"}},
+		},
+	}
+}
+
+// TestRubyInclude_ResolvesToModuleBody — User#hello (a bodyless include stub)
+// resolves to Greet#hello's real body, cross-file (greet.rb), via the
+// IMPLEMENTS(ruby_mixin) walk.
+func TestRubyInclude_ResolvesToModuleBody(t *testing.T) {
+	srv := newTestServer(t, rubyMixinDoc())
+	out := callInspect(t, srv, "cls_hello")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for Ruby mixin method, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected resolved=true for Ruby include, got %v (note=%v)", inh["resolved"], inh["note"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "Greet") {
+		t.Errorf("expected defining_class Greet, got %q", dc)
+	}
+	if rf, _ := inh["resolved_from"].(string); rf != "extends_in_repo" {
+		t.Errorf("expected resolved_from extends_in_repo, got %q", rf)
+	}
+	if df, _ := inh["defining_file"].(string); df != "greet.rb" {
+		t.Errorf("expected defining_file greet.rb (cross-file mixin), got %q", df)
+	}
+}
+
+// TestRubyInclude_TraversalReachesModuleCallee — the bodyless stub hops via
+// INHERITS to Greet.hello and surfaces its real callee Greet.format.
+func TestRubyInclude_TraversalReachesModuleCallee(t *testing.T) {
+	srv := newTestServer(t, rubyMixinDoc())
+	out := callNeighbors3834(t, srv, "cls_hello", "out")
+	names := calleeNames3834(t, out)
+	if !containsString(names, "Greet.hello") {
+		t.Fatalf("expected mixin stub to reach defining Greet.hello via INHERITS, got: %v", names)
+	}
+	if !containsString(names, "Greet.format") {
+		t.Errorf("expected to reach module callee Greet.format THROUGH the body, got: %v", names)
+	}
+}
+
+// phpTraitDoc models `trait Audit { public function log(){...} }` in Audit.php
+// and `class Order { use Audit; }` in Order.php, where Order.log is a bodyless
+// inherited stub. Audit.log calls a helper, the real promoted-through edge.
+func phpTraitDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "trait", Name: "Audit", QualifiedName: "Audit",
+				Kind: "SCOPE.Component", Subtype: "trait", SourceFile: "Audit.php",
+				StartLine: 1, EndLine: 6, Language: "php"},
+			{ID: "trait_log", Name: "Audit.log", QualifiedName: "Audit.log",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Audit.php",
+				StartLine: 2, EndLine: 5, Language: "php"},
+			{ID: "trait_persist", Name: "Audit.persist", QualifiedName: "Audit.persist",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Audit.php",
+				StartLine: 7, EndLine: 8, Language: "php"},
+			{ID: "cls", Name: "Order", QualifiedName: "Order",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "Order.php",
+				StartLine: 1, EndLine: 3, Language: "php"},
+			// Bodyless inherited stub: Order uses Audit::log.
+			{ID: "cls_log", Name: "Order.log", QualifiedName: "Order.log",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Order.php",
+				StartLine: 0, EndLine: 0, Language: "php", Signature: "public function log()"},
+		},
+		Relationships: []graph.Relationship{
+			// use Audit -> IMPLEMENTS(kind=php_trait) with base_name.
+			{ID: "e1", FromID: "cls", ToID: "trait", Kind: "IMPLEMENTS",
+				Properties: map[string]string{"language": "php", "kind": "php_trait", "base_name": "Audit"}},
+			{ID: "e2", FromID: "trait_log", ToID: "trait_persist", Kind: "CALLS",
+				Properties: map[string]string{"language": "php"}},
+		},
+	}
+}
+
+// TestPHPTrait_ResolvesToTraitBody — Order::log (a bodyless trait-use stub)
+// resolves to Audit::log's real body, cross-file (Audit.php).
+func TestPHPTrait_ResolvesToTraitBody(t *testing.T) {
+	srv := newTestServer(t, phpTraitDoc())
+	out := callInspect(t, srv, "cls_log")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for PHP trait method, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected resolved=true for PHP trait, got %v (note=%v)", inh["resolved"], inh["note"])
+	}
+	if dc, _ := inh["defining_class"].(string); !strings.Contains(dc, "Audit") {
+		t.Errorf("expected defining_class Audit, got %q", dc)
+	}
+	if df, _ := inh["defining_file"].(string); df != "Audit.php" {
+		t.Errorf("expected defining_file Audit.php (cross-file trait), got %q", df)
+	}
+}
+
+// TestPHPTrait_TraversalReachesTraitCallee — the bodyless stub hops via INHERITS
+// to Audit.log and surfaces its real callee Audit.persist.
+func TestPHPTrait_TraversalReachesTraitCallee(t *testing.T) {
+	srv := newTestServer(t, phpTraitDoc())
+	out := callNeighbors3834(t, srv, "cls_log", "out")
+	names := calleeNames3834(t, out)
+	if !containsString(names, "Audit.log") {
+		t.Fatalf("expected trait stub to reach defining Audit.log via INHERITS, got: %v", names)
+	}
+	if !containsString(names, "Audit.persist") {
+		t.Errorf("expected to reach trait callee Audit.persist THROUGH the body, got: %v", names)
+	}
+}
+
+// TestRubyInclude_ExternalModule_HonestUnresolved — NEGATIVE: a class including
+// an EXTERNAL/unindexed module (no in-repo body, no pack entry) resolves
+// honest-unresolved. No fabricated body, no synthetic INHERITS edge.
+func TestRubyInclude_ExternalModule_HonestUnresolved(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "cls", Name: "User", QualifiedName: "User",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "user.rb",
+				StartLine: 1, EndLine: 3, Language: "ruby"},
+			// Inherited stub whose module is external (no indexed body).
+			{ID: "cls_serialize", Name: "User.to_json", QualifiedName: "User.to_json",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "user.rb",
+				StartLine: 0, EndLine: 0, Language: "ruby", Signature: "def to_json"},
+			{ID: "ext", Name: "Comparable", Kind: "SCOPE.External", Language: "ruby"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "cls", ToID: "ext", Kind: "IMPLEMENTS",
+				Properties: map[string]string{"language": "ruby", "kind": "ruby_mixin", "mixin_op": "include", "base_name": "Comparable"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "cls_serialize")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for unresolved mixin member, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != false {
+		t.Errorf("expected resolved=false for external module, got %v", inh["resolved"])
+	}
+	if _, hasDC := inh["defining_class"]; hasDC {
+		t.Errorf("unresolved member must NOT carry a defining_class, got %v", inh["defining_class"])
+	}
+	if edges := mroOutboundEdges(srv.State.groups["test"].Repos["repo1"], "cls_serialize"); len(edges) != 0 {
+		t.Errorf("expected no synthetic INHERITS edge for unresolved member, got: %+v", edges)
+	}
+}
+
+// TestPHPTrait_MethodNotInTrait_Unresolved — NEGATIVE: a member that exists in
+// NO mixin/trait (the trait declares log, not ship) is unresolved. The trait
+// body is indexed but does not declare the member, so no fabrication.
+func TestPHPTrait_MethodNotInTrait_Unresolved(t *testing.T) {
+	doc := phpTraitDoc()
+	// Add a bodyless stub Order.ship — Audit declares no `ship`.
+	doc.Entities = append(doc.Entities, graph.Entity{
+		ID: "cls_ship", Name: "Order.ship", QualifiedName: "Order.ship",
+		Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "Order.php",
+		StartLine: 0, EndLine: 0, Language: "php", Signature: "public function ship()",
+	})
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "cls_ship")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != false {
+		t.Errorf("expected resolved=false for member declared in no trait, got %v", inh["resolved"])
+	}
+	if _, hasDC := inh["defining_class"]; hasDC {
+		t.Errorf("unresolved member must NOT carry a defining_class, got %v", inh["defining_class"])
+	}
+}
+
+// TestRubyPrepend_ResolvesToModuleBody — `prepend` is also followed (prepend
+// wins over the class's own method per Ruby MRO; here the class declares no
+// hello body so the prepended module body is what resolves). Asserts the
+// prepend edge resolves cross-file the same as include.
+func TestRubyPrepend_ResolvesToModuleBody(t *testing.T) {
+	doc := rubyMixinDoc()
+	// Flip the edge to prepend.
+	doc.Relationships[0].Properties["mixin_op"] = "prepend"
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "cls_hello")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inheritance section for Ruby prepend, got keys: %v", mapKeys(out))
+	}
+	if inh["resolved"] != true {
+		t.Fatalf("expected resolved=true for Ruby prepend, got %v (note=%v)", inh["resolved"], inh["note"])
+	}
+	if df, _ := inh["defining_file"].(string); df != "greet.rb" {
+		t.Errorf("expected defining_file greet.rb, got %q", df)
+	}
+}


### PR DESCRIPTION
## MRO T8 (#3840, epic #3829) — Ruby mixins + PHP traits

Generalises the cross-language MRO member-resolution walk (T7 #3987) to **Ruby module mixins** (`include`/`prepend`/`extend`) and **PHP traits** (`use`): a method defined in an included module / used trait now resolves to its **defining body cross-file**, the same defining-body semantics already provided for Go struct embedding and Java interface defaults.

### How
- The hierarchy extractor (`internal/extractors/cross/hierarchy/extractor.go`) now emits Ruby mixins and PHP trait-uses as **IMPLEMENTS** edges carrying a `base_name` FQN.
  - Ruby: `kind=ruby_mixin`, `mixin_op=include|prepend|extend` (precedence recoverable).
  - PHP: `kind=php_trait`.
- **No new edge kind.** Reusing IMPLEMENTS (the choice Rust `trait_impl` already makes) means the existing MCP read-path walk (`extendsBases`/`classDeclaredMember` in `internal/mcp/mro.go`) picks them up **unchanged**, and the producer-kind validator stays green.
- **Scope attribution.** Ruby (no braces) uses a lexical `class`/`module`/`end` stack → a mixin attaches to the innermost open class; a top-level mixin with no enclosing class is skipped. PHP trait `use` is disambiguated from a namespace-import `use Foo\Bar;` by **brace depth** — only a `use` inside a class/trait body becomes a trait edge.

### Safe-by-construction (honest-partial)
`classDeclaredMember` requires a **REAL body**, so only genuine module/trait method bodies resolve. An external/unindexed module or trait, or a member declared in no mixin, falls through to **honest-unresolved** — no fabricated body, no synthetic INHERITS edge.

### Prepend precedence
Modelled via the `mixin_op` edge property (`prepend` wins over the class's own method, `include`/`extend` lose). Resolution follows both include and prepend to the defining body; full C3 ordering of the class's own redeclared body vs. a prepended one remains a documented v1 non-goal (matches the existing flat-mixin resolution model).

### Tests (value-asserting)
- **MCP read-path** (`internal/mcp/mro_mixin_trait_3840_test.go`): Ruby `include` + PHP `use` resolve to the **specific** defining body in the other file (`defining_file` cross-file); INHERITS traversal reaches the defining body's real callee; `prepend` resolves the same. Negatives: external module → unresolved + no synthetic edge; member-in-no-trait → unresolved.
- **Extractor** (`internal/extractors/cross/hierarchy/mixin_trait_3840_test.go`): pins edge FROM/TO + `kind` + `mixin_op`, namespaced-leaf resolution, nested innermost attribution, and top-level-import-is-not-a-trait.

### Verification
`gofmt -l` empty · `go vet` clean · `go test` green for `internal/mcp` `internal/extractors/cross/hierarchy` `internal/extractors/ruby` `internal/extractors/php` `internal/types` `tools/coverage` · `coverage validate` 0 errors · `coverage fmt --check` canonical.

### DEPLOY-DEFERRED
Needs a reindex to populate the new IMPLEMENTS(`ruby_mixin`/`php_trait`) edges; the MCP projection works the moment they exist.

Closes #3840

🤖 Generated with [Claude Code](https://claude.com/claude-code)