### PR TITLE
feat(python/di): litestar + sanic native-DI BINDS/INJECTED_INTO extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -106,11 +106,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
 | [python](../by-language/python.md) | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 9/12 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/12 | |
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -36,11 +36,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |
 | [Graphene GraphQL](../detail/lang.python.framework.graphene.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [Hug](../detail/lang.python.framework.hug.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 9/12 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Quart](../detail/lang.python.framework.quart.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Robyn](../detail/lang.python.framework.robyn.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/12 | |
 | [Starlette](../detail/lang.python.framework.starlette.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -67,8 +67,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-06-03` | 3912 | `internal/custom/python/di_graph.go`<br>`internal/custom/python/di_graph_test.go` | litestar native DI: each dependencies={"key": Provide(callable)} dict item (on Litestar/Controller/Router/handler) emits BINDS(key->callable), token=the dependency key the handler param resolves by. Value-asserted TestPyDI_LitestarProvideBindsAndInject (db->get_db); negatives TestPyDI_LitestarDynamicProvideNoEdge (Provide(make_provider()) call-expr skipped), TestPyDI_LitestarPlainParamNoEdge. PARTIAL: cross-file provider resolution + dynamic/kwarg-only Provide skipped (honest); which scope (app/router/controller) governs a key not resolved. |
+| DI injection point | 🟢 `partial` | `2026-06-03` | 3912 | `internal/custom/python/di_graph.go`<br>`internal/custom/python/di_graph_test.go` | litestar resolves DI by handler-parameter name == dependency key; a handler param matching a Provide()-bound key emits INJECTED_INTO(provider->handler). Value-asserted TestPyDI_LitestarProvideBindsAndInject (get_db->list_items). Negatives TestPyDI_LitestarAppLevelBindsOnly (no matching param -> BINDS only, no fabricated injection), TestPyDI_LitestarPlainParamNoEdge. PARTIAL: param-name match is file-local; per-scope governance (app vs controller vs handler dependencies=) not resolved. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -67,8 +67,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-06-03` | 3912 | `internal/custom/python/di_graph.go`<br>`internal/custom/python/di_graph_test.go` | sanic native DI: app.ext.dependency(Impl) / app.ext.add_dependency("name", Impl) registers a DI provider, emitting BINDS(Impl->Impl) (the registered type IS the token, resolved at handler time by annotation). Value-asserted TestPyDI_SanicExtDependencyBinds (Database->Database); negative same test: dependency(SessionFactory()) call-expr skipped. PARTIAL: instance/call-expression registrations skipped (honest); container scope not modeled. |
+| DI injection point | 🔴 `missing` | — | 3912 | — | sanic injects DI by handler parameter TYPE annotation matching a registered app.ext.dependency type; binding is credited (di_binding_extraction) but the per-handler annotation->registered-type match is not yet resolved file-locally, so no INJECTED_INTO edge is fabricated. Honest-missing pending an annotation->type resolver. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -57076,12 +57076,18 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/python/di_graph.go","internal/custom/python/di_graph_test.go"],
+            "issue": "3912",
+            "notes": "litestar native DI: each dependencies={\"key\": Provide(callable)} dict item (on Litestar/Controller/Router/handler) emits BINDS(key-\u003ecallable), token=the dependency key the handler param resolves by. Value-asserted TestPyDI_LitestarProvideBindsAndInject (db-\u003eget_db); negatives TestPyDI_LitestarDynamicProvideNoEdge (Provide(make_provider()) call-expr skipped), TestPyDI_LitestarPlainParamNoEdge. PARTIAL: cross-file provider resolution + dynamic/kwarg-only Provide skipped (honest); which scope (app/router/controller) governs a key not resolved.",
+            "verified_at": "2026-06-03"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/python/di_graph.go","internal/custom/python/di_graph_test.go"],
+            "issue": "3912",
+            "notes": "litestar resolves DI by handler-parameter name == dependency key; a handler param matching a Provide()-bound key emits INJECTED_INTO(provider-\u003ehandler). Value-asserted TestPyDI_LitestarProvideBindsAndInject (get_db-\u003elist_items). Negatives TestPyDI_LitestarAppLevelBindsOnly (no matching param -\u003e BINDS only, no fabricated injection), TestPyDI_LitestarPlainParamNoEdge. PARTIAL: param-name match is file-local; per-scope governance (app vs controller vs handler dependencies=) not resolved.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
             "status": "missing",
@@ -58505,12 +58511,16 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/python/di_graph.go","internal/custom/python/di_graph_test.go"],
+            "issue": "3912",
+            "notes": "sanic native DI: app.ext.dependency(Impl) / app.ext.add_dependency(\"name\", Impl) registers a DI provider, emitting BINDS(Impl-\u003eImpl) (the registered type IS the token, resolved at handler time by annotation). Value-asserted TestPyDI_SanicExtDependencyBinds (Database-\u003eDatabase); negative same test: dependency(SessionFactory()) call-expr skipped. PARTIAL: instance/call-expression registrations skipped (honest); container scope not modeled.",
+            "verified_at": "2026-06-03"
           },
           "di_injection_point": {
             "status": "missing",
-            "issue": "3628"
+            "issue": "3912",
+            "notes": "sanic injects DI by handler parameter TYPE annotation matching a registered app.ext.dependency type; binding is credited (di_binding_extraction) but the per-handler annotation-\u003eregistered-type match is not yet resolved file-locally, so no INJECTED_INTO edge is fabricated. Honest-missing pending an annotation-\u003etype resolver."
           },
           "di_scope_resolution": {
             "status": "missing",

--- a/internal/custom/python/di_graph.go
+++ b/internal/custom/python/di_graph.go
@@ -79,6 +79,26 @@ var (
 
 	// rePyInjectDecorator detects an `@inject` decorator preceding a def.
 	rePyInjectDecorator = regexp.MustCompile(`(?m)^[ \t]*@inject\b`)
+
+	// reLitestarDepsKw locates a `dependencies = {` / `dependencies={` keyword
+	// (litestar declares DI providers in a dict keyed by the handler param name).
+	// The match index marks the position just past the `{` so the dict body can
+	// be balanced-scanned.
+	reLitestarDepsKw = regexp.MustCompile(`\bdependencies[ \t]*=[ \t]*\{`)
+
+	// reLitestarProvideItem matches one dict item `"key": Provide(<callable>)`
+	// inside a litestar `dependencies={...}` mapping. Group 1 = dependency key
+	// (the handler param name / BINDS token), group 2 = the provider callable
+	// passed as Provide()'s first positional argument (best-effort, may be empty
+	// for a dynamic/kwarg-only Provide which is then skipped).
+	reLitestarProvideItem = regexp.MustCompile(
+		`["']([A-Za-z_]\w*)["']\s*:\s*(?:litestar\.di\.|di\.)?Provide[ \t]*\(\s*([A-Za-z_][\w.]*)?`)
+
+	// reSanicDependency matches sanic's native DI registration
+	// `app.ext.dependency(<impl>)` / `app.ext.add_dependency("name", <impl>)`.
+	// Group 1 = the implementation/instance identifier (first positional).
+	reSanicDependency = regexp.MustCompile(
+		`\.ext\.(?:add_)?dependency[ \t]*\(\s*(?:["'][A-Za-z_]\w*["']\s*,\s*)?([A-Za-z_][\w.]*)`)
 )
 
 func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -217,8 +237,220 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		}
 	}
 
+	// ---- litestar native DI: dependencies={"k": Provide(cb)} --------------
+	// BINDS(key -> provider callable) for each dict item; the dependency key is
+	// the token that a handler param resolves by name. Then INJECTED_INTO for any
+	// handler param whose name matches a declared key (litestar resolves DI by
+	// parameter name == dependency key).
+	depKeyToProvider := map[string]string{}
+	for _, ds := range pyLitestarDepsDicts(src) {
+		body := src[ds.start:ds.end]
+		lineBase := lineOf(src, ds.start)
+		for _, m := range reLitestarProvideItem.FindAllStringSubmatchIndex(body, -1) {
+			key := body[m[2]:m[3]]
+			provider := ""
+			if m[4] >= 0 && !pyIdentIsCalled(body, m[5]) {
+				provider = pyLeafIdent(body[m[4]:m[5]])
+			}
+			if provider == "" {
+				// Dynamic/kwarg-only/called Provide(make_dep()) — no resolvable
+				// static callable; skip (honest-partial, never fabricate).
+				continue
+			}
+			line := lineBase + strings.Count(body[:m[0]], "\n")
+			depKeyToProvider[key] = provider
+			addEdge("di_provider", line,
+				map[string]string{
+					"framework": "litestar",
+					"token":     key,
+					"impl":      provider,
+					"via":       "litestar_provide",
+				},
+				types.RelationshipRecord{
+					FromID: key,
+					ToID:   provider,
+					Kind:   string(types.RelationshipKindBinds),
+					Properties: map[string]string{
+						"framework": "litestar",
+						"token":     key,
+						"via":       "litestar_provide",
+					},
+				})
+		}
+	}
+	// INJECTED_INTO: a handler param named like a declared dependency key →
+	// INJECTED_INTO(provider -> handler). Only fires when the key was actually
+	// bound via Provide() above, so the param-name match reflects a real binding.
+	if len(depKeyToProvider) > 0 {
+		for _, fn := range pyFunctions(src) {
+			sig := pyBalancedParen(src, fn.parenOpen)
+			if sig == "" {
+				continue
+			}
+			for _, p := range pySplitParams(sig) {
+				name := pyParamName(p)
+				if name == "" || name == "self" || name == "cls" {
+					continue
+				}
+				provider, ok := depKeyToProvider[name]
+				if !ok {
+					continue
+				}
+				addEdge("di_consumer", fn.line,
+					map[string]string{
+						"framework": "litestar",
+						"di_role":   "provide",
+						"consumer":  fn.name,
+						"provider":  provider,
+						"token":     name,
+						"via":       "litestar_provide",
+					},
+					types.RelationshipRecord{
+						FromID: provider,
+						ToID:   fn.name,
+						Kind:   string(types.RelationshipKindInjectedInto),
+						Properties: map[string]string{
+							"framework": "litestar",
+							"provider":  provider,
+							"consumer":  fn.name,
+							"token":     name,
+							"via":       "litestar_provide",
+						},
+					})
+			}
+		}
+	}
+
+	// ---- sanic native DI: app.ext.dependency(impl) -----------------------
+	// Sanic registers a DI instance/type via app.ext.dependency(...); the
+	// instance is then injected into handlers by type annotation. We can resolve
+	// the registration (BINDS impl -> impl, i.e. the registered provider), but
+	// not the per-handler annotation→type match reliably file-locally, so the
+	// injection point stays honest-missing for sanic.
+	for _, m := range reSanicDependency.FindAllStringSubmatchIndex(src, -1) {
+		if pyIdentIsCalled(src, m[3]) {
+			// dependency(SessionFactory()) — the registered impl is the result of
+			// a call expression, not a static type; skip (honest-partial).
+			continue
+		}
+		impl := pyLeafIdent(src[m[2]:m[3]])
+		if impl == "" {
+			continue
+		}
+		line := lineOf(src, m[0])
+		addEdge("di_provider", line,
+			map[string]string{
+				"framework": "sanic",
+				"token":     impl,
+				"impl":      impl,
+				"via":       "sanic_ext_dependency",
+			},
+			types.RelationshipRecord{
+				FromID: impl,
+				ToID:   impl,
+				Kind:   string(types.RelationshipKindBinds),
+				Properties: map[string]string{
+					"framework": "sanic",
+					"token":     impl,
+					"via":       "sanic_ext_dependency",
+				},
+			})
+	}
+
 	span.SetAttributes(attribute.Int("di_edge_count", edgeCount))
 	return out, nil
+}
+
+// pyLitestarDepsSpan describes the byte span of a litestar `dependencies={...}`
+// dict body (between the braces).
+type pyLitestarDepsSpan struct {
+	start int
+	end   int
+}
+
+// pyLitestarDepsDicts returns the body span of each `dependencies={...}` mapping
+// in the source, balanced-scanning the braces so nested brackets are respected.
+func pyLitestarDepsDicts(src string) []pyLitestarDepsSpan {
+	var out []pyLitestarDepsSpan
+	for _, loc := range reLitestarDepsKw.FindAllStringIndex(src, -1) {
+		// loc[1]-1 is the '{'.
+		open := loc[1] - 1
+		inner := pyBalancedBrace(src, open)
+		if inner < 0 {
+			continue
+		}
+		out = append(out, pyLitestarDepsSpan{start: open + 1, end: inner})
+	}
+	return out
+}
+
+// pyBalancedBrace returns the byte offset of the matching '}' for the '{' at
+// index open (the returned offset points AT the closing brace). Returns -1 on
+// imbalance. Brackets/parens nested inside are balanced too.
+func pyBalancedBrace(src string, open int) int {
+	if open < 0 || open >= len(src) || src[open] != '{' {
+		return -1
+	}
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// pyIdentIsCalled reports whether the identifier ending at byte offset `end`
+// (exclusive) is immediately followed by a `(`, i.e. it is a call expression
+// like `make_dep()` rather than a bare callable reference. Leading whitespace
+// between the identifier and the paren is tolerated.
+func pyIdentIsCalled(src string, end int) bool {
+	for i := end; i < len(src); i++ {
+		switch src[i] {
+		case ' ', '\t':
+			continue
+		case '(':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// pyParamName returns the parameter name from a single parameter declaration,
+// stripping any `:type`, `=default`, and leading `*`/`**`. Returns "" for an
+// empty/positional-only marker (`*`, `/`).
+func pyParamName(param string) string {
+	p := strings.TrimSpace(param)
+	for strings.HasPrefix(p, "*") {
+		p = strings.TrimSpace(p[1:])
+	}
+	if p == "" || p == "/" {
+		return ""
+	}
+	if i := strings.IndexAny(p, ":=)"); i >= 0 {
+		p = p[:i]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if c := p[0]; !(c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+		return ""
+	}
+	for _, c := range p {
+		if !(c == '_' || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+			return ""
+		}
+	}
+	return p
 }
 
 // pyFuncInfo locates a `def` head: its name, source line, and the byte offset

--- a/internal/custom/python/di_graph_test.go
+++ b/internal/custom/python/di_graph_test.go
@@ -135,6 +135,99 @@ func TestPyDI_ProvideWithoutInjectNoEdge(t *testing.T) {
 	}
 }
 
+// litestar: dependencies={"db": Provide(get_db)} on a controller, with a
+// handler param `db: DB` → BINDS(db -> get_db) + INJECTED_INTO(get_db -> get).
+func TestPyDI_LitestarProvideBindsAndInject(t *testing.T) {
+	src := `from litestar import Controller, get
+from litestar.di import Provide
+
+async def get_db() -> DB:
+    return DB()
+
+class ItemController(Controller):
+    dependencies = {"db": Provide(get_db)}
+
+    @get("/items")
+    async def list_items(self, db: DB) -> list:
+        return db.all()
+`
+	rels := diEdges(t, src)
+	if !hasEdge(rels, "db", "get_db", string(types.RelationshipKindBinds)) {
+		t.Fatalf("expected BINDS(db -> get_db); got %+v", rels)
+	}
+	if !hasEdge(rels, "get_db", "list_items", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(get_db -> list_items); got %+v", rels)
+	}
+}
+
+// litestar: app-level Litestar(dependencies={...}) binds, but with no matching
+// handler param only the BINDS fires (no fabricated injection point).
+func TestPyDI_LitestarAppLevelBindsOnly(t *testing.T) {
+	src := `from litestar import Litestar
+from litestar.di import Provide
+
+app = Litestar(route_handlers=[], dependencies={"cache": Provide(get_cache)})
+
+async def handler(other: str) -> str:
+    return other
+`
+	rels := diEdges(t, src)
+	if !hasEdge(rels, "cache", "get_cache", string(types.RelationshipKindBinds)) {
+		t.Fatalf("expected BINDS(cache -> get_cache); got %+v", rels)
+	}
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindInjectedInto) {
+			t.Fatalf("expected no INJECTED_INTO (no matching handler param); got %+v", r)
+		}
+	}
+}
+
+// litestar negative: a plain handler param with no Provide()-bound dependency
+// key yields no DI edge.
+func TestPyDI_LitestarPlainParamNoEdge(t *testing.T) {
+	src := `from litestar import get
+
+@get("/x")
+async def handler(name: str) -> str:
+    return name
+`
+	rels := diEdges(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no DI edges for a plain param; got %+v", rels)
+	}
+}
+
+// litestar negative: a dynamic Provide() with no resolvable callable yields no
+// edge (honest-partial).
+func TestPyDI_LitestarDynamicProvideNoEdge(t *testing.T) {
+	src := `from litestar.di import Provide
+dependencies = {"db": Provide(make_provider())}
+`
+	rels := diEdges(t, src)
+	for _, r := range rels {
+		if r.FromID == "db" {
+			t.Fatalf("expected no BINDS for dynamic Provide(); got %+v", r)
+		}
+	}
+}
+
+// sanic: app.ext.dependency(impl) registers a DI provider → BINDS(impl -> impl).
+func TestPyDI_SanicExtDependencyBinds(t *testing.T) {
+	src := `from sanic import Sanic
+app = Sanic("svc")
+app.ext.dependency(SessionFactory())
+app.ext.add_dependency("db", Database)
+`
+	rels := diEdges(t, src)
+	// SessionFactory() is a call expression → not a resolvable bare ident → skip.
+	if hasEdge(rels, "SessionFactory", "SessionFactory", string(types.RelationshipKindBinds)) {
+		t.Fatalf("did not expect BINDS for SessionFactory() call expr; got %+v", rels)
+	}
+	if !hasEdge(rels, "Database", "Database", string(types.RelationshipKindBinds)) {
+		t.Fatalf("expected BINDS(Database -> Database) from add_dependency; got %+v", rels)
+	}
+}
+
 // Negative: a Configuration() provider with no class arg yields no BINDS.
 func TestPyDI_ConfigurationProviderNoBinds(t *testing.T) {
 	src := `class Container(containers.DeclarativeContainer):


### PR DESCRIPTION
Closes #3912 · Epic #3872 · Audit #3878

## What
Extends the existing `python_di_graph` extractor to cover **litestar** native DI and **sanic** `app.ext.dependency`, beyond the FastAPI `Depends()` / dependency-injector support it already had. No new registered extractor key — dispatch parity is unchanged.

### litestar (di_binding_extraction + di_injection_point → partial)
- **BINDS**: each `dependencies={"key": Provide(callable)}` dict item (on `Litestar` / `Controller` / `Router` / handler) → `BINDS(key -> callable)`; token = the dependency key a handler param resolves by.
- **INJECTED_INTO**: litestar resolves DI by parameter name == dependency key, so a handler param matching a `Provide()`-bound key → `INJECTED_INTO(provider -> handler)`. Only fires when the key was actually bound via `Provide()`, so the name match reflects a real binding (never a coincidental param name).

### sanic (di_binding_extraction → partial)
- **BINDS**: `app.ext.dependency(Impl)` / `app.ext.add_dependency("name", Impl)` → `BINDS(Impl -> Impl)`.
- Injection point stays **honest-missing**: sanic injects by handler-parameter *type annotation* matching a registered type; that annotation→type resolver isn't built, so no INJECTED_INTO is fabricated.

### starlette / quart
Left **missing**: neither has a native DI container of its own; they rely on FastAPI-style `Depends` (already credited to fastapi) or manual wiring. Nothing fires honestly, so no credit.

## Honest-partial
Dynamic / kwarg-only / call-expression providers (`Provide(make_dep())`, `dependency(SessionFactory())`) are skipped, never fabricated — new `pyIdentIsCalled` guard rejects call expressions.

## Value-asserting edges
- `TestPyDI_LitestarProvideBindsAndInject`: `BINDS(db -> get_db)` + `INJECTED_INTO(get_db -> list_items)`
- `TestPyDI_LitestarAppLevelBindsOnly`: app-level bind fires `BINDS(cache -> get_cache)`, no fabricated injection (no matching param)
- `TestPyDI_LitestarPlainParamNoEdge`: plain param → no edge
- `TestPyDI_LitestarDynamicProvideNoEdge`: `Provide(make_provider())` → no BINDS
- `TestPyDI_SanicExtDependencyBinds`: `BINDS(Database -> Database)`; `dependency(SessionFactory())` call-expr skipped

## Verification
- VERIFY-FIRST probe confirmed litestar native DI produced **zero** edges before this change.
- `go test ./internal/custom/python/` (full package) green; `go test ./internal/types/` green.
- Dispatch parity `TestEveryRegisteredCustomKeyDispatches` green (no new key, but confirmed).
- `coverage validate` 0 errors; `coverage fmt --check` canonical; `coverage gen` no drift; `gofmt`/`go vet` clean.
- Registry mirrors the FastAPI DI precedent (the `cites` carry symbols/tests; same accepted "no mapping entry" warning fastapi already emits).

**DEPLOY-DEFERRED** — needs a daemon rebuild + reindex to surface in the live graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)