### PR TITLE
feat(ruby): port flagship error_flow (THROWS/CATCHES) to Ruby

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -115,15 +115,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 8/13 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 4/6 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟡 24/25 | 🟡 9/12 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 8/12 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🟡 2/13 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 4/6 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟢 25/25 | 🟡 9/12 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 8/12 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 23/25 | 🟡 6/10 | |
+| [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 2/13 | |
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -26,15 +26,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 4/6 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟡 24/25 | 🟡 9/12 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 8/12 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 22/25 | 🟡 6/10 | |
-| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 9/24 | 🟡 2/13 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 23/25 | 🟡 7/11 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 4/6 | ✅ 1/1 | 🟢 1/1 | ✅ 1/1 | 🟢 25/25 | 🟡 9/12 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 8/12 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 23/25 | 🟡 6/10 | |
+| [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 2/13 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
+++ b/docs/coverage/detail/lang.ruby.framework.graphql-ruby.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🔴 `missing` | — | 3621 | — | — |
 | Def use chain extraction | 🟢 `partial` | `2026-06-02` | 3948 | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | Per-LANGUAGE Ruby def-use sniffer fires on graphql-ruby resolver .rb bodies (def_use_pass.go dispatches by file language, framework-agnostic). Probed: record def->use chain inside a field resolver (#3948). |
 | Env fallback recognition | 🔴 `missing` | — | 3621 | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Fs effect | 🟢 `partial` | `2026-06-02` | 3948 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | fs_read/fs_write effect (File.read/.write) fires on graphql-ruby resolver file I/O. Per-language Ruby sniffer (#3948). |
 | HTTP effect | 🟢 `partial` | `2026-06-02` | 3948 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | http_out effect (Net::HTTP/HTTParty/Faraday) fires when a graphql-ruby resolver calls an HTTP client. Per-language Ruby sniffer (#3948). |

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | ✅ `full` | `2026-06-02` | 3706 | `internal/engine/feature_flag_edges.go`<br>`internal/engine/feature_flag_edges_test.go`<br>`internal/engine/orm_queries.go` | flag-check call sites -> feature:<key> + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic) |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_ruby.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/ruby/exception_flow.go`<br>`internal/extractors/ruby/exception_flow_test.go` | raise X / raise Mod::X -> THROWS; rescue A, B => e / method-level rescue / Rails rescue_from A, B, with: -> CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -37,7 +37,7 @@ one is a separate detail page.
 | [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 10 full, 16 partial, 23 missing |
 | [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 15 full, 24 partial, 10 missing |
 | [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 23 partial, 10 missing |
-| [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 3 full, 11 partial, 35 missing |
+| [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 4 full, 11 partial, 34 missing |
 | [`lang.rust.framework.async-graphql`](./lang.rust.framework.async-graphql.md) | rust | framework | 11 full, 3 partial, 35 missing |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -63357,8 +63357,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -63629,8 +63631,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -63902,8 +63906,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -64179,8 +64185,10 @@
             "issue": "3621"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -64458,8 +64466,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -64737,8 +64747,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -65025,8 +65037,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "full",
@@ -65317,8 +65331,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -65598,8 +65614,10 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/ruby/exception_flow.go","internal/extractors/ruby/exception_flow_test.go"],
+            "notes": "raise X / raise Mod::X -\u003e THROWS; rescue A, B =\u003e e / method-level rescue / Rails rescue_from A, B, with: -\u003e CATCHES; bare rescue catch-all + string raise + bare re-raise dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",

--- a/internal/extractors/ruby/exception_flow.go
+++ b/internal/extractors/ruby/exception_flow.go
@@ -1,0 +1,203 @@
+// exception_flow.go — supplemental pass that emits THROWS / CATCHES edges from
+// Ruby methods (def / singleton def) to a shared SCOPE.ExceptionType node (epic
+// #3628). It lets the graph answer "what can this method raise?" (outbound
+// THROWS) and "where is NotFoundError handled?" (inbound CATCHES), matching the
+// flagship convergence-node shape every other language emits (see
+// internal/extractor/exception_flow.go): node/edge construction lives in
+// extractor.EmitExceptionEdges, so a Ruby `raise NotFoundError` and an Elixir
+// `raise NotFoundError` resolve to ONE exception:NotFoundError node.
+//
+// Detected shapes (typed only — honest-partial, precision-first):
+//
+//	raise NotFoundError, "msg"                  → THROWS NotFoundError
+//	raise ArgumentError                         → THROWS ArgumentError
+//	raise MyApp::NotFoundError, message: "x"    → THROWS NotFoundError (last segment)
+//	begin … rescue NotFoundError => e … end     → CATCHES NotFoundError
+//	rescue ArgumentError, TypeError => e         → CATCHES ArgumentError + TypeError
+//	def m … rescue RuntimeError => e … end       → CATCHES RuntimeError (method-level rescue)
+//	rescue_from RecordNotFound, with: :handler  → CATCHES RecordNotFound (Rails controller)
+//	rescue_from ArgumentError, RangeError, …    → CATCHES ArgumentError + RangeError
+//
+// Intentionally DROPPED (would mislead error-contract analysis):
+//
+//	raise "just a message"      (string → implicit RuntimeError, no type token)
+//	raise                       (bare re-raise — re-raises $! , carries no NEW type)
+//	rescue => e  /  rescue       (untyped catch-all → StandardError, no class token —
+//	                             matches the flagship catch-all convention: skip)
+//	rescue_from with no leading constant (only a `with:` pair) — no type token
+//
+// All node/edge construction (convergence on one node per type name via a
+// synthetic SourceFile) lives in extractor.EmitExceptionEdges, so the
+// convergence invariant is identical across every language.
+
+package ruby
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitExceptionFlowEdges scans every method / singleton_method body for typed
+// raise / rescue / rescue_from shapes and appends exception-type entities +
+// THROWS / CATCHES edges.
+//
+// entities[0] MUST be the file entity (Extract appends it first). Mutates
+// *entities in place. Safe with nil / empty input. raise / rescue / rescue_from
+// outside any method (class or module scope, e.g. a controller-level
+// `rescue_from`) attach to the file entity via EmitExceptionEdges's fallback.
+func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var edges []extractor.ExceptionEdge
+
+	// Track the nearest enclosing method/singleton_method name so each raise /
+	// rescue / rescue_from is attributed to the right SCOPE.Operation (matched by
+	// Name inside EmitExceptionEdges). The method NAME mirrors operation naming in
+	// ruby.go (buildMethod uses the bare `name` field), so attribution is exact.
+	var walk func(n *sitter.Node, current string)
+	walk = func(n *sitter.Node, current string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "method", "singleton_method":
+			fnName := childFieldText(n, "name", src)
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i), fnName)
+			}
+			return
+		case "call", "command":
+			head := rubyCallTarget(n, src)
+			switch head {
+			case "raise":
+				if t := rubyRaiseType(n, src); t != "" {
+					edges = append(edges, extractor.ExceptionEdge{
+						Type: t, FromName: current, Pattern: "raise",
+					})
+				}
+			case "rescue_from":
+				for _, t := range rubyRescueFromTypes(n, src) {
+					edges = append(edges, extractor.ExceptionEdge{
+						Type: t, FromName: current, Catch: true, Pattern: "rescue_from",
+					})
+				}
+			}
+		case "rescue":
+			for _, t := range rubyRescueTypes(n, src) {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: current, Catch: true, Pattern: "rescue",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), current)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitExceptionEdges(entities, "ruby", edges)
+}
+
+// rubyRaiseType returns the raised exception-class token from a `raise` call /
+// command node, or "" for a message-only / bare / variable raise.
+//
+// Accepted shape: the first argument is a `constant` (or scoped constant, which
+// tree-sitter exposes as a `scope_resolution` whose verbatim text — e.g.
+// `MyApp::NotFoundError` — NormalizeExceptionType reduces to the last segment).
+// `raise NotFoundError, "x"`, `raise ArgumentError`, `raise MyApp::Err, message:`.
+//
+// Returns "" for `raise "msg"` (string → implicit RuntimeError), bare `raise`
+// (re-raise — which the grammar exposes as a lone `identifier`, never a call
+// with arguments, so it never reaches here), and `raise var` / computed types.
+func rubyRaiseType(raiseCall *sitter.Node, src []byte) string {
+	args := raiseCall.ChildByFieldName("arguments")
+	if args == nil {
+		return "" // bare `raise` re-raise (no arguments) — no static type
+	}
+	first := firstNamedChildRuby(args)
+	if first == nil {
+		return ""
+	}
+	switch first.Type() {
+	case "constant", "scope_resolution":
+		// `raise NotFoundError` / `raise MyApp::NotFoundError`. The verbatim text
+		// (possibly `::`-qualified) is normalized to the last segment downstream.
+		return string(src[first.StartByte():first.EndByte()])
+	}
+	// `raise "msg"` (string), `raise var` (identifier), computed — no static type.
+	return ""
+}
+
+// rubyRescueTypes returns the caught exception-class tokens from a `rescue`
+// node. The grammar exposes the rescued type list as the `exceptions` field (an
+// `exceptions` node holding one `constant`/`scope_resolution` per class):
+//
+//	rescue NotFoundError => e           exceptions{constant} → {NotFoundError}
+//	rescue ArgumentError, TypeError => e exceptions{constant,constant} → {ArgumentError,TypeError}
+//	rescue MyApp::BadError               exceptions{scope_resolution} → {BadError}
+//	rescue => e  /  rescue               (no `exceptions` field — catch-all) → {}
+//
+// Untyped catch-alls (bare `rescue`) carry no static class → dropped, matching
+// the flagship catch-all convention (precision over recall).
+func rubyRescueTypes(rescueNode *sitter.Node, src []byte) []string {
+	exc := rescueNode.ChildByFieldName("exceptions")
+	if exc == nil {
+		return nil // bare `rescue => e` / `rescue` — catch-all, no type
+	}
+	var out []string
+	for i := 0; i < int(exc.NamedChildCount()); i++ {
+		el := exc.NamedChild(i)
+		if el == nil {
+			continue
+		}
+		switch el.Type() {
+		case "constant", "scope_resolution":
+			out = append(out, string(src[el.StartByte():el.EndByte()]))
+		}
+		// `splat` / `assignment` / non-constant rescued expressions: no static type.
+	}
+	return out
+}
+
+// rubyRescueFromTypes returns the caught exception-class tokens from a Rails
+// controller `rescue_from` call / command node. The leading positional
+// arguments are the rescued classes; a trailing `with:`/handler `pair` (and any
+// block) is ignored:
+//
+//	rescue_from RecordNotFound, with: :not_found        → {RecordNotFound}
+//	rescue_from ArgumentError, RangeError, with: :bad   → {ArgumentError, RangeError}
+//	rescue_from SomeError do |e| … end                  → {SomeError}
+//
+// Only `constant` / `scope_resolution` arguments yield a type; `pair`
+// (keyword args like `with:`) and anything else are skipped (honest-partial).
+func rubyRescueFromTypes(call *sitter.Node, src []byte) []string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		el := args.NamedChild(i)
+		if el == nil {
+			continue
+		}
+		switch el.Type() {
+		case "constant", "scope_resolution":
+			out = append(out, string(src[el.StartByte():el.EndByte()]))
+		}
+		// `pair` (with: :handler), `simple_symbol`, blocks: not a rescued type.
+	}
+	return out
+}
+
+// firstNamedChildRuby returns the first named child of n, or nil.
+func firstNamedChildRuby(n *sitter.Node) *sitter.Node {
+	if n == nil || n.NamedChildCount() == 0 {
+		return nil
+	}
+	return n.NamedChild(0)
+}

--- a/internal/extractors/ruby/exception_flow_test.go
+++ b/internal/extractors/ruby/exception_flow_test.go
@@ -1,0 +1,304 @@
+package ruby_test
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/ruby"
+	"github.com/cajasmota/archigraph/internal/treesitter"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractRuby parses src with the real grammar and runs the registered ruby
+// extractor, returning the entity records.
+func extractRuby(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("ruby")
+	if !ok {
+		t.Fatal("ruby extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "ruby", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return recs
+}
+
+// edgesByKind returns the set of exception-type names on edges of the given
+// kind whose ToID is the canonical convergence target for that type.
+func edgesByKind(recs []types.EntityRecord, kind string) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == kind {
+				if tn := rel.Properties["exception_type"]; tn != "" &&
+					rel.ToID == extractor.ExceptionTypeTargetID(tn) {
+					out[tn] = true
+				}
+			}
+		}
+	}
+	return out
+}
+
+// convergeNode reports whether a single SCOPE.ExceptionType node exists for
+// typeName with the expected synthetic-file convergence identity.
+func convergeNode(recs []types.EntityRecord, typeName string) bool {
+	want := extractor.ExceptionTypeName(typeName)
+	for _, r := range recs {
+		if r.Kind == string(types.EntityKindExceptionType) &&
+			r.Name == want &&
+			r.QualifiedName == extractor.ExceptionTypeTargetID(typeName) &&
+			r.SourceFile == extractor.ExceptionTypeSourceFile {
+			return true
+		}
+	}
+	return false
+}
+
+// hostHasEdge asserts that the operation entity named host carries a THROWS or
+// CATCHES edge (kind) targeting typeName's convergence node.
+func hostHasEdge(recs []types.EntityRecord, host, kind, typeName string) bool {
+	for _, r := range recs {
+		if r.Name != host {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == kind && rel.ToID == extractor.ExceptionTypeTargetID(typeName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestErrorFlow_RaiseAndRescueConverge(t *testing.T) {
+	src := `class Accounts
+  def find(id)
+    raise NotFoundError, "missing"
+  end
+  def get(id)
+    begin
+      find(id)
+    rescue NotFoundError => e
+      handle(e)
+    end
+  end
+end
+`
+	recs := extractRuby(t, "app/models/accounts.rb", src)
+
+	if !convergeNode(recs, "NotFoundError") {
+		t.Fatal("expected ONE exception:NotFoundError convergence node")
+	}
+	if !hostHasEdge(recs, "find", "THROWS", "NotFoundError") {
+		t.Error("find should THROW NotFoundError")
+	}
+	if !hostHasEdge(recs, "get", "CATCHES", "NotFoundError") {
+		t.Error("get should CATCH NotFoundError")
+	}
+	// Convergence invariant: THROWS and CATCHES share the SAME ToID.
+	throwsTo := ""
+	catchesTo := ""
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "THROWS" {
+				throwsTo = rel.ToID
+			}
+			if rel.Kind == "CATCHES" {
+				catchesTo = rel.ToID
+			}
+		}
+	}
+	if throwsTo == "" || throwsTo != catchesTo ||
+		throwsTo != extractor.ExceptionTypeTargetID("NotFoundError") {
+		t.Fatalf("THROWS (%q) and CATCHES (%q) must converge on ExceptionTypeTargetID(NotFoundError)", throwsTo, catchesTo)
+	}
+}
+
+func TestErrorFlow_MultiClassRescue(t *testing.T) {
+	src := `class Svc
+  def run
+    begin
+      work
+    rescue ArgumentError, TypeError => e
+      log(e)
+    end
+  end
+end
+`
+	recs := extractRuby(t, "svc.rb", src)
+	catches := edgesByKind(recs, "CATCHES")
+	if !catches["ArgumentError"] || !catches["TypeError"] {
+		t.Fatalf("multi-class rescue should CATCH both ArgumentError and TypeError; got %v", catches)
+	}
+	if !hostHasEdge(recs, "run", "CATCHES", "ArgumentError") ||
+		!hostHasEdge(recs, "run", "CATCHES", "TypeError") {
+		t.Error("both catches should attach to run")
+	}
+}
+
+func TestErrorFlow_MethodLevelRescue(t *testing.T) {
+	src := `class Svc
+  def take
+    do_work
+  rescue RuntimeError => e
+    log(e)
+  end
+end
+`
+	recs := extractRuby(t, "svc.rb", src)
+	if !hostHasEdge(recs, "take", "CATCHES", "RuntimeError") {
+		t.Fatal("method-level (implicit begin) rescue should CATCH RuntimeError on take")
+	}
+}
+
+func TestErrorFlow_RescueFrom(t *testing.T) {
+	src := `class FooController < ApplicationController
+  rescue_from RecordNotFound, with: :not_found
+  rescue_from ArgumentError, RangeError, with: :bad
+end
+`
+	recs := extractRuby(t, "app/controllers/foo_controller.rb", src)
+	catches := edgesByKind(recs, "CATCHES")
+	for _, want := range []string{"RecordNotFound", "ArgumentError", "RangeError"} {
+		if !catches[want] {
+			t.Errorf("rescue_from should CATCH %s; got %v", want, catches)
+		}
+	}
+	// The `with:` symbol handler must NOT be treated as a type.
+	if catches["not_found"] || catches["bad"] {
+		t.Error("with: handler symbol must not become an exception type")
+	}
+}
+
+func TestErrorFlow_ScopedConstantNormalizes(t *testing.T) {
+	src := `class Svc
+  def boom
+    raise MyApp::NotFoundError, "x"
+  end
+end
+`
+	recs := extractRuby(t, "svc.rb", src)
+	if !hostHasEdge(recs, "boom", "THROWS", "NotFoundError") {
+		t.Fatal("raise MyApp::NotFoundError should THROW NotFoundError (last segment)")
+	}
+	if !convergeNode(recs, "NotFoundError") {
+		t.Fatal("scoped raise should converge on exception:NotFoundError node")
+	}
+}
+
+// --- Negatives: precision-first, honest-partial ---
+
+func TestErrorFlow_Negatives(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"string_raise", `class S
+  def m
+    raise "plain message"
+  end
+end
+`},
+		{"bare_rescue_catchall", `class S
+  def m
+    begin
+      work
+    rescue => e
+      log(e)
+    end
+  end
+end
+`},
+		{"untyped_bare_rescue", `class S
+  def m
+    work
+  rescue
+    log
+  end
+end
+`},
+		{"plain_method", `class S
+  def m
+    do_work
+  end
+end
+`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			recs := extractRuby(t, "s.rb", c.src)
+			for _, r := range recs {
+				if r.Kind == string(types.EntityKindExceptionType) {
+					t.Errorf("%s: unexpected exception-type node %q", c.name, r.Name)
+				}
+				for _, rel := range r.Relationships {
+					if rel.Kind == "THROWS" {
+						t.Errorf("%s: unexpected THROWS edge %s", c.name, rel.ToID)
+					}
+					if rel.Kind == "CATCHES" {
+						t.Errorf("%s: unexpected CATCHES edge %s", c.name, rel.ToID)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestErrorFlow_BareReraiseAddsNoType: a typed rescue followed by bare `raise`
+// keeps ONLY the rescued type — the re-raise carries no NEW exception type.
+func TestErrorFlow_BareReraiseAddsNoType(t *testing.T) {
+	src := `class S
+  def m
+    begin
+      work
+    rescue NotFoundError => e
+      raise
+    end
+  end
+end
+`
+	recs := extractRuby(t, "s.rb", src)
+	if !hostHasEdge(recs, "m", "CATCHES", "NotFoundError") {
+		t.Fatal("typed rescue should still CATCH NotFoundError")
+	}
+	if throws := edgesByKind(recs, "THROWS"); len(throws) != 0 {
+		t.Fatalf("bare re-raise must add no THROWS type; got %v", throws)
+	}
+}
+
+// TestLiveFireRb drives the FULL production path: ParserFactory.Parse for a real
+// app/*.rb file, then the registry-resolved ruby extractor's Extract, confirming
+// error_flow fires live (THROWS + CATCHES converge on one node).
+func TestLiveFireRb(t *testing.T) {
+	src := []byte("class Accounts\n  def find(id)\n    raise NotFoundError, \"x\"\n  end\n  def get(id)\n    begin\n      find(id)\n    rescue NotFoundError => e\n      e\n    end\n  end\nend\n")
+	pf := treesitter.NewParserFactory(noop.NewTracerProvider().Tracer("t"))
+	res, err := pf.Parse(context.Background(), src, "ruby")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext, ok := extractor.Get("ruby")
+	if !ok {
+		t.Fatal("ruby extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "app/models/accounts.rb", Content: src, Language: "ruby", Tree: res.Tree,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	throws := hostHasEdge(recs, "find", "THROWS", "NotFoundError")
+	catches := hostHasEdge(recs, "get", "CATCHES", "NotFoundError")
+	node := convergeNode(recs, "NotFoundError")
+	t.Logf("LIVE .rb fire: throws=%v catches=%v convergeNode=%v", throws, catches, node)
+	if !(throws && catches && node) {
+		t.Fatal("error_flow did NOT fire live on .rb through ParserFactory + registered extractor")
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -59,6 +59,13 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// relative `t('.k')` shapes (dynamic keys + ambiguous bare `t('plain')`
 	// dropped).
 	emitTranslationKeyEdges(root, file.Content, &entities)
+	// Error-flow topology (epic #3628) — THROWS / CATCHES edges from methods to a
+	// shared SCOPE.ExceptionType node for typed `raise NotFoundError`,
+	// `rescue NotFoundError => e` (incl. method-level + multi-class rescue), and
+	// Rails `rescue_from RecordNotFound, with: :handler`. Bare rescue catch-all,
+	// string raise, and bare re-raise are dropped (precision-first). Mirrors the
+	// flagship convergence-node shape (internal/extractor/exception_flow.go).
+	emitExceptionFlowEdges(root, file.Content, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7585,6 +7585,18 @@ records:
           issues_implemented: ["3628"]
           verified_at: "2026-06-02"
       Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
         feature_flag_gating:
           status: full
           symbols:
@@ -16975,6 +16987,19 @@ records:
 
   lang.ruby.framework.grape:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Middleware:
         middleware_coverage:
           status: partial
@@ -16988,6 +17013,19 @@ records:
 
   lang.ruby.framework.sinatra:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Routing:
         route_extraction:
           status: full
@@ -17113,6 +17151,19 @@ records:
 
   lang.ruby.framework.padrino:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Middleware:
         middleware_coverage:
           status: partial
@@ -17126,6 +17177,19 @@ records:
 
   lang.ruby.framework.hanami:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Middleware:
         middleware_coverage:
           status: partial
@@ -17139,6 +17203,19 @@ records:
 
   lang.ruby.framework.roda:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Middleware:
         middleware_coverage:
           status: partial
@@ -17152,6 +17229,19 @@ records:
 
   lang.ruby.framework.cuba:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Routing:
         endpoint_synthesis:
           status: partial
@@ -17184,6 +17274,19 @@ records:
 
   lang.ruby.framework.dry-rb:
     capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Type System:
         type_extraction:
           status: partial
@@ -17194,6 +17297,22 @@ records:
             - file: internal/custom/ruby/dry_types_test.go
           issues_implemented: ["3282"]
           verified_at: "2026-05-30"
+
+  lang.ruby.framework.graphql-ruby:
+    capabilities:
+      Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/ruby/exception_flow.go
+              functions: [emitExceptionFlowEdges, rubyRaiseType, rubyRescueTypes, rubyRescueFromTypes]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/ruby/exception_flow_test.go
+              functions: [TestErrorFlow_RaiseAndRescueConverge, TestErrorFlow_MultiClassRescue, TestErrorFlow_MethodLevelRescue, TestErrorFlow_RescueFrom, TestErrorFlow_ScopedConstantNormalizes, TestErrorFlow_Negatives, TestErrorFlow_BareReraiseAddsNoType, TestLiveFireRb]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
 
   # ---------------------------------------------------------------------------
   # Ruby ORM lazy loading + migration cells (Part of #3282)


### PR DESCRIPTION
Closes #4088 (epic #3628). **DEPLOY-DEFERRED.**

Ports the flagship convergence-node error-flow model to the native Ruby tree-sitter extractor. `error_flow` was `full` in 8 languages (go/java/jsts/python/csharp/scala/kotlin/elixir) but `missing` across all 9 Ruby frameworks — this closes the Ruby gap.

## What

New `internal/extractors/ruby/exception_flow.go` — a scope-tracking pass wired into `Extractor.Extract` — emits `THROWS` / `CATCHES` edges from Ruby methods to the shared `SCOPE.ExceptionType` convergence node. **No new Kind**: reuses `extractor.EmitExceptionEdges` / `ExceptionTypeTargetID`, so a Ruby `raise NotFoundError` and an Elixir `raise NotFoundError` resolve to ONE `exception:NotFoundError` node. Exact flagship-shape parity.

### Idioms covered (typed only — precision-first / honest-partial)
| Ruby | Edge |
|---|---|
| `raise NotFoundError, "msg"` / `raise ArgumentError` | THROWS |
| `raise MyApp::NotFoundError` (scoped → last segment) | THROWS NotFoundError |
| `begin … rescue NotFoundError => e … end` | CATCHES |
| `rescue ArgumentError, TypeError => e` (multi-class) | CATCHES ×2 |
| method-level `rescue RuntimeError => e` (implicit begin) | CATCHES |
| Rails `rescue_from RecordNotFound, with: :handler` | CATCHES RecordNotFound |

### Deliberately dropped (a single wrong edge misleads error-contract analysis)
- bare `rescue => e` / `rescue` **catch-all** — no static class token. Chosen convention: **skip** (do NOT stamp `StandardError`), matching the flagship catch-all convention in elixir/scala/etc.
- `raise "string message"` — implicit RuntimeError, no type token.
- bare `raise` re-raise — re-raises `$!`, carries no NEW type.
- `rescue_from … with: :handler` — the keyword-arg handler symbol is not a rescued type.

## Convergence invariant (value-asserting)
`TestErrorFlow_RaiseAndRescueConverge` asserts `find` THROWS and `get` CATCHES the SAME `ToID == ExceptionTypeTargetID("NotFoundError")`, and that exactly one `SCOPE.ExceptionType` node exists with the synthetic-file identity. Negatives + multi-class + scoped + method-level + rescue_from all asserted on the specific class, not `len>0`.

## Live .rb firing
`TestLiveFireRb` drives the FULL production path (`ParserFactory.Parse` → registered `ruby` extractor → `Extract`) on a real `app/models/*.rb` and confirms `throws=true catches=true convergeNode=true`.

## Coverage
- All 9 ruby `error_flow` cells flipped `missing → full` (surgical registry edit, canonical).
- capability-map mappings added under each framework's `Substrate` group (incl. a new `graphql-ruby` block); `validate` ruby/error_flow warnings cleared (8673 → 8664), 0 errors.

## Verification
- `go test` green: `internal/extractors/ruby` · `internal/custom/ruby` · `internal/engine` · `internal/extractors` · `internal/types` · `tools/coverage`.
- `covtool fmt --check` canonical · `validate` 0 errors · `gen` 0 drift · `gofmt` empty · `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)