### PR TITLE
[ruby][drivers] raw-driver SQL query+table attribution for pg/mysql2/sqlite3 (#3949)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -141,11 +141,11 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/5 | |
 | [ruby](../by-language/ruby.md) | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/4 | |
-| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/4 | |
+| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/7 | |
-| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/4 | |
+| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/4 | |
-| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/4 | |
+| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟡 1/4 | |
 | [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 7/10 | |
 | [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/7 | |
 | [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 8/11 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -64,11 +64,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | 🟡 1/4 | |
 | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | 🟡 1/5 | |
 | [mongo Ruby Driver](../detail/lang.ruby.driver.mongodb.md) | 🟡 1/4 | |
-| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🔴 0/4 | |
+| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | 🟡 1/4 | |
 | [neo4j-ruby-driver / activegraph OGM](../detail/lang.ruby.driver.neo4j.md) | 🟡 3/7 | |
-| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🔴 0/4 | |
+| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🟡 1/4 | |
 | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/4 | |
-| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🔴 0/4 | |
+| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟡 1/4 | |
 
 
 ## Other

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -29,7 +29,7 @@ one is a separate detail page.
 | [`lang.jsts.driver.mysql`](./lang.jsts.driver.mysql.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.php.driver.mysql`](./lang.php.driver.mysql.md) | php | driver | 1 partial, 4 missing, 6 n/a |
 | [`lang.python.driver.mysql`](./lang.python.driver.mysql.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
-| [`lang.ruby.driver.mysql`](./lang.ruby.driver.mysql.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.ruby.driver.mysql`](./lang.ruby.driver.mysql.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.mysql`](./lang.rust.driver.mysql.md) | rust | driver | 4 missing, 7 n/a |
 
 ## Provenance

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -29,7 +29,7 @@ one is a separate detail page.
 | [`lang.jsts.driver.postgres`](./lang.jsts.driver.postgres.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.php.driver.postgres`](./lang.php.driver.postgres.md) | php | driver | 1 partial, 4 missing, 6 n/a |
 | [`lang.python.driver.postgres`](./lang.python.driver.postgres.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
-| [`lang.ruby.driver.postgres`](./lang.ruby.driver.postgres.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.ruby.driver.postgres`](./lang.ruby.driver.postgres.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.postgres`](./lang.rust.driver.postgres.md) | rust | driver | 4 missing, 7 n/a |
 
 ## Provenance

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -28,7 +28,7 @@ one is a separate detail page.
 | [`lang.jsts.driver.sqlite`](./lang.jsts.driver.sqlite.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.php.driver.sqlite`](./lang.php.driver.sqlite.md) | php | driver | 1 partial, 4 missing, 6 n/a |
 | [`lang.python.driver.sqlite`](./lang.python.driver.sqlite.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
-| [`lang.ruby.driver.sqlite`](./lang.ruby.driver.sqlite.md) | ruby | driver | 4 missing, 7 n/a |
+| [`lang.ruby.driver.sqlite`](./lang.ruby.driver.sqlite.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.sqlite`](./lang.rust.driver.sqlite.md) | rust | driver | 4 missing, 7 n/a |
 | [`lang.rust.orm.rusqlite`](./lang.rust.orm.rusqlite.md) | rust | orm | 1 full, 3 missing, 7 n/a |
 

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3644) | — | YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor. |
+| Query attribution | ✅ `full` | `2026-06-02` | — | `internal/substrate/effects_test.go` | Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3644) | — | YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor. |
+| Query attribution | ✅ `full` | `2026-06-02` | — | `internal/substrate/effects_test.go` | Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | `2026-06-02` | [link](https://github.com/cajasmota/archigraph/issues/3644) | — | YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor. |
+| Query attribution | ✅ `full` | `2026-06-02` | — | `internal/substrate/effects_test.go` | Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives. |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -60700,9 +60700,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/substrate/effects_test.go"],
+            "notes": "Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives.",
             "verified_at": "2026-06-02"
           }
         },
@@ -60834,9 +60834,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/substrate/effects_test.go"],
+            "notes": "Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives.",
             "verified_at": "2026-06-02"
           }
         },
