### PR TITLE
RESTORE graphql client_tools: Relay const-ref hooks + JS/TS gql-client coverage row

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 227 records · **C/C++**: 19 · **C#**: 16 · **dart**: 2 · **elixir**: 14 · **go**: 20 · **java**: 22 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 5
+**Total**: 228 records · **C/C++**: 19 · **C#**: 16 · **dart**: 2 · **elixir**: 14 · **go**: 20 · **java**: 22 · **JS/TS**: 33 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -199,6 +199,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 17/17 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Client (Apollo Client / urql / Relay / graphql-request)](../detail/lang.jsts.framework.graphql-client.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🟡 1/8 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 21/21 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 19/19 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 32 · **Tools**: 21 · **ORMs**: 19 · **Other**: 4
+**Frameworks**: 33 · **Tools**: 21 · **ORMs**: 19 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -47,6 +47,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
 | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 17/17 | |
+| [GraphQL Client (Apollo Client / urql / Relay / graphql-request)](../detail/lang.jsts.framework.graphql-client.md) | 🔴 0/3 | 🔴 0/1 | 🟡 1/24 | 🟡 1/8 | |
 | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 21/21 | |
 | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 17/17 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 19/19 | |

--- a/docs/coverage/detail/lang.jsts.framework.graphql-client.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-client.md
@@ -1,0 +1,99 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.framework.graphql-client` — GraphQL Client (Apollo Client / urql / Relay / graphql-request)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | 🔴 `missing` | — | 3642 | — | — |
+| Context extraction | 🔴 `missing` | — | 3642 | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | 3642 | — | — |
+| Data fetching | ✅ `full` | `2026-06-03` | 3642 | `internal/engine/http_endpoint_client_synthesis.go`<br>`internal/engine/http_endpoint_graphql_client.go`<br>`internal/engine/http_endpoint_graphql_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Apollo Client / urql / Relay (react-relay) / graphql-request client GraphQL operations -> one http_endpoint_call (consumer) per (operation, root field) keyed to the server endpoint shape http:GRAPHQL:/graphql/<RootType>/<field> + FETCHES from the enclosing component (synthesizeGraphQLClientCalls). Root type Query/Mutation/Subscription + root fields parsed from the gql/graphql tagged or raw template document (shared gqlRootFieldsFromDoc with the Dart pass). Idioms: gql-const + useQuery/useMutation/useSubscription/useLazyQuery (Apollo), useQuery({query}) (urql), useLazyLoadQuery/usePreloadedQuery/useClientQuery first-positional-arg doc (Relay), request(endpoint, raw-template) + client.query({query}) (graphql-request). Identical entity shape to the GraphQL server producer so the cross-repo linker pairs the client component with the backend resolver on reindex. Value-asserted: useQuery(GET_USERS) -> http:GRAPHQL:/graphql/Query/users + FETCHES Function:UserList; useMutation -> Mutation/createUser; multi-root urql; Relay usePreloadedQuery(const) -> Query/viewer+notifications; negatives (REST fetch, Relay useFragment fragment-only) emit nothing. Honest-partial: a gql const imported cross-file emits an op-name-keyed graphql_client_unresolved call (field not statically resolvable). |
+| Prop extraction | 🔴 `missing` | — | 3642 | — | — |
+| State management | 🔴 `missing` | — | 3642 | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | 🔴 `missing` | — | 3642 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 3642 | — | — |
+| Interface extraction | 🔴 `missing` | — | 3642 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 3642 | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | 3642 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 3642 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 3642 | — | — |
+| Config consumption | 🔴 `missing` | — | 3642 | — | — |
+| Constant propagation | 🔴 `missing` | — | 3642 | — | — |
+| DB effect | 🔴 `missing` | — | 3642 | — | — |
+| Dead code detection | 🔴 `missing` | — | 3642 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 3642 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 3642 | — | — |
+| Error flow | 🔴 `missing` | — | 3642 | — | — |
+| Feature flag gating | 🔴 `missing` | — | 3642 | — | — |
+| Fs effect | 🔴 `missing` | — | 3642 | — | — |
+| HTTP effect | ✅ `full` | `2026-06-03` | 3642 | `internal/engine/http_endpoint_graphql_client.go`<br>`internal/engine/http_endpoint_graphql_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Client GraphQL operations surface as http_endpoint_call (consumer) entities with the synthetic GRAPHQL verb on canonical path /graphql/<RootType>/<field>, matching the server producer so the cross-repo HTTP linker forms client->server links + FETCHES from the enclosing component. See data_fetching for the per-idiom detail. |
+| Import resolution quality | 🔴 `missing` | — | 3642 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 3642 | — | — |
+| Mutation effect | 🔴 `missing` | — | 3642 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 3642 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 3642 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 3642 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3642 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 3642 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 3642 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 3642 | — | — |
+| Taint source detection | 🔴 `missing` | — | 3642 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 3642 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 3642 | — | — |
+
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.graphql`](./protocol.graphql.md) hub record (GraphQL),
+which tracks the same technology at a higher level.
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.framework.graphql-client ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -28,6 +28,7 @@ one is a separate detail page.
 | [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 31 partial, 12 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 8 partial, 37 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 8 full, 5 partial, 42 missing |
+| [`lang.jsts.framework.graphql-client`](./lang.jsts.framework.graphql-client.md) | JS/TS | framework | 2 full, 34 missing |
 | [`lang.jsts.framework.graphql-resolvers`](./lang.jsts.framework.graphql-resolvers.md) | JS/TS | framework | 10 full, 19 partial, 25 missing, 1 n/a |
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 4 full, 51 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -35128,6 +35128,179 @@
       }
     },
     {
+      "id": "lang.jsts.framework.graphql-client",
+      "category": "http_framework",
+      "subcategory": "ui_frontend",
+      "language": "jsts",
+      "label": "GraphQL Client (Apollo Client / urql / Relay / graphql-request)",
+      "capabilities": {
+        "Structure": {
+          "component_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "data_fetching": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_client_synthesis.go","internal/engine/http_endpoint_graphql_client.go","internal/engine/http_endpoint_graphql_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3642",
+            "notes": "Apollo Client / urql / Relay (react-relay) / graphql-request client GraphQL operations -\u003e one http_endpoint_call (consumer) per (operation, root field) keyed to the server endpoint shape http:GRAPHQL:/graphql/\u003cRootType\u003e/\u003cfield\u003e + FETCHES from the enclosing component (synthesizeGraphQLClientCalls). Root type Query/Mutation/Subscription + root fields parsed from the gql/graphql tagged or raw template document (shared gqlRootFieldsFromDoc with the Dart pass). Idioms: gql-const + useQuery/useMutation/useSubscription/useLazyQuery (Apollo), useQuery({query}) (urql), useLazyLoadQuery/usePreloadedQuery/useClientQuery first-positional-arg doc (Relay), request(endpoint, raw-template) + client.query({query}) (graphql-request). Identical entity shape to the GraphQL server producer so the cross-repo linker pairs the client component with the backend resolver on reindex. Value-asserted: useQuery(GET_USERS) -\u003e http:GRAPHQL:/graphql/Query/users + FETCHES Function:UserList; useMutation -\u003e Mutation/createUser; multi-root urql; Relay usePreloadedQuery(const) -\u003e Query/viewer+notifications; negatives (REST fetch, Relay useFragment fragment-only) emit nothing. Honest-partial: a gql const imported cross-file emits an op-name-keyed graphql_client_unresolved call (field not statically resolvable).",
+            "verified_at": "2026-06-03"
+          },
+          "prop_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "state_management": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "error_flow": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "feature_flag_gating": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_graphql_client.go","internal/engine/http_endpoint_graphql_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3642",
+            "notes": "Client GraphQL operations surface as http_endpoint_call (consumer) entities with the synthetic GRAPHQL verb on canonical path /graphql/\u003cRootType\u003e/\u003cfield\u003e, matching the server producer so the cross-repo HTTP linker forms client-\u003eserver links + FETCHES from the enclosing component. See data_fetching for the per-idiom detail.",
+            "verified_at": "2026-06-03"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "3642"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "3642"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.jsts.framework.graphql-resolvers",
       "category": "http_framework",
       "subcategory": "rpc_framework",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 227 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 228 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 32 | 21 | 19 | 4 |
+| [JS/TS](by-language/jsts.md) | 33 | 21 | 19 | 4 |
 | [python](by-language/python.md) | 23 | 15 | 18 | 10 |
 | [java](by-language/java.md) | 22 | 10 | 15 | 4 |
 | [go](by-language/go.md) | 20 | 8 | 17 | 0 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 227 frameworks · 111 tools · 156 ORMs · 161 other
+Total: 228 frameworks · 111 tools · 156 ORMs · 161 other

--- a/internal/engine/http_endpoint_graphql_client.go
+++ b/internal/engine/http_endpoint_graphql_client.go
@@ -42,6 +42,13 @@
 //
 //   - urql: useQuery({ query: GET_USERS }).
 //
+//   - Relay (react-relay): useLazyLoadQuery(graphql`query …`, vars),
+//     usePreloadedQuery(QUERY, ref), useClientQuery(QUERY) — the operation
+//     document is the FIRST positional argument (inline graphql`` template or a
+//     const reference), resolved the same way as Apollo's bare-arg form. Relay
+//     FRAGMENT hooks (useFragment / usePaginationFragment) take a fragment
+//     document with no operation root field and emit nothing.
+//
 //   - Inline gql docs passed directly to a hook / client call.
 //
 // FETCHES edge: the enclosing function at the call site is recorded as
@@ -287,14 +294,27 @@ var gqlRawTemplateRe = regexp.MustCompile(
 // or `request(endpoint, \`{ users { id } }\`)`. Capture group 1 = doc body.
 var gqlInlineDocRe = regexp.MustCompile("(?s)(?:gql|graphql)\\s*`([^`]*)`")
 
-// gqlHookCallRe matches Apollo/urql hook + client method call sites that take a
-// gql document (by const reference or inline). Capture group 1 = the hook /
-// method keyword, the remainder of the call is scanned for the doc reference.
+// gqlHookCallRe matches Apollo/urql/Relay hook + client method call sites that
+// take a gql document (by const reference or inline). Capture group 1 = the
+// hook / method keyword, the remainder of the call is scanned for the doc
+// reference.
 //
-//	useQuery( / useMutation( / useSubscription( / useLazyQuery( / useSuspenseQuery(
-//	client.query( / client.mutate( / client.subscribe( / .request(
+//	Apollo / urql:
+//	  useQuery( / useMutation( / useSubscription( / useLazyQuery( /
+//	  useSuspenseQuery( / client.query( / client.mutate( / client.subscribe( /
+//	  .request(
+//	Relay (react-relay / relay-runtime): the query DOCUMENT is the FIRST
+//	positional argument — `useLazyLoadQuery(graphql\`…\`, vars)` inline, or
+//	`const Q = graphql\`…\`; usePreloadedQuery(Q, ref)` by const reference —
+//	so it is resolved identically to Apollo's bare-arg `useQuery(GET_USERS)`
+//	form via gqlConstRefRe. Only the OPERATION-bearing Relay hooks are listed;
+//	the FRAGMENT hooks (useFragment / usePaginationFragment /
+//	useRefetchableFragment) take a fragment document (no operation root field)
+//	and are deliberately EXCLUDED so they emit nothing (matching the
+//	fragment-only negative).
+//	  useLazyLoadQuery( / usePreloadedQuery( / useClientQuery(
 var gqlHookCallRe = regexp.MustCompile(
-	`\b(useQuery|useMutation|useSubscription|useLazyQuery|useSuspenseQuery|useSubscriptionQuery|query|mutate|subscribe|request)\s*\(`,
+	`\b(useQuery|useMutation|useSubscription|useLazyQuery|useSuspenseQuery|useSubscriptionQuery|useLazyLoadQuery|usePreloadedQuery|useClientQuery|query|mutate|subscribe|request)\s*\(`,
 )
 
 // gqlConstRefRe extracts the first plausible const identifier referenced inside

--- a/internal/engine/http_endpoint_graphql_client_test.go
+++ b/internal/engine/http_endpoint_graphql_client_test.go
@@ -214,3 +214,95 @@ function search(query) {
 		"http:GRAPHQL:/graphql/Query/search",
 	}, "graphql-client-no-false-positive")
 }
+
+// TestSynth_GraphQLClient_RelayInline asserts Relay's primary hook idiom — an
+// inline `graphql\`…\“ operation passed as the FIRST positional argument to
+// useLazyLoadQuery — emits the per-root-field client-call keyed to the server
+// endpoint shape, plus the FETCHES source_caller. (graphql-tagged inline docs
+// were already recognised; this pins the Relay hook + caller attribution.)
+func TestSynth_GraphQLClient_RelayInline(t *testing.T) {
+	src := `
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+function UserScreen() {
+  const data = useLazyLoadQuery(graphql` + "`" + `
+    query UserScreenQuery {
+      user { id name }
+    }
+  ` + "`" + `, {});
+  return data;
+}
+`
+	_, res := runDetect(t, "typescript", "UserScreen.tsx", src)
+	const wantID = "http:GRAPHQL:/graphql/Query/user"
+	e := findGQLClientEntity(res, wantID)
+	if e == nil {
+		t.Fatalf("missing Relay client-call %q", wantID)
+	}
+	if e.verb != "GRAPHQL" {
+		t.Errorf("verb = %q, want GRAPHQL", e.verb)
+	}
+	if e.sourceCaller != "Function:UserScreen" {
+		t.Errorf("source_caller = %q, want Function:UserScreen (drives FETCHES)", e.sourceCaller)
+	}
+}
+
+// TestSynth_GraphQLClient_RelayConstRef is the regression that motivated this
+// change: a Relay query bound to a `graphql\`…\“ const and consumed by a
+// FIRST-positional-arg hook (usePreloadedQuery(Q, ref)) previously emitted
+// NOTHING because usePreloadedQuery was not a recognised hook keyword — the
+// const→server-field link was lost. It must now resolve to the per-root-field
+// endpoint via the gql-const symbol table.
+func TestSynth_GraphQLClient_RelayConstRef(t *testing.T) {
+	src := `
+import { graphql, usePreloadedQuery } from 'react-relay';
+
+const AppQuery = graphql` + "`" + `
+  query AppQuery {
+    viewer { id }
+    notifications { count }
+  }
+` + "`" + `;
+
+function App(props) {
+  const data = usePreloadedQuery(AppQuery, props.queryRef);
+  return data;
+}
+`
+	got, res := runDetect(t, "typescript", "App.tsx", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/viewer",
+		"http:GRAPHQL:/graphql/Query/notifications",
+	}
+	requireContains(t, got, want, "graphql-client-relay-const-ref")
+	// FETCHES caller must be the consuming component, not the top-level const def.
+	if e := findGQLClientEntity(res, "http:GRAPHQL:/graphql/Query/viewer"); e != nil &&
+		e.sourceCaller != "Function:App" {
+		t.Errorf("source_caller = %q, want Function:App", e.sourceCaller)
+	}
+}
+
+// TestSynth_GraphQLClient_RelayFragmentNoOp asserts a Relay FRAGMENT hook
+// (useFragment) over a `graphql\`fragment …\“ document emits NOTHING: a
+// fragment has no operation root field, so there is no server endpoint to link
+// to. This guards against the Relay-hook widening fabricating a phantom field.
+func TestSynth_GraphQLClient_RelayFragmentNoOp(t *testing.T) {
+	src := `
+import { graphql, useFragment } from 'react-relay';
+
+const UserFrag = graphql` + "`" + `
+  fragment UserCard_user on User { id name }
+` + "`" + `;
+
+function UserCard(props) {
+  const user = useFragment(UserFrag, props.user);
+  return user;
+}
+`
+	got, _ := runDetect(t, "typescript", "UserCard.tsx", src)
+	requireNotContains(t, got, []string{
+		"http:GRAPHQL:/graphql/Query/UserCard_user",
+		"http:GRAPHQL:/graphql/Query/id",
+		"http:GRAPHQL:/graphql/Query/name",
+	}, "graphql-client-relay-fragment-no-op")
+}


### PR DESCRIPTION
Closes #3642 (epic #3625). **DEPLOY-DEFERRED.**

## VERIFY-FIRST finding
The JS/TS GraphQL client->server CONSUMES/FETCHES path for **Apollo Client / urql / graphql-request** was **already implemented and value-tested** in `internal/engine/http_endpoint_graphql_client.go` (epic #3607/#3608). A client gql operation emits an `http_endpoint_call` keyed to the exact server shape `http:GRAPHQL:/graphql/<RootType>/<field>` + a FETCHES edge, so the existing Name-based cross-repo HTTP linker joins client component -> backend resolver with no new linker code. The ticket's "schema key unread / no client->server CONSUMES" premise is **stale** for those three libraries — confirmed by value-asserting probes before any change (a `gql`fragment` and a REST `fetch` correctly emit nothing).

## The one honest gap: Relay
A Relay query bound to a `graphql`` const and consumed by a first-positional-arg hook — `usePreloadedQuery(Q, ref)` / `useLazyLoadQuery(Q, vars)` / `useClientQuery(Q)` — emitted **nothing** because those hooks were absent from `gqlHookCallRe`, so the const->server-field link was lost. (Inline `useLazyLoadQuery(graphql``)` already worked via the inline-doc path.)

## Changes
- **`gqlHookCallRe`**: add `useLazyLoadQuery` / `usePreloadedQuery` / `useClientQuery`. Relay FRAGMENT hooks (`useFragment` / `usePaginationFragment` / `useRefetchableFragment`) are deliberately **excluded** so a fragment document (no operation root field) emits nothing.
- **3 value-asserting tests**:
  - Relay inline `useLazyLoadQuery(graphql`query UserScreenQuery { user {...} }`)` -> `http:GRAPHQL:/graphql/Query/user` + FETCHES `Function:UserScreen`.
  - Relay const-ref `const AppQuery = graphql`...`; usePreloadedQuery(AppQuery, ref)` -> `Query/viewer` + `Query/notifications` + FETCHES `Function:App` (the regression this PR fixes).
  - Relay `useFragment` fragment-only negative -> emits nothing.
- **Registry**: new row `lang.jsts.framework.graphql-client` (Apollo Client / urql / Relay / graphql-request) with `data_fetching` + `http_effect` flipped to **full**, citing the pass + tests — mirroring `lang.dart.framework.graphql-flutter` (#4059) so the previously-untracked JS/TS gql `client_tools` coverage is now visible.

## Covered / deferred
- **Covered (verified, field-level cross-repo link):** Apollo Client, urql, graphql-request, Relay (inline + const-ref operation hooks).
- **Honest-partial (pre-existing):** a gql const imported cross-file -> op-name-keyed `graphql_client_unresolved` call (root field not statically resolvable in-file).
- **Deferred:** none for these four libs. (Relay's `.graphql`-codegen artifact resolution is not needed — the operation document is present at the JS call site.)

## Gates
Full packages green (`internal/custom/javascript`, `internal/engine`, `internal/extractors`, `tools/coverage`); dispatch-parity green (no new custom key — regex-only widening of an existing pass); `validate` 0 errors; `fmt --check` canonical; `gen` 0 drift; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)