### PR TITLE
feat(coverage): credit pgx + bun transaction_function_stamping partial (#4063)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -43,7 +43,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🔴 0/4 | |
 | [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🔴 0/4 | |
 | [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/6 | |
-| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/11 | |
+| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 9/11 | |
 | [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | 🟡 10/11 | |
 | [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/11 | |
 | [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/6 | |
@@ -55,7 +55,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/7 | |
 | [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/6 | |
 | [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/6 | |
-| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/7 | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 5/7 | |
 | [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/7 | |
 | [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/8 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/9 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -81,7 +81,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 3/6 | |
-| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 8/11 | |
+| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 9/11 | |
 | [GORM](../detail/lang.go.orm.gorm.md) | 🟡 10/11 | |
 | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 8/11 | |
 | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟡 3/6 | |
@@ -93,7 +93,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 4/7 | |
 | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 3/6 | |
 | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 3/6 | |
-| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 4/7 | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 5/7 | |
 | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/7 | |
 | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/8 | |
 | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/9 | |

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 | [`lang.c-cpp.driver.libpqxx`](./lang.c-cpp.driver.libpqxx.md) | C/C++ | driver | 3 full, 3 missing, 5 n/a |
 | [`lang.csharp.driver.npgsql`](./lang.csharp.driver.npgsql.md) | C# | driver | 4 missing, 7 n/a |
 | [`lang.elixir.driver.postgrex`](./lang.elixir.driver.postgrex.md) | elixir | driver | 4 missing, 7 n/a |
-| [`lang.go.orm.pgx`](./lang.go.orm.pgx.md) | go | orm | 1 full, 3 partial, 3 missing, 4 n/a |
+| [`lang.go.orm.pgx`](./lang.go.orm.pgx.md) | go | orm | 1 full, 4 partial, 2 missing, 4 n/a |
 | [`lang.jsts.driver.postgres`](./lang.jsts.driver.postgres.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.php.driver.postgres`](./lang.php.driver.postgres.md) | php | driver | 1 partial, 4 missing, 6 n/a |
 | [`lang.python.driver.postgres`](./lang.python.driver.postgres.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |

--- a/docs/coverage/detail/lang.go.orm.bun.md
+++ b/docs/coverage/detail/lang.go.orm.bun.md
@@ -45,7 +45,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
+| Transaction function stamping | 🟢 `partial` | `2026-06-03` | 4063 | `internal/extractors/golang/extractor.go`<br>`internal/txscope/txscope.go`<br>`internal/txscope/txscope_test.go` | #4063: the generic txscope.DetectGo stamper fires on bun's database/sql-compatible surface — db.Begin() stamps transactional=true (tx_source=go_sql_begin) on the enclosing fn. Partial, not full: the bun-idiomatic db.RunInTx(ctx, ...) closure form does NOT fire; no transitive propagation. Tested by TestDetectGo_PgxBun. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -45,7 +45,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction function stamping | 🔴 `missing` | — | 3628-transaction-function-stamping | — | — |
+| Transaction function stamping | 🟢 `partial` | `2026-06-03` | 4063 | `internal/extractors/golang/extractor.go`<br>`internal/txscope/txscope.go`<br>`internal/txscope/txscope_test.go` | #4063: the generic txscope.DetectGo stamper fires on pgx's database/sql-compatible surface — pool.BeginTx(ctx, pgx.TxOptions{}) stamps transactional=true (tx_source=go_sql_begin_tx) on the enclosing fn. Partial, not full: the pgx-idiomatic conn.Begin(ctx) (non-empty parens) does NOT fire (goBeginRE requires Begin()); no transitive propagation. Tested by TestDetectGo_PgxBun. |
 
 ## Related extraction records
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -23668,8 +23668,11 @@
         },
         "Transactions": {
           "transaction_function_stamping": {
-            "status": "missing",
-            "issue": "3628-transaction-function-stamping"
+            "status": "partial",
+            "cites": ["internal/extractors/golang/extractor.go","internal/txscope/txscope.go","internal/txscope/txscope_test.go"],
+            "issue": "4063",
+            "notes": "#4063: the generic txscope.DetectGo stamper fires on bun's database/sql-compatible surface — db.Begin() stamps transactional=true (tx_source=go_sql_begin) on the enclosing fn. Partial, not full: the bun-idiomatic db.RunInTx(ctx, ...) closure form does NOT fire; no transitive propagation. Tested by TestDetectGo_PgxBun.",
+            "verified_at": "2026-06-03"
           }
         }
       }
@@ -24024,8 +24027,11 @@
         },
         "Transactions": {
           "transaction_function_stamping": {
-            "status": "missing",
-            "issue": "3628-transaction-function-stamping"
+            "status": "partial",
+            "cites": ["internal/extractors/golang/extractor.go","internal/txscope/txscope.go","internal/txscope/txscope_test.go"],
+            "issue": "4063",
+            "notes": "#4063: the generic txscope.DetectGo stamper fires on pgx's database/sql-compatible surface — pool.BeginTx(ctx, pgx.TxOptions{}) stamps transactional=true (tx_source=go_sql_begin_tx) on the enclosing fn. Partial, not full: the pgx-idiomatic conn.Begin(ctx) (non-empty parens) does NOT fire (goBeginRE requires Begin()); no transitive propagation. Tested by TestDetectGo_PgxBun.",
+            "verified_at": "2026-06-03"
           }
         }
       }

--- a/internal/txscope/txscope_test.go
+++ b/internal/txscope/txscope_test.go
@@ -259,6 +259,59 @@ func TestDetectGo_BeginTxWithIsolation(t *testing.T) {
 	}
 }
 
+// TestDetectGo_PgxBun locks the honest-partial transaction-boundary that the
+// generic DetectGo stamper achieves for pgx and bun via the shared
+// database/sql-compatible Begin/BeginTx surface (#4063). The framework-idiomatic
+// forms (pgx conn.Begin(ctx), bun db.RunInTx) deliberately do NOT fire — these
+// negatives gate any future 'full' claim for either driver.
+func TestDetectGo_PgxBun(t *testing.T) {
+	// pgx positive: pool.BeginTx(ctx, pgx.TxOptions{}) — database/sql-compat
+	// BeginTx surface stamps a tx boundary on the enclosing fn.
+	pgxBeginTx := `func transfer(ctx context.Context, pool *pgxpool.Pool) error {
+    tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+    if err != nil { return err }
+    defer tx.Rollback(ctx)
+    return tx.Commit(ctx)
+  }`
+	if s := DetectGo(pgxBeginTx); !s.Transactional || s.Source != "go_sql_begin_tx" {
+		t.Fatalf("pgx pool.BeginTx(ctx, pgx.TxOptions{}) should stamp go_sql_begin_tx boundary, got %+v", s)
+	}
+
+	// bun positive: db.Begin() — empty-parens Begin stamps a tx boundary.
+	bunBegin := `func save(ctx context.Context, db *bun.DB) error {
+    tx, err := db.Begin()
+    if err != nil { return err }
+    defer tx.Rollback()
+    return tx.Commit()
+  }`
+	if s := DetectGo(bunBegin); !s.Transactional || s.Source != "go_sql_begin" {
+		t.Fatalf("bun db.Begin() should stamp go_sql_begin boundary, got %+v", s)
+	}
+
+	// pgx NEGATIVE: conn.Begin(ctx) — non-empty parens, the pgx-idiomatic form;
+	// goBeginRE requires Begin() so this must stay uncredited (honest-partial).
+	pgxConnBegin := `func work(ctx context.Context, conn *pgx.Conn) error {
+    tx, err := conn.Begin(ctx)
+    if err != nil { return err }
+    return tx.Commit(ctx)
+  }`
+	if s := DetectGo(pgxConnBegin); s.Transactional {
+		t.Fatalf("pgx conn.Begin(ctx) (non-empty parens) must NOT stamp — honest-partial boundary, got %+v", s)
+	}
+
+	// bun NEGATIVE: db.RunInTx(ctx, ...) — the bun-idiomatic closure form is not
+	// recognised by any DetectGo regex; must stay uncredited (honest-partial).
+	bunRunInTx := `func save(ctx context.Context, db *bun.DB) error {
+    return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+      _, err := tx.NewInsert().Model(&u).Exec(ctx)
+      return err
+    })
+  }`
+	if s := DetectGo(bunRunInTx); s.Transactional {
+		t.Fatalf("bun db.RunInTx(...) must NOT stamp — honest-partial boundary, got %+v", s)
+	}
+}
+
 func TestDetectGo_GormTransaction(t *testing.T) {
 	src := `func run(db *gorm.DB) error {
     return db.Transaction(func(tx *gorm.DB) error {


### PR DESCRIPTION
**Closes #4063** (epic #3872, from Go parity audit #3879). **DEPLOY-DEFERRED** — registry/docs + test only, no extractor/daemon change.

## What
`txscope.DetectGo` already fires on the `database/sql`-compatible Begin/BeginTx surface that pgx and bun expose — the same surface **sqlx is credited `full`** for — yet `lang.go.orm.pgx` and `lang.go.orm.bun` both read `transaction_function_stamping = missing` with no notes. This flips both `missing → partial` (registry-only).

## Honest status: partial (NOT full like sqlx)
sqlx sits on the plain `database/sql` path where `db.Begin()`/`BeginTx` *is* the canonical idiom (→ full). For pgx/bun only the `database/sql`-compat subset fires; the framework-native idioms are deliberately uncredited:

| driver | tx boundary asserted (positive) | tx_source | NEGATIVE (uncredited, idiomatic) |
|---|---|---|---|
| pgx | `pool.BeginTx(ctx, pgx.TxOptions{})` | `go_sql_begin_tx` | `conn.Begin(ctx)` (non-empty parens — `goBeginRE` requires `Begin()`) |
| bun | `db.Begin()` | `go_sql_begin` | `db.RunInTx(ctx, ...)` closure form |

No transitive propagation (a fn receiving a tx handle is not stamped).

## Verify-first
- Confirmed both cells `missing` on live main `dae575cc3` before editing.
- Empirically probed `DetectGo` against all four idioms (2 positive, 2 negative) — matches.
- Locked by **`TestDetectGo_PgxBun`** (value-asserting: named tx boundary per driver + the two negatives that gate a future `full` claim).

## Discipline
- Registry edited surgically by record (verified group placement under each ORM record's `Transactions`; bun cell owned by `lang.go.orm.bun`, pgx by `lang.go.orm.pgx` — confirmed by id-ownership scan after a mis-anchored first attempt was reverted).
- `covtool fmt --check`: canonical. `validate`: 0 errors (pre-existing unrelated capability-map warnings only). `gen`: 0 drift (regenerated bun.md, pgx.md, db.postgres.md rollup, by-category/by-language summaries).
- `go test ./internal/txscope/ ./tools/coverage/`: green. `gofmt -l`: empty. `go vet`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)