### PR TITLE
feat(php): port flagship error-flow (THROWS/CATCHES) to PHP (#3628)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,22 +80,22 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🟡 3/12 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/6 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/6 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/12 | |
-| [php](../by-language/php.md) | [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/24 | 🟡 2/13 | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟢 11/11 | |
-| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 9/11 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
+| [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/12 | |
+| [php](../by-language/php.md) | [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟢 11/11 | |
+| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/13 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟡 9/11 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/13 | |
 | [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/14 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -26,22 +26,22 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/12 | |
-| [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/24 | 🟡 2/13 | |
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟢 11/11 | |
-| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/25 | 🟡 9/11 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
+| [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/12 | |
+| [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 21/24 | 🟡 2/13 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 4/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟢 11/11 | |
+| [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/13 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟡 9/11 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 22/24 | 🟡 2/13 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.php.framework.api-platform-graphql.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform-graphql.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-06-03` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Fs effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.api-platform.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-06-03` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-06-03` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.lighthouse.md
+++ b/docs/coverage/detail/lang.php.framework.lighthouse.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-06-03` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-06-03` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/php/exception_flow.go`<br>`internal/extractors/php/exception_flow_test.go` | throw new X / throw new \Ns\X -> THROWS; catch (X $e) incl PHP8 union A|B -> CATCHES; broad \Throwable/\Exception recorded (typed); re-throw $e / dynamic dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -33,8 +33,8 @@ one is a separate detail page.
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 4 full, 5 partial, 40 missing |
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 5 full, 50 missing |
 | [`msg.graphql-subscriptions`](./msg.graphql-subscriptions.md) | multi |  | 3 full |
-| [`lang.php.framework.api-platform-graphql`](./lang.php.framework.api-platform-graphql.md) | php | framework | 10 full, 16 partial, 23 missing |
-| [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 10 full, 16 partial, 23 missing |
+| [`lang.php.framework.api-platform-graphql`](./lang.php.framework.api-platform-graphql.md) | php | framework | 11 full, 16 partial, 22 missing |
+| [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 11 full, 16 partial, 22 missing |
 | [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 15 full, 24 partial, 10 missing |
 | [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 23 partial, 10 missing |
 | [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 3 full, 11 partial, 35 missing |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -49800,8 +49800,10 @@
             "verified_at": "2026-06-03"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -50067,8 +50069,10 @@
             "verified_at": "2026-06-03"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -50353,8 +50357,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -50638,8 +50644,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -50923,8 +50931,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -51194,8 +51204,10 @@
             "verified_at": "2026-06-03"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -51482,8 +51494,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -51781,8 +51795,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -52056,8 +52072,10 @@
             "verified_at": "2026-06-03"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -52344,8 +52362,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -52631,8 +52651,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -52916,8 +52938,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -53203,8 +53227,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -53498,8 +53524,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -53786,8 +53814,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -54071,8 +54101,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/php/exception_flow.go","internal/extractors/php/exception_flow_test.go"],
+            "notes": "throw new X / throw new \\Ns\\X -\u003e THROWS; catch (X $e) incl PHP8 union A|B -\u003e CATCHES; broad \\Throwable/\\Exception recorded (typed); re-throw $e / dynamic dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",

--- a/internal/extractors/php/exception_flow.go
+++ b/internal/extractors/php/exception_flow.go
@@ -1,0 +1,188 @@
+// exception_flow.go — supplemental pass that emits THROWS / CATCHES edges from
+// PHP methods / functions to a shared SCOPE.ExceptionType node (epic #3628).
+// It lets the graph answer "what can this operation throw?" (outbound THROWS)
+// and "where is NotFoundException handled?" (inbound CATCHES), keeping
+// error-contract parity with the C# / Java / Python / Go / JS flagships. Node /
+// edge construction is delegated to extractor.EmitExceptionEdges so the
+// convergence invariant (identical type names → ONE node) is identical
+// everywhere.
+//
+// Detected shapes (typed only — honest-partial, precision-first):
+//
+//	throw new NotFoundException(...)          → THROWS NotFoundException
+//	throw new \App\Errors\Boom(...)           → THROWS Boom          (qualified → bare)
+//	} catch (NotFoundException $e) { ... }    → CATCHES NotFoundException
+//	} catch (IOException | TimeoutException $e) { ... }
+//	                                          → CATCHES IOException + CATCHES TimeoutException
+//	                                            (PHP 8 union multi-catch — ONE edge per type)
+//	} catch (\Throwable $e) { ... }           → CATCHES Throwable    (qualified → bare)
+//
+// Deliberately NOT recorded (would mislead error-contract analysis):
+//
+//	throw $e;          (re-throw of a variable — carries no NEW type)
+//	throw $this->mk(); (computed throw — the thrown value is dynamic)
+//
+// Catch-all convention: PHP `catch` ALWAYS declares at least one type (there is
+// no untyped `catch { }` form — the type_list is mandatory in the grammar), so
+// unlike C#/JS there is no bare-catch to drop. The broad guards
+// `catch (\Throwable $e)` and `catch (\Exception $e)` ARE statically-recoverable
+// typed catches, so they are recorded as CATCHES Throwable / CATCHES Exception
+// — honest and useful: "this handler swallows everything" is a real, queryable
+// error-contract fact. This mirrors the flagship decision to record the
+// declared catch TYPE verbatim.
+//
+// FromName mirrors the walk() operation naming (`<Class>.<method>` for methods,
+// bare leaf for free functions) so THROWS / CATCHES edges attach to the same
+// SCOPE.Operation host the rest of the extractor emits.
+
+package php
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// phpExceptionLeaf collapses a PHP type token to its bare class name by taking
+// the last `\`-separated segment — the namespace separator the shared
+// extractor.NormalizeExceptionType (which only knows `.` / `::`) does not
+// handle. `\App\Errors\Boom` → "Boom", `\Throwable` → "Throwable",
+// `NotFoundException` → "NotFoundException". NormalizeExceptionType then
+// validates the leaf is a single identifier and drops anything dynamic.
+func phpExceptionLeaf(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if i := strings.LastIndex(raw, "\\"); i >= 0 {
+		raw = raw[i+1:]
+	}
+	return raw
+}
+
+// emitExceptionFlowEdges scans every method / function body (and file scope)
+// for `throw new` and typed `catch` shapes and appends exception-type entities
+// + THROWS / CATCHES edges to *entities.
+//
+// (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	src := file.Content
+
+	var edges []extractor.ExceptionEdge
+
+	// enclosingClass is the innermost class/interface/trait name (matching
+	// walk(), which dots only the immediate parent). enclosing is the host
+	// SCOPE.Operation Name (`<class>.<method>` for methods, bare leaf for free
+	// functions), or "" at file scope.
+	var walk func(n *sitter.Node, enclosingClass, enclosing string)
+	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_declaration", "interface_declaration", "trait_declaration":
+			cls := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), cls, enclosing)
+			}
+			return
+		case "method_declaration":
+			leaf := childFieldText(n, "name", src)
+			name := leaf
+			if enclosingClass != "" && leaf != "" {
+				name = enclosingClass + "." + leaf
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, name)
+			}
+			return
+		case "function_definition":
+			leaf := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), enclosingClass, leaf)
+			}
+			return
+		case "throw_expression":
+			if t := phpThrowType(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosing, Pattern: "throw_new",
+				})
+			}
+		case "catch_clause":
+			for _, t := range phpCatchTypes(n, src) {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosing, Catch: true, Pattern: "catch_type",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingClass, enclosing)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitExceptionEdges(entities, "php", edges)
+}
+
+// phpThrowType returns the constructed exception type for `throw new X(...)` /
+// `throw new \Ns\X(...)`, or "" for a re-throw of a variable (`throw $e;`) or a
+// computed throw (`throw mk();`) which carries no NEW static type. The raw
+// (possibly qualified) type text is returned verbatim; NormalizeExceptionType
+// collapses it to the bare class name.
+//
+// Grammar: a `throw_expression` has an `object_creation_expression` child only
+// when the thrown value is `new X(...)`. The type leaf is the first
+// `name` / `qualified_name` child after the `new` keyword (the `type` field is
+// not consistently set across grammar revisions).
+func phpThrowType(throwNode *sitter.Node, src []byte) string {
+	creation := findFirstChildOfType(throwNode, "object_creation_expression")
+	if creation == nil {
+		return "" // `throw $e;` or `throw mk();` — no NEW type
+	}
+	for i := 0; i < int(creation.ChildCount()); i++ {
+		ch := creation.Child(i)
+		if ch.Type() == "name" || ch.Type() == "qualified_name" {
+			return phpExceptionLeaf(string(src[ch.StartByte():ch.EndByte()]))
+		}
+	}
+	return ""
+}
+
+// phpCatchTypes returns every caught type declared in a catch clause's
+// `type_list`. PHP 8 union multi-catch (`catch (A | B | C $e)`) lists multiple
+// `named_type` children — one CATCHES per type so each guarded type converges
+// on its own exception node. Each `named_type` wraps either a `name` (bare) or
+// a `qualified_name` (`\Ns\X` / `\Throwable`); the raw text is returned
+// verbatim and NormalizeExceptionType collapses it to the bare class name.
+//
+// PHP has no untyped `catch { }` (the type_list is mandatory), so this never
+// needs to drop a bare catch — every clause yields at least one type.
+func phpCatchTypes(catchNode *sitter.Node, src []byte) []string {
+	typeList := catchNode.ChildByFieldName("type")
+	if typeList == nil {
+		typeList = findFirstChildOfType(catchNode, "type_list")
+	}
+	if typeList == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(typeList.ChildCount()); i++ {
+		ch := typeList.Child(i)
+		if ch.Type() != "named_type" {
+			continue // skip the `|` separators
+		}
+		// named_type wraps a single name / qualified_name leaf.
+		for j := 0; j < int(ch.ChildCount()); j++ {
+			leaf := ch.Child(j)
+			if leaf.Type() == "name" || leaf.Type() == "qualified_name" {
+				out = append(out, phpExceptionLeaf(string(src[leaf.StartByte():leaf.EndByte()])))
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/extractors/php/exception_flow_test.go
+++ b/internal/extractors/php/exception_flow_test.go
@@ -1,0 +1,224 @@
+package php_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/php"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractPHPForExc parses + extracts PHP source via the registered extractor.
+func extractPHPForExc(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("php")
+	if !ok {
+		t.Fatal("php extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "svc.php",
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+// exceptionNode returns the SCOPE.ExceptionType entity for bareType, or fails.
+func exceptionNode(t *testing.T, ents []types.EntityRecord, bareType string) types.EntityRecord {
+	t.Helper()
+	want := extractor.ExceptionTypeName(bareType)
+	for _, e := range ents {
+		if e.Kind == string(types.EntityKindExceptionType) && e.Name == want {
+			if e.SourceFile != extractor.ExceptionTypeSourceFile {
+				t.Fatalf("exception node %q SourceFile=%q want synthetic %q",
+					bareType, e.SourceFile, extractor.ExceptionTypeSourceFile)
+			}
+			if e.QualifiedName != extractor.ExceptionTypeTargetID(bareType) {
+				t.Fatalf("exception node %q QualifiedName=%q want %q",
+					bareType, e.QualifiedName, extractor.ExceptionTypeTargetID(bareType))
+			}
+			return e
+		}
+	}
+	t.Fatalf("no SCOPE.ExceptionType node for %q", bareType)
+	return types.EntityRecord{}
+}
+
+// relCount counts edges of kind from the named host entity to bareType's node.
+func relCount(ents []types.EntityRecord, hostName, kind, bareType string) int {
+	target := extractor.ExceptionTypeTargetID(bareType)
+	n := 0
+	for _, e := range ents {
+		if e.Name != hostName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == target {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestPHP_ErrorFlow_ThrowAndCatchConverge asserts a type thrown in one method
+// and caught in another converge on ONE shared exception node (flagship shape).
+func TestPHP_ErrorFlow_ThrowAndCatchConverge(t *testing.T) {
+	src := `<?php
+namespace App;
+class UserService {
+  public function find(int $id) {
+    throw new NotFoundException("missing");
+  }
+  public function handle() {
+    try { $this->find(1); }
+    catch (NotFoundException $e) { }
+  }
+}
+`
+	ents := extractPHPForExc(t, src)
+
+	// Exactly ONE convergence node for NotFoundException.
+	var nodes int
+	for _, e := range ents {
+		if e.Kind == string(types.EntityKindExceptionType) &&
+			e.Name == extractor.ExceptionTypeName("NotFoundException") {
+			nodes++
+		}
+	}
+	if nodes != 1 {
+		t.Fatalf("want 1 NotFoundException node, got %d", nodes)
+	}
+	exceptionNode(t, ents, "NotFoundException")
+
+	// THROWS from UserService.find, CATCHES from UserService.handle — both to
+	// the SAME node id.
+	if got := relCount(ents, "UserService.find", "THROWS", "NotFoundException"); got != 1 {
+		t.Errorf("UserService.find THROWS NotFoundException = %d, want 1", got)
+	}
+	if got := relCount(ents, "UserService.handle", "CATCHES", "NotFoundException"); got != 1 {
+		t.Errorf("UserService.handle CATCHES NotFoundException = %d, want 1", got)
+	}
+}
+
+// TestPHP_ErrorFlow_UnionMultiCatch asserts PHP 8 union catch yields ONE
+// CATCHES edge per type, each to its own node.
+func TestPHP_ErrorFlow_UnionMultiCatch(t *testing.T) {
+	src := `<?php
+class Svc {
+  public function run() {
+    try { go(); }
+    catch (IOException | TimeoutException $e) { }
+  }
+}
+`
+	ents := extractPHPForExc(t, src)
+
+	exceptionNode(t, ents, "IOException")
+	exceptionNode(t, ents, "TimeoutException")
+
+	if got := relCount(ents, "Svc.run", "CATCHES", "IOException"); got != 1 {
+		t.Errorf("Svc.run CATCHES IOException = %d, want 1", got)
+	}
+	if got := relCount(ents, "Svc.run", "CATCHES", "TimeoutException"); got != 1 {
+		t.Errorf("Svc.run CATCHES TimeoutException = %d, want 1", got)
+	}
+}
+
+// TestPHP_ErrorFlow_QualifiedNormalized asserts a fully-qualified thrown type
+// is normalized to its bare leaf.
+func TestPHP_ErrorFlow_QualifiedNormalized(t *testing.T) {
+	src := `<?php
+class Svc {
+  public function boom() {
+    throw new \App\Errors\Boom();
+  }
+}
+`
+	ents := extractPHPForExc(t, src)
+	exceptionNode(t, ents, "Boom")
+	if got := relCount(ents, "Svc.boom", "THROWS", "Boom"); got != 1 {
+		t.Errorf("Svc.boom THROWS Boom = %d, want 1", got)
+	}
+}
+
+// TestPHP_ErrorFlow_CatchAllBroadGuard asserts broad guards \Throwable /
+// \Exception ARE recorded (typed, statically-recoverable) — documented
+// convention.
+func TestPHP_ErrorFlow_CatchAllBroadGuard(t *testing.T) {
+	src := `<?php
+class Svc {
+  public function swallow() {
+    try { go(); }
+    catch (\Throwable $e) { }
+  }
+  public function swallow2() {
+    try { go(); }
+    catch (\Exception $e) { }
+  }
+}
+`
+	ents := extractPHPForExc(t, src)
+	exceptionNode(t, ents, "Throwable")
+	exceptionNode(t, ents, "Exception")
+	if got := relCount(ents, "Svc.swallow", "CATCHES", "Throwable"); got != 1 {
+		t.Errorf("Svc.swallow CATCHES Throwable = %d, want 1", got)
+	}
+	if got := relCount(ents, "Svc.swallow2", "CATCHES", "Exception"); got != 1 {
+		t.Errorf("Svc.swallow2 CATCHES Exception = %d, want 1", got)
+	}
+}
+
+// TestPHP_ErrorFlow_Negatives asserts re-throw, computed throw, and a plain
+// method emit NO exception edges / nodes.
+func TestPHP_ErrorFlow_Negatives(t *testing.T) {
+	src := `<?php
+class Svc {
+  public function rethrow(\Exception $e) {
+    throw $e;
+  }
+  public function computed() {
+    throw $this->makeError();
+  }
+  public function plain(int $id) {
+    return $id + 1;
+  }
+}
+`
+	ents := extractPHPForExc(t, src)
+
+	// No THROWS edges at all (re-throw + computed carry no NEW static type).
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "THROWS" {
+				t.Errorf("unexpected THROWS edge from %q to %q", e.Name, r.ToID)
+			}
+		}
+	}
+	// No exception nodes were fabricated.
+	for _, e := range ents {
+		if e.Kind == string(types.EntityKindExceptionType) {
+			t.Errorf("unexpected exception node %q for negatives-only source", e.Name)
+		}
+	}
+}
+
+// TestPHP_ErrorFlow_FreeFunction asserts edges attach to free-function hosts.
+func TestPHP_ErrorFlow_FreeFunction(t *testing.T) {
+	src := `<?php
+function loadConfig() {
+  throw new ConfigError("bad");
+}
+`
+	ents := extractPHPForExc(t, src)
+	exceptionNode(t, ents, "ConfigError")
+	if got := relCount(ents, "loadConfig", "THROWS", "ConfigError"); got != 1 {
+		t.Errorf("loadConfig THROWS ConfigError = %d, want 1", got)
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -78,6 +78,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// functions / methods to a shared SCOPE.TranslationKey node for Laravel
 	// `__('k')` / `trans('k')` shapes (dynamic / interpolated keys dropped).
 	emitTranslationKeyEdges(root, file, &entities)
+	// Error-flow topology (epic #3628) — THROWS / CATCHES edges from
+	// operations to a shared SCOPE.ExceptionType node for `throw new X()` and
+	// typed `catch (X $e)` (incl. PHP 8 union multi-catch). Dynamic / re-throw
+	// shapes are dropped (precision-first).
+	emitExceptionFlowEdges(root, file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")


### PR DESCRIPTION
## Summary
Ports the cross-language `error_flow` capability (epic #3628) to the **PHP native extractor**, fanning out the flagship model that is already `full` in 8 languages (csharp, elixir, go, java, jsts, kotlin, python, scala). Flips all **16 PHP framework cells** from `missing` → `full`. **No new Kind** — reuses the shared `SCOPE.ExceptionType` convergence node + `THROWS`/`CATCHES` edges from `internal/extractor/exception_flow.go`.

## Flagship-shape parity
Delegates all node/edge construction to `extractor.EmitExceptionEdges`, so identical type names converge on ONE node (synthetic `<exception>` SourceFile, `QualifiedName == ExceptionTypeTargetID`) exactly like csharp/python/go. `FromName` mirrors the PHP `walk()` operation naming (`<Class>.<method>` for methods, bare leaf for free functions).

## Detected (typed, statically-recoverable only — precision-first)
| PHP idiom | Edge |
|---|---|
| `throw new NotFoundException(...)` | THROWS NotFoundException |
| `throw new \App\Errors\Boom(...)` | THROWS Boom (namespace → leaf) |
| `catch (NotFoundException $e) { }` | CATCHES NotFoundException |
| `catch (IOException \| TimeoutException $e)` | CATCHES IOException + CATCHES TimeoutException (PHP 8 union) |
| `catch (\Throwable $e)` / `catch (\Exception $e)` | CATCHES declared type |

**Dropped:** re-throw `throw $e;`, computed `throw mk();`, plain methods.

## Catch-all convention
PHP has **no untyped `catch { }`** (the grammar's `type_list` is mandatory), so there is no bare-catch to drop. Broad guards `\Throwable` / `\Exception` are typed and statically-recoverable, so they are recorded as `CATCHES Throwable` / `CATCHES Exception` — an honest, queryable "this handler swallows everything" fact, matching the flagship decision to record the declared catch TYPE verbatim. Documented in the file header.

## Verification
- New native extractor `internal/extractors/php/exception_flow.go`, wired into `Extract()` and firing **live on .php** via the registered extractor + real tree-sitter grammar in tests.
- Value-asserting tests (`exception_flow_test.go`): throw+catch **converge on ONE node**, PHP 8 union multi-catch (one edge per type), qualified-name normalization, broad-guard recording, negatives (re-throw / computed / plain → zero edges & nodes), free-function host.
- Full packages green: `php`, `engine`, `extractors`, `types`, `coverage`.
- `gofmt` empty · `go vet` clean · `covtool fmt --check` canonical · `covtool validate` 0 errors · `covtool gen` 0 drift.
- The `error_flow` "no mapping entry" validate warning is pre-existing and identical across ALL `full` error_flow languages (csharp, python, …) — parity preserved, nothing new introduced.

DEPLOY-DEFERRED — graph effect lands on next live-daemon rebuild + reindex.

Closes #4090

🤖 Generated with [Claude Code](https://claude.com/claude-code)