### PR TITLE
[go][graphql] gqlgen parity: .graphqls classifier drop + @hasRole/@auth field-directive auth (#4006, epic #3872)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -59,7 +59,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
+| [go](../by-language/go.md) | [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 6/11 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -41,7 +41,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 6/11 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [google/wire (DI)](../detail/lang.go.framework.wire.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
-| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
+| [gqlgen (GraphQL)](../detail/lang.go.framework.gqlgen.md) | 🟡 3/6 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 5/24 | 🟡 2/13 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 3/6 | — | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/11 | |
 

--- a/docs/coverage/detail/lang.go.framework.gqlgen.md
+++ b/docs/coverage/detail/lang.go.framework.gqlgen.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | 3613 | — | — |
+| Auth coverage | 🟢 `partial` | `2026-06-03` | 4006 | `internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go`<br>`internal/extractors/graphql/graphql.go` | #4006 (verify-first): the SDL pass now extracts field-level auth directives — @hasRole(role: ADMIN)/@hasRoles/@hasScope → auth_required+auth_roles=ADMIN; bare @auth/@isAuthenticated → auth_required (no roles); auth_method=graphql_directive, auth_confidence=0.9 — stamped on the SCOPE.Component field node. Proven by TestGqlgen_DirectiveAuth_4006 (Query.adminUsers→ADMIN, Query.me bare @auth, negatives Query.publicStats/User.id), and a non-auth-directive negative (@deprecated/@goField → no auth, TestGqlgen_NonAuthDirective_NoAuth_4006). partial: the schema-directive form is statically recoverable; resolver-body ctx-based checks (auth.ForContext(ctx)) and gqlgen generated directive-runtime wiring are not modelled. |
 
 ### Validation
 
@@ -52,7 +52,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type graph extraction | ✅ `full` | `2026-06-02` | — | `internal/extractors/graphql/graphql.go`<br>`internal/extractors/graphql/type_graph.go` | gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphql files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) already emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph. |
+| Type graph extraction | ✅ `full` | `2026-06-03` | 4006 | `internal/classifier/classifier.go`<br>`internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go`<br>`internal/extractors/graphql/graphql.go`<br>`internal/extractors/graphql/type_graph.go` | gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphqls files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph. #4006 (verify-first) fixed the canonical gqlgen drop: classifier extensionLanguageMap mapped .graphql/.gql but NOT gqlgen's canonical .graphqls, so the pass silently never fired on graph/schema.graphqls (probe: schema.graphqls→lang=""). Added .graphqls→graphql; proven by TestGqlgen_TypeGraph_4006 (User.orders→to_many, User.account→to_one nullable) + classifier TestExtensionCoverage(graph/schema.graphqls→graphql). |
 
 ### Type System
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 |--------|----------|------|--------|
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 4 full, 3 partial, 42 missing |
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
-| [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 6 partial, 39 missing |
+| [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 7 partial, 38 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 4 full, 5 partial, 46 missing |
 | [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 1 missing, 1 n/a |
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -20508,8 +20508,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing",
-            "issue": "3613"
+            "status": "partial",
+            "cites": ["internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go","internal/extractors/graphql/graphql.go"],
+            "issue": "4006",
+            "notes": "#4006 (verify-first): the SDL pass now extracts field-level auth directives — @hasRole(role: ADMIN)/@hasRoles/@hasScope → auth_required+auth_roles=ADMIN; bare @auth/@isAuthenticated → auth_required (no roles); auth_method=graphql_directive, auth_confidence=0.9 — stamped on the SCOPE.Component field node. Proven by TestGqlgen_DirectiveAuth_4006 (Query.adminUsers→ADMIN, Query.me bare @auth, negatives Query.publicStats/User.id), and a non-auth-directive negative (@deprecated/@goField → no auth, TestGqlgen_NonAuthDirective_NoAuth_4006). partial: the schema-directive form is statically recoverable; resolver-body ctx-based checks (auth.ForContext(ctx)) and gqlgen generated directive-runtime wiring are not modelled.",
+            "verified_at": "2026-06-03"
           }
         },
         "Validation": {
@@ -20536,9 +20539,10 @@
         "Schema": {
           "type_graph_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/graphql/graphql.go","internal/extractors/graphql/type_graph.go"],
-            "notes": "gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphql files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) already emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph.",
-            "verified_at": "2026-06-02"
+            "cites": ["internal/classifier/classifier.go","internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go","internal/extractors/graphql/graphql.go","internal/extractors/graphql/type_graph.go"],
+            "issue": "4006",
+            "notes": "gqlgen is SDL-driven: the schema (object types + object-typed fields) is declared in *.graphqls files, so the SDL type→type graph pass (internal/extractors/graphql/type_graph.go, #3805) emits the GRAPH_RELATES object-type→type edges with list/nullable cardinality between the SCOPE.Schema type nodes. gqlgen's generated Go resolvers carry no additional type refs (operation glue only), so no code-first Go extractor is required; the SDL pass is the source of truth for the gqlgen schema relationship graph. #4006 (verify-first) fixed the canonical gqlgen drop: classifier extensionLanguageMap mapped .graphql/.gql but NOT gqlgen's canonical .graphqls, so the pass silently never fired on graph/schema.graphqls (probe: schema.graphqls→lang=\"\"). Added .graphqls→graphql; proven by TestGqlgen_TypeGraph_4006 (User.orders→to_many, User.account→to_one nullable) + classifier TestExtensionCoverage(graph/schema.graphqls→graphql).",
+            "verified_at": "2026-06-03"
           }
         },
         "Type System": {

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -544,6 +544,10 @@ var extensionLanguageMap = map[string]string{
 	// GraphQL
 	".graphql": "graphql",
 	".gql":     "graphql",
+	// #4006 — gqlgen's canonical schema file is graph/schema.graphqls. Without
+	// this mapping the file is dropped (lang=""), so the SDL type→type graph
+	// (#3805) and gqlgen endpoint synthesis never fire on a real gqlgen project.
+	".graphqls": "graphql",
 	// Prisma
 	".prisma": "prisma",
 	// Elm

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -432,6 +432,7 @@ func TestExtensionCoverage(t *testing.T) {
 		{"foo.hcl", "hcl"},
 		{"foo.proto", "protobuf"},
 		{"foo.graphql", "graphql"},
+		{"graph/schema.graphqls", "graphql"}, // #4006 — gqlgen canonical schema file
 		{"foo.prisma", "prisma"},
 		{"foo.hs", "haskell"},
 		{"foo.pony", "pony"},

--- a/internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go
+++ b/internal/extractors/graphql/gqlgen_typegraph_auth_4006_test.go
@@ -1,0 +1,148 @@
+// gqlgen_typegraph_auth_4006_test.go — #4006 (epic #3872) Go GraphQL parity:
+// asserts the SDL type→type graph (GRAPH_RELATES) and the @hasRole/@auth
+// field-directive auth_coverage fire on gqlgen's canonical schema.graphqls.
+// gqlgen is SDL-first / code-generated, so the SDL is the source of truth for
+// both the type-graph and the most statically-recoverable auth signal.
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// gqlgenSDL is a representative gqlgen schema.graphqls: code-first models are
+// generated FROM this SDL, so the SDL is the source of truth for both the
+// type→type graph and the @hasRole field auth directive.
+const gqlgenSDL = `
+directive @hasRole(role: Role!) on FIELD_DEFINITION
+directive @auth on FIELD_DEFINITION
+
+enum Role { ADMIN USER }
+
+type User {
+  id: ID!
+  name: String!
+  account: Account
+  orders: [Order!]!
+}
+
+type Account { id: ID! }
+type Order { id: ID! }
+
+type Query {
+  me: User! @auth
+  adminUsers: [User!]! @hasRole(role: ADMIN)
+  publicStats: Int!
+}
+`
+
+// PROBE 1 (positive, type-graph): the SDL pass must emit User→Order to_many and
+// User→Account to_one nullable GRAPH_RELATES edges. This already works once the
+// extractor runs on the content.
+func TestGqlgen_TypeGraph_4006(t *testing.T) {
+	ents := extractGraphQL(gqlgenSDL, "graph/schema.graphqls")
+	var userToOrder, userToAccount bool
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "GRAPH_RELATES" {
+				continue
+			}
+			if r.Properties["graphql_field"] == "User.orders" {
+				userToOrder = true
+				if r.Properties["cardinality"] != "to_many" {
+					t.Errorf("User.orders cardinality=%q want to_many", r.Properties["cardinality"])
+				}
+				if r.Properties["list"] != "true" {
+					t.Errorf("User.orders list=%q want true", r.Properties["list"])
+				}
+			}
+			if r.Properties["graphql_field"] == "User.account" {
+				userToAccount = true
+				if r.Properties["cardinality"] != "to_one" {
+					t.Errorf("User.account cardinality=%q want to_one", r.Properties["cardinality"])
+				}
+				if r.Properties["nullable"] != "true" {
+					t.Errorf("User.account nullable=%q want true", r.Properties["nullable"])
+				}
+			}
+		}
+	}
+	if !userToOrder {
+		t.Error("PROBE FAIL: missing User->Order GRAPH_RELATES to_many edge")
+	}
+	if !userToAccount {
+		t.Error("PROBE FAIL: missing User->Account GRAPH_RELATES to_one nullable edge")
+	}
+}
+
+// PROBE 2 (value-asserting, auth): @hasRole(role: ADMIN) → auth_required +
+// auth_roles=ADMIN on Query.adminUsers; bare @auth → auth_required, no roles on
+// Query.me; a directive-free field (Query.publicStats) → NO auth.
+func TestGqlgen_DirectiveAuth_4006(t *testing.T) {
+	ext := &Extractor{}
+	ents, _ := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "graph/schema.graphqls",
+		Content: []byte(gqlgenSDL),
+	})
+	byName := map[string]map[string]string{}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "field" {
+			byName[e.Name] = e.Properties
+		}
+	}
+
+	admin, ok := byName["Query.adminUsers"]
+	if !ok {
+		t.Fatal("Query.adminUsers field entity not emitted")
+	}
+	if admin["auth_required"] != "true" {
+		t.Errorf("Query.adminUsers auth_required=%q want true", admin["auth_required"])
+	}
+	if admin["auth_roles"] != "ADMIN" {
+		t.Errorf("Query.adminUsers auth_roles=%q want ADMIN", admin["auth_roles"])
+	}
+	if admin["auth_method"] != "graphql_directive" {
+		t.Errorf("Query.adminUsers auth_method=%q want graphql_directive", admin["auth_method"])
+	}
+
+	me, ok := byName["Query.me"]
+	if !ok {
+		t.Fatal("Query.me field entity not emitted")
+	}
+	if me["auth_required"] != "true" {
+		t.Errorf("Query.me auth_required=%q want true", me["auth_required"])
+	}
+	if me["auth_roles"] != "" {
+		t.Errorf("Query.me auth_roles=%q want empty (bare @auth)", me["auth_roles"])
+	}
+
+	// Negative: a directive-free field carries no auth.
+	if stats := byName["Query.publicStats"]; stats["auth_required"] != "" {
+		t.Errorf("Query.publicStats should have no auth, got %v", stats)
+	}
+	// Negative: a plain object field (User.id, no directive) carries no auth.
+	if id := byName["User.id"]; id["auth_required"] != "" {
+		t.Errorf("User.id should have no auth, got %v", id)
+	}
+}
+
+// PROBE 3 (negative, non-auth directive): @deprecated / @goField must NOT be
+// mistaken for an auth directive.
+func TestGqlgen_NonAuthDirective_NoAuth_4006(t *testing.T) {
+	const sdl = `
+type T {
+  legacy: String @deprecated(reason: "use new")
+  renamed: String @goField(name: "Renamed")
+}
+`
+	ents := extractGraphQL(sdl, "graph/schema.graphqls")
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "field" {
+			if e.Properties["auth_required"] != "" {
+				t.Errorf("%s wrongly flagged auth from non-auth directive: %v", e.Name, e.Properties)
+			}
+		}
+	}
+}

