### PR TITLE
feat(engine): detect gRPC-Java interceptor + Spring-Security auth (Closes part of #4041, gRPC-Java)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 227 records · **C/C++**: 19 · **C#**: 16 · **dart**: 2 · **elixir**: 14 · **go**: 20 · **java**: 22 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 5
+**Total**: 228 records · **C/C++**: 19 · **C#**: 16 · **dart**: 2 · **elixir**: 14 · **go**: 20 · **java**: 23 · **JS/TS**: 32 · **kotlin**: 17 · **lua**: 4 · **php**: 16 · **python**: 23 · **ruby**: 9 · **rust**: 14 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -265,6 +265,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 7/24 | 🟡 7/10 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | — | 🔴 0/1 | 🟢 4/4 | ✅ 1/1 | 🟡 11/24 | 🟡 6/10 | |
+| [java](../by-language/java.md) | [gRPC-Java (grpc-java / grpc-spring-boot-starter)](../detail/lang.java.framework.grpc.md) | — | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 6/17 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | — | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟢 7/7 | |
 | [scala](../by-language/scala.md) | [ScalaPB / zio-grpc / fs2-grpc](../detail/lang.scala.framework.scalapb-grpc.md) | — | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 15/24 | 🟢 7/7 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # java
 
-**Frameworks**: 22 · **Tools**: 10 · **ORMs**: 15 · **Other**: 4
+**Frameworks**: 23 · **Tools**: 10 · **ORMs**: 15 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -65,6 +65,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|
 | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🔴 0/1 | 🟡 20/21 | 🟡 7/8 | |
 | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🔴 0/1 | 🟡 20/21 | 🟡 7/8 | |
+
+
+### RPC Framework
+
+| Name | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [gRPC-Java (grpc-java / grpc-spring-boot-starter)](../detail/lang.java.framework.grpc.md) | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.java.framework.grpc.md
+++ b/docs/coverage/detail/lang.java.framework.grpc.md
@@ -1,0 +1,147 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.grpc` — gRPC-Java (grpc-java / grpc-spring-boot-starter)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** RPC Framework
+- **Capability cells:** 54
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Federation extraction | — `not_applicable` | — | — | — | Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable. |
+| Procedure extraction | 🟢 `partial` | `2026-06-03` | 4041 | `internal/engine/grpc_edges.go`<br>`internal/engine/grpc_edges_test.go` | Each @Override handler on a @GrpcService / XxxGrpc.XxxImplBase impl -> SCOPE.GrpcMethod (grpc:<Service>/<Method>) + GRPC_IMPLEMENTS edge, with streaming variant inferred from the StreamObserver parameter shape. synthesizeJavaGRPC in grpc_edges.go. Same-file methods only. |
+| Schema extraction | 🔴 `missing` | — | 4041 | — | — |
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type->type graph is a GraphQL-SDL concept; gRPC/protobuf message schemas are modelled separately (protocol.protobuf) and have no GraphQL object-type relationship graph. |
+
+### Codegen
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client codegen | 🟢 `partial` | `2026-06-03` | 4041 | `internal/engine/grpc_edges.go`<br>`internal/engine/grpc_edges_test.go` | @GrpcClient-injected stub / ManagedChannelBuilder XxxGrpc.newBlockingStub(ch) site + stub.method(req) call -> SCOPE.GrpcMethod + GRPC_HANDLES edge. |
+
+### Transport
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transport binding | 🟢 `partial` | `2026-06-03` | 4041 | `internal/engine/grpc_edges.go`<br>`internal/engine/grpc_edges_test.go` | RPC service synthesis from a @GrpcService-annotated or XxxGrpc.XxxImplBase-extending class -> SCOPE.GrpcService (grpc_java_server); regex, no AST. synthesizeJavaGRPC in grpc_edges.go. |
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | — `not_applicable` | — | — | — | HTTP endpoint deprecation/versioning (Sunset/Deprecation headers, /v1 route segments) is an HTTP-API concept; gRPC versions via proto package + service evolution, not HTTP route versioning. |
+| Endpoint pagination posture | — `not_applicable` | — | — | — | HTTP limit/offset/page/cursor pagination posture is an HTTP-endpoint concept; gRPC paginates via in-message fields / server-streaming, not HTTP query params. |
+| Endpoint response codes | — `not_applicable` | — | — | — | HTTP status-code sets do not apply to gRPC, which signals outcome via grpc.Status/codes on the trailer, not HTTP 2xx/4xx codes. |
+| Endpoint synthesis | — `not_applicable` | — | — | — | HTTP http_endpoint synthesis (path+verb producer endpoints) does not apply to gRPC; service registration is captured as transport_binding. gRPC method addressing is package.Service/Method, not an HTTP path+verb. |
+| Handler attribution | — `not_applicable` | — | — | — | No HTTP handler->route attribution for gRPC. RPC-method->service binding is modelled by procedure_extraction + GRPC_IMPLEMENTS, not by an HTTP route table. |
+| Route extraction | — `not_applicable` | — | — | — | gRPC has no HTTP route paths; the HTTP route extractor emits 0 entities on a gRPC service impl. RPC method addressing is package.Service/Method, surfaced via procedure_extraction + transport_binding. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | — `not_applicable` | — | — | — | gRPC services render no server-side views/templates; responses are protobuf messages, not rendered views. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | ✅ `full` | `2026-06-03` | — | `internal/engine/grpc_edges.go`<br>`internal/engine/grpc_java_auth.go`<br>`internal/engine/grpc_java_auth_test.go` | gRPC-Java server auth (#4041, epic #3872). resolveJavaGRPCAuth detects two enforcement idioms. (1) ServerInterceptor: an io.grpc.ServerInterceptor whose interceptCall body BOTH reads the call Metadata AND closes/rejects with Status.UNAUTHENTICATED/PERMISSION_DENIED, bound to the service via ServerInterceptors.intercept(service, ...) or a global ServerBuilder.intercept(...) -> auth_method=grpc_interceptor + auth_middleware (HIGH); a conventionally-named (...AuthInterceptor) cross-file interceptor is credited by name (MEDIUM). (2) grpc-spring-boot-starter: a @GrpcService class with Spring/Jakarta-Security @PreAuthorize / @Secured / @RolesAllowed / @DenyAll / @Authenticated on the RPC method (or class) -> auth_method=annotation + auth_roles/auth_permissions/auth_scopes parsed from the SpEL (reusing matchAnnotationPolicy). Stamps auth_required + auth_policy on the SCOPE.GrpcService + its SCOPE.GrpcMethod handlers. Negatives: a logging interceptor (no metadata-reject), a plain @GrpcService method, and a no-interceptor server leave methods UNSTAMPED. HONEST limit: the interceptor binding must live same-file as the service impl (the common impl-in-FooService.java / bootstrap-in-GrpcServer.java split is covered by the annotation path, not the interceptor path). |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | — `not_applicable` | — | — | — | gRPC request/response payloads are protobuf messages (surfaced under protocol.protobuf schema_extraction); MVC DTO inference does not model them. HTTP MVC DTO extractor yields 0 entities on a gRPC service. |
+| Request validation | — `not_applicable` | — | — | — | gRPC has no MVC request-validation pipeline; message-field constraints live in proto. HTTP MVC validation extractor yields 0 entities here. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | — `not_applicable` | — | — | — | gRPC-Java has no HTTP middleware pipeline; cross-cutting concerns are server INTERCEPTORS / @GrpcGlobalServerInterceptor (auth interceptors credited under auth_coverage). The HTTP route-middleware extractor yields 0 entities on a gRPC server. |
+| Rate limit stamping | — `not_applicable` | — | — | — | Rate-limit stamping keys off HTTP route-middleware / decorators; gRPC-Java rate limiting is an interceptor, not an HTTP route rate-limiter. HTTP rate-limit extractor yields 0 entities here. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 4041 | — | — |
+| Interface extraction | 🔴 `missing` | — | 4041 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 4041 | — | — |
+| Type extraction | 🔴 `missing` | — | 4041 | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 4041 | — | — |
+| DI injection point | 🔴 `missing` | — | 4041 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 4041 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 4041 | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | 4041 | — | — |
+| Metric extraction | 🔴 `missing` | — | 4041 | — | — |
+| Trace extraction | 🔴 `missing` | — | 4041 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 4041 | — | — |
+| Config consumption | 🔴 `missing` | — | 4041 | — | — |
+| Constant propagation | 🔴 `missing` | — | 4041 | — | — |
+| DB effect | 🔴 `missing` | — | 4041 | — | — |
+| Dead code detection | 🔴 `missing` | — | 4041 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 4041 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 4041 | — | — |
+| Error flow | 🔴 `missing` | — | 4041 | — | — |
+| Feature flag gating | 🔴 `missing` | — | 4041 | — | — |
+| Fs effect | 🔴 `missing` | — | 4041 | — | — |
+| HTTP effect | 🔴 `missing` | — | 4041 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 4041 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 4041 | — | — |
+| Mutation effect | 🔴 `missing` | — | 4041 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 4041 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 4041 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 4041 | — | — |
+| Request sink dataflow | 🔴 `missing` | — | 4041 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 4041 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 4041 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 4041 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 4041 | — | — |
+| Taint source detection | 🔴 `missing` | — | 4041 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 4041 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 4041 | — | — |
+
+## Related extraction records
+
+This record provides code-level coverage for the
+[`protocol.grpc`](./protocol.grpc.md) hub record (gRPC),
+which tracks the same technology at a higher level.
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.grpc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -26,6 +26,7 @@ one is a separate detail page.
 | [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 7 full, 12 partial, 21 missing, 14 n/a |
 | [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 11 full, 26 partial, 2 missing, 15 n/a |
 | [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 2 full, 20 partial, 18 missing, 14 n/a |
+| [`lang.java.framework.grpc`](./lang.java.framework.grpc.md) | java | framework | 1 full, 3 partial, 37 missing, 13 n/a |
 | [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |
 | [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 9 full, 18 partial, 10 missing, 17 n/a |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -25725,6 +25725,268 @@
       }
     },
     {
+      "id": "lang.java.framework.grpc",
+      "category": "http_framework",
+      "subcategory": "rpc_framework",
+      "language": "java",
+      "label": "gRPC-Java (grpc-java / grpc-spring-boot-starter)",
+      "capabilities": {
+        "Schema": {
+          "federation_extraction": {
+            "status": "not_applicable",
+            "notes": "Apollo GraphQL Federation directives (@key/@external/@requires/@provides/extend type) do not exist in this RPC framework; not applicable."
+          },
+          "procedure_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_edges_test.go"],
+            "issue": "4041",
+            "notes": "Each @Override handler on a @GrpcService / XxxGrpc.XxxImplBase impl -\u003e SCOPE.GrpcMethod (grpc:\u003cService\u003e/\u003cMethod\u003e) + GRPC_IMPLEMENTS edge, with streaming variant inferred from the StreamObserver parameter shape. synthesizeJavaGRPC in grpc_edges.go. Same-file methods only.",
+            "verified_at": "2026-06-03"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "type_graph_extraction": {
+            "status": "not_applicable",
+            "notes": "GraphQL schema type-\u003etype graph is a GraphQL-SDL concept; gRPC/protobuf message schemas are modelled separately (protocol.protobuf) and have no GraphQL object-type relationship graph."
+          }
+        },
+        "Codegen": {
+          "client_codegen": {
+            "status": "partial",
+            "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_edges_test.go"],
+            "issue": "4041",
+            "notes": "@GrpcClient-injected stub / ManagedChannelBuilder XxxGrpc.newBlockingStub(ch) site + stub.method(req) call -\u003e SCOPE.GrpcMethod + GRPC_HANDLES edge.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "partial",
+            "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_edges_test.go"],
+            "issue": "4041",
+            "notes": "RPC service synthesis from a @GrpcService-annotated or XxxGrpc.XxxImplBase-extending class -\u003e SCOPE.GrpcService (grpc_java_server); regex, no AST. synthesizeJavaGRPC in grpc_edges.go.",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Routing": {
+          "endpoint_deprecation_versioning": {
+            "status": "not_applicable",
+            "notes": "HTTP endpoint deprecation/versioning (Sunset/Deprecation headers, /v1 route segments) is an HTTP-API concept; gRPC versions via proto package + service evolution, not HTTP route versioning."
+          },
+          "endpoint_pagination_posture": {
+            "status": "not_applicable",
+            "notes": "HTTP limit/offset/page/cursor pagination posture is an HTTP-endpoint concept; gRPC paginates via in-message fields / server-streaming, not HTTP query params."
+          },
+          "endpoint_response_codes": {
+            "status": "not_applicable",
+            "notes": "HTTP status-code sets do not apply to gRPC, which signals outcome via grpc.Status/codes on the trailer, not HTTP 2xx/4xx codes."
+          },
+          "endpoint_synthesis": {
+            "status": "not_applicable",
+            "notes": "HTTP http_endpoint synthesis (path+verb producer endpoints) does not apply to gRPC; service registration is captured as transport_binding. gRPC method addressing is package.Service/Method, not an HTTP path+verb."
+          },
+          "handler_attribution": {
+            "status": "not_applicable",
+            "notes": "No HTTP handler-\u003eroute attribution for gRPC. RPC-method-\u003eservice binding is modelled by procedure_extraction + GRPC_IMPLEMENTS, not by an HTTP route table."
+          },
+          "route_extraction": {
+            "status": "not_applicable",
+            "notes": "gRPC has no HTTP route paths; the HTTP route extractor emits 0 entities on a gRPC service impl. RPC method addressing is package.Service/Method, surfaced via procedure_extraction + transport_binding."
+          }
+        },
+        "View": {
+          "view_rendering": {
+            "status": "not_applicable",
+            "notes": "gRPC services render no server-side views/templates; responses are protobuf messages, not rendered views."
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "full",
+            "cites": ["internal/engine/grpc_edges.go","internal/engine/grpc_java_auth.go","internal/engine/grpc_java_auth_test.go"],
+            "notes": "gRPC-Java server auth (#4041, epic #3872). resolveJavaGRPCAuth detects two enforcement idioms. (1) ServerInterceptor: an io.grpc.ServerInterceptor whose interceptCall body BOTH reads the call Metadata AND closes/rejects with Status.UNAUTHENTICATED/PERMISSION_DENIED, bound to the service via ServerInterceptors.intercept(service, ...) or a global ServerBuilder.intercept(...) -\u003e auth_method=grpc_interceptor + auth_middleware (HIGH); a conventionally-named (...AuthInterceptor) cross-file interceptor is credited by name (MEDIUM). (2) grpc-spring-boot-starter: a @GrpcService class with Spring/Jakarta-Security @PreAuthorize / @Secured / @RolesAllowed / @DenyAll / @Authenticated on the RPC method (or class) -\u003e auth_method=annotation + auth_roles/auth_permissions/auth_scopes parsed from the SpEL (reusing matchAnnotationPolicy). Stamps auth_required + auth_policy on the SCOPE.GrpcService + its SCOPE.GrpcMethod handlers. Negatives: a logging interceptor (no metadata-reject), a plain @GrpcService method, and a no-interceptor server leave methods UNSTAMPED. HONEST limit: the interceptor binding must live same-file as the service impl (the common impl-in-FooService.java / bootstrap-in-GrpcServer.java split is covered by the annotation path, not the interceptor path).",
+            "verified_at": "2026-06-03"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "not_applicable",
+            "notes": "gRPC request/response payloads are protobuf messages (surfaced under protocol.protobuf schema_extraction); MVC DTO inference does not model them. HTTP MVC DTO extractor yields 0 entities on a gRPC service."
+          },
+          "request_validation": {
+            "status": "not_applicable",
+            "notes": "gRPC has no MVC request-validation pipeline; message-field constraints live in proto. HTTP MVC validation extractor yields 0 entities here."
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "not_applicable",
+            "notes": "gRPC-Java has no HTTP middleware pipeline; cross-cutting concerns are server INTERCEPTORS / @GrpcGlobalServerInterceptor (auth interceptors credited under auth_coverage). The HTTP route-middleware extractor yields 0 entities on a gRPC server."
+          },
+          "rate_limit_stamping": {
+            "status": "not_applicable",
+            "notes": "Rate-limit stamping keys off HTTP route-middleware / decorators; gRPC-Java rate limiting is an interceptor, not an HTTP route rate-limiter. HTTP rate-limit extractor yields 0 entities here."
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "4041"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "4041"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "config_consumption": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "error_flow": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "feature_flag_gating": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "request_sink_dataflow": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "4041"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "4041"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.java.framework.guice",
       "category": "http_framework",
       "subcategory": "jvm_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,15 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 227 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
+**Languages**: 39 (20 active · 19 placeholder) · **Frameworks**: 228 · **ORMs**: 156 · **Tools**: 111 · **Other**: 161
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 32 | 21 | 19 | 4 |
+| [java](by-language/java.md) | 23 | 10 | 15 | 4 |
 | [python](by-language/python.md) | 23 | 15 | 18 | 10 |
-| [java](by-language/java.md) | 22 | 10 | 15 | 4 |
 | [go](by-language/go.md) | 20 | 8 | 17 | 0 |
 | [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 4 |
 | [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 227 frameworks · 111 tools · 156 ORMs · 161 other
+Total: 228 frameworks · 111 tools · 156 ORMs · 161 other

--- a/internal/engine/grpc_edges.go
+++ b/internal/engine/grpc_edges.go
@@ -300,9 +300,13 @@ var javaGrpcCallSiteRe = regexp.MustCompile(
 	`\b(\w+)\s*\.\s*([a-z]\w*)\s*\(`)
 
 // javaGrpcOverrideRe matches `@Override public ... methodName(StreamObserver<Req> req, ...)`.
-// Group 1: method name.
+// Group 1: method name. Tolerates authorization annotations
+// (@PreAuthorize/@Secured/@RolesAllowed/@Authenticated/@DenyAll) interleaved
+// between @Override and the signature — grpc-spring-boot-starter places the
+// Spring-Security annotation there, and without this the handler would not be
+// emitted (and so could not be stamped with auth).
 var javaGrpcOverrideRe = regexp.MustCompile(
-	`@Override\s+(?:public\s+)?(?:void|[\w<>]+)\s+(\w+)\s*\(`)
+	`@Override\s+(?:@[\w.]+(?:\s*\((?:[^()]|\([^()]*\))*\))?\s+)*(?:public\s+)?(?:void|[\w<>]+)\s+(\w+)\s*\(`)
 
 // javaStreamObserverParam detects bidi/client-streaming by presence of two
 // StreamObserver params or request StreamObserver.
@@ -346,6 +350,14 @@ func synthesizeJavaGRPC(
 		if m := javaGrpcImplBaseSimpleRe.FindStringSubmatch(src); len(m) >= 2 {
 			serviceName = m[1]
 		}
+
+		// gRPC-Java server auth (#4041, epic #3872). An auth-enforcing
+		// ServerInterceptor bound to the service, or a class-level
+		// Spring/Jakarta-Security annotation, applies to every method; a
+		// method-level annotation applies to just that method. Same-file,
+		// signal-based; see grpc_java_auth.go for the resolution + limits.
+		auth := resolveJavaGRPCAuth(src, path)
+
 		props := map[string]string{}
 		if hasReflection {
 			props["reflection"] = "true"
@@ -353,33 +365,56 @@ func synthesizeJavaGRPC(
 		if hasGateway {
 			props["has_gateway"] = "true"
 		}
+		// Service-level auth: interceptor binding and/or a class-level
+		// authorization annotation. The interceptor (transport-level) is the
+		// strongest service-wide signal; a class annotation is the
+		// Spring-Security equivalent.
+		if auth.serviceEnforced {
+			for k, v := range grpcJavaInterceptorProps(auth.serviceSymbol, auth.serviceConfidence) {
+				props[k] = v
+			}
+		} else if auth.classPolicy != nil {
+			for k, v := range grpcJavaPolicyProps(*auth.classPolicy) {
+				props[k] = v
+			}
+		}
 		emitService(serviceName, "grpc_java_server", props)
 
 		// Scan for @Override methods — each is a handler.
-		for _, m := range javaGrpcOverrideRe.FindAllStringSubmatch(src, -1) {
-			if len(m) < 2 {
+		for _, m := range javaGrpcOverrideRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 4 {
 				continue
 			}
-			methodName := m[1]
-			// Determine streaming variant.
+			methodName := src[m[2]:m[3]]
+			// Determine streaming variant from THIS match's body window.
 			streaming := "unary"
-			// Find the method body window (~500 chars after the match).
-			idx := javaGrpcOverrideRe.FindStringIndex(src)
-			if idx != nil {
-				windowEnd := idx[1] + 600
-				if windowEnd > len(src) {
-					windowEnd = len(src)
+			windowEnd := m[1] + 600
+			if windowEnd > len(src) {
+				windowEnd = len(src)
+			}
+			window := src[m[1]:windowEnd]
+			if javaStreamObserverBidiRe.MatchString(window) {
+				streaming = "bidi_streaming"
+			} else if strings.Contains(window, "stream.Send") || strings.Contains(window, "responseObserver.onNext") {
+				streaming = "server_streaming"
+			}
+			methodProps := map[string]string{"streaming": streaming}
+			// Per-method auth: a method-level annotation wins; else the
+			// service-wide interceptor / class annotation flows down.
+			if mp, ok := auth.methodPolicies[methodName]; ok {
+				for k, v := range grpcJavaPolicyProps(mp) {
+					methodProps[k] = v
 				}
-				window := src[idx[1]:windowEnd]
-				if javaStreamObserverBidiRe.MatchString(window) {
-					streaming = "bidi_streaming"
-				} else if strings.Contains(window, "stream.Send") || strings.Contains(window, "responseObserver.onNext") {
-					streaming = "server_streaming"
+			} else if auth.serviceEnforced {
+				for k, v := range grpcJavaInterceptorProps(auth.serviceSymbol, auth.serviceConfidence) {
+					methodProps[k] = v
+				}
+			} else if auth.classPolicy != nil {
+				for k, v := range grpcJavaPolicyProps(*auth.classPolicy) {
+					methodProps[k] = v
 				}
 			}
-			emitMethod(serviceName, methodName, "grpc_java_server", map[string]string{
-				"streaming": streaming,
-			})
+			emitMethod(serviceName, methodName, "grpc_java_server", methodProps)
 			handlerQualified := className + "." + methodName
 			emitImplementsEdge(handlerQualified, serviceName, methodName, streaming, "grpc_java_server")
 		}

--- a/internal/engine/grpc_java_auth.go
+++ b/internal/engine/grpc_java_auth.go
@@ -1,0 +1,517 @@
+// gRPC-Java server-auth detection (#4041, epic #3872).
+//
+// The Java auth sniffers (internal/engine/java_annotation_routes.go +
+// java_auth_policy.go) are HTTP-route/annotation-keyed: they resolve auth on
+// JAX-RS / Spring-MVC handlers attached to a URL route. A gRPC-Java service
+// carries none of that — a gRPC server enforces auth one of two ways, neither
+// of which is an HTTP route:
+//
+//  1. A transport-level io.grpc.ServerInterceptor wired into the server. The
+//     interceptor reads the call Metadata (the request headers) and, on a
+//     failed credential check, closes the call with a gRPC auth status —
+//     Status.UNAUTHENTICATED / Status.PERMISSION_DENIED:
+//
+//     class AuthInterceptor implements ServerInterceptor {
+//     public <Q,A> ServerCall.Listener<Q> interceptCall(
+//     ServerCall<Q,A> call, Metadata headers, ServerCallHandler<Q,A> next) {
+//     if (headers.get(AUTHZ) == null) {
+//     call.close(Status.UNAUTHENTICATED.withDescription("no token"), new Metadata());
+//     return new ServerCall.Listener<Q>() {};
+//     }
+//     return next.startCall(call, headers);
+//     }
+//     }
+//
+//     It is bound to a service via ServerInterceptors.intercept(service, ...)
+//     or globally via ServerBuilder.intercept(...) /
+//     .addService(ServerInterceptors.intercept(service, new AuthInterceptor())).
+//
+//  2. grpc-spring-boot-starter (net.devh): an @GrpcService class whose RPC
+//     methods (or the class itself) carry a Spring-Security / Jakarta-Security
+//     authorization annotation — @PreAuthorize("hasRole('ADMIN')"),
+//     @Secured("ROLE_ADMIN"), @RolesAllowed({...}), @DenyAll, or the
+//     grpc-spring-boot-starter @Authenticated marker. These annotations name
+//     the exact method (and its required roles), so they bind precisely.
+//
+// Because applyGRPCEdges (grpc_edges.go) already emits one SCOPE.GrpcService
+// per server impl and one SCOPE.GrpcMethod per handler method, this resolver
+// re-walks the SAME file and returns the auth contract to stamp on the service
+// and its methods. Same-file, signal-based, append-property-only — it never
+// adds or removes entities.
+//
+// Output keys mirror the HTTP Java auth stamping (java_annotation_routes.go) so
+// archigraph_auth_coverage signal-1 + the security dashboard light up:
+//
+//	auth_required   — "true"
+//	auth_method     — "grpc_interceptor" (path 1) | "annotation" (path 2)
+//	auth_confidence — "high"
+//	auth_roles      — CSV of required roles (path 2)
+//	auth_permissions / auth_scopes — fine-grained grants (path 2)
+//	auth_middleware — the interceptor symbol (MCP signal-1, path 1)
+//	auth_policy     — JSON-encoded AuthPolicy (dashboard source chain)
+//
+// HONEST LIMITS (documented, not papered over):
+//
+//   - Cross-file interceptor binding. The ServerInterceptors.intercept /
+//     ServerBuilder.intercept wiring must live in the SAME file as the service
+//     impl (the same same-file boundary the rest of grpc_edges.go synthesis
+//     lives in). The common layout — service impl in FooService.java, server
+//     bootstrap in GrpcServer.java — is NOT stamped by the interceptor path. It
+//     is stamped by the Spring-Security path when the methods carry annotations.
+//   - Interceptor definition cross-file. An interceptor referenced by name but
+//     defined in another file is credited only when it is bound by the
+//     conventional (auth|authentication|jwt|security)…Interceptor naming
+//     (MEDIUM confidence); an arbitrarily-named cross-file interceptor is not
+//     chased.
+package engine
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// grpcJavaInterceptorAuthMethod is the auth_method stamped on a gRPC-Java
+// service/method served by an auth-enforcing ServerInterceptor. Distinct from
+// the Go "grpc_interceptor" value only in that it is the same string — the
+// dashboard groups gRPC-interceptor auth across languages under one method.
+const grpcJavaInterceptorAuthMethod = "grpc_interceptor"
+
+// javaServerInterceptorDeclRe matches a class declaring it implements
+// io.grpc.ServerInterceptor. Group 1 = the interceptor class name.
+var javaServerInterceptorDeclRe = regexp.MustCompile(
+	`(?m)class\s+(\w+)[^\{]*\bimplements\b[^\{]*\bServerInterceptor\b`)
+
+// javaGrpcMetadataReadRe detects an interceptor reading the call Metadata —
+// the canonical way a gRPC-Java interceptor obtains the request credentials.
+// headers.get(...) / Metadata.Key / metadata.get(...) all qualify.
+var javaGrpcMetadataReadRe = regexp.MustCompile(
+	`\b(?:headers|metadata|md)\.get\s*\(|\bMetadata\.Key\b|AUTHORIZATION_KEY|AUTHORIZATION_METADATA_KEY`)
+
+// javaGrpcAuthRejectRe detects a rejection with a gRPC authentication /
+// authorization status — the decisive evidence the interceptor gates access.
+// Status.UNAUTHENTICATED / Status.PERMISSION_DENIED, and their
+// .asException()/.asRuntimeException() throw forms.
+var javaGrpcAuthRejectRe = regexp.MustCompile(
+	`\bStatus\.(?:UNAUTHENTICATED|PERMISSION_DENIED)\b`)
+
+// javaServerInterceptorsInterceptRe matches a per-service interceptor binding
+// `ServerInterceptors.intercept(<service>, <interceptors...>)`. Group 1 = the
+// argument list (service ref + interceptor refs).
+var javaServerInterceptorsInterceptRe = regexp.MustCompile(
+	`\bServerInterceptors\s*\.\s*intercept\s*\(`)
+
+// javaServerBuilderInterceptRe matches a global builder interceptor binding
+// `.intercept(<interceptor>)` on a ServerBuilder chain.
+var javaServerBuilderInterceptRe = regexp.MustCompile(
+	`\.intercept\s*\(`)
+
+// javaGrpcConventionalInterceptorRe matches a conventionally-named auth
+// interceptor identifier (cross-file definitions credited by name, MEDIUM
+// confidence). e.g. AuthInterceptor, JwtAuthInterceptor, AuthServerInterceptor,
+// SecurityInterceptor, AuthenticationInterceptor.
+var javaGrpcConventionalInterceptorRe = regexp.MustCompile(
+	`(?i)\b(?:auth|authentication|jwt|security)\w*interceptor\b`)
+
+// javaAuthenticatedAnnoRe matches the grpc-spring-boot-starter / Quarkus
+// @Authenticated marker — "any authenticated principal", no specific role.
+var javaAuthenticatedAnnoRe = regexp.MustCompile(`@Authenticated\b`)
+
+// javaGrpcMethodDeclRe matches a gRPC handler method declaration on a service
+// impl, tolerant of annotations interleaved between @Override and the
+// signature (which the @Override-anchored scan in grpc_edges.go misses). It
+// keys off the StreamObserver response parameter that every server-side gRPC
+// handler takes. Group 1 = method name.
+var javaGrpcMethodDeclRe = regexp.MustCompile(
+	`(?m)public\s+void\s+(\w+)\s*\([^)]*StreamObserver\s*<`)
+
+// grpcJavaAuth is the resolved per-file gRPC-Java auth verdict.
+type grpcJavaAuth struct {
+	// serviceEnforced is true when an auth-enforcing ServerInterceptor is
+	// bound to the service(s) in this file (per-service or global builder).
+	serviceEnforced bool
+	// serviceSymbol is the interceptor symbol credited (auth_middleware).
+	serviceSymbol string
+	// serviceConfidence is "high" (in-file auth interceptor) or "medium"
+	// (conventionally-named, possibly cross-file interceptor).
+	serviceConfidence string
+	// classPolicy, when present, is a class-level Spring/Jakarta-Security
+	// annotation applying to every method.
+	classPolicy *AuthPolicy
+	// methodPolicies maps a handler method name to its method-level
+	// Spring/Jakarta-Security annotation policy.
+	methodPolicies map[string]AuthPolicy
+}
+
+// resolveJavaGRPCAuth inspects a Java gRPC source file and returns the auth
+// contract to stamp on its service + methods. Same-file, signal-based.
+func resolveJavaGRPCAuth(src, path string) grpcJavaAuth {
+	out := grpcJavaAuth{methodPolicies: map[string]AuthPolicy{}}
+
+	// ---- Path 1: ServerInterceptor auth ----
+	sym, conf := javaInterceptorAuthBinding(src)
+	if sym != "" {
+		out.serviceEnforced = true
+		out.serviceSymbol = sym
+		out.serviceConfidence = conf
+	}
+
+	// ---- Path 2: Spring/Jakarta-Security annotations ----
+	// Class-level annotation (applies to all methods).
+	if cp, ok := resolveJavaGRPCClassAuth(src, path); ok {
+		out.classPolicy = &cp
+	}
+	// Method-level annotations, keyed to the method they precede.
+	for name, pol := range resolveJavaGRPCMethodAuth(src, path) {
+		out.methodPolicies[name] = pol
+	}
+
+	return out
+}
+
+// javaInterceptorAuthBinding returns the crediting interceptor symbol and the
+// confidence when an auth-enforcing ServerInterceptor is bound to a service in
+// this file, else ("", "").
+//
+//   - HIGH: an in-file `class X implements ServerInterceptor` whose body BOTH
+//     reads the call Metadata AND rejects with Status.UNAUTHENTICATED /
+//     PERMISSION_DENIED, where X is referenced in a ServerInterceptors.intercept
+//     / ServerBuilder.intercept binding in the same file.
+//   - MEDIUM: a binding argument that is a conventionally-named auth interceptor
+//     (…AuthInterceptor / …SecurityInterceptor) whose definition may be
+//     cross-file — credited by naming convention.
+func javaInterceptorAuthBinding(src string) (symbol, confidence string) {
+	// Must have at least one interceptor binding site to bind anything to.
+	hasBinding := javaServerInterceptorsInterceptRe.MatchString(src) ||
+		javaServerBuilderInterceptRe.MatchString(src)
+	if !hasBinding {
+		return "", ""
+	}
+
+	// In-file auth-enforcing interceptor classes (HIGH).
+	highNames := javaAuthEnforcingInterceptorNames(src)
+
+	// Collect the identifier arguments of every binding site.
+	bound := javaBoundInterceptorIdents(src)
+
+	// HIGH: a bound identifier names an in-file auth-enforcing interceptor.
+	for _, b := range bound {
+		if highNames[b.className] {
+			return b.className, "high"
+		}
+	}
+	// MEDIUM: a bound identifier is a conventionally-named auth interceptor
+	// (definition may be cross-file).
+	for _, b := range bound {
+		if javaGrpcConventionalInterceptorRe.MatchString(b.raw) {
+			return b.className, "medium"
+		}
+	}
+	return "", ""
+}
+
+// javaAuthEnforcingInterceptorNames returns the set of in-file class names that
+// implement ServerInterceptor and whose body BOTH reads Metadata AND rejects
+// with a gRPC auth status — the decisive in-file auth interceptor signal.
+func javaAuthEnforcingInterceptorNames(src string) map[string]bool {
+	names := map[string]bool{}
+	for _, loc := range javaServerInterceptorDeclRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[loc[2]:loc[3]]
+		// Body span: from the class decl to the matching close brace.
+		body, ok := javaBalancedBraceBody(src, loc[1])
+		if !ok {
+			// Fall back to a bounded window so a brace-walk miss does not drop
+			// a real auth interceptor; the regexes are still anchored to it.
+			end := loc[1] + 4000
+			if end > len(src) {
+				end = len(src)
+			}
+			body = src[loc[1]:end]
+		}
+		if javaGrpcMetadataReadRe.MatchString(body) && javaGrpcAuthRejectRe.MatchString(body) {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+// boundInterceptor is one interceptor reference passed to a binding site.
+type boundInterceptor struct {
+	raw       string // the raw argument text, e.g. "new AuthInterceptor()"
+	className string // the resolved class identifier, e.g. "AuthInterceptor"
+}
+
+// javaGrpcNewIdentRe extracts the class name from `new Foo(` and a bare
+// identifier `foo`. Group 1 (new form) or group 2 (bare) is the name.
+var javaGrpcNewIdentRe = regexp.MustCompile(`\bnew\s+([A-Za-z_]\w*)\s*\(|^\s*([A-Za-z_][\w.]*)\b`)
+
+// javaBoundInterceptorIdents collects the interceptor identifier arguments of
+// every ServerInterceptors.intercept(...) and ServerBuilder.intercept(...)
+// binding in src. For ServerInterceptors.intercept(service, i1, i2) the first
+// argument is the service, the rest interceptors; for builder .intercept(i) the
+// single argument is the interceptor.
+func javaBoundInterceptorIdents(src string) []boundInterceptor {
+	var out []boundInterceptor
+
+	add := func(arg string) {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			return
+		}
+		cls := arg
+		if m := javaGrpcNewIdentRe.FindStringSubmatch(arg); m != nil {
+			if m[1] != "" {
+				cls = m[1]
+			} else if m[2] != "" {
+				// bare identifier — strip any leading qualifier path.
+				cls = m[2]
+				if i := strings.LastIndex(cls, "."); i >= 0 {
+					cls = cls[i+1:]
+				}
+			}
+		}
+		out = append(out, boundInterceptor{raw: arg, className: cls})
+	}
+
+	// ServerInterceptors.intercept(service, ...interceptors)
+	for _, loc := range javaServerInterceptorsInterceptRe.FindAllStringIndex(src, -1) {
+		args, ok := javaBalancedParenArgs(src, loc[1]-1)
+		if !ok {
+			continue
+		}
+		parts := splitTopLevelArgs(args)
+		// Skip the first arg (the service); the rest are interceptors.
+		for i := 1; i < len(parts); i++ {
+			add(parts[i])
+		}
+	}
+	// Builder .intercept(interceptor)
+	for _, loc := range javaServerBuilderInterceptRe.FindAllStringIndex(src, -1) {
+		args, ok := javaBalancedParenArgs(src, loc[1]-1)
+		if !ok {
+			continue
+		}
+		for _, p := range splitTopLevelArgs(args) {
+			add(p)
+		}
+	}
+	return out
+}
+
+// resolveJavaGRPCClassAuth returns a class-level Spring/Jakarta-Security policy
+// when one decorates the @GrpcService impl class itself (applies to every
+// method). The annotation block scanned is the run of annotations immediately
+// preceding the `class` keyword.
+func resolveJavaGRPCClassAuth(src, path string) (AuthPolicy, bool) {
+	m := javaClassDeclRe.FindStringIndex(src)
+	if m == nil {
+		return AuthPolicy{}, false
+	}
+	// Annotation run preceding the class declaration (bounded window).
+	start := m[0] - 1200
+	if start < 0 {
+		start = 0
+	}
+	annoBlock := src[start:m[0]]
+	line := lineOfOffset(src, m[0])
+	if pol, ok := matchAnnotationPolicy(annoBlock, line, path, ""); ok {
+		return pol, true
+	}
+	if javaAuthenticatedAnnoRe.MatchString(annoBlock) {
+		return javaAuthenticatedPolicy(line, path), true
+	}
+	return AuthPolicy{}, false
+}
+
+// resolveJavaGRPCMethodAuth returns the per-method Spring/Jakarta-Security
+// policies for every gRPC handler method that carries an authorization
+// annotation. The annotation block is the run of annotations between the
+// previous declaration and the method signature.
+func resolveJavaGRPCMethodAuth(src, path string) map[string]AuthPolicy {
+	out := map[string]AuthPolicy{}
+	decls := javaGrpcMethodDeclRe.FindAllStringSubmatchIndex(src, -1)
+	prevEnd := 0
+	for _, d := range decls {
+		name := src[d[2]:d[3]]
+		// Annotation block: from the end of the previous method (or class
+		// start) up to this method signature.
+		annoBlock := src[prevEnd:d[0]]
+		prevEnd = d[1]
+		// Only the trailing run after the last `}` / `;` is this method's
+		// annotation set — earlier text belongs to prior members.
+		if i := strings.LastIndexAny(annoBlock, "};"); i >= 0 {
+			annoBlock = annoBlock[i+1:]
+		}
+		line := lineOfOffset(src, d[0])
+		if pol, ok := matchAnnotationPolicy(annoBlock, line, path, ""); ok {
+			out[name] = pol
+			continue
+		}
+		if javaAuthenticatedAnnoRe.MatchString(annoBlock) {
+			out[name] = javaAuthenticatedPolicy(line, path)
+		}
+	}
+	return out
+}
+
+// javaAuthenticatedPolicy builds the AuthPolicy for an @Authenticated marker —
+// required, any authenticated principal, no specific role.
+func javaAuthenticatedPolicy(line int, file string) AuthPolicy {
+	return AuthPolicy{
+		Required:   true,
+		Method:     "annotation",
+		Confidence: "high",
+		SourceChain: []AuthSignal{{
+			Kind: "annotation",
+			Text: "@Authenticated",
+			File: file,
+			Line: line,
+		}},
+	}
+}
+
+// grpcJavaInterceptorProps returns the props to merge onto a service/method
+// protected by an auth-enforcing ServerInterceptor.
+func grpcJavaInterceptorProps(symbol, confidence string) map[string]string {
+	if confidence == "" {
+		confidence = "high"
+	}
+	props := map[string]string{
+		"auth_required":   "true",
+		"auth_method":     grpcJavaInterceptorAuthMethod,
+		"auth_confidence": confidence,
+	}
+	if symbol != "" {
+		props["auth_middleware"] = symbol
+	}
+	policy := AuthPolicy{
+		Required:   true,
+		Method:     "middleware",
+		Confidence: confidence,
+		SourceChain: []AuthSignal{{
+			Kind: "middleware",
+			Text: "grpc-interceptor: " + symbol,
+		}},
+	}
+	if j := EncodeAuthPolicy(policy); j != "" {
+		props["auth_policy"] = j
+	}
+	return props
+}
+
+// grpcJavaPolicyProps turns a resolved Spring/Jakarta-Security AuthPolicy into
+// the flat companion props + auth_policy JSON, mirroring the HTTP Java stamping
+// in java_annotation_routes.go.
+func grpcJavaPolicyProps(policy AuthPolicy) map[string]string {
+	props := map[string]string{}
+	if j := EncodeAuthPolicy(policy); j != "" {
+		props["auth_policy"] = j
+	}
+	props["auth_method"] = policy.Method
+	props["auth_confidence"] = policy.Confidence
+	if policy.Required {
+		props["auth_required"] = "true"
+	} else if policy.Method != "unknown" {
+		props["auth_required"] = "false"
+	}
+	if len(policy.Roles) > 0 {
+		props["auth_roles"] = strings.Join(policy.Roles, ",")
+	}
+	if len(policy.Permissions) > 0 {
+		perms := append([]string(nil), policy.Permissions...)
+		sort.Strings(perms)
+		props["auth_permissions"] = strings.Join(perms, ",")
+	}
+	if len(policy.Scopes) > 0 {
+		scs := append([]string(nil), policy.Scopes...)
+		sort.Strings(scs)
+		props["auth_scopes"] = strings.Join(scs, ",")
+	}
+	return props
+}
+
+// javaBalancedParenArgs returns the substring inside the parentheses whose
+// opening `(` is at index openParen, walking balanced parens while skipping
+// double-quoted, single-quoted and char spans. Excludes the outer parens.
+func javaBalancedParenArgs(s string, openParen int) (string, bool) {
+	if openParen < 0 || openParen >= len(s) || s[openParen] != '(' {
+		return "", false
+	}
+	depth := 0
+	i := openParen
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case '"', '\'':
+			i = javaSkipQuoted(s, i)
+			continue
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[openParen+1 : i], true
+			}
+		}
+		i++
+	}
+	return "", false
+}
+
+// javaBalancedBraceBody returns the substring inside the first `{...}` block at
+// or after index from, walking balanced braces while skipping quoted spans.
+func javaBalancedBraceBody(s string, from int) (string, bool) {
+	open := -1
+	for i := from; i < len(s); i++ {
+		c := s[i]
+		if c == '"' || c == '\'' {
+			i = javaSkipQuoted(s, i) - 1
+			continue
+		}
+		if c == '{' {
+			open = i
+			break
+		}
+	}
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	i := open
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case '"', '\'':
+			i = javaSkipQuoted(s, i)
+			continue
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[open+1 : i], true
+			}
+		}
+		i++
+	}
+	return "", false
+}
+
+// javaSkipQuoted returns the index just past the quoted span starting at i
+// (s[i] is the opening quote). Handles backslash escapes.
+func javaSkipQuoted(s string, i int) int {
+	quote := s[i]
+	i++
+	for i < len(s) {
+		c := s[i]
+		if c == '\\' {
+			i += 2
+			continue
+		}
+		if c == quote {
+			return i + 1
+		}
+		i++
+	}
+	return len(s)
+}

--- a/internal/engine/grpc_java_auth_test.go
+++ b/internal/engine/grpc_java_auth_test.go
@@ -1,0 +1,380 @@
+// Tests for gRPC-Java server-auth detection (#4041, epic #3872).
+//
+// VALUE-ASSERTING: each positive asserts auth_required=true + the specific
+// auth_method / auth_roles on the SPECIFIC gRPC method served by an
+// auth-enforcing ServerInterceptor or carrying a Spring/Jakarta-Security
+// annotation (not len>0). Negatives prove a logging interceptor, a plain
+// @GrpcService method, and a no-interceptor server leave the methods UNSTAMPED.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func javaGRPCMethodEntity(ents []types.EntityRecord, service, method string) *types.EntityRecord {
+	want := "grpc:" + service + "/" + method
+	for i := range ents {
+		if ents[i].Kind == grpcMethodKind && ents[i].Name == want {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func javaGRPCServiceEntity(ents []types.EntityRecord, service string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == grpcServiceKind && ents[i].Name == service {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// requireJavaGRPCInterceptorAuth asserts the method + its service carry the
+// interceptor auth contract.
+func requireJavaGRPCInterceptorAuth(t *testing.T, ents []types.EntityRecord, service, method, wantSymbol, wantConf string) {
+	t.Helper()
+	m := javaGRPCMethodEntity(ents, service, method)
+	if m == nil {
+		t.Fatalf("expected GrpcMethod grpc:%s/%s; got %v", service, method, ents)
+	}
+	if got := m.Properties["auth_required"]; got != "true" {
+		t.Errorf("method %s/%s: auth_required = %q, want true", service, method, got)
+	}
+	if got := m.Properties["auth_method"]; got != grpcJavaInterceptorAuthMethod {
+		t.Errorf("method %s/%s: auth_method = %q, want %q", service, method, got, grpcJavaInterceptorAuthMethod)
+	}
+	if got := m.Properties["auth_middleware"]; got != wantSymbol {
+		t.Errorf("method %s/%s: auth_middleware = %q, want %q", service, method, got, wantSymbol)
+	}
+	if got := m.Properties["auth_confidence"]; got != wantConf {
+		t.Errorf("method %s/%s: auth_confidence = %q, want %q", service, method, got, wantConf)
+	}
+	policy := DecodeAuthPolicy(m.Properties["auth_policy"])
+	if !policy.Required || policy.Method != "middleware" {
+		t.Errorf("method %s/%s: auth_policy = %+v, want required middleware", service, method, policy)
+	}
+	if svc := javaGRPCServiceEntity(ents, service); svc != nil {
+		if svc.Properties["auth_required"] != "true" {
+			t.Errorf("service %s: auth_required = %q, want true", service, svc.Properties["auth_required"])
+		}
+	}
+}
+
+func requireNoJavaGRPCAuth(t *testing.T, ents []types.EntityRecord, service, method string) {
+	t.Helper()
+	m := javaGRPCMethodEntity(ents, service, method)
+	if m == nil {
+		t.Fatalf("expected GrpcMethod grpc:%s/%s; got %v", service, method, ents)
+	}
+	for _, k := range []string{"auth_required", "auth_method", "auth_middleware", "auth_policy", "auth_roles"} {
+		if v := m.Properties[k]; v != "" {
+			t.Errorf("method %s/%s: expected no auth, but %s = %q", service, method, k, v)
+		}
+	}
+}
+
+// --- Path 1: ServerInterceptor auth ---
+
+// TestGRPCJavaAuth_Interceptor_PerService: an in-file AuthInterceptor that
+// reads Metadata and closes with Status.UNAUTHENTICATED, bound to the service
+// via ServerInterceptors.intercept(service, new AuthInterceptor()).
+func TestGRPCJavaAuth_Interceptor_PerService(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import io.demo.proto.GreeterGrpc;
+
+class AuthInterceptor implements ServerInterceptor {
+    static final Metadata.Key<String> AUTHZ =
+        Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+    public <Q, A> ServerCall.Listener<Q> interceptCall(
+            ServerCall<Q, A> call, Metadata headers, ServerCallHandler<Q, A> next) {
+        if (headers.get(AUTHZ) == null) {
+            call.close(Status.UNAUTHENTICATED.withDescription("missing token"), new Metadata());
+            return new ServerCall.Listener<Q>() {};
+        }
+        return next.startCall(call, headers);
+    }
+}
+
+public class GreeterService extends GreeterGrpc.GreeterImplBase {
+    @Override
+    public void sayHello(HelloRequest req, StreamObserver<HelloReply> observer) {
+        observer.onNext(HelloReply.newBuilder().build());
+        observer.onCompleted();
+    }
+    @Override
+    public void sayGoodbye(HelloRequest req, StreamObserver<HelloReply> observer) {
+        observer.onCompleted();
+    }
+}
+
+class Server {
+    void start() throws Exception {
+        ServerBuilder.forPort(8080)
+            .addService(ServerInterceptors.intercept(new GreeterService(), new AuthInterceptor()))
+            .build().start();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "GreeterService.java", src)
+	requireJavaGRPCInterceptorAuth(t, ents, "Greeter", "sayHello", "AuthInterceptor", "high")
+	requireJavaGRPCInterceptorAuth(t, ents, "Greeter", "sayGoodbye", "AuthInterceptor", "high")
+}
+
+// TestGRPCJavaAuth_Interceptor_GlobalBuilder: a global ServerBuilder.intercept
+// binding of an in-file auth interceptor.
+func TestGRPCJavaAuth_Interceptor_GlobalBuilder(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import io.demo.proto.OrderGrpc;
+
+class JwtAuthInterceptor implements ServerInterceptor {
+    public <Q, A> ServerCall.Listener<Q> interceptCall(
+            ServerCall<Q, A> call, Metadata headers, ServerCallHandler<Q, A> next) {
+        String tok = headers.get(Metadata.Key.of("auth", Metadata.ASCII_STRING_MARSHALLER));
+        if (!valid(tok)) {
+            call.close(Status.PERMISSION_DENIED.withDescription("denied"), new Metadata());
+            return new ServerCall.Listener<Q>() {};
+        }
+        return next.startCall(call, headers);
+    }
+}
+
+public class OrderService extends OrderGrpc.OrderImplBase {
+    @Override
+    public void placeOrder(OrderRequest req, StreamObserver<OrderReply> observer) {
+        observer.onCompleted();
+    }
+}
+
+class Boot {
+    void run() throws Exception {
+        ServerBuilder.forPort(9090)
+            .addService(new OrderService())
+            .intercept(new JwtAuthInterceptor())
+            .build().start();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "OrderService.java", src)
+	requireJavaGRPCInterceptorAuth(t, ents, "Order", "placeOrder", "JwtAuthInterceptor", "high")
+}
+
+// TestGRPCJavaAuth_Interceptor_ConventionalCrossFile: a bound interceptor whose
+// definition is cross-file but is conventionally named — credited MEDIUM.
+func TestGRPCJavaAuth_Interceptor_ConventionalCrossFile(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import io.demo.proto.PayGrpc;
+import io.demo.security.AuthServerInterceptor; // defined elsewhere
+
+public class PayService extends PayGrpc.PayImplBase {
+    @Override
+    public void charge(ChargeRequest req, StreamObserver<ChargeReply> observer) {
+        observer.onCompleted();
+    }
+}
+
+class Boot {
+    void run() throws Exception {
+        ServerBuilder.forPort(7070)
+            .addService(ServerInterceptors.intercept(new PayService(), new AuthServerInterceptor()))
+            .build().start();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "PayService.java", src)
+	requireJavaGRPCInterceptorAuth(t, ents, "Pay", "charge", "AuthServerInterceptor", "medium")
+}
+
+// --- Path 2: Spring/Jakarta-Security annotations ---
+
+// TestGRPCJavaAuth_PreAuthorize_Method: @GrpcService + per-method
+// @PreAuthorize("hasRole('ADMIN')") → auth_roles=ADMIN on that method only.
+func TestGRPCJavaAuth_PreAuthorize_Method(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.stub.StreamObserver;
+import org.springframework.security.access.prepost.PreAuthorize;
+import net.devh.boot.grpc.server.service.GrpcService;
+import io.demo.proto.AdminGrpc;
+
+@GrpcService
+public class AdminService extends AdminGrpc.AdminImplBase {
+    @Override
+    @PreAuthorize("hasRole('ADMIN')")
+    public void deleteAll(Empty req, StreamObserver<Empty> observer) {
+        observer.onCompleted();
+    }
+    @Override
+    public void ping(Empty req, StreamObserver<Empty> observer) {
+        observer.onCompleted();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "AdminService.java", src)
+	m := javaGRPCMethodEntity(ents, "Admin", "deleteAll")
+	if m == nil {
+		t.Fatalf("expected GrpcMethod grpc:Admin/deleteAll; got %v", ents)
+	}
+	if m.Properties["auth_required"] != "true" {
+		t.Errorf("deleteAll: auth_required = %q, want true", m.Properties["auth_required"])
+	}
+	if m.Properties["auth_method"] != "annotation" {
+		t.Errorf("deleteAll: auth_method = %q, want annotation", m.Properties["auth_method"])
+	}
+	if m.Properties["auth_roles"] != "ADMIN" {
+		t.Errorf("deleteAll: auth_roles = %q, want ADMIN", m.Properties["auth_roles"])
+	}
+	// ping has no annotation and there is no service-wide interceptor → public.
+	requireNoJavaGRPCAuth(t, ents, "Admin", "ping")
+}
+
+// TestGRPCJavaAuth_Secured_Method: @Secured("ROLE_MANAGER") → role MANAGER
+// (ROLE_ prefix stripped).
+func TestGRPCJavaAuth_Secured_Method(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.stub.StreamObserver;
+import org.springframework.security.access.annotation.Secured;
+import net.devh.boot.grpc.server.service.GrpcService;
+import io.demo.proto.ReportGrpc;
+
+@GrpcService
+public class ReportService extends ReportGrpc.ReportImplBase {
+    @Override
+    @Secured("ROLE_MANAGER")
+    public void export(ReportRequest req, StreamObserver<ReportReply> observer) {
+        observer.onCompleted();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "ReportService.java", src)
+	m := javaGRPCMethodEntity(ents, "Report", "export")
+	if m == nil {
+		t.Fatalf("expected GrpcMethod grpc:Report/export; got %v", ents)
+	}
+	if m.Properties["auth_required"] != "true" || m.Properties["auth_roles"] != "MANAGER" {
+		t.Errorf("export: auth_required=%q auth_roles=%q, want true / MANAGER",
+			m.Properties["auth_required"], m.Properties["auth_roles"])
+	}
+}
+
+// TestGRPCJavaAuth_Authenticated_Class: class-level @Authenticated flows down to
+// every method as required (no specific role).
+func TestGRPCJavaAuth_Authenticated_Class(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.security.Authenticated;
+import net.devh.boot.grpc.server.service.GrpcService;
+import io.demo.proto.AccountGrpc;
+
+@GrpcService
+@Authenticated
+public class AccountService extends AccountGrpc.AccountImplBase {
+    @Override
+    public void balance(AccountRequest req, StreamObserver<AccountReply> observer) {
+        observer.onCompleted();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "AccountService.java", src)
+	m := javaGRPCMethodEntity(ents, "Account", "balance")
+	if m == nil {
+		t.Fatalf("expected GrpcMethod grpc:Account/balance; got %v", ents)
+	}
+	if m.Properties["auth_required"] != "true" || m.Properties["auth_method"] != "annotation" {
+		t.Errorf("balance: auth_required=%q auth_method=%q, want true / annotation",
+			m.Properties["auth_required"], m.Properties["auth_method"])
+	}
+	if m.Properties["auth_roles"] != "" {
+		t.Errorf("balance: auth_roles = %q, want empty (@Authenticated has no role)", m.Properties["auth_roles"])
+	}
+}
+
+// --- Negatives ---
+
+// TestGRPCJavaAuth_Negative_LoggingInterceptor: a logging interceptor (no
+// metadata-reject) bound to the service does NOT enforce auth.
+func TestGRPCJavaAuth_Negative_LoggingInterceptor(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import io.demo.proto.GreeterGrpc;
+
+class LoggingInterceptor implements ServerInterceptor {
+    public <Q, A> ServerCall.Listener<Q> interceptCall(
+            ServerCall<Q, A> call, Metadata headers, ServerCallHandler<Q, A> next) {
+        System.out.println("call: " + call.getMethodDescriptor().getFullMethodName());
+        return next.startCall(call, headers);
+    }
+}
+
+public class GreeterService extends GreeterGrpc.GreeterImplBase {
+    @Override
+    public void sayHello(HelloRequest req, StreamObserver<HelloReply> observer) {
+        observer.onCompleted();
+    }
+}
+
+class Server {
+    void start() throws Exception {
+        ServerBuilder.forPort(8080)
+            .addService(ServerInterceptors.intercept(new GreeterService(), new LoggingInterceptor()))
+            .build().start();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "GreeterService.java", src)
+	requireNoJavaGRPCAuth(t, ents, "Greeter", "sayHello")
+}
+
+// TestGRPCJavaAuth_Negative_PlainGrpcService: a plain @GrpcService method with
+// no interceptor and no security annotation is public.
+func TestGRPCJavaAuth_Negative_PlainGrpcService(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+import io.demo.proto.EchoGrpc;
+
+@GrpcService
+public class EchoService extends EchoGrpc.EchoImplBase {
+    @Override
+    public void echo(EchoRequest req, StreamObserver<EchoReply> observer) {
+        observer.onNext(EchoReply.newBuilder().build());
+        observer.onCompleted();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "EchoService.java", src)
+	requireNoJavaGRPCAuth(t, ents, "Echo", "echo")
+}
+
+// TestGRPCJavaAuth_Negative_NoInterceptorServer: a server with no interceptor
+// binding at all leaves methods unstamped.
+func TestGRPCJavaAuth_Negative_NoInterceptorServer(t *testing.T) {
+	src := `package io.demo.grpc;
+import io.grpc.*;
+import io.grpc.stub.StreamObserver;
+import io.demo.proto.GreeterGrpc;
+
+public class GreeterService extends GreeterGrpc.GreeterImplBase {
+    @Override
+    public void sayHello(HelloRequest req, StreamObserver<HelloReply> observer) {
+        observer.onCompleted();
+    }
+}
+
+class Server {
+    void start() throws Exception {
+        ServerBuilder.forPort(8080).addService(new GreeterService()).build().start();
+    }
+}
+`
+	ents, _ := runGRPCDetect(t, "java", "GreeterService.java", src)
+	requireNoJavaGRPCAuth(t, ents, "Greeter", "sayHello")
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -15171,6 +15171,61 @@ records:
               functions: [TestTransactional_JTARollbackOn_3863, TestTransactional_Dropwizard_3863]
           issues_implemented: ["3863"]
           verified_at: "2026-06-03"
+  lang.java.framework.grpc:
+    capabilities:
+      Auth:
+        auth_coverage:
+          # gRPC-Java server auth (#4041, epic #3872). Two idioms:
+          # (1) io.grpc.ServerInterceptor whose interceptCall reads the call
+          # Metadata AND closes with Status.UNAUTHENTICATED/PERMISSION_DENIED,
+          # bound via ServerInterceptors.intercept(service,...) / a global
+          # ServerBuilder.intercept(...) -> auth_method=grpc_interceptor +
+          # auth_middleware (HIGH; conventional cross-file ...AuthInterceptor
+          # credited MEDIUM). (2) grpc-spring-boot-starter @GrpcService class
+          # with Spring/Jakarta-Security @PreAuthorize/@Secured/@RolesAllowed/
+          # @DenyAll/@Authenticated on the method (or class) -> auth_method=
+          # annotation + auth_roles/permissions/scopes (matchAnnotationPolicy).
+          # Stamps the SCOPE.GrpcService + its same-file SCOPE.GrpcMethod handlers.
+          status: full
+          symbols:
+            - file: internal/engine/grpc_java_auth.go
+              functions: [resolveJavaGRPCAuth, javaInterceptorAuthBinding, javaAuthEnforcingInterceptorNames, javaBoundInterceptorIdents, resolveJavaGRPCClassAuth, resolveJavaGRPCMethodAuth, grpcJavaInterceptorProps, grpcJavaPolicyProps]
+            - file: internal/engine/grpc_edges.go
+              functions: [synthesizeJavaGRPC]
+          tests:
+            - file: internal/engine/grpc_java_auth_test.go
+          issues_implemented: ["4041"]
+          verified_at: "2026-06-03"
+      Schema:
+        procedure_extraction:
+          status: partial
+          symbols:
+            - file: internal/engine/grpc_edges.go
+              functions: [synthesizeJavaGRPC]
+          tests:
+            - file: internal/engine/grpc_edges_test.go
+          issues_implemented: ["725"]
+          verified_at: "2026-06-03"
+      Transport:
+        transport_binding:
+          status: partial
+          symbols:
+            - file: internal/engine/grpc_edges.go
+              functions: [synthesizeJavaGRPC]
+          tests:
+            - file: internal/engine/grpc_edges_test.go
+          issues_implemented: ["725"]
+          verified_at: "2026-06-03"
+      Codegen:
+        client_codegen:
+          status: partial
+          symbols:
+            - file: internal/engine/grpc_edges.go
+              functions: [synthesizeJavaGRPC]
+          tests:
+            - file: internal/engine/grpc_edges_test.go
+          issues_implemented: ["725"]
+          verified_at: "2026-06-03"
   lang.java.framework.helidon:
     capabilities:
       Routing:


### PR DESCRIPTION
## Summary

Builds the **gRPC-Java** slice of #4041 (epic #3872). The Java auth sniffers (`java_annotation_routes.go` / `java_auth_policy.go`) are HTTP-route/annotation-keyed and miss gRPC server auth, which lives in a transport-level `io.grpc.ServerInterceptor` or in grpc-spring-boot-starter Spring-Security annotations on the `@GrpcService` methods. Mirrors the gRPC-Go slice (#4064).

New `internal/engine/grpc_java_auth.go` (`resolveJavaGRPCAuth`, wired into `synthesizeJavaGRPC`) detects two enforcement idioms and stamps the auth contract on the `SCOPE.GrpcService` + its same-file `SCOPE.GrpcMethod` handlers:

1. **ServerInterceptor** — an `io.grpc.ServerInterceptor` whose `interceptCall` body BOTH reads the call `Metadata` AND closes/rejects with `Status.UNAUTHENTICATED` / `PERMISSION_DENIED`, bound via `ServerInterceptors.intercept(service, ...)` or a global `ServerBuilder.intercept(...)` → `auth_method=grpc_interceptor` + `auth_middleware` (HIGH); a conventionally-named (`...AuthInterceptor`) cross-file interceptor is credited by name (MEDIUM).
2. **grpc-spring-boot-starter** — a `@GrpcService` class with Spring/Jakarta-Security `@PreAuthorize` / `@Secured` / `@RolesAllowed` / `@DenyAll` / `@Authenticated` on the RPC method (or class) → `auth_method=annotation` + `auth_roles`/`auth_permissions`/`auth_scopes` (reusing `matchAnnotationPolicy`).

The `@Override`-anchored method scan in `grpc_edges.go` is widened to tolerate authorization annotations interleaved between `@Override` and the signature (grpc-spring-boot-starter places them there — without this the handler is never emitted, so couldn't be stamped). Same change fixes a latent bug where streaming detection always reused the *first* match's window for every method.

## VERIFY-FIRST

Confirmed (probe, pre-build) that Java gRPC methods carried `auth_required=""` / `auth_method=""` today.

## Value-asserting tests (+ negatives) — `grpc_java_auth_test.go`

Positives assert on the **specific** method:
- `Greeter/sayHello`,`sayGoodbye` via `ServerInterceptors.intercept(svc, new AuthInterceptor())` → `auth_required=true`, `auth_method=grpc_interceptor`, `auth_middleware=AuthInterceptor`, confidence HIGH.
- `Order/placeOrder` via global `ServerBuilder.intercept(new JwtAuthInterceptor())` → HIGH.
- `Pay/charge` via conventionally-named cross-file `AuthServerInterceptor` → MEDIUM.
- `Admin/deleteAll` `@PreAuthorize("hasRole('ADMIN')")` → `auth_roles=ADMIN` (and `Admin/ping` stays public).
- `Report/export` `@Secured("ROLE_MANAGER")` → `auth_roles=MANAGER` (prefix stripped).
- `Account/balance` class-level `@Authenticated` → required, no role.

Negatives (UNSTAMPED): logging interceptor (no metadata-reject), plain `@GrpcService` method, no-interceptor server.

## What's left on #4041

C++ / Scala / Elixir gRPC interceptor auth + grpc-net `[Authorize]` (Go #4064 + tRPC #4060 already done). DEPLOY-DEFERRED.

## Honest limits

- Interceptor binding must live **same-file** as the service impl (the rest of `grpc_edges.go` Java synthesis lives within the same boundary). The common impl-in-`FooService.java` / bootstrap-in-`GrpcServer.java` split is covered by the **annotation** path, not the interceptor path.
- An arbitrarily-named cross-file interceptor (not `(auth|authentication|jwt|security)…Interceptor`) is not chased.

## Registry

New `lang.java.framework.grpc` (rpc_framework) mirroring `lang.go.framework.grpc`, `auth_coverage` → **full**; capability-map.yaml entry added; `protocol.grpc` hub row added. `covtool validate` clean (no new warnings), `gen` 0 drift, `fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)