### PR TITLE
feat(scala): rate_limit_stamping for http4s Throttle + akka/pekko throttle (#4105)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -173,8 +173,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 6/9 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/19 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
-| [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 7/19 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/9 | |
+| [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 8/19 | |
 | [scala](../by-language/scala.md) | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 5/19 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
 | [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/6 | |
@@ -182,7 +182,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 9/12 | |
 | [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
 | [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 9/12 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/9 | |
 | [scala](../by-language/scala.md) | [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 4/19 | |
 | [scala](../by-language/scala.md) | [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 6/19 | |
 

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -26,8 +26,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
-| [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 7/19 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/9 | |
+| [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 8/19 | |
 | [Caliban](../detail/lang.scala.framework.caliban.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 5/19 | |
 | [Cask](../detail/lang.scala.framework.cask.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
 | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟡 1/4 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/6 | |
@@ -35,7 +35,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 9/12 | |
 | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
 | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 9/12 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/9 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/9 | |
 | [sttp (HTTP client)](../detail/lang.scala.framework.sttp.md) | 🟡 2/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 4/19 | |
 | [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | ✅ 1/1 | 🟡 16/24 | 🟡 6/19 | |
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks deep extractor: akka-http handleRejections/handleExceptions with named handler, cors(), and transform directives (mapRequest/mapResponse/encodeResponse/decodeRequest/logRequestResult/...) stamped by middleware_name. Value-asserting tests. File-local. |
-| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/scala/rate_limit.go` | #4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on akka/pekko-http Streams `.throttle(elements, per, ...)` stages (positional AND named-arg forms). amount + FiniteDuration window resolved to a human rate (100/1s) when literal; scope=route (the throttle guards a streamed response inside a route — a precise verb+path join is heuristic, so no route fabricated); source=akka_throttle. Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives (plain route, non-throttle middleware). File-local marker (SCOPE.Pattern/rate_limit). |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks deep extractor: http4s named middleware CORS/GZip/Logger/Timeout/AutoSlash/CSRF/HSTS + composition order mw1(mw2(routes)) recorded as outer>inner(target). Value-asserting tests. File-local. |
-| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/scala/rate_limit.go` | #4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on the http4s Throttle middleware — Throttle(amount, per)(app), Throttle.httpApp[F](amount, per)(app), Throttle.httpRoutes(amount, per)(routes) from org.http4s.server.middleware. amount (Int) + per (FiniteDuration literal: 1.minute/10.seconds/100.millis) resolved to a human rate (100/60s; sub-second windows rendered as 200/100ms) when literal; scope=app (Throttle wraps the whole HttpApp/HttpRoutes — app-wide, not a named route, so none fabricated); source=http4s_throttle. Gated on an http4s file signal. Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives (plain route, CORS/GZip non-throttle middleware, non-http4s Throttle). File-local marker (SCOPE.Pattern/rate_limit). |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.scala.framework.pekko-http.md
+++ b/docs/coverage/detail/lang.scala.framework.pekko-http.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks deep extractor: pekko-http shares the akka-http middleware branch — handleRejections/handleExceptions(+named handler), cors(), transform directives (mapRequest/mapResponse/encodeResponse/...). pekko-http-cors recognised. File-local. |
-| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/scala/rate_limit.go` | #4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on pekko-http Streams `.throttle(elements, per, ...)` stages (positional AND named-arg). amount + FiniteDuration window resolved to a human rate (5/120s) when literal; scope=route (throttle guards a streamed response inside a route — precise verb+path join is heuristic, so none fabricated); source=pekko_throttle (org.apache.pekko.* disambiguates from akka). Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives. File-local marker (SCOPE.Pattern/rate_limit). |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -71106,8 +71106,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/rate_limit.go"],
+            "notes": "#4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on akka/pekko-http Streams `.throttle(elements, per, ...)` stages (positional AND named-arg forms). amount + FiniteDuration window resolved to a human rate (100/1s) when literal; scope=route (the throttle guards a streamed response inside a route — a precise verb+path join is heuristic, so no route fabricated); source=akka_throttle. Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives (plain route, non-throttle middleware). File-local marker (SCOPE.Pattern/rate_limit).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {
@@ -72716,8 +72718,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/rate_limit.go"],
+            "notes": "#4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on the http4s Throttle middleware — Throttle(amount, per)(app), Throttle.httpApp[F](amount, per)(app), Throttle.httpRoutes(amount, per)(routes) from org.http4s.server.middleware. amount (Int) + per (FiniteDuration literal: 1.minute/10.seconds/100.millis) resolved to a human rate (100/60s; sub-second windows rendered as 200/100ms) when literal; scope=app (Throttle wraps the whole HttpApp/HttpRoutes — app-wide, not a named route, so none fabricated); source=http4s_throttle. Gated on an http4s file signal. Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives (plain route, CORS/GZip non-throttle middleware, non-http4s Throttle). File-local marker (SCOPE.Pattern/rate_limit).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {
@@ -73371,8 +73375,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/rate_limit.go"],
+            "notes": "#4105 greenfield: custom_scala_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) on pekko-http Streams `.throttle(elements, per, ...)` stages (positional AND named-arg). amount + FiniteDuration window resolved to a human rate (5/120s) when literal; scope=route (throttle guards a streamed response inside a route — precise verb+path join is heuristic, so none fabricated); source=pekko_throttle (org.apache.pekko.* disambiguates from akka). Honest-partial (rate omitted) when amount/per is config/expression-driven. Value-asserting tests pin the exact amount/per; negatives. File-local marker (SCOPE.Pattern/rate_limit).",
+            "verified_at": "2026-06-03"
           }
         },
         "Testing": {

--- a/internal/custom/scala/rate_limit.go
+++ b/internal/custom/scala/rate_limit.go
@@ -1,0 +1,387 @@
+// rate_limit.go — endpoint rate-limit / throttle stamping for Scala web
+// frameworks (#4105, child of #3628 Middleware/rate_limit_stamping). Scala
+// greenfield: prior to this pass every scala framework cell for
+// rate_limit_stamping was `missing` — an http4s `Throttle(...)`-guarded app or
+// an akka/pekko `.throttle(...)`-guarded route carried no rate-limit signal.
+//
+// Scala greenfield sibling of the Kotlin pass
+// (internal/custom/kotlin/rate_limit_endpoint.go, #4095), the Ruby pass
+// (internal/custom/ruby/rate_limit_endpoint.go, #4074) and the Elixir pass
+// (internal/custom/elixir/rate_limit.go, #4099). It stamps the SAME flat
+// property contract the other languages use so the graph answers "which
+// surfaces are throttled and at what rate?":
+//
+//	rate_limited      — "true" when a throttle applies.
+//	rate_limit        — human rate "100/60s" when statically resolvable from a
+//	                    literal amount + a literal FiniteDuration window;
+//	                    OMITTED (honest-partial) when amount/per is
+//	                    config-/expression-driven.
+//	rate_limit_scope  — "app"   (http4s Throttle wraps a whole HttpApp/HttpRoutes,
+//	                    not a named route — the binding is app-wide, so claiming a
+//	                    route would be dishonest)
+//	                    | "route" (akka/pekko `.throttle(...)` is applied inside a
+//	                    route/flow guarding the response stream for that route).
+//	rate_limit_source — the recognised idiom (`http4s_throttle`, `akka_throttle`,
+//	                    `pekko_throttle`).
+//	limit / period    — the resolved numeric cap + window-seconds (when literal).
+//
+// Two recognised Scala surfaces:
+//
+//	http4s Throttle middleware —
+//	    `Throttle(amount, per)(httpApp)`              (http4s ≤0.21 apply)
+//	    `Throttle.httpApp(amount, per)(app)`          (http4s 0.23+ httpApp)
+//	    `Throttle.httpRoutes(amount, per)(routes)`    (http4s 0.23+ httpRoutes)
+//	  from `org.http4s.server.middleware.Throttle`. The FIRST arg is the request
+//	  cap (Int), the SECOND a `scala.concurrent.duration.FiniteDuration`
+//	  (`1.minute`, `100.millis`, `10.seconds`). We resolve amount + per/window
+//	  when both are literal and stamp one marker entity per Throttle call. The
+//	  middleware wraps the entire app/routes value, so scope=app (no per-route
+//	  binding to fabricate). A `Throttle.apply` overload that takes a custom
+//	  `TokenBucket` instead of `(amount, per)` is honest-partial (rate omitted).
+//
+//	akka-http / pekko-http `.throttle(...)` directive —
+//	    `complete(source.throttle(100, 1.second))`               (positional)
+//	    `.throttle(elements = 100, per = 1.second, ...)`         (named)
+//	  the Akka/Pekko Streams throttle stage (also used inside akka-http route
+//	  responses to rate-limit a streamed entity). The FIRST arg is `elements`
+//	  (Int cap per window), a later FiniteDuration arg is the `per` window. We
+//	  stamp the throttle posture on a marker entity (the throttle binds to a
+//	  stream/response inside a route — a precise route join is heuristic, so we
+//	  record scope=route without fabricating a specific verb+path). Resolved
+//	  amount/per when literal. akka vs pekko is disambiguated by the file's
+//	  framework (org.apache.pekko.* → pekko_throttle).
+//
+// Like the sibling passes these surfaces add NO new node KIND beyond a marker
+// (`SCOPE.Pattern/rate_limit`) — there is no single per-route endpoint to attach
+// an app-wide http4s Throttle to, and the akka throttle binds to a stream rather
+// than a named route. MergeWithCustom dedups by Name; the marker carries the
+// full throttle posture as evidence.
+//
+// Honest-partial cases (rate_limited stamped, numeric rate OMITTED):
+//   - the amount or the duration arg is not a literal (a config val / expr);
+//   - the duration unit is unrecognised;
+//   - a Throttle overload taking a custom TokenBucket (no (amount, per) pair).
+//
+// Refs #4105.
+package scala
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_rate_limit", &scalaRateLimitExtractor{})
+}
+
+type scalaRateLimitExtractor struct{}
+
+func (e *scalaRateLimitExtractor) Language() string { return "custom_scala_rate_limit" }
+
+var (
+	// reHttp4sThrottle matches the http4s Throttle middleware in its three
+	// recognised call shapes, capturing the (amount, per) head:
+	//   Throttle(100, 1.minute)(httpApp)
+	//   Throttle.httpApp(100, 1.minute)(app)
+	//   Throttle.httpRoutes(100, 1.minute)(routes)
+	// Group 1 = optional `.httpApp` / `.httpRoutes` selector (or empty for the
+	// bare apply); group 2 = amount expression; group 3 = per (FiniteDuration)
+	// expression. An optional `[F]`/`[IO]` type-argument list (http4s 0.23+
+	// `Throttle.httpApp[F]`) is allowed between the selector and the value-arg
+	// paren. The args are matched non-greedily up to the first comma /
+	// close-paren so a trailing `, throttleResponse` arg does not bleed in.
+	reHttp4sThrottle = regexp.MustCompile(
+		`\bThrottle(\.httpApp|\.httpRoutes|\.apply)?\s*(?:\[[^\]]*\]\s*)?\(\s*([^,()]+?)\s*,\s*([^,()]+?)\s*[,)]`)
+
+	// reAkkaThrottlePositional matches a positional Streams/akka-http throttle:
+	//   .throttle(100, 1.second)
+	//   .throttle(100, 1.second, 10, ThrottleMode.Shaping)
+	// Group 1 = elements (cap), group 2 = per (FiniteDuration). Extra args
+	// (maximumBurst, mode) after the per arg are ignored.
+	reAkkaThrottlePositional = regexp.MustCompile(
+		`\.throttle\s*\(\s*([0-9][\w.]*?)\s*,\s*([0-9][\w.]*(?:second|minute|hour|day|milli|nano)s?)\b`)
+
+	// reAkkaThrottleNamed matches a named-arg throttle:
+	//   .throttle(elements = 100, per = 1.second, ...)
+	// Group 1 = elements expr, group 2 = per expr.
+	reAkkaThrottleNamed = regexp.MustCompile(
+		`\.throttle\s*\(\s*elements\s*=\s*([^,()]+?)\s*,\s*per\s*=\s*([^,()]+?)\s*[,)]`)
+
+	// reScalaIntLit matches a clean integer literal (allowing the Scala `_` digit
+	// separator, e.g. 1_000).
+	reScalaIntLit = regexp.MustCompile(`^[0-9][0-9_]*$`)
+
+	// reScalaDurationLit matches a scala.concurrent.duration literal in the
+	// extension form `N.unit` (1.minute / 100.millis / 10.seconds / 2.hours).
+	// Group 1 = count, group 2 = unit stem.
+	reScalaDurationLit = regexp.MustCompile(
+		`^([0-9][0-9_]*)\.(nanos?|nanoseconds?|micros?|microseconds?|millis?|milliseconds?|seconds?|minutes?|hours?|days?)$`)
+)
+
+// parseScalaInt parses a Scala integer literal allowing `_` digit grouping.
+// Returns (n, true) only for a clean integer literal.
+func parseScalaInt(lit string) (int, bool) {
+	lit = strings.TrimSpace(lit)
+	if !reScalaIntLit.MatchString(lit) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.ReplaceAll(lit, "_", ""))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// scalaDurationSeconds resolves a scala.concurrent.duration FiniteDuration
+// literal in the `N.unit` extension form to whole seconds, returning
+// (seconds, true) only when statically literal AND the window divides into a
+// whole number of seconds. Sub-second windows (millis/micros/nanos) are honest
+// about not being whole seconds: they return (0, false) so the caller renders a
+// sub-second human rate (see scalaHumanRate) instead of rounding to 0s. The
+// bare-second/minute/hour/day units resolve directly.
+func scalaDurationSeconds(lit string) (int, bool) {
+	lit = strings.TrimSpace(lit)
+	m := reScalaDurationLit.FindStringSubmatch(lit)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.ReplaceAll(m[1], "_", ""))
+	if err != nil {
+		return 0, false
+	}
+	switch {
+	case strings.HasPrefix(m[2], "second"):
+		return n, true
+	case strings.HasPrefix(m[2], "minute"):
+		return n * 60, true
+	case strings.HasPrefix(m[2], "hour"):
+		return n * 3600, true
+	case strings.HasPrefix(m[2], "day"):
+		return n * 86400, true
+	}
+	// Sub-second unit: not a whole-second window.
+	return 0, false
+}
+
+// scalaDurationMillis resolves a FiniteDuration literal to whole milliseconds
+// (for sub-second windows), returning (ms, true) only when literal. Used to
+// render an honest "<n>/<ms>ms" rate when the window is sub-second.
+func scalaDurationMillis(lit string) (int, bool) {
+	lit = strings.TrimSpace(lit)
+	m := reScalaDurationLit.FindStringSubmatch(lit)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.ReplaceAll(m[1], "_", ""))
+	if err != nil {
+		return 0, false
+	}
+	switch {
+	case strings.HasPrefix(m[2], "milli"):
+		return n, true
+	case strings.HasPrefix(m[2], "second"):
+		return n * 1000, true
+	case strings.HasPrefix(m[2], "minute"):
+		return n * 60000, true
+	case strings.HasPrefix(m[2], "hour"):
+		return n * 3600000, true
+	case strings.HasPrefix(m[2], "day"):
+		return n * 86400000, true
+	}
+	// nanos/micros: below ms resolution — honest-partial.
+	return 0, false
+}
+
+// scalaHumanRate builds the shared "<count>/<window>s" human rate from a literal
+// amount and a literal FiniteDuration window, or "" (honest-partial) when either
+// is not statically resolvable. A sub-second window is rendered in milliseconds
+// ("<count>/<ms>ms") to stay honest rather than rounding the window to 0s.
+func scalaHumanRate(amountLit, perLit string) (rate string, limit int, periodSecs int, hasPeriod bool) {
+	n, okN := parseScalaInt(amountLit)
+	if !okN {
+		return "", 0, 0, false
+	}
+	limit = n
+	if secs, ok := scalaDurationSeconds(perLit); ok {
+		return strconv.Itoa(n) + "/" + strconv.Itoa(secs) + "s", n, secs, true
+	}
+	if ms, ok := scalaDurationMillis(perLit); ok {
+		return strconv.Itoa(n) + "/" + strconv.Itoa(ms) + "ms", n, 0, false
+	}
+	return "", n, 0, false
+}
+
+func (e *scalaRateLimitExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_rate_limit.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: must mention one of the recognised idioms.
+	if !strings.Contains(src, "Throttle") && !strings.Contains(src, ".throttle") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, ent := range e.extractHttp4sThrottle(src, file) {
+		add(ent)
+	}
+	for _, ent := range e.extractAkkaThrottle(src, file) {
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// extractHttp4sThrottle stamps the flat contract on a marker per http4s
+// `Throttle(amount, per)(...)` call. http4s Throttle wraps a whole
+// HttpApp/HttpRoutes value, so the binding is app-wide (scope=app) — there is no
+// single per-route endpoint to attach to, so we emit a marker carrying the
+// resolved amount/per. Only fires when the file is an http4s file (imports
+// org.http4s) so a same-named `Throttle` from another library is not
+// mis-attributed.
+func (e *scalaRateLimitExtractor) extractHttp4sThrottle(src string, file extractor.FileInput) []types.EntityRecord {
+	if !strings.Contains(src, "Throttle") {
+		return nil
+	}
+	// Gate on http4s: the Throttle middleware lives in
+	// org.http4s.server.middleware. Without an http4s signal a bare `Throttle`
+	// identifier could be anything — honest skip.
+	if !strings.Contains(src, "org.http4s") && !strings.Contains(src, "http4s") {
+		return nil
+	}
+
+	var out []types.EntityRecord
+	idx := 0
+	for _, m := range reHttp4sThrottle.FindAllStringSubmatchIndex(src, -1) {
+		amount := strings.TrimSpace(src[m[4]:m[5]])
+		per := strings.TrimSpace(src[m[6]:m[7]])
+		ln := lineOf(src, m[0])
+		idx++
+		// Unique marker name: include amount/per + line so multiple Throttles in
+		// one file each get a distinct node.
+		name := "http4s_throttle:" + amount + ":" + per + ":" + strconv.Itoa(ln)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, ln)
+		setProps(&ent,
+			"framework", "http4s",
+			"kind", "rate_limit",
+			"provenance", "INFERRED_FROM_HTTP4S_THROTTLE",
+			"rate_limited", "true",
+			"rate_limit_source", "http4s_throttle",
+			// http4s Throttle wraps the whole HttpApp/HttpRoutes — app-wide, not a
+			// named route.
+			"rate_limit_scope", "app",
+		)
+		rate, limit, periodSecs, hasPeriod := scalaHumanRate(amount, per)
+		if _, okN := parseScalaInt(amount); okN {
+			ent.Properties["limit"] = strconv.Itoa(limit)
+		}
+		if hasPeriod {
+			ent.Properties["period"] = strconv.Itoa(periodSecs)
+		}
+		if rate != "" {
+			ent.Properties["rate_limit"] = rate
+		}
+		out = append(out, ent)
+	}
+	return out
+}
+
+// extractAkkaThrottle stamps the flat contract on a marker per akka/pekko
+// Streams `.throttle(elements, per, ...)` stage (positional or named). The
+// throttle binds to a stream/response inside a route — a precise verb+path join
+// is heuristic, so we record scope=route without fabricating a route. akka vs
+// pekko is disambiguated by the file's framework. Only fires in an akka/pekko
+// file so a stray `.throttle` from another stream library is not mis-attributed.
+func (e *scalaRateLimitExtractor) extractAkkaThrottle(src string, file extractor.FileInput) []types.EntityRecord {
+	if !strings.Contains(src, ".throttle") {
+		return nil
+	}
+	framework := detectScalaFramework(src)
+	source := ""
+	switch framework {
+	case "akka-http":
+		source = "akka_throttle"
+	case "pekko-http":
+		source = "pekko_throttle"
+	default:
+		// Also honour a raw akka/pekko Streams file (not necessarily akka-http)
+		// when the akka/pekko package is imported — the throttle stage is a
+		// Streams primitive used in and out of HTTP routes.
+		switch {
+		case strings.Contains(src, "org.apache.pekko"):
+			source = "pekko_throttle"
+		case strings.Contains(src, "akka."):
+			source = "akka_throttle"
+		default:
+			return nil
+		}
+	}
+
+	var out []types.EntityRecord
+	emit := func(amount, per string, off int) {
+		ln := lineOf(src, off)
+		name := source + ":" + amount + ":" + per + ":" + strconv.Itoa(ln)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, ln)
+		setProps(&ent,
+			"framework", framework,
+			"kind", "rate_limit",
+			"provenance", "INFERRED_FROM_AKKA_THROTTLE",
+			"rate_limited", "true",
+			"rate_limit_source", source,
+			// The throttle guards a stream/response inside a route; a precise
+			// verb+path binding is heuristic, so scope=route without a route name.
+			"rate_limit_scope", "route",
+		)
+		rate, limit, periodSecs, hasPeriod := scalaHumanRate(amount, per)
+		if _, okN := parseScalaInt(amount); okN {
+			ent.Properties["limit"] = strconv.Itoa(limit)
+		}
+		if hasPeriod {
+			ent.Properties["period"] = strconv.Itoa(periodSecs)
+		}
+		if rate != "" {
+			ent.Properties["rate_limit"] = rate
+		}
+		out = append(out, ent)
+	}
+
+	// Named form first (more specific), then positional. A named throttle's
+	// `.throttle(elements = ...` cannot match the positional regex (which
+	// requires a leading digit after the paren), so the two never double-count
+	// the same call.
+	for _, m := range reAkkaThrottleNamed.FindAllStringSubmatchIndex(src, -1) {
+		emit(strings.TrimSpace(src[m[2]:m[3]]), strings.TrimSpace(src[m[4]:m[5]]), m[0])
+	}
+	for _, m := range reAkkaThrottlePositional.FindAllStringSubmatchIndex(src, -1) {
+		emit(strings.TrimSpace(src[m[2]:m[3]]), strings.TrimSpace(src[m[4]:m[5]]), m[0])
+	}
+	return out
+}

--- a/internal/custom/scala/rate_limit_test.go
+++ b/internal/custom/scala/rate_limit_test.go
@@ -1,0 +1,239 @@
+package scala_test
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// custom_scala_rate_limit — http4s Throttle + akka/pekko throttle stamping
+// (#4105). Value-asserting: each test pins the SPECIFIC amount/per resolved on
+// the SPECIFIC throttle idiom and the flat contract props
+// (rate_limited / rate_limit / rate_limit_scope / rate_limit_source). A
+// "≥1 entity" check is NEVER used. Negatives required.
+// ---------------------------------------------------------------------------
+
+const rlKey = "custom_scala_rate_limit"
+
+// findRL returns the first rate_limit marker matching source (and optionally a
+// substring of its name), with its props.
+func findRLBySource(ents []entitySummary, source string) (entitySummary, bool) {
+	for _, e := range ents {
+		if e.Subtype == "rate_limit" && e.Props["rate_limit_source"] == source {
+			return e, true
+		}
+	}
+	return entitySummary{}, false
+}
+
+func TestScalaRateLimit_Http4sThrottle_Apply(t *testing.T) {
+	src := `
+import org.http4s._
+import org.http4s.server.middleware.Throttle
+import scala.concurrent.duration._
+
+val routes = HttpRoutes.of[IO] {
+  case GET -> Root / "users" => Ok("ok")
+}
+val throttled = Throttle(100, 1.minute)(routes.orNotFound)
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	e, ok := findRLBySource(ents, "http4s_throttle")
+	if !ok {
+		t.Fatalf("expected http4s_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if e.Props["rate_limit"] != "100/60s" {
+		t.Errorf("rate_limit = %q, want 100/60s", e.Props["rate_limit"])
+	}
+	if e.Props["limit"] != "100" {
+		t.Errorf("limit = %q, want 100", e.Props["limit"])
+	}
+	if e.Props["period"] != "60" {
+		t.Errorf("period = %q, want 60", e.Props["period"])
+	}
+	if e.Props["rate_limit_scope"] != "app" {
+		t.Errorf("rate_limit_scope = %q, want app", e.Props["rate_limit_scope"])
+	}
+	if e.Props["framework"] != "http4s" {
+		t.Errorf("framework = %q, want http4s", e.Props["framework"])
+	}
+}
+
+func TestScalaRateLimit_Http4sThrottle_HttpApp(t *testing.T) {
+	src := `
+import org.http4s.server.middleware.Throttle
+import scala.concurrent.duration._
+val app = Throttle.httpApp[IO](50, 10.seconds)(myApp)
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	e, ok := findRLBySource(ents, "http4s_throttle")
+	if !ok {
+		t.Fatalf("expected http4s_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limit"] != "50/10s" {
+		t.Errorf("rate_limit = %q, want 50/10s", e.Props["rate_limit"])
+	}
+	if e.Props["period"] != "10" {
+		t.Errorf("period = %q, want 10", e.Props["period"])
+	}
+}
+
+func TestScalaRateLimit_Http4sThrottle_SubSecondWindow(t *testing.T) {
+	// 100.millis window: honest sub-second rate "200/100ms", no whole-second period.
+	src := `
+import org.http4s.server.middleware.Throttle
+import scala.concurrent.duration._
+val app = Throttle.httpRoutes(200, 100.millis)(routes)
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	e, ok := findRLBySource(ents, "http4s_throttle")
+	if !ok {
+		t.Fatalf("expected http4s_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limit"] != "200/100ms" {
+		t.Errorf("rate_limit = %q, want 200/100ms", e.Props["rate_limit"])
+	}
+	if e.Props["limit"] != "200" {
+		t.Errorf("limit = %q, want 200", e.Props["limit"])
+	}
+	if _, has := e.Props["period"]; has {
+		t.Errorf("period should be omitted for a sub-second window; got %q", e.Props["period"])
+	}
+}
+
+func TestScalaRateLimit_Http4sThrottle_HonestPartialNonLiteral(t *testing.T) {
+	// amount + per come from config vals — rate_limited stamped, numeric rate omitted.
+	src := `
+import org.http4s.server.middleware.Throttle
+val app = Throttle(cfg.maxReqs, cfg.window)(routes)
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	e, ok := findRLBySource(ents, "http4s_throttle")
+	if !ok {
+		t.Fatalf("expected http4s_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if v, has := e.Props["rate_limit"]; has {
+		t.Errorf("rate_limit should be omitted (non-literal); got %q", v)
+	}
+	if v, has := e.Props["limit"]; has {
+		t.Errorf("limit should be omitted (non-literal amount); got %q", v)
+	}
+}
+
+func TestScalaRateLimit_AkkaThrottle_Positional(t *testing.T) {
+	src := `
+import akka.http.scaladsl.server.Directives._
+import akka.stream.scaladsl.Source
+import scala.concurrent.duration._
+
+val route =
+  path("events") {
+    get {
+      complete(eventsSource.throttle(100, 1.second))
+    }
+  }
+`
+	ents := extract(t, rlKey, fi("Routes.scala", "scala", src))
+	e, ok := findRLBySource(ents, "akka_throttle")
+	if !ok {
+		t.Fatalf("expected akka_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if e.Props["rate_limit"] != "100/1s" {
+		t.Errorf("rate_limit = %q, want 100/1s", e.Props["rate_limit"])
+	}
+	if e.Props["rate_limit_scope"] != "route" {
+		t.Errorf("rate_limit_scope = %q, want route", e.Props["rate_limit_scope"])
+	}
+	if e.Props["framework"] != "akka-http" {
+		t.Errorf("framework = %q, want akka-http", e.Props["framework"])
+	}
+}
+
+func TestScalaRateLimit_PekkoThrottle_Named(t *testing.T) {
+	src := `
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.stream.scaladsl.Source
+import scala.concurrent.duration._
+
+val route =
+  path("stream") {
+    get {
+      complete(src.throttle(elements = 5, per = 2.minutes, maximumBurst = 1, mode = ThrottleMode.Shaping))
+    }
+  }
+`
+	ents := extract(t, rlKey, fi("Routes.scala", "scala", src))
+	e, ok := findRLBySource(ents, "pekko_throttle")
+	if !ok {
+		t.Fatalf("expected pekko_throttle marker; got: %+v", ents)
+	}
+	if e.Props["rate_limit"] != "5/120s" {
+		t.Errorf("rate_limit = %q, want 5/120s", e.Props["rate_limit"])
+	}
+	if e.Props["period"] != "120" {
+		t.Errorf("period = %q, want 120", e.Props["period"])
+	}
+	if e.Props["framework"] != "pekko-http" {
+		t.Errorf("framework = %q, want pekko-http", e.Props["framework"])
+	}
+}
+
+// --- NEGATIVES ------------------------------------------------------------
+
+func TestScalaRateLimit_Negative_PlainRoute(t *testing.T) {
+	src := `
+import org.http4s._
+val routes = HttpRoutes.of[IO] {
+  case GET -> Root / "users" => Ok("ok")
+}
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	for _, e := range ents {
+		if e.Subtype == "rate_limit" {
+			t.Errorf("plain route must not stamp a rate_limit marker; got %s", e.Name)
+		}
+	}
+}
+
+func TestScalaRateLimit_Negative_NonThrottleMiddleware(t *testing.T) {
+	// CORS / GZip middleware are NOT throttles → no rate_limit stamping.
+	src := `
+import org.http4s.server.middleware.{CORS, GZip}
+val app = CORS.policy(GZip(routes)).orNotFound
+`
+	ents := extract(t, rlKey, fi("App.scala", "scala", src))
+	for _, e := range ents {
+		if e.Subtype == "rate_limit" {
+			t.Errorf("non-throttle middleware must not stamp rate_limit; got %s", e.Name)
+		}
+	}
+}
+
+func TestScalaRateLimit_Negative_NonHttp4sThrottle(t *testing.T) {
+	// A `Throttle` symbol with no http4s signal in the file is not attributed.
+	src := `
+package mygame
+class Throttle(amount: Int, per: Int)
+val t = Throttle(10, 5)
+`
+	ents := extract(t, rlKey, fi("Game.scala", "scala", src))
+	for _, e := range ents {
+		if e.Subtype == "rate_limit" {
+			t.Errorf("non-http4s Throttle must not stamp rate_limit; got %s", e.Name)
+		}
+	}
+}
+
+func TestScalaRateLimit_Negative_WrongLanguage(t *testing.T) {
+	src := `Throttle(100, 1.minute)(routes)`
+	ents := extract(t, rlKey, fi("App.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("kotlin file must yield no scala rate_limit entities; got %+v", ents)
+	}
+}


### PR DESCRIPTION
## Summary
Greenfield Scala `rate_limit_stamping` (#4105, child of epic #3628). Scala endpoints carried **no** rate-limit signal before this pass (verified: an http4s `Throttle(100, 1.minute)(routes)` and an akka/pekko `.throttle(100, 1.second)` produced zero `rate_limited` props). New `custom_scala_rate_limit` extractor stamps the shared flat contract on the two principal Scala throttle idioms, mirroring the kotlin/ruby/elixir greenfield passes.

## What it stamps
Flat contract: `rate_limited` / `rate_limit` / `rate_limit_scope` / `rate_limit_source` / `limit` / `period`.

**http4s Throttle middleware** (`org.http4s.server.middleware.Throttle`):
- `Throttle(amount, per)(app)` · `Throttle.httpApp[F](amount, per)(app)` · `Throttle.httpRoutes(amount, per)(routes)`
- amount (Int) + per (FiniteDuration literal `1.minute`/`10.seconds`/`100.millis`) → human rate `100/60s`; sub-second windows rendered honestly as `200/100ms`.
- `rate_limit_scope=app` — Throttle wraps the whole HttpApp/HttpRoutes, not a named route (no route fabricated). Gated on an http4s file signal so a same-named `Throttle` from another lib is not mis-attributed. `source=http4s_throttle`.

**akka/pekko-http Streams `.throttle(elements, per, ...)`** (positional + named-arg):
- `rate_limit_scope=route` — guards a streamed response inside a route; a precise verb+path join is heuristic, so none is fabricated. akka vs pekko disambiguated by `org.apache.pekko.*`. `source=akka_throttle` / `pekko_throttle`.

**Honest-partial** (rate_limited stamped, numeric rate omitted) when amount/per is config-/expression-driven. No new node kind — emits a `SCOPE.Pattern/rate_limit` marker (no single per-route endpoint to attach an app-wide / stream throttle to), same shape as the elixir PlugAttack marker.

## Verification
- Value-asserting tests pin the **exact** amount/per per idiom (`100/60s`, `50/10s`, `200/100ms`, `5/120s`), `limit`, `period`, `scope`, `framework`.
- Negatives: plain route, CORS/GZip non-throttle middleware, non-http4s `Throttle` symbol, wrong-language file.
- Full package tests green: `internal/custom/scala/`, `internal/engine/`, `internal/extractors/` (dispatch-parity included — `custom_scala_` prefix), `tools/coverage/`. `internal/types/` green.
- `covtool validate` 0 errors; `fmt --check` canonical; `gen` 0 drift (derived md regenerated); gofmt empty; vet clean.

## Registry
Flips `rate_limit_stamping` `missing → partial` (honest) for the 3 flagship scala records: akka-http, http4s, pekko-http.

DEPLOY-DEFERRED.

Closes #4105

🤖 Generated with [Claude Code](https://claude.com/claude-code)