--- a/internal/extractors/graphql/graphql.go
+++ b/internal/extractors/graphql/graphql.go
@@ -237,7 +237,7 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 				// Emit the field as its own SCOPE.Component entity so the
 				// resolver can attach the structural-ref ToID.
 				fieldStartLine := strings.Count(src[:bodyStart], "\n") + 1 + f.lineOffset
-				entities = append(entities, types.EntityRecord{
+				fieldEnt := types.EntityRecord{
 					Name:       name + "." + f.name,
 					Kind:       "SCOPE.Component",
 					Subtype:    "field",
@@ -246,7 +246,22 @@ func extractGraphQL(src, filePath string) []types.EntityRecord {
 					StartLine:  fieldStartLine,
 					EndLine:    fieldStartLine,
 					Signature:  name + "." + f.name,
-				})
+				}
+				// #4006 — auth_coverage: a recognised field-level auth directive
+				// (@hasRole(role: ADMIN) / @auth / @isAuthenticated / @hasScope)
+				// stamps the auth contract on the field node. Roles/scopes are
+				// comma-joined; a bare @auth carries auth_required with no roles.
+				if f.authReq {
+					fieldEnt.Properties = map[string]string{
+						"auth_required":   "true",
+						"auth_method":     "graphql_directive",
+						"auth_confidence": "0.9",
+					}
+					if f.authRoles != "" {
+						fieldEnt.Properties["auth_roles"] = f.authRoles
+					}
+				}
+				entities = append(entities, fieldEnt)
 			}
 		}
 
