### PR TITLE
perf(daemon): worktree-aware graph clone — stop cold-reindex churn + GC vanished stores (#3680)

### DIFF
--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -1,0 +1,211 @@
+// reaper.go — vanished-repo store GC (issue #3680).
+//
+// # Problem
+//
+// archigraph dogfoods itself, so the daemon's watcher catches every
+// `git worktree add` and (pre-#3680) cold-indexes the worktree as a SEPARATE
+// repo with its OWN ~100MB full graph store under hash(worktreePath). When the
+// rewrite agent later deletes those worktrees, the directories vanish from disk
+// but the daemon keeps tracking them: the tier Manager still holds their slots
+// (counting toward memory pressure and attempting cold-wakes) and the on-disk
+// store dir is never deleted. The live daemon's `~/.archigraph/store/` grew to
+// 7.2GB dominated by ~25 such orphaned worktree stores, with the tier Manager
+// logging `stat repo: ... no such file or directory`.
+//
+// # Fix
+//
+// The Reaper periodically reconciles the tracked repo set against the
+// filesystem. For every tracked repo path whose directory no longer exists it:
+//
+//  1. deletes the on-disk store directory (repoBaseDir), reclaiming its bytes,
+//  2. forgets the repo's tier slots (decrementing the in-memory accounting),
+//  3. lets the caller drop any other registry/worktree-store tracking via the
+//     Untrack callback.
+//
+// An EXISTING repo is never reaped. The reaper is conservative: a path that
+// cannot be stat'd for any reason OTHER than "does not exist" (e.g. a transient
+// permission error) is left untouched so a flaky filesystem can never cause the
+// daemon to nuke a live repo's graph.
+package daemon
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// TierForgetter is the narrow slice of tier.Manager the reaper needs: drop all
+// slots for a repo path and report how many were dropped. Implemented by
+// *tier.Manager.Forget.
+type TierForgetter interface {
+	Forget(repoPath string) int
+}
+
+// ReaperConfig wires the vanished-repo reaper. All hooks are optional except
+// TrackedRepos; a nil hook is simply skipped.
+type ReaperConfig struct {
+	// TrackedRepos returns the current set of absolute repo paths the daemon
+	// tracks (registered repos + active worktree children). Called on every
+	// sweep so newly-tracked repos are covered without restarting the reaper.
+	// Required; a nil value makes Sweep a no-op.
+	TrackedRepos func() []string
+
+	// StoreDirForRepo returns the absolute on-disk store directory for a repo
+	// path (the top-level slot, e.g. repoBaseDir). The reaper RemoveAll's this
+	// directory when the repo has vanished. When nil, store deletion is skipped
+	// (slots are still forgotten).
+	StoreDirForRepo func(repoPath string) string
+
+	// Tier, when non-nil, has Forget(repoPath) called for every vanished repo
+	// so its slots leave the in-memory accounting.
+	Tier TierForgetter
+
+	// Untrack, when non-nil, is called once per vanished repo so the caller can
+	// drop the path from any other tracking surface (worktree store, head
+	// poller, fsnotify subscription). Invoked after the store is removed.
+	Untrack func(repoPath string)
+
+	// Interval between sweeps. Default (zero value): 5 minutes.
+	Interval time.Duration
+
+	// Logger for sweep diagnostics. nil → a default stderr logger.
+	Logger *slog.Logger
+}
+
+// ReapResult summarises one Sweep.
+type ReapResult struct {
+	// Vanished is the number of tracked repos found missing on disk.
+	Vanished int
+	// StoresRemoved is the number of on-disk store directories deleted.
+	StoresRemoved int
+	// SlotsForgotten is the total tier slots dropped from accounting.
+	SlotsForgotten int
+	// FreedBytes is the total bytes reclaimed from deleted store dirs.
+	FreedBytes int64
+}
+
+// Reaper periodically GCs stores for repos that no longer exist on disk.
+type Reaper struct {
+	cfg    ReaperConfig
+	logger *slog.Logger
+}
+
+// NewReaper constructs a Reaper. Call Start to run it in the background, or
+// call Sweep directly (tests / one-shot).
+func NewReaper(cfg ReaperConfig) *Reaper {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "reaper")
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = 5 * time.Minute
+	}
+	return &Reaper{cfg: cfg, logger: logger}
+}
+
+// Start runs the reaper loop until stopCh is closed. It performs one immediate
+// sweep after a short startup delay, then sweeps on the configured interval.
+func (r *Reaper) Start(stopCh <-chan struct{}) {
+	go func() {
+		// Brief startup delay so boot-time indexing settles first.
+		select {
+		case <-stopCh:
+			return
+		case <-time.After(30 * time.Second):
+		}
+		r.Sweep()
+		t := time.NewTicker(r.cfg.Interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-t.C:
+				r.Sweep()
+			}
+		}
+	}()
+}
+
+// Sweep runs one reconciliation pass synchronously and returns what it reaped.
+// Safe to call directly from tests.
+func (r *Reaper) Sweep() ReapResult {
+	var res ReapResult
+	if r.cfg.TrackedRepos == nil {
+		return res
+	}
+	for _, repo := range r.cfg.TrackedRepos() {
+		if repo == "" {
+			continue
+		}
+		if repoExists(repo) {
+			continue // live repo — never reaped.
+		}
+		res.Vanished++
+		r.logger.Info("reaper: tracked repo vanished from disk — GCing store", "repo", repo)
+
+		// 1. Delete the on-disk store.
+		if r.cfg.StoreDirForRepo != nil {
+			storeDir := r.cfg.StoreDirForRepo(repo)
+			if storeDir != "" {
+				if sz, err := r.removeStore(storeDir); err != nil {
+					r.logger.Warn("reaper: store removal failed (non-fatal)", "repo", repo, "store", storeDir, "err", err)
+				} else if sz >= 0 {
+					res.StoresRemoved++
+					res.FreedBytes += sz
+					r.logger.Info("reaper: store removed", "repo", repo, "store", storeDir, "freed_bytes", sz)
+				}
+			}
+		}
+
+		// 2. Forget tier slots (decrement in-memory accounting).
+		if r.cfg.Tier != nil {
+			res.SlotsForgotten += r.cfg.Tier.Forget(repo)
+		}
+
+		// 3. Drop any other tracking.
+		if r.cfg.Untrack != nil {
+			r.cfg.Untrack(repo)
+		}
+	}
+	if res.Vanished > 0 {
+		r.logger.Info("reaper: sweep complete",
+			"vanished", res.Vanished,
+			"stores_removed", res.StoresRemoved,
+			"slots_forgotten", res.SlotsForgotten,
+			"freed_bytes", res.FreedBytes)
+	}
+	return res
+}
+
+// removeStore deletes storeDir and returns the bytes it freed. A non-existent
+// store dir is not an error (returns 0 freed). Returns -1 freed when the dir
+// did not exist so the caller can distinguish "nothing to remove" from "removed
+// 0-byte dir".
+func (r *Reaper) removeStore(storeDir string) (int64, error) {
+	sz, err := dirSizeHygiene(storeDir)
+	if err != nil {
+		// Most likely the store dir never existed — nothing to free.
+		if errors.Is(err, os.ErrNotExist) {
+			return -1, nil
+		}
+		// Other walk errors: still attempt removal but report 0 freed.
+		sz = 0
+	}
+	if rmErr := os.RemoveAll(storeDir); rmErr != nil {
+		return 0, rmErr
+	}
+	return sz, nil
+}
+
+// repoExists reports whether repoPath is an existing directory on disk. It
+// returns true on any stat error OTHER than "not exist" so a transient
+// permission/IO error never causes a live repo to be reaped (fail-safe).
+func repoExists(repoPath string) bool {
+	fi, err := os.Stat(repoPath)
+	if err != nil {
+		return !errors.Is(err, os.ErrNotExist)
+	}
+	return fi.IsDir()
+}

