### PR TITLE
feat(elixir): error_flow capability — raise/try-rescue → THROWS/CATCHES (#4084)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -32,18 +32,18 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [HotChocolate (GraphQL)](../detail/lang.csharp.framework.hotchocolate.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 3/24 | 🔴 0/13 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/12 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
-| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/25 | 🟡 3/11 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 9/24 | 🟡 3/12 | |
-| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 4/12 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 7/12 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 4/9 | |
+| [elixir](../by-language/elixir.md) | [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/24 | 🟡 3/12 | |
+| [elixir](../by-language/elixir.md) | [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 12/25 | 🟡 3/11 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 1/6 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [elixir](../by-language/elixir.md) | [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
+| [elixir](../by-language/elixir.md) | [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/24 | 🟡 4/12 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 3/6 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 5/6 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 24/24 | 🟡 8/12 | |
@@ -210,7 +210,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 21/24 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 5/5 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🟢 2/2 | 🔴 0/1 | 🟡 21/24 | 🟡 2/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | ✅ 8/8 | |
@@ -265,7 +265,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 3/15 | |
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 7/24 | 🟡 7/10 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 10/10 | |
-| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | — | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 11/24 | 🟡 6/10 | |
+| [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | — | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 12/24 | 🟡 6/10 | |
 | [go](../by-language/go.md) | [gRPC-Go (google.golang.org/grpc)](../detail/lang.go.framework.grpc.md) | — | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |
 | [java](../by-language/java.md) | [gRPC-Java (grpc-java / grpc-spring-boot-starter)](../detail/lang.java.framework.grpc.md) | — | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/25 | 🟡 6/17 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,32 +26,32 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 7/12 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 4/9 | |
-| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
-| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/25 | 🟡 3/11 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 1/6 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 5/10 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 9/24 | 🟡 3/12 | |
-| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 4/12 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 3/6 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 7/12 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟡 3/6 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 4/9 | |
+| [Finch](../detail/lang.elixir.framework.finch.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/24 | 🟡 3/12 | |
+| [Guardian](../detail/lang.elixir.framework.guardian.md) | 🔴 0/6 | ✅ 1/1 | 🔴 0/4 | ✅ 1/1 | 🟡 12/25 | 🟡 3/11 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 1/6 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/4 | — | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 5/10 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | 🟡 3/6 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Req](../detail/lang.elixir.framework.req.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 10/24 | 🟡 3/12 | |
+| [Tesla](../detail/lang.elixir.framework.tesla.md) | 🟡 1/6 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🟡 11/24 | 🟡 4/12 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 21/24 | 🟢 5/5 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 5/5 | |
 
 
 ### RPC Framework
 
 | Name | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 11/24 | 🟡 6/10 | |
+| [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 12/24 | 🟡 6/10 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.finch.md
+++ b/docs/coverage/detail/lang.elixir.framework.finch.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | @base_url System.get_env(VAR, default) fallback literal resolved for Finch URLs (#1496/#3511) |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_jsts_client_1483.go`<br>`internal/engine/http_endpoint_jsts_client_1483_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Finch.build modeled as outbound HTTP effect (#1483/#3511) |

--- a/docs/coverage/detail/lang.elixir.framework.grpc.md
+++ b/docs/coverage/detail/lang.elixir.framework.grpc.md
@@ -111,7 +111,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.elixir.framework.guardian.md
+++ b/docs/coverage/detail/lang.elixir.framework.guardian.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -75,7 +75,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |

--- a/docs/coverage/detail/lang.elixir.framework.req.md
+++ b/docs/coverage/detail/lang.elixir.framework.req.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Req verb calls modeled as outbound HTTP effects (#3511) |

--- a/docs/coverage/detail/lang.elixir.framework.tesla.md
+++ b/docs/coverage/detail/lang.elixir.framework.tesla.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_elixir.go` | Elixir def-use sniffer registered; intra-procedural def-use chains over .ex/.exs |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/elixir/exception_flow.go`<br>`internal/extractors/elixir/exception_flow_test.go` | raise X / raise mod.X -> THROWS; rescue e in [A,B] / unbound typed rescue -> CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_elixir_tesla.go`<br>`internal/engine/http_endpoint_elixir_tesla_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Tesla verb calls modeled as outbound HTTP effects (#3511) |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 |--------|----------|------|--------|
 | [`lang.csharp.framework.hotchocolate`](./lang.csharp.framework.hotchocolate.md) | C# | framework | 4 full, 3 partial, 42 missing |
 | [`lang.dart.framework.graphql-flutter`](./lang.dart.framework.graphql-flutter.md) | dart | framework | 1 full, 36 missing |
-| [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 6 full, 31 partial, 12 missing |
+| [`lang.elixir.framework.absinthe`](./lang.elixir.framework.absinthe.md) | elixir | framework | 7 full, 31 partial, 11 missing |
 | [`lang.go.framework.gqlgen`](./lang.go.framework.gqlgen.md) | go | framework | 4 full, 8 partial, 37 missing |
 | [`lang.java.framework.spring-graphql`](./lang.java.framework.spring-graphql.md) | java | framework | 8 full, 5 partial, 42 missing |
 | [`lang.jsts.framework.graphql-client`](./lang.jsts.framework.graphql-client.md) | JS/TS | framework | 2 full, 34 missing |

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -25,7 +25,7 @@ one is a separate detail page.
 |--------|----------|------|--------|
 | [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 8 full, 12 partial, 20 missing, 14 n/a |
 | [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 11 full, 26 partial, 2 missing, 15 n/a |
-| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 2 full, 21 partial, 17 missing, 14 n/a |
+| [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 3 full, 21 partial, 16 missing, 14 n/a |
 | [`lang.go.framework.grpc`](./lang.go.framework.grpc.md) | go | framework | 1 full, 3 partial, 37 missing, 13 n/a |
 | [`lang.java.framework.grpc`](./lang.java.framework.grpc.md) | java | framework | 1 full, 3 partial, 37 missing, 13 n/a |
 | [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13813,8 +13813,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -14098,8 +14100,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -14376,8 +14380,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -14684,8 +14690,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -14958,8 +14966,10 @@
             "verified_at": "2026-05-30"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -15250,8 +15260,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -15515,8 +15527,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -15776,8 +15790,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -16055,8 +16071,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -16342,8 +16360,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -16565,8 +16585,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -16848,8 +16870,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -17121,8 +17145,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -17385,8 +17411,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/elixir/exception_flow.go","internal/extractors/elixir/exception_flow_test.go"],
+            "notes": "raise X / raise mod.X -\u003e THROWS; rescue e in [A,B] / unbound typed rescue -\u003e CATCHES; bare rescue + string raise + reraise + catch :throw + {:error,_} tuple dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",

--- a/internal/extractors/elixir/elixir.go
+++ b/internal/extractors/elixir/elixir.go
@@ -66,6 +66,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
 	walkNode(file.Tree.RootNode(), file, &entities)
+	// Epic #3628 — error_flow: emit THROWS / CATCHES edges from def/defp
+	// bodies to the shared SCOPE.ExceptionType convergence node for typed
+	// `raise Type` / `rescue e in [Type]` shapes.
+	emitExceptionFlowEdges(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "elixir")
 	extractor.TagEntitiesLanguage(entities, "elixir")

--- a/internal/extractors/elixir/exception_flow.go
+++ b/internal/extractors/elixir/exception_flow.go
@@ -1,0 +1,221 @@
+// exception_flow.go — supplemental pass that emits THROWS / CATCHES edges from
+// Elixir functions (def/defp) to a shared SCOPE.ExceptionType node (epic
+// #3628). It lets the graph answer "what can this function raise?" (outbound
+// THROWS) and "where is X handled?" (inbound CATCHES), matching the flagship
+// convergence-node shape every other language emits (see
+// internal/extractor/exception_flow.go).
+//
+// Detected shapes (typed only — honest-partial, precision-first):
+//
+//	raise NotFoundError, "msg"          → THROWS NotFoundError
+//	raise ArgumentError                 → THROWS ArgumentError
+//	raise MyApp.NotFoundError, message: → THROWS NotFoundError   (last segment)
+//	try do … rescue e in NotFoundError  → CATCHES NotFoundError
+//	rescue e in [RuntimeError, ArgErr]  → CATCHES RuntimeError + ArgErr
+//	rescue MyApp.BadError ->            → CATCHES BadError        (no binding)
+//
+// Intentionally DROPPED (would mislead error-contract analysis):
+//
+//	raise "just a message"              (string → implicit RuntimeError, no type token)
+//	reraise err, __STACKTRACE__         (re-raise of a bound variable — not `raise`)
+//	rescue _ -> …  /  rescue e -> …     (untyped catch-all — no exception type)
+//	catch :throw, val -> …              (value/exit catch, not the exception model)
+//	{:error, reason}                    (tuple convention is value-based, not error_flow)
+//
+// All node/edge construction (convergence on one node per type name via a
+// synthetic SourceFile) lives in extractor.EmitExceptionEdges, so the
+// convergence invariant is identical across every language.
+
+package elixir
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitExceptionFlowEdges scans every def/defp body for typed raise / rescue
+// shapes and appends exception-type entities + THROWS / CATCHES edges.
+//
+// entities[0] MUST be the file entity (Extract appends it first). Mutates
+// *entities in place. Safe with nil / empty input. raise / rescue outside any
+// def (module scope) attach to the file entity via EmitExceptionEdges's
+// fallback.
+func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var edges []extractor.ExceptionEdge
+
+	// In tree-sitter-elixir every form is a `call`; def/defp introduce the
+	// enclosing-function scope. We track the nearest def/defp name so each
+	// raise / rescue is attributed to the right SCOPE.Operation (matched by
+	// Name inside EmitExceptionEdges).
+	var walk func(n *sitter.Node, current string)
+	walk = func(n *sitter.Node, current string) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "call" {
+			head := callHeadName(n, src)
+			switch head {
+			case "def", "defp":
+				// Enter a new function scope for the body; the head/args
+				// (the function signature) keep the outer scope.
+				fnName := extractFunctionName(n, src)
+				body := findDefBody(n)
+				for i := 0; i < int(n.ChildCount()); i++ {
+					ch := n.Child(i)
+					if ch == body {
+						walk(ch, fnName)
+					} else {
+						walk(ch, current)
+					}
+				}
+				return
+			case "raise":
+				if t := elixirRaiseType(n, src); t != "" {
+					edges = append(edges, extractor.ExceptionEdge{
+						Type: t, FromName: current, Pattern: "raise",
+					})
+				}
+				// raise takes no nested def/raise of interest; fall through to
+				// descend anyway is harmless but unnecessary — descend for safety.
+			}
+		}
+		if n.Type() == "rescue_block" {
+			for _, t := range elixirRescueTypes(n, src) {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: current, Catch: true, Pattern: "rescue",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), current)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitExceptionEdges(entities, "elixir", edges)
+}
+
+// elixirRaiseType returns the raised exception-module token from a `raise`
+// call node, or "" for a message-only raise (`raise "msg"` → implicit
+// RuntimeError, no static type token) or any non-alias first argument.
+//
+// Accepted shape: the first argument is an `alias` (the exception module),
+// e.g. `raise NotFoundError, "x"`, `raise ArgumentError`,
+// `raise MyApp.NotFoundError, message: "x"`. The verbatim (possibly dotted)
+// alias text is returned; NormalizeExceptionType strips qualification and
+// rejects non-identifier tokens downstream.
+//
+// NOTE: `reraise err, __STACKTRACE__` is a DIFFERENT call head ("reraise"),
+// never reaches this function, and so emits no edge — honest, since the type
+// is a bound variable.
+func elixirRaiseType(raiseCall *sitter.Node, src []byte) string {
+	args := childOfType(raiseCall, "arguments")
+	if args == nil {
+		return ""
+	}
+	first := firstNamedChild(args)
+	if first == nil || first.Type() != "alias" {
+		return "" // `raise "msg"` / `raise var` / computed — no static type
+	}
+	return nodeSrc(first, src)
+}
+
+// elixirRescueTypes returns the caught exception-module tokens from a
+// rescue_block. Each `stab_clause` head is one of:
+//
+//	e in NotFoundError -> …            binary_operator(in); RHS alias        → {NotFoundError}
+//	e in [RuntimeError, ArgError] -> … binary_operator(in); RHS list(alias)  → {RuntimeError, ArgError}
+//	MyApp.BadError -> …                bare alias (no binding)               → {BadError}
+//	_ -> …  /  e -> …                  identifier (untyped catch-all)        → {}
+//
+// Untyped catch-alls and non-alias shapes yield nothing (honest-partial).
+func elixirRescueTypes(rescueBlock *sitter.Node, src []byte) []string {
+	var out []string
+	for i := 0; i < int(rescueBlock.NamedChildCount()); i++ {
+		stab := rescueBlock.NamedChild(i)
+		if stab == nil || stab.Type() != "stab_clause" {
+			continue
+		}
+		args := childOfType(stab, "arguments")
+		if args == nil {
+			continue
+		}
+		head := firstNamedChild(args)
+		if head == nil {
+			continue
+		}
+		switch head.Type() {
+		case "binary_operator":
+			// `e in <type-or-list>` — the rescued type(s) are the RHS, the
+			// second named child. Only the `in` operator carries a type list;
+			// any other binary operator is not a typed rescue.
+			if rhs := nthNamedChild(head, 1); rhs != nil {
+				out = append(out, aliasTokens(rhs, src)...)
+			}
+		case "alias":
+			// `MyApp.BadError ->` — typed rescue without a binding.
+			out = append(out, nodeSrc(head, src))
+		}
+		// identifier / `_` (untyped catch-all) and anything else: no type.
+	}
+	return out
+}
+
+// aliasTokens collects exception-module tokens from a rescue RHS that is
+// either a single `alias` or a `list` of `alias` nodes. Non-alias elements
+// are skipped.
+func aliasTokens(n *sitter.Node, src []byte) []string {
+	switch n.Type() {
+	case "alias":
+		return []string{nodeSrc(n, src)}
+	case "list":
+		var out []string
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			el := n.NamedChild(i)
+			if el != nil && el.Type() == "alias" {
+				out = append(out, nodeSrc(el, src))
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// childOfType returns the first direct child of n whose Type() == t, or nil.
+func childOfType(n *sitter.Node, t string) *sitter.Node {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch != nil && ch.Type() == t {
+			return ch
+		}
+	}
+	return nil
+}
+
+// firstNamedChild returns the first named child of n, or nil.
+func firstNamedChild(n *sitter.Node) *sitter.Node {
+	if n.NamedChildCount() == 0 {
+		return nil
+	}
+	return n.NamedChild(0)
+}
+
+// nthNamedChild returns the i-th named child of n (0-based), or nil.
+func nthNamedChild(n *sitter.Node, i int) *sitter.Node {
+	if i < 0 || i >= int(n.NamedChildCount()) {
+		return nil
+	}
+	return n.NamedChild(i)
+}
+
+// nodeSrc returns the verbatim source text spanned by n.
+func nodeSrc(n *sitter.Node, src []byte) string {
+	return string(src[n.StartByte():n.EndByte()])
+}

--- a/internal/extractors/elixir/exception_flow_test.go
+++ b/internal/extractors/elixir/exception_flow_test.go
@@ -1,0 +1,318 @@
+package elixir_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractEx parses Elixir source and runs the registered extractor, returning
+// the entity records.
+func extractEx(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("elixir")
+	if !ok {
+		t.Fatal("elixir extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "elixir",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return recs
+}
+
+// exEdge reports whether the entity Named fromName has a relationship of the
+// given kind whose ToID targets the exception type (the convergence-node ref).
+func exEdge(recs []types.EntityRecord, fromName, kind, typeName string) bool {
+	want := extractor.ExceptionTypeTargetID(typeName)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == kind && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// exNodeCount returns how many SCOPE.ExceptionType nodes exist for typeName.
+func exNodeCount(recs []types.EntityRecord, typeName string) int {
+	want := extractor.ExceptionTypeName(typeName)
+	count := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) && recs[i].Name == want {
+			count++
+		}
+	}
+	return count
+}
+
+// TestExExceptionFlow_RaiseRescueConverge: `raise NotFoundError` in find and
+// `rescue e in NotFoundError` in get must produce THROWS + CATCHES edges that
+// converge on the SAME exception-type node — the value of the capability.
+func TestExExceptionFlow_RaiseRescueConverge(t *testing.T) {
+	src := `
+defmodule Accounts do
+  def find(id) do
+    raise NotFoundError, "missing #{id}"
+  end
+
+  def get(id) do
+    try do
+      find(id)
+    rescue
+      e in NotFoundError -> handle(e)
+    end
+  end
+end
+`
+	recs := extractEx(t, src, "accounts.ex")
+
+	if !exEdge(recs, "find", "THROWS", "NotFoundError") {
+		t.Errorf("missing THROWS(find -> NotFoundError)")
+	}
+	if !exEdge(recs, "get", "CATCHES", "NotFoundError") {
+		t.Errorf("missing CATCHES(get -> NotFoundError)")
+	}
+
+	// Convergence invariant: exactly one NotFoundError node, and the THROWS +
+	// CATCHES ToIDs both equal ExceptionTypeTargetID("NotFoundError").
+	if n := exNodeCount(recs, "NotFoundError"); n != 1 {
+		t.Fatalf("THROWS + CATCHES must converge on ONE NotFoundError node, got %d", n)
+	}
+	target := extractor.ExceptionTypeTargetID("NotFoundError")
+	for i := range recs {
+		if recs[i].Kind != string(types.EntityKindExceptionType) || recs[i].Name != extractor.ExceptionTypeName("NotFoundError") {
+			continue
+		}
+		if recs[i].QualifiedName != target {
+			t.Fatalf("exception node QualifiedName=%q, want %q (byQualifiedName binding)", recs[i].QualifiedName, target)
+		}
+	}
+}
+
+// TestExExceptionFlow_PlainRaise: `raise ArgumentError` (no message arg) still
+// THROWS the named module.
+func TestExExceptionFlow_PlainRaise(t *testing.T) {
+	src := `
+defmodule M do
+  def parse(x) do
+    raise ArgumentError
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	if !exEdge(recs, "parse", "THROWS", "ArgumentError") {
+		t.Errorf("missing THROWS(parse -> ArgumentError)")
+	}
+}
+
+// TestExExceptionFlow_QualifiedRaise: `raise MyApp.NotFoundError, message:`
+// THROWS the normalized last segment (NotFoundError).
+func TestExExceptionFlow_QualifiedRaise(t *testing.T) {
+	src := `
+defmodule M do
+  def go(x) do
+    raise MyApp.NotFoundError, message: "x"
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	if !exEdge(recs, "go", "THROWS", "NotFoundError") {
+		t.Errorf("missing THROWS(go -> NotFoundError) from qualified raise")
+	}
+}
+
+// TestExExceptionFlow_MultiRescue: `rescue e in [RuntimeError, ArgumentError]`
+// yields a CATCHES edge for EACH named type.
+func TestExExceptionFlow_MultiRescue(t *testing.T) {
+	src := `
+defmodule M do
+  def run(x) do
+    try do
+      go(x)
+    rescue
+      e in [RuntimeError, ArgumentError] -> handle(e)
+    end
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	if !exEdge(recs, "run", "CATCHES", "RuntimeError") {
+		t.Errorf("missing CATCHES(run -> RuntimeError)")
+	}
+	if !exEdge(recs, "run", "CATCHES", "ArgumentError") {
+		t.Errorf("missing CATCHES(run -> ArgumentError)")
+	}
+}
+
+// TestExExceptionFlow_RescueNoBinding: `rescue MyApp.BadError ->` (no `e in`
+// binding) still CATCHES the normalized type.
+func TestExExceptionFlow_RescueNoBinding(t *testing.T) {
+	src := `
+defmodule M do
+  def run(x) do
+    try do
+      go(x)
+    rescue
+      MyApp.BadError -> :err
+    end
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	if !exEdge(recs, "run", "CATCHES", "BadError") {
+		t.Errorf("missing CATCHES(run -> BadError) from unbound typed rescue")
+	}
+}
+
+// --- Negatives (precision-first / honest-partial) ---
+
+// TestExExceptionFlow_NegBareRescue: `rescue _ ->` and `rescue e ->` carry no
+// exception type → NO CATCHES edge, NO exception node.
+func TestExExceptionFlow_NegBareRescue(t *testing.T) {
+	src := `
+defmodule M do
+  def run(x) do
+    try do
+      go(x)
+    rescue
+      _ -> :error
+    end
+  end
+
+  def run2(x) do
+    try do
+      go(x)
+    rescue
+      e -> log(e)
+    end
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) {
+			t.Fatalf("untyped catch-all rescue must emit no exception node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindCatches) {
+				t.Fatalf("untyped catch-all rescue must emit no CATCHES edge, got ToID=%q", r.ToID)
+			}
+		}
+	}
+}
+
+// TestExExceptionFlow_NegStringRaise: `raise "msg"` (implicit RuntimeError, no
+// static type token) emits NO THROWS edge — honest-partial.
+func TestExExceptionFlow_NegStringRaise(t *testing.T) {
+	src := `
+defmodule M do
+  def boom(x) do
+    raise "something broke"
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindThrows) {
+				t.Fatalf("message-only raise must emit no THROWS edge, got ToID=%q", r.ToID)
+			}
+		}
+	}
+}
+
+// TestExExceptionFlow_NegReraise: `reraise err, __STACKTRACE__` re-raises a
+// bound variable (dynamic type) → NO THROWS edge.
+func TestExExceptionFlow_NegReraise(t *testing.T) {
+	src := `
+defmodule M do
+  def again(x) do
+    reraise err, __STACKTRACE__
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindThrows) {
+				t.Fatalf("reraise must emit no THROWS edge, got ToID=%q", r.ToID)
+			}
+		}
+	}
+}
+
+// TestExExceptionFlow_NegErrorTuple: the `{:error, reason}` value convention is
+// NOT the exception model → no error_flow edge at all.
+func TestExExceptionFlow_NegErrorTuple(t *testing.T) {
+	src := `
+defmodule M do
+  def find(id) do
+    {:error, :not_found}
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) {
+			t.Fatalf("error tuple must emit no exception node, got %q", recs[i].Name)
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindThrows) || r.Kind == string(types.RelationshipKindCatches) {
+				t.Fatalf("error tuple must emit no error_flow edge, got %s ToID=%q", r.Kind, r.ToID)
+			}
+		}
+	}
+}
+
+// TestExExceptionFlow_NegCatchThrow: `catch :throw, val ->` is a value/exit
+// catch, not the typed-exception model → no CATCHES edge.
+func TestExExceptionFlow_NegCatchThrow(t *testing.T) {
+	src := `
+defmodule M do
+  def run(x) do
+    try do
+      go(x)
+    catch
+      :throw, val -> val
+    end
+  end
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == string(types.RelationshipKindCatches) {
+				t.Fatalf("catch :throw must emit no CATCHES edge, got ToID=%q", r.ToID)
+			}
+		}
+	}
+}
+
+// TestExExceptionFlow_NegPlainDef: a plain function with no raise/rescue emits
+// no error_flow entities.
+func TestExExceptionFlow_NegPlainDef(t *testing.T) {
+	src := `
+defmodule M do
+  def add(a, b), do: a + b
+end
+`
+	recs := extractEx(t, src, "m.ex")
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) {
+			t.Fatalf("plain def must emit no exception node, got %q", recs[i].Name)
+		}
+	}
+}

--- a/internal/extractors/elixir/live_fire_test.go
+++ b/internal/extractors/elixir/live_fire_test.go
@@ -1,0 +1,52 @@
+package elixir_test
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/treesitter"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestLiveFireEx drives the FULL production path: ParserFactory.Parse for a
+// real lib/*.ex file, then the registry-resolved elixir extractor's Extract,
+// confirming error_flow fires live (THROWS + CATCHES converge on one node).
+func TestLiveFireEx(t *testing.T) {
+	src := []byte("defmodule Accounts do\n  def find(id) do\n    raise NotFoundError, \"x\"\n  end\n  def get(id) do\n    try do\n      find(id)\n    rescue\n      e in NotFoundError -> e\n    end\n  end\nend\n")
+	pf := treesitter.NewParserFactory(noop.NewTracerProvider().Tracer("t"))
+	res, err := pf.Parse(context.Background(), src, "elixir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext, ok := extractor.Get("elixir")
+	if !ok {
+		t.Fatal("elixir extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "lib/accounts.ex", Content: src, Language: "elixir", Tree: res.Tree,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var throws, catches, node bool
+	for _, r := range recs {
+		if r.Kind == string(types.EntityKindExceptionType) && r.Name == "exception:NotFoundError" {
+			node = true
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == "THROWS" && rel.ToID == extractor.ExceptionTypeTargetID("NotFoundError") {
+				throws = true
+			}
+			if rel.Kind == "CATCHES" && rel.ToID == extractor.ExceptionTypeTargetID("NotFoundError") {
+				catches = true
+			}
+		}
+	}
+	t.Logf("LIVE .ex fire: throws=%v catches=%v convergeNode=%v", throws, catches, node)
+	if !(throws && catches && node) {
+		t.Fatal("error_flow did NOT fire live on .ex through ParserFactory + registered extractor")
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -13645,6 +13645,18 @@ records:
               functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/elixir/exception_flow.go
+              functions: [emitExceptionFlowEdges, elixirRaiseType, elixirRescueTypes, aliasTokens]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/elixir/exception_flow_test.go
+              functions: [TestExExceptionFlow_RaiseRescueConverge, TestExExceptionFlow_MultiRescue, TestExExceptionFlow_RescueNoBinding, TestExExceptionFlow_QualifiedRaise, TestExExceptionFlow_NegBareRescue]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
         env_fallback_recognition:
           status: full
           symbols:


### PR DESCRIPTION
## Summary
Ports the flagship cross-language **error_flow** convergence-node model (epic #3628) to the native **Elixir** extractor. error_flow was `full` in go/java/jsts/python/csharp/scala and **missing** in Elixir — this closes the fan-out gap.

Reuses the shared model in `internal/extractor/exception_flow.go` verbatim: one `SCOPE.ExceptionType` node per normalized type name (synthetic `<exception>` SourceFile → cross-file/cross-language convergence), `RelationshipKindThrows`/`RelationshipKindCatches` edges, and `ExceptionTypeTargetID` carried as the edge ToID + entity QualifiedName for byQualifiedName binding. **No new Kind.**

## Idioms covered (typed-only, precision-first)
| Elixir | Edge |
|---|---|
| `raise NotFoundError, "msg"` | THROWS NotFoundError |
| `raise ArgumentError` | THROWS ArgumentError |
| `raise MyApp.NotFoundError, message:` | THROWS NotFoundError (last segment) |
| `try … rescue e in NotFoundError ->` | CATCHES NotFoundError |
| `rescue e in [RuntimeError, ArgumentError] ->` | CATCHES RuntimeError + ArgumentError |
| `rescue MyApp.BadError ->` (unbound) | CATCHES BadError |

## Honest-partial drops (no edge — would mislead error-contract analysis)
bare `rescue _ ->` / `rescue e ->` (untyped) · message-only `raise "..."` (implicit RuntimeError, no type token) · `reraise err, __STACKTRACE__` (bound var) · `catch :throw, val ->` (value/exit, not typed exception) · `{:error, reason}` tuple (value convention, not the exception model).

## Flagship-shape parity (asserted)
`raise NotFoundError` in `Accounts.find` + `rescue e in NotFoundError` in `Accounts.get` produce **THROWS + CATCHES converging on ONE** `exception:NotFoundError` node, with both edge ToIDs == `ExceptionTypeTargetID("NotFoundError")` == that node's QualifiedName.

## Live .ex firing
The pass runs inside `Extractor.Extract` — the live `.ex` dispatch path (`.ex`/`.exs` → `elixir`, parsed by tree-sitter-elixir, extractor auto-registered via `registry_gen.go`). `TestLiveFireEx` drives the full production path (`ParserFactory.Parse` + registry-resolved extractor on `lib/accounts.ex`) and confirms THROWS+CATCHES+converge-node end-to-end.

## Tests / gates
- `internal/extractors/elixir/exception_flow_test.go`: 11 cases incl. 6 negatives (bare rescue, string raise, reraise, error-tuple, catch :throw, plain def).
- Full mandated packages green: `elixir` · `custom/elixir` · `engine` · `extractors` · `types` · `tools/coverage`.
- `covtool validate` 0 errors · `fmt --check` canonical · `gen` 0 drift · `gofmt`/`go vet` clean.
- Flips the 14 elixir error_flow registry cells to full + capability-map entry under `lang.elixir.framework.phoenix` (validated symbols/tests resolve).

Closes #4084 · epic #3628

**DEPLOY-DEFERRED**: requires a coordinated live-daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)