@@ -60961,9 +60961,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3644",
-            "notes": "YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor.",
+            "status": "full",
+            "cites": ["internal/substrate/effects_test.go"],
+            "notes": "Native effect-substrate raw-driver SQL attribution (#3949): pg conn.exec/exec_params, mysql2 client.query, sqlite3 db.execute carrying a SQL string literal are parsed to a db_read (SELECT/WITH) or db_write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) effect naming the target table in the sink tag (rawsql.read(orders) / rawsql.write(users)) at full confidence. Table extraction mirrors internal/patterns/raw_sql_extractor.go. Non-SQL string args yield no DB effect; dynamic/interpolated tables stamp the effect with an honest no-table sink (rawsql.read(?)) -- no fabrication. Value-asserting test TestSniffEffectsRuby_RawDriverSQL covers all 3 drivers + negatives.",
             "verified_at": "2026-06-02"
           }
         },

--- a/internal/substrate/effect_sinks_ruby.go
+++ b/internal/substrate/effect_sinks_ruby.go
@@ -7,15 +7,19 @@
 //     URI.open / URI.parse(...).open
 //   - db_read   : ActiveRecord `.where / .find / .find_by / .find_each /
 //     .all / .first / .last / .pluck / .count / .exists?`,
-//     raw `connection.execute("SELECT ...")`, `ActiveRecord::
-//     Base.connection.exec_query`
+//     and raw-driver SELECT/WITH queries — pg `conn.exec` /
+//     `conn.exec_params`, mysql2 `client.query`, sqlite3 /
+//     ActiveRecord `db.execute` — with the FROM table named in
+//     the sink (e.g. rawsql.read(orders)) (#3949)
 //   - db_write  : ActiveRecord `.create / .create! / .update / .update! /
 //     .update_all / .destroy / .destroy_all / .delete /
 //     .delete_all / .save / .save! / .insert / .insert_all /
-//     .upsert / .upsert_all`, raw `connection.execute(
-//     "INSERT|UPDATE|DELETE ...")`, and Sequel dataset writes
-//     `DB[:table]…insert/update/delete/multi_insert/import/
-//     truncate` (table named in the sink, e.g. sequel.write(users))
+//     .upsert / .upsert_all`, raw-driver INSERT/UPDATE/DELETE/…
+//     queries via pg/mysql2/sqlite3 `exec|exec_params|query|
+//     execute` with the target table named in the sink
+//     (e.g. rawsql.write(users)) (#3949), and Sequel dataset
+//     writes `DB[:table]…insert/update/delete/multi_insert/
+//     import/truncate` (e.g. sequel.write(users))
 //   - fs_read   : File.read / .open (default "r"), File.readlines, IO.read,
 //     Dir.entries / .glob / .[], Pathname#read
 //   - fs_write  : File.write / .open with "w"/"a"/"x"/binary modes,
@@ -30,7 +34,10 @@
 // the substrate's needs.
 package substrate
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 func init() { RegisterEffectSniffer("ruby", sniffEffectsRuby) }
 
@@ -58,20 +65,10 @@ var rubyDBReadRe = regexp.MustCompile(
 		`|\bconnection\s*\.\s*(?:execute|exec_query|select_all|select_one|select_value|select_values|select_rows)\s*\(`,
 )
 
