### PR TITLE
feat(php): rate-limit stamping for Laravel throttle + Symfony RateLimiter (#4073)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -86,13 +86,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 10/11 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟢 11/11 | |
 | [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
 | [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 8/11 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 9/11 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -32,13 +32,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 10/11 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟢 11/11 | |
 | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
 | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 8/11 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 9/11 | |
 | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route ->middleware() attachment and ->withoutMiddleware() exclusion |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | ✅ `full` | `2026-06-03` | 4073 | `internal/engine/http_endpoint_php_ratelimit.go`<br>`internal/engine/http_endpoint_php_ratelimit_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | #4073: applyLaravelRateLimit stamps the flat rate_limited/rate_limit/rate_limit_scope/rate_limit_source contract on Laravel http_endpoint_definition synthetics. Per-route ->middleware('throttle:60,1') resolves rate=60/1min at route scope; Route::group(['middleware'=>['throttle:30,1']]) propagates at group scope; a NAMED limiter throttle:api is honest-partial (limit/window live in a RateLimiter::for() registration, rate omitted). Non-throttle middleware (auth/cache.headers) and plain routes are negatives. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/php/symfony.go` | EventSubscriberInterface implementors with getSubscribedEvents() event name extraction; addListener/addSubscriber kernel event registration; kernel event names emitted as SCOPE.Pattern |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | ✅ `full` | `2026-06-03` | 4073 | `internal/custom/php/symfony.go`<br>`internal/custom/php/symfony_ratelimit_test.go` | #4073: the custom_php_symfony extractor stamps the flat rate_limited/rate_limit_scope/rate_limit_source contract on Symfony route SCOPE.Operation endpoints when a #[RateLimiter('name')] attribute is co-located with the #[Route(...)] action (attribute order within the block is free). Honest-partial: the named limiter's limit/window live in config/packages/rate_limiter.yaml, so the numeric rate is omitted. A sibling action without the attribute is a negative; the limiter never mis-pairs across actions. |
 
 ### Schema
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -51541,9 +51541,11 @@
             "notes": "Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route -\u003emiddleware() attachment and -\u003ewithoutMiddleware() exclusion"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_php_ratelimit.go","internal/engine/http_endpoint_php_ratelimit_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "4073",
+            "notes": "#4073: applyLaravelRateLimit stamps the flat rate_limited/rate_limit/rate_limit_scope/rate_limit_source contract on Laravel http_endpoint_definition synthetics. Per-route -\u003emiddleware('throttle:60,1') resolves rate=60/1min at route scope; Route::group(['middleware'=\u003e['throttle:30,1']]) propagates at group scope; a NAMED limiter throttle:api is honest-partial (limit/window live in a RateLimiter::for() registration, rate omitted). Non-throttle middleware (auth/cache.headers) and plain routes are negatives.",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {
@@ -53258,9 +53260,11 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "full",
+            "cites": ["internal/custom/php/symfony.go","internal/custom/php/symfony_ratelimit_test.go"],
+            "issue": "4073",
+            "notes": "#4073: the custom_php_symfony extractor stamps the flat rate_limited/rate_limit_scope/rate_limit_source contract on Symfony route SCOPE.Operation endpoints when a #[RateLimiter('name')] attribute is co-located with the #[Route(...)] action (attribute order within the block is free). Honest-partial: the named limiter's limit/window live in config/packages/rate_limiter.yaml, so the numeric rate is omitted. A sibling action without the attribute is a negative; the limiter never mis-pairs across actions.",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {

--- a/internal/custom/php/symfony.go
+++ b/internal/custom/php/symfony.go
@@ -122,6 +122,16 @@ var (
 	reSymServiceClass = regexp.MustCompile(
 		`(?m)class\s+(\w+)\b`,
 	)
+
+	// PHP8 RateLimiter attribute (symfony/rate-limiter bundle / custom limiter
+	// attribute): #[RateLimiter('anonymous_api')] / #[RateLimiter(limiter: 'login')].
+	// Group 1 = the limiter name. The numeric limit/window live in
+	// config/packages/rate_limiter.yaml (or framework.rate_limiter.*), so the
+	// posture is honest-partial: rate_limited + the named limiter source resolve,
+	// the rate is never fabricated here.
+	reSymRateLimiterAttr = regexp.MustCompile(
+		`#\[RateLimiter\s*\(\s*(?:limiter\s*:\s*)?['"]([^'"]+)['"]`,
+	)
 )
 
 // ---------------------------------------------------------------------------
@@ -238,6 +248,111 @@ func symParseRouteName(body string) string {
 		return m[1]
 	}
 	return ""
+}
+
+// symRateLimiterNear returns the limiter name of a #[RateLimiter('name')]
+// attribute co-located with a #[Route(...)] attribute at byte offset routeStart,
+// or "" when none is present. PHP8 attributes that decorate the same controller
+// action sit in one contiguous block above the `function` declaration — e.g.
+//
+//	#[Route('/login', methods: ['POST'])]
+//	#[RateLimiter('login')]
+//	public function login() { … }
+//
+// The limiter may appear before OR after the route attribute, so we scan a
+// bounded window on both sides bounded by the nearest `function`/`}`/`;` so a
+// RateLimiter on a *different* action is never mis-paired.
+func symRateLimiterNear(src string, routeStart int) string {
+	// Window: from the start of the attribute block (walk back over preceding
+	// `#[` attribute lines) to the action's `function` keyword (walk forward).
+	lo := routeStart
+	// Walk back to the beginning of the current line, then keep including
+	// immediately-preceding lines that are attribute (`#[`) lines so a
+	// RateLimiter attribute ABOVE the Route attribute is captured.
+	for {
+		ls := lineStartOffset(src, lo)
+		line := strings.TrimSpace(src[ls:lineEndOffset(src, lo)])
+		if lo != routeStart && !strings.HasPrefix(line, "#[") {
+			lo = ls
+			break
+		}
+		if ls == 0 {
+			lo = 0
+			break
+		}
+		lo = ls - 1 // step into the previous line
+	}
+	// Forward bound: the action body / next statement. Stop at the first
+	// `function`, `{`, or `;` after the route so a limiter on a sibling action
+	// is excluded.
+	hi := routeStart
+	for hi < len(src) {
+		switch src[hi] {
+		case '{', ';':
+			goto done
+		}
+		if strings.HasPrefix(src[hi:], "function") {
+			// Include up to and past the function signature head.
+			if nl := strings.IndexByte(src[hi:], '{'); nl >= 0 {
+				hi = hi + nl
+			} else {
+				hi = len(src)
+			}
+			goto done
+		}
+		hi++
+	}
+done:
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > len(src) {
+		hi = len(src)
+	}
+	if m := reSymRateLimiterAttr.FindStringSubmatch(src[lo:hi]); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// lineStartOffset returns the offset of the first byte of the line containing
+// off.
+func lineStartOffset(src string, off int) int {
+	if off > len(src) {
+		off = len(src)
+	}
+	i := strings.LastIndexByte(src[:off], '\n')
+	if i < 0 {
+		return 0
+	}
+	return i + 1
+}
+
+// lineEndOffset returns the offset of the newline (or EOF) ending the line
+// containing off.
+func lineEndOffset(src string, off int) int {
+	if off > len(src) {
+		return len(src)
+	}
+	i := strings.IndexByte(src[off:], '\n')
+	if i < 0 {
+		return len(src)
+	}
+	return off + i
+}
+
+// symStampRateLimit writes the flat rate-limit contract onto a Symfony route
+// endpoint entity for a co-located #[RateLimiter('name')] attribute. The rate is
+// honest-partial (omitted): the limit/window are defined in the named limiter's
+// config, not on the attribute. Mirrors the shared
+// rate_limited/rate_limit_scope/rate_limit_source property contract.
+func symStampRateLimit(ent *types.EntityRecord, limiter string) {
+	if limiter == "" {
+		return
+	}
+	setProps(ent, "rate_limited", "true",
+		"rate_limit_scope", "route",
+		"rate_limit_source", "#[RateLimiter:"+limiter+"]")
 }
 
 // symSplitMethodList splits a raw comma-separated list of HTTP methods (which
@@ -364,6 +479,12 @@ func (e *symfonyExtractor) Extract(ctx context.Context, file extractor.FileInput
 		body := src[m[4]:m[5]]
 		methods := symParseRouteMethods(body)
 		routeName := symParseRouteName(body)
+		// #4073 — a #[RateLimiter('name')] attribute co-located on the same
+		// controller action stamps the flat rate-limit contract on this route's
+		// endpoint(s). Honest-partial: the named limiter's limit/window live in
+		// config/packages/rate_limiter.yaml, so only rate_limited + source +
+		// scope are stamped (the numeric rate is never fabricated here).
+		limiter := symRateLimiterNear(src, m[0])
 
 		if len(methods) == 0 {
 			// Emit one endpoint without method prefix (matches existing tests)
@@ -373,6 +494,7 @@ func (e *symfonyExtractor) Extract(ctx context.Context, file extractor.FileInput
 			if routeName != "" {
 				setProps(&ent, "route_name", routeName)
 			}
+			symStampRateLimit(&ent, limiter)
 			add(ent)
 		} else {
 			for _, method := range methods {
@@ -383,6 +505,7 @@ func (e *symfonyExtractor) Extract(ctx context.Context, file extractor.FileInput
 				if routeName != "" {
 					setProps(&ent, "route_name", routeName)
 				}
+				symStampRateLimit(&ent, limiter)
 				add(ent)
 			}
 			// Also emit a bare path entity for backward-compat deduplication
@@ -392,6 +515,7 @@ func (e *symfonyExtractor) Extract(ctx context.Context, file extractor.FileInput
 			if routeName != "" {
 				setProps(&bareEnt, "route_name", routeName)
 			}
+			symStampRateLimit(&bareEnt, limiter)
 			add(bareEnt)
 		}
 	}

--- a/internal/custom/php/symfony_ratelimit_test.go
+++ b/internal/custom/php/symfony_ratelimit_test.go
@@ -1,0 +1,145 @@
+package php_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/php"
+)
+
+// symEndpoint runs the custom_php_symfony extractor and returns the route
+// endpoint entity named `name` (e.g. "POST /login"), with full Properties.
+func symEndpoint(t *testing.T, src, name string) types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_php_symfony")
+	if !ok {
+		t.Fatal("extractor custom_php_symfony not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: "src/Controller/ApiController.php", Language: "php", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	for _, ent := range ents {
+		if ent.Kind == "SCOPE.Operation" && ent.Name == name {
+			return ent
+		}
+	}
+	names := make([]string, 0, len(ents))
+	for _, ent := range ents {
+		if ent.Kind == "SCOPE.Operation" {
+			names = append(names, ent.Name)
+		}
+	}
+	t.Fatalf("endpoint %q not found (got: %v)", name, names)
+	return types.EntityRecord{}
+}
+
+// TestSymfonyRateLimit_AttributeHonestPartial — the canonical spec case: a
+// #[RateLimiter('login')] attribute co-located with a #[Route(...)] action →
+// the endpoint is rate_limited=true naming the limiter at route scope. The rate
+// is honest-partial (omitted): the limit/window live in
+// config/packages/rate_limiter.yaml.
+func TestSymfonyRateLimit_AttributeHonestPartial(t *testing.T) {
+	src := `<?php
+namespace App\Controller;
+use Symfony\Component\RateLimiter\Attribute\RateLimiter;
+use Symfony\Component\Routing\Annotation\Route;
+class ApiController {
+    #[Route('/login', methods: ['POST'], name: 'login')]
+    #[RateLimiter('login')]
+    public function login() { return null; }
+
+    #[Route('/health', methods: ['GET'], name: 'health')]
+    public function health() { return null; }
+}
+`
+	login := symEndpoint(t, src, "POST /login")
+	if login.Properties["rate_limited"] != "true" {
+		t.Errorf("POST /login: rate_limited=%q, want true (props: %v)", login.Properties["rate_limited"], login.Properties)
+	}
+	if login.Properties["rate_limit_scope"] != "route" {
+		t.Errorf("POST /login: rate_limit_scope=%q, want route", login.Properties["rate_limit_scope"])
+	}
+	if login.Properties["rate_limit_source"] != "#[RateLimiter:login]" {
+		t.Errorf("POST /login: rate_limit_source=%q, want #[RateLimiter:login]", login.Properties["rate_limit_source"])
+	}
+	// Honest-partial: the named limiter's rate lives in config; never fabricate.
+	if login.Properties["rate_limit"] != "" {
+		t.Errorf("POST /login: rate_limit=%q, want omitted (config-driven honest-partial)", login.Properties["rate_limit"])
+	}
+
+	// Negative: a sibling action with no RateLimiter attribute is unthrottled.
+	health := symEndpoint(t, src, "GET /health")
+	if health.Properties["rate_limited"] == "true" {
+		t.Errorf("GET /health: rate_limited=true, want unthrottled (props: %v)", health.Properties)
+	}
+	if health.Properties["rate_limit_source"] != "" {
+		t.Errorf("GET /health: leaked rate_limit_source=%q (props: %v)", health.Properties["rate_limit_source"], health.Properties)
+	}
+}
+
+// TestSymfonyRateLimit_LimiterKeyword — the keyword form
+// #[RateLimiter(limiter: 'anonymous_api')] resolves the limiter name too.
+func TestSymfonyRateLimit_LimiterKeyword(t *testing.T) {
+	src := `<?php
+namespace App\Controller;
+class ApiController {
+    #[Route('/api/items', methods: ['GET'])]
+    #[RateLimiter(limiter: 'anonymous_api')]
+    public function items() { return null; }
+}
+`
+	p := symEndpoint(t, src, "GET /api/items").Properties
+	if p["rate_limited"] != "true" {
+		t.Errorf("GET /api/items: rate_limited=%q, want true (props: %v)", p["rate_limited"], p)
+	}
+	if p["rate_limit_source"] != "#[RateLimiter:anonymous_api]" {
+		t.Errorf("GET /api/items: rate_limit_source=%q, want #[RateLimiter:anonymous_api]", p["rate_limit_source"])
+	}
+}
+
+// TestSymfonyRateLimit_AttributeAboveRoute — the RateLimiter attribute may sit
+// ABOVE the Route attribute (order within the block is free); it must still bind.
+func TestSymfonyRateLimit_AttributeAboveRoute(t *testing.T) {
+	src := `<?php
+namespace App\Controller;
+class ApiController {
+    #[RateLimiter('signup')]
+    #[Route('/signup', methods: ['POST'])]
+    public function signup() { return null; }
+}
+`
+	p := symEndpoint(t, src, "POST /signup").Properties
+	if p["rate_limited"] != "true" || p["rate_limit_source"] != "#[RateLimiter:signup]" {
+		t.Errorf("POST /signup: want rate_limited + #[RateLimiter:signup] (props: %v)", p)
+	}
+}
+
+// TestSymfonyRateLimit_NotMisPairedToSibling — a RateLimiter on one action must
+// NOT leak onto a different action's route in the same class.
+func TestSymfonyRateLimit_NotMisPairedToSibling(t *testing.T) {
+	src := `<?php
+namespace App\Controller;
+class ApiController {
+    #[Route('/a', methods: ['GET'])]
+    public function a() { return null; }
+
+    #[Route('/b', methods: ['GET'])]
+    #[RateLimiter('b_limiter')]
+    public function b() { return null; }
+}
+`
+	a := symEndpoint(t, src, "GET /a").Properties
+	if a["rate_limited"] == "true" {
+		t.Errorf("GET /a: rate_limited=true, want unthrottled — RateLimiter belongs to /b (props: %v)", a)
+	}
+	b := symEndpoint(t, src, "GET /b").Properties
+	if b["rate_limit_source"] != "#[RateLimiter:b_limiter]" {
+		t.Errorf("GET /b: rate_limit_source=%q, want #[RateLimiter:b_limiter]", b["rate_limit_source"])
+	}
+}

--- a/internal/engine/http_endpoint_php_ratelimit.go
+++ b/internal/engine/http_endpoint_php_ratelimit.go
@@ -1,0 +1,298 @@
+// http_endpoint_php_ratelimit.go — endpoint rate-limit / throttle stamping for
+// the PHP backend-HTTP frameworks (child of #3628 → #4073, "[api] PHP endpoint
+// rate-limit / throttle stamping"). Sibling of the Java pass
+// (http_endpoint_java_ratelimit.go), the JS/TS pass
+// (http_endpoint_jsts_ratelimit.go) and the Python pass
+// (internal/custom/python/rate_limit_endpoint.go); stamps the SAME flat property
+// contract on the producer-side http_endpoint_definition entity (no parallel
+// node):
+//
+//	rate_limited      — "true" when a throttle applies to the endpoint.
+//	rate_limit        — human rate "60/1min" when statically resolvable from a
+//	                    `throttle:<max>,<minutes>` middleware argument; OMITTED
+//	                    (honest-partial) for a NAMED limiter
+//	                    (`throttle:api`) whose limit/window live in a
+//	                    `RateLimiter::for('api', …)` registration (usually a
+//	                    different file).
+//	rate_limit_scope  — "route" (per-route `->middleware('throttle:…')`) |
+//	                    "group" (a `Route::group(['middleware'=>['throttle:…']])`
+//	                    wrapping the route).
+//	rate_limit_source — the recognised middleware token (evidence):
+//	                    "throttle:60,1" for a literal limiter, "throttle:api" for
+//	                    a named one.
+//
+// Recognised Laravel surfaces:
+//
+//	per-route   — `Route::get('/x', …)->middleware('throttle:60,1')` and the
+//	              array form `->middleware(['throttle:60,1','auth'])`. The
+//	              throttle token is paired to the route by statement proximity
+//	              (the chain sits between this `Route::<verb>(` and the next).
+//	  group     — `Route::group(['middleware' => ['throttle:30,1']], fn)` /
+//	              `'middleware' => 'throttle:30,1'`: every route whose byte
+//	              offset falls inside the group body inherits the throttle at
+//	              "group" scope. A per-route throttle takes precedence.
+//
+// `throttle:<max>,<minutes>` → rate "<max>/<minutes>min". A named limiter
+// `throttle:<name>` (non-numeric first arg) is honest-partial: rate_limited +
+// source resolve, the numeric rate is omitted.
+//
+// Like the other passes this adds NO entity — it mutates the Properties of the
+// http_endpoint_definition entities synthesizeLaravel already emitted. `before`
+// is the entity-slice length captured before the PHP synthesizers ran.
+//
+// Refs #3628, #4073.
+package engine
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// phpRateLimit is a resolved throttle posture for one endpoint.
+type phpRateLimit struct {
+	rate   string // "60/1min", "30/1min", … or "" (honest-partial named limiter)
+	scope  string // "route" | "group"
+	source string // evidence middleware token, e.g. "throttle:60,1" / "throttle:api"
+	found  bool
+}
+
+// stamp writes the resolved posture onto an endpoint Properties map using the
+// shared flat contract. No-op when no throttle signal was recognised (never
+// fabricates rate_limited=false).
+func (r phpRateLimit) stamp(props map[string]string) {
+	if props == nil || !r.found {
+		return
+	}
+	props["rate_limited"] = "true"
+	if r.scope != "" {
+		props["rate_limit_scope"] = r.scope
+	}
+	if r.source != "" {
+		props["rate_limit_source"] = r.source
+	}
+	if r.rate != "" {
+		props["rate_limit"] = r.rate
+	}
+}
+
+// lrThrottleTokenRe captures a Laravel `throttle:<args>` middleware token from a
+// quoted string. Group 1 = the args after the colon ("60,1", "api", "10,1,key").
+var lrThrottleTokenRe = regexp.MustCompile(`['"]throttle:([a-zA-Z0-9_,]+)['"]`)
+
+// lrThrottleNumericArgsRe matches a literal limiter argument list: <max>,<minutes>
+// (the optional 3rd `:key` segment is not part of the comma list). Group 1 =
+// max, group 2 = minutes.
+var lrThrottleNumericArgsRe = regexp.MustCompile(`^([0-9]+),([0-9]+)$`)
+
+// resolveLaravelThrottleToken turns a `throttle:<args>` token's args into a
+// posture. A numeric `<max>,<minutes>` resolves the rate; a named limiter (or a
+// single-number / non-numeric form) is honest-partial (rate omitted).
+func resolveLaravelThrottleToken(args string) phpRateLimit {
+	rl := phpRateLimit{found: true, source: "throttle:" + args}
+	if am := lrThrottleNumericArgsRe.FindStringSubmatch(args); am != nil {
+		// max requests per <minutes> minute window. minutes==1 → "60/1min".
+		max := am[1]
+		mins := am[2]
+		if n, err := strconv.Atoi(mins); err == nil && n > 0 {
+			rl.rate = max + "/" + mins + "min"
+		}
+	}
+	return rl
+}
+
+// lrRouteThrottleSite is a per-route throttle keyed by the route's canonical
+// (verb, path) — the same key synthesizeLaravel stamps on the endpoint — plus
+// the resolved posture. Path-keyed (not line-keyed) because the Laravel
+// producer leaves StartLine=0 on its synthetics; this mirrors the Java pass.
+type lrRouteThrottleSite struct {
+	verb string
+	path string // canonical path (group prefix applied, Express-canonicalized)
+	rl   phpRateLimit
+}
+
+// indexLaravelRouteThrottles finds every `Route::<verb>(` registration that
+// carries a `throttle:…` token in its method-chain. The chain is the byte span
+// from this route match to just before the next route match (or EOF); the first
+// throttle token found in that span is paired to the route. This binds
+// `Route::get('/x', …)->middleware('throttle:60,1')` and the array form
+// `->middleware(['throttle:60,1','auth'])` while ignoring throttles that belong
+// to a later route. The route is keyed by the SAME canonical (verb, path)
+// synthesizeLaravel emits (group prefix applied), so the apply pass matches the
+// producer endpoint exactly.
+func indexLaravelRouteThrottles(content string, groupSpans []lrGroupSpan) []lrRouteThrottleSite {
+	verbMatches := lrRouteVerbRe.FindAllStringSubmatchIndex(content, -1)
+	if len(verbMatches) == 0 {
+		return nil
+	}
+	var out []lrRouteThrottleSite
+	for i, m := range verbMatches {
+		if len(m) < 8 {
+			continue
+		}
+		// Bound the route's statement at the next route match OR the first `;`
+		// terminator, whichever comes first, so a `throttle:` token that belongs
+		// to a LATER statement (e.g. a following Route::group middleware) is not
+		// mis-paired to this route. The `->middleware('throttle:…')` chain of a
+		// fluent route registration sits before that route's own `;`.
+		spanEnd := len(content)
+		if i+1 < len(verbMatches) {
+			spanEnd = verbMatches[i+1][0]
+		}
+		if semi := strings.IndexByte(content[m[0]:spanEnd], ';'); semi >= 0 {
+			spanEnd = m[0] + semi
+		}
+		span := content[m[0]:spanEnd]
+		tm := lrThrottleTokenRe.FindStringSubmatch(span)
+		if tm == nil {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := ""
+		if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			raw = content[m[6]:m[7]]
+		}
+		if raw == "" {
+			continue
+		}
+		// Apply group prefix the SAME way synthesizeLaravel does (left-to-right
+		// over containing group spans).
+		prefix := ""
+		for _, gs := range groupSpans {
+			if m[0] >= gs.bodyStart && m[0] < gs.bodyEnd {
+				prefix = prefix + "/" + strings.Trim(gs.prefix, "/")
+			}
+		}
+		if prefix != "" {
+			raw = prefix + "/" + strings.TrimLeft(raw, "/")
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		rl := resolveLaravelThrottleToken(tm[1])
+		rl.scope = "route"
+		out = append(out, lrRouteThrottleSite{verb: verb, path: canonical, rl: rl})
+	}
+	return out
+}
+
+// indexLaravelGroupThrottles scans for Route::group(['middleware' => …]) calls
+// whose middleware carries a `throttle:…` token, then enumerates the
+// `Route::<verb>(` registrations nested INSIDE each such group body and returns
+// them as path-keyed sites at "group" scope. Enumerating inner routes by path
+// (rather than recording a byte span) keeps binding robust even though the
+// Laravel producer leaves StartLine=0 on its synthetics, and naturally handles
+// prefix-less groups. groupSpans is the full set of prefix group spans (from
+// synthesizeLaravel's helper) used to canonicalize each inner route's path the
+// same way the producer does.
+func indexLaravelGroupThrottles(content string, groupSpans []lrGroupSpan) []lrRouteThrottleSite {
+	var out []lrRouteThrottleSite
+	for _, m := range lrRouteGroupMwRe.FindAllStringSubmatchIndex(content, -1) {
+		// lrRouteGroupMwRe groups: 1=single-quoted, 2=double-quoted, 3=first
+		// array element. A group can carry a list `['auth','throttle:30,1']`
+		// where a non-first element is the throttle, so re-scan a bounded window
+		// of the options array for any throttle token.
+		winEnd := m[1] + 400
+		if winEnd > len(content) {
+			winEnd = len(content)
+		}
+		tok := lrThrottleTokenRe.FindStringSubmatch(content[m[0]:winEnd])
+		if tok == nil {
+			continue
+		}
+		rl := resolveLaravelThrottleToken(tok[1])
+		rl.scope = "group"
+
+		// Locate the group callback body span (the `{ … }` after the options).
+		bodyOpen := -1
+		for i := m[1]; i < len(content) && i < m[1]+1000; i++ {
+			if content[i] == '{' {
+				bodyOpen = i
+				break
+			}
+		}
+		if bodyOpen < 0 {
+			continue
+		}
+		bodyEnd := lrFindMatchingBrace(content, bodyOpen)
+		if bodyEnd < 0 {
+			continue
+		}
+
+		// Enumerate inner Route::<verb>( routes and key them by canonical path.
+		for _, vm := range lrRouteVerbRe.FindAllStringSubmatchIndex(content, -1) {
+			if len(vm) < 8 || vm[0] < bodyOpen+1 || vm[0] >= bodyEnd {
+				continue
+			}
+			verb := strings.ToUpper(content[vm[2]:vm[3]])
+			raw := ""
+			if vm[4] >= 0 {
+				raw = content[vm[4]:vm[5]]
+			} else if vm[6] >= 0 {
+				raw = content[vm[6]:vm[7]]
+			}
+			if raw == "" {
+				continue
+			}
+			prefix := ""
+			for _, gs := range groupSpans {
+				if vm[0] >= gs.bodyStart && vm[0] < gs.bodyEnd {
+					prefix = prefix + "/" + strings.Trim(gs.prefix, "/")
+				}
+			}
+			if prefix != "" {
+				raw = prefix + "/" + strings.TrimLeft(raw, "/")
+			}
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+			out = append(out, lrRouteThrottleSite{verb: verb, path: canonical, rl: rl})
+		}
+	}
+	return out
+}
+
+// applyLaravelRateLimit resolves and stamps the flat rate-limit contract on
+// every Laravel synthetic backend endpoint synthesizeLaravel emitted. It mutates
+// Properties in place and never adds or removes entities. `before` is the
+// entity-slice length captured before the PHP synthesizers ran.
+//
+// Resolution order per endpoint: a per-route `->middleware('throttle:…')`
+// (strongest, "route" scope) wins; otherwise a Route::group throttle whose body
+// span contains the route's source line applies at "group" scope.
+func applyLaravelRateLimit(content, path string, entities []types.EntityRecord, before int) {
+	if len(content) == 0 || before >= len(entities) {
+		return
+	}
+	groupSpans := lrExtractGroupSpans(content)
+	routeSites := indexLaravelRouteThrottles(content, groupSpans)
+	groupSites := indexLaravelGroupThrottles(content, groupSpans)
+	if len(routeSites) == 0 && len(groupSites) == 0 {
+		return
+	}
+	// Per-route sites take precedence over group sites for the same key, so
+	// index groups first then overlay routes.
+	byKey := make(map[string]phpRateLimit, len(routeSites)+len(groupSites))
+	for _, s := range groupSites {
+		byKey[s.verb+" "+s.path] = s.rl
+	}
+	for _, s := range routeSites {
+		byKey[s.verb+" "+s.path] = s.rl
+	}
+
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		// Only stamp endpoints the Laravel route synthesizer produced.
+		if e.Properties["framework"] != "laravel" {
+			continue
+		}
+		key := e.Properties["verb"] + " " + e.Properties["path"]
+		if rl, ok := byKey[key]; ok {
+			rl.stamp(e.Properties)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_php_ratelimit_test.go
+++ b/internal/engine/http_endpoint_php_ratelimit_test.go
@@ -1,0 +1,170 @@
+package engine
+
+import "testing"
+
+// phpRLProps runs full synthesis over a Laravel routes file and returns the
+// endpoint at "<VERB> <path>".
+func phpRLProps(t *testing.T, content, key string) map[string]string {
+	t.Helper()
+	eps := authProps(t, "php", "routes/api.php", content)
+	e, ok := eps[key]
+	if !ok {
+		keys := make([]string, 0, len(eps))
+		for k := range eps {
+			keys = append(keys, k)
+		}
+		t.Fatalf("endpoint %q not synthesised (got: %v)", key, keys)
+	}
+	return e.Properties
+}
+
+// TestLaravelRateLimit_PerRouteLiteralThrottle — the canonical spec case:
+// `Route::get('/api/x', …)->middleware('throttle:60,1')` → that endpoint is
+// rate_limited=true with the resolved literal rate 60/1min at route scope; a
+// sibling plain route is NOT stamped (negative).
+func TestLaravelRateLimit_PerRouteLiteralThrottle(t *testing.T) {
+	src := `<?php
+Route::get('/api/x', [ApiController::class, 'x'])->middleware('throttle:60,1');
+Route::get('/api/free', [ApiController::class, 'free']);
+`
+	x := phpRLProps(t, src, "GET /api/x")
+	if x["rate_limited"] != "true" {
+		t.Errorf("GET /api/x: rate_limited=%q, want true (props: %v)", x["rate_limited"], x)
+	}
+	if x["rate_limit"] != "60/1min" {
+		t.Errorf("GET /api/x: rate_limit=%q, want 60/1min", x["rate_limit"])
+	}
+	if x["rate_limit_scope"] != "route" {
+		t.Errorf("GET /api/x: rate_limit_scope=%q, want route", x["rate_limit_scope"])
+	}
+	if x["rate_limit_source"] != "throttle:60,1" {
+		t.Errorf("GET /api/x: rate_limit_source=%q, want throttle:60,1", x["rate_limit_source"])
+	}
+
+	// Negative: a plain route must NOT be stamped.
+	free := phpRLProps(t, src, "GET /api/free")
+	if free["rate_limited"] == "true" {
+		t.Errorf("GET /api/free: rate_limited=true, want unthrottled (props: %v)", free)
+	}
+	if free["rate_limit"] != "" || free["rate_limit_source"] != "" {
+		t.Errorf("GET /api/free: leaked rate_limit props (props: %v)", free)
+	}
+}
+
+// TestLaravelRateLimit_PerRouteArrayMiddleware — the throttle token resolves
+// even when it is one element of a middleware array alongside a non-throttle
+// middleware (auth), and the auth middleware does NOT itself trigger a
+// rate-limit stamp on the path.
+func TestLaravelRateLimit_PerRouteArrayMiddleware(t *testing.T) {
+	src := `<?php
+Route::post('/api/upload', [UploadController::class, 'store'])->middleware(['auth', 'throttle:10,1']);
+`
+	p := phpRLProps(t, src, "POST /api/upload")
+	if p["rate_limited"] != "true" {
+		t.Errorf("POST /api/upload: rate_limited=%q, want true (props: %v)", p["rate_limited"], p)
+	}
+	if p["rate_limit"] != "10/1min" {
+		t.Errorf("POST /api/upload: rate_limit=%q, want 10/1min", p["rate_limit"])
+	}
+	if p["rate_limit_source"] != "throttle:10,1" {
+		t.Errorf("POST /api/upload: rate_limit_source=%q, want throttle:10,1", p["rate_limit_source"])
+	}
+}
+
+// TestLaravelRateLimit_MultiMinuteWindow — `throttle:100,5` is 100 requests per
+// 5-minute window → rate "100/5min" (window is honored, never normalised away).
+func TestLaravelRateLimit_MultiMinuteWindow(t *testing.T) {
+	src := `<?php
+Route::get('/api/report', [ReportController::class, 'index'])->middleware('throttle:100,5');
+`
+	p := phpRLProps(t, src, "GET /api/report")
+	if p["rate_limit"] != "100/5min" {
+		t.Errorf("GET /api/report: rate_limit=%q, want 100/5min", p["rate_limit"])
+	}
+}
+
+// TestLaravelRateLimit_NamedLimiterHonestPartial — `throttle:api` is a NAMED
+// limiter whose limit/window live in a RateLimiter::for('api', …) registration
+// (often app/Providers/RouteServiceProvider.php). rate_limited + source resolve;
+// the numeric rate MUST be omitted (never fabricated).
+func TestLaravelRateLimit_NamedLimiterHonestPartial(t *testing.T) {
+	src := `<?php
+Route::middleware('throttle:api')->get('/api/named', [ApiController::class, 'n']);
+Route::get('/api/named2', [ApiController::class, 'n2'])->middleware('throttle:api');
+`
+	// The second form (chained after the verb route) is the one synthesizeLaravel
+	// emits an endpoint for; assert on it.
+	p := phpRLProps(t, src, "GET /api/named2")
+	if p["rate_limited"] != "true" {
+		t.Errorf("GET /api/named2: rate_limited=%q, want true (props: %v)", p["rate_limited"], p)
+	}
+	if p["rate_limit_source"] != "throttle:api" {
+		t.Errorf("GET /api/named2: rate_limit_source=%q, want throttle:api", p["rate_limit_source"])
+	}
+	if p["rate_limit"] != "" {
+		t.Errorf("GET /api/named2: rate_limit=%q, want omitted (named limiter is config-driven honest-partial)", p["rate_limit"])
+	}
+}
+
+// TestLaravelRateLimit_GroupScope — a Route::group with a throttle middleware
+// propagates the throttle to every nested route at "group" scope; a route
+// OUTSIDE the group is unaffected (negative).
+func TestLaravelRateLimit_GroupScope(t *testing.T) {
+	src := `<?php
+Route::group(['prefix' => 'admin', 'middleware' => ['throttle:30,1']], function () {
+    Route::get('/dash', [AdminController::class, 'dash']);
+    Route::post('/save', [AdminController::class, 'save']);
+});
+Route::get('/public', [PublicController::class, 'index']);
+`
+	dash := phpRLProps(t, src, "GET /admin/dash")
+	if dash["rate_limited"] != "true" {
+		t.Errorf("GET /admin/dash: rate_limited=%q, want true (props: %v)", dash["rate_limited"], dash)
+	}
+	if dash["rate_limit"] != "30/1min" {
+		t.Errorf("GET /admin/dash: rate_limit=%q, want 30/1min", dash["rate_limit"])
+	}
+	if dash["rate_limit_scope"] != "group" {
+		t.Errorf("GET /admin/dash: rate_limit_scope=%q, want group", dash["rate_limit_scope"])
+	}
+	save := phpRLProps(t, src, "POST /admin/save")
+	if save["rate_limited"] != "true" || save["rate_limit"] != "30/1min" {
+		t.Errorf("POST /admin/save: want group-inherited 30/1min (props: %v)", save)
+	}
+
+	// Negative: route outside the throttled group must be unthrottled.
+	pub := phpRLProps(t, src, "GET /public")
+	if pub["rate_limited"] == "true" {
+		t.Errorf("GET /public: rate_limited=true, want unthrottled (props: %v)", pub)
+	}
+}
+
+// TestLaravelRateLimit_PerRouteWinsOverGroup — when a nested route has its own
+// throttle, the per-route ("route" scope) posture takes precedence over the
+// group's.
+func TestLaravelRateLimit_PerRouteWinsOverGroup(t *testing.T) {
+	src := `<?php
+Route::group(['middleware' => ['throttle:30,1']], function () {
+    Route::get('/strict', [C::class, 'strict'])->middleware('throttle:5,1');
+});
+`
+	p := phpRLProps(t, src, "GET /strict")
+	if p["rate_limit"] != "5/1min" {
+		t.Errorf("GET /strict: rate_limit=%q, want 5/1min (per-route wins over group)", p["rate_limit"])
+	}
+	if p["rate_limit_scope"] != "route" {
+		t.Errorf("GET /strict: rate_limit_scope=%q, want route", p["rate_limit_scope"])
+	}
+}
+
+// TestLaravelRateLimit_NonThrottleMiddlewareNegative — a route carrying only
+// non-throttle middleware (auth, cache.headers) is NOT rate-limited.
+func TestLaravelRateLimit_NonThrottleMiddlewareNegative(t *testing.T) {
+	src := `<?php
+Route::get('/api/cached', [C::class, 'cached'])->middleware(['auth', 'cache.headers:public;max_age=60']);
+`
+	p := phpRLProps(t, src, "GET /api/cached")
+	if p["rate_limited"] == "true" {
+		t.Errorf("GET /api/cached: rate_limited=true, want unthrottled — only auth/cache middleware (props: %v)", p)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -942,8 +942,23 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Consumer side (#721 wave 2c): reqwest, hyper, ureq, surf.
 		synthesizeRustClientWithRuntime(string(content), emitClientRuntime)
 	case "php":
+		// Capture the producer-side entity count before the PHP backend
+		// synthesizers run so the rate-limit pass (#4073) stamps over exactly
+		// the http_endpoint_definition entities this file emits.
+		phpRLBefore := len(entities)
 		// Producer side (#1419): Laravel Route::verb/resource/apiResource.
 		synthesizeLaravel(string(content), emit, emitResource)
+		// #3628 → #4073 rate-limit child — stamp the flat rate-limit contract
+		// (rate_limited/rate_limit/rate_limit_scope/rate_limit_source) on the
+		// Laravel endpoints emitted above: per-route
+		// `->middleware('throttle:60,1')` and group-level
+		// `Route::group(['middleware'=>['throttle:30,1']])` throttle middleware.
+		// `throttle:<max>,<min>` resolves the rate; a NAMED limiter
+		// (`throttle:api`) is honest-partial (limit/window live in a
+		// RateLimiter::for() registration). Symfony's `#[RateLimiter(...)]`
+		// attribute is stamped on its own SCOPE.Operation endpoints in
+		// internal/custom/php/symfony.go.
+		applyLaravelRateLimit(string(content), path, entities, phpRLBefore)
 		// Consumer side (#721 wave 2c): Guzzle, Symfony HttpClient, cURL, file_get_contents,
 		// WordPress HTTP API, Laravel Http facade.
 		synthesizePHPClientWithRuntime(string(content), emitClientRuntime)


### PR DESCRIPTION
Builds the #3628 `rate_limit_stamping` capability for **PHP** — greenfield (PHP had zero rate_limit cells; only ~8 exist full/partial across all languages). Stamps the shared flat contract on PHP endpoints, mirroring the Java (#3790), JS/TS + Python (#3778), and Ruby (#4072) passes.

## Contract (shared, flat — same as Java/JSTS/Python)
- `rate_limited` = "true" when a throttle applies
- `rate_limit` = human rate "60/1min" when statically resolvable; OMITTED (honest-partial) when config-driven
- `rate_limit_scope` = "route" | "group"
- `rate_limit_source` = recognised middleware / attribute (evidence)

## Laravel (engine producer side, `http_endpoint_definition`)
`applyLaravelRateLimit` wired into the PHP synthesis case after `synthesizeLaravel`.
- **Per-route** `Route::get('/x', …)->middleware('throttle:60,1')` → `rate_limited=true`, `rate_limit=60/1min`, scope=route, source=`throttle:60,1`. Also handles the array form `->middleware(['auth','throttle:10,1'])` and multi-minute windows (`throttle:100,5` → `100/5min`). The throttle token is statement-bounded (route match → first `;`) so a following group throttle is never mis-paired.
- **Group** `Route::group(['middleware'=>['throttle:30,1']], fn)` propagates to every nested route at **group** scope. Inner routes are enumerated by canonical path (group prefix applied) because the Laravel producer leaves `StartLine=0` on its synthetics. A per-route throttle takes precedence over the group's.
- **Named limiter** `throttle:api` is **honest-partial**: `rate_limited` + `source=throttle:api` resolve, the numeric rate is omitted (limit/window live in a `RateLimiter::for('api', …)` registration, usually a different file).
- **Negatives**: non-throttle middleware (`auth`, `cache.headers`) and plain routes are not stamped.

## Symfony (`custom_php_symfony` extractor, `SCOPE.Operation` endpoints)
A `#[RateLimiter('name')]` / `#[RateLimiter(limiter: 'name')]` attribute co-located with a `#[Route(...)]` action stamps `rate_limited=true`, scope=route, source=`#[RateLimiter:name]`. Attribute order within the block is free (before or after the Route attribute); the limiter never mis-pairs across sibling actions (window bounded by the action's `function`). **Honest-partial**: the named limiter's limit/window live in `config/packages/rate_limiter.yaml`, so the numeric rate is omitted.

## Scope
Flips the **Laravel** + **Symfony** `rate_limit_stamping` cells to `full`. The other 14 PHP frameworks (CakePHP, CodeIgniter, Slim, Lumen, API Platform, …) remain honestly `missing` — their limiter integrations are future work.

## Quality gates
- No new extractor registration, no new entity Kind.
- Full package tests green: `internal/custom/php`, `internal/engine`, `internal/extractors`, `internal/types`, `tools/coverage`.
- 7 Laravel engine tests + 4 Symfony tests, all value-asserting (specific limiter/limit/window/scope/source) with negatives.
- `covtool fmt --check` canonical; `validate` 0 errors; `gen` stable (no drift); `gofmt` empty; `go vet` clean.

VERIFY-FIRST: confirmed the four route shapes synthesise with no rate_limit at baseline before building.

Closes #4073. **DEPLOY-DEFERRED** (no daemon rebuild/reindex in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)