### PR TITLE
feat(cpp): port error_flow THROWS/CATCHES model to C++

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,20 +11,20 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟡 9/11 | |
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 3/6 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 24/25 | 🟡 9/11 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟡 3/6 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 9/11 | |
@@ -191,7 +191,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟡 21/24 | 🟢 8/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟡 23/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟡 23/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟡 23/24 | 🟢 8/8 | |
@@ -246,8 +246,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 10/13 | 🟢 2/2 | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 10/13 | 🟢 2/2 | |
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 11/13 | 🟢 2/2 | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 11/13 | 🟢 2/2 | |
 | [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | 🟡 12/13 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | 🟡 12/13 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | 🟡 12/13 | 🟢 3/3 | |
@@ -262,8 +262,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 3/15 | |
-| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 7/24 | 🟡 7/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 8/25 | 🟡 3/15 | |
+| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 8/24 | 🟡 7/10 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 10/10 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | — | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 12/24 | 🟡 6/10 | |
 | [go](../by-language/go.md) | [gRPC-Go (google.golang.org/grpc)](../detail/lang.go.framework.grpc.md) | — | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -26,43 +26,43 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 3/8 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟡 21/24 | 🟢 8/8 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | 🟢 8/8 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 10/13 | 🟢 2/2 | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 10/13 | 🟢 2/2 | |
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 11/13 | 🟢 2/2 | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 11/13 | 🟢 2/2 | |
 
 
 ### RPC Framework
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 7/25 | 🟡 3/15 | |
-| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 7/24 | 🟡 7/10 | |
+| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 8/25 | 🟡 3/15 | |
+| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 8/24 | 🟡 7/10 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -111,7 +111,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047 |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | c-cpp def-use sniffer fires on .cc handler bodies (named def->use, e.g. SayHello name/greeting); #4047 |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -111,7 +111,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-06-03` | backfill:dictionary-completeness | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | c-cpp entry-point sniffer roots reachability/dead-code on the generated service-method library_export; #4047 |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | c-cpp def-use sniffer fires on .cc handler bodies (named def->use, e.g. SayHello name/greeting); #4047 |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -64,7 +64,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.ros.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ros.md
@@ -39,7 +39,7 @@ Auto-generated. Back to [summary](../summary.md).
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
@@ -39,7 +39,7 @@ Auto-generated. Back to [summary](../summary.md).
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | throw X(...) / ns::X{} / std::X(...) / new X() -> THROWS (qualified -> bare last segment); catch (const X&) / (X*) / (X) -> CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -23,7 +23,7 @@ one is a separate detail page.
 
 | Record | Language | Kind | Status |
 |--------|----------|------|--------|
-| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 8 full, 12 partial, 20 missing, 14 n/a |
+| [`lang.c-cpp.framework.grpc`](./lang.c-cpp.framework.grpc.md) | C/C++ | framework | 9 full, 12 partial, 19 missing, 14 n/a |
 | [`lang.csharp.framework.grpc-net`](./lang.csharp.framework.grpc-net.md) | C# | framework | 12 full, 26 partial, 1 missing, 15 n/a |
 | [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 3 full, 21 partial, 16 missing, 14 n/a |
 | [`lang.go.framework.grpc`](./lang.go.framework.grpc.md) | go | framework | 1 full, 3 partial, 37 missing, 13 n/a |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2811,8 +2811,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -3083,8 +3086,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -3355,8 +3361,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -3636,8 +3645,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -3920,8 +3932,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -4204,8 +4219,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -4511,8 +4529,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -4778,8 +4799,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -5050,8 +5074,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -5348,8 +5375,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -5705,8 +5735,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -5989,8 +6022,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -6273,8 +6309,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -6560,8 +6599,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -6766,8 +6808,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -7040,8 +7085,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -7324,8 +7372,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -7471,8 +7522,11 @@
             "cites": ["internal/substrate/c_cpp.go"]
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -7561,8 +7615,11 @@
             "cites": ["internal/substrate/c_cpp.go"]
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/cpp/exception_flow.go","internal/extractors/cpp/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "throw X(...) / ns::X{} / std::X(...) / new X() -\u003e THROWS (qualified -\u003e bare last segment); catch (const X\u0026) / (X*) / (X) -\u003e CATCHES; catch(...) + throw;/throw e re-throw dropped (#3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",

--- a/internal/extractors/cpp/exception_flow.go
+++ b/internal/extractors/cpp/exception_flow.go
@@ -1,0 +1,165 @@
+// exception_flow.go — supplemental pass that emits THROWS / CATCHES edges from
+// C / C++ functions and methods to a shared SCOPE.ExceptionType node (epic
+// #3628). It lets the graph answer "what can this function throw?" (outbound
+// THROWS) and "where is NotFoundException handled?" (inbound CATCHES), keeping
+// error-contract parity cross-language with the Java / Python / Go / JS / C# /
+// PHP flagships. Node/edge construction is delegated to
+// extractor.EmitExceptionEdges so the convergence invariant (identical type
+// names → ONE node) is identical everywhere.
+//
+// Detected shapes (typed only — honest-partial, precision-first):
+//
+//	throw NotFoundException("msg")           → THROWS NotFoundException  (throw-by-value, call_expression)
+//	throw MyNs::Boom{}                        → THROWS Boom               (qualified compound literal → bare)
+//	throw std::runtime_error("x")            → THROWS runtime_error      (std:: → bare last segment)
+//	throw new Foo()                           → THROWS Foo                (rare in C++, but valid; new_expression)
+//	} catch (const NotFoundException& e) { }  → CATCHES NotFoundException (const-ref qualified)
+//	} catch (std::runtime_error& e) { }       → CATCHES runtime_error     (std:: ref → bare)
+//	} catch (MyError* p) { }                   → CATCHES MyError           (pointer)
+//	} catch (ValueErr e) { }                   → CATCHES ValueErr          (by value)
+//
+// Reference (`const X&`), pointer (`X*`), and by-value (`X`) catches all yield
+// the bare type X because the catch parameter_declaration's `type` field always
+// names the unadorned type; `const` qualifiers and `&`/`*` declarators are
+// sibling nodes, not part of the type.
+//
+// Deliberately NOT recorded (would mislead error-contract analysis):
+//
+//	throw;            (bare re-throw — carries no NEW type)
+//	throw ex;         (re-throw of a variable — identifier, no NEW type)
+//	catch (...) { }   (catch-all — untyped, no parameter_declaration)
+//
+// std:: / namespace normalization: extractor.NormalizeExceptionType collapses
+// any `::`-qualified token to its last segment, so `std::runtime_error` →
+// `runtime_error` and `MyNs::Boom` → `Boom`. This matches the flagship
+// last-segment convention (a `std::exception` raised in one TU and caught in
+// another converge on ONE `exception:exception` node).
+//
+// FromName is the bare enclosing function/method Name, mirroring the C/C++
+// extractor's operation naming (extractFunction emits the unqualified leaf name,
+// e.g. `find`, `handle`), so THROWS / CATCHES edges attach to the same
+// SCOPE.Operation host the rest of the extractor emits. Throws/catches at file
+// scope (outside any function) fall back to the file entity via
+// extractor.EmitExceptionEdges.
+
+package cpp
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitExceptionFlowEdges scans every function/method body for `throw` and typed
+// `catch` shapes and appends exception-type entities + THROWS / CATCHES edges to
+// *entities.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var edges []extractor.ExceptionEdge
+
+	// enclosingFn is the bare Name of the innermost function/method
+	// (matching extractFunction's resolveFunctionName leaf), or "" at file
+	// scope. Lambdas inside a function keep the outer function's name so the
+	// edge stays attributed to the host operation.
+	var walk func(n *sitter.Node, enclosingFn string)
+	walk = func(n *sitter.Node, enclosingFn string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "function_definition":
+			if decl := n.ChildByFieldName("declarator"); decl != nil {
+				if name := resolveFunctionName(decl, src); name != "" {
+					enclosingFn = name
+				}
+			}
+		case "throw_statement":
+			if t := cppThrowType(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Pattern: "throw",
+				})
+			}
+		case "catch_clause":
+			if t := cppCatchType(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Catch: true, Pattern: "catch_type",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingFn)
+		}
+	}
+	walk(root, "")
+
+	extractor.EmitExceptionEdges(entities, "cpp", edges)
+}
+
+// cppThrowType returns the constructed exception type for a throw statement, or
+// "" for a bare re-throw (`throw;`) or a re-throw of a variable (`throw ex;`)
+// which carry no NEW type. The raw (possibly `::`-qualified) type text is
+// returned verbatim; extractor.NormalizeExceptionType collapses it to the bare
+// class name.
+//
+// Handled throw expression shapes:
+//
+//	call_expression               throw Foo(...)   / throw ns::Foo(...)   (throw-by-value, the C++ idiom)
+//	compound_literal_expression   throw Foo{}      / throw ns::Foo{}      (brace-init temporary)
+//	new_expression                throw new Foo()                          (rare; heap-allocated, valid)
+//
+// An `identifier` child (`throw ex;`) or no expression child (`throw;`) returns
+// "" — a re-throw introduces no new type.
+func cppThrowType(throwNode *sitter.Node, src []byte) string {
+	for i := 0; i < int(throwNode.NamedChildCount()); i++ {
+		c := throwNode.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "call_expression":
+			if fn := c.ChildByFieldName("function"); fn != nil {
+				return nodeText(fn, src)
+			}
+		case "compound_literal_expression", "new_expression":
+			if ty := c.ChildByFieldName("type"); ty != nil {
+				return nodeText(ty, src)
+			}
+		}
+		// First named child is the throw operand; if it isn't one of the
+		// constructed-exception shapes above (e.g. a bare identifier for
+		// `throw ex;`), there is no NEW type to record.
+		return ""
+	}
+	return "" // `throw;` — bare re-throw, no operand
+}
+
+// cppCatchType returns the caught type from a catch clause's parameter, or "" for
+// the untyped catch-all `catch (...) { }` (which has no parameter_declaration).
+//
+// The catch parameter is `(const X& e)` / `(X* p)` / `(X e)` etc.; the
+// parameter_declaration's `type` field always names the bare type X regardless
+// of const-qualification or reference/pointer declarators (those are sibling
+// nodes), so reference, pointer, and by-value catches all yield X.
+func cppCatchType(catchNode *sitter.Node, src []byte) string {
+	params := catchNode.ChildByFieldName("parameters")
+	if params == nil {
+		return ""
+	}
+	for i := 0; i < int(params.NamedChildCount()); i++ {
+		c := params.NamedChild(i)
+		if c == nil || c.Type() != "parameter_declaration" {
+			continue // `catch (...)` has a `...` child, not a declaration
+		}
+		if ty := c.ChildByFieldName("type"); ty != nil {
+			return nodeText(ty, src)
+		}
+	}
+	return ""
+}

