### PR TITLE
feat(mobile-graphql): GraphQL client operations for graphql_flutter (Dart) + Apollo-iOS (Swift)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 225 records · **C/C++**: 19 · **C#**: 16 · **dart**: 1 · **elixir**: 14 · **go**: 20 · **java**: 22 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 4
+**Total**: 227 records · **C/C++**: 19 · **C#**: 16 · **dart**: 2 · **elixir**: 14 · **go**: 20 · **java**: 22 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -226,6 +226,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🟢 2/2 | 🟢 1/1 | 🟡 22/24 | 🟢 9/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🟢 2/2 | 🟢 1/1 | 🟡 22/24 | 🟢 9/9 | |
+| [dart](../by-language/dart.md) | [graphql_flutter (GraphQL client)](../detail/lang.dart.framework.graphql-flutter.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🔴 0/1 | 🟡 20/21 | 🟡 7/8 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🔴 0/1 | 🟡 20/21 | 🟡 7/8 | |
@@ -236,6 +237,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | ✅ 1/1 | 🟡 18/21 | 🟢 9/9 | |
 | [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | ✅ 1/1 | 🟡 21/24 | 🟢 8/8 | |
 | [swift](../by-language/swift.md) | [Alamofire (HTTP client)](../detail/lang.swift.framework.alamofire.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
+| [swift](../by-language/swift.md) | [Apollo-iOS (GraphQL client)](../detail/lang.swift.framework.apollo-ios.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 | [swift](../by-language/swift.md) | [URLSession (HTTP client)](../detail/lang.swift.framework.urlsession.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 
 

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # dart
 
-**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 2 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -27,6 +27,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
 | [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🟢 1/1 | 🟡 9/24 | 🟡 5/8 | |
+
+
+### Mobile
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [graphql_flutter (GraphQL client)](../detail/lang.dart.framework.graphql-flutter.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # swift
 
-**Frameworks**: 4 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 5 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -41,6 +41,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
 | [Alamofire (HTTP client)](../detail/lang.swift.framework.alamofire.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
+| [Apollo-iOS (GraphQL client)](../detail/lang.swift.framework.apollo-ios.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 | [URLSession (HTTP client)](../detail/lang.swift.framework.urlsession.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/9 | |
 
 

--- a/docs/coverage/detail/lang.dart.framework.graphql-flutter.md
+++ b/docs/coverage/detail/lang.dart.framework.graphql-flutter.md
@@ -1,0 +1,110 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.dart.framework.graphql-flutter` — graphql_flutter (GraphQL client)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [dart](../by-language/dart.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Mobile
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Deep link extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Navigation extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Screen detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Platform branching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ✅ `full` | `2026-06-03` | 4036 | `internal/engine/http_endpoint_dart_client.go`<br>`internal/engine/http_endpoint_dart_graphql_client.go`<br>`internal/engine/http_endpoint_dart_graphql_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | graphql_flutter / graphql gql(r'''...''') documents -> one http_endpoint_call (consumer) per (operation, root field) keyed to the server endpoint shape http:GRAPHQL:/graphql/<RootType>/<field> + FETCHES from the enclosing func (top-level const resolved via reference site). Root type Query/Mutation/Subscription + root fields parsed from the inline gql document (shared gqlRootFieldsFromDoc with the JS/TS pass). Identical entity shape to the GraphQL server producer so the cross-repo linker pairs the Flutter screen with the backend resolver on reindex. Value-asserted: gql(r'''query GetUser { user { id name } }''') -> http:GRAPHQL:/graphql/Query/user; inline mutation createUser; multi-field query; subscription messageAdded; negatives (REST dio.get, plain string) emit nothing. |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.dart.framework.graphql-flutter ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.swift.framework.apollo-ios.md
+++ b/docs/coverage/detail/lang.swift.framework.apollo-ios.md
@@ -1,0 +1,104 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.swift.framework.apollo-ios` — Apollo-iOS (GraphQL client)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [swift](../by-language/swift.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Mobile
+- **Capability cells:** 37
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Deep link extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Navigation extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Screen detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Platform branching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🟢 `partial` | `2026-06-03` | 4036 | `internal/engine/http_endpoint_swift_client.go`<br>`internal/engine/http_endpoint_swift_graphql_client.go`<br>`internal/engine/http_endpoint_swift_graphql_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | HONEST-PARTIAL. Apollo-iOS apollo.fetch(query: GetUserQuery()) / .perform(mutation:) / .subscribe(subscription:) -> one operation REFERENCE per call site keyed http:GRAPHQL:/graphql/<Root>/<OpName> (op name recovered from the generated type by trimming the Query/Mutation/Subscription suffix) + FETCHES from the enclosing func. PARTIAL because Apollo-iOS code-generates the operation from a .graphql file, so the selected ROOT FIELD is NOT present at the Swift call site -> the entity is keyed on the operation NAME (discoverable), not the schema field, so a guaranteed field-level cross-repo link is not yet established (framework label apollo_ios_unresolved). Full field resolution requires parsing companion .graphql files (deferred, #4036). Value-asserted: GetUserQuery() -> Query/GetUser; AddUserMutation() -> Mutation/AddUser; OnMessageSubscription() -> Subscription/OnMessage; negatives (Alamofire REST, bare SearchQuery() constructor) emit nothing. |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.swift.framework.apollo-ios ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -24,6 +24,7 @@ one is a separate detail page.
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 4 full, 3 partial, 42 missing |
+| [`lang.dart.framework.graphql-flutter`](./lang.dart.framework.graphql-flutter.md) | dart | framework | 1 full, 36 missing |
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 31 partial, 12 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 8 partial, 37 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 8 full, 5 partial, 42 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12900,6 +12900,184 @@
       }
     },
     {
+      "id": "lang.dart.framework.graphql-flutter",
+      "category": "http_framework",
+      "subcategory": "mobile",
+      "language": "dart",
+      "label": "graphql_flutter (GraphQL client)",
+      "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "navigation_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "screen_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Platform": {
+          "platform_branching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "error_flow": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "feature_flag_gating": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_dart_client.go","internal/engine/http_endpoint_dart_graphql_client.go","internal/engine/http_endpoint_dart_graphql_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "4036",
+            "notes": "graphql_flutter / graphql gql(r'''...''') documents -\u003e one http_endpoint_call (consumer) per (operation, root field) keyed to the server endpoint shape http:GRAPHQL:/graphql/\u003cRootType\u003e/\u003cfield\u003e + FETCHES from the enclosing func (top-level const resolved via reference site). Root type Query/Mutation/Subscription + root fields parsed from the inline gql document (shared gqlRootFieldsFromDoc with the JS/TS pass). Identical entity shape to the GraphQL server producer so the cross-repo linker pairs the Flutter screen with the backend resolver on reindex. Value-asserted: gql(r'''query GetUser { user { id name } }''') -\u003e http:GRAPHQL:/graphql/Query/user; inline mutation createUser; multi-field query; subscription messageAdded; negatives (REST dio.get, plain string) emit nothing.",
+            "verified_at": "2026-06-03"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.elixir.driver.dynamodb",
       "category": "orm",
       "subcategory": "orm_mapper",
@@ -74641,6 +74819,184 @@
             "status": "full",
             "cites": ["internal/engine/http_endpoint_swift_client.go","internal/engine/http_endpoint_swift_client_test.go","internal/engine/http_endpoint_synthesis.go"],
             "notes": "Alamofire AF.request(\"...\", method: .verb) / session.request(...) outbound calls -\u003e one http_endpoint_call (consumer) per call site + FETCHES from the enclosing func; host stripped, \\(expr) -\u003e {param}; verb from method: .verb (default GET). Same entity shape as the backend producer so the cross-repo linker pairs the iOS screen with the backend route on reindex. Value-asserted in http_endpoint_swift_client_test.go (AF.request(\"/auth/login\", method: .post) -\u003e POST /auth/login)."
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.swift.framework.apollo-ios",
+      "category": "http_framework",
+      "subcategory": "mobile",
+      "language": "swift",
+      "label": "Apollo-iOS (GraphQL client)",
+      "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "navigation_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "screen_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Platform": {
+          "platform_branching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "error_flow": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "feature_flag_gating": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_swift_client.go","internal/engine/http_endpoint_swift_graphql_client.go","internal/engine/http_endpoint_swift_graphql_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "4036",
+            "notes": "HONEST-PARTIAL. Apollo-iOS apollo.fetch(query: GetUserQuery()) / .perform(mutation:) / .subscribe(subscription:) -\u003e one operation REFERENCE per call site keyed http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cOpName\u003e (op name recovered from the generated type by trimming the Query/Mutation/Subscription suffix) + FETCHES from the enclosing func. PARTIAL because Apollo-iOS code-generates the operation from a .graphql file, so the selected ROOT FIELD is NOT present at the Swift call site -\u003e the entity is keyed on the operation NAME (discoverable), not the schema field, so a guaranteed field-level cross-repo link is not yet established (framework label apollo_ios_unresolved). Full field resolution requires parsing companion .graphql files (deferred, #4036). Value-asserted: GetUserQuery() -\u003e Query/GetUser; AddUserMutation() -\u003e Mutation/AddUser; OnMessageSubscription() -\u003e Subscription/OnMessage; negatives (Alamofire REST, bare SearchQuery() constructor) emit nothing.",
+            "verified_at": "2026-06-03"
           },
           "import_resolution_quality": {
             "status": "missing",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 225 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 227 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
 
 ## Coverage by language
 
@@ -19,9 +19,9 @@
 | [rust](by-language/rust.md) | 14 | 6 | 15 | 3 |
 | [scala](by-language/scala.md) | 14 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 9 | 6 | 14 | 7 |
+| [swift](by-language/swift.md) | 5 | 1 | 0 | 0 |
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 0 |
-| [swift](by-language/swift.md) | 4 | 1 | 0 | 0 |
-| [dart](by-language/dart.md) | 1 | 1 | 0 | 0 |
+| [dart](by-language/dart.md) | 2 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 4 |
 | [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 225 frameworks · 111 tools · 156 ORMs · 161 other
+Total: 227 frameworks · 111 tools · 156 ORMs · 161 other

--- a/internal/engine/http_endpoint_dart_client.go
+++ b/internal/engine/http_endpoint_dart_client.go
@@ -94,6 +94,15 @@ type dartClientEmitFn func(method, canonicalPath, framework, refKind, refName st
 // from applyHTTPEndpointSynthesis. Emits one outbound http_endpoint_call per
 // Dio / http verb call site + a FETCHES edge from the enclosing function.
 func synthesizeDartClientWithRuntime(content string, emit dartClientEmitFn) {
+	// GraphQL client operations (graphql_flutter / graphql `gql(...)` documents)
+	// emit operation-level http_endpoint_call entities keyed to the server
+	// endpoint shape http:GRAPHQL:/graphql/<Root>/<field> (#4036). Run BEFORE the
+	// REST early-exit guard below, since a pure-GraphQL Flutter file may contain
+	// none of the Dio / package:http markers.
+	if strings.Contains(content, "gql(") {
+		synthesizeDartGraphQLClient(content, indexDartFuncs(content), emit)
+	}
+
 	if !strings.Contains(content, "dio") && !strings.Contains(content, "Dio") &&
 		!strings.Contains(content, "http.") && !strings.Contains(content, "Uri.parse") &&
 		!strings.Contains(content, ".get(") && !strings.Contains(content, ".post(") {

--- a/internal/engine/http_endpoint_dart_graphql_client.go
+++ b/internal/engine/http_endpoint_dart_graphql_client.go
@@ -1,0 +1,197 @@
+// Dart / Flutter GraphQL client-side (consumer) operation synthesis
+// (#4036, epic #3872; mirrors the JS/TS GraphQL client pass in
+// http_endpoint_graphql_client.go).
+//
+// The graphql_flutter / graphql Dart packages express GraphQL operations by
+// wrapping a GraphQL document string in the `gql(...)` parser function and
+// passing it to a Query / Mutation / Subscription widget or a
+// GraphQLClient.query / .mutate / .subscribe call:
+//
+//	final GET_USER = gql(r'''query GetUser { user { id name } }''');
+//	Query(options: QueryOptions(document: GET_USER), ...)
+//
+//	client.mutate(MutationOptions(
+//	  document: gql(r'''mutation AddUser { createUser(input: ...) { id } }'''),
+//	));
+//
+//	client.query(QueryOptions(document: gql('query D { stats { count } }')));
+//
+// Before this pass these produced no operation entity and no cross-repo link:
+// the Dart HTTP-client pass (http_endpoint_dart_client.go) only recognises REST
+// (Dio / package:http) verb calls, so a Flutter screen talking to a GraphQL
+// backend was invisible at the operation level.
+//
+// This pass recognises the `gql(<string-literal>)` document — whether bound to
+// a const/final and referenced by name, or inlined directly at the call site —
+// parses its operation type (query/mutation/subscription) and ROOT FIELD(s),
+// and emits one synthetic http_endpoint_call per (operation, root field) keyed
+// to EXACTLY match the GraphQL server endpoint shape produced by the resolver
+// synthesis (http_endpoint_synthesis.go):
+//
+//	http:GRAPHQL:/graphql/<RootType>/<field>   e.g. http:GRAPHQL:/graphql/Query/user
+//
+// Because the ID is identical to the server-side definition's ID, the existing
+// Name-based cross-repo HTTP linker (links/http_pass.go) joins the Flutter
+// client operation to the backend resolver on reindex with NO new linker code —
+// exactly like the REST Dart client pass and the JS/TS GraphQL client pass.
+//
+// The GraphQL document parser (gqlRootFieldsFromDoc / gqlTopLevelFields and
+// friends) is shared verbatim with the JS/TS pass — the GraphQL grammar is
+// language-agnostic; only the host-language string-extraction differs.
+//
+// FETCHES edge: the enclosing Dart function/method at the call (or const-def)
+// site is recorded as source_caller (Function:<name>); the shared
+// emitClientRuntime → ResolveHTTPEndpointHandlers turns that into the FETCHES
+// edge, the same mechanism as every other consumer pass.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// dartGqlDocRe matches a `gql(<string-literal>)` call in Dart and captures the
+// document body. Dart string literals come in several flavours, all handled by
+// the alternation below (optional `r` raw prefix in every case):
+//
+//	gql(r'''query { ... }''')   triple-quoted raw (the dominant graphql_flutter form)
+//	gql("""query { ... }""")    triple-quoted double
+//	gql(r'query { ... }')       single-quoted raw
+//	gql('query { ... }')        single-quoted
+//	gql("query { ... }")        double-quoted
+//
+// Capture groups (mutually exclusive, exactly one is non-empty):
+//
+//	1 = triple-single body, 2 = triple-double body,
+//	3 = single-quote body,  4 = double-quote body.
+//
+// (?s) so the `.`-equivalents span newlines inside a multi-line document.
+var dartGqlDocRe = regexp.MustCompile(
+	`(?s)\bgql\s*\(\s*r?(?:'''(.*?)'''|"""(.*?)"""|'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)")`,
+)
+
+// dartGqlConstDefRe captures a Dart declaration whose initializer is a
+// gql(...) document, capturing the const/final NAME (group 1). The gql body is
+// re-parsed from the same span via dartGqlDocRe; this regex only anchors the
+// name so a TOP-LEVEL const (whose gql site has no enclosing function) can have
+// its FETCHES caller resolved from the REFERENCE site instead. It tolerates an
+// optional type between the keyword and the name
+// (`final DocumentNode GET_USER = gql(...)`).
+var dartGqlConstDefRe = regexp.MustCompile(
+	`\b(?:final|const|var)\s+(?:[\w<>,\[\]?.]+\s+)?([A-Za-z_$][\w$]*)\s*=\s*gql\s*\(`,
+)
+
+// Note: unlike the JS/TS pass, Dart graphql_flutter ALWAYS inlines the document
+// string inside the gql(...) parser call — `final GET_USER = gql(r”'...”')` —
+// so the document body is present at EVERY operation site (there is no
+// cross-file honest-partial case: every gql(...) carries its own document).
+// The only subtlety is FETCHES caller attribution for a TOP-LEVEL const: its
+// gql site has no enclosing function, so we attribute the caller to the
+// function that REFERENCES the const (`document: GET_USER`) — typically the
+// widget build() method — which is the real consumer of the operation.
+//
+// synthesizeDartGraphQLClient scans a Dart file for graphql_flutter / graphql
+// GraphQL operations and emits one http_endpoint_call per (operation, root
+// field), keyed to match the server endpoint shape
+// http:GRAPHQL:/graphql/<RootType>/<field>, plus a FETCHES edge from the
+// enclosing Dart function.
+//
+// It is invoked from synthesizeDartClientWithRuntime so it shares the Dart
+// dispatch and the runtime-aware emitter.
+func synthesizeDartGraphQLClient(content string, funcs []jsFuncSpan, emit dartClientEmitFn) {
+	// File-signal gate: require the `gql(` parser marker so this is a no-op on
+	// ordinary REST/widget Dart files. (`gql(` is the parser-call form unique to
+	// the graphql/graphql_flutter packages; the REST Dart pass keys off `dio`/
+	// `http.`/`Uri.parse` instead, so the two passes never collide.)
+	if !strings.Contains(content, "gql(") {
+		return
+	}
+
+	// emitDoc emits one client-call per resolved root field for a gql document.
+	emitDoc := func(rt string, fields []string, caller string) {
+		for _, f := range fields {
+			path := "/graphql/" + rt + "/" + f
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			// runtimeDynamic=false: the operation root field is statically resolved
+			// from the literal gql document, so the endpoint is fully concrete.
+			emit(gqlVerb, canonical, "graphql_flutter", "Function", caller, false)
+		}
+	}
+
+	// dartGqlDocBody returns the document body from a dartGqlDocRe submatch
+	// (exactly one of the four quote-flavour groups is populated).
+	dartGqlDocBody := func(m []string) string {
+		for g := 1; g <= 4; g++ {
+			if m[g] != "" {
+				return m[g]
+			}
+		}
+		return ""
+	}
+
+	// Record each gql const-definition span → the const NAME, so a gql site that
+	// resolves to an empty enclosing function (a top-level const) can have its
+	// FETCHES caller resolved from a reference site below. dartGqlConstDefRe
+	// spans from the `final`/`const`/`var` keyword through the `(` of `gql(`, so
+	// the gql token sits inside [start, end).
+	type constSpan struct {
+		start, end int
+		name       string
+	}
+	var constSpans []constSpan
+	for _, dm := range dartGqlConstDefRe.FindAllStringSubmatchIndex(content, -1) {
+		constSpans = append(constSpans, constSpan{start: dm[0], end: dm[1], name: content[dm[2]:dm[3]]})
+	}
+	constNameForGqlSite := func(gqlOff int) string {
+		for _, cs := range constSpans {
+			if cs.start <= gqlOff && gqlOff < cs.end {
+				return cs.name
+			}
+		}
+		return ""
+	}
+
+	// refCallerForConst returns the enclosing function of the FIRST reference to
+	// `name` (`document: name`, `query: name`, or a bare `name` argument) that
+	// lands inside some function, so a top-level gql const is attributed to its
+	// consumer (the widget build()/method that passes it to Query/Mutation).
+	refCallerForConst := func(name string) string {
+		if name == "" {
+			return ""
+		}
+		ref := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+		for _, loc := range ref.FindAllStringIndex(content, -1) {
+			if c := enclosingDartFuncAt(funcs, loc[0]); c != "" {
+				return c
+			}
+		}
+		return ""
+	}
+
+	// Every gql(...) site, in source order, handled exactly once. The caller is
+	// the enclosing Dart function; for a top-level const def (no enclosing
+	// function) the caller is resolved from the const's reference site.
+	for _, m := range dartGqlDocRe.FindAllStringSubmatchIndex(content, -1) {
+		bodyGroups := dartGqlDocRe.FindStringSubmatch(content[m[0]:m[1]])
+		if bodyGroups == nil {
+			continue
+		}
+		doc := dartGqlDocBody(bodyGroups)
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		rt, fields, ok := gqlRootFieldsFromDoc(doc)
+		if !ok || len(fields) == 0 {
+			continue
+		}
+		caller := enclosingDartFuncAt(funcs, m[0])
+		if caller == "" {
+			// Top-level gql site: if it is a const definition, attribute the
+			// operation to the function that references the const.
+			caller = refCallerForConst(constNameForGqlSite(m[0]))
+		}
+		emitDoc(rt, fields, caller)
+	}
+}

--- a/internal/engine/http_endpoint_dart_graphql_client_test.go
+++ b/internal/engine/http_endpoint_dart_graphql_client_test.go
@@ -1,0 +1,134 @@
+package engine
+
+import "testing"
+
+// TestDartGraphQLClient_QueryConstRef covers the canonical graphql_flutter
+// idiom: a gql doc bound to a const, referenced by a Query widget's
+// QueryOptions(document:). Asserts the SPECIFIC operation root field
+// (`user`) mapped to the server endpoint shape
+// http:GRAPHQL:/graphql/Query/user (value-asserting), plus the FETCHES edge.
+func TestDartGraphQLClient_QueryConstRef(t *testing.T) {
+	src := `
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+final GET_USER = gql(r'''
+  query GetUser {
+    user { id name }
+  }
+''');
+
+class UserScreen extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Query(
+      options: QueryOptions(document: GET_USER),
+      builder: (result, {fetchMore, refetch}) => Text("x"),
+    );
+  }
+}
+`
+	ids, rels := runDetectWithRels(t, "dart", "lib/user_screen.dart", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/user",
+	}, "dart-gql-query-const")
+	requireFetches(t, rels, "http:GRAPHQL:/graphql/Query/user", "dart-gql-query-const")
+}
+
+// TestDartGraphQLClient_InlineMutation covers an inline gql mutation passed
+// straight into MutationOptions(document: gql(r'...')), asserting the
+// Mutation root field `createUser` → http:GRAPHQL:/graphql/Mutation/createUser.
+func TestDartGraphQLClient_InlineMutation(t *testing.T) {
+	src := `
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+Future<void> submit(GraphQLClient client) async {
+  await client.mutate(MutationOptions(
+    document: gql(r'''
+      mutation AddUser {
+        createUser(input: {name: "x"}) { id }
+      }
+    '''),
+  ));
+}
+`
+	ids, rels := runDetectWithRels(t, "dart", "lib/add_user.dart", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+	}, "dart-gql-inline-mutation")
+	requireFetches(t, rels, "http:GRAPHQL:/graphql/Mutation/createUser", "dart-gql-inline-mutation")
+}
+
+// TestDartGraphQLClient_ClientQueryInline covers
+// client.query(QueryOptions(document: gql('...'))) with a single-quoted gql
+// doc and MULTIPLE root fields, asserting both server endpoints.
+func TestDartGraphQLClient_ClientQueryInline(t *testing.T) {
+	src := `
+import 'package:graphql/client.dart';
+
+Future<QueryResult> load(GraphQLClient client) async {
+  return client.query(QueryOptions(
+    document: gql('query Dashboard { stats { count } alerts { id } }'),
+  ));
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/dashboard.dart", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/stats",
+		"http:GRAPHQL:/graphql/Query/alerts",
+	}, "dart-gql-client-query")
+}
+
+// TestDartGraphQLClient_Subscription covers a subscription gql doc, asserting
+// the Subscription root type mapping.
+func TestDartGraphQLClient_Subscription(t *testing.T) {
+	src := `
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+final SUB = gql(r'''
+  subscription OnMessage {
+    messageAdded { id body }
+  }
+''');
+
+Widget build(BuildContext ctx) {
+  return Subscription(options: SubscriptionOptions(document: SUB), builder: (r) => Text("x"));
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/chat.dart", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Subscription/messageAdded",
+	}, "dart-gql-subscription")
+}
+
+// TestDartGraphQLClient_NegativeRest asserts a Dart file with only a REST
+// dio.get call (no gql) produces NO GraphQL operation entity.
+func TestDartGraphQLClient_NegativeRest(t *testing.T) {
+	src := `
+import 'package:dio/dio.dart';
+
+Future<void> load() async {
+  await dio.get("/users");
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/rest.dart", src)
+	for _, id := range ids {
+		if len(id) >= 14 && id[:14] == "http:GRAPHQL:/" {
+			t.Errorf("dart-gql-neg-rest: unexpected GraphQL op %q from a REST-only file", id)
+		}
+	}
+}
+
+// TestDartGraphQLClient_NegativePlainString asserts a non-GraphQL raw string
+// that merely looks like braces does not yield a GraphQL operation.
+func TestDartGraphQLClient_NegativePlainString(t *testing.T) {
+	src := `
+class Config {
+  final String template = r'{ just a plain string }';
+}
+`
+	ids, _ := runDetectWithRels(t, "dart", "lib/config.dart", src)
+	for _, id := range ids {
+		if len(id) >= 14 && id[:14] == "http:GRAPHQL:/" {
+			t.Errorf("dart-gql-neg-plain: unexpected GraphQL op %q from a plain string", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_swift_client.go
+++ b/internal/engine/http_endpoint_swift_client.go
@@ -93,6 +93,15 @@ type swiftClientEmitFn func(method, canonicalPath, framework, refKind, refName s
 // from applyHTTPEndpointSynthesis. Emits one outbound http_endpoint_call per
 // URLSession / Alamofire call site + a FETCHES edge from the enclosing func.
 func synthesizeSwiftClientWithRuntime(content string, emit swiftClientEmitFn) {
+	// GraphQL client operations (Apollo-iOS `apollo.fetch/perform/subscribe`)
+	// emit honest-partial operation references keyed to the server endpoint shape
+	// http:GRAPHQL:/graphql/<Root>/<OpName> (#4036). Run BEFORE the REST
+	// early-exit guard below, since a pure-Apollo Swift file may contain none of
+	// the URLSession / Alamofire markers.
+	if strings.Contains(content, "apollo") || strings.Contains(content, "Apollo") {
+		synthesizeSwiftGraphQLClient(content, indexSwiftFuncs(content), emit)
+	}
+
 	if !strings.Contains(content, "URL(string:") && !strings.Contains(content, "URL(string :") &&
 		!strings.Contains(content, ".request(") && !strings.Contains(content, "URLSession") &&
 		!strings.Contains(content, "AF.") {

--- a/internal/engine/http_endpoint_swift_graphql_client.go
+++ b/internal/engine/http_endpoint_swift_graphql_client.go
@@ -1,0 +1,126 @@
+// Swift (iOS) Apollo-iOS GraphQL client-side (consumer) operation synthesis
+// (#4036, epic #3872; mirrors the JS/TS GraphQL client pass in
+// http_endpoint_graphql_client.go and the Dart pass in
+// http_endpoint_dart_graphql_client.go).
+//
+// Apollo-iOS does NOT embed the GraphQL document at the Swift call site. The
+// Apollo codegen reads `.graphql` operation files and generates one Swift type
+// per operation — `GetUserQuery`, `AddUserMutation`, `OnMessageSubscription` —
+// which the app instantiates and passes to the client:
+//
+//	apollo.fetch(query: GetUserQuery()) { result in ... }
+//	apollo.perform(mutation: AddUserMutation(name: name)) { ... }
+//	apollo.subscribe(subscription: OnMessageSubscription()) { ... }
+//
+// Because the selected ROOT FIELD lives only in the generated/.graphql file —
+// not in the Swift source we are scanning — the Swift call site carries just
+// the operation NAME and KIND (encoded in the generated type's name + the
+// fetch/perform/subscribe verb). This is an HONEST-PARTIAL: we emit one
+// operation REFERENCE per call site, keyed on the operation NAME under the
+// matching root type:
+//
+//	apollo.fetch(query: GetUserQuery())  →  http:GRAPHQL:/graphql/Query/GetUser
+//
+// plus a FETCHES edge from the enclosing func — exactly the same shape and
+// mechanism as the JS/TS `graphql_client_unresolved` path (where a gql const
+// is imported cross-file and its root field cannot be resolved locally). The
+// operation therefore becomes DISCOVERABLE on the iOS side; it does NOT
+// guarantee a field-level cross-repo link to the backend resolver (the server
+// endpoint is keyed on the schema field, not the operation name), which is why
+// the framework label is `apollo_ios_unresolved`. Full field resolution would
+// require parsing the companion `.graphql` files; that is deferred (#4036).
+//
+// The generated-type recognition is intentionally NARROW: only identifiers
+// passed as the `query:`/`mutation:`/`subscription:` argument of an
+// `apollo`-receiver `.fetch`/`.perform`/`.subscribe` call are treated as
+// operations, so an arbitrary `SearchQuery()` constructor used elsewhere is
+// never mis-attributed.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// swiftApolloOpRe matches an Apollo-iOS client operation call and captures the
+// generated operation type name:
+//
+//	apollo.fetch(query: GetUserQuery())
+//	store.apollo.perform(mutation: AddUserMutation(name: x))
+//	client.subscribe(subscription: OnMessageSubscription())
+//
+// Receiver allow-list (left of the `.`): an identifier ending in / equal to
+// `apollo` or `client` (apollo, _apollo, apolloClient, client). Group 1 = the
+// method (fetch/perform/subscribe), group 2 = the argument label
+// (query/mutation/subscription), group 3 = the generated operation type name.
+//
+// The argument-label ↔ method pairing is enforced by the label→kind map below
+// (fetch/query, perform/mutation, subscribe/subscription), so a mismatched
+// `apollo.fetch(mutation: ...)` is not silently coerced.
+var swiftApolloOpRe = regexp.MustCompile(
+	`\b(?:[A-Za-z_]\w*\.)?(?:apollo|_apollo|apolloClient|client)\s*\.\s*(fetch|perform|subscribe)\s*\(\s*(query|mutation|subscription)\s*:\s*([A-Za-z_]\w*)\s*\(`,
+)
+
+// swiftApolloArgLabelToRoot maps the Apollo call argument label to the GraphQL
+// server root-type name used in the synthetic path.
+var swiftApolloArgLabelToRoot = map[string]string{
+	"query":        "Query",
+	"mutation":     "Mutation",
+	"subscription": "Subscription",
+}
+
+// swiftApolloTypeSuffix maps a root type to the conventional generated-type
+// name suffix Apollo-iOS appends (GetUserQuery, AddUserMutation,
+// OnMessageSubscription) so the operation NAME can be recovered.
+var swiftApolloTypeSuffix = map[string]string{
+	"Query":        "Query",
+	"Mutation":     "Mutation",
+	"Subscription": "Subscription",
+}
+
+// synthesizeSwiftGraphQLClient scans a Swift file for Apollo-iOS client
+// operations and emits one honest-partial operation reference per call site,
+// keyed on the operation NAME under the matching root type, plus a FETCHES edge
+// from the enclosing func.
+//
+// It is invoked from synthesizeSwiftClientWithRuntime so it shares the Swift
+// dispatch and the runtime-aware emitter.
+func synthesizeSwiftGraphQLClient(content string, funcs []jsFuncSpan, emit swiftClientEmitFn) {
+	// File-signal gate: require an Apollo client marker so this is a no-op on
+	// ordinary URLSession/Alamofire Swift files.
+	if !strings.Contains(content, "apollo") && !strings.Contains(content, "Apollo") {
+		return
+	}
+
+	for _, m := range swiftApolloOpRe.FindAllStringSubmatchIndex(content, -1) {
+		label := content[m[4]:m[5]]
+		typeName := content[m[6]:m[7]]
+		root, ok := swiftApolloArgLabelToRoot[label]
+		if !ok {
+			continue
+		}
+
+		// Recover the operation NAME by trimming the conventional Apollo type
+		// suffix (GetUserQuery → GetUser). If the generated type does not carry
+		// the expected suffix (non-conventional codegen config), keep the full
+		// type name — still a discoverable, correctly-rooted operation reference.
+		opName := typeName
+		if suffix := swiftApolloTypeSuffix[root]; suffix != "" && strings.HasSuffix(typeName, suffix) && len(typeName) > len(suffix) {
+			opName = strings.TrimSuffix(typeName, suffix)
+		}
+		if opName == "" {
+			continue
+		}
+
+		path := "/graphql/" + root + "/" + opName
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		caller := enclosingSwiftFuncAt(funcs, m[0])
+		// runtimeDynamic=false: the operation reference is statically resolved from
+		// the generated type name (the endpoint ID itself is concrete). It is an
+		// honest-PARTIAL only in that the root FIELD — and thus a guaranteed
+		// field-level cross-repo link — is unresolved without the .graphql file.
+		emit(gqlVerb, canonical, "apollo_ios_unresolved", "Function", caller, false)
+	}
+}

--- a/internal/engine/http_endpoint_swift_graphql_client_test.go
+++ b/internal/engine/http_endpoint_swift_graphql_client_test.go
@@ -1,0 +1,116 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// gqlOpIDsFrom returns the GraphQL operation synthetic IDs from a detect run.
+func gqlOpIDsFrom(ids []string) []string {
+	var out []string
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:GRAPHQL:/") {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// TestSwiftGraphQLClient_FetchQuery covers the canonical Apollo-iOS idiom
+// `apollo.fetch(query: GetUserQuery())`. Apollo-iOS code-generates the
+// operation type from a `.graphql` file, so the Swift call site carries ONLY
+// the operation NAME (GetUser), not the selected root field — the field lives
+// in the generated/.graphql file. Honest-partial: we emit an operation
+// REFERENCE keyed on the operation name + Query kind
+// (http:GRAPHQL:/graphql/Query/GetUser) so the operation is discoverable, plus
+// the FETCHES edge from the enclosing func. (This does NOT guarantee a
+// cross-repo field-level link; see the file header.)
+func TestSwiftGraphQLClient_FetchQuery(t *testing.T) {
+	src := `
+import Apollo
+
+class UserService {
+  let apollo: ApolloClient
+
+  func loadUser() {
+    apollo.fetch(query: GetUserQuery()) { result in
+      print(result)
+    }
+  }
+}
+`
+	ids, rels := runDetectWithRels(t, "swift", "UserService.swift", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/GetUser",
+	}, "swift-apollo-fetch-query")
+	requireFetches(t, rels, "http:GRAPHQL:/graphql/Query/GetUser", "swift-apollo-fetch-query")
+}
+
+// TestSwiftGraphQLClient_PerformMutation covers
+// `apollo.perform(mutation: AddUserMutation(...))`, asserting the Mutation kind
+// and the operation name AddUser.
+func TestSwiftGraphQLClient_PerformMutation(t *testing.T) {
+	src := `
+import Apollo
+
+func addUser(_ apollo: ApolloClient, name: String) {
+  apollo.perform(mutation: AddUserMutation(name: name)) { result in
+  }
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "AddUserService.swift", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Mutation/AddUser",
+	}, "swift-apollo-perform-mutation")
+}
+
+// TestSwiftGraphQLClient_Subscription covers
+// `apollo.subscribe(subscription: OnMessageSubscription())`.
+func TestSwiftGraphQLClient_Subscription(t *testing.T) {
+	src := `
+import Apollo
+
+func listen(_ apollo: ApolloClient) {
+  apollo.subscribe(subscription: OnMessageSubscription()) { _ in }
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "Chat.swift", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Subscription/OnMessage",
+	}, "swift-apollo-subscription")
+}
+
+// TestSwiftGraphQLClient_NegativeRest asserts an Alamofire REST call yields no
+// GraphQL operation entity.
+func TestSwiftGraphQLClient_NegativeRest(t *testing.T) {
+	src := `
+import Alamofire
+
+func load() {
+  AF.request("/users", method: .get)
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "Rest.swift", src)
+	if ops := gqlOpIDsFrom(ids); len(ops) != 0 {
+		t.Errorf("swift-gql-neg-rest: unexpected GraphQL ops %v from a REST-only file", ops)
+	}
+}
+
+// TestSwiftGraphQLClient_NegativeNonApollo asserts a Swift type whose name
+// merely ends in Query but is NOT passed to an apollo.fetch/perform/subscribe
+// call yields nothing (avoids attributing arbitrary `*Query()` constructors).
+func TestSwiftGraphQLClient_NegativeNonApollo(t *testing.T) {
+	src := `
+struct SearchQuery {
+  let term: String
+}
+
+func build() -> SearchQuery {
+  return SearchQuery(term: "x")
+}
+`
+	ids, _ := runDetectWithRels(t, "swift", "Search.swift", src)
+	if ops := gqlOpIDsFrom(ids); len(ops) != 0 {
+		t.Errorf("swift-gql-neg-nonapollo: unexpected GraphQL ops %v from a non-Apollo Query type", ops)
+	}
+}


### PR DESCRIPTION
Closes #4036 (epic #3872, mobile audit #3888).

## What
Mobile GraphQL clients were uncovered. This builds operation extraction + cross-repo linking for both mobile languages, mirroring the JS/TS GraphQL client pass (`http_endpoint_graphql_client.go`, #3608). Each recognised operation emits one `http_endpoint_call` keyed to the GraphQL server endpoint shape `http:GRAPHQL:/graphql/<RootType>/<field>` + a FETCHES edge, so the existing Name-based cross-repo HTTP linker pairs the mobile screen with the backend resolver on reindex — no new linker code.

## Dart graphql_flutter — FULL
`internal/engine/http_endpoint_dart_graphql_client.go` parses the inline `gql(r'''...''')` document, derives the operation root type (Query/Mutation/Subscription) and root fields via the shared `gqlRootFieldsFromDoc`, and emits one concrete operation endpoint per root field. Top-level `gql` consts have their FETCHES caller resolved from the reference site (the widget `build()`/method).

Value-asserted (`http_endpoint_dart_graphql_client_test.go`):
- `gql(r'''query GetUser { user { id name } }''')` → `http:GRAPHQL:/graphql/Query/user`
- inline `createUser` mutation → `Mutation/createUser`
- multi-field `query Dashboard { stats {} alerts {} }` → both endpoints
- `subscription OnMessage { messageAdded {} }` → `Subscription/messageAdded`
- Negatives: REST `dio.get` and a plain brace string emit nothing.

## Swift Apollo-iOS — HONEST-PARTIAL
`internal/engine/http_endpoint_swift_graphql_client.go` recognises `apollo.fetch/perform/subscribe(query|mutation|subscription: *Query()/*Mutation()/*Subscription())` and emits one operation REFERENCE keyed on the operation NAME (recovered from the generated type by trimming the kind suffix). **Partial** because Apollo-iOS code-generates operations from a `.graphql` file, so the selected root FIELD is not present at the Swift call site — the entity is keyed on the operation name (discoverable), not the schema field, so a guaranteed field-level cross-repo link is **deferred** (framework label `apollo_ios_unresolved`). Full field resolution requires parsing the companion `.graphql` files (deferred, #4036).

Value-asserted (`http_endpoint_swift_graphql_client_test.go`):
- `apollo.fetch(query: GetUserQuery())` → `Query/GetUser`
- `apollo.perform(mutation: AddUserMutation())` → `Mutation/AddUser`
- `apollo.subscribe(subscription: OnMessageSubscription())` → `Subscription/OnMessage`
- Negatives: Alamofire REST call and a bare `SearchQuery()` constructor emit nothing.

## Coverage
Two new mobile `http_framework` records, taxonomy cells seeded, docs regenerated:
- `lang.dart.framework.graphql-flutter` — `http_effect=full`
- `lang.swift.framework.apollo-ios` — `http_effect=partial`

`covtool validate` ok (0 errors; the `http_effect`-has-no-mapping-entry warnings match the established alamofire/urlsession precedent — 180 such pre-existing). `fmt` canonical, `gen` idempotent.

## Verification
- Full package tests green: `internal/custom/dart` `internal/custom/swift` `internal/engine` `internal/extractors` `internal/types` `tools/coverage`
- `go vet ./internal/engine/` clean, `gofmt` empty on all touched files
- VERIFY-FIRST: probes confirmed zero GraphQL operations for both languages before the build; negatives held throughout
- No custom extractor key added (these are engine synthesis passes), so dispatch-parity is unaffected; `TestEveryRegisteredCustomKeyDispatches` still green

**DEPLOY-DEFERRED**: engine-pass + registry change; takes effect on the next coordinated daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)