### PR TITLE
feat(scala/caliban): detect GraphQL field auth via @GQLDirective (#3992)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -175,7 +175,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 1/19 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/9 | |
 | [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🟡 1/24 | 🟡 6/19 | |
-| [scala](../by-language/scala.md) | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/19 | |
+| [scala](../by-language/scala.md) | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🟢 1/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/19 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/9 | |
 | [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/6 | |
 | [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 9/12 | |

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -28,7 +28,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|---|---|
 | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/9 | |
 | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🟡 1/24 | 🟡 6/19 | |
-| [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/19 | |
+| [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🟢 1/1 | 🟡 2/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/19 | |
 | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/9 | |
 | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/6 | |
 | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 9/12 | |

--- a/docs/coverage/detail/lang.scala.framework.caliban.md
+++ b/docs/coverage/detail/lang.scala.framework.caliban.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Auth coverage | 🟢 `partial` | `2026-06-03` | 3992 | `internal/custom/scala/caliban.go`<br>`internal/custom/scala/caliban_test.go` | #3992: a resolver-field @GQLDirective(Authenticated) (or Authorized/Secured/RequiresAuth) gates the synthesised GRAPHQL endpoint — stamps the flat shared auth contract auth_required=true / auth_method=directive / auth_confidence=high / auth_directive=<name> / auth_guard=<name>. A custom role directive @GQLDirective(HasRole("admin")) / RequireRole/HasPermission/HasScope parses quoted role tokens into auth_roles (sorted). Non-auth directives (@GQLDeprecated, @GQLDirective(deprecated)) and directive-free fields stay unauthenticated. TestCalibanAuthDirective. PARTIAL honest limit: only field-level @GQLDirective auth is recovered (positional + intra-file, same binding limit as endpoint synthesis); Caliban Wrapper-based auth middleware and ZIO auth-environment requirements are NOT statically chased, and custom role directives with non-literal (computed/enum) role args stamp auth_required+auth_directive but leave auth_roles absent. |
 
 ### Validation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -69044,8 +69044,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/caliban.go","internal/custom/scala/caliban_test.go"],
+            "issue": "3992",
+            "notes": "#3992: a resolver-field @GQLDirective(Authenticated) (or Authorized/Secured/RequiresAuth) gates the synthesised GRAPHQL endpoint — stamps the flat shared auth contract auth_required=true / auth_method=directive / auth_confidence=high / auth_directive=\u003cname\u003e / auth_guard=\u003cname\u003e. A custom role directive @GQLDirective(HasRole(\"admin\")) / RequireRole/HasPermission/HasScope parses quoted role tokens into auth_roles (sorted). Non-auth directives (@GQLDeprecated, @GQLDirective(deprecated)) and directive-free fields stay unauthenticated. TestCalibanAuthDirective. PARTIAL honest limit: only field-level @GQLDirective auth is recovered (positional + intra-file, same binding limit as endpoint synthesis); Caliban Wrapper-based auth middleware and ZIO auth-environment requirements are NOT statically chased, and custom role directives with non-literal (computed/enum) role args stamp auth_required+auth_directive but leave auth_roles absent.",
+            "verified_at": "2026-06-03"
           }
         },
         "Validation": {

--- a/internal/custom/scala/caliban.go
+++ b/internal/custom/scala/caliban.go
@@ -3,6 +3,7 @@ package scala
 import (
 	"context"
 	"regexp"
+	"sort"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -78,9 +79,25 @@ var (
 	//   user: UserArgs => URIO[Any, User]
 	//   users: () => List[User]
 	//   name: String
-	// Capture group 1 is the field name, group 2 is its (trimmed) type text up
-	// to the next top-level comma.
-	reCalibanField = regexp.MustCompile(`(?m)^\s*([A-Za-z_]\w*)\s*:\s*`)
+	//   @GQLDirective(Authenticated) me: () => URIO[Auth, User]
+	// Group 1 is the field name. A leading annotation block (@GQLDirective(...)
+	// / @GQLDeprecated / ...) is skipped so an annotated field's NAME is still
+	// captured; the annotation text itself is parsed separately by
+	// reCalibanGQLDirective for auth.
+	reCalibanField = regexp.MustCompile(`(?:@[A-Za-z_]\w*(?:\([^)]*\))?\s*)*([A-Za-z_]\w*)\s*:\s*`)
+
+	// `@GQLDirective(<expr>)` field/type annotation. Group 1 is the directive
+	// expression, e.g. `Authenticated`, `HasRole("admin")`, a custom directive.
+	// Caliban auth idiom: a built-in/library `Authenticated` directive, or a
+	// custom `HasRole("admin")` / `HasPermission("...")` directive constructor.
+	reCalibanGQLDirective = regexp.MustCompile(`@GQLDirective\s*\(\s*([A-Za-z_][\w.]*(?:\s*\([^)]*\))?)`)
+
+	// Role/permission argument inside a directive constructor, e.g.
+	// `HasRole("admin")` / `RequireRole("ADMIN", "OPS")`. Group 1 = the quoted
+	// argument list region; individual quoted tokens are pulled out separately.
+	reCalibanDirectiveRole = regexp.MustCompile(`^(?:Has|Require|With)?(?:Role|Roles|Permission|Permissions|Scope|Scopes)\s*\(([^)]*)\)`)
+
+	reCalibanQuotedArg = regexp.MustCompile(`"([^"]*)"`)
 
 	// Caliban schema annotations that mark a case class / enum as a GraphQL
 	// schema type. Capture group 2 is the annotated type name.
@@ -146,18 +163,86 @@ func calibanSplitTopLevel(s string) []string {
 	return parts
 }
 
-// calibanResolverFields parses the field NAMES declared in a case-class
-// parameter list. Each top-level `name: Type` segment contributes its name.
-func calibanResolverFields(params string) []string {
-	var fields []string
+// calibanField is one resolver case-class field: its GraphQL name plus the
+// auth posture derived from any @GQLDirective(...) annotation on it.
+type calibanField struct {
+	name string
+	auth calibanFieldAuth
+}
+
+// calibanFieldAuth is the resolved auth posture of a single resolver field,
+// derived from a @GQLDirective(...) auth directive. zero value = no auth.
+type calibanFieldAuth struct {
+	required  bool
+	directive string   // directive name, e.g. "Authenticated", "HasRole"
+	roles     []string // role/permission names parsed from the directive args
+}
+
+// calibanResolverFields parses the field NAMES + auth posture declared in a
+// case-class parameter list. Each top-level `name: Type` segment (optionally
+// preceded by @GQLDirective(...) / @GQL* annotations) contributes one field.
+func calibanResolverFields(params string) []calibanField {
+	var fields []calibanField
 	for _, seg := range calibanSplitTopLevel(params) {
 		m := reCalibanField.FindStringSubmatch(seg)
 		if m == nil {
 			continue
 		}
-		fields = append(fields, m[1])
+		fields = append(fields, calibanField{
+			name: m[1],
+			auth: calibanFieldAuthFromSegment(seg),
+		})
 	}
 	return fields
+}
+
+// calibanFieldAuthFromSegment inspects a field segment for a @GQLDirective(...)
+// auth directive and returns the resolved auth posture. Only directives whose
+// name denotes authentication/authorization (Authenticated, or a Has/Require
+// Role/Permission/Scope constructor) gate the field; non-auth directives
+// (@GQLDeprecated, @GQLDirective(deprecated), @GQLDirective(specifiedBy(...)))
+// are ignored, leaving the field unauthenticated.
+func calibanFieldAuthFromSegment(seg string) calibanFieldAuth {
+	for _, dm := range reCalibanGQLDirective.FindAllStringSubmatch(seg, -1) {
+		expr := strings.TrimSpace(dm[1])
+		name := calibanLeadingType(expr)
+		if name == "" {
+			continue
+		}
+		if calibanIsAuthDirective(name) {
+			auth := calibanFieldAuth{required: true, directive: name}
+			if rm := reCalibanDirectiveRole.FindStringSubmatch(expr); rm != nil {
+				for _, qm := range reCalibanQuotedArg.FindAllStringSubmatch(rm[1], -1) {
+					if r := strings.TrimSpace(qm[1]); r != "" {
+						auth.roles = append(auth.roles, r)
+					}
+				}
+			}
+			return auth
+		}
+	}
+	return calibanFieldAuth{}
+}
+
+// calibanIsAuthDirective reports whether a @GQLDirective directive name denotes
+// auth. `Authenticated` is the canonical Caliban auth directive; the role/
+// permission/scope constructors are the common custom-directive idiom. The
+// match is conservative: a directive named for deprecation / description /
+// federation is NOT auth.
+func calibanIsAuthDirective(name string) bool {
+	switch name {
+	case "Authenticated", "Authorized", "RequiresAuth", "Auth", "Secured", "Private":
+		return true
+	}
+	switch {
+	case strings.HasPrefix(name, "HasRole"), strings.HasPrefix(name, "HasRoles"),
+		strings.HasPrefix(name, "HasPermission"), strings.HasPrefix(name, "HasScope"),
+		strings.HasPrefix(name, "RequireRole"), strings.HasPrefix(name, "RequireRoles"),
+		strings.HasPrefix(name, "RequirePermission"), strings.HasPrefix(name, "RequireScope"),
+		strings.HasPrefix(name, "WithRole"), strings.HasPrefix(name, "WithPermission"):
+		return true
+	}
+	return false
 }
 
 // calibanOperationForIndex maps a RootResolver positional argument index to its
@@ -229,7 +314,7 @@ func (e *calibanExtractor) Extract(ctx context.Context, file extractor.FileInput
 	// Index every case class by name -> its parameter-list field names, so a
 	// RootResolver argument can be resolved to the fields it contributes.
 	type ccInfo struct {
-		fields []string
+		fields []calibanField
 		off    int
 	}
 	caseClasses := make(map[string]ccInfo)
@@ -277,15 +362,21 @@ func (e *calibanExtractor) Extract(ctx context.Context, file extractor.FileInput
 			}
 			rootNames = append(rootNames, root)
 			for _, field := range cc.fields {
-				path := "/graphql/" + root + "/" + field
+				path := "/graphql/" + root + "/" + field.name
 				name := "GRAPHQL " + path
 				ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, cc.off))
 				setProps(&ent, "framework", "caliban",
 					"provenance", "INFERRED_FROM_CALIBAN_RESOLVER",
 					"http_method", "GRAPHQL", "verb", "GRAPHQL",
 					"route_path", path, "graphql_operation", operation,
-					"graphql_root", root, "graphql_field", field,
-					"handler_name", root+"."+field)
+					"graphql_root", root, "graphql_field", field.name,
+					"handler_name", root+"."+field.name)
+				// Auth (#3992): a @GQLDirective(Authenticated) / custom
+				// HasRole(...) directive on the resolver field gates the
+				// synthesised GraphQL endpoint. Stamp the flat shared auth
+				// contract (auth_required/auth_method/auth_guard/auth_roles)
+				// so archigraph_auth_coverage counts the field as covered.
+				calibanStampFieldAuth(&ent, field.auth)
 				add(ent)
 			}
 		}
@@ -340,6 +431,55 @@ func (e *calibanExtractor) Extract(ctx context.Context, file extractor.FileInput
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// calibanStampFieldAuth writes the flat, framework-agnostic auth contract onto
+// a synthesised GraphQL endpoint when the resolver field carries an auth
+// @GQLDirective. It mirrors the shared contract used by the other GraphQL
+// stampers (Lighthouse / spring-graphql / HotChocolate):
+//
+//	auth_required   "true"
+//	auth_method     "directive"
+//	auth_confidence "high"      (statically-visible @GQLDirective on the field)
+//	auth_directive  directive name (Authenticated / HasRole / ...)
+//	auth_guard      directive name — the key archigraph_auth_coverage counts
+//	auth_roles      comma-joined, sorted role/permission names (when present)
+//
+// HONEST PARTIAL: for a custom role directive whose role tokens are NOT quoted
+// string literals (computed/enum role args), only the directive NAME is
+// recoverable — auth_required + auth_directive are stamped, auth_roles is left
+// absent. No-op when the field carries no auth directive.
+func calibanStampFieldAuth(ent *types.EntityRecord, auth calibanFieldAuth) {
+	if !auth.required {
+		return
+	}
+	setProps(ent,
+		"auth_required", "true",
+		"auth_method", "directive",
+		"auth_confidence", "high",
+		"auth_directive", auth.directive,
+		"auth_guard", auth.directive)
+	if len(auth.roles) > 0 {
+		setProps(ent, "auth_roles", strings.Join(calibanDedupSortedRoles(auth.roles), ","))
+	}
+}
+
+// calibanDedupSortedRoles returns a sorted, de-duplicated copy (drops empties)
+// so the comma-joined auth_roles field is deterministic across runs — matching
+// the dedupSorted contract the JVM/PHP GraphQL stampers apply.
+func calibanDedupSortedRoles(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // calibanDTORole classifies a schema DTO by its declaration keyword.

--- a/internal/custom/scala/caliban_test.go
+++ b/internal/custom/scala/caliban_test.go
@@ -144,6 +144,81 @@ object Schemas {
 	}
 }
 
+// TestCalibanAuthDirective is the VERIFY-FIRST probe (#3992): a resolver field
+// carrying @GQLDirective(Authenticated) is auth-gated, and @GQLDirective(
+// HasRole("admin")) carries a role. Directive-free fields and non-auth
+// directives (@GQLDeprecated / @GQLDirective(deprecated)) carry NO auth.
+func TestCalibanAuthDirective(t *testing.T) {
+	src := `
+import caliban._
+import caliban.schema.Annotations._
+
+case class Queries(
+  @GQLDirective(Authenticated) me: () => URIO[Auth, User],
+  @GQLDirective(HasRole("admin")) adminStats: () => URIO[Auth, Stats],
+  @GQLDeprecated("use me") legacy: () => UIO[User],
+  health: () => UIO[String],
+)
+
+object Api {
+  val api = graphQL(RootResolver(Queries(resolveMe, resolveAdmin, resolveLegacy, resolveHealth)))
+}
+`
+	ents := extract(t, "custom_scala_caliban", fi("Api.scala", "scala", src))
+
+	// @GQLDirective(Authenticated) → auth_required=true, method=directive,
+	// the directive name is recorded, and auth_guard makes it count as covered.
+	me := findEntity(ents, "SCOPE.Operation", "GRAPHQL /graphql/Queries/me")
+	if me == nil {
+		t.Fatalf("expected endpoint for me")
+	}
+	if me.Props["auth_required"] != "true" {
+		t.Errorf("me: auth_required = %q, want true", me.Props["auth_required"])
+	}
+	if me.Props["auth_method"] != "directive" {
+		t.Errorf("me: auth_method = %q, want directive", me.Props["auth_method"])
+	}
+	if me.Props["auth_directive"] != "Authenticated" {
+		t.Errorf("me: auth_directive = %q, want Authenticated", me.Props["auth_directive"])
+	}
+	if me.Props["auth_guard"] != "Authenticated" {
+		t.Errorf("me: auth_guard = %q, want Authenticated", me.Props["auth_guard"])
+	}
+
+	// @GQLDirective(HasRole("admin")) → auth_roles=admin + auth_required=true.
+	admin := findEntity(ents, "SCOPE.Operation", "GRAPHQL /graphql/Queries/adminStats")
+	if admin == nil {
+		t.Fatalf("expected endpoint for adminStats")
+	}
+	if admin.Props["auth_required"] != "true" {
+		t.Errorf("adminStats: auth_required = %q, want true", admin.Props["auth_required"])
+	}
+	if admin.Props["auth_roles"] != "admin" {
+		t.Errorf("adminStats: auth_roles = %q, want admin", admin.Props["auth_roles"])
+	}
+	if admin.Props["auth_directive"] != "HasRole" {
+		t.Errorf("adminStats: auth_directive = %q, want HasRole", admin.Props["auth_directive"])
+	}
+
+	// NEGATIVE: @GQLDeprecated is a non-auth directive → no auth_required.
+	legacy := findEntity(ents, "SCOPE.Operation", "GRAPHQL /graphql/Queries/legacy")
+	if legacy == nil {
+		t.Fatalf("expected endpoint for legacy")
+	}
+	if _, ok := legacy.Props["auth_required"]; ok {
+		t.Errorf("legacy: auth_required should be absent, got %q", legacy.Props["auth_required"])
+	}
+
+	// NEGATIVE: a directive-free field carries no auth.
+	health := findEntity(ents, "SCOPE.Operation", "GRAPHQL /graphql/Queries/health")
+	if health == nil {
+		t.Fatalf("expected endpoint for health")
+	}
+	if _, ok := health.Props["auth_required"]; ok {
+		t.Errorf("health: auth_required should be absent, got %q", health.Props["auth_required"])
+	}
+}
+
 func TestCalibanNoFalsePositive(t *testing.T) {
 	// A plain http4s/tapir Scala file with no Caliban markers must yield nothing.
 	src := `


### PR DESCRIPTION
## What

Wires **Caliban (Scala GraphQL) auth detection** — the recurring GraphQL-auth meta-pattern (epic #3872, from Scala audit #3887). `internal/custom/scala/caliban.go` extracted schema/resolvers but stamped **no auth**.

A resolver-field `@GQLDirective(...)` auth directive now gates the synthesised GRAPHQL endpoint:

- `@GQLDirective(Authenticated)` (also `Authorized`/`Secured`/`RequiresAuth`/`Auth`/`Private`) → flat shared auth contract: `auth_required=true` / `auth_method=directive` / `auth_confidence=high` / `auth_directive=<name>` / `auth_guard=<name>` (`auth_guard` is the key `archigraph_auth_coverage` counts as covered).
- Custom role directives `@GQLDirective(HasRole("admin"))` / `RequireRole`/`HasPermission`/`HasScope` → quoted role tokens parsed into sorted `auth_roles`.
- **Negatives**: `@GQLDeprecated`, `@GQLDirective(deprecated)`, and directive-free fields stay unauthenticated.

The resolver-field parser now skips a leading `@GQL*` annotation block so an annotated field's NAME is still captured (previously an annotated field produced no endpoint at all).

## VERIFY-FIRST

`TestCalibanAuthDirective` was written **before** the change and reproduced the gap (the `me` field with `@GQLDirective(Authenticated)` produced no endpoint, zero auth). It value-asserts:

- `me` → `auth_required=true`, `auth_method=directive`, `auth_directive=Authenticated`, `auth_guard=Authenticated`
- `adminStats` (`@GQLDirective(HasRole("admin"))`) → `auth_roles=admin`, `auth_directive=HasRole`, `auth_required=true`
- `legacy` (`@GQLDeprecated`) → no `auth_required`
- `health` (directive-free) → no `auth_required`

## Honest PARTIAL

Registry `lang.scala.framework.caliban` Auth/auth_coverage **missing → partial**. Only field-level `@GQLDirective` auth is recovered (positional + intra-file, the same binding limit as endpoint synthesis). Caliban `Wrapper`-based auth middleware and ZIO auth-environment requirements are NOT statically chased; custom role directives with non-literal (computed/enum) role args stamp `auth_required`+`auth_directive` but leave `auth_roles` absent.

## Gates

- `go test ./internal/custom/scala/ ./internal/substrate/ ./internal/types/ ./tools/coverage/` green
- `gofmt -l` empty, `go vet` clean
- `covtool validate` 0 errors, `fmt --check` canonical, `gen` → 0 doc drift
- No new entity/edge Kinds.

**DEPLOY-DEFERRED.**

Closes #3992

🤖 Generated with [Claude Code](https://claude.com/claude-code)