### PR TITLE
feat(coverage): make rpc_framework parity measurable vs http_backend (csharp grpc-net) (#3963)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -257,15 +257,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## RPC Framework
 
-| Language | Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🟡 2/24 | 🟡 3/4 | |
-| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/24 | 🟢 4/4 | |
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟡 22/24 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/24 | 🟡 3/4 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 23/24 | ✅ 4/4 | |
-| [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🟡 15/24 | 🟢 4/4 | |
+| Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 3/15 | |
+| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 4/15 | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
+| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/25 | 🟡 3/15 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 6/17 | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 4/15 | |
+| [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 15/25 | 🟡 4/15 | |
 
 
 ## AI Integration

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -59,10 +59,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### RPC Framework
 
-| Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|
-| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🟡 2/24 | 🟡 3/4 | |
-| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/24 | 🟢 4/4 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 3/15 | |
+| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 4/15 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -63,9 +63,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### RPC Framework
 
-| Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟡 22/24 | 🟢 4/4 | |
+| Name | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -49,9 +49,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### RPC Framework
 
-| Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|
-| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/24 | 🟡 3/4 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/25 | 🟡 3/15 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -83,10 +83,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### RPC Framework
 
-| Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 6/6 | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 23/24 | ✅ 4/4 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 6/17 | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 4/15 | |
 
 
 ### AI Integration

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -49,9 +49,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### RPC Framework
 
-| Name | Substrate | Other capabilities | Notes |
-|---|---|---|---|
-| [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🟡 15/24 | 🟢 4/4 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 15/25 | 🟡 4/15 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | RPC endpoint synthesis from service-impl override methods + RegisterService; regex, no AST |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | request message type name from RPC method args; field shapes are protoc-generated |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | response message type name from RPC method args; field shapes are protoc-generated |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | .proto service+rpc -> SCOPE.Service + RPC SCOPE.Operation endpoints with streaming kind |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc request message names from .proto service rpc decls |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc response message names from .proto service rpc decls |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/grpc_net.go`<br>`internal/custom/csharp/grpc_net_test.go` | app.MapGrpcService<T>() endpoint registration, services.AddGrpc(), ServerCredentials/SslServerCredentials security bindings, and GrpcServiceOptions/GrpcChannelOptions usage detected. |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | — `not_applicable` | — | — | — | HTTP endpoint deprecation/versioning (Sunset/Deprecation headers, /v1 route segments) is an HTTP-API concept; gRPC versions via proto package + service evolution, not HTTP route versioning. |
+| Endpoint pagination posture | — `not_applicable` | — | — | — | HTTP limit/offset/page/cursor pagination posture is an HTTP-endpoint concept; gRPC paginates via in-message fields / server-streaming, not HTTP query params. |
+| Endpoint response codes | — `not_applicable` | — | — | — | HTTP status-code sets do not apply to gRPC, which signals outcome via grpc::StatusCode (OK/NOT_FOUND/...) on the trailer, not HTTP 2xx/4xx codes. |
+| Endpoint synthesis | — `not_applicable` | — | — | — | HTTP http_endpoint synthesis (path+verb producer endpoints) does not apply to gRPC; gRPC service registration is captured as transport_binding (MapGrpcService<T>/AddGrpc). VERIFIED 0 HTTP endpoints synthesized from a gRPC service impl. |
+| Handler attribution | — `not_applicable` | — | — | — | No HTTP handler->route attribution for gRPC. VERIFIED 0 entities from aspnet_core route extractor. rpc-method->service binding is modelled by procedure_extraction (proto rpc/service) + the XxxServiceBase impl in schema_extraction. |
+| Route extraction | — `not_applicable` | — | — | — | gRPC-net has no HTTP route paths. VERIFIED: the aspnet route extractor (MapGet/attribute routes) emits 0 entities on a GreeterService:Greeter.GreeterBase impl. RPC method addressing is package.Service/Method, surfaced via procedure_extraction (rpc/service) + transport_binding (MapGrpcService). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | — `not_applicable` | — | — | — | gRPC services render no server-side views/templates; responses are protobuf messages. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/auth.go`<br>`internal/custom/csharp/auth_test.go` | [Authorize]/[Authorize(Roles=...)]/[Authorize(Policy=...)]/[AllowAnonymous]/RequireAuthorization attrs fire framework-agnostically on gRPC service methods (custom_csharp_auth). VERIFIED: [Authorize(Roles="admin")] on an override Task<HelloReply> SayHello(...) gRPC method emits SCOPE.Pattern/auth_coverage/auth:Authorize:roles:admin. |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | — `not_applicable` | — | — | — | gRPC request/response payloads are protobuf messages, surfaced under schema_extraction (message:/datacontract:/service_impl:). MVC DTO inference (FluentValidation AbstractValidator<T> / DataAnnotation model classes) does not model gRPC payloads. VERIFIED 0 entities from custom_csharp_aspnet_reqresp on a gRPC service. |
+| Request validation | — `not_applicable` | — | — | — | gRPC has no MVC request-validation pipeline (FluentValidation/DataAnnotations on action models); message-field constraints live in proto. VERIFIED 0 entities from custom_csharp_validation on a gRPC service. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | — `not_applicable` | — | — | — | gRPC cross-cutting concerns use Interceptors (Interceptor base / AddInterceptor), not the ASP.NET Core Use*/middleware pipeline. VERIFIED 0 entities from custom_csharp_middleware_extra on a gRPC service. gRPC interceptor cataloguing is potential future work, tracked separately if needed. |
+| Rate limit stamping | — `not_applicable` | — | — | — | HTTP endpoint rate-limit/throttle stamping is an HTTP-middleware concept; gRPC throttling is done via interceptors/server options, not HTTP rate limiters. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | ✅ `full` | `2026-06-03` | — | `internal/extractor/enum_valueset.go`<br>`internal/extractors/csharp/csharp.go` | enum_declaration -> SCOPE.Schema/enum + value-carrying SCOPE.Enum value-set (buildEnumValueSet); framework-agnostic, fires on enums in gRPC service/contract code. |
+| Interface extraction | ✅ `full` | `2026-06-03` | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration -> SCOPE.Component/interface; framework-agnostic. |
+| Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases (same as all C# frameworks). |
+| Type extraction | ✅ `full` | `2026-06-03` | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration -> SCOPE.Component; framework-agnostic, fires on every .cs incl. gRPC service impl classes and proto-generated partial classes. |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3699 ExtractDotnetDI fires framework-agnostically. VERIFIED on a gRPC project Program.cs: services.AddScoped<IGreetRepository,GreetRepository>() emits IGreetRepository BINDS GreetRepository (lifetime=Scoped). |
+| DI injection point | 🟢 `partial` | `2026-06-03` | 3963 | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3699 constructor params emit INJECTED_INTO (service type -> consumer class). VERIFIED: a GreeterService(IGreetRepository repo, ILogger<> logger) ctor emits IGreetRepository INJECTED_INTO GreeterService (ILogger<>/primitives rejected). PARTIAL: same caveat as aspnet-core (impl resolves cross-file only via resolver pass; factory-lambda registrations not linked). |
+| DI scope resolution | ✅ `full` | `2026-06-03` | — | `internal/custom/csharp/dotnet_di.go`<br>`internal/custom/csharp/dotnet_di_test.go` | #3699 BINDS edges carry Singleton/Scoped/Transient lifetime parsed from the AddXxx verb; framework-agnostic, fires for gRPC service registrations. |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | ✅ `full` | `2026-06-03` | — | `internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | C# NUnit/xUnit/MSTest [Fact]/[Theory]/[Test]/[TestMethod] detected via csharp*MethodRE; framework-agnostic, links gRPC service tests like any C# tests. |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🟢 `partial` | — | 3963 | `internal/custom/csharp/observability.go`<br>`internal/substrate/template_pattern_csharp.go` | ILogger<T> decl + _logger.Log<Level>/Console.WriteLine captured framework-agnostically. VERIFIED on a gRPC service: ILogger<GreeterService> field + _logger.LogInformation(...) emit log_extraction entities. PARTIAL: recording-win, heuristic. |
+| Metric extraction | 🟢 `partial` | — | 3963 | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram + prometheus-net regex extractor; framework-agnostic, fires for gRPC services that instrument metrics. PARTIAL: heuristic. |
+| Trace extraction | 🟢 `partial` | — | 3963 | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; framework-agnostic. PARTIAL: heuristic. |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | — |
 | Reachability analysis | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| Request sink dataflow | — `not_applicable` | — | — | — | The C# request->sink dataflow sniffer (dataflow_csharp.go) roots taint at ASP.NET MVC binders ([FromBody]/[FromQuery]/[FromForm]/[FromHeader]/[FromRoute]) + Request.Query/Form/RouteValues accessors. gRPC service methods take a strongly-typed protobuf request + ServerCallContext (no MVC binders), so there is no MVC request-root to seed; not applicable to this transport. |
 | Response shape extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_csharp.go` | — |
 | Schema drift detection | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | use GRPC.Server / GRPC.Service / GRPC.Stub modules emitted as SCOPE.GrpcService with grpc_role server|definition|client; service name resolved from name:/service: option. |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc request message type recorded as request_message on each SCOPE.GrpcMethod. |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc response message type recorded as response_message on each SCOPE.GrpcMethod. |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 31
+- **Capability cells:** 55
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | ✅ `full` | `2026-05-28` | 2906 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/graphql_transport_http.ts`<br>`testdata/fixtures/typescript/graphql_transport_http_ws.ts` | — |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🟢 `partial` | `2026-05-29` | 3076 | `internal/links/pure_function_pass.go`<br>`testdata/fixtures/typescript/substrate_graphql/resolver.ts` | — |
 | Reachability analysis | 🟢 `partial` | `2026-05-29` | 3076 | `internal/links/reachability.go`<br>`internal/substrate/entry_points_jsts.go`<br>`testdata/fixtures/typescript/substrate_graphql/resolver.ts` | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-29` | 3076 | `internal/substrate/payload_shapes_graphql.go`<br>`internal/substrate/payload_shapes_jsts.go`<br>`testdata/fixtures/graphql/schema.graphql` | — |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-29` | 3076 | `internal/substrate/payload_shapes_graphql.go`<br>`internal/substrate/payload_shapes_jsts.go`<br>`testdata/fixtures/graphql/schema.graphql` | — |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-29` | 3076 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_graphql/resolver.ts` | — |
 | Schema drift detection | ✅ `full` | `2026-05-29` | 3076 | `internal/links/payload_drift.go`<br>`internal/substrate/payload_shapes_graphql.go`<br>`internal/substrate/payload_shapes_graphql_test.go`<br>`internal/substrate/payload_shapes_jsts.go`<br>`testdata/fixtures/graphql/schema.graphql` | GraphQL SDL sniffing added (#3076 B-part): input types map to request shapes, object types to response shapes, and inline operation args to per-operation request shapes. payload_drift.go picks these up via the generic PayloadShapeSnifferFor dispatch after LanguageForPath returns graphql for .graphql/.gql files. |

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | ✅ `full` | `2026-05-28` | 2906 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/trpc_transport_http.ts`<br>`testdata/fixtures/typescript/trpc_transport_http_ws.ts`<br>`testdata/fixtures/typescript/trpc_transport_none.ts`<br>`testdata/fixtures/typescript/trpc_transport_ws.ts` | — |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🟢 `partial` | `2026-05-29` | 3057 | `internal/links/pure_function_pass.go` | — |
 | Reachability analysis | 🟢 `partial` | `2026-05-29` | 3057 | `internal/links/reachability.go`<br>`internal/substrate/entry_points_jsts.go` | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-29` | 3057 | `internal/substrate/payload_shapes_jsts.go` | — |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-29` | 3057 | `internal/substrate/payload_shapes_jsts.go` | — |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-29` | 3057 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_trpc/router.ts` | ctx.req.body/params shapes are detected by jstsSourceReqRe; the typed input parameter (primary user-input channel in tRPC, post-zod validation) is a known gap — not matched by current sniffer |
 | Schema drift detection | 🟢 `partial` | `2026-05-29` | 3057 | `internal/links/payload_drift.go` | — |

--- a/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
+++ b/docs/coverage/detail/lang.scala.framework.scalapb-grpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 30
+- **Capability cells:** 54
 
 ## Capabilities
 
@@ -32,6 +32,74 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Transport binding | ✅ `full` | `2026-05-31` | — | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | custom_scala_grpc: RPC endpoint synthesis /<Service>/<rpc> from the service-trait method set; service trait emitted as SCOPE.Service grpc_service. Value-asserting tests pin the path + grpc_service. Regex, file-local; no .proto/AST. |
 
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint response codes | 🔴 `missing` | — | 3963 | — | — |
+| Endpoint synthesis | 🔴 `missing` | — | 3963 | — | — |
+| Handler attribution | 🔴 `missing` | — | 3963 | — | — |
+| Route extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | 3963 | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 3963 | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | 3963 | — | — |
+| Request validation | 🔴 `missing` | — | 3963 | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | 3963 | — | — |
+| Rate limit stamping | 🔴 `missing` | — | 3963 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3963 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3963 | — | — |
+| Type extraction | 🔴 `missing` | — | 3963 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3963 | — | — |
+| DI injection point | 🔴 `missing` | — | 3963 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3963 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3963 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 3963 | — | — |
+| Metric extraction | 🔴 `missing` | — | 3963 | — | — |
+| Trace extraction | 🔴 `missing` | — | 3963 | — | — |
+
 ### Substrate
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
@@ -53,6 +121,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🟢 `partial` | `2026-06-03` | — | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags Scala functions with no effect properties; framework-agnostic (esp. apt for effectful/functional Scala idioms). |
 | Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | Language-agnostic reachability pass seeded from Scala entry points (entry_points_scala.go); framework-agnostic. |
 | Request shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | Request message type NAME recovered from the RPC param type; field shapes live in ScalaPB-generated message companions (not statically present). Value-asserted (HelloRequest). |
+| Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/scala/grpc.go`<br>`internal/custom/scala/grpc_test.go` | Response message type NAME recovered as the last effect type-argument (Future/ZIO/F[_]); generated message field shapes not statically resolvable. Value-asserted (HelloReply). |
 | Sanitizer recognition | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | Scala taint sniffer (taint_sites_scala.go) recognises parameterised-SQL/HTML-escape/Form-mapping sanitizers; framework-agnostic. |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 7 partial, 38 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 8 full, 5 partial, 42 missing |
-| [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 1 missing, 1 n/a |
+| [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 25 missing, 1 n/a |
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 4 full, 51 missing |
 | [`msg.graphql-subscriptions`](./msg.graphql-subscriptions.md) | multi |  | 3 full |

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -23,11 +23,11 @@ one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
-| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 6 partial, 22 missing, 2 n/a |
-| [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 4 full, 22 partial, 2 missing, 2 n/a |
-| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 6 partial, 22 missing, 2 n/a |
+| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 6 partial, 46 missing, 2 n/a |
+| [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 11 full, 26 partial, 2 missing, 15 n/a |
+| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 6 partial, 46 missing, 2 n/a |
 | [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |
-| [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 2 full, 17 partial, 9 missing, 2 n/a |
+| [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 2 full, 17 partial, 33 missing, 2 n/a |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4341,6 +4341,116 @@
             "verified_at": "2026-05-30"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "missing",
@@ -4412,6 +4522,10 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "request message type name from RPC method args; field shapes are protoc-generated",
             "verified_at": "2026-05-30"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -6255,6 +6369,116 @@
             "verified_at": "2026-05-30"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "missing",
@@ -6326,6 +6550,10 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "rpc request message names from .proto service rpc decls",
             "verified_at": "2026-05-30"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -10259,6 +10487,139 @@
             "notes": "app.MapGrpcService\u003cT\u003e() endpoint registration, services.AddGrpc(), ServerCredentials/SslServerCredentials security bindings, and GrpcServiceOptions/GrpcChannelOptions usage detected."
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "not_applicable",
+            "notes": "HTTP endpoint deprecation/versioning (Sunset/Deprecation headers, /v1 route segments) is an HTTP-API concept; gRPC versions via proto package + service evolution, not HTTP route versioning."
+          },
+          "endpoint_pagination_posture": {
+            "status": "not_applicable",
+            "notes": "HTTP limit/offset/page/cursor pagination posture is an HTTP-endpoint concept; gRPC paginates via in-message fields / server-streaming, not HTTP query params."
+          },
+          "endpoint_response_codes": {
+            "status": "not_applicable",
+            "notes": "HTTP status-code sets do not apply to gRPC, which signals outcome via grpc::StatusCode (OK/NOT_FOUND/...) on the trailer, not HTTP 2xx/4xx codes."
+          },
+          "endpoint_synthesis": {
+            "status": "not_applicable",
+            "notes": "HTTP http_endpoint synthesis (path+verb producer endpoints) does not apply to gRPC; gRPC service registration is captured as transport_binding (MapGrpcService\u003cT\u003e/AddGrpc). VERIFIED 0 HTTP endpoints synthesized from a gRPC service impl."
+          },
+          "handler_attribution": {
+            "status": "not_applicable",
+            "notes": "No HTTP handler-\u003eroute attribution for gRPC. VERIFIED 0 entities from aspnet_core route extractor. rpc-method-\u003eservice binding is modelled by procedure_extraction (proto rpc/service) + the XxxServiceBase impl in schema_extraction."
+          },
+          "route_extraction": {
+            "status": "not_applicable",
+            "notes": "gRPC-net has no HTTP route paths. VERIFIED: the aspnet route extractor (MapGet/attribute routes) emits 0 entities on a GreeterService:Greeter.GreeterBase impl. RPC method addressing is package.Service/Method, surfaced via procedure_extraction (rpc/service) + transport_binding (MapGrpcService)."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "not_applicable",
+            "notes": "gRPC services render no server-side views/templates; responses are protobuf messages."
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/csharp/auth.go","internal/custom/csharp/auth_test.go"],
+            "notes": "[Authorize]/[Authorize(Roles=...)]/[Authorize(Policy=...)]/[AllowAnonymous]/RequireAuthorization attrs fire framework-agnostically on gRPC service methods (custom_csharp_auth). VERIFIED: [Authorize(Roles=\"admin\")] on an override Task\u003cHelloReply\u003e SayHello(...) gRPC method emits SCOPE.Pattern/auth_coverage/auth:Authorize:roles:admin.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "not_applicable",
+            "notes": "gRPC request/response payloads are protobuf messages, surfaced under schema_extraction (message:/datacontract:/service_impl:). MVC DTO inference (FluentValidation AbstractValidator\u003cT\u003e / DataAnnotation model classes) does not model gRPC payloads. VERIFIED 0 entities from custom_csharp_aspnet_reqresp on a gRPC service."
+          },
+          "request_validation": {
+            "status": "not_applicable",
+            "notes": "gRPC has no MVC request-validation pipeline (FluentValidation/DataAnnotations on action models); message-field constraints live in proto. VERIFIED 0 entities from custom_csharp_validation on a gRPC service."
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "not_applicable",
+            "notes": "gRPC cross-cutting concerns use Interceptors (Interceptor base / AddInterceptor), not the ASP.NET Core Use*/middleware pipeline. VERIFIED 0 entities from custom_csharp_middleware_extra on a gRPC service. gRPC interceptor cataloguing is potential future work, tracked separately if needed."
+          },
+          "rate_limit_stamping": {
+            "status": "not_applicable",
+            "notes": "HTTP endpoint rate-limit/throttle stamping is an HTTP-middleware concept; gRPC throttling is done via interceptors/server options, not HTTP rate limiters."
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractor/enum_valueset.go","internal/extractors/csharp/csharp.go"],
+            "notes": "enum_declaration -\u003e SCOPE.Schema/enum + value-carrying SCOPE.Enum value-set (buildEnumValueSet); framework-agnostic, fires on enums in gRPC service/contract code.",
+            "verified_at": "2026-06-03"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration -\u003e SCOPE.Component/interface; framework-agnostic.",
+            "verified_at": "2026-06-03"
+          },
+          "type_alias_extraction": {
+            "status": "not_applicable",
+            "notes": "C# has only file-scoped using-aliases, not first-class type aliases (same as all C# frameworks)."
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration -\u003e SCOPE.Component; framework-agnostic, fires on every .cs incl. gRPC service impl classes and proto-generated partial classes.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3699 ExtractDotnetDI fires framework-agnostically. VERIFIED on a gRPC project Program.cs: services.AddScoped\u003cIGreetRepository,GreetRepository\u003e() emits IGreetRepository BINDS GreetRepository (lifetime=Scoped).",
+            "verified_at": "2026-06-03"
+          },
+          "di_injection_point": {
+            "status": "partial",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_test.go"],
+            "issue": "3963",
+            "notes": "#3699 constructor params emit INJECTED_INTO (service type -\u003e consumer class). VERIFIED: a GreeterService(IGreetRepository repo, ILogger\u003c\u003e logger) ctor emits IGreetRepository INJECTED_INTO GreeterService (ILogger\u003c\u003e/primitives rejected). PARTIAL: same caveat as aspnet-core (impl resolves cross-file only via resolver pass; factory-lambda registrations not linked).",
+            "verified_at": "2026-06-03"
+          },
+          "di_scope_resolution": {
+            "status": "full",
+            "cites": ["internal/custom/csharp/dotnet_di.go","internal/custom/csharp/dotnet_di_test.go"],
+            "notes": "#3699 BINDS edges carry Singleton/Scoped/Transient lifetime parsed from the AddXxx verb; framework-agnostic, fires for gRPC service registrations.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "C# NUnit/xUnit/MSTest [Fact]/[Theory]/[Test]/[TestMethod] detected via csharp*MethodRE; framework-agnostic, links gRPC service tests like any C# tests.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go","internal/substrate/template_pattern_csharp.go"],
+            "issue": "3963",
+            "notes": "ILogger\u003cT\u003e decl + _logger.Log\u003cLevel\u003e/Console.WriteLine captured framework-agnostically. VERIFIED on a gRPC service: ILogger\u003cGreeterService\u003e field + _logger.LogInformation(...) emit log_extraction entities. PARTIAL: recording-win, heuristic."
+          },
+          "metric_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "3963",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram + prometheus-net regex extractor; framework-agnostic, fires for gRPC services that instrument metrics. PARTIAL: heuristic."
+          },
+          "trace_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "3963",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; framework-agnostic. PARTIAL: heuristic."
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "full",
@@ -10345,6 +10706,10 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2771",
             "verified_at": "2026-05-29"
+          },
+          "request_sink_dataflow": {
+            "status": "not_applicable",
+            "notes": "The C# request-\u003esink dataflow sniffer (dataflow_csharp.go) roots taint at ASP.NET MVC binders ([FromBody]/[FromQuery]/[FromForm]/[FromHeader]/[FromRoute]) + Request.Query/Form/RouteValues accessors. gRPC service methods take a strongly-typed protobuf request + ServerCallContext (no MVC binders), so there is no MVC request-root to seed; not applicable to this transport."
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -14434,6 +14799,116 @@
             "verified_at": "2026-05-31"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "missing",
@@ -14508,6 +14983,10 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "rpc request message type recorded as request_message on each SCOPE.GrpcMethod.",
             "verified_at": "2026-05-31"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -34263,6 +34742,116 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "partial",
@@ -34365,6 +34954,10 @@
             "cites": ["internal/substrate/payload_shapes_graphql.go","internal/substrate/payload_shapes_jsts.go","testdata/fixtures/graphql/schema.graphql"],
             "issue": "3076",
             "verified_at": "2026-05-29"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -39662,6 +40255,116 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "partial",
@@ -39764,6 +40467,10 @@
             "cites": ["internal/substrate/payload_shapes_jsts.go"],
             "issue": "3057",
             "verified_at": "2026-05-29"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",
@@ -71574,6 +72281,116 @@
             "verified_at": "2026-05-31"
           }
         },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_pagination_posture": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_response_codes": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "rate_limit_stamping": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "3963"
+          }
+        },
         "Substrate": {
           "confidence_overlay": {
             "status": "missing",
@@ -71663,6 +72480,10 @@
             "issue": "backfill:dictionary-completeness",
             "notes": "Request message type NAME recovered from the RPC param type; field shapes live in ScalaPB-generated message companions (not statically present). Value-asserted (HelloRequest).",
             "verified_at": "2026-05-31"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "3963"
           },
           "response_shape_extraction": {
             "status": "partial",

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -470,6 +470,17 @@ subcategories:
   rpc_framework:
     display: "RPC Framework"
     parent_category: http_framework
+    # The HTTP-server universal-core lanes (Routing/View/Auth/Validation/
+    # Middleware/Type System/DI/Testing/Observability + request_sink_dataflow)
+    # were mirrored from http_backend so cross-subcategory parity with the
+    # flagship HTTP backends is MEASURABLE — an RPC framework's record now
+    # carries an explicit cell (status, incl. not_applicable) for every lane
+    # the HTTP backends declare, rather than omitting the column entirely.
+    # Genuinely HTTP-server-shaped lanes (routes/views/MVC-DTOs/middleware-
+    # pipeline) are not_applicable for an RPC transport; cross-cutting lanes
+    # that DO fire on a .cs/.ex/.scala/.ts RPC service (auth attrs, DI graph,
+    # CST type extraction, OTel/log sniffers, test-attr linkage) are credited
+    # honestly per-language. Issue #3963 / epic #3872.
     capabilities:
       - procedure_extraction
       - schema_extraction
@@ -477,6 +488,29 @@ subcategories:
       - type_graph_extraction
       - client_codegen
       - transport_binding
+      - endpoint_synthesis
+      - handler_attribution
+      - route_extraction
+      - endpoint_deprecation_versioning
+      - endpoint_pagination_posture
+      - endpoint_response_codes
+      - view_rendering
+      - auth_coverage
+      - request_validation
+      - dto_extraction
+      - middleware_coverage
+      - rate_limit_stamping
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - type_extraction
+      - di_binding_extraction
+      - di_injection_point
+      - di_scope_resolution
+      - tests_linkage
+      - trace_extraction
+      - log_extraction
+      - metric_extraction
       - constant_propagation
       - env_fallback_recognition
       - config_consumption
@@ -500,6 +534,7 @@ subcategories:
       - pure_function_tagging
       - module_cycle_detection
       - def_use_chain_extraction
+      - request_sink_dataflow
       - template_pattern_catalog
     groups:
       - name: Schema
@@ -508,8 +543,26 @@ subcategories:
         keys: [client_codegen]
       - name: Transport
         keys: [transport_binding]
+      - name: Routing
+        keys: [endpoint_synthesis, handler_attribution, route_extraction, endpoint_deprecation_versioning, endpoint_pagination_posture, endpoint_response_codes]
+      - name: View
+        keys: [view_rendering]
+      - name: Auth
+        keys: [auth_coverage]
+      - name: Validation
+        keys: [request_validation, dto_extraction]
+      - name: Middleware
+        keys: [middleware_coverage, rate_limit_stamping]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction, type_extraction]
+      - name: DI
+        keys: [di_binding_extraction, di_injection_point, di_scope_resolution]
+      - name: Testing
+        keys: [tests_linkage]
+      - name: Observability
+        keys: [trace_extraction, log_extraction, metric_extraction]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, config_consumption, error_flow, feature_flag_gating, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
+        keys: [constant_propagation, env_fallback_recognition, config_consumption, error_flow, feature_flag_gating, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, request_sink_dataflow, template_pattern_catalog]
 
   static_site:
     display: "Static Site"


### PR DESCRIPTION
Closes #3963. Refs epic #3872. **DEPLOY-DEFERRED** (taxonomy + registry/docs only — no extractor or index change).

## Problem (corrected premise)
Audit #3882 read `lang.csharp.framework.grpc-net` as "missing ~19 cells vs aspnet-core's 49." Verification showed the real cause: the **`rpc_framework` subcategory taxonomy declared only 30 lanes**, and the registry's grouped-completeness validator (`completenessGateIsError=true`) gates each record EXACTLY to its subcategory taxonomy. So grpc-net — and all 4 sibling rpc_framework records (`c-cpp.grpc`, `elixir.grpc`, `jsts.trpc`, `scala.scalapb-grpc`) — were **byte-identical at 30 cells** and literally could not surface a column the taxonomy never declared. Cross-subcategory parity vs the HTTP backends was *unmeasurable*, not deficient. (rust's gRPC `tonic` already lives under `http_backend` with the 49-cell grid — confirming rpc_framework was under-specified.)

## Change
Mirrors the HTTP-server universal-core lanes onto the `rpc_framework` taxonomy (Routing / View / Auth / Validation / Middleware / Type System / DI / Testing / Observability + `request_sink_dataflow`), so every rpc_framework record now carries an **explicit cell — including `not_applicable`** — for every lane the HTTP backends declare. grpc-net goes 30 → 54 cells.

## VERIFY-FIRST (value-asserting probes run against gRPC-net idioms, then reverted)
**Credited — fires framework-agnostically on a `.cs` gRPC service:**
- `auth_coverage`=**full** — `[Authorize(Roles="admin")]` on `override Task<HelloReply> SayHello(HelloRequest, ServerCallContext)` emits `SCOPE.Pattern/auth_coverage/auth:Authorize:roles:admin` (`custom_csharp_auth`)
- `di_binding_extraction`/`di_scope_resolution`=**full**, `di_injection_point`=**partial** — `AddScoped<IGreetRepository,GreetRepository>()` → BINDS w/ lifetime; ctor `IGreetRepository` → INJECTED_INTO `GreeterService` (`custom_csharp_dotnet_di`)
- `type_extraction`/`interface_extraction`/`enum_extraction`=**full** (tree-sitter CST); `type_alias_extraction`=**n/a** (C# has no first-class type aliases)
- `log_extraction`/`metric_extraction`/`trace_extraction`=**partial** (OTel/ILogger sniffers); `tests_linkage`=**full** ([Fact]/[Theory]/[Test]/[TestMethod] testmap)

**`not_applicable` — HTTP-server-shaped, VERIFIED 0 entities on a gRPC service impl:**
`endpoint_synthesis` / `route_extraction` / `handler_attribution` / `endpoint_deprecation_versioning` / `endpoint_pagination_posture` / `endpoint_response_codes` / `view_rendering` / `dto_extraction` / `request_validation` / `middleware_coverage` / `rate_limit_stamping` / `request_sink_dataflow`. gRPC uses `MapGrpcService` + proto messages + interceptors + `grpc::StatusCode`, not HTTP routes/views/MVC-binders/middleware-pipeline. RPC method/message shapes stay surfaced via the existing `procedure_extraction`/`schema_extraction`/`transport_binding` cells.

## What's left missing (and why)
The **6 sibling rpc_framework records** (`c-cpp.grpc`, `c-cpp.protobuf`, `elixir.grpc`, `jsts.trpc`, `jsts.graphql-resolvers`, `scala.scalapb-grpc`) carry the 24 new lanes as `missing` under #3963 — honest "declared, not yet triaged per-language" — mirroring the #3818 `endpoint_response_codes` backfill precedent. Per-language triage of those is follow-up.

## Gates
`covtool validate` 0 errors · `fmt --check` canonical · `backfill --check` 0 pending · `gen` 0 drift · `go test ./tools/coverage/ ./internal/types/ ./internal/custom/csharp/` + dispatch-parity all green · gofmt/vet clean. No extractor added (taxonomy + registry only). Registry diff is purely additive (+821 lines, 0 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)