### PR TITLE
[python][drf] credit DRF browsable-API & HTML render paths (view_rendering) — Closes #3914

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -100,7 +100,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | 🟡 4/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 5/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/17 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 5/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 13/17 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [Django](../detail/lang.python.framework.django.md) | 🟡 4/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/12 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 5/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 12/17 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | 🟡 5/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 25/25 | 🟡 13/17 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 10/11 | |
 | [Flask](../detail/lang.python.framework.flask.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 10/13 | |

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -26,7 +26,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
+| View rendering | ✅ `full` | `2026-06-03` | 3914 | `internal/extractor/template_render.go`<br>`internal/extractors/python/template_render.go`<br>`internal/extractors/python/template_render_test.go` | DRF render paths: renderer_classes=[BrowsableAPIRenderer|TemplateHTMLRenderer|StaticHTMLRenderer|AdminRenderer|HTMLFormRenderer] -> RENDERS scope.template drf/<Renderer>; TemplateHTMLRenderer.template_name='x.html' -> RENDERS x.html (framework-agnostic detector); JSON-only renderer lists + dynamic/settings-derived renderer_classes emit nothing (#3914 over #3628) |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -55613,8 +55613,11 @@
         },
         "View": {
           "view_rendering": {
-            "status": "missing",
-            "issue": "view_rendering:#3628-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/extractor/template_render.go","internal/extractors/python/template_render.go","internal/extractors/python/template_render_test.go"],
+            "issue": "3914",
+            "notes": "DRF render paths: renderer_classes=[BrowsableAPIRenderer|TemplateHTMLRenderer|StaticHTMLRenderer|AdminRenderer|HTMLFormRenderer] -\u003e RENDERS scope.template drf/\u003cRenderer\u003e; TemplateHTMLRenderer.template_name='x.html' -\u003e RENDERS x.html (framework-agnostic detector); JSON-only renderer lists + dynamic/settings-derived renderer_classes emit nothing (#3914 over #3628)",
+            "verified_at": "2026-06-03"
           }
         },
         "Auth": {

--- a/internal/extractors/python/template_render.go
+++ b/internal/extractors/python/template_render.go
@@ -8,6 +8,20 @@
 //	render_template('users/list.html', ...)   → RENDERS users/list.html   (Flask)
 //	render(request, 'home.html', ...)          → RENDERS home.html          (Django)
 //	class X(TemplateView): template_name = 'd.html'  → RENDERS d.html       (Django CBV)
+//	class X(APIView): renderer_classes = [BrowsableAPIRenderer]             (DRF browsable API)
+//	                                          → RENDERS drf/BrowsableAPIRenderer
+//
+// The DRF (Django REST Framework) browsable/HTML render path is a class-scope
+// `renderer_classes = [...]` list naming HTML-producing renderers
+// (BrowsableAPIRenderer / TemplateHTMLRenderer / StaticHTMLRenderer). Each such
+// renderer becomes a RENDERS edge from the view class to a synthetic
+// `drf/<RendererName>` template-convergence node, so the graph answers "which
+// views expose the browsable API?" (inbound RENDERS on drf/BrowsableAPIRenderer)
+// and "what HTML render path does this view have?" (outbound RENDERS). The
+// DRF `TemplateHTMLRenderer` + `template_name = 'x.html'` case is ALREADY
+// covered by the framework-agnostic class-scope template_name detector above —
+// it needs no DRF-specific code. JSON-only renderer lists (JSONRenderer only)
+// emit nothing: there is no HTML/browsable render path to record.
 //
 // Intentionally DROPPED (would mislead view-layer analysis):
 //
@@ -72,6 +86,14 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 				if tpl := pyTemplateNameAttr(body, src); tpl != "" {
 					edges = append(edges, extractor.TemplateEdge{
 						Name: tpl, FromName: childCls, Pattern: "template_name",
+					})
+				}
+				// DRF browsable / HTML render path: renderer_classes = [...]
+				// naming HTML-producing renderers. Each becomes a RENDERS edge to
+				// a synthetic drf/<RendererName> convergence node.
+				for _, rdr := range pyDRFHTMLRenderers(body, src) {
+					edges = append(edges, extractor.TemplateEdge{
+						Name: "drf/" + rdr, FromName: childCls, Pattern: "drf_renderer_classes",
 					})
 				}
 				for i := 0; i < int(body.ChildCount()); i++ {
@@ -223,4 +245,80 @@ func pyTemplateNameAttr(body *sitter.Node, src []byte) string {
 		}
 	}
 	return ""
+}
+
+// drfHTMLRenderers is the set of DRF built-in renderer classes that produce an
+// HTML / browsable presentation (an actual view-layer render path), as opposed
+// to data renderers (JSONRenderer, etc.) which have no template/HTML output.
+// Matching is by trailing class name only, so both the bare import name and a
+// dotted `renderers.BrowsableAPIRenderer` reference are recognized.
+var drfHTMLRenderers = map[string]bool{
+	"BrowsableAPIRenderer": true, // the DRF browsable API HTML page
+	"TemplateHTMLRenderer": true, // renders an HTML template (template_name)
+	"StaticHTMLRenderer":   true, // renders a pre-rendered HTML string
+	"AdminRenderer":        true, // the DRF admin-style HTML interface
+	"HTMLFormRenderer":     true, // renders a serializer as an HTML form
+}
+
+// pyDRFHTMLRenderers scans a class body for a `renderer_classes = [...]` (or
+// tuple) assignment — the Django REST Framework declaration of which renderers a
+// view supports — and returns, in source order, the distinct HTML-producing
+// renderer class names present (BrowsableAPIRenderer, TemplateHTMLRenderer, …).
+//
+// Honest-partial / precision-first:
+//   - Only a class-scope `renderer_classes` literal list/tuple is read. A
+//     dynamically built or settings-derived list yields nothing.
+//   - Only elements that are an identifier or attribute (e.g. `JSONRenderer` or
+//     `renderers.BrowsableAPIRenderer`) whose TRAILING name is a known DRF HTML
+//     renderer count. JSON / data-only renderers and unknown names are skipped,
+//     so a JSON-only view emits no HTML render path.
+func pyDRFHTMLRenderers(body *sitter.Node, src []byte) []string {
+	var out []string
+	seen := map[string]bool{}
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil {
+			continue
+		}
+		var assign *sitter.Node
+		if stmt.Type() == "expression_statement" && stmt.NamedChildCount() > 0 {
+			assign = stmt.NamedChild(0)
+		} else if stmt.Type() == "assignment" {
+			assign = stmt
+		}
+		if assign == nil || assign.Type() != "assignment" {
+			continue
+		}
+		left := assign.ChildByFieldName("left")
+		right := assign.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		if left.Type() != "identifier" || nodeText(left, src) != "renderer_classes" {
+			continue
+		}
+		if right.Type() != "list" && right.Type() != "tuple" {
+			continue // dynamic / settings-derived → drop
+		}
+		for j := 0; j < int(right.NamedChildCount()); j++ {
+			el := right.NamedChild(j)
+			if el == nil {
+				continue
+			}
+			name := ""
+			switch el.Type() {
+			case "identifier":
+				name = nodeText(el, src)
+			case "attribute":
+				if a := el.ChildByFieldName("attribute"); a != nil {
+					name = nodeText(a, src)
+				}
+			}
+			if name != "" && drfHTMLRenderers[name] && !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	return out
 }

--- a/internal/extractors/python/template_render_test.go
+++ b/internal/extractors/python/template_render_test.go
@@ -79,6 +79,112 @@ class AboutView(TemplateView):
 	}
 }
 
