### PR TITLE
credit(c-cpp): restinio auth_coverage (BUILT-UNCREDITED routing/auth/middleware/validation wave) #4046

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -19,7 +19,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -34,7 +34,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | — `not_applicable` | — | — | — | restinio is a minimal HTTP server lib; no built-in authentication subsystem |
+| Auth coverage | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/custom/cpp/restinio_middleware.go` | restinio has no built-in auth subsystem, but the middleware extractor classifies auth from make_chain<...> handler-chain link names: an auth-named link (e.g. JwtAuthHandler) cross-emits a restinio:auth:<handler> entity with auth_method/auth_subtype + middleware_order (TestRestinioMakeChain asserts restinio:auth:JwtAuthHandler auth_method=jwt order=1). partial: name-inferred from the chain link only — no header/realm/scheme parsing and no cross-file handler-type resolution. |
 
 ### Validation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -7159,8 +7159,11 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "not_applicable",
-            "notes": "restinio is a minimal HTTP server lib; no built-in authentication subsystem"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/restinio_middleware.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "restinio has no built-in auth subsystem, but the middleware extractor classifies auth from make_chain\u003c...\u003e handler-chain link names: an auth-named link (e.g. JwtAuthHandler) cross-emits a restinio:auth:\u003chandler\u003e entity with auth_method/auth_subtype + middleware_order (TestRestinioMakeChain asserts restinio:auth:JwtAuthHandler auth_method=jwt order=1). partial: name-inferred from the chain link only — no header/realm/scheme parsing and no cross-file handler-type resolution.",
+            "verified_at": "2026-06-03"
           }
         },
         "Validation": {


### PR DESCRIPTION
Closes #4046 · Epic #3872 · Audit #3883 · **DEPLOY-DEFERRED** (registry-only, no extractor/pipeline change)

## Summary
CREDIT-WAVE (registry-honesty) for C/C++ HTTP `routing/auth/middleware/validation` cells. **VERIFY-FIRST** per cell against the already-shipped `internal/custom/cpp/*` extractors and their `_test.go` value-asserting fixtures.

Key finding: the #3883 audit snapshot ("0 full, 14 partial, 26 missing") is **stale**. The credit work already landed in `main` (c034a7c8a) for almost all in-scope cells. The **one remaining genuine BUILT-UNCREDITED gap** in scope is restinio `auth_coverage`, which was wrongly stamped `not_applicable`.

## Cell flipped
| Framework | Group | Cell | Before → After | Asserted artifact |
|---|---|---|---|---|
| restinio | Auth | `auth_coverage` | `not_applicable` → **`partial`** | `restinio::router::make_chain<LoggingHandler, JwtAuthHandler, ApiRouter>()` → `restinio:auth:JwtAuthHandler` `auth_method=jwt` `middleware_order=1` (`TestRestinioMakeChain`, `new_extractors_test.go`) |

`restinio_middleware.go` classifies auth from `make_chain<...>` handler-chain link names (an auth-named link cross-emits a `restinio:auth:<handler>` entity with `auth_method`/`auth_subtype` + order) — the same name-inference model that earns crow/oatpp/drogon their auth credit. Honest status is **partial**: name-inferred from the chain link only; no header/realm/scheme parsing, no cross-file handler-type resolution.

## Already-credited in main (verified honest, left unchanged)
- **Routing** `endpoint_synthesis`/`handler_attribution`/`route_extraction`: **full ×8** (crow, drogon, oatpp, pistache, poco, restbed, restinio, cpprestsdk) — cited to each `*_routes.go`.
- **Auth**/**Middleware**: **full** on crow/drogon/oatpp (rich named-symbol + ordered-template capture via `auth_middleware.go`); **partial** on cpprestsdk/pistache/poco/restbed (generic header / single chain-marker only — honest ceiling per the extractor's own docstring); restinio middleware **full** (`restinio_middleware.go`).
- **Validation** `dto_extraction`/`request_validation`: **partial ×8** (oatpp `dto_extraction` full) — cited to `validation.go`.

## Dictionary-gated out / left missing (real gaps, not this ticket)
- `rate_limit_stamping` (×8) → `missing` #3778 (no native limiter extraction).
- `endpoint_deprecation_versioning` #3628 / `endpoint_response_codes` #3818 → `missing`.
- restinio auth remains `partial` (not full): no framework auth subsystem; name-inference ceiling.

## Validation
- `covtool validate`: 0 errors (pre-existing test.* capability-map warnings only).
- `covtool fmt --check`: canonical (surgical line edit; `gen` re-derived the 3 markdown docs, no collateral drift).
- `gofmt -l` empty; `go vet` clean.
- Full package tests green: `go test ./internal/custom/cpp/ ./internal/engine/ ./tools/coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)