### PR TITLE
fix(coverage): honest datastore cites — re-cite 7 under-cited cells + downgrade 2 query_attribution (Closes #3637)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -59,7 +59,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 4/7 | |
 | [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/8 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/9 | |
-| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/6 | |
+| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 2/6 | |
 | [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/10 | |
 | [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/10 | |
 | [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/10 | |
@@ -165,5 +165,5 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/6 | |
 | [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/8 | |
 | [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/9 | |
-| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/6 | |
+| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 2/6 | |
 | [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/10 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -96,7 +96,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 3/6 | |
+| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 2/6 | |
 | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/10 | |
 | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/10 | |
 | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/10 | |

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -73,5 +73,5 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 3/6 | |
 | [Quill](../detail/lang.scala.orm.quill.md) | 🟡 5/8 | |
 | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | 🟡 6/9 | |
-| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 3/6 | |
+| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | 🟡 2/6 | |
 | [Slick](../detail/lang.scala.orm.slick.md) | 🟡 7/10 | |

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -25,13 +25,13 @@ one is a separate detail page.
 | [`lang.csharp.driver.dynamodb`](./lang.csharp.driver.dynamodb.md) | C# | driver | 1 partial, 4 missing, 6 n/a |
 | [`lang.elixir.driver.dynamodb`](./lang.elixir.driver.dynamodb.md) | elixir | driver | 4 missing, 7 n/a |
 | [`lang.go.driver.dynamodb`](./lang.go.driver.dynamodb.md) | go | driver | 3 partial, 3 missing, 5 n/a |
-| [`lang.java.orm.dynamodb`](./lang.java.orm.dynamodb.md) | java | orm | 2 full, 1 partial, 3 missing, 5 n/a |
+| [`lang.java.orm.dynamodb`](./lang.java.orm.dynamodb.md) | java | orm | 1 full, 1 partial, 4 missing, 5 n/a |
 | [`lang.jsts.driver.dynamodb`](./lang.jsts.driver.dynamodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.php.driver.dynamodb`](./lang.php.driver.dynamodb.md) | php | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.driver.dynamodb`](./lang.python.driver.dynamodb.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.ruby.driver.dynamodb`](./lang.ruby.driver.dynamodb.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.dynamodb`](./lang.rust.driver.dynamodb.md) | rust | driver | 4 missing, 7 n/a |
-| [`lang.scala.orm.scanamo`](./lang.scala.orm.scanamo.md) | scala | orm | 1 full, 2 partial, 3 missing, 5 n/a |
+| [`lang.scala.orm.scanamo`](./lang.scala.orm.scanamo.md) | scala | orm | 1 full, 1 partial, 4 missing, 5 n/a |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ✅ `full` | `2026-05-29` | 3099 | `internal/engine/rules/java/orms/dynamodb_java.yaml` | YAML rule covers DynamoDbEnhancedClient scan/query operations; query_attribution fully covered by existing rule. |
+| Query attribution | 🔴 `missing` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3645) | — | Overstated cite corrected (#3637): dynamodb_java.yaml is detection-only (empty source_patterns/relationship_rules; the custom_extractors Python block never runs in Go) and dynamodb_java.go extracts only @DynamoDbBean model + @DynamoDbPartitionKey/SortKey/Attribute key schema — NO scan/query call-site attribution and no QUERIES edge. No native query-topology extractor exists; honest status is missing. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
+| Model extraction | 🟢 `partial` | `2026-06-03` | 3098 | `internal/custom/java/neo4j.go`<br>`internal/custom/java/neo4j_test.go` | Cite corrected (#3637): custom_java_neo4j (neo4j.go) emits one SCOPE.Schema/node per Spring Data Neo4j @Node and Neo4j OGM @NodeEntity class (value-asserting TestNeo4jNodeEntityExtracted / TestNeo4jOGMNodeEntityExtracted). Partial: regex, same-file @Property/@Id only — full document-shape mapping not parsed. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | 🟢 `partial` | — | 3098 | `internal/custom/java/neo4j.go` | No Neo4j Java ORM extractor; @Node annotation for node entity extraction not implemented. |
 

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` | — |
+| Model extraction | ✅ `full` | `2026-06-03` | 3064 | `internal/custom/javascript/extractors_test.go`<br>`internal/custom/javascript/mongoose.go` | Cite corrected (#3637): custom_js_mongoose (mongoose.go) emits a SCOPE.Schema/model entity per mongoose.model("Name", schema) call plus the new Schema({...}) definition; matches the already-cited sibling schema_extraction cell. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_test.go`<br>`internal/custom/javascript/mongoose.go` | — |
 

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
+| Model extraction | 🟢 `partial` | `2026-06-03` | 3072 | `internal/custom/python/orm_schema.go`<br>`internal/custom/python/orm_schema_test.go` | Cite corrected (#3637): python_beanie_schema (BeanieSchemaExtractor) emits a SCOPE.Schema document-model entity per Beanie Document subclass plus annotated field entities (value-asserting TestBeanieSchema_DocumentEmitted / TestBeanieSchema_FieldsEmitted). Partial: Pydantic-typed field depth limited. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | 🟢 `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities. |
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
+| Model extraction | 🟢 `partial` | `2026-06-03` | 3072 | `internal/custom/python/orm_schema.go`<br>`internal/custom/python/orm_schema_test.go` | Cite corrected (#3637): python_mongoengine_schema (MongoEngineSchemaExtractor) emits a SCOPE.Schema document-model entity per MongoEngine Document subclass plus StringField/IntField/etc field entities (value-asserting TestMongoEngineSchema_DocumentEmitted / TestMongoEngineSchema_FieldsEmitted). Partial: field-type depth limited. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | 🟢 `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema. |
 

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
+| Model extraction | 🟢 `partial` | `2026-06-03` | 3625 | `internal/custom/scala/orm_extractors.go`<br>`internal/custom/scala/orm_extractors_test.go` | Cite corrected (#3637): custom_scala_elastic4s (elastic4sExtractor) emits SCOPE.Schema document models from case class defs, HitReader[T]/HitWriter[T] mappings, and createIndex/indexInto index defs (value-asserting TestElastic4sHitReader / TestElastic4sIndexValues). Partial: field-level document mapping not parsed. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | ✅ `full` | — | — | `internal/custom/scala/orm_extractors.go` | elastic4sIndexRe captures createIndex/indexInto index defs; elastic4sHitReaderRe captures HitReader[T]/HitWriter[T] document type mappings; elastic4sCaseClassRe captures document case classes |
 
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-06-03` | 3625 | `internal/custom/scala/orm_extractors.go`<br>`internal/custom/scala/orm_extractors_test.go` | Cite corrected (#3637): elastic4sSearchRe captures search("index") calls and emits SCOPE.Operation/query carrying the target index_name (value-asserting TestElastic4sSearch / TestElastic4sSearchAndHitValues). Partial: index-level attribution only — query-body / DSL clause structure not parsed. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
+| Model extraction | 🟢 `partial` | `2026-06-03` | 3625 | `internal/custom/scala/orm_extractors.go`<br>`internal/custom/scala/orm_extractors_test.go` | Cite corrected (#3637): custom_scala_scanamo (scanamoExtractor) emits SCOPE.Schema for Table[T]("name") DynamoDB table defs, item case classes, and DynamoFormat[T] derivations (value-asserting TestScanamoTableDef / TestScanamoTableValues). Partial: field-level item schema not parsed. |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
 | Schema extraction | ✅ `full` | — | — | `internal/custom/scala/orm_extractors.go` | scanamoTableRe captures Table[T]("name") DynamoDB table defs; scanamoDynamoFormatRe captures DynamoFormat[T] implicit derivations; scanamoCaseClassRe captures item case classes |
 
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
+| Query attribution | 🔴 `missing` | `2026-06-03` | [link](https://github.com/cajasmota/archigraph/issues/3645) | — | Overstated cite corrected (#3637): scanamo.yaml is detection-only (empty source_patterns/relationship_rules; dead custom_extractors Python block) and custom_scala_scanamo emits only table-def / item-model SCOPE.Schema entities — NO query/scan call-site SCOPE.Operation entity and no QUERIES edge. No native query-topology extractor exists; honest status is missing. |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -30898,11 +30898,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "full",
-            "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
-            "issue": "3099",
-            "notes": "YAML rule covers DynamoDbEnhancedClient scan/query operations; query_attribution fully covered by existing rule.",
-            "verified_at": "2026-05-29"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "Overstated cite corrected (#3637): dynamodb_java.yaml is detection-only (empty source_patterns/relationship_rules; the custom_extractors Python block never runs in Go) and dynamodb_java.go extracts only @DynamoDbBean model + @DynamoDbPartitionKey/SortKey/Attribute key schema — NO scan/query call-site attribution and no QUERIES edge. No native query-topology extractor exists; honest status is missing.",
+            "verified_at": "2026-06-03"
           }
         },
         "Migrations": {
@@ -31415,8 +31414,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/neo4j.go","internal/custom/java/neo4j_test.go"],
+            "issue": "3098",
+            "notes": "Cite corrected (#3637): custom_java_neo4j (neo4j.go) emits one SCOPE.Schema/node per Spring Data Neo4j @Node and Neo4j OGM @NodeEntity class (value-asserting TestNeo4jNodeEntityExtracted / TestNeo4jOGMNodeEntityExtracted). Partial: regex, same-file @Property/@Id only — full document-shape mapping not parsed.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -41851,8 +41852,10 @@
         "Models": {
           "model_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/javascript/extractors_test.go","internal/custom/javascript/mongoose.go"],
+            "issue": "3064",
+            "notes": "Cite corrected (#3637): custom_js_mongoose (mongoose.go) emits a SCOPE.Schema/model entity per mongoose.model(\"Name\", schema) call plus the new Schema({...}) definition; matches the already-cited sibling schema_extraction cell.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -60987,8 +60990,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/python/orm_schema.go","internal/custom/python/orm_schema_test.go"],
+            "issue": "3072",
+            "notes": "Cite corrected (#3637): python_beanie_schema (BeanieSchemaExtractor) emits a SCOPE.Schema document-model entity per Beanie Document subclass plus annotated field entities (value-asserting TestBeanieSchema_DocumentEmitted / TestBeanieSchema_FieldsEmitted). Partial: Pydantic-typed field depth limited.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -61146,8 +61151,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/python/orm_schema.go","internal/custom/python/orm_schema_test.go"],
+            "issue": "3072",
+            "notes": "Cite corrected (#3637): python_mongoengine_schema (MongoEngineSchemaExtractor) emits a SCOPE.Schema document-model entity per MongoEngine Document subclass plus StringField/IntField/etc field entities (value-asserting TestMongoEngineSchema_DocumentEmitted / TestMongoEngineSchema_FieldsEmitted). Partial: field-type depth limited.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -74515,8 +74522,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/scala/orm_extractors.go","internal/custom/scala/orm_extractors_test.go"],
+            "issue": "3625",
+            "notes": "Cite corrected (#3637): custom_scala_elastic4s (elastic4sExtractor) emits SCOPE.Schema document models from case class defs, HitReader[T]/HitWriter[T] mappings, and createIndex/indexInto index defs (value-asserting TestElastic4sHitReader / TestElastic4sIndexValues). Partial: field-level document mapping not parsed.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -74553,8 +74562,10 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/scala/orm_extractors.go","internal/custom/scala/orm_extractors_test.go"],
+            "issue": "3625",
+            "notes": "Cite corrected (#3637): elastic4sSearchRe captures search(\"index\") calls and emits SCOPE.Operation/query carrying the target index_name (value-asserting TestElastic4sSearch / TestElastic4sSearchAndHitValues). Partial: index-level attribution only — query-body / DSL clause structure not parsed.",
+            "verified_at": "2026-06-03"
           }
         },
         "Migrations": {
@@ -74727,8 +74738,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/scala/orm_extractors.go","internal/custom/scala/orm_extractors_test.go"],
+            "issue": "3625",
+            "notes": "Cite corrected (#3637): custom_scala_scanamo (scanamoExtractor) emits SCOPE.Schema for Table[T](\"name\") DynamoDB table defs, item case classes, and DynamoFormat[T] derivations (value-asserting TestScanamoTableDef / TestScanamoTableValues). Partial: field-level item schema not parsed.",
+            "verified_at": "2026-06-03"
           },
           "model_lifecycle_extraction": {
             "status": "missing",
@@ -74764,9 +74777,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3645",
+            "notes": "Overstated cite corrected (#3637): scanamo.yaml is detection-only (empty source_patterns/relationship_rules; dead custom_extractors Python block) and custom_scala_scanamo emits only table-def / item-model SCOPE.Schema entities — NO query/scan call-site SCOPE.Operation entity and no QUERIES edge. No native query-topology extractor exists; honest status is missing.",
+            "verified_at": "2026-06-03"
           }
         },
         "Migrations": {


### PR DESCRIPTION
Closes #3637 (child of #3625). **HONESTY/ACCURACY fix** — make the datastore coverage registry cite the real native Go extractor that backs each cell, and downgrade two `query_attribution` cells that no extractor actually backs. Each cell was **verified against the extractor source**; no cell was inflated. **DEPLOY-DEFERRED** (docs/registry only).

## Re-cited (status unchanged — real extractor confirmed by an existing value-asserting test)
| record · cell | status | new cite | proof test |
|---|---|---|---|
| java.orm.neo4j · model_extraction | partial | `internal/custom/java/neo4j.go` | `TestNeo4jNodeEntityExtracted` (SCOPE.Schema/node per @Node/@NodeEntity) |
| scala.orm.elastic4s · model_extraction | partial | `internal/custom/scala/orm_extractors.go` | `TestElastic4sHitReader` (case-class / HitReader / index defs) |
| scala.orm.elastic4s · query_attribution | partial | `internal/custom/scala/orm_extractors.go` | `TestElastic4sSearch` (`search("idx")` → SCOPE.Operation/query w/ index_name) |
| scala.orm.scanamo · model_extraction | partial | `internal/custom/scala/orm_extractors.go` | `TestScanamoTableDef` (Table[T]/case-class/DynamoFormat) |
| jsts.orm.mongoose · model_extraction | full | `internal/custom/javascript/mongoose.go` | matches already-cited sibling schema_extraction |
| python.orm.beanie · model_extraction | partial | `internal/custom/python/orm_schema.go` | `TestBeanieSchema_DocumentEmitted` |
| python.orm.mongoengine · model_extraction | partial | `internal/custom/python/orm_schema.go` | `TestMongoEngineSchema_DocumentEmitted` |

## Honest downgrades (no query call-site / no QUERIES edge in any extractor; cited YAML was detection-only with a dead `custom_extractors` Python block the Go engine never runs)
| record · cell | before → after | why |
|---|---|---|
| java.orm.dynamodb · query_attribution | **full → missing** (#3645) | `dynamodb_java.go` extracts only @DynamoDbBean model + @DynamoDbPartitionKey/SortKey/Attribute key schema — no scan/query call-site attribution. (Ticket guessed "downgrade to partial" via key schema, but key schema is model/schema, not query → honest status is `missing`.) |
| scala.orm.scanamo · query_attribution | **partial → missing** (#3645) | scanamo extractor emits only table-def / item-model SCOPE.Schema entities — zero query Operation entities. |

Both routed to **#3645**, matching the already-`missing` sibling `lang.java.orm.neo4j` query_attribution cell in the same registry.

## NOT downgraded — redis stays `full` (ticket premise was stale)
The ticket asked to downgrade `python.driver.redis · query_attribution` full→partial on the belief that `redis.go` lost key/channel/stream topology. **Verified against the code: that is no longer true.** `internal/custom/python/redis.go` (#3643, commit `45d482f15`, already on `main`) extracts concrete keys, prefix globs from concat/f-strings, and emits `READS_FROM`/`WRITES_TO`/`PUBLISHES_TO`/`SUBSCRIBES_TO` edges to SCOPE.Datastore keyspace targets — matching the JS `scanJSRedis` parity bar — with comprehensive value-asserting tests (`TestRedis_CacheOp_SetWritesTo`, `_ConcatPrefix`, `_FStringPrefix`, `_PubSub_Channel`, `_Stream_Key`, `_Keyspace_Dedup`). Downgrading would **under-credit real, tested extraction** and break honesty. Cell left unchanged (already `full`, cites `redis.go`, #3643, verified 2026-06-02).

## Cleanup
Added tracking issue `#3625` to the 3 re-cited scala partial cells, clearing pre-existing `partial capability has no tracking issue` warnings (validate warnings 8581 → 8578).

## Gates (all green)
- `covtool fmt --check`: canonical
- `covtool validate`: **0 errors**, 655 records
- `covtool gen`: 0 drift
- `go test ./tools/coverage/` (incl. `TestDatastoreCiteValidityGuard`): ok
- `go test ./internal/custom/{java,scala,javascript,python}/`: ok
- gofmt empty · go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)