### PR TITLE
feat(elixir/absinthe): Absinthe code-first GraphQL type-graph extraction (#4028)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -32,7 +32,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/13 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/12 | |
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/12 | |
 | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -52,7 +52,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type graph extraction | 🔴 `missing` | — | 3804 | — | GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks. |
+| Type graph extraction | 🟢 `partial` | — | 3804 | `internal/custom/elixir/absinthe_typegraph.go`<br>`internal/custom/elixir/absinthe_typegraph_test.go` | #4028: absintheTypeGraphExtractor builds the Absinthe code-first object-type→type graph — each `object :name` (plus interface/union as valid targets) emits a SCOPE.Schema/type node, and each object-typed `field :f, <type>` emits a GRAPH_RELATES edge with the cross-language cardinality contract (field_name/list/nullable/item_nullable/cardinality/self_ref/graphql_field). Parses non_null(:t)/list_of(:t)/list_of(non_null(:t))/non_null(list_of(:t)) wrappers; self-ref handled. Value-asserted (TestAbsintheTypeGraph_*: user.orders->order to_many list, user.account->account to_one, user.manager->user self_ref; scalar/enum/input_object fields emit NO edge). Partial (not full): same-file heuristic only — cross-file multi-module schemas split via `import_types` are not chased, and input_object/enum relations are excluded from the output object graph by design. |
 
 ### Type System
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -24,7 +24,7 @@ one is a separate detail page.
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 4 full, 3 partial, 42 missing |
-| [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 30 partial, 13 missing |
+| [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 31 partial, 12 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 7 partial, 38 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 8 full, 5 partial, 42 missing |
 | [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 25 missing, 1 n/a |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13432,9 +13432,10 @@
         },
         "Schema": {
           "type_graph_extraction": {
-            "status": "missing",
+            "status": "partial",
+            "cites": ["internal/custom/elixir/absinthe_typegraph.go","internal/custom/elixir/absinthe_typegraph_test.go"],
             "issue": "3804",
-            "notes": "GraphQL object-type→type graph applies (this is a GraphQL server) but is not yet implemented for this framework/language; SDL servers are covered by internal/extractors/graphql/type_graph.go (#3805) and the TS/Python code-first set (TypeGraphQL/Nexus/Pothos/Strawberry/graphene) by the code-first type-graph extractors. This lane is the remaining backfill for other-language GraphQL frameworks."
+            "notes": "#4028: absintheTypeGraphExtractor builds the Absinthe code-first object-type→type graph — each `object :name` (plus interface/union as valid targets) emits a SCOPE.Schema/type node, and each object-typed `field :f, \u003ctype\u003e` emits a GRAPH_RELATES edge with the cross-language cardinality contract (field_name/list/nullable/item_nullable/cardinality/self_ref/graphql_field). Parses non_null(:t)/list_of(:t)/list_of(non_null(:t))/non_null(list_of(:t)) wrappers; self-ref handled. Value-asserted (TestAbsintheTypeGraph_*: user.orders-\u003eorder to_many list, user.account-\u003eaccount to_one, user.manager-\u003euser self_ref; scalar/enum/input_object fields emit NO edge). Partial (not full): same-file heuristic only — cross-file multi-module schemas split via `import_types` are not chased, and input_object/enum relations are excluded from the output object graph by design."
           }
         },
         "Type System": {

--- a/internal/custom/elixir/absinthe_typegraph.go
+++ b/internal/custom/elixir/absinthe_typegraph.go
@@ -1,0 +1,334 @@
+package elixir
+
+// absinthe_typegraph.go — code-first GraphQL schema type→type graph for Absinthe
+// (Elixir), epic #3872, elixir audit #3885, completes #3804 for Elixir. Mirrors
+// internal/custom/{python,rust}/graphql_codefirst_typegraph.go.
+//
+// The existing Absinthe support (internal/engine/elixir_routes.go +
+// internal/engine/rules/elixir/frameworks/absinthe.yaml) only matches `object :`
+// / `field :` as ROUTING signals — each `field :name` under a query/mutation/
+// subscription block synthesizes an http_endpoint. It does NOT emit the GraphQL
+// object-type → referenced-type graph: which object type references which other
+// object type, and with what cardinality. So Absinthe's
+// Schema.type_graph_extraction was HONESTLY missing.
+//
+// This extractor closes that gap for Absinthe's code-first schema notation:
+//
+//	object :user do
+//	  field :id, :id                      # scalar  -> no edge
+//	  field :name, non_null(:string)      # scalar  -> no edge
+//	  field :orders, list_of(:order)      # GRAPH_RELATES user->order  to_many
+//	  field :account, :account            # GRAPH_RELATES user->account to_one
+//	  field :manager, :user               # GRAPH_RELATES user->user  self_ref
+//	end
+//
+//	object :order do
+//	  field :total, :decimal
+//	end
+//
+// Each declared output object type (`object :name`, plus `interface :name` and
+// `union :name`, which are valid field targets) becomes a SCOPE.Schema/type node
+// addressed with the SAME canonical structural ref the SDL pass and the py/rust
+// code-first passes use (BuildOperationStructuralRef("graphql", file, name)), so
+// identities converge on one node per type. Each object-typed `field` becomes a
+// GRAPH_RELATES edge carrying the identical cardinality property contract:
+//
+//	{field_name, list, nullable, item_nullable, cardinality:to_one|to_many,
+//	 self_ref, graphql_field, framework}
+//
+// HONEST LIMITS:
+//   - Field-type resolution is heuristic and same-file: a `field`'s referenced
+//     atom must be a GraphQL object/interface/union type declared in the SAME
+//     file. A scalar atom (:id/:string/:integer/...) or an atom that is not a
+//     known object type in this file produces NO edge. Cross-file type
+//     references (multi-module schemas split across `import_types`) and custom
+//     scalars are not chased.
+//   - `input_object` and `enum` are NOT owners and NOT edge targets — inputs and
+//     enums are the flat DTO/value catalog, not the output object→object data
+//     relationship graph. (`enum :name` carries members, not type refs.)
+//   - The query/mutation/subscription operation roots are already modelled as
+//     http_endpoint roots by the routing synthesizer; here they are owners of
+//     resolver fields, so a `field :user, :user` under `query do` does emit the
+//     root→type edge (the operation's data relation). They are not themselves
+//     field targets.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_absinthe_typegraph", &absintheTypeGraphExtractor{})
+}
+
+// absintheTypeGraphExtractor builds the object-type→type relationship graph for
+// Absinthe code-first schemas.
+type absintheTypeGraphExtractor struct{}
+
+func (e *absintheTypeGraphExtractor) Language() string {
+	return "custom_elixir_absinthe_typegraph"
+}
+
+// absintheScalars never make a type→type edge: the GraphQL built-ins plus the
+// common Absinthe / custom-scalar atoms used as scalar field types.
+var absintheScalars = map[string]bool{
+	"id": true, "string": true, "integer": true, "int": true, "float": true,
+	"boolean": true, "bool": true,
+	"datetime": true, "naive_datetime": true, "date": true, "time": true,
+	"decimal": true, "uuid": true, "uuid4": true, "json": true, "map": true,
+}
+
+var (
+	// `object :name do` / `interface :name do` / `union :name do` — output
+	// object-graph types: owners (object) and/or valid field targets (all three).
+	// Group 1 = macro (object|interface|union), group 2 = atom type name.
+	reAbObjectDecl = regexp.MustCompile(
+		`(?m)^[ \t]*(object|interface|union)\s+:([a-z_]\w*)\b`,
+	)
+	// query do / mutation do / subscription do — operation roots. These are
+	// field owners (their resolver fields carry data relations) but are NOT
+	// field targets. Group 1 = root keyword.
+	reAbRootDecl = regexp.MustCompile(
+		`(?m)^[ \t]*(query|mutation|subscription)\s+do\b`,
+	)
+	// A `field :name, <type-expr>` declaration. Group 1 = field name, group 2 =
+	// the type expression up to the line end / a trailing `do` block / `, opts`.
+	// The `do` block form `field :x, :t do ... end` is handled by stopping the
+	// type expression before the ` do`.
+	reAbFieldDecl = regexp.MustCompile(
+		`(?m)^[ \t]*field\s+:([a-z_]\w*)\s*,\s*([^\n]+)`,
+	)
+)
+
+func (e *absintheTypeGraphExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.absinthe_typegraph_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "absinthe"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "elixir" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// File-signal gate: require an Absinthe schema-notation marker plus the
+	// object/field constructs this extractor reads.
+	if !strings.Contains(src, "Absinthe") && !strings.Contains(src, "object :") {
+		return nil, nil
+	}
+	if !strings.Contains(src, "field :") {
+		return nil, nil
+	}
+
+	// Pass 1: collect declared object-graph type names (edge targets) and the
+	// (owner, kind, line, body) blocks whose fields we walk.
+	type ownerBlock struct {
+		name string
+		kind string // "object" | "interface" | "union" | "root"
+		line int
+		body string
+	}
+	var owners []ownerBlock
+	known := map[string]bool{} // valid field-target object types
+
+	for _, m := range reAbObjectDecl.FindAllStringSubmatchIndex(src, -1) {
+		macro := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		body := ectoBlockBody(src, m[1])
+		owners = append(owners, ownerBlock{name: name, kind: macro, line: lineOf(src, m[0]), body: body})
+		known[name] = true
+	}
+	for _, m := range reAbRootDecl.FindAllStringSubmatchIndex(src, -1) {
+		root := src[m[2]:m[3]] // query | mutation | subscription
+		// The root regex consumes the block `do`; start the body scan from the
+		// match start so ectoBlockBody finds that same `do` (not the next one).
+		body := ectoBlockBody(src, m[0])
+		owners = append(owners, ownerBlock{name: root, kind: "root", line: lineOf(src, m[0]), body: body})
+		// roots are NOT field targets; do not add to `known`.
+	}
+
+	if len(owners) == 0 {
+		return nil, nil
+	}
+
+	nodes := map[string]int{}
+	var out []types.EntityRecord
+	nodeFor := func(name string, line int) int {
+		if idx, ok := nodes[name]; ok {
+			return idx
+		}
+		ent := makeEntity(name, "SCOPE.Schema", "type", file.Path, file.Language, line)
+		setProps(&ent,
+			"graphql_type", name,
+			"framework", "absinthe",
+			"code_first", "true",
+			"structural_ref", extractor.BuildOperationStructuralRef("graphql", file.Path, name),
+			"provenance", "INFERRED_FROM_CODEFIRST_GRAPHQL_OBJECTTYPE",
+		)
+		out = append(out, ent)
+		nodes[name] = len(out) - 1
+		return nodes[name]
+	}
+
+	seen := map[string]bool{}
+	emit := func(owner, fieldName, target string, tc absintheCard) {
+		if !known[target] || absintheScalars[target] {
+			return
+		}
+		key := owner + "|" + fieldName + "|" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ownerRef := extractor.BuildOperationStructuralRef("graphql", file.Path, owner)
+		targetRef := extractor.BuildOperationStructuralRef("graphql", file.Path, target)
+		props := map[string]string{
+			"field_name":    fieldName,
+			"list":          absintheBool(tc.list),
+			"nullable":      absintheBool(tc.nullable),
+			"cardinality":   absintheCardLabel(tc),
+			"self_ref":      absintheBool(target == owner),
+			"graphql_field": owner + "." + fieldName,
+			"framework":     "absinthe",
+			"provenance":    "INFERRED_FROM_CODEFIRST_GRAPHQL_FIELD",
+		}
+		if tc.list {
+			props["item_nullable"] = absintheBool(tc.itemNullable)
+		}
+		idx := nodes[owner]
+		out[idx].Relationships = append(out[idx].Relationships,
+			types.RelationshipRecord{
+				FromID:     ownerRef,
+				ToID:       targetRef,
+				Kind:       string(types.RelationshipKindGraphRelates),
+				Properties: props,
+			})
+	}
+
+	for _, ow := range owners {
+		// Only object/interface/union/root carry output fields; enums/inputs are
+		// not in `owners`. Interfaces/unions rarely own object-typed fields, but
+		// an interface that declares fields is a legitimate owner.
+		nodeFor(ow.name, ow.line)
+		for _, fm := range reAbFieldDecl.FindAllStringSubmatch(ow.body, -1) {
+			fieldName := fm[1]
+			typeExpr := strings.TrimSpace(fm[2])
+			base, tc := absintheParseTypeExpr(typeExpr)
+			if base == "" {
+				continue
+			}
+			emit(ow.name, fieldName, base, tc)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// --- cardinality model (mirrors internal/extractors/graphql/type_graph.go) ---
+
+type absintheCard struct {
+	list         bool
+	nullable     bool
+	itemNullable bool
+}
+
+func absintheBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func absintheCardLabel(tc absintheCard) string {
+	if tc.list {
+		return "to_many"
+	}
+	return "to_one"
+}
+
+var absintheAtomRe = regexp.MustCompile(`:([a-z_]\w*)`)
+
+// absintheParseTypeExpr resolves an Absinthe field type expression into its base
+// object-type atom and GraphQL cardinality.
+//
+//	:order                       -> base=order  (nullable to_one — Absinthe fields
+//	                                default nullable)
+//	non_null(:order)             -> base=order  nullable=false
+//	list_of(:order)              -> base=order  list=true  item nullable
+//	non_null(list_of(:order))    -> base=order  list=true  nullable=false (list)
+//	list_of(non_null(:order))    -> base=order  list=true  item_nullable=false
+//	non_null(list_of(non_null(:order)))
+//	                             -> base=order  list=true  nullable=false item non-null
+//
+// Absinthe semantics: a bare `field :x, :t` is nullable; `non_null/1` removes
+// nullability; `list_of/1` is a list (whose elements are nullable unless wrapped
+// in non_null). The type expression may be followed by a `do` resolver block or
+// `, resolve: ...` option keywords — only the leading type term is read.
+//
+// Returns base="" when no atom can be recovered (e.g. a `field :x, do: ...`
+// virtual field, or a non-atom expression).
+func absintheParseTypeExpr(expr string) (string, absintheCard) {
+	tc := absintheCard{nullable: true} // Absinthe fields default to nullable.
+
+	// Cut the type expression off before a trailing `do` resolver block or an
+	// option-keyword tail (`, resolve: ...`, `, description: ...`). We only need
+	// the leading wrapper(s) + the innermost atom; the first top-level atom is
+	// the type reference, anything after the closing wrappers is options.
+	e := strings.TrimSpace(expr)
+	if i := strings.Index(e, " do"); i >= 0 {
+		// Only cut if ` do` begins a block (followed by end/newline), not part of
+		// an atom name. Atoms are lowercase identifiers, ` do` has a leading space.
+		e = strings.TrimSpace(e[:i])
+	}
+
+	hasNonNull := strings.Contains(e, "non_null")
+	hasList := strings.Contains(e, "list_of")
+
+	// Locate the innermost atom (the referenced type).
+	m := absintheAtomRe.FindStringSubmatch(e)
+	if m == nil {
+		return "", tc
+	}
+	base := m[1]
+
+	if hasList {
+		tc.list = true
+		tc.nullable = true // a bare list_of(...) field is itself nullable.
+		// Item nullability: list_of(non_null(:t)) -> item non-null; otherwise
+		// the list elements are nullable.
+		inner := e
+		if li := strings.Index(inner, "list_of"); li >= 0 {
+			inner = inner[li+len("list_of"):]
+		}
+		tc.itemNullable = !strings.Contains(inner, "non_null")
+		// non_null(list_of(...)) -> the LIST is non-null (outer wrapper before
+		// list_of).
+		if hasNonNull {
+			outer := e
+			if li := strings.Index(outer, "list_of"); li >= 0 {
+				outer = outer[:li]
+			}
+			if strings.Contains(outer, "non_null") {
+				tc.nullable = false
+			}
+		}
+	} else if hasNonNull {
+		tc.nullable = false
+	}
+
+	return base, tc
+}

--- a/internal/custom/elixir/absinthe_typegraph_test.go
+++ b/internal/custom/elixir/absinthe_typegraph_test.go
@@ -1,0 +1,337 @@
+package elixir_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractRaw runs the named extractor and returns the raw EntityRecords (with
+// Relationships intact, which the entitySummary helper drops).
+func extractRaw(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+// findType returns the SCOPE.Schema/type node named `name`, or nil.
+func findType(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "type" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// findGraphRelates returns the GRAPH_RELATES edge from the owner node for the
+// given field_name, or nil.
+func findGraphRelates(owner *types.EntityRecord, fieldName string) *types.RelationshipRecord {
+	if owner == nil {
+		return nil
+	}
+	for i := range owner.Relationships {
+		r := owner.Relationships[i]
+		if r.Kind == string(types.RelationshipKindGraphRelates) && r.Properties["field_name"] == fieldName {
+			return &owner.Relationships[i]
+		}
+	}
+	return nil
+}
+
+// TestAbsintheTypeGraph_ObjectFieldEdges asserts the core value: object type
+// nodes plus field→type GRAPH_RELATES edges with the correct cardinality, and
+// that scalar fields produce NO edge.
+func TestAbsintheTypeGraph_ObjectFieldEdges(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Schema do
+  use Absinthe.Schema
+
+  object :user do
+    field :id, :id
+    field :name, non_null(:string)
+    field :orders, list_of(:order)
+    field :account, :account
+    field :manager, :user
+  end
+
+  object :order do
+    field :total, :decimal
+  end
+
+  object :account do
+    field :balance, :decimal
+  end
+end
+`
+	ents := extractRaw(t, "custom_elixir_absinthe_typegraph", fi("schema.ex", "elixir", src))
+
+	user := findType(ents, "user")
+	if user == nil {
+		t.Fatal("expected SCOPE.Schema/type node :user")
+	}
+	if got := user.Properties["framework"]; got != "absinthe" {
+		t.Errorf("expected framework absinthe, got %q", got)
+	}
+	if got := user.Properties["graphql_type"]; got != "user" {
+		t.Errorf("expected graphql_type user, got %q", got)
+	}
+	if findType(ents, "order") == nil {
+		t.Fatal("expected SCOPE.Schema/type node :order")
+	}
+	if findType(ents, "account") == nil {
+		t.Fatal("expected SCOPE.Schema/type node :account")
+	}
+
+	// scalar fields -> NO edge.
+	if e := findGraphRelates(user, "id"); e != nil {
+		t.Errorf("scalar :id field must not emit an edge, got %+v", e.Properties)
+	}
+	if e := findGraphRelates(user, "name"); e != nil {
+		t.Errorf("scalar non_null(:string) field must not emit an edge, got %+v", e.Properties)
+	}
+
+	// list_of(:order) -> to_many list edge user->order.
+	orders := findGraphRelates(user, "orders")
+	if orders == nil {
+		t.Fatal("expected GRAPH_RELATES user.orders -> order")
+	}
+	if orders.ToID != extreg.BuildOperationStructuralRef("graphql", "schema.ex", "order") {
+		t.Errorf("orders edge ToID = %q, want ref to :order", orders.ToID)
+	}
+	if orders.Properties["list"] != "true" {
+		t.Errorf("orders list = %q, want true", orders.Properties["list"])
+	}
+	if orders.Properties["cardinality"] != "to_many" {
+		t.Errorf("orders cardinality = %q, want to_many", orders.Properties["cardinality"])
+	}
+	if orders.Properties["self_ref"] != "false" {
+		t.Errorf("orders self_ref = %q, want false", orders.Properties["self_ref"])
+	}
+	if orders.Properties["graphql_field"] != "user.orders" {
+		t.Errorf("orders graphql_field = %q", orders.Properties["graphql_field"])
+	}
+
+	// :account -> to_one nullable edge.
+	account := findGraphRelates(user, "account")
+	if account == nil {
+		t.Fatal("expected GRAPH_RELATES user.account -> account")
+	}
+	if account.Properties["list"] != "false" {
+		t.Errorf("account list = %q, want false", account.Properties["list"])
+	}
+	if account.Properties["cardinality"] != "to_one" {
+		t.Errorf("account cardinality = %q, want to_one", account.Properties["cardinality"])
+	}
+	if account.Properties["nullable"] != "true" {
+		t.Errorf("account nullable = %q, want true (bare Absinthe field)", account.Properties["nullable"])
+	}
+
+	// self-ref :user -> :user.
+	manager := findGraphRelates(user, "manager")
+	if manager == nil {
+		t.Fatal("expected GRAPH_RELATES user.manager -> user (self-ref)")
+	}
+	if manager.Properties["self_ref"] != "true" {
+		t.Errorf("manager self_ref = %q, want true", manager.Properties["self_ref"])
+	}
+}
+
+// TestAbsintheTypeGraph_NonNullNullability asserts non_null/1 wrappers flip the
+// nullable flag (and item_nullable inside lists) per Absinthe semantics.
+func TestAbsintheTypeGraph_NonNullNullability(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Schema do
+  use Absinthe.Schema
+
+  object :post do
+    field :author, non_null(:user)
+    field :tags, list_of(non_null(:tag))
+    field :reviewers, non_null(list_of(:user))
+  end
+
+  object :user do
+    field :id, :id
+  end
+
+  object :tag do
+    field :name, :string
+  end
+end
+`
+	ents := extractRaw(t, "custom_elixir_absinthe_typegraph", fi("schema.ex", "elixir", src))
+	post := findType(ents, "post")
+	if post == nil {
+		t.Fatal("expected :post type node")
+	}
+
+	// non_null(:user) -> nullable=false, to_one.
+	author := findGraphRelates(post, "author")
+	if author == nil {
+		t.Fatal("expected GRAPH_RELATES post.author -> user")
+	}
+	if author.Properties["nullable"] != "false" {
+		t.Errorf("author nullable = %q, want false", author.Properties["nullable"])
+	}
+	if author.Properties["list"] != "false" {
+		t.Errorf("author list = %q, want false", author.Properties["list"])
+	}
+
+	// list_of(non_null(:tag)) -> list=true, item_nullable=false, list itself nullable.
+	tags := findGraphRelates(post, "tags")
+	if tags == nil {
+		t.Fatal("expected GRAPH_RELATES post.tags -> tag")
+	}
+	if tags.Properties["list"] != "true" {
+		t.Errorf("tags list = %q, want true", tags.Properties["list"])
+	}
+	if tags.Properties["item_nullable"] != "false" {
+		t.Errorf("tags item_nullable = %q, want false", tags.Properties["item_nullable"])
+	}
+	if tags.Properties["nullable"] != "true" {
+		t.Errorf("tags nullable = %q, want true (bare list_of is nullable)", tags.Properties["nullable"])
+	}
+
+	// non_null(list_of(:user)) -> list=true, nullable=false (the list), item nullable.
+	reviewers := findGraphRelates(post, "reviewers")
+	if reviewers == nil {
+		t.Fatal("expected GRAPH_RELATES post.reviewers -> user")
+	}
+	if reviewers.Properties["list"] != "true" {
+		t.Errorf("reviewers list = %q, want true", reviewers.Properties["list"])
+	}
+	if reviewers.Properties["nullable"] != "false" {
+		t.Errorf("reviewers nullable = %q, want false (non_null list)", reviewers.Properties["nullable"])
+	}
+	if reviewers.Properties["item_nullable"] != "true" {
+		t.Errorf("reviewers item_nullable = %q, want true", reviewers.Properties["item_nullable"])
+	}
+}
+
+// TestAbsintheTypeGraph_RootAndUnknownTargets asserts operation roots own
+// resolver-field edges to declared types, an interface/union node is emitted and
+// is a valid field target, and a field referencing an UNKNOWN (cross-file /
+// scalar) atom produces no edge.
+func TestAbsintheTypeGraph_RootAndUnknownTargets(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Schema do
+  use Absinthe.Schema
+
+  query do
+    field :current_user, :user
+    field :external, :remote_thing
+  end
+
+  interface :node do
+    field :id, non_null(:id)
+  end
+
+  union :search_result do
+    types [:user]
+  end
+
+  object :user do
+    field :id, :id
+    field :kind, :search_result
+  end
+end
+`
+	ents := extractRaw(t, "custom_elixir_absinthe_typegraph", fi("schema.ex", "elixir", src))
+
+	// interface + union emit type nodes.
+	if findType(ents, "node") == nil {
+		t.Error("expected interface :node type node")
+	}
+	if findType(ents, "search_result") == nil {
+		t.Error("expected union :search_result type node")
+	}
+
+	// query root owns a resolver-field edge to a declared type.
+	root := findType(ents, "query")
+	if root == nil {
+		t.Fatal("expected query root node")
+	}
+	cu := findGraphRelates(root, "current_user")
+	if cu == nil {
+		t.Fatal("expected GRAPH_RELATES query.current_user -> user")
+	}
+	if cu.ToID != extreg.BuildOperationStructuralRef("graphql", "schema.ex", "user") {
+		t.Errorf("current_user ToID = %q", cu.ToID)
+	}
+	// :remote_thing is not declared in this file -> no edge.
+	if e := findGraphRelates(root, "external"); e != nil {
+		t.Errorf("field to unknown :remote_thing must not emit an edge, got %+v", e.Properties)
+	}
+
+	// union is a valid field target.
+	user := findType(ents, "user")
+	if findGraphRelates(user, "kind") == nil {
+		t.Error("expected GRAPH_RELATES user.kind -> search_result (union is a target)")
+	}
+}
+
+// TestAbsintheTypeGraph_InputAndEnumNotOwners asserts input_object and enum are
+// neither type nodes nor edge targets in the output type graph.
+func TestAbsintheTypeGraph_InputAndEnumNotOwners(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Schema do
+  use Absinthe.Schema
+
+  input_object :user_filter do
+    field :name, :string
+  end
+
+  enum :role do
+    value :admin
+    value :user
+  end
+
+  object :user do
+    field :role, :role
+    field :filter, :user_filter
+  end
+end
+`
+	ents := extractRaw(t, "custom_elixir_absinthe_typegraph", fi("schema.ex", "elixir", src))
+
+	if findType(ents, "user_filter") != nil {
+		t.Error("input_object :user_filter must NOT be a type node")
+	}
+	if findType(ents, "role") != nil {
+		t.Error("enum :role must NOT be a type node")
+	}
+	user := findType(ents, "user")
+	if user == nil {
+		t.Fatal("expected :user type node")
+	}
+	// field referencing an enum or an input_object -> no edge (not output objects).
+	if e := findGraphRelates(user, "role"); e != nil {
+		t.Errorf("field to enum :role must not emit an edge, got %+v", e.Properties)
+	}
+	if e := findGraphRelates(user, "filter"); e != nil {
+		t.Errorf("field to input_object :user_filter must not emit an edge, got %+v", e.Properties)
+	}
+}
+
+// TestAbsintheTypeGraph_NoSignalNoOutput asserts a non-Absinthe / non-schema
+// file emits nothing.
+func TestAbsintheTypeGraph_NoSignalNoOutput(t *testing.T) {
+	src := `
+defmodule MyApp.Plain do
+  def hello, do: :world
+end
+`
+	ents := extractRaw(t, "custom_elixir_absinthe_typegraph", fi("plain.ex", "elixir", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-Absinthe file, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary
Builds the Absinthe (Elixir GraphQL) **code-first type-graph** — the JS/TS (`http_endpoint_graphql_jsts_codefirst.go`) and Python/Rust (`graphql_codefirst_typegraph.go`) equivalent that did not exist for Elixir. Before this, `object :`/`field :` were matched **only as routing signals** (endpoint synthesis) with no GraphQL type nodes and no field→type edges, so `lang.elixir.framework.absinthe` had `Schema.type_graph_extraction: missing`. Closes #4028 (epic #3872, audit #3885).

## What it does
`internal/custom/elixir/absinthe_typegraph.go` (registered `custom_elixir_absinthe_typegraph`, mapped `custom_elixir_` prefix):
- Emits a `SCOPE.Schema/type` node per `object :name` (plus `interface :name` / `union :name`, which are valid field targets), addressed with the canonical `BuildOperationStructuralRef("graphql", file, name)` so identities converge with the SDL/py/rust passes.
- Emits a `GRAPH_RELATES` edge per object-typed `field :f, <type>` with the cross-language cardinality contract: `field_name`, `list`, `nullable`, `item_nullable`, `cardinality` (`to_one`/`to_many`), `self_ref`, `graphql_field`, `framework`.
- Parses Absinthe type wrappers: bare `:t` (nullable to_one), `non_null(:t)`, `list_of(:t)`, `list_of(non_null(:t))`, `non_null(list_of(:t))`.

## Cardinality / negative cases asserted (value-asserting, not len>0)
- `field :orders, list_of(:order)` → `user`→`order` `list=true cardinality=to_many`
- `field :account, :account` → `user`→`account` `to_one nullable=true`
- `field :manager, :user` → `self_ref=true`
- `non_null(:user)` → `nullable=false`; `list_of(non_null(:tag))` → `item_nullable=false`; `non_null(list_of(:user))` → list `nullable=false`, `item_nullable=true`
- **No edge**: scalar atoms (`:id`/`:string`), `enum` fields, `input_object` fields, unknown cross-file atoms; non-Absinthe file emits nothing.
- Operation roots (query/mutation/subscription) own their resolver-field edges to declared types.

## Honest partial (not full)
Same-file heuristic only: cross-file multi-module schemas split via `import_types` are not chased; `input_object`/`enum` relations are excluded from the output object graph by design. Registry flipped `missing → partial` with cites + honest notes.

## Verification
- `go test ./internal/custom/elixir/ ./internal/extractors/ ./internal/types/ ./tools/coverage/` — all green
- `TestEveryRegisteredCustomKeyDispatches` (dispatch-parity) — green; confirms the key dispatches **live**
- `gofmt -l` empty; `go vet` clean; `covtool validate` 0 errors; `covtool fmt --check` canonical; `covtool gen` no drift (derived docs regenerated)

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)