-// rubyCursorSelectRe pairs raw `execute("SELECT ...")` calls as reads.
-var rubyCursorSelectRe = regexp.MustCompile(
-	`\.\s*execute\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)`,
-)
-
 // rubyDBWriteRe matches ActiveRecord and raw write primitives.
 var rubyDBWriteRe = regexp.MustCompile(
 	`\.\s*(?:create|create!|update|update!|update_all|update_column|update_columns|destroy|destroy!|destroy_all|delete|delete_all|save|save!|insert|insert_all|insert_all!|upsert|upsert_all|increment!|decrement!|touch|toggle!)\s*[\(.!]?` +
 		`|\.\s*save\s*$`,
-)
-
-// rubyCursorWriteRe matches raw INSERT/UPDATE/DELETE executes.
-var rubyCursorWriteRe = regexp.MustCompile(
-	`\.\s*execute\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
 )
 
 // rubySequelDatasetWriteRe matches Sequel dataset writes anchored on the
@@ -92,6 +89,36 @@ var rubySequelDatasetWriteRe = regexp.MustCompile(
 	`\bDB\s*\[\s*:?["']?(\w+)["']?\s*\]` + // DB[:users] / DB['users']
 		`[^\n;]*?` + // optional read-only refinement chain
 		`\.\s*(?:insert|multi_insert|import|update|update_all|delete|truncate|insert_ignore)\b`,
+)
+
+// rubyRawDriverCallRe matches a raw-driver query call carrying a SQL string
+// literal as its first argument (#3949). It anchors on the Rails-adjacent raw
+// drivers' call shapes:
+//
+//	pg      : conn.exec("SELECT ...")        / conn.exec_params("INSERT ...", [])
+//	mysql2  : client.query("SELECT ...")
+//	sqlite3 : db.execute("UPDATE ...")       (also covers ActiveRecord
+//	          connection.execute, kept for the table-naming upgrade)
+//
+// The verb set is restricted to {exec, exec_params, query, execute} so this
+// does NOT fire on arbitrary `.foo("SELECT...")` strings. Capture group 1 is
+// the SQL string body (single- or double-quoted, no escape unescaping needed
+// for table extraction). Interpolated table names (`#{...}`) remain in the
+// captured body and are deliberately NOT matched by the table regexes below,
+// so a dynamic table yields an honest no-table effect (no fabrication).
+var rubyRawDriverCallRe = regexp.MustCompile(
+	`\.\s*(?:exec|exec_params|query|execute)\s*\(\s*["']([^"']*)["']`,
+)
+
+// Raw-SQL table extractors mirror internal/patterns/raw_sql_extractor.go so the
+// table name surfaced here is consistent with the raw-SQL entity extractor.
+// Each capture group 1 is the (leaf) table name; an optional `schema.` prefix
+// is tolerated and stripped by the regex's non-capturing `(?:\w+\.)?`.
+var (
+	rubySQLSelectTableRe = regexp.MustCompile(`(?i)\bSELECT\b[\s\S]*?\bFROM\s+(?:\w+\.)?(\w+)`)
+	rubySQLInsertTableRe = regexp.MustCompile(`(?i)\bINSERT\s+(?:IGNORE\s+)?INTO\s+(?:\w+\.)?(\w+)`)
+	rubySQLUpdateTableRe = regexp.MustCompile(`(?i)\bUPDATE\s+(?:\w+\.)?(\w+)\s+SET\b`)
+	rubySQLDeleteTableRe = regexp.MustCompile(`(?i)\bDELETE\s+FROM\s+(?:\w+\.)?(\w+)`)
 )
 
 // rubyFSReadRe matches read-only filesystem primitives.
@@ -134,9 +161,8 @@ func sniffEffectsRuby(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendRubyMatches(out, content, headers, rubyHTTPRe, EffectHTTPOut, "Net::HTTP/HTTParty/Faraday", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyDBReadRe, EffectDBRead, "activerecord.read", 0.85)
-	out = appendRubyMatches(out, content, headers, rubyCursorSelectRe, EffectDBRead, "connection.execute(SELECT)", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyDBWriteRe, EffectDBWrite, "activerecord.write", 0.85)
-	out = appendRubyMatches(out, content, headers, rubyCursorWriteRe, EffectDBWrite, "connection.execute(WRITE)", 1.0)
+	out = appendRubyRawDriverSQL(out, content, headers)
 	out = appendRubySequelDatasetWrites(out, content, headers)
 	out = appendRubyMatches(out, content, headers, rubyFSReadRe, EffectFSRead, "File.read/IO.read", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyFSWriteRe, EffectFSWrite, "File.write/FileUtils", 1.0)
@@ -169,6 +195,98 @@ func appendRubyMatches(out []EffectMatch, content string, headers []funcHeader, 
 		})
 	}
 	return out
+}
+
+// appendRubyRawDriverSQL stamps a read/write EffectMatch for each raw-driver
+// SQL call (#3949) — pg `conn.exec`/`exec_params`, mysql2 `client.query`,
+// sqlite3 `db.execute` (and ActiveRecord `connection.execute`). The SQL string
+// literal is parsed to (a) classify the statement as a read (SELECT/WITH) or a
+// write (INSERT/UPDATE/DELETE/…) and (b) name the target table in the sink tag,
+// e.g. `pg.exec(users)` / `mysql2.query(orders)` / `sqlite3.execute(accounts)`.
+//
+// Effect classification:
+//   - SELECT / WITH …                 → db_read
+//   - INSERT / UPDATE / DELETE /
+//     REPLACE / MERGE / TRUNCATE      → db_write
+//
+// Table naming reuses the same shapes as the raw-SQL entity extractor
+// (internal/patterns/raw_sql_extractor.go). When the statement is a recognised
+// DML verb but no table can be extracted — e.g. a dynamic / interpolated table
+// (`"SELECT * FROM #{t}"`) or a non-DML statement — the effect is still stamped
+// (the call genuinely touches the DB) but WITHOUT a fabricated table name; the
+// sink tag falls back to the bare verb (`pg.exec(?)`). A non-SQL string arg
+// (no DML verb at all) is NOT a DB effect and is skipped entirely.
+//
+// Full confidence: the restricted verb set + explicit SQL DML token make the
+// effect unambiguous (unlike the generic ActiveRecord `.where`/`.save`
+// heuristics which fire on unknown receivers at 0.85).
+func appendRubyRawDriverSQL(out []EffectMatch, content string, headers []funcHeader) []EffectMatch {
+	for _, m := range rubyRawDriverCallRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		sql := content[m[2]:m[3]]
+		eff, table, ok := classifyRubyRawSQL(sql)
+		if !ok {
+			continue // non-SQL string arg: not a DB effect.
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       rubyRawSQLSink(eff, table),
+			Confidence: 1.0,
+		})
+	}
+	return out
+}
+
+// classifyRubyRawSQL inspects a raw SQL string body and returns the effect
+// (db_read / db_write), the target table (empty when not statically
+// recoverable), and ok=false when the body carries no recognised SQL DML verb
+// (so the caller can skip non-SQL string args without fabricating an effect).
+func classifyRubyRawSQL(sql string) (Effect, string, bool) {
+	if m := rubySQLInsertTableRe.FindStringSubmatch(sql); m != nil {
+		return EffectDBWrite, m[1], true
+	}
+	if m := rubySQLUpdateTableRe.FindStringSubmatch(sql); m != nil {
+		return EffectDBWrite, m[1], true
+	}
+	if m := rubySQLDeleteTableRe.FindStringSubmatch(sql); m != nil {
+		return EffectDBWrite, m[1], true
+	}
+	if m := rubySQLSelectTableRe.FindStringSubmatch(sql); m != nil {
+		return EffectDBRead, m[1], true
+	}
+	// Verb present but table not statically recoverable (e.g. interpolated
+	// table, bare INSERT without a parseable INTO, or a write keyword without
+	// a SET). Classify the effect honestly with no fabricated table.
+	upper := strings.ToUpper(sql)
+	switch {
+	case strings.Contains(upper, "INSERT ") || strings.Contains(upper, "UPDATE ") ||
+		strings.Contains(upper, "DELETE ") || strings.Contains(upper, "REPLACE ") ||
+		strings.Contains(upper, "MERGE ") || strings.Contains(upper, "TRUNCATE "):
+		return EffectDBWrite, "", true
+	case strings.HasPrefix(strings.TrimSpace(upper), "SELECT") ||
+		strings.HasPrefix(strings.TrimSpace(upper), "WITH"):
+		return EffectDBRead, "", true
+	}
+	return "", "", false
+}
+
+// rubyRawSQLSink builds the sink tag for a raw-driver SQL effect, naming the
+// table when known and falling back to `(?)` when it is not.
+func rubyRawSQLSink(eff Effect, table string) string {
+	verb := "rawsql.read"
+	if eff == EffectDBWrite {
+		verb = "rawsql.write"
+	}
+	if table == "" {
+		return verb + "(?)"
+	}
+	return verb + "(" + table + ")"
 }
 
 // appendRubySequelDatasetWrites stamps a db_write EffectMatch for each Sequel

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -496,6 +496,122 @@ end
 	}
 }
 
