### PR TITLE
coverage(php): credit di_injection_point on Slim/Laminas/Lumen/Magento (#4058)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -85,13 +85,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 10/11 | |
 | [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 8/11 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -31,13 +31,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 10/11 | |
 | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
+| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 8/11 | |
 | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -68,7 +68,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/php/di_graph.go`<br>`internal/custom/php/di_graph_test.go` | Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface->ClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints => no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -68,7 +68,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/php/di_graph.go`<br>`internal/custom/php/di_graph_test.go` | Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface->ClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints => no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -68,7 +68,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/php/di_graph.go`<br>`internal/custom/php/di_graph_test.go` | Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface->ClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints => no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -68,7 +68,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
-| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🟢 `partial` | `2026-06-03` | — | `internal/custom/php/di_graph.go`<br>`internal/custom/php/di_graph_test.go` | Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface->ClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints => no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED. |
 | DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
 
 ### Testing

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -50278,8 +50278,10 @@
             "issue": "3628"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/php/di_graph.go","internal/custom/php/di_graph_test.go"],
+            "notes": "Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface-\u003eClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints =\u003e no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
             "status": "missing",
@@ -51107,8 +51109,10 @@
             "issue": "3628"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/php/di_graph.go","internal/custom/php/di_graph_test.go"],
+            "notes": "Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface-\u003eClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints =\u003e no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
             "status": "missing",
@@ -51392,8 +51396,10 @@
             "issue": "3628"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/php/di_graph.go","internal/custom/php/di_graph_test.go"],
+            "notes": "Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface-\u003eClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints =\u003e no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
             "status": "missing",
@@ -51962,8 +51968,10 @@
             "issue": "3628"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "partial",
+            "cites": ["internal/custom/php/di_graph.go","internal/custom/php/di_graph_test.go"],
+            "notes": "Constructor type-hint autowiring via the framework-agnostic php-di path: a class __construct(SomeInterface $p, ...) emits INJECTED_INTO(SomeInterface-\u003eClassName) per class-typed param, fired by di_graph.go's phpClasses() loop on any .php file (not gated to a framework). Value-asserted on this framework's idiom (TestPhpDI_Slim/Laminas/Lumen/Magento_ConstructorInjection in di_graph_test.go) and the shared TestPhpDI_ConstructorInjection; negative TestPhpDI_ScalarParamNoEdge (string/int/array hints =\u003e no edge). PARTIAL: constructor injection only -- method/property/contextual injection not linked; impl resolves cross-file via resolver. Credit-only #4058 (epic #3872, audit #3881); DEPLOY-DEFERRED.",
+            "verified_at": "2026-06-03"
           },
           "di_scope_resolution": {
             "status": "missing",

--- a/internal/custom/php/di_graph_test.go
+++ b/internal/custom/php/di_graph_test.go
@@ -105,3 +105,81 @@ func TestPhpDI_SymfonyServicesYAML(t *testing.T) {
 		t.Fatalf("expected BINDS(TransportInterface -> SmtpTransport); got %+v", rels)
 	}
 }
+
+// Slim (PHP-DI / PSR-11): an action class autowired via constructor type-hint.
+// The framework-agnostic php-di path must emit INJECTED_INTO for the Slim idiom.
+func TestPhpDI_Slim_ConstructorInjection(t *testing.T) {
+	src := `<?php
+namespace App\Action;
+
+final class ListUsersAction {
+    public function __construct(
+        private UserRepository $users,
+        LoggerInterface $logger
+    ) {}
+
+    public function __invoke($request, $response) { return $response; }
+}`
+	rels := phpDIEdges(t, "src/Action/ListUsersAction.php", src)
+	if !phpHasEdge(rels, "UserRepository", "ListUsersAction", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(UserRepository -> ListUsersAction); got %+v", rels)
+	}
+	if !phpHasEdge(rels, "LoggerInterface", "ListUsersAction", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(LoggerInterface -> ListUsersAction); got %+v", rels)
+	}
+}
+
+// Laminas / Mezzio (laminas-servicemanager): handlers receive collaborators via
+// constructor, produced by a factory. The constructor type-hint is the idiom.
+func TestPhpDI_Laminas_ConstructorInjection(t *testing.T) {
+	src := `<?php
+namespace App\Handler;
+
+class HomePageHandler implements RequestHandlerInterface {
+    public function __construct(private TemplateRendererInterface $renderer) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface {}
+}`
+	rels := phpDIEdges(t, "src/Handler/HomePageHandler.php", src)
+	if !phpHasEdge(rels, "TemplateRendererInterface", "HomePageHandler", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(TemplateRendererInterface -> HomePageHandler); got %+v", rels)
+	}
+}
+
+// Lumen (= Laravel container): controllers autowire collaborators via constructor.
+func TestPhpDI_Lumen_ConstructorInjection(t *testing.T) {
+	src := `<?php
+namespace App\Http\Controllers;
+
+class UserController extends Controller {
+    public function __construct(private UserService $service, AuthManager $auth) {}
+}`
+	rels := phpDIEdges(t, "app/Http/Controllers/UserController.php", src)
+	if !phpHasEdge(rels, "UserService", "UserController", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(UserService -> UserController); got %+v", rels)
+	}
+	if !phpHasEdge(rels, "AuthManager", "UserController", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(AuthManager -> UserController); got %+v", rels)
+	}
+}
+
+// Magento (ObjectManager constructor DI): every class declares its dependencies
+// as constructor type-hints; the ObjectManager autowires them.
+func TestPhpDI_Magento_ConstructorInjection(t *testing.T) {
+	src := `<?php
+namespace Vendor\Module\Model;
+
+class Product {
+    public function __construct(
+        ProductRepositoryInterface $productRepository,
+        private StoreManagerInterface $storeManager
+    ) {}
+}`
+	rels := phpDIEdges(t, "Model/Product.php", src)
+	if !phpHasEdge(rels, "ProductRepositoryInterface", "Product", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(ProductRepositoryInterface -> Product); got %+v", rels)
+	}
+	if !phpHasEdge(rels, "StoreManagerInterface", "Product", string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(StoreManagerInterface -> Product); got %+v", rels)
+	}
+}


### PR DESCRIPTION
Closes #4058. Epic #3872, audit #3881.

## What
The php-di constructor-injection path in `internal/custom/php/di_graph.go` is **framework-agnostic**: it iterates `phpClasses(src)` over EVERY class, finds `__construct(Interface $x, ...)` and emits `INJECTED_INTO(Interface -> Class)` tagged `framework="php-di"`/`via="php_constructor"`. It is NOT gated to Laravel/Symfony, yet `DI.di_injection_point` was credited `partial` only on those two.

This **registry-only** credit wave flips `di_injection_point` = `partial` on the four high-confidence PSR-11 / constructor-autowiring frameworks, mirroring the laravel/symfony sibling exactly (same cites `[di_graph.go, di_graph_test.go]`, partial = constructor-only).

## Cells flipped (4)
| Framework | before | after | injection-point asserted |
|---|---|---|---|
| Slim | `missing` | `partial` | `UserRepository`,`LoggerInterface` -> `ListUsersAction` |
| Laminas/Mezzio | `missing` | `partial` | `TemplateRendererInterface` -> `HomePageHandler` |
| Lumen | `missing` | `partial` | `UserService`,`AuthManager` -> `UserController` |
| Magento | `missing` | `partial` | `ProductRepositoryInterface`,`StoreManagerInterface` -> `Product` |

Already-credited siblings (laravel, symfony) untouched. `di_binding_extraction` / `di_scope_resolution` are correctly framework-gated (Laravel container / Symfony services.yaml) and left `missing` — honest scope: injection-point only.

Yii/Phalcon/CakePHP intentionally NOT credited (per ticket: only with a confirming idiomatic fixture; deferred as conservative).

## Verification (VERIFY-FIRST, value-asserting)
- Confirmed each cell's CURRENT status = `missing` on live main `c034a7c8a` before flipping.
- One value-asserting fixture per framework on its real idiom (constructor promotion + namespaced classes), each named `INJECTED_INTO`-asserting (not len>0): `TestPhpDI_{Slim,Laminas,Lumen,Magento}_ConstructorInjection` — all pass.
- Group placement: under `DI`, between `di_binding_extraction` and `di_scope_resolution`, identical to laravel sibling.

## Gates
- `go run ./tools/coverage validate` — 0 errors (pre-existing warnings only)
- `fmt --check` — canonical
- `gen` — 0 drift (regenerated detail/by-language/by-category docs committed)
- `gofmt -l` empty, `go vet` clean
- Full package tests green: `go test ./internal/custom/php/ ./tools/coverage/`

**DEPLOY-DEFERRED**: live-daemon reindex is a separate coordinated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)