### PR TITLE
[B5][coverage-docs] Sparse-table audit + drop stranded all-N/A columns from flat by-category tables (#3874)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -6,96 +6,96 @@
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
-| Language | Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | — | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [Catch2](../detail/test.catch2.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | — | 🔴 | |
-| [C#](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | — | — | — | 🔴 | |
-| [C#](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | 🟢 | — | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | 🟢 | — | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | 🟢 | — | — | — | 🟢 | |
-| [C#](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | — | ✅ | |
-| [C#](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | 🟢 | — | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | — | ✅ | |
-| [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | 🟢 | — | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | — | ✅ | |
-| [elixir](../by-language/elixir.md) | [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [Ginkgo](../detail/test.ginkgo.md) | 🟢 | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [Gomega](../detail/test.gomega.md) | 🟢 | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [Mage](../detail/build.mage.md) | ✅ | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [Task (taskfile.dev)](../detail/build.task.md) | ✅ | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | — | ✅ | |
-| [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ✅ | — | — | — | ✅ | |
-| [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | 🔴 | — | — | — | 🔴 | |
-| [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | 🔴 | — | — | — | 🔴 | |
-| [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | — | ✅ | |
-| [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | 🟢 | — | — | — | 🟢 | |
-| [java](../by-language/java.md) | [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | — | ✅ | |
-| [java](../by-language/java.md) | [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | — | ✅ | |
-| [java](../by-language/java.md) | [Mockito](../detail/test.mockito.md) | 🔴 | — | — | — | 🟢 | |
-| [java](../by-language/java.md) | [REST-assured](../detail/test.restassured.md) | 🔴 | — | — | — | 🔴 | |
-| [java](../by-language/java.md) | [TestNG](../detail/test.testng.md) | 🔴 | — | — | — | 🟢 | |
-| [JS/TS](../by-language/jsts.md) | [AVA](../detail/test.ava.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Cypress](../detail/test.cypress.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Jasmine](../detail/test.jasmine.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Jest](../detail/test.jest.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Lerna](../detail/build.lerna.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Mocha](../detail/test.mocha.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Nx (monorepo)](../detail/build.nx.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Parcel](../detail/build.parcel.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Playwright](../detail/test.playwright.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Rollup](../detail/build.rollup.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Turborepo](../detail/build.turborepo.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Vite](../detail/build.vite.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Vitest](../detail/test.vitest.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Webpack](../detail/build.webpack.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Yarn](../detail/build.yarn.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [esbuild](../detail/build.esbuild.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [npm](../detail/build.npm.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [pnpm](../detail/build.pnpm.md) | ✅ | — | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [tap / node:test](../detail/test.tap.md) | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | — | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | — | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | — | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | — | — | — | ✅ | |
-| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | — | ✅ | |
-| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [Pipenv](../detail/build.pipenv.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Poetry](../detail/build.poetry.md) | ✅ | — | — | — | ✅ | |
-| [python](../by-language/python.md) | [doctest (stdlib)](../detail/test.doctest.md) | — | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [nose2](../detail/test.nose2.md) | — | — | — | — | 🔴 | |
-| [python](../by-language/python.md) | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | — | ✅ | |
-| [python](../by-language/python.md) | [pytest](../detail/test.pytest.md) | ✅ | — | — | — | ✅ | |
-| [python](../by-language/python.md) | [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [unittest (stdlib)](../detail/test.unittest.md) | ✅ | — | — | — | ✅ | |
-| [python](../by-language/python.md) | [uv (Astral)](../detail/build.uv.md) | ✅ | — | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Cucumber](../detail/test.cucumber.md) | 🔴 | — | — | — | 🔴 | |
-| [ruby](../by-language/ruby.md) | [Minitest](../detail/test.minitest.md) | 🟢 | — | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [RSpec](../detail/test.rspec.md) | ✅ | — | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Rake](../detail/build.rake.md) | 🔴 | — | — | — | 🟢 | |
-| [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ✅ | — | — | — | ✅ | |
-| [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ✅ | — | — | — | ✅ | |
-| [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | — | — | — | 🔴 | |
-| [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | — | — | — | ✅ | |
+| Language | Name | Dependency graph | Target extraction | Notes |
+|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Boost.Test](../detail/test.boost-test.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [Catch2](../detail/test.catch2.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CppUTest](../detail/test.cpputest.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CppUnit](../detail/test.cppunit.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [GoogleTest (gtest)](../detail/test.gtest.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Meson](../detail/lang.c-cpp.tool.meson.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | 🔴 | |
+| [C#](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | 🔴 | 🔴 | |
+| [C#](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | ✅ | |
+| [C#](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | 🟢 | 🟢 | |
+| [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | ✅ | |
+| [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | 🟢 | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | ✅ | |
+| [elixir](../by-language/elixir.md) | [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | ✅ | |
+| [go](../by-language/go.md) | [Ginkgo](../detail/test.ginkgo.md) | 🟢 | ✅ | |
+| [go](../by-language/go.md) | [Gomega](../detail/test.gomega.md) | 🟢 | ✅ | |
+| [go](../by-language/go.md) | [Mage](../detail/build.mage.md) | ✅ | ✅ | |
+| [go](../by-language/go.md) | [Task (taskfile.dev)](../detail/build.task.md) | ✅ | ✅ | |
+| [go](../by-language/go.md) | [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | ✅ | |
+| [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | ✅ | |
+| [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ✅ | ✅ | |
+| [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | 🔴 | 🔴 | |
+| [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | 🔴 | 🔴 | |
+| [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | ✅ | |
+| [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | 🟢 | 🟢 | |
+| [java](../by-language/java.md) | [JUnit 5](../detail/test.junit5.md) | ✅ | ✅ | |
+| [java](../by-language/java.md) | [Maven (pom.xml)](../detail/build.maven.md) | ✅ | ✅ | |
+| [java](../by-language/java.md) | [Mockito](../detail/test.mockito.md) | 🔴 | 🟢 | |
+| [java](../by-language/java.md) | [REST-assured](../detail/test.restassured.md) | 🔴 | 🔴 | |
+| [java](../by-language/java.md) | [TestNG](../detail/test.testng.md) | 🔴 | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [AVA](../detail/test.ava.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Bun (runtime + manager)](../detail/build.bun.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Cypress](../detail/test.cypress.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Jasmine](../detail/test.jasmine.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Jest](../detail/test.jest.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Lerna](../detail/build.lerna.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Mocha](../detail/test.mocha.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Nx (monorepo)](../detail/build.nx.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Parcel](../detail/build.parcel.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Playwright](../detail/test.playwright.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Rollup](../detail/build.rollup.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Turborepo](../detail/build.turborepo.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Vite](../detail/build.vite.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Vitest](../detail/test.vitest.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Webpack](../detail/build.webpack.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Yarn](../detail/build.yarn.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [esbuild](../detail/build.esbuild.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [npm](../detail/build.npm.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [pnpm](../detail/build.pnpm.md) | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [tap / node:test](../detail/test.tap.md) | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | 🟢 | |
+| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | 🟢 | |
+| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | 🟢 | |
+| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | ✅ | |
+| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | ✅ | |
+| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | 🔴 | |
+| [python](../by-language/python.md) | [Pipenv](../detail/build.pipenv.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Poetry](../detail/build.poetry.md) | ✅ | ✅ | |
+| [python](../by-language/python.md) | [doctest (stdlib)](../detail/test.doctest.md) | — | 🔴 | |
+| [python](../by-language/python.md) | [nose2](../detail/test.nose2.md) | — | 🔴 | |
+| [python](../by-language/python.md) | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | ✅ | |
+| [python](../by-language/python.md) | [pytest](../detail/test.pytest.md) | ✅ | ✅ | |
+| [python](../by-language/python.md) | [setuptools / setup.py](../detail/build.setuptools.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [unittest (stdlib)](../detail/test.unittest.md) | ✅ | ✅ | |
+| [python](../by-language/python.md) | [uv (Astral)](../detail/build.uv.md) | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [Cucumber](../detail/test.cucumber.md) | 🔴 | 🔴 | |
+| [ruby](../by-language/ruby.md) | [Minitest](../detail/test.minitest.md) | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [RSpec](../detail/test.rspec.md) | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [Rake](../detail/build.rake.md) | 🔴 | 🟢 | |
+| [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ✅ | ✅ | |
+| [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | 🔴 | |
+| [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -5,14 +5,14 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Call line precision | Core extraction | DB effect | Discriminates on | Fs effect | HTTP effect | Import resolution quality | Navigates to | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| [assembly](../by-language/assembly.md) | [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | ✅ | 🟢 | — | — | — | — | 🟢 | — | 🟢 | |
-| [assembly](../by-language/assembly.md) | [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
-| [assembly](../by-language/assembly.md) | [MASM](../detail/lang.assembly.toolchain.masm.md) | ✅ | 🟢 | — | — | — | — | 🟢 | — | 🟢 | |
-| [assembly](../by-language/assembly.md) | [NASM](../detail/lang.assembly.toolchain.nasm.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | — | — | — | — | ✅ | ✅ | — | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | — | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | — | ✅ | |
-| [JCL](../by-language/jcl.md) | [IBM z/OS JCL (JES2/JES3)](../detail/lang.jcl.runtime.zos.md) | ✅ | ✅ | — | — | — | — | — | — | ✅ | |
+| Language | Name | Call line precision | Core extraction | DB effect | Fs effect | HTTP effect | Import resolution quality | Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [assembly](../by-language/assembly.md) | [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | ✅ | 🟢 | — | — | — | 🟢 | 🟢 | |
+| [assembly](../by-language/assembly.md) | [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
+| [assembly](../by-language/assembly.md) | [MASM](../detail/lang.assembly.toolchain.masm.md) | ✅ | 🟢 | — | — | — | 🟢 | 🟢 | |
+| [assembly](../by-language/assembly.md) | [NASM](../detail/lang.assembly.toolchain.nasm.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
+| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | — | — | — | ✅ | ✅ | — | ✅ | |
+| [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | ✅ | |
+| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
+| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| [JCL](../by-language/jcl.md) | [IBM z/OS JCL (JES2/JES3)](../detail/lang.jcl.runtime.zos.md) | ✅ | ✅ | — | — | — | — | ✅ | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -6,25 +6,25 @@
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
-| Language | Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
-|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | — | 🟢 | — | |
-| [C/C++](../by-language/c-cpp.md) | [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | — | 🔴 | 🔴 | — | |
-| [C/C++](../by-language/c-cpp.md) | [build2](../detail/lang.c-cpp.tool.build2.md) | — | — | 🔴 | 🔴 | — | |
-| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | — | 🟢 | 🟢 | — | |
-| [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | — | ✅ | ✅ | — | |
-| [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | — | 🔴 | ✅ | — | |
-| [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | — | 🔴 | — | |
-| [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | — | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | — | 🔴 | 🟢 | — | |
-| [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | — | ✅ | — | |
-| [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | — | ✅ | ✅ | — | |
-| [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | — | ✅ | — | — | — | |
-| [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | — | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | — | 🟢 | 🟢 | — | |
-| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | — | 🟢 | ✅ | — | |
-| [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | — | ✅ | — | |
-| [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | — | 🔴 | ✅ | — | |
-| [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | — | 🔴 | ✅ | — | |
-| [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | — | 🔴 | — | |
-| [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | — | 🔴 | — | |
+| Language | Name | Dependency usage status | Lockfile parsing | Manifest parsing | Notes |
+|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [build2](../detail/lang.c-cpp.tool.build2.md) | — | 🔴 | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ✅ | ✅ | |
+| [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | 🔴 | ✅ | |
+| [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | |
+| [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | |
+| [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | 🔴 | 🟢 | |
+| [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | ✅ | — | — | |
+| [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | |
+| [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | 🔴 | ✅ | |
+| [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | |
+| [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | 🔴 | |
+| [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | 🔴 | |

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -829,6 +829,12 @@ func generate(reg *Registry, outRoot string) error {
 			return rows[i].Label < rows[j].Label
 		})
 		subSecs, flatRows := splitCategoryRowsBySubcategory(n, rows)
+		// Don't-strand guard for the flat (un-subcategorised) table (#3874):
+		// drop any bucket-union capability column that is "—" for every flat
+		// record so grab-bag tool/infra categories (build_system,
+		// message_broker, package_manager) stop rendering always-empty
+		// columns. Presentation-only — registry statuses are untouched.
+		keys = nonStrandedCapKeys(keys, flatRows)
 		if err := renderToFile(tmpls, "by-category.md.tmpl",
 			filepath.Join(root, "by-category", n+".md"),
 			categoryPageData{
@@ -1053,6 +1059,46 @@ func nonStrandedGroupNames(candidates []string, records int, digestFor func(rec 
 				break
 			}
 		}
+	}
+	return out
+}
+
+// nonStrandedCapKeys is the per-capability-column analogue of
+// nonStrandedGroupNames for FLAT (un-subcategorised) by-category tables
+// (#3874). A flat category renders one column per capability key drawn
+// from the bucket-wide union (bucketCapabilityKeys) or the category's
+// declared keys. For grab-bag tool/infra categories — build_system,
+// message_broker, package_manager — that union is far wider than any one
+// record's vocabulary: build tools and test frameworks never declare a
+// "Lockfile parsing" cell, so that column is "—" for every row. Such an
+// all-"—" column is pure visual noise (it is "truly N/A for the records
+// present", not "tracked-but-missing"), and it is the root cause of the
+// sparse-table / repeated-name disease the audit targets.
+//
+// This guard drops any candidate key whose cell is non-applicable
+// (statusGlyph → "—": StatusNotApplicable, empty, or absent) for EVERY
+// record in the table. A key kept by even one record survives. The result
+// preserves candidates' order, is a fresh allocation (never aliases
+// candidates), and never reaches into registry status values to change
+// them — it is presentation-only. Determinism: iteration is over the
+// ordered candidates and the explicitly-ordered record slice. When every
+// column would be stranded (a degenerate all-"—" category) the candidates
+// are returned unchanged so the table never renders header-less.
+func nonStrandedCapKeys(candidates []string, rows []categoryRow) []string {
+	if len(candidates) == 0 || len(rows) == 0 {
+		return candidates
+	}
+	out := make([]string, 0, len(candidates))
+	for _, key := range candidates {
+		for _, r := range rows {
+			if statusGlyph(r.CapByKey[key].Status) != "—" {
+				out = append(out, key)
+				break
+			}
+		}
+	}
+	if len(out) == 0 {
+		return candidates
 	}
 	return out
 }

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -381,6 +381,50 @@ func TestNonStrandedGroupNames(t *testing.T) {
 	}
 }
 
+// TestNonStrandedCapKeys covers the per-capability-column don't-strand
+// guard for FLAT (un-subcategorised) by-category tables (#3874): a column
+// whose cell is "—" (not_applicable / empty / absent) for EVERY record is
+// dropped, a column with at least one extracted cell (full/partial) OR a
+// tracked-but-missing cell is kept, and candidate order is preserved. This
+// is the fix for the build_system / package_manager grab-bag sparsity —
+// build tools never declare "Lockfile parsing", so that bucket-union column
+// is all-"—" and gets removed.
+func TestNonStrandedCapKeys(t *testing.T) {
+	mk := func(byKey map[string]string) categoryRow {
+		m := map[string]Capability{}
+		for k, s := range byKey {
+			m[k] = Capability{Status: s}
+		}
+		return categoryRow{CapByKey: m}
+	}
+	candidates := []string{"dependency_graph", "lockfile_parsing", "manifest_parsing", "target_extraction"}
+	rows := []categoryRow{
+		// A build tool: declares dependency_graph + target_extraction only.
+		mk(map[string]string{"dependency_graph": StatusFull, "target_extraction": StatusMissing}),
+		// A test framework: same two lanes, lockfile/manifest absent (→ "—").
+		mk(map[string]string{"dependency_graph": StatusPartial, "target_extraction": StatusFull}),
+	}
+	got := nonStrandedCapKeys(candidates, rows)
+	want := []string{"dependency_graph", "target_extraction"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("nonStrandedCapKeys = %v, want %v (lockfile/manifest are all-\"—\" → dropped)", got, want)
+	}
+	// not_applicable is treated as "—" and dropped when uniform.
+	naRows := []categoryRow{mk(map[string]string{"a": StatusFull, "b": StatusNotApplicable})}
+	if g := nonStrandedCapKeys([]string{"a", "b"}, naRows); !reflect.DeepEqual(g, []string{"a"}) {
+		t.Errorf("not_applicable column should be stranded, got %v", g)
+	}
+	// All-stranded → candidates returned unchanged (never a header-less table).
+	allDash := []categoryRow{mk(map[string]string{"a": StatusNotApplicable, "b": ""})}
+	if g := nonStrandedCapKeys([]string{"a", "b"}, allDash); !reflect.DeepEqual(g, []string{"a", "b"}) {
+		t.Errorf("all-stranded should pass candidates through, got %v", g)
+	}
+	// Zero rows / nil candidates → passthrough (no panic, no filtering).
+	if g := nonStrandedCapKeys(candidates, nil); !reflect.DeepEqual(g, candidates) {
+		t.Errorf("zero rows should pass candidates through, got %v", g)
+	}
+}
+
 // TestBuildBucketSectionHidesStrandedGroups proves the guard wired into
 // buildBucketSection drops an all-"—" universal-core column from the
 // rendered subsection while keeping a populated universal lane — and that

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -16,10 +16,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## Other
 
-| Language | Name | Auth coverage | Endpoint synthesis | Handler attribution | Middleware coverage | Notes |
-|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | — | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟢 | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | — | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | — | ✅ | — | — | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | — | 🔴 | 🔴 | — | |
+| Language | Name | Auth coverage | Endpoint synthesis | Handler attribution | Notes |
+|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟢 | ✅ | ✅ | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | — | ✅ | — | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | — | 🔴 | 🔴 | |


### PR DESCRIPTION
Closes #3874 · Epic #3871 · Program #3628

## What

Flat (un-subcategorised) by-category tables rendered one column per capability key from the **bucket-wide union** (`bucketCapabilityKeys`) or the category's declared keys, with **no don't-strand guard** (unlike subcategory group-columns, which already had `nonStrandedGroupNames`). For grab-bag tool/infra categories the union is far wider than any single record's vocabulary — build tools and test frameworks never declare "Lockfile parsing", so that column was `—` for every row. That is the sparse-table / repeated-name disease the audit targets.

Added `nonStrandedCapKeys` (the per-capability-column analogue of `nonStrandedGroupNames`) and wired it into the flat by-category render path. It drops any column that is `—` (not_applicable / empty / absent) for **every** record, keeps columns with ≥1 extracted or tracked-but-missing cell, preserves order, and falls back to the full set if every column would strand (never header-less).

**Presentation-only:** `registry.json` is byte-identical to `main`; every cell's status still comes from the registry unchanged. `gen` is idempotent (run twice → 0 drift).

## Sparsity before → after (em-dash cells)

| Category | before | after | verdict |
|---|---|---|---|
| `build_system` (91) | 276 | **3** | FIXED by column-strand (dropped Dependency usage status / Lockfile parsing / Manifest parsing — never applicable to build/test tools) |
| `package_manager` (20) | 67 | **27** | FIXED (kept only the 3 pkg columns that apply; dropped build-tool columns) |
| `language` (extractors) | 46 | **28** | FIXED (dropped stranded effect/quality columns) |
| `message_broker` (44) | 104 | 104 | **REDESIGN** — columns carry ≥1 real cell, so a column-drop can't help; needs a registry **subcategory split** |
| `platform` | 57 | 57 | OK — already subcategorised in #3861; residual `—` are legitimate per-lane cells |
| `orm` (156) | 0 | 0 | OK — single `orm_mapper` subcategory, uniform columns |
| `databases`, `validation` | 0 | 0 | OK |
| `observability` (9), `protocol` (12), `security` (13), `ci_cd` (12), `http_framework` | low/grouped | unchanged | OK — small, grouped, or column-fit already tight |

## REDESIGN verdict: `message_broker` (the strongest remaining candidate)

The 44 records mix four behaviourally distinct subgroups, which is why `Room channel grouping` (non-`—` for only 4 records) and `Signature verification` (only `msg.webhook`) are near-empty union columns. Confirmed per-record:

- **Schedulers** (consumer-only; no producer/topic/room/sig): apscheduler, hangfire-recurring, node-schedule, rufus-scheduler, whenever
- **Task queues** (producer; no topic/room/sig): dramatiq, sidekiq, resque, celery, bullmq, …
- **Brokers** (producer + topic attribution): kafka, rabbitmq, sns, sqs, nats, pulsar, redis, eventbridge, … + native clients (librdkafka, lapin, mqtt, zeromq)
- **Realtime channels** (room/channel grouping; no signature): actioncable, django-channels, phoenix-channels, websocket
- **Webhooks** (signature verification): webhook

Proposed subcategory columns (mirroring `http_framework`'s per-lane taxonomy, no empty-column unions):
- Schedulers → Consumer extraction · Status
- Task queues → Consumer · Producer · Status
- Brokers → Consumer · Producer · Topic attribution · Status
- Realtime channels → Consumer · Producer · Room channel grouping · Topic attribution · Status
- Webhooks → Consumer · Signature verification · Status

This requires tagging `subcategory` in `registry.json` (a serialized data change, behind #3861/#3873 per the doc-thrash rule) — out of scope for this presentation-only PR; a B5 redesign child ticket should be filed for it.

## Tests
- New value-asserting `TestNonStrandedCapKeys` (drops uniform-`—` / not_applicable columns, keeps tracked-but-missing, order-preserving, all-strand + nil passthrough).
- Golden fixture updated: `http_framework` "Other" tail drops the all-`—` `Middleware coverage` column.
- `go test ./tools/coverage/...` green · `coverage validate` 0 errors · `fmt --check` canonical · `gofmt -l` empty · `go vet` clean.

DEPLOY-DEFERRED: docs + generator only, no runtime/indexer path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)