--- a/internal/daemon/reaper_test.go
+++ b/internal/daemon/reaper_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeForgetter records Forget calls and returns a fixed slot count per repo.
+type fakeForgetter struct {
+	slots     map[string]int // repo -> slots it "holds"
+	forgotten []string
+}
+
+func (f *fakeForgetter) Forget(repoPath string) int {
+	f.forgotten = append(f.forgotten, repoPath)
+	n := f.slots[repoPath]
+	delete(f.slots, repoPath) // accounting decremented
+	return n
+}
+
+// writeStore creates a fake store dir with `bytes` worth of content and returns
+// its path.
+func writeStore(t *testing.T, root, name string, bytes int) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Join(dir, "refs", "main"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "refs", "main", "graph.fb"), make([]byte, bytes), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestReaper_evictsVanishedRepoStore is the value-assertion for fix #1: a
+// tracked repo whose directory has been deleted gets its store removed, its
+// tier slots forgotten, its accounting decremented, and Untrack invoked.
+func TestReaper_evictsVanishedRepoStore(t *testing.T) {
+	tmp := t.TempDir()
+	storeRoot := filepath.Join(tmp, "store")
+
+	// A repo that STILL exists on disk.
+	liveRepo := filepath.Join(tmp, "live-repo")
+	if err := os.MkdirAll(liveRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	liveStore := writeStore(t, storeRoot, "live-abcdef0123456789", 1000)
+
+	// A repo that has VANISHED (we never create its dir).
+	goneRepo := filepath.Join(tmp, "gone-worktree")
+	goneStore := writeStore(t, storeRoot, "gone-fedcba9876543210", 4096)
+
+	forgetter := &fakeForgetter{slots: map[string]int{
+		liveRepo: 2,
+		goneRepo: 3,
+	}}
+	var untracked []string
+
+	storeFor := map[string]string{liveRepo: liveStore, goneRepo: goneStore}
+	r := NewReaper(ReaperConfig{
+		TrackedRepos:    func() []string { return []string{liveRepo, goneRepo} },
+		StoreDirForRepo: func(repo string) string { return storeFor[repo] },
+		Tier:            forgetter,
+		Untrack:         func(repo string) { untracked = append(untracked, repo) },
+	})
+
+	res := r.Sweep()
+
+	// --- vanished repo reaped ---
+	if res.Vanished != 1 {
+		t.Fatalf("Vanished = %d, want 1 (only gone-worktree)", res.Vanished)
+	}
+	if res.StoresRemoved != 1 {
+		t.Fatalf("StoresRemoved = %d, want 1", res.StoresRemoved)
+	}
+	if _, err := os.Stat(goneStore); !os.IsNotExist(err) {
+		t.Fatalf("vanished repo's store still on disk: %v", err)
+	}
+	if res.FreedBytes < 4096 {
+		t.Fatalf("FreedBytes = %d, want >= 4096 (the graph.fb payload)", res.FreedBytes)
+	}
+	// tier slots forgotten + accounting decremented.
+	if res.SlotsForgotten != 3 {
+		t.Fatalf("SlotsForgotten = %d, want 3", res.SlotsForgotten)
+	}
+	if _, still := forgetter.slots[goneRepo]; still {
+		t.Fatalf("vanished repo's tier accounting was not decremented")
+	}
+	// Untrack invoked for the vanished repo.
+	if len(untracked) != 1 || untracked[0] != goneRepo {
+		t.Fatalf("Untrack = %v, want [%s]", untracked, goneRepo)
+	}
+
+	// --- NEGATIVE: the live repo is untouched ---
+	if _, err := os.Stat(liveStore); err != nil {
+		t.Fatalf("live repo's store was wrongly removed: %v", err)
+	}
+	for _, f := range forgetter.forgotten {
+		if f == liveRepo {
+			t.Fatalf("live repo's tier slots were wrongly forgotten")
+		}
+	}
+	if n, still := forgetter.slots[liveRepo]; !still || n != 2 {
+		t.Fatalf("live repo's accounting changed: got %d (present=%v), want 2", n, still)
+	}
+}
+
+// TestReaper_failSafeOnStatError asserts the reaper does NOT reap a repo when
+// the path exists (a permission/IO error must never nuke a live graph). We
+// model "exists" by creating the dir; a vanished dir is the only reap trigger.
+func TestReaper_existingRepoNeverReaped(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "present")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := writeStore(t, filepath.Join(tmp, "store"), "present-0011223344556677", 512)
+
+	r := NewReaper(ReaperConfig{
+		TrackedRepos:    func() []string { return []string{repo} },
+		StoreDirForRepo: func(string) string { return store },
+		Tier:            &fakeForgetter{slots: map[string]int{repo: 1}},
+	})
+	res := r.Sweep()
+
+	if res.Vanished != 0 || res.StoresRemoved != 0 || res.SlotsForgotten != 0 {
+		t.Fatalf("existing repo was reaped: %+v", res)
+	}
+	if _, err := os.Stat(store); err != nil {
+		t.Fatalf("existing repo's store was removed: %v", err)
+	}
+}
+
+// TestReaper_noOpWhenNoTracker guards the nil-config path.
+func TestReaper_noOpWhenNoTracker(t *testing.T) {
+	r := NewReaper(ReaperConfig{})
+	if res := r.Sweep(); res != (ReapResult{}) {
+		t.Fatalf("nil TrackedRepos should be a no-op, got %+v", res)
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -84,6 +84,18 @@ type GroupsForRepoFn func(repoPath string) []string
 // job is admitted regardless of budget).
 type PredictFn func(repoPath string) int64
 
+// SkipEnqueueFn reports whether an enqueue for repoPath should be DROPPED
+// before it ever reaches the admission queue. It is the root-cause guard for
+// issue #3680: a path that is a linked git worktree of an already-indexed
+// primary repo must NOT be cold-indexed as a brand-new root repo (which would
+// spawn its own ~100MB full graph store and blow the RSS budget). The worktree
+// subsystem still tracks such a path as an ephemeral child with aggressive
+// TTLs; it simply must not become an independent root index job.
+//
+// Returning true silently skips the enqueue. nil disables the guard (every
+// enqueue is accepted — legacy behaviour).
+type SkipEnqueueFn func(repoPath string) bool
+
 // IncrementalResult carries the outcome of a S3 incremental reindex attempt.
 // Mirrors extractors.Result without importing that package here to avoid a
 // circular dependency (extractors imports daemon for StateDirForRepo).
@@ -125,6 +137,13 @@ type Config struct {
 	// assumed to cost 1MB (admission control still serialises but is
 	// effectively disabled unless many workers are configured).
 	Predict PredictFn
+
+	// SkipEnqueue, when non-nil, is consulted at the top of EnqueueRef. When
+	// it returns true the enqueue is dropped before entering the pending
+	// queue. This is the worktree-churn guard for issue #3680: linked
+	// worktrees of already-indexed primaries are not cold-indexed as new
+	// root repos. nil = accept every enqueue (legacy behaviour).
+	SkipEnqueue SkipEnqueueFn
 
 	// History, when non-nil, overrides Predict for repos that have a
 	// recorded peak. The scheduler also writes each completed job's
@@ -387,6 +406,13 @@ func (s *Scheduler) Enqueue(repoPath string) {
 // events) where the new ref has already been observed — no extra git call
 // needed. Safe to call from arbitrary goroutines.
 func (s *Scheduler) EnqueueRef(repoPath, ref string) {
+	// Issue #3680: drop enqueues for linked worktrees of already-indexed
+	// primaries so they never become independent root index jobs (each of
+	// which would spawn its own ~100MB store and pressure the RSS budget).
+	if s.cfg.SkipEnqueue != nil && s.cfg.SkipEnqueue(repoPath) {
+		s.logEvent("enqueue_skipped", repoPath, "linked worktree of indexed primary — not cold-indexed as a new root (#3680)")
+		return
+	}
 	select {
 	case s.enq <- enqueueRequest{repoPath: repoPath, ref: ref}:
 	case <-s.stop:

--- a/internal/daemon/sched/scheduler_test.go
+++ b/internal/daemon/sched/scheduler_test.go
@@ -464,3 +464,63 @@ func TestRunLinksUsesShutdownCtx(t *testing.T) {
 		t.Error("Stop() did not return after Links callback exited")
 	}
 }
+
+// TestSkipEnqueue_dropsLinkedWorktree asserts the #3680 guard: when
+// Config.SkipEnqueue returns true for a path, that enqueue is dropped before
+// it can become a root index job — so the indexer never runs for it. A
+// non-matching path is still indexed normally (negative case).
+func TestSkipEnqueue_dropsLinkedWorktree(t *testing.T) {
+	const worktreePath = "/repos/primary/.worktrees/agent-7"
+	const realRepo = "/repos/primary"
+
+	var indexed sync.Map // repoPath -> struct{}
+	done := make(chan string, 4)
+	s := New(Config{
+		Workers: 1,
+		// Gate: treat the worktree path as a linked worktree of an indexed
+		// primary; everything else is a normal root repo.
+		SkipEnqueue: func(repoPath string) bool {
+			return repoPath == worktreePath
+		},
+		Index: func(_ context.Context, repoPath string, _ string) error {
+			indexed.Store(repoPath, struct{}{})
+			done <- repoPath
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	// Gated: must NOT be indexed.
+	s.Enqueue(worktreePath)
+	// Ungated: must be indexed (proves the gate is selective, not a kill-switch).
+	s.Enqueue(realRepo)
+
+	select {
+	case got := <-done:
+		if got != realRepo {
+			t.Fatalf("indexed unexpected repo %q; the gated worktree must not be indexed", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("real repo was never indexed — gate must not block non-worktree paths")
+	}
+
+	// Give any (erroneously) admitted worktree job time to run, then assert
+	// it never did.
+	time.Sleep(150 * time.Millisecond)
+	if _, ok := indexed.Load(worktreePath); ok {
+		t.Fatalf("linked-worktree path %q was cold-indexed despite the #3680 gate", worktreePath)
+	}
+
+	// The skip must be recorded in the recent-log telemetry for observability.
+	snap := s.Snapshot()
+	var sawSkip bool
+	for _, e := range snap.RecentLog {
+		if e.Kind == "enqueue_skipped" && e.Repo == worktreePath {
+			sawSkip = true
+		}
+	}
+	if !sawSkip {
+		t.Errorf("expected an enqueue_skipped log entry for the gated worktree")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -302,6 +302,13 @@ func Run(ctx context.Context, cfg Config) error {
 			RefCapture: func(repoPath string) string {
 				return gitmeta.Capture(repoPath).Ref
 			},
+			// #3680: drop enqueues for linked git worktrees of an
+			// already-indexed primary repo so they never become independent
+			// root index jobs (each spawning its own ~100MB full graph store
+			// and pressuring the RSS admission budget). The worktree subsystem
+			// still tracks such paths as ephemeral children with aggressive
+			// TTLs. The indexed-primary set is the boot-time ReposToWatch list.
+			SkipEnqueue: makeWorktreeEnqueueGate(cfg.ReposToWatch),
 			// S3 incremental file-level reindex (issue #2153). When nil
 			// the scheduler falls through to full reindex on every tick.
 			Incremental: cfg.SchedulerIncremental,
@@ -397,9 +404,10 @@ func Run(ctx context.Context, cfg Config) error {
 			// Gated on the fsnotify watcher being up (we reuse it to watch each
 			// worktree's working tree) and on a caller-supplied parents provider
 			// (non-nil only when some group opts into worktree tracking).
+			var wtStore *worktree.Store
 			if cfg.WorktreeParents != nil {
 				wtStorePath := filepath.Join(cfg.Layout.Root, "worktrees.json")
-				wtStore := worktree.NewStore(wtStorePath)
+				wtStore = worktree.NewStore(wtStorePath)
 				if err := wtStore.Load(); err != nil {
 					logger.Warn("worktree: failed to load store; starting empty", "path", wtStorePath, "err", err)
 				}
@@ -431,6 +439,24 @@ func Run(ctx context.Context, cfg Config) error {
 				logger.Info("worktree: discovery started",
 					"store", wtStorePath, "reconcile_env", "ARCHIGRAPH_WORKTREE_POLL_SECONDS")
 			}
+
+			// #3680: vanished-repo store reaper. Tracked repos (registered +
+			// active worktree children) whose directory no longer exists on
+			// disk have their store dir deleted and their fsnotify
+			// subscription dropped, reclaiming the orphaned ~100MB worktree
+			// stores that accumulated under ~/.archigraph/store/.
+			reaper := NewReaper(ReaperConfig{
+				TrackedRepos:    makeReaperTrackedRepos(cfg.ReposToWatch, wtStore),
+				StoreDirForRepo: repoBaseDir,
+				Untrack: func(repoPath string) {
+					watcher.RemoveRepo(repoPath)
+				},
+				Logger: logger,
+			})
+			reaperStop := make(chan struct{})
+			reaper.Start(reaperStop)
+			defer close(reaperStop)
+			logger.Info("reaper: vanished-repo store GC started", "interval", "5m")
 		}
 	}
 

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -472,6 +472,34 @@ func (m *Manager) Touch(key SlotKey) error {
 	return nil
 }
 
+// Forget removes every slot for repoPath (all refs) from the Manager, dropping
+// them from the in-memory accounting WITHOUT firing eviction/disk callbacks.
+// It is the tier-side half of the vanished-repo reaper (issue #3680): once a
+// repo's directory no longer exists on disk, its slots must be untracked so the
+// Manager stops counting them toward pressure and stops attempting cold-wakes
+// against a path that is gone. The on-disk store is removed separately by the
+// reaper. Returns the number of slots forgotten.
+func (m *Manager) Forget(repoPath string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for k := range m.slots {
+		if k.RepoPath == repoPath {
+			delete(m.slots, k)
+			n++
+		}
+	}
+	return n
+}
+
+// Len returns the number of slots currently tracked. Used by the reaper's
+// memory-accounting assertions and diagnostics.
+func (m *Manager) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.slots)
+}
+
 // Get returns the current Tier for key. Returns TierCold for unknown slots.
 func (m *Manager) Get(key SlotKey) Tier {
 	m.mu.Lock()

--- a/internal/daemon/tier/tier_test.go
+++ b/internal/daemon/tier/tier_test.go
@@ -419,3 +419,36 @@ func TestPinnedMainNeverDiskEvicted(t *testing.T) {
 		t.Fatalf("disk evict must not fire for pinned main, got %d calls", diskEvictCalled.Load())
 	}
 }
+
+// TestManager_Forget removes all refs for a vanished repo and decrements the
+// in-memory accounting, without touching other repos' slots (issue #3680).
+func TestManager_Forget(t *testing.T) {
+	clock, _ := makeClock()
+	m := tier.NewManagerForTest(tier.DefaultTTLConfig(), clock, noopEvict, noopReload)
+
+	gone := "/repos/gone-worktree"
+	live := "/repos/live"
+	m.Register(tier.SlotKey{RepoPath: gone, Ref: "main"}, false, tier.SlotKindWorktree)
+	m.Register(tier.SlotKey{RepoPath: gone, Ref: "feat/x"}, false, tier.SlotKindWorktree)
+	m.Register(tier.SlotKey{RepoPath: live, Ref: "main"}, true, tier.SlotKindBranchMain)
+
+	if got := m.Len(); got != 3 {
+		t.Fatalf("Len before = %d, want 3", got)
+	}
+
+	n := m.Forget(gone)
+	if n != 2 {
+		t.Fatalf("Forget returned %d, want 2 (both refs of the vanished repo)", n)
+	}
+	if got := m.Len(); got != 1 {
+		t.Fatalf("Len after = %d, want 1 (only the live repo remains)", got)
+	}
+	// Negative: the live repo's slot survives untouched.
+	if m.Get(tier.SlotKey{RepoPath: live, Ref: "main"}) != tier.TierHot {
+		t.Fatalf("live repo slot was wrongly evicted by Forget")
+	}
+	// Idempotent: forgetting again is a no-op.
+	if n := m.Forget(gone); n != 0 {
+		t.Fatalf("second Forget returned %d, want 0", n)
+	}
+}

--- a/internal/daemon/worktree/classify.go
+++ b/internal/daemon/worktree/classify.go
@@ -1,0 +1,193 @@
+// classify.go — linked-worktree detection (issue #3680).
+//
+// # Why
+//
+// archigraph dogfoods itself: the `archigraph` repo is an indexed group, so
+// the daemon's fsnotify watcher catches every `git worktree add` and would
+// cold-index the new worktree as a SEPARATE repo, keyed under
+// hash(worktreePath) with its OWN ~100MB full graph store. The rewrite agent
+// creates many agent-worktrees, so this proliferates stores and blows the RSS
+// admission budget.
+//
+// A linked git worktree has a `.git` FILE (not a directory) whose single line
+// is:
+//
+//	gitdir: <primary>/.git/worktrees/<name>
+//
+// From that pointer we can recover the PRIMARY repo's checkout path. When the
+// primary is an already-indexed root repo, the worktree should NOT be onboarded
+// as a brand-new root repo with a cold full clone — it shares the primary's
+// graph (the daemon already tracks the worktree as an ephemeral WorktreeChild
+// and overlays only its diff). A real standalone repo (`.git` is a DIRECTORY)
+// is still classified as a root and indexed normally.
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RootKind classifies a candidate repo root for onboarding decisions.
+type RootKind int8
+
+const (
+	// RootKindStandalone is a normal repository: `.git` is a directory.
+	// Onboard and index it as its own root repo.
+	RootKindStandalone RootKind = iota
+	// RootKindLinkedWorktree is a git linked worktree: `.git` is a file
+	// containing a `gitdir:` pointer into a primary repo's
+	// .git/worktrees/<name>. Do NOT cold-index it as a new root repo; it
+	// shares the primary's graph (tracked as an ephemeral WorktreeChild).
+	RootKindLinkedWorktree
+	// RootKindUnknown is returned when the path has no `.git` entry, is not a
+	// directory, or the `.git` file cannot be parsed. Callers should treat it
+	// conservatively (do not onboard as a new root).
+	RootKindUnknown
+)
+
+// String returns the lowercase JSON-safe kind name.
+func (k RootKind) String() string {
+	switch k {
+	case RootKindStandalone:
+		return "standalone"
+	case RootKindLinkedWorktree:
+		return "linked_worktree"
+	default:
+		return "unknown"
+	}
+}
+
+// RootClassification is the result of ClassifyRoot.
+type RootClassification struct {
+	// Kind is the structural classification of the candidate path.
+	Kind RootKind
+	// PrimaryRepoPath is the absolute checkout path of the primary repo that
+	// owns this worktree. Set only when Kind == RootKindLinkedWorktree and the
+	// primary checkout could be resolved; "" otherwise.
+	PrimaryRepoPath string
+	// GitDir is the resolved absolute gitdir the `.git` file points at
+	// (<primary>/.git/worktrees/<name>). Set only for linked worktrees.
+	GitDir string
+}
+
+// ClassifyRoot inspects candidatePath's `.git` entry and classifies it.
+//
+//   - `.git` is a directory                       → RootKindStandalone.
+//   - `.git` is a file with a valid gitdir pointer
+//     of the shape  <common>/worktrees/<name>     → RootKindLinkedWorktree,
+//     with PrimaryRepoPath resolved to the primary checkout (the parent of
+//     the common `.git` dir).
+//   - anything else (missing `.git`, unparsable
+//     pointer, malformed shape)                   → RootKindUnknown.
+//
+// ClassifyRoot performs only cheap filesystem reads (one Stat + at most one
+// small ReadFile); it never shells out to git, so it is safe to call on the
+// onboarding hot path.
+func ClassifyRoot(candidatePath string) RootClassification {
+	gitPath := filepath.Join(candidatePath, ".git")
+	fi, err := os.Lstat(gitPath)
+	if err != nil {
+		return RootClassification{Kind: RootKindUnknown}
+	}
+	if fi.IsDir() {
+		// Normal repository — `.git` is a directory.
+		return RootClassification{Kind: RootKindStandalone}
+	}
+
+	gitdir := readGitdirPointer(gitPath)
+	if gitdir == "" {
+		return RootClassification{Kind: RootKindUnknown}
+	}
+
+	// A linked worktree's gitdir is <common>/worktrees/<name>. Verify the
+	// shape so we don't misclassify a submodule (gitdir: <common>/modules/<name>)
+	// or any other non-worktree pointer as a worktree.
+	parent := filepath.Dir(gitdir) // <common>/worktrees
+	if filepath.Base(parent) != "worktrees" {
+		return RootClassification{Kind: RootKindUnknown}
+	}
+	commonGitDir := filepath.Dir(parent) // <common>  (== <primary>/.git)
+	primary := primaryFromCommonGitDir(commonGitDir)
+
+	return RootClassification{
+		Kind:            RootKindLinkedWorktree,
+		PrimaryRepoPath: primary,
+		GitDir:          gitdir,
+	}
+}
+
+// readGitdirPointer reads a `.git` FILE and returns the absolute path the
+// `gitdir:` line points at, or "" when the file is unreadable / malformed.
+// Relative pointers (git can write `gitdir: ../.git/worktrees/x`) are resolved
+// against the directory containing the `.git` file.
+func readGitdirPointer(gitFilePath string) string {
+	data, err := os.ReadFile(gitFilePath)
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	rest, ok := strings.CutPrefix(line, "gitdir:")
+	if !ok {
+		return ""
+	}
+	gitdir := strings.TrimSpace(rest)
+	if gitdir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(filepath.Dir(gitFilePath), gitdir)
+	}
+	return filepath.Clean(gitdir)
+}
+
+// primaryFromCommonGitDir derives the primary checkout path from the common
+// git directory (<primary>/.git). The common case is `<primary>/.git`, so the
+// primary is its parent. When the common dir is a bare repo (no trailing
+// `.git` component) we return it as-is — callers key the primary by path and a
+// bare repo is still a usable parent key.
+func primaryFromCommonGitDir(commonGitDir string) string {
+	if commonGitDir == "" || commonGitDir == "." {
+		return ""
+	}
+	if filepath.Base(commonGitDir) == ".git" {
+		return filepath.Dir(commonGitDir)
+	}
+	return commonGitDir
+}
+
+// IsLinkedWorktreeOf reports whether candidatePath is a linked worktree whose
+// primary checkout is one of the already-indexed primary repo paths in
+// indexedPrimaries. This is the onboarding-gate predicate: when it returns
+// true, the daemon must NOT onboard candidatePath as a new root repo (which
+// would trigger a cold full-store clone) — the worktree shares the primary's
+// graph and is tracked as an ephemeral WorktreeChild instead.
+//
+// Paths are compared after canonicalisation (normPath + symlink resolution) so
+// separator/case quirks on git's porcelain output and OS symlink aliases
+// (e.g. macOS /var → /private/var) do not cause false negatives.
+func IsLinkedWorktreeOf(candidatePath string, indexedPrimaries []string) bool {
+	c := ClassifyRoot(candidatePath)
+	if c.Kind != RootKindLinkedWorktree || c.PrimaryRepoPath == "" {
+		return false
+	}
+	want := canonPath(c.PrimaryRepoPath)
+	for _, p := range indexedPrimaries {
+		if canonPath(p) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// canonPath canonicalises p for cross-source path comparison: it normalises
+// separators/case via normPath and then resolves symlinks when possible.
+// EvalSymlinks failures (e.g. the path no longer exists) fall back to the
+// normalised path so the comparison still works on a best-effort basis.
+func canonPath(p string) string {
+	n := normPath(p)
+	if resolved, err := filepath.EvalSymlinks(n); err == nil {
+		return resolved
+	}
+	return n
+}

--- a/internal/daemon/worktree/classify_test.go
+++ b/internal/daemon/worktree/classify_test.go
@@ -1,0 +1,104 @@
+package worktree_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/worktree"
+)
+
+// TestClassifyRoot_standalone asserts a real standalone repo (.git is a DIR)
+// is classified as a root that should be indexed normally — NOT as a worktree.
+func TestClassifyRoot_standalone(t *testing.T) {
+	repo := t.TempDir()
+	initGitRepo(t, repo)
+
+	got := worktree.ClassifyRoot(repo)
+	if got.Kind != worktree.RootKindStandalone {
+		t.Fatalf("standalone repo classified as %v, want standalone", got.Kind)
+	}
+	if got.PrimaryRepoPath != "" {
+		t.Fatalf("standalone repo should have no primary, got %q", got.PrimaryRepoPath)
+	}
+}
+
+// TestClassifyRoot_linkedWorktree asserts a path whose .git is a worktree
+// pointer FILE is classified as a linked worktree and resolves back to the
+// primary checkout — so it will NOT be cold-indexed as a new root repo.
+func TestClassifyRoot_linkedWorktree(t *testing.T) {
+	primary := t.TempDir()
+	initGitRepo(t, primary)
+	wt := filepath.Join(t.TempDir(), "wt-feature")
+	addWorktree(t, primary, wt, "feature-x")
+
+	// Sanity: the worktree's .git must be a FILE, not a dir.
+	fi, err := os.Lstat(filepath.Join(wt, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.IsDir() {
+		t.Fatalf("expected worktree .git to be a file, got dir")
+	}
+
+	got := worktree.ClassifyRoot(wt)
+	if got.Kind != worktree.RootKindLinkedWorktree {
+		t.Fatalf("linked worktree classified as %v, want linked_worktree", got.Kind)
+	}
+	// Primary must resolve back to the original checkout (EvalSymlinks because
+	// macOS /var → /private/var aliases the TempDir).
+	gotPrimary, _ := filepath.EvalSymlinks(got.PrimaryRepoPath)
+	wantPrimary, _ := filepath.EvalSymlinks(primary)
+	if gotPrimary != wantPrimary {
+		t.Fatalf("primary = %q, want %q", gotPrimary, wantPrimary)
+	}
+}
+
+// TestClassifyRoot_missingGit returns unknown for a non-repo directory.
+func TestClassifyRoot_missingGit(t *testing.T) {
+	dir := t.TempDir()
+	if got := worktree.ClassifyRoot(dir); got.Kind != worktree.RootKindUnknown {
+		t.Fatalf("non-repo dir classified as %v, want unknown", got.Kind)
+	}
+}
+
+// TestClassifyRoot_submodulePointerNotWorktree guards against misclassifying a
+// submodule (gitdir: <common>/modules/<name>) as a worktree.
+func TestClassifyRoot_submodulePointerNotWorktree(t *testing.T) {
+	dir := t.TempDir()
+	gitFile := filepath.Join(dir, ".git")
+	// Submodule-shaped pointer — "modules", not "worktrees".
+	if err := os.WriteFile(gitFile, []byte("gitdir: /some/super/.git/modules/sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := worktree.ClassifyRoot(dir); got.Kind == worktree.RootKindLinkedWorktree {
+		t.Fatalf("submodule pointer misclassified as linked_worktree")
+	}
+}
+
+// TestIsLinkedWorktreeOf is the onboarding-gate predicate: a worktree of an
+// INDEXED primary returns true (skip new-root onboarding); a worktree whose
+// primary is NOT indexed returns false; a standalone repo returns false.
+func TestIsLinkedWorktreeOf(t *testing.T) {
+	primary := t.TempDir()
+	initGitRepo(t, primary)
+	wt := filepath.Join(t.TempDir(), "wt-a")
+	addWorktree(t, primary, wt, "feat-a")
+
+	// Positive: primary is in the indexed set → gate fires (skip onboarding).
+	if !worktree.IsLinkedWorktreeOf(wt, []string{primary}) {
+		t.Fatalf("worktree of indexed primary should be gated as linked worktree")
+	}
+
+	// Negative: primary NOT in the indexed set → do not gate (unrelated repo).
+	if worktree.IsLinkedWorktreeOf(wt, []string{filepath.Join(t.TempDir(), "other")}) {
+		t.Fatalf("worktree of an UNindexed primary must not be gated")
+	}
+
+	// Negative: a standalone repo is never a linked worktree.
+	other := t.TempDir()
+	initGitRepo(t, other)
+	if worktree.IsLinkedWorktreeOf(other, []string{primary, other}) {
+		t.Fatalf("standalone repo must not be classified as a linked worktree")
+	}
+}

--- a/internal/daemon/worktree_gate.go
+++ b/internal/daemon/worktree_gate.go
@@ -1,0 +1,69 @@
+// worktree_gate.go — daemon wiring for the #3680 worktree-churn fixes.
+//
+// Two small adapters connect the daemon's existing tracking surfaces to the
+// linked-worktree classifier (internal/daemon/worktree) and the vanished-repo
+// reaper (reaper.go):
+//
+//   - makeWorktreeEnqueueGate builds the scheduler SkipEnqueue predicate that
+//     drops cold-index enqueues for linked worktrees of an already-indexed
+//     primary repo.
+//   - makeReaperTrackedRepos builds the reaper's tracked-repo provider from the
+//     registered repos plus any active worktree children.
+package daemon
+
+import (
+	"github.com/cajasmota/archigraph/internal/daemon/worktree"
+)
+
+// makeWorktreeEnqueueGate returns a sched.SkipEnqueueFn-compatible predicate
+// that returns true when repoPath is a linked git worktree whose primary
+// checkout is one of the currently-registered repos (reposToWatch). Such a
+// path must NOT be cold-indexed as an independent root repo (#3680).
+//
+// reposToWatch may be nil (no registered repos resolvable yet) — the gate then
+// never fires, preserving legacy behaviour. The registered set is re-read on
+// every call so repos registered after boot are covered.
+func makeWorktreeEnqueueGate(reposToWatch func() []string) func(repoPath string) bool {
+	if reposToWatch == nil {
+		return nil
+	}
+	return func(repoPath string) bool {
+		// Fast structural reject: only `.git`-is-a-file worktrees can be gated.
+		// ClassifyRoot is a single Stat for the common standalone case, so this
+		// stays cheap on the hot path.
+		c := worktree.ClassifyRoot(repoPath)
+		if c.Kind != worktree.RootKindLinkedWorktree {
+			return false
+		}
+		return worktree.IsLinkedWorktreeOf(repoPath, reposToWatch())
+	}
+}
+
+// makeReaperTrackedRepos returns the reaper's TrackedRepos provider: the union
+// of the registered repos (reposToWatch) and the active worktree children, so
+// the reaper GCs stores for any of them that vanish from disk. Either input may
+// be nil. Duplicate paths are de-duplicated.
+func makeReaperTrackedRepos(reposToWatch func() []string, wtStore *worktree.Store) func() []string {
+	return func() []string {
+		seen := map[string]bool{}
+		var out []string
+		add := func(p string) {
+			if p == "" || seen[p] {
+				return
+			}
+			seen[p] = true
+			out = append(out, p)
+		}
+		if reposToWatch != nil {
+			for _, r := range reposToWatch() {
+				add(r)
+			}
+		}
+		if wtStore != nil {
+			for _, c := range wtStore.Active() {
+				add(c.Path)
+			}
+		}
+		return out
+	}
+}

--- a/internal/daemon/worktree_gate_test.go
+++ b/internal/daemon/worktree_gate_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/worktree"
+)
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", dir)
+	run("-C", dir, "config", "user.email", "t@t")
+	run("-C", dir, "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("-C", dir, "add", ".")
+	run("-C", dir, "commit", "-qm", "init")
+}
+
+// TestMakeWorktreeEnqueueGate asserts the gate fires for a linked worktree of a
+// registered primary and stays silent for the primary itself and for unrelated
+// standalone repos (#3680).
+func TestMakeWorktreeEnqueueGate(t *testing.T) {
+	primary := t.TempDir()
+	gitInit(t, primary)
+	wt := filepath.Join(t.TempDir(), "agent-1")
+	cmd := exec.Command("git", "-C", primary, "worktree", "add", wt, "-b", "feat")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("worktree add: %v\n%s", err, out)
+	}
+
+	gate := makeWorktreeEnqueueGate(func() []string { return []string{primary} })
+	if gate == nil {
+		t.Fatal("gate must be non-nil when reposToWatch is provided")
+	}
+
+	// Positive: the worktree of a registered primary is gated.
+	if !gate(wt) {
+		t.Errorf("linked worktree of a registered primary must be gated")
+	}
+	// Negative: the primary checkout itself is a normal root — never gated.
+	if gate(primary) {
+		t.Errorf("primary checkout must not be gated")
+	}
+	// Negative: an unrelated standalone repo is never gated.
+	other := t.TempDir()
+	gitInit(t, other)
+	if gate(other) {
+		t.Errorf("unrelated standalone repo must not be gated")
+	}
+
+	// nil reposToWatch disables the gate entirely.
+	if makeWorktreeEnqueueGate(nil) != nil {
+		t.Errorf("nil reposToWatch must yield a nil gate (legacy behaviour)")
+	}
+}
+
+// TestMakeReaperTrackedRepos asserts the tracked set is the de-duplicated union
+// of registered repos and active worktree children.
+func TestMakeReaperTrackedRepos(t *testing.T) {
+	store := worktree.NewStore(filepath.Join(t.TempDir(), "wt.json"))
+	// Inject an active child via the watcher's discovery path would need git;
+	// instead drive Active() by polling a real worktree.
+	primary := t.TempDir()
+	gitInit(t, primary)
+	wtPath := filepath.Join(t.TempDir(), "child")
+	cmd := exec.Command("git", "-C", primary, "worktree", "add", wtPath, "-b", "b")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("worktree add: %v\n%s", err, out)
+	}
+	w := worktree.NewWatcher(store, func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "s", Path: primary}}
+	}, nil)
+	w.Poll() // discovers wtPath → active child
+
+	tracked := makeReaperTrackedRepos(func() []string { return []string{primary, primary} }, store)
+	got := tracked()
+
+	canon := func(p string) string {
+		if r, err := filepath.EvalSymlinks(p); err == nil {
+			return r
+		}
+		return filepath.Clean(p)
+	}
+	cPrimary, cChild := canon(primary), canon(wtPath)
+	wantPrimary, wantChild := false, false
+	for _, p := range got {
+		switch canon(p) {
+		case cPrimary:
+			wantPrimary = true
+		case cChild:
+			wantChild = true
+		}
+	}
+	if !wantPrimary {
+		t.Errorf("tracked set missing the registered primary; got %v", got)
+	}
+	if !wantChild {
+		t.Errorf("tracked set missing the active worktree child; got %v", got)
+	}
+	// De-dup: primary appears once despite being listed twice.
+	count := 0
+	for _, p := range got {
+		if canon(p) == cPrimary {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("primary appeared %d times, want 1 (de-dup)", count)
+	}
+}


### PR DESCRIPTION
Closes #3680. **DEPLOY-DEFERRED** — takes effect after a daemon rebuild+restart (deploy #9), which also reclaims the orphaned ~7.2GB store.

## Problem
archigraph dogfoods itself, so the daemon's watcher caught every `git worktree add` and cold-indexed the worktree as a **separate root repo** with its own ~100MB full graph store keyed by `hash(worktreePath)`. The rewrite agent's churn proliferated these stores (`~/.archigraph/store/` at 7.2GB, ~25 orphaned `wt-*`/`agent-*` stores), and each cold rebuild predicted ~2.4GB — blowing the 2048MB admission budget (RSS 3.8GB, headroom 0).

## Two root-cause fixes (each independently tested)

### 1. Vanished-repo store reaper (`reaper.go`)
Periodically reconciles the tracked-repo set (registered repos + active worktree children) against the filesystem. For each repo whose directory no longer exists it:
- deletes the on-disk store dir (`repoBaseDir`), reclaiming its bytes,
- forgets its tier slots via new `tier.Manager.Forget` (decrementing in-memory accounting),
- drops its fsnotify subscription (`Untrack`).

Fail-safe: a path that can't be stat'd for any reason *other than* "not exist" is never reaped, so a transient FS error can't nuke a live graph. Existing repos are never touched.

### 2. Linked-worktree detection + enqueue gate (`worktree/classify.go`, scheduler `SkipEnqueue`)
`ClassifyRoot` distinguishes a standalone repo (`.git` is a **dir**) from a linked worktree (`.git` is a **file** with a `gitdir: <primary>/.git/worktrees/<name>` pointer) and resolves the primary checkout (rejecting submodule pointers). The scheduler gains a `SkipEnqueue` guard that drops enqueues for linked worktrees of an already-indexed primary, so they never become independent root index jobs. The worktree subsystem still tracks them as ephemeral children with aggressive TTLs.

**Skip vs overlay:** chose **skip**, not overlay. Graphs are keyed by repo path with no overlay/parent-derivation mechanism in the store layer; a true warm-clone overlay would be a much larger change. Skipping the redundant root index is the minimal root-cause fix the codebase supports today — the worktree's edits are still served from the primary's graph + ephemeral-child tracking.

## Value-asserting tests (with negatives)
- **Reaper**: vanished repo → store removed, `FreedBytes >= payload`, slots forgotten, accounting decremented, `Untrack` fired; **negative** — live repo's store + slots untouched; nil-tracker no-op.
- **tier.Forget**: removes all refs of a vanished repo, decrements `Len()`, idempotent; **negative** — sibling live slot survives.
- **ClassifyRoot / IsLinkedWorktreeOf**: standalone `.git`-dir → standalone; worktree `.git`-file → linked + primary resolved; **negatives** — submodule pointer not a worktree, worktree of an *unindexed* primary not gated, standalone never gated.
- **Scheduler SkipEnqueue**: gated worktree path never indexed + `enqueue_skipped` logged; **negative** — real repo still indexed (gate is selective, not a kill-switch).
- **Wiring** (`makeWorktreeEnqueueGate`, `makeReaperTrackedRepos`): gate fires for a real worktree of a registered primary; tracked set is the de-duplicated union of registered repos + active children.

## Estimated reclaim once deployed
The reaper deletes the ~25 orphaned `wt-*`/`agent-*` stores at ~100MB each — roughly **2.5–7GB of disk** reclaimed from `~/.archigraph/store/` — and forgets their tier slots so they stop counting toward RSS pressure. The enqueue gate prevents future worktrees from ever creating new ~100MB stores or ~2.4GB cold rebuilds, removing the recurring admission-budget churn at the source.

## Test status
Targeted suites green: `internal/daemon/worktree`, `internal/daemon/tier`, `internal/daemon/sched`, `internal/types`. `gofmt -l` empty, `go vet` clean. The only `internal/daemon` failures are 4 pre-existing socket-based daemon-readiness tests (`TestIndexProgress_*`, `TestRebuildWithoutToken`) that fail identically on pristine `origin/main` in this sandbox — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)