### PR TITLE
[c-cpp][credit] Credit universal substrate cells on grpc + protobuf records (#4047)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -259,8 +259,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 3/15 | |
-| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 4/15 | |
+| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 3/15 | |
+| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 4/15 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 11/25 | 🟡 3/15 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 6/17 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -61,8 +61,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 3/15 | |
-| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 2/25 | 🟡 4/15 | |
+| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 3/15 | |
+| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 4/15 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -108,18 +108,18 @@ Auto-generated. Back to [summary](../summary.md).
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047 |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | c-cpp def-use sniffer fires on .cc handler bodies (named def->use, e.g. SayHello name/greeting); #4047 |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | language-agnostic Tarjan SCC over IMPORTS; c-cpp #include edges flow through extractor; #4047 |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | c-cpp effect sniffer registered; handler methods with no effect match tagged pure=true; #4047 |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability on the generated service-method library_export; #4047 |
 | Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | request message type name from RPC method args; field shapes are protoc-generated |
 | Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | response message type name from RPC method args; field shapes are protoc-generated |

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -108,18 +108,18 @@ Auto-generated. Back to [summary](../summary.md).
 | Config consumption | 🔴 `missing` | — | 3641 | — | — |
 | Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047 |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | c-cpp def-use sniffer fires on .cc handler bodies (named def->use, e.g. SayHello name/greeting); #4047 |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Error flow | 🔴 `missing` | — | 3628 | — | — |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | language-agnostic Tarjan SCC over IMPORTS; c-cpp #include edges flow through extractor; #4047 |
 | Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | c-cpp effect sniffer registered; handler methods with no effect match tagged pure=true; #4047 |
+| Reachability analysis | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability on the generated service-method library_export; #4047 |
 | Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc request message names from .proto service rpc decls |
 | Request sink dataflow | 🔴 `missing` | — | 3963 | — | — |
 | Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc response message names from .proto service rpc decls |

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -23,7 +23,7 @@ one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
-| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 6 partial, 46 missing, 2 n/a |
+| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 11 partial, 41 missing, 2 n/a |
 | [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 11 full, 26 partial, 2 missing, 15 n/a |
 | [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 14 partial, 38 missing, 2 n/a |
 | [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4469,12 +4469,17 @@
             "issue": "backfill:dictionary-completeness"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047",
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp def-use sniffer fires on .cc handler bodies (named def-\u003euse, e.g. SayHello name/greeting); #4047"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -4501,20 +4506,27 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-agnostic Tarjan SCC over IMPORTS; c-cpp #include edges flow through extractor; #4047"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp effect sniffer registered; handler methods with no effect match tagged pure=true; #4047"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp entry-point sniffer roots reachability on the generated service-method library_export; #4047",
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
             "status": "partial",
@@ -6497,12 +6509,17 @@
             "issue": "backfill:dictionary-completeness"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047",
+            "verified_at": "2026-06-03"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp def-use sniffer fires on .cc handler bodies (named def-\u003euse, e.g. SayHello name/greeting); #4047"
           },
           "env_fallback_recognition": {
             "status": "missing",
@@ -6529,20 +6546,27 @@
             "issue": "backfill:dictionary-completeness"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-agnostic Tarjan SCC over IMPORTS; c-cpp #include edges flow through extractor; #4047"
           },
           "mutation_effect": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp effect sniffer registered; handler methods with no effect match tagged pure=true; #4047"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "c-cpp entry-point sniffer roots reachability on the generated service-method library_export; #4047",
+            "verified_at": "2026-06-03"
           },
           "request_shape_extraction": {
             "status": "partial",

--- a/internal/substrate/c_cpp_trailing_records_test.go
+++ b/internal/substrate/c_cpp_trailing_records_test.go
@@ -1,0 +1,92 @@
+// Value-asserting fixtures for the trailing C/C++ gRPC/protobuf records (#4047,
+// epic #3872, from C/C++ audit #3883): lang.c-cpp.framework.grpc and
+// lang.c-cpp.framework.protobuf.
+//
+// The C/C++ substrate sniffers (def_use_c_cpp.go, entry_points_c_cpp.go, and the
+// effect/taint/template/payload siblings) all register on the "c-cpp" slug with
+// NO framework gate — they are framework-AGNOSTIC and fire on any C/C++ source
+// dispatched via LanguageForPath (.c/.h/.cc/.cpp/.cxx/.hpp/.hh/.hxx). The 15
+// flagship C/C++ HTTP/networking frameworks (cpprestsdk/crow/drogon/oatpp/…)
+// already carry the full language-level Substrate at partial; the grpc/protobuf
+// records previously carried ONLY request/response_shape (via the protobuf
+// message-type path). This re-stamps the UNIVERSAL, entry-rooted substrate cells
+// — def_use, dead_code, reachability, pure_function, module_cycle — to the SAME
+// partial sibling status, proven by the fixture below firing on a generated .cc
+// service-method body.
+//
+// SCOPE NOTE (honest, taxonomy-gated): the capability dictionary only admits the
+// Substrate lane on the rpc_framework subcategory among the trailing c-cpp
+// records. The driver/orm records (category=orm), message_broker, validation,
+// and the ros/unreal-engine (subcategory=desktop) records do NOT admit the
+// missing universal Substrate cells under the taxonomy, so they are correctly
+// LEFT MISSING — even though the framework-agnostic sniffers would fire on their
+// raw source. request_sink_dataflow (DATA_FLOWS_TO) is the separate real-gap
+// (#4049) and is left missing.
+package substrate
+
+import "testing"
+
+// hasEntryCCPP asserts an entry point with the given ident+kind was produced.
+func hasEntryCCPP(t *testing.T, eps []EntryPoint, ident string, kind EntryKind) {
+	t.Helper()
+	for _, e := range eps {
+		if e.Ident == ident && e.Kind == kind {
+			return
+		}
+	}
+	t.Errorf("expected entry point %s/%s; got %+v", ident, kind, eps)
+}
+
+// ---------------------------------------------------------------------------
+// gRPC / protobuf family — grpc, protobuf.
+// Idiom: a generated C++ service method. request/response_shape already carried
+// via the protobuf message-type path; this proves the UNIVERSAL substrate cells
+// fire on the .cc handler body:
+//   - def_use_chain_extraction: the local `name`/`greeting` def->use chain.
+//   - reachability_analysis / dead_code_detection: the non-static top-level
+//     service method is a library_export entry-root that seeds reachability and
+//     (its complement) dead-code.
+//   - pure_function_tagging: effect-free methods are tagged pure=true.
+//   - module_cycle_detection: language-agnostic Tarjan SCC over the #include
+//     IMPORTS edges.
+// ---------------------------------------------------------------------------
+
+const ccppGrpcSrc = `
+#include <grpcpp/grpcpp.h>
+
+Status SayHello(ServerContext* ctx, const HelloRequest* request, HelloReply* reply) {
+    std::string name = request->name();
+    std::string greeting = "Hello " + name;
+    reply->set_message(greeting);
+    return Status::OK;
+}
+`
+
+func TestCCPPGrpc_DefUse(t *testing.T) {
+	defs, uses := sniffDefUseCCPP(ccppGrpcSrc)
+	hasDefUse(t, defs, uses, "SayHello", "name")
+}
+
+func TestCCPPGrpc_EntryRootedUniversals(t *testing.T) {
+	// The non-static top-level service method is the library_export root that
+	// feeds reachability / dead-code / pure-fn (and the import-graph that
+	// module-cycle walks).
+	hasEntryCCPP(t, sniffCCPPEntryPoints(ccppGrpcSrc), "SayHello", EntryKindLibraryExport)
+}
+
+// TestCCPPGrpc_LeftMissing_NoFalsePositives pins the honest left-missing ledger
+// for the grpc/protobuf records: the trivial generated handler exercises NO
+// effect, taint, or template dimension, so only the universal entry/def-use
+// cells (plus the pre-existing protobuf-message-type shapes) are credited — the
+// effect/taint/template substrate cells are correctly left missing here.
+func TestCCPPGrpc_LeftMissing_NoFalsePositives(t *testing.T) {
+	for _, m := range sniffEffectsCCPP(ccppGrpcSrc) {
+		t.Errorf("unexpected effect on grpc handler: %+v", m)
+	}
+	for _, m := range sniffTaintCCPP(ccppGrpcSrc) {
+		t.Errorf("unexpected taint site on grpc handler: %+v", m)
+	}
+	for _, m := range sniffTemplatePatternsCCPP(ccppGrpcSrc) {
+		t.Errorf("unexpected template pattern on grpc handler: %+v", m)
+	}
+}


### PR DESCRIPTION
**Closes #4047** · epic #3872 · from C/C++ audit #3883 · **DEPLOY-DEFERRED** (registry-only; live daemon untouched).

## What
The C/C++ substrate sniffers (`def_use_c_cpp.go`, `entry_points_c_cpp.go` + effect/taint/template/payload siblings) all register on the `c-cpp` slug with **no framework gate** — framework-AGNOSTIC, firing on any `.c/.h/.cc/.cpp/.cxx/.hpp/.hh/.hxx` source dispatched via `LanguageForPath`. The 15 flagship C/C++ HTTP/networking records already carry the full language-level Substrate at partial; the **grpc** + **protobuf** records previously carried ONLY `request/response_shape` (protobuf message-type path). This re-stamps the **universal, entry-rooted** substrate cells to the SAME partial sibling status (cites copied sibling-exact from the `cpprestsdk` canonical block).

## Cells flipped missing → partial (5 per record, 10 total)
`grpc` + `protobuf`: `def_use_chain_extraction`, `dead_code_detection`, `reachability_analysis`, `pure_function_tagging`, `module_cycle_detection`.

## Verify-first
`internal/substrate/c_cpp_trailing_records_test.go` proves the c-cpp def-use sniffer produces the named `SayHello` `name`→`greeting` def→use chain, and the entry-point sniffer roots a `library_export` on the generated `.cc` service method (the root feeding reachability/dead-code/pure-fn, and the `#include` IMPORTS graph module-cycle walks). A negative-assertion test pins the honest **left-missing** ledger: the trivial generated handler exercises **no** effect/taint/template dimension, so those cells stay missing here.

## Honest scope (taxonomy-gated)
The capability dictionary only admits the Substrate lane on the **rpc_framework** subcategory among the trailing c-cpp records. The driver/orm records (`category=orm`), the message_broker (librdkafka/mqtt/zeromq) and validation (nlohmann-json) records, and ros/unreal-engine (`subcategory=desktop`) records do **not** admit the missing universal Substrate cells (`coverage update` rejects them "not valid for category"), so they are correctly **left missing** even though the agnostic sniffers would fire on raw source. ros/unreal-engine keep their pre-existing effect/reachability/dead_code partials (the desktop-subcategory ceiling).

## Out of scope (untouched)
routing/auth/validation (#4046); testing/observability/orm/grpc-protocol cells (#4048); `request_sink_dataflow` / DATA_FLOWS_TO — the separate real-gap (#4049) — stays missing on every record.

## Gates
Full `internal/substrate/` + `internal/custom/cpp/` + `tools/coverage/` tests green; `coverage validate` 0 errors; `fmt --check` canonical; `gen` 0 drift; gofmt/vet clean. Group placement matches siblings (alphabetical within the Substrate group; cites sibling-exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)