--- a/internal/extractors/cpp/exception_flow_test.go
+++ b/internal/extractors/cpp/exception_flow_test.go
@@ -1,0 +1,221 @@
+package cpp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// cppExcEdge asserts a THROWS / CATCHES edge from fromName to the shared
+// exception-type node for typeName (matching the flagship edge shape: ToID ==
+// ExceptionTypeTargetID, Kind == THROWS/CATCHES).
+func cppExcEdge(recs []types.EntityRecord, fromName, kind, typeName string) bool {
+	want := extractor.ExceptionTypeTargetID(typeName)
+	for i := range recs {
+		if recs[i].Name != fromName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == kind && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cppExcNodeCount counts SCOPE.ExceptionType nodes named exception:<typeName>.
+func cppExcNodeCount(recs []types.EntityRecord, typeName string) int {
+	want := extractor.ExceptionTypeName(typeName)
+	c := 0
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) && recs[i].Name == want {
+			c++
+		}
+	}
+	return c
+}
+
+// cppExcNode returns the shared exception-type entity for typeName, or nil.
+func cppExcNode(recs []types.EntityRecord, typeName string) *types.EntityRecord {
+	want := extractor.ExceptionTypeName(typeName)
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) && recs[i].Name == want {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+// TestCppExceptionFlowConvergence is the flagship value-assertion: a type thrown
+// in one method and caught in another converges on ONE exception-type node, and
+// both edges target that node's ExceptionTypeTargetID.
+func TestCppExceptionFlowConvergence(t *testing.T) {
+	src := `
+class NotFoundException {};
+class UserService {
+  User find(int id) {
+    throw NotFoundException("missing");
+  }
+  void handle() {
+    try {
+      find(1);
+    } catch (const NotFoundException& e) {
+    }
+  }
+};
+`
+	recs, err := extractCPP(src, "svc.cpp")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	if !cppExcEdge(recs, "find", "THROWS", "NotFoundException") {
+		t.Errorf("expected find --THROWS--> NotFoundException")
+	}
+	if !cppExcEdge(recs, "handle", "CATCHES", "NotFoundException") {
+		t.Errorf("expected handle --CATCHES--> NotFoundException")
+	}
+	// Convergence: exactly ONE shared node for the type.
+	if n := cppExcNodeCount(recs, "NotFoundException"); n != 1 {
+		t.Errorf("expected exactly 1 NotFoundException exception node, got %d", n)
+	}
+	// The node's structural ToID is the THROWS/CATCHES edge target.
+	node := cppExcNode(recs, "NotFoundException")
+	if node == nil {
+		t.Fatal("missing NotFoundException exception node")
+	}
+	if node.QualifiedName != extractor.ExceptionTypeTargetID("NotFoundException") {
+		t.Errorf("node QualifiedName=%q, want %q",
+			node.QualifiedName, extractor.ExceptionTypeTargetID("NotFoundException"))
+	}
+}
+
+// TestCppThrowVariants asserts each throw-by-value / brace-init / qualified /
+// std:: / new shape yields the correct bare exception type.
+func TestCppThrowVariants(t *testing.T) {
+	src := `
+namespace MyNs { struct Boom {}; }
+void a() { throw NotFoundException("x"); }
+void b() { throw MyNs::Boom{}; }
+void c() { throw std::runtime_error("oops"); }
+void d() { throw BoomLit{}; }
+void e() { throw new HeapErr(); }
+`
+	recs, err := extractCPP(src, "t.cpp")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	cases := []struct{ fn, typ string }{
+		{"a", "NotFoundException"},
+		{"b", "Boom"},          // qualified MyNs::Boom -> bare last segment
+		{"c", "runtime_error"}, // std::runtime_error -> bare last segment
+		{"d", "BoomLit"},       // compound literal
+		{"e", "HeapErr"},       // new_expression
+	}
+	for _, tc := range cases {
+		if !cppExcEdge(recs, tc.fn, "THROWS", tc.typ) {
+			t.Errorf("fn %s: expected THROWS %s", tc.fn, tc.typ)
+		}
+	}
+}
+
+// TestCppCatchVariants asserts const-ref / pointer / by-value / qualified / std::
+// typed catches all yield the bare caught type.
+func TestCppCatchVariants(t *testing.T) {
+	src := `
+void h() {
+  try { work(); }
+  catch (const NotFoundException& e) {}
+  catch (std::runtime_error& e) {}
+  catch (MyError* p) {}
+  catch (ValueErr v) {}
+  catch (MyNs::Domain d) {}
+}
+`
+	recs, err := extractCPP(src, "h.cpp")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, typ := range []string{"NotFoundException", "runtime_error", "MyError", "ValueErr", "Domain"} {
+		if !cppExcEdge(recs, "h", "CATCHES", typ) {
+			t.Errorf("expected h CATCHES %s", typ)
+		}
+	}
+}
+
+// TestCppExceptionFlowNegatives asserts catch-all, re-throws, and a plain
+// function emit NO typed edges (precision-first, honest-partial).
+func TestCppExceptionFlowNegatives(t *testing.T) {
+	src := `
+void catchAll() {
+  try { work(); } catch (...) {}
+}
+void rethrowBare() {
+  try { work(); } catch (const Foo& e) { throw; }
+}
+void rethrowVar() {
+  try { work(); } catch (Foo e) { throw e; }
+}
+int plain(int x) { return x + 1; }
+`
+	recs, err := extractCPP(src, "neg.cpp")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	// catch (...) is untyped → no CATCHES edge and no fabricated node.
+	for i := range recs {
+		if recs[i].Name == "catchAll" {
+			for _, r := range recs[i].Relationships {
+				if r.Kind == "CATCHES" || r.Kind == "THROWS" {
+					t.Errorf("catchAll should emit no typed edges, got %s -> %s", r.Kind, r.ToID)
+				}
+			}
+		}
+	}
+
+	// `throw;` (bare) and `throw e;` (variable) introduce no new type, so the
+	// only THROWS edge anywhere must be absent — the caught Foo is the sole
+	// exception node here, from the CATCHES sides.
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "THROWS" {
+				t.Errorf("no THROWS edge expected (only re-throws present), got from %s -> %s",
+					recs[i].Name, r.ToID)
+			}
+		}
+	}
+
+	// Plain function with no throw/catch produces no exception edges.
+	for i := range recs {
+		if recs[i].Name == "plain" {
+			for _, r := range recs[i].Relationships {
+				if r.Kind == "CATCHES" || r.Kind == "THROWS" {
+					t.Errorf("plain function should have no exception edges, got %s", r.Kind)
+				}
+			}
+		}
+	}
+
+	// The catch-all-only function fabricates no exception node from `...`.
+	if cppExcNodeCount(recs, "...") != 0 {
+		t.Error("catch-all must not create an exception node")
+	}
+}
+
+// TestCExceptionFlowNoEdges asserts plain C (no exceptions) yields no
+// exception-flow artifacts — C has no try/catch/throw.
+func TestCExceptionFlowNoEdges(t *testing.T) {
+	src := `int add(int a, int b){ return a + b; }`
+	recs, err := extractC(src, "add.c")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindExceptionType) {
+			t.Errorf("C source must produce no exception-type nodes, got %s", recs[i].Name)
+		}
+	}
+}

