### PR TITLE
feat(coverage): surface node-type dimensions on dedicated platform lanes (#3875)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -56,18 +56,33 @@ Back to [summary](../summary.md). Bucket: **Other**.
 
 ## App Topology & Integration
 
-| Language | Name | Dependency attribution | External service dependency | Resource extraction | Shared data coupling | Translation key usage | Status | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Frontend route → component graph (SPA client routing)](../detail/frontend.routing.spa-route-component.md) | 🟢 | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | — | 🟢 | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | — | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | — | 🟢 | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [i18n translation-key usage (USES_TRANSLATION)](../detail/analysis.localization.i18n-keys.md) | — | — | — | — | 🟢 | 🟢 | |
+| Language | Name | Dependency attribution | Resource extraction | Shared data coupling | Status | Notes |
+|---|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [API-gateway route topology (application frameworks)](../detail/infra.gateway.api-routing.md) | ✅ | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Reverse-proxy / gateway request topology](../detail/infra.deployment.request-topology.md) | ✅ | 🟢 | — | 🟢 | |
+| [multi](../by-language/multi.md) | [Shared-database cross-service coupling (SHARES_DATA)](../detail/analysis.architecture.shared-db-coupling.md) | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Structural coupling metrics (Ca/Ce/instability)](../detail/analysis.architecture.structural-coupling.md) | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | ✅ | — | ✅ | |
+
+## External Service Integration
+
+| Language | Name | External service dependency | Status | Notes |
+|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [Third-party SDK service dependencies (DEPENDS_ON_SERVICE)](../detail/analysis.integration.third-party-sdk.md) | 🟢 | 🟢 | |
+
+## Localization / i18n
+
+| Language | Name | Translation key usage | Status | Notes |
+|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [i18n translation-key usage (USES_TRANSLATION)](../detail/analysis.localization.i18n-keys.md) | 🟢 | 🟢 | |
+
+## Frontend Routing
+
+| Language | Name | Dependency attribution | Resource extraction | Status | Notes |
+|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [Frontend route → component graph (SPA client routing)](../detail/frontend.routing.spa-route-component.md) | 🟢 | 🟢 | 🟢 | |

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -52,7 +52,10 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Containers & Orchestration](by-category/platform.md#containers--orchestration) | 5 | Dockerfile, Helm charts, Kubernetes manifests, Kustomize, … |
 | [Config Files](by-category/platform.md#config-files) | 7 | .env, .ini, .properties, .toml, … |
 | [Workflow / DAG & State Machines](by-category/platform.md#workflow--dag--state-machines) | 7 | Apache Airflow, Argo Workflows, Celery canvas, Python transitions, … |
-| [App Topology & Integration](by-category/platform.md#app-topology--integration) | 13 | API-gateway route topology, AWS CDK, AWS CloudFormation, Frontend route, … |
+| [App Topology & Integration](by-category/platform.md#app-topology--integration) | 10 | API-gateway route topology, AWS CDK, AWS CloudFormation, Helm charts, … |
+| [External Service Integration](by-category/platform.md#external-service-integration) | 1 | Third-party SDK service dependencies |
+| [Localization / i18n](by-category/platform.md#localization--i18n) | 1 | i18n translation-key usage |
+| [Frontend Routing](by-category/platform.md#frontend-routing) | 1 | Frontend route |
 
 ## Languages with extractor support, no records yet
 

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -66,7 +66,7 @@ categories:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
     capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency, translation_key_usage]
-    subcategory_order: [iac_provisioning, container_orchestration, config_files, workflow_dag, app_topology]
+    subcategory_order: [iac_provisioning, container_orchestration, config_files, workflow_dag, app_topology, integration_external, localization, frontend_routing]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection, cors_policy]
   protocol:
@@ -685,6 +685,38 @@ subcategories:
       - resource_extraction
       - dependency_attribution
       - shared_data_coupling
+    groups: []
+
+  # B6 (#3875): the recently-added node-type dimensions previously shared
+  # the broad app_topology lane, where each filled exactly one column and
+  # left the rest of the lane's resource-graph rows blank in that column
+  # (the sparse external_service_dependency / translation_key_usage
+  # empty-column problem from #3861's acceptance). They are split here into
+  # their own dense, single-purpose lanes — each declaring only the
+  # capability column its records actually carry — so the dimension is
+  # reported on the right page with appropriate columns and no empty
+  # cross-column leak. Records are routed here by presentationSubcategory
+  # in generate.go (presentation-only — registry subcategory/status fields
+  # are unchanged; cells still validate against the platform category-level
+  # capability allow-list).
+  integration_external:
+    display: "External Service Integration"
+    parent_category: platform
+    capabilities:
       - external_service_dependency
+    groups: []
+
+  localization:
+    display: "Localization / i18n"
+    parent_category: platform
+    capabilities:
       - translation_key_usage
+    groups: []
+
+  frontend_routing:
+    display: "Frontend Routing"
+    parent_category: platform
+    capabilities:
+      - resource_extraction
+      - dependency_attribution
     groups: []

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -304,6 +304,37 @@ type frameworkSpecificView struct {
 	CapList []capEntry
 }
 
+// presentationLaneRemap routes a few recently-added platform node-type
+// dimension records out of the broad app_topology lane and onto their own
+// single-purpose subcategory lanes (B6, #3875). The registry keeps these
+// records under subcategory=app_topology (a valid, stable slug whose cells
+// validate against the platform category-level allow-list); the remap is
+// applied only when materialising the render view, so it relocates which
+// lane/page the record appears on WITHOUT touching any registry status or
+// the on-disk subcategory field. Each target lane declares only the one
+// capability column the record carries, eliminating the sparse
+// external_service_dependency / translation_key_usage empty-column leak
+// that previously spanned every resource-graph row of app_topology.
+//
+// Keyed by registry record ID so the mapping is explicit and auditable;
+// adding a future dimension is a one-line entry plus a dictionary lane.
+var presentationLaneRemap = map[string]string{
+	"analysis.integration.third-party-sdk": "integration_external",
+	"analysis.localization.i18n-keys":      "localization",
+	"frontend.routing.spa-route-component": "frontend_routing",
+}
+
+// presentationSubcategory returns the subcategory slug the record should
+// render under. It honours presentationLaneRemap for the B6 node-type
+// dimensions and otherwise returns the registry subcategory unchanged.
+// Deterministic and pure — gen stays idempotent.
+func presentationSubcategory(rec Record) string {
+	if to, ok := presentationLaneRemap[rec.ID]; ok {
+		return to
+	}
+	return rec.Subcategory
+}
+
 // recordToView materialises a Record with sorted capability entries so
 // templates iterate deterministically.
 func recordToView(rec Record) recordView {
@@ -318,7 +349,7 @@ func recordToView(rec Record) recordView {
 	view := recordView{
 		ID:                rec.ID,
 		Category:          rec.Category,
-		Subcategory:       rec.Subcategory,
+		Subcategory:       presentationSubcategory(rec),
 		Language:          rec.Language,
 		Label:             rec.Label,
 		Bucket:            bucketOf(rec.Category),

--- a/tools/coverage/platform_subcategory_test.go
+++ b/tools/coverage/platform_subcategory_test.go
@@ -43,6 +43,7 @@ func platformReg() *Registry {
 			rec("analysis.architecture.shared-db-coupling", "app_topology", map[string]string{"shared_data_coupling": "full"}),
 			rec("analysis.integration.third-party-sdk", "app_topology", map[string]string{"external_service_dependency": "partial"}),
 			rec("analysis.localization.i18n-keys", "app_topology", map[string]string{"translation_key_usage": "partial"}),
+			rec("frontend.routing.spa-route-component", "app_topology", map[string]string{"resource_extraction": "partial", "dependency_attribution": "partial"}),
 		},
 	}
 }
@@ -69,6 +70,8 @@ func labelFor(id string) string {
 		return "Third-party SDK service dependencies"
 	case "analysis.localization.i18n-keys":
 		return "i18n translation-key usage"
+	case "frontend.routing.spa-route-component":
+		return "Frontend route → component graph"
 	}
 	return id
 }
@@ -139,6 +142,73 @@ func TestPlatformByCategoryRendersSubcategoryLanes(t *testing.T) {
 
 	// No structurally-always-empty column: every column header in every
 	// lane table must be backed by at least one non-"—" cell.
+	assertNoAlwaysEmptyColumn(t, page)
+}
+
+// TestB6NodeTypeDimensionsOnOwnLanes asserts the B6 (#3875) fix: the
+// recently-added platform node-type dimension records (external-service
+// integration, i18n localization, frontend routing) are reported on their
+// OWN single-purpose subcategory lane with the right column — not crammed
+// into the broad App Topology lane where each filled exactly one column
+// and left every resource-graph row blank in that column. Verifies:
+//   - each dimension renders under its dedicated lane heading,
+//   - each dimension's value cell survives the move (no fabricated/dropped
+//     coverage — presentation-only),
+//   - App Topology no longer declares the migrated dimension columns
+//     (the sparse external_service / translation_key empty-column leak is
+//     gone), and
+//   - no dimension is double-reported (it left App Topology entirely).
+func TestB6NodeTypeDimensionsOnOwnLanes(t *testing.T) {
+	root := t.TempDir()
+	if err := generate(platformReg(), root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	page := readFile(t, filepath.Join(root, "docs/coverage/by-category/platform.md"))
+
+	cases := []struct {
+		lane   string
+		recID  string
+		col    string
+		glyph  string // expected non-empty cell glyph for the migrated value
+		appCol bool   // whether the column must be ABSENT from App Topology now
+	}{
+		{"## External Service Integration", "analysis.integration.third-party-sdk", "External service dependency", "🟢", true},
+		{"## Localization / i18n", "analysis.localization.i18n-keys", "Translation key usage", "🟢", true},
+		{"## Frontend Routing", "frontend.routing.spa-route-component", "Resource extraction", "🟢", false},
+	}
+
+	appTopo := sectionBody(page, "## App Topology & Integration")
+	appHeader := firstTableHeader(appTopo)
+
+	for _, c := range cases {
+		if !strings.Contains(page, c.lane) {
+			t.Errorf("platform.md missing dedicated lane %q\n%s", c.lane, page)
+			continue
+		}
+		body := sectionBody(page, c.lane)
+		if !strings.Contains(body, c.recID) {
+			t.Errorf("lane %q should contain record %s\n%s", c.lane, c.recID, body)
+		}
+		header := firstTableHeader(body)
+		if !strings.Contains(header, c.col) {
+			t.Errorf("lane %q header missing its own column %q: %s", c.lane, c.col, header)
+		}
+		if !strings.Contains(body, c.glyph) {
+			t.Errorf("lane %q lost the migrated %q value cell (expected %q): %s", c.lane, c.col, c.glyph, body)
+		}
+		// No double-reporting: the dimension record left App Topology.
+		if strings.Contains(appTopo, c.recID) {
+			t.Errorf("record %s is double-reported — still present in App Topology lane", c.recID)
+		}
+		// The migrated dimension columns are gone from App Topology (the
+		// sparse empty-column leak the B6 ticket removes).
+		if c.appCol && strings.Contains(appHeader, c.col) {
+			t.Errorf("App Topology header still declares migrated column %q (sparse leak): %s", c.col, appHeader)
+		}
+	}
+
+	// The full page must carry no structurally-always-empty column after
+	// the split.
 	assertNoAlwaysEmptyColumn(t, page)
 }
 


### PR DESCRIPTION
**Closes #3875** · Epic #3871 · Parent program #3628 · Serialized behind #3861 + B3 (#3873, both merged).

## Scope (B6)
Recently-added platform **node-type dimension** records previously shared the broad `app_topology` lane on `by-category/platform.md`, where each filled exactly **one** capability column and left every resource-graph row blank in that column — the sparse `external_service_dependency` / `translation_key_usage` empty-column problem #3861's acceptance criteria flagged. This splits each dimension onto its own single-purpose subcategory lane with the right column.

## Node-types surfaced (and where)
| Record | Capability | New lane |
|---|---|---|
| `analysis.integration.third-party-sdk` | `external_service_dependency` | **External Service Integration** |
| `analysis.localization.i18n-keys` | `translation_key_usage` | **Localization / i18n** |
| `frontend.routing.spa-route-component` | resource/dependency | **Frontend Routing** |

`App Topology & Integration` is now dense (resource / dependency / coupling only) — the two sparse cross-columns are gone, no dimension is double-reported, and each appears on exactly one correct lane. The summary's "Platform subcategories" discoverability section links all three new lanes.

## How (presentation-only, 0 status change)
- New `platform` subcategory lanes in `capability-dictionary.yaml`, each declaring only the capability column its records carry.
- `presentationSubcategory(rec)` in `generate.go` routes the 3 records by registry ID at **render time** — registry subcategory and **status fields are unchanged**; cells still validate against the platform category-level allow-list. `registry.json` is byte-identical (`fmt --check` canonical).

## Acceptance / checks
- Value-asserting test `TestB6NodeTypeDimensionsOnOwnLanes`: each dimension on its dedicated lane with the right column + surviving value cell, App Topology no longer declares the migrated columns, no double-reporting, no always-empty column.
- `go test ./tools/coverage/...` green · `validate` 0 errors (8228 warnings, base-identical) · `fmt --check` canonical · `gofmt` clean · `vet` clean · `covtool gen` idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)