@@ -458,6 +473,53 @@ type fieldHit struct {
 	name       string
 	typeExpr   string // the raw GraphQL type expression, e.g. "[Order!]!"
 	lineOffset int    // 0-based line offset within the body
+	authReq    bool   // #4006 — field carries an auth directive (@auth/@hasRole/…)
+	authRoles  string // #4006 — comma-joined roles from @hasRole(role: X)/@hasRoles
+}
+
+// authDirectiveRE matches a field-level GraphQL auth directive and the optional
+// role argument, the most statically-recoverable gqlgen/graph-gophers auth
+// signal (a `@hasRole(role: ADMIN)` SDL directive on a FIELD_DEFINITION).
+//
+//	@auth                          → authReq, no role
+//	@isAuthenticated               → authReq, no role
+//	@hasRole(role: ADMIN)          → authReq, role=ADMIN
+//	@hasRole(role: [ADMIN, USER])  → authReq, role=ADMIN,USER
+//	@hasRole(roles: [ADMIN])       → authReq, role=ADMIN
+//	@hasScope(scope: "read:user")  → authReq, role=read:user
+//
+// The directive must be one of the recognised auth names so a plain
+// `@deprecated` / `@goField` does NOT trigger auth (negative-tested).
+var authDirectiveRE = regexp.MustCompile(
+	`@(auth|isAuthenticated|hasRole|hasAnyRole|hasRoles|requireAuth|hasScope|hasPermission)\b` +
+		`(?:\s*\(\s*(?:role|roles|scope|scopes|permission|permissions)\s*:\s*(\[[^\]]*\]|"[^"]*"|\w+))?`,
+)
+
+// roleTokenRE picks the bare role/scope tokens out of a captured directive
+// argument, tolerating list `[A, B]`, quoted `"read:user"`, or a bare `ADMIN`.
+var roleTokenRE = regexp.MustCompile(`"[^"]*"|[A-Za-z_][\w:.-]*`)
+
+// scanFieldAuth inspects one field line (name : Type @directive…) for a
+// recognised auth directive, returning whether auth is required and the
+// comma-joined role/scope set (empty when the directive carries no argument).
+func scanFieldAuth(line string) (required bool, roles string) {
+	m := authDirectiveRE.FindStringSubmatch(line)
+	if m == nil {
+		return false, ""
+	}
+	required = true
+	arg := strings.TrimSpace(m[2])
+	if arg == "" {
+		return true, ""
+	}
+	var toks []string
+	for _, t := range roleTokenRE.FindAllString(arg, -1) {
+		t = strings.Trim(t, `"`)
+		if t != "" {
+			toks = append(toks, t)
+		}
+	}
+	return true, strings.Join(toks, ",")
 }
 
 // fieldDeclRE re-parses a field line to split the leading name from the type