--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -131,6 +131,11 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 	// may have been declared above or below the definition.
 	attachOutOfLineContains(&records, file.Path, lang)
 
+	// Issue #3628 — error-flow: scan throw / typed-catch sites and emit
+	// THROWS / CATCHES edges to a shared SCOPE.ExceptionType convergence node
+	// (records[0] is the file entity required by EmitExceptionEdges).
+	emitExceptionFlowEdges(root, file.Content, &records)
+
 	span.SetAttributes(
 		attribute.String("language", lang),
 		attribute.Int("file_line_count", lineCount),


### PR DESCRIPTION
Closes #4097 — part of epic #3628.

## What
Ports the flagship error-flow topology to the C/C++ extractor. `error_flow` was `full` in 10 languages but missing in C/C++ despite native `try`/`catch`/`throw`. New `internal/extractors/cpp/exception_flow.go` reuses the shared `internal/extractor/exception_flow.go` machinery (`SCOPE.ExceptionType` convergence node + `THROWS`/`CATCHES` edges) — **no new Kind**, identical convergence invariant as C#/Java/Python/Go/JS.

## Detected shapes (typed only — precision-first, honest-partial)
| C++ idiom | Edge | Result |
|---|---|---|
| `throw NotFoundException("x")` (call) | THROWS | `NotFoundException` |
| `throw MyNs::Boom{}` (compound literal) | THROWS | `Boom` (qualified → bare) |
| `throw std::runtime_error(...)` | THROWS | `runtime_error` (std:: → bare last segment) |
| `throw new Foo()` (new_expression) | THROWS | `Foo` |
| `catch (const NotFoundException& e)` | CATCHES | `NotFoundException` |
| `catch (std::runtime_error& e)` | CATCHES | `runtime_error` |
| `catch (MyError* p)` | CATCHES | `MyError` |
| `catch (ValueErr v)` | CATCHES | `ValueErr` |

## Deliberately NOT recorded
- `catch (...)` — untyped catch-all
- `throw;` — bare re-throw
- `throw e;` — re-throw of a variable (no NEW type)

The catch `parameter_declaration` `type` field yields the bare type uniformly across const/ref/ptr/by-value. `FromName` mirrors the extractors bare operation naming so edges attach to the same `SCOPE.Operation` host; file-scope throws/catches fall back to the file entity.

## std:: normalization
`::`-qualified tokens collapse to the last segment via the shared `NormalizeExceptionType` (flagship convention), so `std::runtime_error` → `runtime_error` and `MyNs::Boom` → `Boom`. A type raised in one TU and caught in another converge on ONE node.

## Tests
Value-asserting (not len>0): convergence (one node, edges target its `ExceptionTypeTargetID`), throw/catch variants, and negatives (catch-all, both re-throw forms, plain fn, plain C). Full required packages green: `extractors/cpp`, `custom/cpp`, `engine`, `extractors`, `types`, `tools/coverage`. gofmt + vet clean.

## Coverage
Flips the 19 `lang.c-cpp.framework.*` `Substrate/error_flow` cells `missing` → `full` (cited + verified). `covtool validate` 0 errors, `fmt --check` canonical, `gen` regenerated docs.

**DEPLOY-DEFERRED** — needs a coordinated daemon rebuild + reindex to surface live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)