### PR TITLE
credit 41 language-level substrate cells on 5 trailing Elixir frameworks (#4026)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -36,14 +36,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/12 | |
-| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 11/25 | 🔴 0/11 | |
 | [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/12 | |
-| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🔴 0/12 | |
+| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 1/12 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 5/6 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 8/12 | |
@@ -262,7 +262,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🟡 2/24 | 🟡 3/4 | |
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/24 | 🟢 4/4 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟡 22/24 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/24 | 🟡 3/4 | |
+| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 11/24 | 🟡 3/4 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟡 23/24 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟡 23/24 | ✅ 4/4 | |
 | [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | 🟡 15/24 | 🟢 4/4 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -30,14 +30,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/12 | |
-| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/12 | |
+| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🔴 0/12 | |
+| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 11/25 | 🔴 0/11 | |
 | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
 | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/12 | |
-| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🔴 0/12 | |
+| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 1/12 | |
 
 
 ### Meta Framework
@@ -51,7 +51,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 3/24 | 🟡 3/4 | |
+| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟡 11/24 | 🟡 3/4 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.elixir.framework.finch.md
+++ b/docs/coverage/detail/lang.elixir.framework.finch.md
@@ -98,26 +98,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | @base_url module-attr resolution into Finch URL canonical path (#1483/#3511) |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | @base_url System.get_env(VAR, default) fallback literal resolved for Finch URLs (#1496/#3511) |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Finch.build modeled as outbound HTTP effect (#1483/#3511) |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_elixir.go` | Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
 | Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -39,26 +39,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | Cross-repo identity grpc:<service>/<method> matches the shared #725 linker convention so client stub and server impl join across repos. |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_elixir.go` | Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Request shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc request message type recorded as request_message on each SCOPE.GrpcMethod. |
 | Response shape extraction | 🟢 `partial` | `2026-05-31` | backfill:dictionary-completeness | `internal/custom/elixir/grpc.go`<br>`internal/custom/elixir/grpc_test.go` | rpc response message type recorded as response_message on each SCOPE.GrpcMethod. |
-| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Related extraction records

--- a/docs/coverage/detail/lang.elixir.framework.guardian.md
+++ b/docs/coverage/detail/lang.elixir.framework.guardian.md
@@ -89,7 +89,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
@@ -98,26 +97,27 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_elixir.go` | Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Request shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| Sanitizer recognition | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.elixir.framework.req.md
+++ b/docs/coverage/detail/lang.elixir.framework.req.md
@@ -98,26 +98,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🟢 `partial` | `2026-05-30` | 3511 | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_synthesis.go` | Req string-concat + @module-attr interpolation resolved; Req.new(base_url:) cross-call base merge pending (#3511) |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Req verb calls modeled as outbound HTTP effects (#3511) |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_elixir.go` | Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
 | Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.elixir.framework.tesla.md
+++ b/docs/coverage/detail/lang.elixir.framework.tesla.md
@@ -98,26 +98,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_synthesis.go` | Tesla.Middleware.BaseUrl literal + @module-attr resolution into canonical path (#3511) |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Tesla verb calls modeled as outbound HTTP effects (#3511) |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_elixir.go` | Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| Request shape extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 | Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
 | Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_elixir.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_elixir.go` | Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 |--------|----------|------|--------|
 | [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 6 partial, 22 missing, 2 n/a |
 | [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 4 full, 22 partial, 2 missing, 2 n/a |
-| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 6 partial, 22 missing, 2 n/a |
+| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 14 partial, 14 missing, 2 n/a |
 | [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |
 | [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 2 full, 17 partial, 9 missing, 2 n/a |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14296,12 +14296,15 @@
             "verified_at": "2026-05-30"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -14332,20 +14335,25 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go","internal/substrate/effect_sinks_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
             "status": "missing",
@@ -14372,12 +14380,15 @@
             "issue": "backfill:dictionary-completeness"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -14448,16 +14459,20 @@
             "issue": "backfill:dictionary-completeness"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -14487,20 +14502,25 @@
             "verified_at": "2026-05-31"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go","internal/substrate/effect_sinks_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
             "status": "partial",
@@ -14517,8 +14537,9 @@
             "verified_at": "2026-05-31"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "schema_drift_detection": {
             "status": "missing",
@@ -14533,8 +14554,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -14672,12 +14695,6 @@
             "issue": "backfill:dictionary-completeness"
           }
         },
-        "Data": {
-          "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
-          }
-        },
         "Substrate": {
           "confidence_overlay": {
             "status": "missing",
@@ -14691,13 +14708,21 @@
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-06-03"
+          },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -14724,36 +14749,46 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go","internal/substrate/effect_sinks_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-06-03"
           },
           "request_sink_dataflow": {
             "status": "missing",
             "issue": "3740"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-06-03"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "schema_drift_detection": {
             "status": "missing",
@@ -14764,12 +14799,15 @@
             "issue": "backfill:dictionary-completeness"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -16271,12 +16309,15 @@
             "verified_at": "2026-05-30"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -16305,20 +16346,25 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go","internal/substrate/effect_sinks_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
             "status": "missing",
@@ -16345,12 +16391,15 @@
             "issue": "backfill:dictionary-completeness"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -16513,12 +16562,15 @@
             "verified_at": "2026-05-30"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -16547,24 +16599,31 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic Tarjan SCC over IMPORTS edges; Elixir use/alias/import edges flow through extractor"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go","internal/substrate/effect_sinks_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir effect sniffer registered; functions with no elixir effect matches tagged pure=true; immutable semantics make Elixir especially suitable"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-06-03"
           },
           "request_sink_dataflow": {
             "status": "missing",
@@ -16587,12 +16646,15 @@
             "issue": "backfill:dictionary-completeness"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_elixir.go"],
+            "verified_at": "2026-06-03"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_elixir.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Elixir template-pattern sniffer registered: i18n (gettext/dgettext), log_format (Logger.*), SQL literals via Ecto.Adapters.SQL"
           },
           "vulnerability_finding": {
             "status": "missing",

--- a/internal/substrate/elixir_trailing_frameworks_test.go
+++ b/internal/substrate/elixir_trailing_frameworks_test.go
@@ -1,0 +1,396 @@
+// Value-asserting fixtures for the 5 trailing Elixir frameworks (#4026,
+// epic #3872, from Elixir audit #3885): guardian / grpc / finch / tesla / req.
+//
+// The Elixir substrate sniffers (def_use_elixir.go, effect_sinks_elixir.go,
+// taint_sites_elixir.go, payload_shapes_elixir.go, template_pattern_elixir.go,
+// entry_points_elixir.go) all register on the "elixir" slug with NO framework
+// gate — they are framework-AGNOSTIC and fire on any .ex/.exs source dispatched
+// via LanguageForPath. The 4 flagship Elixir frameworks (oban/phoenix/plug/
+// absinthe) already carry these language-level Substrate cells at partial; this
+// re-stamps the trailing frameworks to the SAME partial sibling status for the
+// cells that genuinely fire on each framework's real idiom.
+//
+// VERIFY-FIRST discipline: each test below proves the sniffer produces the
+// SPECIFIC artifact (a named def->use pair / a named effect sink on a named
+// function / a categorised taint site / a field-bearing payload shape / a named
+// template literal / a named entry point) on that framework's idiomatic source.
+// Cells that do NOT fire on a framework's idiom are deliberately LEFT MISSING
+// (see the file footer for the honest left-missing ledger) — no over-credit.
+package substrate
+
+import (
+	"testing"
+)
+
+// hasTaint asserts a taint match of the given kind (and, when cat != "", that
+// category) was produced inside fn.
+func hasTaintElixir(t *testing.T, ms []TaintMatch, fn string, kind TaintKind, cat TaintCategory) {
+	t.Helper()
+	for _, m := range ms {
+		if m.Function == fn && m.Kind == kind && (cat == "" || m.Category == cat) {
+			return
+		}
+	}
+	t.Errorf("expected taint %s/%s in %q; got %+v", kind, cat, fn, ms)
+}
+
+// hasTemplate asserts a template pattern of the given kind whose literal
+// contains want was attributed to fn.
+func hasTemplateElixir(t *testing.T, ps []TemplatePattern, fn string, kind TemplateKind, want string) {
+	t.Helper()
+	for _, p := range ps {
+		if p.Function == fn && p.Kind == kind && contains(p.Literal, want) {
+			return
+		}
+	}
+	t.Errorf("expected template %s ~%q in %q; got %+v", kind, want, fn, ps)
+}
+
+// hasEntry asserts an entry point with the given ident+kind was produced.
+func hasEntryElixir(t *testing.T, eps []EntryPoint, ident string, kind EntryKind) {
+	t.Helper()
+	for _, e := range eps {
+		if e.Ident == ident && e.Kind == kind {
+			return
+		}
+	}
+	t.Errorf("expected entry point %s/%s; got %+v", ident, kind, eps)
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// ---------------------------------------------------------------------------
+// guardian — an authentication pipeline / token-verification module.
+// Credited: def_use, dead_code, reachability, pure_fn, module_cycle (universal)
+//           + db_effect, taint_source, sanitizer, request_shape,
+//             response_shape, template_pattern.
+// ---------------------------------------------------------------------------
+
+const guardianSrc = `
+defmodule MyApp.Auth.Pipeline do
+  use Guardian.Plug.Pipeline, otp_app: :my_app
+  require Logger
+
+  def authenticate(conn, %{"token" => token, "scope" => scope}) do
+    creds = conn.params
+    {:ok, claims} = Guardian.decode_and_verify(token)
+    user = MyApp.Repo.get(MyApp.User, claims["sub"])
+    verified = Phoenix.Token.verify(MyApp.Endpoint, "user", token)
+    Logger.info("guardian authenticated user")
+    conn |> json(%{id: user.id, scope: scope})
+  end
+end
+`
+
+func TestElixirTrailing_Guardian_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseElixir(guardianSrc)
+	hasDefUse(t, defs, uses, "authenticate", "user")
+}
+
+func TestElixirTrailing_Guardian_DBEffect(t *testing.T) {
+	by := groupByEffect(sniffEffectsElixir(guardianSrc))
+	mustHave(t, by, EffectDBRead, "authenticate") // MyApp.Repo.get -> db_read
+}
+
+func TestElixirTrailing_Guardian_TaintSource(t *testing.T) {
+	// conn.params is the canonical Plug.Conn external-input source.
+	hasTaintElixir(t, sniffTaintElixir(guardianSrc), "authenticate", TaintKindSource, TaintCategoryGeneric)
+}
+
+func TestElixirTrailing_Guardian_Sanitizer(t *testing.T) {
+	// Repo.get parameterises; Phoenix.Token.verify proves message origin.
+	hasTaintElixir(t, sniffTaintElixir(guardianSrc), "authenticate", TaintKindSanitizer, "")
+}
+
+func TestElixirTrailing_Guardian_RequestShape(t *testing.T) {
+	shapes := sniffPayloadShapesElixir(guardianSrc)
+	req := findShape(shapes, "authenticate", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected guardian request shape from %%{\"token\"=>..}; got %+v", shapes)
+	}
+	if got := sortedNames(req.Fields); !equalStrs(got, []string{"scope", "token"}) {
+		t.Errorf("guardian request fields: want [scope token] got %v", got)
+	}
+}
+
+func TestElixirTrailing_Guardian_ResponseShape(t *testing.T) {
+	shapes := sniffPayloadShapesElixir(guardianSrc)
+	resp := findShape(shapes, "authenticate", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected guardian json(%%{id:..,scope:..}) response shape; got %+v", shapes)
+	}
+	if got := sortedNames(resp.Fields); !equalStrs(got, []string{"id", "scope"}) {
+		t.Errorf("guardian response fields: want [id scope] got %v", got)
+	}
+}
+
+func TestElixirTrailing_Guardian_Template(t *testing.T) {
+	hasTemplateElixir(t, sniffTemplatePatternsElixir(guardianSrc), "authenticate", TemplateKindLog, "guardian authenticated")
+}
+
+func TestElixirTrailing_Guardian_EntryReachability(t *testing.T) {
+	// public def -> library_export root feeds reachability/dead-code/pure-fn.
+	hasEntryElixir(t, sniffElixirEntryPoints(guardianSrc), "authenticate", EntryKindLibraryExport)
+}
+
+// ---------------------------------------------------------------------------
+// grpc — a GRPC.Server service implementation module.
+// Credited: universal + db_effect, sanitizer, template_pattern.
+// (request/response_shape already carried via the grpc protobuf message-type
+//  path in internal/custom/elixir/grpc.go — left untouched.)
+// ---------------------------------------------------------------------------
+
+const grpcSrc = `
+defmodule Helloworld.Greeter.Server do
+  use GRPC.Server, service: Helloworld.Greeter.Service
+  require Logger
+
+  def say_hello(request, _stream) do
+    name = request.name
+    user = MyApp.Repo.get_by(MyApp.User, name: name)
+    Logger.info("grpc say_hello invoked")
+    %Helloworld.HelloReply{message: "Hello " <> name, user_id: user.id}
+  end
+end
+`
+
+func TestElixirTrailing_Grpc_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseElixir(grpcSrc)
+	hasDefUse(t, defs, uses, "say_hello", "user")
+}
+
+func TestElixirTrailing_Grpc_DBEffect(t *testing.T) {
+	by := groupByEffect(sniffEffectsElixir(grpcSrc))
+	mustHave(t, by, EffectDBRead, "say_hello") // Repo.get_by -> db_read
+}
+
+func TestElixirTrailing_Grpc_Sanitizer(t *testing.T) {
+	// Repo.get_by parameterises the lookup => SQL sanitizer.
+	hasTaintElixir(t, sniffTaintElixir(grpcSrc), "say_hello", TaintKindSanitizer, TaintCategorySQL)
+}
+
+func TestElixirTrailing_Grpc_Template(t *testing.T) {
+	hasTemplateElixir(t, sniffTemplatePatternsElixir(grpcSrc), "say_hello", TemplateKindLog, "grpc say_hello")
+}
+
+func TestElixirTrailing_Grpc_EntryReachability(t *testing.T) {
+	hasEntryElixir(t, sniffElixirEntryPoints(grpcSrc), "say_hello", EntryKindLibraryExport)
+}
+
+// ---------------------------------------------------------------------------
+// finch — a low-level HTTP client wrapper module.
+// Credited: universal + taint_source, template_pattern.
+// (http_effect already FULL — left untouched.)
+// ---------------------------------------------------------------------------
+
+const finchSrc = `
+defmodule MyApp.HttpClient do
+  require Logger
+
+  def fetch_user(id) do
+    base = System.get_env("API_BASE_URL")
+    url = base <> "/users/" <> id
+    req = Finch.build(:get, url)
+    {:ok, resp} = Finch.request(req, MyApp.Finch)
+    Logger.info("finch fetched user")
+    resp
+  end
+end
+`
+
+func TestElixirTrailing_Finch_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseElixir(finchSrc)
+	hasDefUse(t, defs, uses, "fetch_user", "url")
+}
+
+func TestElixirTrailing_Finch_HTTPEffect(t *testing.T) {
+	// Already-full cell; assert the sniffer really fires Finch.build/request.
+	by := groupByEffect(sniffEffectsElixir(finchSrc))
+	mustHave(t, by, EffectHTTPOut, "fetch_user")
+}
+
+func TestElixirTrailing_Finch_TaintSource(t *testing.T) {
+	// System.get_env is an external-config taint source.
+	hasTaintElixir(t, sniffTaintElixir(finchSrc), "fetch_user", TaintKindSource, TaintCategoryGeneric)
+}
+
+func TestElixirTrailing_Finch_Template(t *testing.T) {
+	hasTemplateElixir(t, sniffTemplatePatternsElixir(finchSrc), "fetch_user", TemplateKindLog, "finch fetched")
+}
+
+func TestElixirTrailing_Finch_EntryReachability(t *testing.T) {
+	hasEntryElixir(t, sniffElixirEntryPoints(finchSrc), "fetch_user", EntryKindLibraryExport)
+}
+
+// ---------------------------------------------------------------------------
+// tesla — a Tesla.Client-based HTTP API client module.
+// Credited: universal + taint_source, request_shape, template_pattern.
+// (http_effect already FULL — left untouched.)
+// ---------------------------------------------------------------------------
+
+const teslaSrc = `
+defmodule MyApp.ApiClient do
+  use Tesla
+  require Logger
+
+  def create_order(client, name, total) do
+    token = System.get_env("API_TOKEN")
+    Logger.info("tesla creating order")
+    result = Tesla.post(client, "https://api.example.com/orders", %{name: name, total: total})
+    result
+  end
+end
+`
+
+func TestElixirTrailing_Tesla_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseElixir(teslaSrc)
+	hasDefUse(t, defs, uses, "create_order", "result")
+}
+
+func TestElixirTrailing_Tesla_HTTPEffect(t *testing.T) {
+	by := groupByEffect(sniffEffectsElixir(teslaSrc))
+	mustHave(t, by, EffectHTTPOut, "create_order")
+}
+
+func TestElixirTrailing_Tesla_TaintSource(t *testing.T) {
+	hasTaintElixir(t, sniffTaintElixir(teslaSrc), "create_order", TaintKindSource, TaintCategoryGeneric)
+}
+
+func TestElixirTrailing_Tesla_RequestShape(t *testing.T) {
+	// Tesla.post(client, url, %{name:..,total:..}) is the consumer-side body.
+	shapes := sniffPayloadShapesElixir(teslaSrc)
+	var found *PayloadShape
+	for i := range shapes {
+		if shapes[i].Function == "create_order" && shapes[i].Direction == PayloadDirectionRequest && shapes[i].Side == PayloadSideConsumer {
+			found = &shapes[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected tesla consumer request shape; got %+v", shapes)
+	}
+	if got := sortedNames(found.Fields); !equalStrs(got, []string{"name", "total"}) {
+		t.Errorf("tesla request fields: want [name total] got %v", got)
+	}
+	if found.VerbHint != "POST" || found.EndpointHint != "https://api.example.com/orders" {
+		t.Errorf("tesla verb/endpoint hint: got %q %q", found.VerbHint, found.EndpointHint)
+	}
+}
+
+func TestElixirTrailing_Tesla_Template(t *testing.T) {
+	hasTemplateElixir(t, sniffTemplatePatternsElixir(teslaSrc), "create_order", TemplateKindLog, "tesla creating order")
+}
+
+func TestElixirTrailing_Tesla_EntryReachability(t *testing.T) {
+	hasEntryElixir(t, sniffElixirEntryPoints(teslaSrc), "create_order", EntryKindLibraryExport)
+}
+
+// ---------------------------------------------------------------------------
+// req — a Req high-level HTTP client module.
+// Credited: universal + taint_source, template_pattern.
+// (http_effect already FULL — left untouched.)
+// ---------------------------------------------------------------------------
+
+const reqSrc = `
+defmodule MyApp.ReqClient do
+  require Logger
+
+  def post_event(payload) do
+    base = System.get_env("EVENTS_URL")
+    Logger.info("req posting event")
+    resp = Req.post(base, json: payload)
+    resp
+  end
+end
+`
+
+func TestElixirTrailing_Req_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseElixir(reqSrc)
+	hasDefUse(t, defs, uses, "post_event", "resp")
+}
+
+func TestElixirTrailing_Req_HTTPEffect(t *testing.T) {
+	by := groupByEffect(sniffEffectsElixir(reqSrc))
+	mustHave(t, by, EffectHTTPOut, "post_event")
+}
+
+func TestElixirTrailing_Req_TaintSource(t *testing.T) {
+	hasTaintElixir(t, sniffTaintElixir(reqSrc), "post_event", TaintKindSource, TaintCategoryGeneric)
+}
+
+func TestElixirTrailing_Req_Template(t *testing.T) {
+	hasTemplateElixir(t, sniffTemplatePatternsElixir(reqSrc), "post_event", TemplateKindLog, "req posting event")
+}
+
+func TestElixirTrailing_Req_EntryReachability(t *testing.T) {
+	hasEntryElixir(t, sniffElixirEntryPoints(reqSrc), "post_event", EntryKindLibraryExport)
+}
+
+// ---------------------------------------------------------------------------
+// Negative assertions — honest left-missing ledger. These prove the cells we
+// deliberately LEFT MISSING genuinely do not fire on each framework's idiom,
+// so the registry omission is correct (no silent under-credit, no over-credit).
+// ---------------------------------------------------------------------------
+
+func TestElixirTrailing_LeftMissing_NoFalsePositives(t *testing.T) {
+	noEffect := func(src, fn string, eff Effect) {
+		by := groupByEffect(sniffEffectsElixir(src))
+		if by[eff][fn] {
+			t.Errorf("unexpected %s effect on %q", eff, fn)
+		}
+	}
+	noTaintKind := func(src string, kind TaintKind) {
+		for _, m := range sniffTaintElixir(src) {
+			if m.Kind == kind {
+				t.Errorf("unexpected taint %s in fixture: %+v", kind, m)
+			}
+		}
+	}
+	// fs_effect / mutation_effect fire on none of the 5 idioms.
+	for _, src := range []string{guardianSrc, grpcSrc, finchSrc, teslaSrc, reqSrc} {
+		noEffect(src, "authenticate", EffectFSWrite)
+		noEffect(src, "say_hello", EffectMutation)
+	}
+	// taint_sink / vulnerability_finding fire on none of the 5 idioms.
+	for _, src := range []string{guardianSrc, grpcSrc, finchSrc, teslaSrc, reqSrc} {
+		noTaintKind(src, TaintKindSink)
+	}
+	// db_effect must NOT fire on the pure HTTP-client idioms (finch/tesla/req).
+	for _, src := range []string{finchSrc, teslaSrc, reqSrc} {
+		by := groupByEffect(sniffEffectsElixir(src))
+		for fn := range by[EffectDBRead] {
+			t.Errorf("unexpected db_read on HTTP-client idiom fn %q", fn)
+		}
+		for fn := range by[EffectDBWrite] {
+			t.Errorf("unexpected db_write on HTTP-client idiom fn %q", fn)
+		}
+	}
+	// grpc idiom yields no Plug.Conn / env taint source.
+	for _, m := range sniffTaintElixir(grpcSrc) {
+		if m.Kind == TaintKindSource {
+			t.Errorf("unexpected taint source on grpc idiom: %+v", m)
+		}
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #4026 (epic #3872, from Elixir audit #3885). **DEPLOY-DEFERRED.**

## What
The Elixir substrate sniffers (`def_use_elixir.go`, `effect_sinks_elixir.go`, `taint_sites_elixir.go`, `payload_shapes_elixir.go`, `template_pattern_elixir.go`, `entry_points_elixir.go`) all register on the `"elixir"` slug with **no framework gate** — they fire on any `.ex/.exs` file. The 4 flagship Elixir frameworks (oban/phoenix/plug/absinthe) already carry these language-level Substrate cells at `partial`. This re-stamps the 5 trailing frameworks (guardian/grpc/finch/tesla/req) to the **same partial sibling status** (oban cites/issue/notes copied verbatim) — registry-only, zero extractor change.

## VERIFY-FIRST (per-idiom, value-asserting)
`internal/substrate/elixir_trailing_frameworks_test.go` proves each sniffer produces the **specific** artifact on each framework's idiomatic source (named def→use pair, named effect sink on a named function, categorised taint source/sanitizer, field-bearing request/response shape with asserted field names, named log-template literal, named `library_export` entry point). A negative-assertion test pins the honest left-missing ledger (no false positives).

## Cells flipped to partial (sibling-exact, no over/under-credit) — 41 total
| framework | flipped | cells |
|---|---|---|
| guardian | 11 | def_use, dead_code, reachability, pure_fn, module_cycle, db_effect, taint_source, sanitizer, request_shape, response_shape, template_pattern |
| grpc | 8 | universal-5 + db_effect, sanitizer, template_pattern |
| finch | 7 | universal-5 + taint_source, template_pattern |
| tesla | 8 | universal-5 + taint_source, request_shape, template_pattern |
| req | 7 | universal-5 + taint_source, template_pattern |

(universal-5 = def_use / dead_code / reachability / pure_fn / module_cycle.)

## Left honest after verification (NOT credited — sniffer does not fire on the idiom)
- `fs_effect`, `mutation_effect` — no `File.*`/Agent/GenServer/`:ets` in auth/rpc/http-client modules.
- `taint_sink_detection`, `vulnerability_finding` — no SQL-splice / cmd-exec / path-traversal sink in these idioms.
- `schema_drift_detection` — engine route-bound producer↔consumer drift pairing these non-route libraries lack.
- `db_effect` on finch/tesla/req — HTTP clients don't query Repo.
- `http_effect` on guardian/grpc — not outbound-HTTP (auth / server).
- `sanitizer`/`request`/`response_shape` on finch/req; `response_shape` on tesla; `taint_source` on grpc — not exercised by those idioms.

## Untouched (out of scope)
finch/tesla/req `http_effect` stays **full**; grpc request/response_shape stay partial via the protobuf message-type path (`internal/custom/elixir/grpc.go`); absinthe `type_graph` (#4028) and tests_linkage/observability (#4027) not touched.

## Gates
`internal/substrate/` + `tools/coverage/` + `internal/types/` tests green · coverage validate **0 errors** · `fmt --check` canonical · `gen` 0 drift · gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)