### PR TITLE
[elixir][credit] Testing.tests_linkage + Observability on guardian/finch/tesla/req (#4027)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -36,14 +36,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🔴 0/12 | |
-| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 11/25 | 🔴 0/11 | |
+| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
+| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/25 | 🟡 3/11 | |
 | [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🔴 0/12 | |
-| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 1/12 | |
+| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 9/24 | 🟡 3/12 | |
+| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 4/12 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 5/6 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 8/12 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -30,14 +30,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🔴 0/12 | |
-| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 11/25 | 🔴 0/11 | |
+| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
+| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/25 | 🟡 3/11 | |
 | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
 | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
 | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🔴 0/12 | |
-| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 1/12 | |
+| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 9/24 | 🟡 3/12 | |
+| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 4/12 | |
 
 
 ### Meta Framework

--- a/docs/coverage/detail/lang.elixir.framework.finch.md
+++ b/docs/coverage/detail/lang.elixir.framework.finch.md
@@ -75,15 +75,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ✅ `full` | `2026-06-03` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test "..." do leaves, describe groups via balanced do/end body walk) + StreamData (property "..." do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Finch_TestsLinkage) asserts the finch-idiom ExUnit test->target edge to Finch.request. Sibling of the flagship full status (#4027). |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Finch_Trailing) asserts the finch-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027). |
+| Metric extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Finch_Trailing) proves the exact finch-idiom :telemetry.execute event name. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027). |
+| Trace extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Finch_Trailing) proves the exact finch-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.guardian.md
+++ b/docs/coverage/detail/lang.elixir.framework.guardian.md
@@ -75,15 +75,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ✅ `full` | `2026-06-03` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test "..." do leaves, describe groups via balanced do/end body walk) + StreamData (property "..." do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Guardian_TestsLinkage) asserts the guardian-idiom ExUnit test->target edge to Guardian.decode_and_verify. Sibling of the flagship full status (#4027). |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Guardian_Trailing) asserts the guardian-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027). |
+| Metric extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Guardian_Trailing) proves the exact guardian-idiom :telemetry.execute event name. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027). |
+| Trace extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Guardian_Trailing) proves the exact guardian-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.req.md
+++ b/docs/coverage/detail/lang.elixir.framework.req.md
@@ -75,15 +75,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ✅ `full` | `2026-06-03` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test "..." do leaves, describe groups via balanced do/end body walk) + StreamData (property "..." do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Req_TestsLinkage) asserts the req-idiom ExUnit test->target edge to MyApp.ReqClient.post_event. Sibling of the flagship full status (#4027). |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Req_Trailing) asserts the req-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027). |
+| Metric extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Req_Trailing) proves the exact req-idiom :telemetry.execute event name. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027). |
+| Trace extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Req_Trailing) proves the exact req-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.tesla.md
+++ b/docs/coverage/detail/lang.elixir.framework.tesla.md
@@ -75,15 +75,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ✅ `full` | `2026-06-03` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test "..." do leaves, describe groups via balanced do/end body walk) + StreamData (property "..." do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Tesla_TestsLinkage) asserts the tesla-idiom ExUnit test->target edge to MyApp.ApiClient.create_order. Sibling of the flagship full status (#4027). |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Tesla_Trailing) asserts the tesla-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027). |
+| Metric extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Tesla_Trailing) proves the exact tesla-idiom :telemetry.execute event name. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027). |
+| Trace extraction | 🟢 `partial` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Tesla_Trailing) proves the exact tesla-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027). |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14621,22 +14621,33 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test \"...\" do leaves, describe groups via balanced do/end body walk) + StreamData (property \"...\" do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Finch_TestsLinkage) asserts the finch-idiom ExUnit test-\u003etarget edge to Finch.request. Sibling of the flagship full status (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Finch_Trailing) asserts the finch-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Finch_Trailing) proves the exact finch-idiom :telemetry.execute event name. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Finch_Trailing) proves the exact finch-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Data": {
@@ -15156,22 +15167,33 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test \"...\" do leaves, describe groups via balanced do/end body walk) + StreamData (property \"...\" do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Guardian_TestsLinkage) asserts the guardian-idiom ExUnit test-\u003etarget edge to Guardian.decode_and_verify. Sibling of the flagship full status (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Guardian_Trailing) asserts the guardian-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Guardian_Trailing) proves the exact guardian-idiom :telemetry.execute event name. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Guardian_Trailing) proves the exact guardian-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Substrate": {
@@ -16747,22 +16769,33 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test \"...\" do leaves, describe groups via balanced do/end body walk) + StreamData (property \"...\" do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Req_TestsLinkage) asserts the req-idiom ExUnit test-\u003etarget edge to MyApp.ReqClient.post_event. Sibling of the flagship full status (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Req_Trailing) asserts the req-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Req_Trailing) proves the exact req-idiom :telemetry.execute event name. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Req_Trailing) proves the exact req-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Data": {
@@ -17001,22 +17034,33 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Elixir TESTS linkage (framework-agnostic; keys on .exs + use ExUnit.Case): ExUnit (test \"...\" do leaves, describe groups via balanced do/end body walk) + StreamData (property \"...\" do) with subject-from-module-name + body call resolution (Foo.bar(...) promoted high); Elixir assertion stopwords (assert/refute/assert_raise/...). Value-asserting test in extractor_test.go (TestElixir_Tesla_TestsLinkage) asserts the tesla-idiom ExUnit test-\u003etarget edge to MyApp.ApiClient.create_order. Sibling of the flagship full status (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Logger.debug/info/warning/error(...) statements captured by framework-agnostic observabilityExtractor (fires on any .ex) as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. Value-asserting test (TestObservability_Tesla_Trailing) asserts the tesla-idiom Logger.info artifact. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Tesla_Trailing) proves the exact tesla-idiom :telemetry.execute event name. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved. Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by framework-agnostic observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test (TestObservability_Tesla_Trailing) proves the exact tesla-idiom :telemetry.span name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). Sibling of flagship partial (#4027).",
+            "verified_at": "2026-06-03"
           }
         },
         "Data": {

--- a/internal/custom/elixir/observability_test.go
+++ b/internal/custom/elixir/observability_test.go
@@ -181,6 +181,159 @@ end
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Elixir trailing-framework Observability credit (#4027, epic #3872, from
+// Elixir audit #3885).
+//
+// custom_elixir_observability is framework-AGNOSTIC: it fires on ANY .ex
+// dispatched as language "elixir" with no framework gate, capturing Logger.*
+// (log), :telemetry.execute / Telemetry.Metrics (metric) and :telemetry.span
+// (trace). The flagship Elixir frameworks carry Observability.{log,metric,
+// trace}_extraction at `partial`; these tests prove the SAME artifacts fire on
+// the trailing frameworks guardian/finch/tesla/req — justifying the registry
+// re-stamp to the flagship `partial` sibling status.
+//
+// Each is value-asserting: it proves a SPECIFIC named artifact on each
+// framework's real idiom (a Logger.info message, a dotted :telemetry.execute
+// metric name, and a dotted :telemetry.span trace name). The cells stay
+// PARTIAL for the same reason as the flagships (handler-attach / reporter /
+// exporter binding spans multiple files and is not resolved here).
+// ---------------------------------------------------------------------------
+
+func assertLog(t *testing.T, ents []entitySummary, level, message string) {
+	t.Helper()
+	e := findEntity(ents, "SCOPE.Pattern", "Logger."+level)
+	if e == nil {
+		t.Fatalf("expected Logger.%s log_statement", level)
+	}
+	if e.Subtype != "log_statement" {
+		t.Errorf("expected subtype log_statement, got %q", e.Subtype)
+	}
+	if got := e.Props["message"]; got != message {
+		t.Errorf("expected message %q, got %q", message, got)
+	}
+	if got := e.Props["signal"]; got != "log" {
+		t.Errorf("expected signal log, got %q", got)
+	}
+}
+
+func assertMetric(t *testing.T, ents []entitySummary, event string) {
+	t.Helper()
+	e := findEntity(ents, "SCOPE.Pattern", event)
+	if e == nil {
+		t.Fatalf("expected metric %s", event)
+	}
+	if e.Subtype != "metric" {
+		t.Errorf("expected subtype metric, got %q", e.Subtype)
+	}
+	if got := e.Props["telemetry_event"]; got != event {
+		t.Errorf("expected telemetry_event %s, got %q", event, got)
+	}
+	if got := e.Props["signal"]; got != "metric" {
+		t.Errorf("expected signal metric, got %q", got)
+	}
+}
+
+func assertTrace(t *testing.T, ents []entitySummary, event string) {
+	t.Helper()
+	e := findEntity(ents, "SCOPE.Pattern", event)
+	if e == nil {
+		t.Fatalf("expected trace_span %s", event)
+	}
+	if e.Subtype != "trace_span" {
+		t.Errorf("expected subtype trace_span, got %q", e.Subtype)
+	}
+	if got := e.Props["span_name"]; got != event {
+		t.Errorf("expected span_name %s, got %q", event, got)
+	}
+	if got := e.Props["signal"]; got != "trace" {
+		t.Errorf("expected signal trace, got %q", got)
+	}
+}
+
+// TestObservability_Guardian_Trailing — a Guardian auth pipeline that logs a
+// verification result, emits a :telemetry.execute auth metric and a
+// :telemetry.span around verification.
+func TestObservability_Guardian_Trailing(t *testing.T) {
+	src := `defmodule MyApp.Auth.Pipeline do
+  use Guardian.Plug.Pipeline, otp_app: :my_app
+  require Logger
+
+  def authenticate(token) do
+    Logger.info("guardian authenticated user")
+    :telemetry.execute([:my_app, :guardian, :verify], %{count: 1}, %{})
+    :telemetry.span([:my_app, :guardian, :pipeline], %{}, fn ->
+      {Guardian.decode_and_verify(token), %{}}
+    end)
+  end
+end`
+	ents := extract(t, "custom_elixir_observability", fi("pipeline.ex", "elixir", src))
+	assertLog(t, ents, "info", "guardian authenticated user")
+	assertMetric(t, ents, "my_app.guardian.verify")
+	assertTrace(t, ents, "my_app.guardian.pipeline")
+}
+
+// TestObservability_Finch_Trailing — a Finch HTTP client that logs the fetch,
+// emits a request metric and wraps the call in a :telemetry.span.
+func TestObservability_Finch_Trailing(t *testing.T) {
+	src := `defmodule MyApp.HttpClient do
+  require Logger
+
+  def fetch_user(id) do
+    Logger.info("finch fetched user")
+    :telemetry.execute([:my_app, :finch, :request, :stop], %{duration: 1}, %{})
+    :telemetry.span([:my_app, :finch, :request], %{}, fn ->
+      {Finch.request(req, MyApp.Finch), %{}}
+    end)
+  end
+end`
+	ents := extract(t, "custom_elixir_observability", fi("http_client.ex", "elixir", src))
+	assertLog(t, ents, "info", "finch fetched user")
+	assertMetric(t, ents, "my_app.finch.request.stop")
+	assertTrace(t, ents, "my_app.finch.request")
+}
+
+// TestObservability_Tesla_Trailing — a Tesla API client that logs the call,
+// emits a request metric and wraps the post in a :telemetry.span.
+func TestObservability_Tesla_Trailing(t *testing.T) {
+	src := `defmodule MyApp.ApiClient do
+  use Tesla
+  require Logger
+
+  def create_order(client, payload) do
+    Logger.info("tesla creating order")
+    :telemetry.execute([:my_app, :tesla, :call, :stop], %{duration: 2}, %{})
+    :telemetry.span([:my_app, :tesla, :call], %{}, fn ->
+      {Tesla.post(client, "/orders", payload), %{}}
+    end)
+  end
+end`
+	ents := extract(t, "custom_elixir_observability", fi("api_client.ex", "elixir", src))
+	assertLog(t, ents, "info", "tesla creating order")
+	assertMetric(t, ents, "my_app.tesla.call.stop")
+	assertTrace(t, ents, "my_app.tesla.call")
+}
+
+// TestObservability_Req_Trailing — a Req HTTP client that logs the post, emits
+// a request metric and wraps the post in a :telemetry.span.
+func TestObservability_Req_Trailing(t *testing.T) {
+	src := `defmodule MyApp.ReqClient do
+  require Logger
+
+  def post_event(payload) do
+    Logger.info("req posting event")
+    :telemetry.execute([:my_app, :req, :post, :stop], %{duration: 3}, %{})
+    :telemetry.span([:my_app, :req, :post], %{}, fn ->
+      {Req.post(base, json: payload), %{}}
+    end)
+  end
+end`
+	ents := extract(t, "custom_elixir_observability", fi("req_client.ex", "elixir", src))
+	assertLog(t, ents, "info", "req posting event")
+	assertMetric(t, ents, "my_app.req.post.stop")
+	assertTrace(t, ents, "my_app.req.post")
+}
+
 func TestObservabilityNoMatch(t *testing.T) {
 	src := `defmodule MyApp.Plain do
   def add(a, b), do: a + b

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -3723,3 +3723,117 @@ end`
 		t.Errorf("assert_raise must be stop-worded")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Elixir trailing-framework Testing.tests_linkage credit (#4027, epic #3872,
+// from Elixir audit #3885).
+//
+// The deep ExUnit TESTS linkage is framework-AGNOSTIC: it keys on the `.exs`
+// test file + `use ExUnit.Case` import hint and resolves `test "…" do` leaves
+// to their production call targets regardless of which Elixir framework the
+// system-under-test uses. The flagship Elixir frameworks (oban/phoenix/plug/
+// absinthe/…) already carry Testing.tests_linkage at `full`; these tests prove
+// the SAME linkage fires on the trailing frameworks guardian/finch/tesla/req,
+// justifying the registry re-stamp to the flagship `full` sibling status.
+//
+// Each is value-asserting: it proves a SPECIFIC test->target TESTS edge to the
+// framework's real call idiom (Guardian.decode_and_verify, Finch.request,
+// Tesla.post, Req.post), and that the ExUnit `assert` macro is stop-worded.
+// ---------------------------------------------------------------------------
+
+// TestElixir_Guardian_TestsLinkage — an ExUnit test for a Guardian token
+// pipeline links to Guardian.decode_and_verify.
+func TestElixir_Guardian_TestsLinkage(t *testing.T) {
+	src := `defmodule MyApp.Auth.PipelineTest do
+  use ExUnit.Case
+
+  test "verifies a signed token" do
+    assert {:ok, _claims} = Guardian.decode_and_verify(token)
+  end
+end`
+	recs := runExtract(t, "test/my_app/auth/pipeline_test.exs", "elixir", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected elixir entities for guardian ExUnit test")
+	}
+	if recs[0].Properties["test_framework"] != "exunit" {
+		t.Errorf("framework=%q, want exunit", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_verifies_a_signed_token", "Guardian.decode_and_verify") {
+		t.Fatalf("expected TESTS edge to Guardian.decode_and_verify; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_verifies_a_signed_token", "assert") {
+		t.Errorf("assert macro must be stop-worded, not a tested target")
+	}
+}
+
+// TestElixir_Finch_TestsLinkage — an ExUnit test for a Finch HTTP client links
+// to Finch.request.
+func TestElixir_Finch_TestsLinkage(t *testing.T) {
+	src := `defmodule MyApp.HttpClientTest do
+  use ExUnit.Case
+
+  test "issues the request" do
+    assert {:ok, _resp} = Finch.request(req, MyApp.Finch)
+  end
+end`
+	recs := runExtract(t, "test/my_app/http_client_test.exs", "elixir", src)
+	if recs[0].Properties["test_framework"] != "exunit" {
+		t.Errorf("framework=%q, want exunit", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_issues_the_request", "Finch.request") {
+		t.Fatalf("expected TESTS edge to Finch.request; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_issues_the_request", "assert") {
+		t.Errorf("assert macro must be stop-worded, not a tested target")
+	}
+}
+
+// TestElixir_Tesla_TestsLinkage — an ExUnit test for a Tesla API client links
+// to the client wrapper under test (MyApp.ApiClient.create_order). NOTE the
+// bare HTTP verb method `Tesla.post` is deliberately stop-worded by the
+// resolver (HTTP verbs are test-dispatch helpers, not production targets), so
+// the linkage flows through the framework's own wrapper call — the honest,
+// real-idiom target for a Tesla client test.
+func TestElixir_Tesla_TestsLinkage(t *testing.T) {
+	src := `defmodule MyApp.ApiClientTest do
+  use ExUnit.Case
+
+  test "creates an order via the client" do
+    assert {:ok, _env} = MyApp.ApiClient.create_order(client, %{name: "x"})
+  end
+end`
+	recs := runExtract(t, "test/my_app/api_client_test.exs", "elixir", src)
+	if recs[0].Properties["test_framework"] != "exunit" {
+		t.Errorf("framework=%q, want exunit", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_creates_an_order_via_the_client", "MyApp.ApiClient.create_order") {
+		t.Fatalf("expected TESTS edge to MyApp.ApiClient.create_order; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_creates_an_order_via_the_client", "assert") {
+		t.Errorf("assert macro must be stop-worded, not a tested target")
+	}
+}
+
+// TestElixir_Req_TestsLinkage — an ExUnit test for a Req HTTP client links to
+// the client wrapper under test (MyApp.ReqClient.post_event). As with Tesla,
+// the bare `Req.post` HTTP verb is stop-worded; the linkage flows through the
+// framework's own wrapper function — the honest, real-idiom target.
+func TestElixir_Req_TestsLinkage(t *testing.T) {
+	src := `defmodule MyApp.ReqClientTest do
+  use ExUnit.Case
+
+  test "posts an event via the client" do
+    assert {:ok, _resp} = MyApp.ReqClient.post_event(payload)
+  end
+end`
+	recs := runExtract(t, "test/my_app/req_client_test.exs", "elixir", src)
+	if recs[0].Properties["test_framework"] != "exunit" {
+		t.Errorf("framework=%q, want exunit", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_posts_an_event_via_the_client", "MyApp.ReqClient.post_event") {
+		t.Fatalf("expected TESTS edge to MyApp.ReqClient.post_event; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_posts_an_event_via_the_client", "assert") {
+		t.Errorf("assert macro must be stop-worded, not a tested target")
+	}
+}


### PR DESCRIPTION
**Closes #4027** · Epic #3872 · Parent audit #3885 · registry credit-miss (NO new extractor code) · **DEPLOY-DEFERRED**

## What
Two framework-agnostic Elixir capabilities are credited on the flagship Elixir frameworks but were `missing` on the trailing ones — same root cause as the merged sibling #4026 (language-keyed dispatch, no framework gate):

- **Testing.tests_linkage** — the deep testmap ExUnit TESTS linkage (`internal/extractors/cross/testmap/`) keys on `.exs` + `use ExUnit.Case` with no framework gate.
- **Observability.{log,metric,trace}_extraction** — `custom_elixir_observability` (`internal/custom/elixir/observability.go`) fires on any `.ex` (Logger.* / :telemetry.execute / :telemetry.span).

This re-stamps **guardian / finch / tesla / req** to the SAME sibling status as the flagships (`tests_linkage=full`, observability `partial`). Registry-only; copies the flagship cites; group placement (Testing + Observability) matches the flagship.

## Cells flipped (16)
| framework | tests_linkage | log | metric | trace |
|---|---|---|---|---|
| guardian | full | partial | partial | partial |
| finch | full | partial | partial | partial |
| tesla | full | partial | partial | partial |
| req | full | partial | partial | partial |

## Value-asserting fixtures (per credited cell)
- `testmap/extractor_test.go`: `TestElixir_{Guardian,Finch,Tesla,Req}_TestsLinkage` assert specific ExUnit `test "…" do` → target edges — `Guardian.decode_and_verify`, `Finch.request`, `MyApp.ApiClient.create_order`, `MyApp.ReqClient.post_event` — and that the `assert` macro is stop-worded.
- `internal/custom/elixir/observability_test.go`: `TestObservability_{Guardian,Finch,Tesla,Req}_Trailing` assert the exact `Logger.info` message + `:telemetry.execute` metric name + `:telemetry.span` trace name on each framework's real `.ex` idiom.

## Honest left-as-is
- **tesla / req `tests_linkage`** assert the linkage via the framework's own wrapper call rather than the bare `Tesla.post` / `Req.post` — bare HTTP verbs are deliberately stop-worded by the resolver (HTTP-verb dispatch is a test helper, not a production target). The subject-from-module-name fallback still yields a TESTS edge, so the cell genuinely fires; the wrapper assertion is the honest real-idiom target.
- Observability cells stay **partial** (not full) for the same reason as the flagships: handler-attach / reporter / exporter binding spans multiple files and is not statically resolved.
- The `capability-map ... no mapping entry` validate warnings on these cells are pre-existing and identical on the flagship phoenix/oban records — exact sibling parity, no new debt.

## Quality gates
- `go test ./internal/extractors/cross/testmap/ ./internal/custom/elixir/ ./tools/coverage/` green
- `coverage validate` 0 errors · `coverage fmt --check` canonical · `coverage gen` deterministic (docs regenerated)
- `gofmt -l` empty · `go vet` clean
- Surgical canonical 2-space registry edits; no whole-file re-serialize

🤖 Generated with [Claude Code](https://claude.com/claude-code)