### PR TITLE
[kotlin][obs] Micronaut + Quarkus (Kotlin) Observability — metric/trace full, log partial (#4015)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -165,8 +165,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
 | [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/19 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 12/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/18 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/18 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 9/18 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 9/18 | |
 | [kotlin](../by-language/kotlin.md) | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/6 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/19 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 4/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/18 | |
 | [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 1/19 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -31,8 +31,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/9 | |
 | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/19 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 12/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/18 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/18 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 9/18 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 9/18 | |
 | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/6 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/24 | 🔴 0/19 | |
 | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 4/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/18 | |
 | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 1/19 | |

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -92,9 +92,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; SLF4J/@Slf4j on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 (obsFrameworks["micronaut"]=true) |
-| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; Micrometer @Timed on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 (obsFrameworks["micronaut"]=true) |
-| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274 |
+| Log extraction | 🟢 `partial` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: custom_kotlin_observability fires on Micronaut .kt (Java pass is dead for kotlin — patterns_dispatch skips non-java). SLF4J LoggerFactory.getLogger + log.info partial; TestKotlinObservability_Micronaut_Issue4015. Partial: regex file-local, no cross-file logger correlation, interpolated messages. |
+| Metric extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: Micronaut Micrometer literal names asserted — @Timed("orders.count"), @Counted("orders.created"), meterRegistry.counter("orders.listed"); TestKotlinObservability_Micronaut_Issue4015. metric_name_source=literal. |
+| Trace extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: Micronaut Tracing @NewSpan("load") literal span name asserted; TestKotlinObservability_Micronaut_Issue4015. span_name_source=literal. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -92,9 +92,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; obsFrameworks["quarkus"]=true; SLF4J/@Slf4j proven by TestKotlinObservability_Slf4j_Issue3274 |
-| Metric extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @Timed Micrometer proven by TestKotlinObservability_Micrometer_Issue3274 |
-| Trace extraction | 🔴 `missing` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3586) | `internal/custom/java/kotlin_port_test.go`<br>`internal/custom/java/observability.go` | java extractor language-gated to kotlin; @WithSpan OTel proven by TestKotlinObservability_OTel_Issue3274 |
+| Log extraction | 🟢 `partial` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: custom_kotlin_observability fires on Quarkus .kt (Java pass is dead for kotlin — patterns_dispatch skips non-java). SLF4J LoggerFactory.getLogger + log.info partial; TestKotlinObservability_Quarkus_Issue4015. Partial: regex file-local, no cross-file logger correlation, interpolated messages. |
+| Metric extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: Quarkus Micrometer/MicroProfile literal names asserted — @Counted("checkout.attempts"), @Timed("checkout.duration"); TestKotlinObservability_Quarkus_Issue4015. metric_name_source=literal. |
+| Trace extraction | ✅ `full` | `2026-06-03` | — | `internal/custom/kotlin/observability.go`<br>`internal/custom/kotlin/observability_test.go` | #4015: Quarkus OpenTelemetry @WithSpan span name asserted (defaults to fun name when no literal arg); TestKotlinObservability_Quarkus_Issue4015. |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45376,25 +45376,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; SLF4J/@Slf4j on Kotlin proven by TestKotlinObservability_Slf4j_Issue3274 (obsFrameworks[\"micronaut\"]=true)",
-            "verified_at": "2026-05-30"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: custom_kotlin_observability fires on Micronaut .kt (Java pass is dead for kotlin — patterns_dispatch skips non-java). SLF4J LoggerFactory.getLogger + log.info partial; TestKotlinObservability_Micronaut_Issue4015. Partial: regex file-local, no cross-file logger correlation, interpolated messages.",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; Micrometer @Timed on Kotlin proven by TestKotlinObservability_Micrometer_Issue3274 (obsFrameworks[\"micronaut\"]=true)",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: Micronaut Micrometer literal names asserted — @Timed(\"orders.count\"), @Counted(\"orders.created\"), meterRegistry.counter(\"orders.listed\"); TestKotlinObservability_Micronaut_Issue4015. metric_name_source=literal.",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; @WithSpan OTel on Kotlin proven by TestKotlinObservability_OTel_Issue3274",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: Micronaut Tracing @NewSpan(\"load\") literal span name asserted; TestKotlinObservability_Micronaut_Issue4015. span_name_source=literal.",
+            "verified_at": "2026-06-03"
           }
         },
         "Substrate": {
@@ -45703,25 +45700,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; obsFrameworks[\"quarkus\"]=true; SLF4J/@Slf4j proven by TestKotlinObservability_Slf4j_Issue3274",
-            "verified_at": "2026-05-30"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: custom_kotlin_observability fires on Quarkus .kt (Java pass is dead for kotlin — patterns_dispatch skips non-java). SLF4J LoggerFactory.getLogger + log.info partial; TestKotlinObservability_Quarkus_Issue4015. Partial: regex file-local, no cross-file logger correlation, interpolated messages.",
+            "verified_at": "2026-06-03"
           },
           "metric_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; @Timed Micrometer proven by TestKotlinObservability_Micrometer_Issue3274",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: Quarkus Micrometer/MicroProfile literal names asserted — @Counted(\"checkout.attempts\"), @Timed(\"checkout.duration\"); TestKotlinObservability_Quarkus_Issue4015. metric_name_source=literal.",
+            "verified_at": "2026-06-03"
           },
           "trace_extraction": {
-            "status": "missing",
-            "cites": ["internal/custom/java/kotlin_port_test.go","internal/custom/java/observability.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/3586",
-            "notes": "java extractor language-gated to kotlin; @WithSpan OTel proven by TestKotlinObservability_OTel_Issue3274",
-            "verified_at": "2026-05-30"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/observability.go","internal/custom/kotlin/observability_test.go"],
+            "notes": "#4015: Quarkus OpenTelemetry @WithSpan span name asserted (defaults to fun name when no literal arg); TestKotlinObservability_Quarkus_Issue4015.",
+            "verified_at": "2026-06-03"
           }
         },
         "Substrate": {

--- a/internal/custom/kotlin/observability.go
+++ b/internal/custom/kotlin/observability.go
@@ -1,20 +1,23 @@
-// Package kotlin — observability extractor for Kotlin frameworks not covered by
-// the Java observability pass (internal/custom/java/observability.go).
+// Package kotlin — observability extractor for Kotlin source.
 //
-// The Java pass already handles: spring-boot, spring_webflux, quarkus,
-// micronaut, javalin, vertx, dropwizard, helidon, akka_http, struts, etc.
-// This file adds coverage for Kotlin-idiomatic frameworks that are gated out
-// of the Java pass:
+// The Java observability pass (internal/custom/java/observability.go) accepts
+// Kotlin sources in principle, but is only dispatched under custom_java_patterns
+// which hard-skips any non-java file (patterns_dispatch.go: language != "java").
+// So for Kotlin, ALL HTTP-framework observability flows through THIS extractor.
 //
-// Covered cells (ktor / http4k / arrow / coroutines):
+// Covered cells (ktor / http4k / arrow / coroutines / micronaut / quarkus):
 //   - Observability/log_extraction    → partial (see honest limit below)
 //   - Observability/metric_extraction → full    (literal meter names captured)
 //   - Observability/trace_extraction  → full    (literal span names captured)
 //
-// Detection is shared across all four frameworks because SLF4J, Micrometer,
+// Detection is shared across ALL Kotlin frameworks because SLF4J, Micrometer,
 // and OpenTelemetry are language-level (not framework-level) in Kotlin. Any
 // Kotlin file that uses these APIs is covered, regardless of which HTTP
-// framework it belongs to.
+// framework it belongs to:
+//   - Micronaut: Micrometer @Timed/@Counted + meterRegistry.counter(...),
+//     Micronaut Tracing @NewSpan/@ContinueSpan, SLF4J LoggerFactory.getLogger.
+//   - Quarkus: Micrometer / MicroProfile Metrics @Timed/@Counted,
+//     OpenTelemetry @WithSpan, SLF4J/JBoss logging.
 //
 // Name capture (the deepened part — CORE issue #3438):
 //

--- a/internal/custom/kotlin/observability_test.go
+++ b/internal/custom/kotlin/observability_test.go
@@ -310,6 +310,192 @@ func TestKotlinObservability_KotlinLoggingNameAndLambda(t *testing.T) {
 	}
 }
 
+// --- Micronaut (Kotlin) observability probes (issue #4015) ---
+//
+// Micronaut observability uses Micrometer (@Timed/@Counted, meterRegistry),
+// Micronaut Tracing (@NewSpan/@ContinueSpan over OTel/Brave), and SLF4J
+// (LoggerFactory.getLogger). These are detected language-level by
+// custom_kotlin_observability — the same extractor that covers ktor/http4k —
+// so a Micronaut .kt file flows through it unchanged. These probes assert the
+// SPECIFIC named metric/span/logger fires for Micronaut idioms.
+const obsMicronautSrc = `
+package com.example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.tracing.annotation.NewSpan
+import io.micrometer.core.annotation.Timed
+import io.micrometer.core.annotation.Counted
+import io.micrometer.core.instrument.MeterRegistry
+import org.slf4j.LoggerFactory
+
+@Controller("/orders")
+class OrderController(private val meterRegistry: MeterRegistry) {
+
+    private val log = LoggerFactory.getLogger(OrderController::class.java)
+
+    @Get
+    @Timed("orders.count")
+    fun list(): List<String> {
+        log.info("listing orders")
+        meterRegistry.counter("orders.listed")
+        return emptyList()
+    }
+
+    @Counted("orders.created")
+    fun create(name: String) {}
+
+    @NewSpan("load")
+    fun load(id: Long) {}
+}
+`
+
+func TestKotlinObservability_Micronaut_Issue4015(t *testing.T) {
+	ents := extract(t, "custom_kotlin_observability", fi("OrderController.kt", "kotlin", obsMicronautSrc))
+	if len(ents) == 0 {
+		t.Fatal("[obs][micronaut] expected entities, got none")
+	}
+
+	// metric: @Timed("orders.count") — literal metric name asserted.
+	if e := findMetricByName(ents, "orders.count"); e == nil {
+		t.Error("[obs][micronaut] expected @Timed metric_name=orders.count")
+	} else if src := e.Props["metric_name_source"]; src != "literal" {
+		t.Errorf("[obs][micronaut] @Timed(\"orders.count\") should be literal, got %q", src)
+	}
+	// metric: @Counted("orders.created").
+	if e := findMetricByName(ents, "orders.created"); e == nil {
+		t.Error("[obs][micronaut] expected @Counted metric_name=orders.created")
+	} else if src := e.Props["metric_name_source"]; src != "literal" {
+		t.Errorf("[obs][micronaut] @Counted(\"orders.created\") should be literal, got %q", src)
+	}
+	// metric: meterRegistry.counter("orders.listed") — literal registry meter name.
+	if e := findMetricByName(ents, "orders.listed"); e == nil {
+		t.Error("[obs][micronaut] expected meterRegistry.counter metric_name=orders.listed")
+	}
+	// trace: @NewSpan("load") — literal span name asserted (Micronaut Tracing).
+	if e := findSpanByName(ents, "load"); e == nil {
+		t.Error("[obs][micronaut] expected @NewSpan span_name=load")
+	} else if src := e.Props["span_name_source"]; src != "literal" {
+		t.Errorf("[obs][micronaut] @NewSpan(\"load\") should be literal, got %q", src)
+	}
+	// log: SLF4J LoggerFactory.getLogger + log.info — partial signal present.
+	gotLogger := false
+	gotLogStmt := false
+	for _, e := range ents {
+		if e.Subtype == "logger" {
+			gotLogger = true
+		}
+		if e.Subtype == "log_statement" {
+			gotLogStmt = true
+		}
+	}
+	if !gotLogger {
+		t.Error("[obs][micronaut] expected SLF4J logger entity")
+	}
+	if !gotLogStmt {
+		t.Error("[obs][micronaut] expected log.info statement entity")
+	}
+}
+
+// --- Quarkus (Kotlin) observability probes (issue #4015) ---
+//
+// Quarkus observability uses Micrometer/MicroProfile Metrics (@Timed/@Counted),
+// OpenTelemetry (@WithSpan), and JBoss/SLF4J logging. Detected language-level
+// by custom_kotlin_observability.
+const obsQuarkusSrc = `
+package com.example.quarkus
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import org.eclipse.microprofile.metrics.annotation.Timed
+import org.eclipse.microprofile.metrics.annotation.Counted
+import org.slf4j.LoggerFactory
+
+@Path("/checkout")
+class CheckoutResource {
+
+    private val log = LoggerFactory.getLogger(CheckoutResource::class.java)
+
+    @GET
+    @WithSpan
+    fun handle() {
+        log.info("handling checkout")
+    }
+
+    @Counted("checkout.attempts")
+    fun attempt() {}
+
+    @Timed("checkout.duration")
+    fun finalize(id: Long) {}
+}
+`
+
+func TestKotlinObservability_Quarkus_Issue4015(t *testing.T) {
+	ents := extract(t, "custom_kotlin_observability", fi("CheckoutResource.kt", "kotlin", obsQuarkusSrc))
+	if len(ents) == 0 {
+		t.Fatal("[obs][quarkus] expected entities, got none")
+	}
+
+	// trace: @WithSpan (no literal) — span name defaults to fun name `handle`.
+	if e := findSpanByName(ents, "handle"); e == nil {
+		t.Error("[obs][quarkus] expected @WithSpan span_name=handle (defaulted to fun)")
+	} else if src := e.Props["span_name_source"]; src != "defaulted_to_decl" {
+		t.Errorf("[obs][quarkus] bare @WithSpan should be defaulted_to_decl, got %q", src)
+	}
+	// metric: @Counted("checkout.attempts").
+	if e := findMetricByName(ents, "checkout.attempts"); e == nil {
+		t.Error("[obs][quarkus] expected @Counted metric_name=checkout.attempts")
+	} else if src := e.Props["metric_name_source"]; src != "literal" {
+		t.Errorf("[obs][quarkus] @Counted(\"checkout.attempts\") should be literal, got %q", src)
+	}
+	// metric: @Timed("checkout.duration").
+	if e := findMetricByName(ents, "checkout.duration"); e == nil {
+		t.Error("[obs][quarkus] expected @Timed metric_name=checkout.duration")
+	} else if src := e.Props["metric_name_source"]; src != "literal" {
+		t.Errorf("[obs][quarkus] @Timed(\"checkout.duration\") should be literal, got %q", src)
+	}
+	// log: SLF4J logger + log.info partial.
+	gotLogger := false
+	gotLogStmt := false
+	for _, e := range ents {
+		if e.Subtype == "logger" {
+			gotLogger = true
+		}
+		if e.Subtype == "log_statement" {
+			gotLogStmt = true
+		}
+	}
+	if !gotLogger {
+		t.Error("[obs][quarkus] expected SLF4J logger entity")
+	}
+	if !gotLogStmt {
+		t.Error("[obs][quarkus] expected log.info statement entity")
+	}
+}
+
+// Negative: a plain Micronaut/Quarkus-shaped controller with NO observability
+// APIs must yield no obs entities (framework presence alone is not a signal).
+const obsMicronautNoObsSrc = `
+package com.example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/ping")
+class PingController {
+    @Get
+    fun ping(): String = "pong"
+}
+`
+
+func TestKotlinObservability_MicronautNoObs_Issue4015(t *testing.T) {
+	ents := extract(t, "custom_kotlin_observability", fi("PingController.kt", "kotlin", obsMicronautNoObsSrc))
+	if len(ents) != 0 {
+		t.Errorf("[obs][micronaut] plain controller with no obs APIs should yield 0 entities, got %d", len(ents))
+	}
+}
+
 func findMetricByName(ents []entitySummary, metricName string) *entitySummary {
 	for i := range ents {
 		if ents[i].Subtype == "metric" && ents[i].Props["metric_name"] == metricName {


### PR DESCRIPTION
Closes #4015 · Epic #3872 · Audit #3886

## Finding (verified)
The native Kotlin observability extractor `custom_kotlin_observability`
(`internal/custom/kotlin/observability.go`) detects SLF4J / Micrometer /
OpenTelemetry at the **language level**, so it already fires on Micronaut and
Quarkus `.kt` files. The registry, however, marked their Observability cells
`missing` with **dead cites** pointing at the Java pass
(`internal/custom/java/observability.go`) — which is unreachable for Kotlin
because `custom_java_patterns` hard-skips any non-java file
(`patterns_dispatch.go`: `language != "java"`). So the root cause was a
registry/doc gap, not a code gap.

## What changed
- **VALUE-ASSERTING probes** (`observability_test.go`) proving the SPECIFIC
  named metric/span/log fire through `custom_kotlin_observability`:
  - **Micronaut** (`TestKotlinObservability_Micronaut_Issue4015`):
    - metric: `@Timed("orders.count")`, `@Counted("orders.created")`,
      `meterRegistry.counter("orders.listed")` → literal names, `metric_name_source=literal`
    - trace: `@NewSpan("load")` → literal span name (`span_name_source=literal`)
    - log: SLF4J `LoggerFactory.getLogger` + `log.info` → logger + log_statement
  - **Quarkus** (`TestKotlinObservability_Quarkus_Issue4015`):
    - metric: `@Counted("checkout.attempts")`, `@Timed("checkout.duration")` → literal
    - trace: bare `@WithSpan` → span name defaulted to fun `handle` (`defaulted_to_decl`)
    - log: SLF4J logger + `log.info`
  - **Negative** (`TestKotlinObservability_MicronautNoObs_Issue4015`): plain
    `@Controller` with no obs APIs → **0 entities** (framework presence is not a signal).
- Corrected the extractor doc comment (Java pass is dead for kotlin;
  Micronaut/Quarkus covered here).
- Flipped registry cells honestly (with cites + notes):
  - micronaut/quarkus Observability: **metric → full**, **trace → full**, **log → partial**.

## Honest partial / left missing
- **log → partial** (not full): regex, file-local. No cross-file logger-field
  correlation; interpolated/dynamic message strings (`"user {}"`, `$id`) not
  resolved. Same bar held for Java/PHP/Rust obs logging.
- Config-driven reporter binding (e.g. which Micrometer registry / OTel exporter
  a meter/span flushes to) is **not** resolved — only the call-site literal
  meter/span name is asserted.

## Verification
- No new extractor key registered — existing `custom_kotlin_observability`
  extended. `TestEveryRegisteredCustomKeyDispatches` (dispatch-parity) **green**.
- Full packages green: `internal/custom/kotlin/`, `internal/extractors/`, `tools/coverage/`.
- `covtool validate` 0 errors, `fmt --check` canonical, `gen` 0 drift (derived docs regenerated), `gofmt` clean, `go vet` clean.

**DEPLOY-DEFERRED**: registry/extractor change; rebuild + reindex on the next coordinated daemon deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)