+// DRF browsable-API render path: renderer_classes naming the browsable / HTML
+// renderer emits a RENDERS edge to a drf/<Renderer> convergence node, while a
+// JSON-only renderer in the same list contributes NO render path.
+func TestPyTemplate_DRFRendererClasses(t *testing.T) {
+	src := `from rest_framework.viewsets import ViewSet
+from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+
+class FooViewSet(ViewSet):
+    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "FooViewSet", "drf/BrowsableAPIRenderer") {
+		t.Error("missing RENDERS(FooViewSet -> drf/BrowsableAPIRenderer)")
+	}
+	// JSONRenderer is a data renderer, not an HTML/browsable render path.
+	if tplEdge(recs, "FooViewSet", "drf/JSONRenderer") {
+		t.Error("JSONRenderer must NOT yield an HTML render path")
+	}
+	if tplNode(recs, "drf/BrowsableAPIRenderer") != 1 {
+		t.Error("expected one drf/BrowsableAPIRenderer convergence node")
+	}
+	if tplNode(recs, "drf/JSONRenderer") != 0 {
+		t.Error("JSONRenderer must not create a render node")
+	}
+}
+
+// DRF TemplateHTMLRenderer + template_name: BOTH the concrete template (via the
+// framework-agnostic template_name detector) AND the renderer render-path node
+// are recorded, and a dotted `renderers.BrowsableAPIRenderer` reference matches.
+func TestPyTemplate_DRFTemplateHTMLRenderer(t *testing.T) {
+	src := `from rest_framework.views import APIView
+from rest_framework import renderers
+
+class UserDetail(APIView):
+    renderer_classes = [renderers.TemplateHTMLRenderer]
+    template_name = "user_detail.html"
+
+    def get(self, request, pk):
+        return Response({"x": 1})
+`
+	recs := extractPy(t, src, "views.py")
+	if !tplEdge(recs, "UserDetail", "user_detail.html") {
+		t.Error("missing RENDERS(UserDetail -> user_detail.html)")
+	}
+	if !tplEdge(recs, "UserDetail", "drf/TemplateHTMLRenderer") {
+		t.Error("missing RENDERS(UserDetail -> drf/TemplateHTMLRenderer) for dotted ref")
+	}
+}
+
+// Negative: a DRF view that renders JSON only has NO HTML/browsable render path.
+func TestPyTemplate_DRFJSONOnlyNoRender(t *testing.T) {
+	src := `from rest_framework.viewsets import ModelViewSet
+from rest_framework.renderers import JSONRenderer
+
+class WidgetViewSet(ModelViewSet):
+    renderer_classes = [JSONRenderer]
+`
+	recs := extractPy(t, src, "views.py")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			t.Fatalf("JSON-only DRF view must not create any render node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" {
+				t.Fatalf("JSON-only DRF view must not yield a RENDERS edge")
+			}
+		}
+	}
+}
+
+// Negative: a plain non-DRF class with no renderer_classes / template_name is
+// never claimed as a render path.
+func TestPyTemplate_NonDRFClassNoRender(t *testing.T) {
+	src := `class PlainService:
+    def compute(self):
+        return 42
+`
+	recs := extractPy(t, src, "service.py")
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" {
+				t.Fatalf("plain non-view class must not yield a RENDERS edge")
+			}
+		}
+	}
+}
+
+// Negative: a dynamically built renderer_classes (not a list/tuple literal)
+// yields nothing — precision over recall.
+func TestPyTemplate_DRFDynamicRenderersDropped(t *testing.T) {
+	src := `class DynView(APIView):
+    renderer_classes = get_default_renderers()
+`
+	recs := extractPy(t, src, "views.py")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindTemplate) {
+			t.Fatalf("dynamic renderer_classes must not create a render node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "RENDERS" {
+				t.Fatalf("dynamic renderer_classes must not yield a RENDERS edge")
+			}
+		}
+	}
+}
+
 // Convergence: two views rendering the same template → one node.
 func TestPyTemplate_Convergence(t *testing.T) {
 	src := `from flask import render_template

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -654,6 +654,19 @@ records:
 
   lang.python.framework.django-drf:
     capabilities:
+      View:
+        view_rendering:
+          status: full
+          symbols:
+            - file: internal/extractors/python/template_render.go
+              functions: [emitTemplateRenderEdges, pyTemplateNameAttr, pyDRFHTMLRenderers]
+            - file: internal/extractor/template_render.go
+              functions: [EmitTemplateEdges, TemplateEntity, TemplateTargetID, NormalizeTemplateName]
+          tests:
+            - file: internal/extractors/python/template_render_test.go
+              functions: [TestPyTemplate_DRFRendererClasses, TestPyTemplate_DRFTemplateHTMLRenderer, TestPyTemplate_DRFJSONOnlyNoRender, TestPyTemplate_DRFDynamicRenderersDropped]
+          issues_implemented: ["3914"]
+          verified_at: "2026-06-03"
       Type System:
         interface_extraction:
           status: partial


### PR DESCRIPTION
Closes #3914. Parent epic #3628 (view-layer topology) · audit #3878.

## VERIFY-FIRST findings
django-drf `View.view_rendering` was `missing` (`view_rendering:#3628-not-yet-extracted`). Probed the actual extractor:

- **DRF `TemplateHTMLRenderer` + `template_name='x.html'` ALREADY fired.** The class-scope `pyTemplateNameAttr` detector is framework-agnostic, so a DRF `APIView`/`ViewSet` with `template_name` already emitted `RENDERS <view> -> x.html`. No code change needed for that path.
- **DRF `renderer_classes = [..., BrowsableAPIRenderer]` was UNCREDITED** — the list was captured only as a generic `SCOPE.Schema` field; no render-path signal naming the renderer.

## Extension (precision-first / honest-partial)
- New `pyDRFHTMLRenderers` reads a class-scope `renderer_classes` **list/tuple literal** and emits one `RENDERS` edge per HTML-producing DRF renderer (`BrowsableAPIRenderer`, `TemplateHTMLRenderer`, `StaticHTMLRenderer`, `AdminRenderer`, `HTMLFormRenderer`) to a synthetic `drf/<Renderer>` template convergence node — answering "which views expose the browsable API?" (inbound) and "what HTML render path does this view have?" (outbound).
- Matches bare (`BrowsableAPIRenderer`) and dotted (`renderers.BrowsableAPIRenderer`) refs by trailing class name.
- **Negatives that emit nothing:** data-only renderers (`JSONRenderer`, …); dynamic / settings-derived `renderer_classes` (non-literal RHS); non-DRF plain classes. No false render path.

## What's asserted (value-asserting, not len>0)
- `[JSONRenderer, BrowsableAPIRenderer]` → `RENDERS drf/BrowsableAPIRenderer`; `JSONRenderer` yields NO edge/node.
- dotted renderer + `template_name="user_detail.html"` → BOTH `user_detail.html` AND `drf/TemplateHTMLRenderer`.
- JSON-only view → no render path; plain class → not claimed; dynamic list → dropped.

## What remains missing (and why)
- Per-action `@action(renderer_classes=[...])` / `@renderer_classes([...])` decorator overrides are not yet read (class-scope only) — honest partial; can extend if a downstream rewrite needs method-level granularity.
- Renderer→template binding for `TemplateHTMLRenderer` relies on the existing `template_name` literal (dynamic `template_name` per existing #3628 policy stays dropped).

## Quality gates (all green)
- Full packages: `go test ./internal/custom/python/ ./internal/engine/ ./tools/coverage/ ./internal/extractors/python/` ✅
- gofmt empty · go vet clean · no new Kind (reused `EntityKindTemplate`) · no custom-key registration (existing extractor, dispatch-parity N/A).
- Coverage: `validate` 0 errors · `fmt --check` canonical · `gen` no-drift. django-drf `View.view_rendering` flipped `missing`→`full` (surgical registry edit, capability-map `View` block added, docs regenerated).

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)