### PR TITLE
feat(coverage): port endpoint_deprecation_versioning to C#/.NET

### DIFF
--- a/internal/engine/http_endpoint_deprecation.go
+++ b/internal/engine/http_endpoint_deprecation.go
@@ -68,10 +68,11 @@ const (
 // from the endpoint's own canonical `path` property. Honest-partial: a path
 // with no explicit version segment (or an out-of-range number) is left
 // untouched — no api_version property is added.
-func applyEndpointAPIVersion(entities []types.EntityRecord, path string, before int) {
+func applyEndpointAPIVersion(lang, content string, entities []types.EntityRecord, path string, before int) {
 	if before < 0 || before >= len(entities) {
 		return
 	}
+	normLang := normaliseDeprecationLang(lang)
 	for i := before; i < len(entities); i++ {
 		e := &entities[i]
 		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path {
@@ -86,6 +87,17 @@ func applyEndpointAPIVersion(entities []types.EntityRecord, path string, before 
 		}
 		if v, ok := apiVersionFromPath(routePath); ok {
 			e.Properties["api_version"] = strconv.Itoa(v)
+			continue
+		}
+		// Honest-partial fallback: when the route path carries no explicit
+		// version segment, a language-specific declarative version attribute can
+		// still pin the version. ASP.NET Core's [ApiVersion("2.0")] (Asp.Versioning)
+		// on the controller/action sets the version even though the conventional
+		// route is `api/[controller]` with no /vN segment (#3628 C# port).
+		if normLang == "csharp" && content != "" {
+			if v, ok := csharpAPIVersionFromAttribute(content, e); ok {
+				e.Properties["api_version"] = strconv.Itoa(v)
+			}
 		}
 	}
 }
@@ -202,6 +214,13 @@ func resolveEndpointDeprecation(lang, content string, e *types.EntityRecord) dep
 		}
 	case "python":
 		if v, ok := pythonDeprecationVerdict(region, content, handlerStart); ok {
+			return v
+		}
+	case "csharp":
+		// ASP.NET Core marks a deprecated action/controller with the standard
+		// [Obsolete("…")] attribute, the ApiExplorer [Deprecated] attribute, or
+		// an [ApiVersion(..., Deprecated = true)] flag (#3628 C# port).
+		if v, ok := csharpDeprecationVerdict(region); ok {
 			return v
 		}
 	default:

--- a/internal/engine/http_endpoint_deprecation_csharp.go
+++ b/internal/engine/http_endpoint_deprecation_csharp.go
@@ -1,0 +1,156 @@
+// C# / ASP.NET Core deprecation + API-version signals for the language-agnostic
+// endpoint enrichment passes in http_endpoint_deprecation.go (epic #3628).
+//
+// The flagship pass (http_endpoint_deprecation.go) already gives C# two things
+// for free, because they are language-agnostic:
+//
+//   - api_version from an explicit `/api/v2/...` route segment (applyEndpointAPIVersion).
+//   - deprecated=true from a `Sunset`/`Deprecation` response header written in
+//     the action body, and from a leading `// DEPRECATED` banner comment.
+//
+// What C# additionally needs — and what this file adds — are the .NET-idiomatic
+// markers the generic passes cannot see:
+//
+//   - Deprecation: the standard [Obsolete("…")] attribute, the ApiExplorer
+//     [Deprecated] attribute, and the [ApiVersion(..., Deprecated = true)] flag
+//     in the endpoint handler's attribute region. (All are handler-region
+//     scoped — a controller-wide [ApiVersion(Deprecated=true)] is honest-partial
+//     for deprecation so a class-wide flag can't leak across controllers in a
+//     multi-class file; the version it names is still pinned, see below.)
+//   - API version: the [ApiVersion("2.0")] attribute (Asp.Versioning /
+//     Microsoft.AspNetCore.Mvc.Versioning), which pins the version even when the
+//     conventional route (`api/[controller]`) carries no /vN segment.
+//
+// Property contract is IDENTICAL to the flagship (deprecated / deprecated_since /
+// deprecated_replacement / deprecation_source / api_version). HONEST-PARTIAL:
+// a non-obsolete action carries no `deprecated`; a versionless route with no
+// [ApiVersion] attribute carries no `api_version`; a since/replacement that the
+// [Obsolete] message does not name is left empty (never fabricated).
+//
+// Refs #3628.
+package engine
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// csObsoleteAttrRe matches an [Obsolete] attribute, with the optional message
+// argument captured. Covers `[Obsolete]`, `[Obsolete("use /api/v2")]`,
+// `[Obsolete("msg", true)]` and the fully-qualified `[System.Obsolete("…")]`.
+// The `\b` after Obsolete keeps `[ObsoleteSomething]` from matching.
+var csObsoleteAttrRe = regexp.MustCompile(`\[\s*(?:System\.)?Obsolete\b\s*(?:\(\s*(?:@?"([^"]{0,200})")?[^)]*\))?\s*\]`)
+
+// csDeprecatedAttrRe matches the ApiExplorer [Deprecated] attribute
+// (Microsoft.AspNetCore.OData / Mvc.ApiExplorer), optionally fully-qualified.
+// `\b` prevents `[DeprecatedHelper]` from matching.
+var csDeprecatedAttrRe = regexp.MustCompile(`\[\s*Deprecated\b\s*(?:\([^)]{0,200}\))?\s*\]`)
+
+// csApiVersionDeprecatedRe matches an [ApiVersion("1.0", Deprecated = true)]
+// flag — the Asp.Versioning way to mark a version as sunset.
+var csApiVersionDeprecatedRe = regexp.MustCompile(`(?i)\[\s*ApiVersion\b[^\]]*\bDeprecated\s*=\s*true[^\]]*\]`)
+
+// csharpDeprecationVerdict resolves a C#/.NET deprecation marker from the
+// attribute/comment region that decorates the endpoint's handler. Returns
+// (verdict, true) on the first marker found; (zero, false) when none apply.
+func csharpDeprecationVerdict(region string) (deprecationVerdict, bool) {
+	// [Obsolete("message")] — the canonical .NET deprecation marker. The
+	// message commonly names the replacement ("use /api/v2/users") and may
+	// carry a "since X" hint, both pulled by the shared message parser.
+	if m := csObsoleteAttrRe.FindStringSubmatch(region); m != nil {
+		v := deprecationVerdict{deprecated: true, source: "[Obsolete]"}
+		if m[1] != "" {
+			v.since, v.replacement = parseDeprecationMessage(m[1])
+		}
+		return v, true
+	}
+	// [ApiVersion(..., Deprecated = true)] — version-level sunset flag.
+	if csApiVersionDeprecatedRe.MatchString(region) {
+		return deprecationVerdict{deprecated: true, source: "[ApiVersion(Deprecated=true)]"}, true
+	}
+	// [Deprecated] — ApiExplorer deprecation attribute.
+	if csDeprecatedAttrRe.MatchString(region) {
+		return deprecationVerdict{deprecated: true, source: "[Deprecated]"}, true
+	}
+	return deprecationVerdict{}, false
+}
+
+// csApiVersionAttrRe captures the leading numeric component of an
+// [ApiVersion("2.0")] / [ApiVersion("2")] attribute (the major version). The
+// minor component ("2.0" → 2) is intentionally dropped to match the flagship
+// `api_version` shape, which is the bare major version with no leading 'v'.
+var csApiVersionAttrRe = regexp.MustCompile(`\[\s*ApiVersion\s*\(\s*@?"v?(\d+)(?:\.\d+)?"`)
+
+// csharpAPIVersionFromAttribute resolves an api_version for a C# endpoint whose
+// route path carries no explicit version segment, by reading an [ApiVersion]
+// attribute. It prefers an action-level attribute in the handler's decorator
+// region (anchored on the route declaration line) and falls back to a single
+// controller-level attribute for the whole file. Honest-partial: when no
+// [ApiVersion] attribute exists, or the file declares conflicting versions that
+// cannot be attributed to this endpoint, no version is returned.
+func csharpAPIVersionFromAttribute(content string, e *types.EntityRecord) (int, bool) {
+	// 1. Action-level [ApiVersion] in the handler decorator region.
+	anchor := e.StartLine
+	if anchor <= 0 {
+		anchor = routeDeclarationLine(content, e.Properties["path"], e.Properties["verb"])
+	}
+	if anchor > 0 {
+		region, _ := handlerDecoratorRegion(content, anchor)
+		if v, ok := csParseAPIVersion(region); ok {
+			return v, true
+		}
+	}
+	// 2. Controller-level: a single unambiguous [ApiVersion] in the file.
+	if v, ok := csSoleFileAPIVersion(content); ok {
+		return v, true
+	}
+	return 0, false
+}
+
+// csParseAPIVersion returns the major version named by the FIRST [ApiVersion]
+// attribute in s (in range), and whether one was found.
+func csParseAPIVersion(s string) (int, bool) {
+	m := csApiVersionAttrRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0, false
+	}
+	return csVersionInRange(m[1])
+}
+
+// csSoleFileAPIVersion returns the file's controller-level api_version only when
+// every [ApiVersion] attribute in the file names the SAME major version — a
+// file declaring both v1 and v2 is ambiguous per-endpoint, so it yields nothing
+// (the action-level region check above already had its chance).
+func csSoleFileAPIVersion(content string) (int, bool) {
+	ms := csApiVersionAttrRe.FindAllStringSubmatch(content, -1)
+	if len(ms) == 0 {
+		return 0, false
+	}
+	first, ok := csVersionInRange(ms[0][1])
+	if !ok {
+		return 0, false
+	}
+	for _, m := range ms[1:] {
+		v, ok := csVersionInRange(m[1])
+		if !ok || v != first {
+			return 0, false
+		}
+	}
+	return first, true
+}
+
+// csVersionInRange parses a major-version string and bounds-checks it against
+// the same [min,max] the path-derived version uses.
+func csVersionInRange(s string) (int, bool) {
+	v, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, false
+	}
+	if v < endpointAPIVersionMin || v > endpointAPIVersionMax {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/engine/http_endpoint_deprecation_csharp_test.go
+++ b/internal/engine/http_endpoint_deprecation_csharp_test.go
@@ -1,0 +1,344 @@
+package engine
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// C# / ASP.NET Core deprecation + api_version port (epic #3628).
+//
+// Mirrors the flagship property contract exactly: deprecated / deprecated_since
+// / deprecated_replacement / deprecation_source / api_version. Uses the shared
+// deprecProps/mustEndpoint harness from http_endpoint_deprecation_test.go.
+// ---------------------------------------------------------------------------
+
+// [Obsolete("use /api/v2/users")] on an attribute-routed action under
+// /api/v1/users → deprecated=true + replacement + source + api_version=1 (path).
+func TestDeprecation_CSharpObsoleteAttribute(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+public class UsersController : ControllerBase
+{
+    [Obsolete("use /api/v2/users")]
+    [HttpGet("/api/v1/users")]
+    public IActionResult GetUsers() { return Ok(); }
+
+    [HttpGet("/api/v1/health")]
+    public IActionResult Health() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/UsersController.cs", src)
+
+	dep := mustEndpoint(t, eps, "GET /api/v1/users")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("GET /api/v1/users deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "[Obsolete]" {
+		t.Errorf("deprecation_source=%q, want [Obsolete]", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/api/v2/users" {
+		t.Errorf("deprecated_replacement=%q, want /api/v2/users", got)
+	}
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1 (path-derived)", got)
+	}
+
+	// Negative: the non-obsolete sibling action carries no deprecation.
+	live := mustEndpoint(t, eps, "GET /api/v1/health")
+	if _, ok := live.Properties["deprecated"]; ok {
+		t.Fatalf("GET /api/v1/health deprecated fabricated, want absent (props: %v)", live.Properties)
+	}
+}
+
+// [Obsolete("Deprecated since 2.0, use /reports/v2 instead")] resolves both the
+// since-version and the replacement out of the message via the shared parser.
+func TestDeprecation_CSharpObsoleteSinceAndReplacement(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public class ReportsController : ControllerBase
+{
+    [Obsolete("since 2.0 use /reports/v2 instead")]
+    [HttpGet("/reports")]
+    public IActionResult GetReports() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/ReportsController.cs", src)
+	dep := mustEndpoint(t, eps, "GET /reports")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("GET /reports deprecated=%q, want true", dep.Properties["deprecated"])
+	}
+	if got := dep.Properties["deprecated_since"]; got != "2.0" {
+		t.Errorf("deprecated_since=%q, want 2.0", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/reports/v2" {
+		t.Errorf("deprecated_replacement=%q, want /reports/v2", got)
+	}
+}
+
+// ApiExplorer [Deprecated] attribute marks the action deprecated.
+func TestDeprecation_CSharpDeprecatedAttribute(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public class LegacyController : ControllerBase
+{
+    [Deprecated]
+    [HttpGet("/legacy")]
+    public IActionResult GetLegacy() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/LegacyController.cs", src)
+	dep := mustEndpoint(t, eps, "GET /legacy")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("GET /legacy deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "[Deprecated]" {
+		t.Errorf("deprecation_source=%q, want [Deprecated]", got)
+	}
+}
+
+// An action-level [ApiVersion("1.0", Deprecated = true)] sunset flag in the
+// handler's attribute region marks that action deprecated AND pins its version.
+func TestDeprecation_CSharpApiVersionDeprecatedFlag(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+
+[ApiController]
+[Route("api/[controller]")]
+public class BillingController : ControllerBase
+{
+    [ApiVersion("1.0", Deprecated = true)]
+    [HttpGet("/billing")]
+    public IActionResult GetBilling() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/BillingController.cs", src)
+	dep := mustEndpoint(t, eps, "GET /billing")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("GET /billing deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "[ApiVersion(Deprecated=true)]" {
+		t.Errorf("deprecation_source=%q, want [ApiVersion(Deprecated=true)]", got)
+	}
+	// The version itself is pinned from the same attribute (no /vN in route).
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1 (from [ApiVersion])", got)
+	}
+}
+
+// Honest-partial: a CONTROLLER-level [ApiVersion(Deprecated = true)] is not
+// attributed to the action's deprecation state (the handler-region model keeps
+// a class-wide flag from leaking across controllers in a multi-class file), but
+// the version is still pinned via the sole-file [ApiVersion] fallback.
+func TestDeprecation_CSharpControllerApiVersionDeprecatedIsPartial(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+
+[ApiController]
+[ApiVersion("1.0", Deprecated = true)]
+[Route("api/[controller]")]
+public class BillingController : ControllerBase
+{
+    [HttpGet("/billing")]
+    public IActionResult GetBilling() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/BillingController.cs", src)
+	dep := mustEndpoint(t, eps, "GET /billing")
+	if _, ok := dep.Properties["deprecated"]; ok {
+		t.Fatalf("controller-level [ApiVersion(Deprecated)] leaked deprecation (props: %v)", dep.Properties)
+	}
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1 (sole-file [ApiVersion])", got)
+	}
+}
+
+// A Sunset response header written in the action body is a runtime deprecation
+// signal (cross-language flagship path), proven to fire for C#.
+func TestDeprecation_CSharpSunsetResponseHeader(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public class PaymentsController : ControllerBase
+{
+    [HttpGet("/payments")]
+    public IActionResult GetPayments() {
+        Response.Headers.Append("Sunset", "Sat, 31 Dec 2025 23:59:59 GMT");
+        return Ok();
+    }
+}
+`
+	eps := deprecProps(t, "csharp", "src/PaymentsController.cs", src)
+	dep := mustEndpoint(t, eps, "GET /payments")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("GET /payments deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "Sunset response header" {
+		t.Errorf("deprecation_source=%q, want 'Sunset response header'", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// api_version — [ApiVersion] attribute fallback (no /vN route segment)
+// ---------------------------------------------------------------------------
+
+// [ApiVersion("2.0")] on the controller pins api_version=2 (major only) on a
+// conventional `api/[controller]` route that carries no version segment.
+func TestAPIVersion_CSharpApiVersionAttribute(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+
+[ApiController]
+[ApiVersion("2.0")]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    [HttpGet("/orders")]
+    public IActionResult GetOrders() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/OrdersController.cs", src)
+	e := mustEndpoint(t, eps, "GET /orders")
+	if got := e.Properties["api_version"]; got != "2" {
+		t.Fatalf("api_version=%q, want 2 (from [ApiVersion(\"2.0\")])", got)
+	}
+}
+
+// Negative: a versionless route with NO [ApiVersion] attribute carries no
+// api_version (honest-partial — never fabricated).
+func TestAPIVersion_CSharpNoVersionNoAttribute(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public class StatusController : ControllerBase
+{
+    [HttpGet("/status")]
+    public IActionResult GetStatus() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/StatusController.cs", src)
+	e := mustEndpoint(t, eps, "GET /status")
+	if got, ok := e.Properties["api_version"]; ok {
+		t.Fatalf("api_version=%q fabricated on versionless route, want absent", got)
+	}
+}
+
+// The path-derived version wins over (and never conflicts with) the attribute
+// path: an explicit /api/v3 segment yields api_version=3 even if an [ApiVersion]
+// attribute names something else — path is the authoritative routable version.
+func TestAPIVersion_CSharpPathWinsOverAttribute(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+
+[ApiController]
+[ApiVersion("2.0")]
+public class CatalogController : ControllerBase
+{
+    [HttpGet("/api/v3/catalog")]
+    public IActionResult GetCatalog() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/CatalogController.cs", src)
+	e := mustEndpoint(t, eps, "GET /api/v3/catalog")
+	if got := e.Properties["api_version"]; got != "3" {
+		t.Fatalf("api_version=%q, want 3 (path-derived wins)", got)
+	}
+}
+
+// Negative: a non-route [Obsolete] helper method must not leak deprecation onto
+// an unrelated sibling endpoint.
+func TestDeprecation_CSharpNonRouteObsoleteDoesNotLeak(t *testing.T) {
+	src := `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+public class AccountsController : ControllerBase
+{
+    [Obsolete("internal helper")]
+    private string LegacyHelper() { return "x"; }
+
+    [HttpGet("/api/v1/accounts")]
+    public IActionResult GetAccounts() { return Ok(); }
+}
+`
+	eps := deprecProps(t, "csharp", "src/AccountsController.cs", src)
+	e := mustEndpoint(t, eps, "GET /api/v1/accounts")
+	if _, ok := e.Properties["deprecated"]; ok {
+		t.Fatalf("non-route [Obsolete] leaked onto GET /api/v1/accounts (props: %v)", e.Properties)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unit-level: attribute parsers
+// ---------------------------------------------------------------------------
+
+func TestCsharpDeprecationVerdict(t *testing.T) {
+	cases := []struct {
+		name       string
+		region     string
+		wantDep    bool
+		wantSource string
+		wantRepl   string
+	}{
+		{"obsolete bare", `[Obsolete]`, true, "[Obsolete]", ""},
+		{"obsolete msg", `[Obsolete("use /api/v2/x")]`, true, "[Obsolete]", "/api/v2/x"},
+		{"obsolete two-arg", `[Obsolete("gone", true)]`, true, "[Obsolete]", ""},
+		{"fq obsolete", `[System.Obsolete("use /v2")]`, true, "[Obsolete]", "/v2"},
+		{"deprecated attr", `[Deprecated]`, true, "[Deprecated]", ""},
+		{"apiversion deprecated", `[ApiVersion("1.0", Deprecated = true)]`, true, "[ApiVersion(Deprecated=true)]", ""},
+		{"none", `[HttpGet("/x")]`, false, "", ""},
+		{"obsoletesomething no match", `[ObsoleteHelper]`, false, "", ""},
+	}
+	for _, c := range cases {
+		v, ok := csharpDeprecationVerdict(c.region)
+		if ok != c.wantDep {
+			t.Errorf("%s: ok=%v, want %v", c.name, ok, c.wantDep)
+			continue
+		}
+		if !c.wantDep {
+			continue
+		}
+		if v.source != c.wantSource {
+			t.Errorf("%s: source=%q, want %q", c.name, v.source, c.wantSource)
+		}
+		if v.replacement != c.wantRepl {
+			t.Errorf("%s: replacement=%q, want %q", c.name, v.replacement, c.wantRepl)
+		}
+	}
+}
+
+func TestCsParseAPIVersion(t *testing.T) {
+	cases := []struct {
+		s    string
+		want int
+		ok   bool
+	}{
+		{`[ApiVersion("2.0")]`, 2, true},
+		{`[ApiVersion("1")]`, 1, true},
+		{`[ApiVersion( "3.1" )]`, 3, true},
+		{`[ApiVersion("v2")]`, 2, true},
+		{`[ApiVersion("100.0")]`, 0, false}, // out of range
+		{`[Route("api/x")]`, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := csParseAPIVersion(c.s)
+		if ok != c.ok || got != c.want {
+			t.Errorf("csParseAPIVersion(%q)=(%d,%v), want (%d,%v)", c.s, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// A file declaring two DIFFERENT [ApiVersion] majors is ambiguous at the
+// controller level → csSoleFileAPIVersion returns nothing.
+func TestCsSoleFileAPIVersion_AmbiguousIsPartial(t *testing.T) {
+	content := `[ApiVersion("1.0")] class A {} [ApiVersion("2.0")] class B {}`
+	if v, ok := csSoleFileAPIVersion(content); ok {
+		t.Fatalf("ambiguous file yielded api_version=%d, want none", v)
+	}
+	// Two identical declarations are unambiguous.
+	content2 := `[ApiVersion("2.0")] class A {} [ApiVersion("2.0")] class B {}`
+	if v, ok := csSoleFileAPIVersion(content2); !ok || v != 2 {
+		t.Fatalf("identical-version file yielded (%d,%v), want (2,true)", v, ok)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1084,7 +1084,7 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	//     endpoint's handler in the source file (JS/TS JSDoc @deprecated, Spring
 	//     @Deprecated, DRF deprecated=True, Python @deprecated / docstring, a
 	//     Sunset/Deprecation response header, or a `// DEPRECATED` comment).
-	applyEndpointAPIVersion(entities, path, deprecationBefore)
+	applyEndpointAPIVersion(lang, string(content), entities, path, deprecationBefore)
 	applyEndpointDeprecation(lang, string(content), path, entities, deprecationBefore)
 
 	// #3628 (epic) — endpoint pagination-posture stamping. Mutates Properties on

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -11622,6 +11622,35 @@ records:
             - file: internal/custom/csharp/extractors_test.go
           issues_implemented: ["3261"]
           verified_at: "2026-05-30"
+        endpoint_deprecation_versioning:
+          # #3628 (epic) — stamps api_version + deprecated / deprecated_since /
+          # deprecated_replacement / deprecation_source onto the
+          # http_endpoint_definition op (synthesizeASPNetCore producer). C#/.NET
+          # signals: [Obsolete("…")] (message yields replacement / since), the
+          # ApiExplorer [Deprecated] attribute, an action-region
+          # [ApiVersion(..., Deprecated = true)] flag, plus the cross-language
+          # Sunset/Deprecation response-header write. api_version is path-derived
+          # (/api/vN) with an [ApiVersion("2.0")] attribute fallback (major only).
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_deprecation_csharp.go
+              functions:
+                - csharpDeprecationVerdict
+                - csharpAPIVersionFromAttribute
+                - csParseAPIVersion
+                - csSoleFileAPIVersion
+            - file: internal/engine/http_endpoint_deprecation.go
+              functions:
+                - applyEndpointAPIVersion
+                - applyEndpointDeprecation
+          tests:
+            - file: internal/engine/http_endpoint_deprecation_csharp_test.go
+              functions:
+                - TestDeprecation_CSharpObsoleteAttribute
+                - TestAPIVersion_CSharpApiVersionAttribute
+                - TestDeprecation_CSharpApiVersionDeprecatedFlag
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
       Auth:
         auth_coverage:
           # [Authorize] (plain/roles/policy/positional/scheme), [AllowAnonymous],


### PR DESCRIPTION
Closes #4102. Refs #3628 (extraction-quality audit roadmap). DEPLOY-DEFERRED.

## What
Fan-out fix: `endpoint_deprecation_versioning` was **full** in java/jsts/python/go but **missing** for C#/.NET. ASP.NET Core endpoints (synthesized by `synthesizeASPNetCore`) now carry the SAME flat property contract the flagship stamps:
`deprecated` / `deprecated_since` / `deprecated_replacement` / `deprecation_source` / `api_version`.

## Verify-first (current state, probed before building)
- `api_version` from an explicit `/api/vN/...` segment ALREADY worked (path-derived, language-agnostic).
- A `Sunset`/`Deprecation` response header in the action body ALREADY marked `deprecated=true` (cross-language signal) — kept.
- `[Obsolete]` / `[Deprecated]` / `[ApiVersion(Deprecated=true)]` were NOT recognized → no `deprecated`.
- `[ApiVersion("2.0")]` on a conventional `api/[controller]` route did NOT pin `api_version`.

## New C#/.NET signals
`internal/engine/http_endpoint_deprecation_csharp.go`:
- `[Obsolete("use /api/v2/x")]` → `deprecated=true`, `deprecation_source=[Obsolete]`; replacement/since parsed from the message via the shared `parseDeprecationMessage`.
- ApiExplorer `[Deprecated]` → `deprecation_source=[Deprecated]`.
- action-region `[ApiVersion(..., Deprecated = true)]` → `deprecation_source=[ApiVersion(Deprecated=true)]`.
- `[ApiVersion("2.0")]` attribute fallback → `api_version=2` (major only) when the route has no `/vN`; path-derived version still wins when present.

Wired into the language-agnostic passes: `resolveEndpointDeprecation` gains a `case "csharp"`; `applyEndpointAPIVersion` now takes `lang`+`content` so the `[ApiVersion]` fallback can fire.

## Honest-partial (0 tech debt)
- Never fabricates `deprecated=false`.
- A controller-wide `[ApiVersion(Deprecated)]` is partial for deprecation (avoids leakage across controllers in a multi-class file) while still pinning the version.
- A file declaring conflicting `[ApiVersion]` majors pins no version.

## Verification
- Full package tests green: `internal/custom/csharp/ internal/engine/ internal/extractors/ tools/coverage/`.
- New value-asserting tests (positive idioms + negatives): `TestDeprecation_CSharpObsoleteAttribute`, `TestDeprecation_CSharpObsoleteSinceAndReplacement`, `TestDeprecation_CSharpDeprecatedAttribute`, `TestDeprecation_CSharpApiVersionDeprecatedFlag`, `TestDeprecation_CSharpControllerApiVersionDeprecatedIsPartial`, `TestDeprecation_CSharpSunsetResponseHeader`, `TestAPIVersion_CSharpApiVersionAttribute`, `TestAPIVersion_CSharpNoVersionNoAttribute`, `TestAPIVersion_CSharpPathWinsOverAttribute`, `TestDeprecation_CSharpNonRouteObsoleteDoesNotLeak`, plus unit tables.
- `covtool validate` 0 errors; `covtool fmt --check` canonical; `covtool gen` 0 drift; gofmt empty; vet clean.
- **No extractor touched** (engine-only enrichment) — no dispatch-parity change.

## Coverage
`lang.csharp.framework.aspnet-core` Routing → `endpoint_deprecation_versioning: full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)