@@ -490,7 +552,14 @@ func collectFields(body string) []fieldHit {
 		if mm := fieldDeclRE.FindStringSubmatch(body[m[0]:m[1]]); mm != nil {
 			typeExpr = strings.TrimSpace(mm[2])
 		}
-		out = append(out, fieldHit{name: name, typeExpr: typeExpr, lineOffset: offset})
+		// #4006 — capture a field-level auth directive (@hasRole/@auth/…). The
+		// directive tail lives after the type expression on the same line; the
+		// fieldRE span [m[0],m[1]) covers the whole line.
+		authReq, authRoles := scanFieldAuth(body[m[0]:m[1]])
+		out = append(out, fieldHit{
+			name: name, typeExpr: typeExpr, lineOffset: offset,
+			authReq: authReq, authRoles: authRoles,
+		})
 	}
 	return out
 }


### PR DESCRIPTION
Closes #4006 · epic #3872 · **DEPLOY-DEFERRED**

Go GraphQL parity credit, mirroring the GraphQL meta-pattern just closed for rust (#3983/#4005), java (#3995), php (#3998), python and js/ts. **VERIFY-FIRST**: wrote value-asserting probes on real gqlgen SDL before changing.

## Findings (verify-first)
**GAP 1 — `.graphqls` classifier drop (type_graph silently never fired):**
gqlgen's canonical schema file is `graph/schema.graphqls`. The classifier `extensionLanguageMap` mapped `.graphql`/`.gql` → `graphql` but **not `.graphqls`**:
```
graph/schema.graphqls -> lang=""        # DROPPED
graph/schema.graphql  -> lang="graphql"
```
So the SDL `type_graph.go` pass (#3805, GRAPH_RELATES field→type edges) never ran on a real gqlgen project's primary schema — the registry's "type_graph_extraction = ✅ full" was only true for the non-canonical `.graphql` extension. Fix: add `.graphqls → graphql`.

**GAP 2 — `@hasRole`/`@auth` field-directive auth uncredited (`auth_coverage` = 🔴):**
The most statically-recoverable gqlgen/graph-gophers auth is the SDL field directive. Now extracted: `@auth`/`@isAuthenticated`/`@hasRole`/`@hasRoles`/`@hasScope`/`@hasPermission` on FIELD_DEFINITION → `auth_required` + `auth_roles` + `auth_method=graphql_directive` + `auth_confidence=0.9` on the field SCOPE.Component node.

## What I credited
- **type_graph_extraction**: stays ✅ full — now genuinely fires on `.graphqls`. Probe `TestGqlgen_TypeGraph_4006` asserts the SPECIFIC edges: `User.orders` → GRAPH_RELATES `to_many` (list=true), `User.account` → `to_one` nullable.
- **auth_coverage**: 🔴 missing → 🟢 **partial**. Probe `TestGqlgen_DirectiveAuth_4006` asserts `@hasRole(role: ADMIN)` on `Query.adminUsers` → `auth_required=true`, `auth_roles=ADMIN`, `auth_method=graphql_directive`; bare `@auth` on `Query.me` → `auth_required` no roles. Negatives: `Query.publicStats` + `User.id` (directive-free) → no auth; `TestGqlgen_NonAuthDirective_NoAuth_4006` proves `@deprecated`/`@goField` do NOT trigger auth.

## Honest scope
gqlgen is **SDL-first / code-generated** — Go resolver structs carry no GraphQL field type tags, so the SDL is the type-graph + auth source of truth; **no code-first Go extractor is needed**. Resolver-body `ctx`-based auth (`auth.ForContext(ctx)`) and the gqlgen generated directive-runtime are not statically recoverable here → `auth_coverage` honestly stays **partial**.

## Gates
- `go test ./internal/extractors/graphql/ ./internal/classifier/ ./internal/types/ ./internal/engine/ ./internal/custom/golang/ ./internal/extractors/golang/` — green
- No new entity/edge Kind (`go test ./internal/types/` green)
- `covtool validate` 0 errors · `covtool fmt --check` canonical · `covtool gen` 0 residual drift · `gofmt -l` empty · `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)