+// TestSniffEffectsRuby_RawDriverSQL asserts the pg / mysql2 / sqlite3 raw
+// drivers surface the specific read/write effect AND name the specific table
+// extracted from the SQL string (#3949), and that the negatives hold:
+//   - a non-SQL string arg yields no DB effect,
+//   - a SELECT is a read (not a write),
+//   - a dynamic/interpolated table is an honest no-table effect (no fabrication).
+func TestSniffEffectsRuby_RawDriverSQL(t *testing.T) {
+	const src = `
+class Repo
+  # pg: write naming users
+  def add_user(name)
+    conn.exec("INSERT INTO users (name) VALUES ($1)", [name])
+  end
+
+  # pg exec_params: read naming products
+  def list_products
+    conn.exec_params("SELECT id, name FROM products", [])
+  end
+
+  # mysql2: read naming orders
+  def get_order(id)
+    client.query("SELECT * FROM orders WHERE id = ?")
+  end
+
+  # sqlite3: write naming accounts
+  def zero_account
+    db.execute("UPDATE accounts SET balance = 0")
+  end
+
+  # pg: write naming sessions
+  def purge
+    conn.exec("DELETE FROM sessions WHERE stale = true")
+  end
+
+  # negative: non-SQL string is not a DB effect
+  def ping
+    client.query("ping pong")
+  end
+
+  # negative: dynamic table -> honest no-table read, not fabricated
+  def from_dynamic(t)
+    conn.exec("SELECT * FROM #{t}")
+  end
+end
+`
+	got := sniffEffectsRuby(src)
+
+	type want struct {
+		eff  Effect
+		sink string
+	}
+	cases := map[string]want{
+		"add_user":      {EffectDBWrite, "rawsql.write(users)"},    // pg .exec INSERT
+		"list_products": {EffectDBRead, "rawsql.read(products)"},   // pg .exec_params SELECT
+		"get_order":     {EffectDBRead, "rawsql.read(orders)"},     // mysql2 .query SELECT
+		"zero_account":  {EffectDBWrite, "rawsql.write(accounts)"}, // sqlite3 .execute UPDATE
+		"purge":         {EffectDBWrite, "rawsql.write(sessions)"}, // pg .exec DELETE
+	}
+	for fn, w := range cases {
+		found := false
+		for _, m := range got {
+			if m.Function == fn && m.Effect == w.eff && m.Sink == w.sink {
+				found = true
+				if m.Confidence != 1.0 {
+					t.Errorf("%s: raw-driver SQL effect should be full confidence, got %.2f", fn, m.Confidence)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected %s sink %q; got %+v", fn, w.eff, w.sink, rawSinks(got, fn))
+		}
+	}
+
+	// SELECT must be a read, never a write.
+	if effectPresent(got, "get_order", EffectDBWrite) {
+		t.Errorf("get_order: SELECT must not be db_write")
+	}
+
+	// Non-SQL string must yield no DB effect at all.
+	if effectPresent(got, "ping", EffectDBRead) || effectPresent(got, "ping", EffectDBWrite) {
+		t.Errorf("ping: non-SQL string must not be a DB effect; got %+v", rawSinks(got, "ping"))
+	}
+
+	// Dynamic/interpolated table: a read effect is present but NO table is
+	// fabricated — the sink must be the honest no-table form.
+	if !effectPresent(got, "from_dynamic", EffectDBRead) {
+		t.Errorf("from_dynamic: interpolated SELECT should still register a db_read")
+	}
+	for _, m := range got {
+		if m.Function == "from_dynamic" && (m.Effect == EffectDBRead || m.Effect == EffectDBWrite) {
+			if m.Sink != "rawsql.read(?)" {
+				t.Errorf("from_dynamic: dynamic table must not fabricate a name; got sink %q", m.Sink)
+			}
+		}
+	}
+}
+
+func effectPresent(ms []EffectMatch, fn string, eff Effect) bool {
+	for _, m := range ms {
+		if m.Function == fn && m.Effect == eff {
+			return true
+		}
+	}
+	return false
+}
+
+func rawSinks(ms []EffectMatch, fn string) []string {
+	var out []string
+	for _, m := range ms {
+		if m.Function == fn && (m.Effect == EffectDBRead || m.Effect == EffectDBWrite) {
+			out = append(out, string(m.Effect)+":"+m.Sink)
+		}
+	}
+	return out
+}
+
 func sequelSinks(ms []EffectMatch, fn string) []string {
 	var out []string
 	for _, m := range ms {


### PR DESCRIPTION
Closes #3949 · Epic #3872 · Audit #3880

## What
Wires native SQL query + table attribution for the Rails-adjacent raw drivers that were `query_attribution=missing`:

| Driver  | Call shape                          | Effect    | Sink (table named)        |
|---------|-------------------------------------|-----------|---------------------------|
| pg      | `conn.exec("INSERT INTO users …")`  | db_write  | `rawsql.write(users)`     |
| pg      | `conn.exec_params("SELECT … products")` | db_read | `rawsql.read(products)` |
| mysql2  | `client.query("SELECT * FROM orders …")` | db_read | `rawsql.read(orders)`  |
| sqlite3 | `db.execute("UPDATE accounts SET …")` | db_write | `rawsql.write(accounts)` |

SQL strings are parsed to classify read (SELECT/WITH) vs write (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE) and to name the target table in the sink tag, at full confidence. Table extraction reuses the same FROM / INSERT INTO / UPDATE…SET / DELETE FROM shapes as `internal/patterns/raw_sql_extractor.go`. The verb set is restricted to `{exec, exec_params, query, execute}` so arbitrary `.foo("SELECT…")` strings do not fire. The old unnamed `connection.execute(SELECT|WRITE)` cursor passes are superseded by this table-naming pass (no behavior loss — `.execute` is still covered, now with a table).

## Honest negatives (no fabrication)
- Non-SQL string arg → **no DB effect**.
- A `SELECT` is a **read**, never a write.
- Dynamic/interpolated table (`"SELECT * FROM #{t}"`) → effect stamped with **no-table** sink `rawsql.read(?)`, not a guessed name.

## Tests / gates
- Value-asserting `TestSniffEffectsRuby_RawDriverSQL` asserts the specific table + read/write effect per driver across all 3 drivers, plus the 3 negatives.
- `go test ./internal/substrate/ ./internal/types/ ./tools/coverage/` green; `gofmt -l` empty; `go vet` clean.
- `covtool validate` 0 errors; `fmt --check` canonical; `gen` → 0 drift. Flips `query_attribution` → `full` for `lang.ruby.driver.{postgres,mysql,sqlite}`.
- No new entity/edge Kinds (reuses existing `EffectMatch` substrate model).

## DEPLOY-DEFERRED
Requires a live-daemon rebuild + reindex to surface in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)