### PR TITLE
[parity][dart] Flutter: credit working DI/substrate/tests cells (#4034)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -195,7 +195,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟡 22/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟡 22/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟡 22/24 | 🟢 8/8 | |
-| [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🟡 4/8 | |
+| [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🟢 1/1 | 🟡 9/24 | 🟡 5/8 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 17/17 | |

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -26,7 +26,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🟡 4/8 | |
+| [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🟢 1/1 | 🟡 9/24 | 🟡 5/8 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.dart.framework.flutter.md
+++ b/docs/coverage/detail/lang.dart.framework.flutter.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ✅ `full` | — | [link](https://github.com/cajasmota/archigraph/issues/3505) | `internal/custom/dart/extractors_test.go`<br>`internal/custom/dart/flutter.go` | StatelessWidget/StatefulWidget class declarations -> SCOPE.UIComponent (widget_type stateless/stateful). Regex/heuristic but catches the canonical Flutter widget idiom; value-asserting tests (TestFlutterStatelessWidget/StatefulWidget). |
-| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Context extraction | ✅ `full` | — | — | `internal/custom/dart/extractors_test.go`<br>`internal/custom/dart/flutter.go`<br>`internal/custom/dart/flutter_edges_resolve_test.go` | DI / state-binding (Provider, Riverpod, BLoC) emits USES edges from the enclosing widget. flutter.go steps 10-13: context.read|watch|select<T>, BlocBuilder<T,S>, BlocProvider.of<T>/Provider.of<T>/RepositoryProvider.of<T>, and Riverpod ref.watch|read|listen(xProvider). Host attributed via brace-span tracking; edges resolve to hex IDs via ReferencesEmbedded. Value-asserting + resolver tests: ProfileScreen USES ProfileBloc (context.read), CartWidget USES CartModel (Provider.of), CounterView USES counterProvider (ref.watch). This is the DI home cell for the ui_frontend subcategory. |
 
 ### Data Flow
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/loader.go`<br>`internal/engine/rules/dart/test_patterns.yaml` | flutter_test / integration_test / Dart test-package classification via rules/dart/test_patterns.yaml (testWidgets/WidgetTester/pumpWidget/find.byType + group/test/expect), embedded and loaded by engine/loader.go (go:embed all:rules). PARTIAL: classifies test files/frameworks but no testmap framework detector exists for Flutter yet, so no graph TESTS edges are synthesised from testWidgets() to the widget under test (cf. lang.kotlin.*/php pest+phpunit which have testmap detectors -> full). Deepening (a flutter_test detector in internal/extractors/cross/testmap) is the path to full. |
 
 ### Substrate
 
@@ -60,26 +60,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/effect_sinks_dart.go`<br>`internal/substrate/effect_sinks_t3_test.go` | sqflite db.query/rawQuery (db_read) and db.insert/update/delete/execute (db_write), plus drift generated methods, recognised by the framework-blind Dart effect sniffer (gated on .dart via LanguageForPath). Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps fetchUsers->db_read, saveUser->db_write. PARTIAL: regex heuristic on canonical primitives, not a full ORM corpus. |
 | Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/dart_flutter_substrate_credit_4034_test.go`<br>`internal/substrate/def_use_dart.go` | var/final/const/late and typed local declarations -> defs; bare identifier reads -> uses, both attributed to the nearest enclosing Dart function/method header. Value-asserted: TestFlutterSubstrate_DefUseChainExtraction (final name=userId; final greeting=name; -> name/greeting defs + name use, attributed to loadUser). PARTIAL: regex heuristic, function-local scope. |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
-| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/effect_sinks_dart.go`<br>`internal/substrate/effect_sinks_t3_test.go` | dart:io File(...).readAsString/openRead (fs_read) and writeAsString/openWrite/create (fs_write) recognised by the Dart effect sniffer. Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps loadConfig->fs_read, writeLog->fs_write. PARTIAL: regex heuristic on canonical primitives. |
 | HTTP effect | ✅ `full` | — | — | `internal/engine/http_endpoint_dart_client.go`<br>`internal/engine/http_endpoint_dart_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Each Dio / package:http call is recorded as an outbound HTTP effect (verb + canonical path) emitted with the SAME http_endpoint_call entity shape as the backend producer side, so the cross-repo linker pairs the Flutter screen with the backend route on reindex. Value-asserted in http_endpoint_dart_client_test.go. |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/effect_sinks_dart.go`<br>`internal/substrate/effect_sinks_t3_test.go` | this.field = ... assignments inside a method body recognised as mutation effects by the Dart effect sniffer. Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps saveUser->mutation. PARTIAL: regex heuristic. |
 | Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/dart_flutter_substrate_credit_4034_test.go`<br>`internal/substrate/taint_sites_dart.go`<br>`internal/substrate/taint_sites_test.go` | Parameterised sqflite (db.query(..., whereArgs: [...]) / substitutionValues) recognised as a sanitizer by the Dart taint sniffer. Value-asserted: TestTaintSniffer_Dart_RawQueryIsSink (db.query(whereArgs:) -> sanitizer). PARTIAL: regex heuristic. |
 | Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/dart_flutter_substrate_credit_4034_test.go`<br>`internal/substrate/taint_sites_dart.go`<br>`internal/substrate/taint_sites_test.go` | sqflite db.rawQuery/rawInsert/rawUpdate/rawDelete with non-literal args (SQL injection), Process.run/start (command injection), File.write* with non-literal path (path traversal) flagged as sinks by the Dart taint sniffer. Value-asserted: TestTaintSniffer_Dart_RawQueryIsSink (db.rawQuery(concat) -> SQL sink). PARTIAL: regex heuristic. |
+| Taint source detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/dart_flutter_substrate_credit_4034_test.go`<br>`internal/substrate/taint_sites_dart.go`<br>`internal/substrate/taint_sites_test.go` | dart:io HttpRequest.uri.queryParameters/requestedUri/read and shelf Request inputs flagged as taint sources by the Dart taint sniffer. Value-asserted: TestFlutterSubstrate_TaintSourceDetection (request.uri.queryParameters -> source). PARTIAL: regex heuristic, server-side Dart idioms. |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/dart_flutter_substrate_credit_4034_test.go`<br>`internal/substrate/template_pattern_dart.go` | i18n (AppLocalizations.of(context).x / tr / Intl.message / easy_localization), log_format (print/debugPrint/Logger), and SQL literals (sqflite/drift raw queries) catalogued by the Dart template-pattern sniffer. Value-asserted: TestFlutterSubstrate_TemplatePatternCatalog (debugPrint->log_format, AppLocalizations.translate->i18n, SELECT...->sql). PARTIAL: regex heuristic, conservative i18n package set. |
 | Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12682,8 +12682,9 @@
             "notes": "StatelessWidget/StatefulWidget class declarations -\u003e SCOPE.UIComponent (widget_type stateless/stateful). Regex/heuristic but catches the canonical Flutter widget idiom; value-asserting tests (TestFlutterStatelessWidget/StatefulWidget)."
           },
           "context_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/dart/extractors_test.go","internal/custom/dart/flutter.go","internal/custom/dart/flutter_edges_resolve_test.go"],
+            "notes": "DI / state-binding (Provider, Riverpod, BLoC) emits USES edges from the enclosing widget. flutter.go steps 10-13: context.read|watch|select\u003cT\u003e, BlocBuilder\u003cT,S\u003e, BlocProvider.of\u003cT\u003e/Provider.of\u003cT\u003e/RepositoryProvider.of\u003cT\u003e, and Riverpod ref.watch|read|listen(xProvider). Host attributed via brace-span tracking; edges resolve to hex IDs via ReferencesEmbedded. Value-asserting + resolver tests: ProfileScreen USES ProfileBloc (context.read), CartWidget USES CartModel (Provider.of), CounterView USES counterProvider (ref.watch). This is the DI home cell for the ui_frontend subcategory."
           }
         },
         "Data Flow": {
@@ -12737,8 +12738,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/engine/loader.go","internal/engine/rules/dart/test_patterns.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "flutter_test / integration_test / Dart test-package classification via rules/dart/test_patterns.yaml (testWidgets/WidgetTester/pumpWidget/find.byType + group/test/expect), embedded and loaded by engine/loader.go (go:embed all:rules). PARTIAL: classifies test files/frameworks but no testmap framework detector exists for Flutter yet, so no graph TESTS edges are synthesised from testWidgets() to the widget under test (cf. lang.kotlin.*/php pest+phpunit which have testmap detectors -\u003e full). Deepening (a flutter_test detector in internal/extractors/cross/testmap) is the path to full."
           }
         },
         "Substrate": {
@@ -12755,16 +12758,20 @@
             "issue": "backfill:dictionary-completeness"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_dart.go","internal/substrate/effect_sinks_t3_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "sqflite db.query/rawQuery (db_read) and db.insert/update/delete/execute (db_write), plus drift generated methods, recognised by the framework-blind Dart effect sniffer (gated on .dart via LanguageForPath). Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps fetchUsers-\u003edb_read, saveUser-\u003edb_write. PARTIAL: regex heuristic on canonical primitives, not a full ORM corpus."
           },
           "dead_code_detection": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/dart_flutter_substrate_credit_4034_test.go","internal/substrate/def_use_dart.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "var/final/const/late and typed local declarations -\u003e defs; bare identifier reads -\u003e uses, both attributed to the nearest enclosing Dart function/method header. Value-asserted: TestFlutterSubstrate_DefUseChainExtraction (final name=userId; final greeting=name; -\u003e name/greeting defs + name use, attributed to loadUser). PARTIAL: regex heuristic, function-local scope."
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -12779,8 +12786,10 @@
             "issue": "feature_flag_gating:#3706-not-yet-extracted"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_dart.go","internal/substrate/effect_sinks_t3_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "dart:io File(...).readAsString/openRead (fs_read) and writeAsString/openWrite/create (fs_write) recognised by the Dart effect sniffer. Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps loadConfig-\u003efs_read, writeLog-\u003efs_write. PARTIAL: regex heuristic on canonical primitives."
           },
           "http_effect": {
             "status": "full",
@@ -12796,8 +12805,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_dart.go","internal/substrate/effect_sinks_t3_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "this.field = ... assignments inside a method body recognised as mutation effects by the Dart effect sniffer. Value-asserted: TestSniffEffectsDart_PrimitiveCoverage maps saveUser-\u003emutation. PARTIAL: regex heuristic."
           },
           "pure_function_tagging": {
             "status": "missing",
@@ -12816,24 +12827,32 @@
             "issue": "backfill:dictionary-completeness"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/dart_flutter_substrate_credit_4034_test.go","internal/substrate/taint_sites_dart.go","internal/substrate/taint_sites_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Parameterised sqflite (db.query(..., whereArgs: [...]) / substitutionValues) recognised as a sanitizer by the Dart taint sniffer. Value-asserted: TestTaintSniffer_Dart_RawQueryIsSink (db.query(whereArgs:) -\u003e sanitizer). PARTIAL: regex heuristic."
           },
           "schema_drift_detection": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "taint_sink_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/dart_flutter_substrate_credit_4034_test.go","internal/substrate/taint_sites_dart.go","internal/substrate/taint_sites_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "sqflite db.rawQuery/rawInsert/rawUpdate/rawDelete with non-literal args (SQL injection), Process.run/start (command injection), File.write* with non-literal path (path traversal) flagged as sinks by the Dart taint sniffer. Value-asserted: TestTaintSniffer_Dart_RawQueryIsSink (db.rawQuery(concat) -\u003e SQL sink). PARTIAL: regex heuristic."
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/dart_flutter_substrate_credit_4034_test.go","internal/substrate/taint_sites_dart.go","internal/substrate/taint_sites_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "dart:io HttpRequest.uri.queryParameters/requestedUri/read and shelf Request inputs flagged as taint sources by the Dart taint sniffer. Value-asserted: TestFlutterSubstrate_TaintSourceDetection (request.uri.queryParameters -\u003e source). PARTIAL: regex heuristic, server-side Dart idioms."
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/dart_flutter_substrate_credit_4034_test.go","internal/substrate/template_pattern_dart.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "i18n (AppLocalizations.of(context).x / tr / Intl.message / easy_localization), log_format (print/debugPrint/Logger), and SQL literals (sqflite/drift raw queries) catalogued by the Dart template-pattern sniffer. Value-asserted: TestFlutterSubstrate_TemplatePatternCatalog (debugPrint-\u003elog_format, AppLocalizations.translate-\u003ei18n, SELECT...-\u003esql). PARTIAL: regex heuristic, conservative i18n package set."
           },
           "vulnerability_finding": {
             "status": "missing",

--- a/internal/substrate/dart_flutter_substrate_credit_4034_test.go
+++ b/internal/substrate/dart_flutter_substrate_credit_4034_test.go
@@ -1,0 +1,121 @@
+// Flutter/Dart substrate proving tests (#4034, epic #3872, audit #3888).
+//
+// CREDIT-WAVE: these tests prove that the framework-blind Dart substrate
+// sniffers (gated on .dart via LanguageForPath) fire on canonical Flutter
+// idioms, so the corresponding registry cells on lang.dart.framework.flutter
+// can be credited honestly. No new extractor code — these are value-asserting
+// fixtures for cells whose sniffers shipped without a Flutter-shaped test.
+//
+// Sibling tests already prove the effect/taint/sanitizer primitives:
+//   - effect_sinks_t3_test.go  TestSniffEffectsDart_PrimitiveCoverage
+//     (db_read/db_write/mutation/fs_read/fs_write/http_out)
+//   - taint_sites_test.go      TestTaintSniffer_Dart_RawQueryIsSink
+//     (SQL sink + whereArgs sanitizer)
+//
+// This file adds the three that lacked a Dart-shaped fixture:
+//   - def_use_chain_extraction  (sniffDefUseDart)
+//   - template_pattern_catalog  (sniffTemplatePatternsdart)
+//   - taint_source_detection    (sniffTaintDart — source side)
+package substrate
+
+import "testing"
+
+// TestFlutterSubstrate_DefUseChainExtraction proves def_use_chain_extraction:
+// local `final` bindings inside a widget method become defs, and the bare
+// identifiers that read them become uses, both attributed to the enclosing
+// function. Mirrors the canonical Flutter `build`/handler body.
+func TestFlutterSubstrate_DefUseChainExtraction(t *testing.T) {
+	const src = `
+class ProfileScreen extends StatelessWidget {
+  Future<void> loadUser(String userId) async {
+    final name = userId;
+    final greeting = name;
+  }
+}
+`
+	defs, uses := sniffDefUseDart(src)
+	if len(defs) == 0 {
+		t.Fatal("expected def-use defs on Flutter widget method, got none")
+	}
+	var sawNameDef, sawGreetingDef bool
+	for _, d := range defs {
+		if d.Function != "loadUser" {
+			t.Errorf("def %q attributed to %q, want loadUser", d.Var, d.Function)
+		}
+		if d.Var == "name" {
+			sawNameDef = true
+		}
+		if d.Var == "greeting" {
+			sawGreetingDef = true
+		}
+	}
+	if !sawNameDef || !sawGreetingDef {
+		t.Errorf("expected defs for name and greeting; got %+v", defs)
+	}
+	// `name` is read by the `greeting` binding — a genuine def->use chain.
+	var sawNameUse bool
+	for _, u := range uses {
+		if u.Var == "name" && u.Function == "loadUser" {
+			sawNameUse = true
+		}
+	}
+	if !sawNameUse {
+		t.Errorf("expected a use of name (read by greeting); got %+v", uses)
+	}
+}
+
+// TestFlutterSubstrate_TemplatePatternCatalog proves template_pattern_catalog:
+// a Flutter build body using debugPrint (log_format), gen-l10n
+// AppLocalizations (i18n), and a sqflite raw SQL literal (sql) yields one
+// template pattern per kind.
+func TestFlutterSubstrate_TemplatePatternCatalog(t *testing.T) {
+	const src = `
+class HomeScreen extends StatelessWidget {
+  Widget build(BuildContext context) {
+    debugPrint("home build");
+    final title = AppLocalizations.of(context).translate("home.title");
+    db.rawQuery("SELECT id FROM users WHERE active = 1");
+    return Container();
+  }
+}
+`
+	got := sniffTemplatePatternsdart(src)
+	if len(got) == 0 {
+		t.Fatal("expected template patterns on Flutter build body, got none")
+	}
+	kinds := map[TemplateKind]string{}
+	for _, p := range got {
+		kinds[p.Kind] = p.Literal
+	}
+	if kinds[TemplateKindLog] != "home build" {
+		t.Errorf("log_format: got %q, want %q", kinds[TemplateKindLog], "home build")
+	}
+	if kinds[TemplateKindI18n] != "home.title" {
+		t.Errorf("i18n: got %q, want %q", kinds[TemplateKindI18n], "home.title")
+	}
+	if kinds[TemplateKindSQL] == "" {
+		t.Errorf("expected an sql template literal; got %+v", got)
+	}
+}
+
+// TestFlutterSubstrate_TaintSourceDetection proves taint_source_detection:
+// a Dart server-side / shelf-style HttpRequest query-parameter read is
+// flagged as a taint source. (The sink + sanitizer sides are proven by
+// TestTaintSniffer_Dart_RawQueryIsSink in taint_sites_test.go.)
+func TestFlutterSubstrate_TaintSourceDetection(t *testing.T) {
+	const src = `
+Future<Response> handle(HttpRequest request) async {
+  final id = request.uri.queryParameters['id'];
+  return Response.ok(id);
+}
+`
+	var hasSrc bool
+	for _, m := range sniffTaintDart(src) {
+		if m.Kind == TaintKindSource {
+			hasSrc = true
+		}
+	}
+	if !hasSrc {
+		t.Error("expected request.uri.queryParameters to be flagged as a taint source")
+	}
+}


### PR DESCRIPTION
Parent epic #3872 · audit #3888 · CREDIT-WAVE (registry-only, mirrors scala-credit #4000 / elixir-credit #4031).

## What
`internal/custom/dart/flutter.go` and the framework-blind Dart substrate sniffers already fire on canonical Flutter idioms and pass tests, yet 10 cells on `lang.dart.framework.flutter` were `missing`. This re-stamps each to the honest status it genuinely achieves, citing the code path + a value-asserting test. **No extractor code changed.**

## Cells flipped (10)
| Group | Cell | before → after | Evidence |
|---|---|---|---|
| Structure | `context_extraction` | missing → **full** | DI USES edges (flutter.go steps 10-13); `TestFlutterUses{BlocViaContextRead,ModelViaProvider,ProviderViaRiverpod}` + resolver test |
| Testing | `tests_linkage` | missing → **partial** | `rules/dart/test_patterns.yaml` via `loader.go` go:embed |
| Substrate | `db_effect` | missing → **partial** | `effect_sinks_dart.go`; `TestSniffEffectsDart_PrimitiveCoverage` (db_read/db_write) |
| Substrate | `fs_effect` | missing → **partial** | same test (fs_read/fs_write) |
| Substrate | `mutation_effect` | missing → **partial** | same test (mutation) |
| Substrate | `taint_source_detection` | missing → **partial** | `taint_sites_dart.go`; **new** `TestFlutterSubstrate_TaintSourceDetection` |
| Substrate | `taint_sink_detection` | missing → **partial** | `TestTaintSniffer_Dart_RawQueryIsSink` (SQL sink) |
| Substrate | `sanitizer_recognition` | missing → **partial** | `TestTaintSniffer_Dart_RawQueryIsSink` (whereArgs sanitizer) |
| Substrate | `def_use_chain_extraction` | missing → **partial** | `def_use_dart.go`; **new** `TestFlutterSubstrate_DefUseChainExtraction` |
| Substrate | `template_pattern_catalog` | missing → **partial** | `template_pattern_dart.go`; **new** `TestFlutterSubstrate_TemplatePatternCatalog` |

## Status rationale (honest)
- **context_extraction → full**: DI / state-binding (Provider, Riverpod, BLoC) emits *resolved* USES edges from the enclosing widget. This is the DI home cell for the `ui_frontend` subcategory.
- **tests_linkage → partial (not full)**: the rules yaml classifies flutter_test/integration_test/Dart-test files, but **no testmap framework detector exists for Flutter yet**, so no graph TESTS edges are synthesised from `testWidgets()` to the widget under test (cf. kotlin/php pest+phpunit which have testmap detectors → full). Honest gap, documented in the cell note.
- **Substrate → partial**: the framework-blind Dart sniffers (gated on `.dart` via `LanguageForPath`) fire on canonical idioms — mirrors the mobile-substrate JS/TS precedent (#3059): regex heuristic, value-asserted but not a comprehensive corpus.

## New value-asserting fixtures
`internal/substrate/dart_flutter_substrate_credit_4034_test.go` — the 3 cells whose sniffer shipped without a Dart-shaped test:
- `final name = userId; final greeting = name;` → def(name,greeting) + use(name) attributed to `loadUser`
- `debugPrint(...)` → log_format, `AppLocalizations.of(context).translate("home.title")` → i18n, `SELECT ...` → sql
- `request.uri.queryParameters['id']` → taint source

## Decisions / notes
- **Subcategory anomaly** (audit-flagged): this record lives in `ui_frontend` (router_pattern), not `mobile` (navigation_extraction). Navigation breadth (Navigator/go_router NAVIGATES_TO) and state-management kinds (BLoC/Cubit/ChangeNotifier/InheritedWidget/StreamBuilder) are **already credited `full`** under `router_pattern` / `state_management` — the `ui_frontend` taxonomy supports them, so **no new nav/DI cell was fabricated**. The minimal honest choice was to keep DI under `context_extraction` (the Structure-group cell the subcategory already declares).
- **Left missing**: real-gap cells `payload_shapes` / `entry_points` (#4035) untouched; all other `missing` substrate cells (constant_propagation, reachability, dead_code, request/response_shape, etc.) have no Dart sniffer that fires and stay `missing`.

## Gates
- Full package tests green: `internal/custom/dart`, `internal/substrate`, `tools/coverage`
- `covtool validate`: 0 errors (warnings are pre-existing capability-map gaps, structural)
- `covtool fmt --check`: canonical; `gofmt`/`go vet` clean; `covtool gen`: docs regenerated (0 drift)

**DEPLOY-DEFERRED**: registry/docs + one test file only; no indexer behaviour change. Picks up on the next coverage-docs regen.

Closes #4034

🤖 Generated with [Claude Code](https://claude.com/claude-code)