### PR TITLE
feat(coverage): read-only `parity` probe for flagship→sibling coverage gaps

### DIFF
--- a/tools/coverage/AGENTS.md
+++ b/tools/coverage/AGENTS.md
@@ -10,8 +10,9 @@ The `coverage` command maintains the archigraph capabilities registry at `docs/c
 
 ## Files
 
-- `main.go` — CLI dispatcher; subcommands: `list`, `get`, `add`, `update`, `gaps`, `stats`, `validate`, `gen`, `discover`, `map-status`
+- `main.go` — CLI dispatcher; subcommands: `list`, `get`, `add`, `update`, `gaps`, `stats`, `validate`, `gen`, `discover`, `map-status`, `parity`
 - `schema.go` — registry + record shape
+- `parity.go` — READ-ONLY coverage parity probe (#3876): flags flagship→sibling asymmetry (a capability credited on one framework but missing on same-language siblings in the same `(language, category, subcategory)` group). Uniform-scaffold (all-missing) cells are suppressed by design. `--strict` is a CI gate.
 - `store.go` — load / save / canonical ordering of `registry.json`
 - `validate.go` — schema invariants (referential integrity, status enum, dictionary key conformance)
 - `capability_map.go` + `capability-map.yaml` — capability → file/function mapping for traceability

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -61,6 +61,8 @@ func run(argv []string, stdout, stderr io.Writer) error {
 		return cmdMapStatus(rest, stdout)
 	case "delta":
 		return cmdDelta(rest, stdout)
+	case "parity":
+		return cmdParity(rest, stdout)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -94,7 +96,11 @@ subcommands:
               map-status <record-id>/<group>/<capability>     (grouped)
             (--repo-root, --json)
   delta     diff registry.json before→after two git refs, emit markdown coverage-delta report
-            (--base origin/main, --head HEAD, --lang <slug>, --post <PR#>, --file)`)
+            (--base origin/main, --head HEAD, --lang <slug>, --post <PR#>, --file)
+  parity    READ-ONLY probe for flagship→sibling coverage asymmetry: a capability credited
+            (full/partial) on one framework but missing on same-language siblings in the same
+            (language, category, subcategory) group. Uniform-scaffold (all-missing) cells are
+            suppressed. (--language, --min-group, --include-partial, --json, --strict, --file)`)
 }
 
 // registryFlag adds a shared --file flag for overriding the registry

--- a/tools/coverage/parity.go
+++ b/tools/coverage/parity.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Coverage parity probe (#3876).
+//
+// The per-language audits hand-spotted a recurring meta-pattern: a
+// framework-agnostic capability is credited (full/partial) on one
+// framework in a language but left missing on its same-language siblings
+// — a likely BUILT-UNCREDITED gap (the extractor already handles it; the
+// sibling record just was never re-verified). This probe finds that
+// asymmetry continuously so it no longer has to be eyeballed.
+//
+// Grouping key: (language, category, subcategory). Records in the same
+// group are genuine siblings — the same kind of thing (e.g. JVM HTTP
+// backends) in the same language. A capability is compared only against
+// peers in its own group.
+//
+// Scaffold suppression (the stale-audit trap): the http_framework+orm
+// matrix seeds EVERY framework with the same all-`missing` lane cells as
+// a scaffold default. Those uniform-missing cells are NOT gaps — nobody
+// has it, so there is no "flagship" to trail. The probe only emits a
+// finding when there is REAL ASYMMETRY within a group: at least one
+// credited framework AND at least one missing framework for the same
+// capability. A group where every framework is missing (uniform
+// scaffold) yields zero findings, as does a group where every framework
+// is credited.
+
+// parityCredited reports whether a status counts as "the capability is
+// present" for parity purposes. partial is included by default because
+// the by-hand audits treat a partial flagship as enough to expose a
+// trailing missing sibling; --no-partial narrows it to full-only.
+func parityCredited(status string, includePartial bool) bool {
+	if status == StatusFull {
+		return true
+	}
+	return includePartial && status == StatusPartial
+}
+
+// parityFrameworkStatus records one framework's status for a capability
+// within a (language, category, subcategory) group.
+type parityFrameworkStatus struct {
+	RecordID string `json:"record_id"`
+	Label    string `json:"label"`
+	Status   string `json:"status"`
+}
+
+// ParityFinding is a single flagship→sibling asymmetry: within one
+// (language, category, subcategory) group, Capability is credited on the
+// FullIn/PartialIn frameworks but missing on the TrailingIn frameworks.
+// Such a finding is a candidate BUILT-UNCREDITED gap to re-verify.
+type ParityFinding struct {
+	Language    string                  `json:"language"`
+	Category    string                  `json:"category"`
+	Subcategory string                  `json:"subcategory,omitempty"`
+	Capability  string                  `json:"capability"`
+	GroupSize   int                     `json:"group_size"`
+	FullIn      []parityFrameworkStatus `json:"full_in"`
+	PartialIn   []parityFrameworkStatus `json:"partial_in,omitempty"`
+	TrailingIn  []parityFrameworkStatus `json:"trailing_in"`
+}
+
+// ParityReport is the full deterministic output of the probe.
+type ParityReport struct {
+	// MinGroup is the minimum number of sibling frameworks (records) a
+	// group must contain before its capabilities are eligible for a
+	// finding. With min-group 1 a singleton group can never be asymmetric
+	// (it has no peer), so the effective floor is 2; the field is surfaced
+	// for transparency and CI configurability.
+	MinGroup        int             `json:"min_group"`
+	IncludePartial  bool            `json:"include_partial"`
+	GroupsScanned   int             `json:"groups_scanned"`
+	CellsCompared   int             `json:"cells_compared"`
+	Findings        []ParityFinding `json:"findings"`
+	SuppressedScaff int             `json:"suppressed_uniform_scaffold"`
+}
+
+// parityGroupKey identifies a sibling cohort.
+type parityGroupKey struct {
+	language    string
+	category    string
+	subcategory string
+}
+
+// computeParity scans the registry and returns the asymmetry report.
+//
+// language, when non-empty, restricts the scan to that language slug.
+// minGroup is the minimum sibling-count threshold (see ParityReport).
+// includePartial controls whether a partial cell counts as credited.
+func computeParity(reg *Registry, language string, minGroup int, includePartial bool) ParityReport {
+	if minGroup < 1 {
+		minGroup = 1
+	}
+	// group → capability → frameworks (each framework's status for that cap)
+	groups := map[parityGroupKey]map[string][]parityFrameworkStatus{}
+	// distinct record IDs per group, to size the sibling cohort honestly
+	// even when frameworks declare disjoint capability sets.
+	groupRecords := map[parityGroupKey]map[string]struct{}{}
+
+	for _, rec := range reg.Records {
+		if language != "" && rec.Language != language {
+			continue
+		}
+		key := parityGroupKey{rec.Language, rec.Category, rec.Subcategory}
+		if groups[key] == nil {
+			groups[key] = map[string][]parityFrameworkStatus{}
+			groupRecords[key] = map[string]struct{}{}
+		}
+		groupRecords[key][rec.ID] = struct{}{}
+		for cap, cell := range rec.AllCapabilitiesIncludingFrameworkSpecific() {
+			groups[key][cap] = append(groups[key][cap], parityFrameworkStatus{
+				RecordID: rec.ID,
+				Label:    rec.Label,
+				Status:   cell.Status,
+			})
+		}
+	}
+
+	report := ParityReport{
+		MinGroup:       minGroup,
+		IncludePartial: includePartial,
+	}
+
+	for key, caps := range groups {
+		groupSize := len(groupRecords[key])
+		report.GroupsScanned++
+		if groupSize < minGroup || groupSize < 2 {
+			// A singleton (or sub-threshold) cohort has no peer to trail,
+			// so no capability in it can be an asymmetry. Skip whole group.
+			continue
+		}
+		for cap, fws := range caps {
+			if len(fws) < 2 {
+				continue
+			}
+			report.CellsCompared++
+			var full, partial, trailing []parityFrameworkStatus
+			for _, fw := range fws {
+				switch {
+				case fw.Status == StatusFull:
+					full = append(full, fw)
+				case includePartial && fw.Status == StatusPartial:
+					partial = append(partial, fw)
+				case fw.Status == StatusMissing:
+					trailing = append(trailing, fw)
+				}
+				// not_applicable (and partial when !includePartial) are
+				// neither credited nor a gap — they drop out of both lists.
+			}
+			credited := len(full) + len(partial)
+			if credited == 0 || len(trailing) == 0 {
+				// Uniform scaffold (all missing) or all-credited or a mix
+				// with no real trailing sibling: not an asymmetry.
+				if credited == 0 && len(trailing) >= 2 {
+					// Every comparable peer is missing → the uniform
+					// scaffold default. Count it so the report can prove
+					// it suppressed the matrix rather than missing it.
+					report.SuppressedScaff++
+				}
+				continue
+			}
+			sortFrameworks(full)
+			sortFrameworks(partial)
+			sortFrameworks(trailing)
+			report.Findings = append(report.Findings, ParityFinding{
+				Language:    key.language,
+				Category:    key.category,
+				Subcategory: key.subcategory,
+				Capability:  cap,
+				GroupSize:   groupSize,
+				FullIn:      full,
+				PartialIn:   partial,
+				TrailingIn:  trailing,
+			})
+		}
+	}
+
+	sortFindings(report.Findings)
+	return report
+}
+
+// sortFrameworks orders a framework slice by record ID for deterministic
+// output.
+func sortFrameworks(fs []parityFrameworkStatus) {
+	sort.Slice(fs, func(i, j int) bool { return fs[i].RecordID < fs[j].RecordID })
+}
+
+// sortFindings orders findings deterministically: language, category,
+// subcategory, then capability.
+func sortFindings(fs []ParityFinding) {
+	sort.Slice(fs, func(i, j int) bool {
+		a, b := fs[i], fs[j]
+		if a.Language != b.Language {
+			return a.Language < b.Language
+		}
+		if a.Category != b.Category {
+			return a.Category < b.Category
+		}
+		if a.Subcategory != b.Subcategory {
+			return a.Subcategory < b.Subcategory
+		}
+		return a.Capability < b.Capability
+	})
+}
+
+// cmdParity implements `coverage parity`: a READ-ONLY probe. It never
+// mutates the registry. Exit is non-zero only when --strict is set and
+// at least one finding exists (CI gate); otherwise findings are purely
+// informational.
+func cmdParity(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("parity", flag.ContinueOnError)
+	path := registryFlag(fs)
+	lang := fs.String("language", "", "restrict to one language slug")
+	minGroup := fs.Int("min-group", 2, "minimum sibling frameworks in a (language,category,subcategory) group before its capabilities are compared")
+	includePartial := fs.Bool("include-partial", true, "count a partial cell as credited (a partial flagship still exposes a missing sibling)")
+	asJSON := fs.Bool("json", false, "JSON output")
+	strict := fs.Bool("strict", false, "exit non-zero when any parity gap is found (CI gate)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	report := computeParity(reg, *lang, *minGroup, *includePartial)
+	if *asJSON {
+		if err := printJSON(out, report); err != nil {
+			return err
+		}
+	} else {
+		printParityText(out, report)
+	}
+	if *strict && len(report.Findings) > 0 {
+		return fmt.Errorf("parity: %d flagship→sibling gap(s) found", len(report.Findings))
+	}
+	return nil
+}
+
+// printParityText writes a human-readable, diffable parity report.
+func printParityText(w io.Writer, r ParityReport) {
+	fmt.Fprintf(w, "coverage parity probe — %d finding(s)\n", len(r.Findings))
+	fmt.Fprintf(w, "  groups scanned: %d   cells compared: %d   uniform-scaffold suppressed: %d\n",
+		r.GroupsScanned, r.CellsCompared, r.SuppressedScaff)
+	fmt.Fprintf(w, "  min-group: %d   include-partial: %v\n\n", r.MinGroup, r.IncludePartial)
+	if len(r.Findings) == 0 {
+		fmt.Fprintln(w, "no flagship→sibling asymmetry detected.")
+		return
+	}
+	for _, f := range r.Findings {
+		lane := f.Category
+		if f.Subcategory != "" {
+			lane = f.Category + "/" + f.Subcategory
+		}
+		fmt.Fprintf(w, "%-10s %-28s %s  (group of %d)\n", f.Language, lane, f.Capability, f.GroupSize)
+		for _, fw := range f.FullIn {
+			fmt.Fprintf(w, "    full     %s\n", fw.RecordID)
+		}
+		for _, fw := range f.PartialIn {
+			fmt.Fprintf(w, "    partial  %s\n", fw.RecordID)
+		}
+		for _, fw := range f.TrailingIn {
+			fmt.Fprintf(w, "    MISSING  %s  <- trailing sibling\n", fw.RecordID)
+		}
+		fmt.Fprintln(w)
+	}
+}

--- a/tools/coverage/parity_test.go
+++ b/tools/coverage/parity_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// rec is a tiny helper to build a flat-capability record for parity
+// fixtures. Each entry in caps is "key:status".
+func rec(id, lang, cat, sub string, caps ...string) Record {
+	m := map[string]Capability{}
+	for _, c := range caps {
+		parts := strings.SplitN(c, ":", 2)
+		m[parts[0]] = Capability{Status: parts[1]}
+	}
+	return Record{ID: id, Language: lang, Category: cat, Subcategory: sub, Label: id, Capabilities: m}
+}
+
+// findFinding returns the finding for a capability, or nil.
+func findFinding(r ParityReport, cap string) *ParityFinding {
+	for i := range r.Findings {
+		if r.Findings[i].Capability == cap {
+			return &r.Findings[i]
+		}
+	}
+	return nil
+}
+
+func ids(fs []parityFrameworkStatus) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.RecordID
+	}
+	return out
+}
+
+// TestParityAsymmetryFlagsTrailingSiblings is the core value assertion:
+// a group with 1 full + 2 missing for a capability yields exactly one
+// finding that names BOTH trailing frameworks, the flagship, and the
+// honest group size.
+func TestParityAsymmetryFlagsTrailingSiblings(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.x.framework.a", "x", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.x.framework.b", "x", "http_framework", "http_backend", "auth_coverage:missing"),
+		rec("lang.x.framework.c", "x", "http_framework", "http_backend", "auth_coverage:missing"),
+	}}
+	r := computeParity(reg, "", 2, true)
+	if len(r.Findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d: %+v", len(r.Findings), r.Findings)
+	}
+	f := r.Findings[0]
+	if f.Capability != "auth_coverage" {
+		t.Fatalf("wrong capability: %q", f.Capability)
+	}
+	if f.GroupSize != 3 {
+		t.Fatalf("expected group size 3, got %d", f.GroupSize)
+	}
+	if got := ids(f.FullIn); len(got) != 1 || got[0] != "lang.x.framework.a" {
+		t.Fatalf("flagship mismatch: %v", got)
+	}
+	if got := ids(f.TrailingIn); len(got) != 2 ||
+		got[0] != "lang.x.framework.b" || got[1] != "lang.x.framework.c" {
+		t.Fatalf("expected both trailing siblings named in order, got %v", got)
+	}
+}
+
+// TestParityUniformScaffoldSuppressed is the anti-trap assertion: a group
+// where EVERY framework is missing the capability (the http_framework+orm
+// matrix scaffold default) produces ZERO findings, and is counted as a
+// suppressed scaffold so the report proves it saw and ignored it.
+func TestParityUniformScaffoldSuppressed(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.y.framework.a", "y", "orm", "", "orm_mapping:missing"),
+		rec("lang.y.framework.b", "y", "orm", "", "orm_mapping:missing"),
+		rec("lang.y.framework.c", "y", "orm", "", "orm_mapping:missing"),
+	}}
+	r := computeParity(reg, "", 2, true)
+	if len(r.Findings) != 0 {
+		t.Fatalf("uniform-all-missing scaffold must yield 0 findings, got %d: %+v", len(r.Findings), r.Findings)
+	}
+	if r.SuppressedScaff != 1 {
+		t.Fatalf("expected 1 suppressed-scaffold cell, got %d", r.SuppressedScaff)
+	}
+}
+
+// TestParityAllCreditedNoFinding: a group where every framework is full
+// (no trailing sibling) is not an asymmetry.
+func TestParityAllCreditedNoFinding(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.z.framework.a", "z", "http_framework", "http_backend", "endpoint_synthesis:full"),
+		rec("lang.z.framework.b", "z", "http_framework", "http_backend", "endpoint_synthesis:full"),
+	}}
+	r := computeParity(reg, "", 2, true)
+	if len(r.Findings) != 0 {
+		t.Fatalf("all-credited group must yield 0 findings, got %+v", r.Findings)
+	}
+	if r.SuppressedScaff != 0 {
+		t.Fatalf("all-credited is not a scaffold suppression, got %d", r.SuppressedScaff)
+	}
+}
+
+// TestParityPartialFlagshipExposesGap: a partial flagship still exposes a
+// missing sibling when include-partial is on, and lands in PartialIn.
+// With include-partial off, partial is neither credit nor gap so the cell
+// becomes all-missing-but-one-partial → no credited flagship → no finding.
+func TestParityPartialFlagship(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.p.framework.a", "p", "http_framework", "http_backend", "request_validation:partial"),
+		rec("lang.p.framework.b", "p", "http_framework", "http_backend", "request_validation:missing"),
+	}}
+	on := computeParity(reg, "", 2, true)
+	f := findFinding(on, "request_validation")
+	if f == nil {
+		t.Fatal("partial flagship should expose the missing sibling when include-partial=true")
+	}
+	if got := ids(f.PartialIn); len(got) != 1 || got[0] != "lang.p.framework.a" {
+		t.Fatalf("expected partial flagship in PartialIn, got %v", got)
+	}
+	if len(f.FullIn) != 0 {
+		t.Fatalf("no full flagship expected, got %v", ids(f.FullIn))
+	}
+
+	off := computeParity(reg, "", 2, false)
+	if findFinding(off, "request_validation") != nil {
+		t.Fatal("with include-partial=false, a partial-only flagship must not produce a finding")
+	}
+}
+
+// TestParityMinGroupThreshold: a singleton group (only one framework
+// declares the capability / only one sibling exists) is never flagged.
+func TestParityMinGroupThreshold(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.s.framework.solo", "s", "http_framework", "http_backend", "auth_coverage:full"),
+	}}
+	r := computeParity(reg, "", 2, true)
+	if len(r.Findings) != 0 {
+		t.Fatalf("singleton group must never be flagged, got %+v", r.Findings)
+	}
+
+	// A 2-framework asymmetric group is flagged at min-group=2 but
+	// suppressed when the threshold is raised to 3.
+	reg2 := &Registry{Records: []Record{
+		rec("lang.s.framework.a", "s", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.s.framework.b", "s", "http_framework", "http_backend", "auth_coverage:missing"),
+	}}
+	if got := len(computeParity(reg2, "", 2, true).Findings); got != 1 {
+		t.Fatalf("min-group=2: expected 1 finding, got %d", got)
+	}
+	if got := len(computeParity(reg2, "", 3, true).Findings); got != 0 {
+		t.Fatalf("min-group=3: expected 0 findings, got %d", got)
+	}
+}
+
+// TestParityNotApplicableIsNeutral: a not_applicable cell is neither a
+// flagship nor a trailing gap. A group of {full, not_applicable} has no
+// missing sibling → no finding. {not_applicable, missing} has no credited
+// flagship → no finding (and is not a scaffold either, since n/a≠missing).
+func TestParityNotApplicableIsNeutral(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.n.framework.a", "n", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.n.framework.b", "n", "http_framework", "http_backend", "auth_coverage:not_applicable"),
+	}}
+	if got := computeParity(reg, "", 2, true).Findings; len(got) != 0 {
+		t.Fatalf("{full, n/a} has no trailing gap, got %+v", got)
+	}
+	reg2 := &Registry{Records: []Record{
+		rec("lang.n.framework.a", "n", "http_framework", "http_backend", "auth_coverage:not_applicable"),
+		rec("lang.n.framework.b", "n", "http_framework", "http_backend", "auth_coverage:missing"),
+	}}
+	r := computeParity(reg2, "", 2, true)
+	if len(r.Findings) != 0 {
+		t.Fatalf("{n/a, missing} has no credited flagship, got %+v", r.Findings)
+	}
+	if r.SuppressedScaff != 0 {
+		t.Fatalf("{n/a, missing} is not a uniform scaffold (n/a != missing), got %d", r.SuppressedScaff)
+	}
+}
+
+// TestParitySubcategoryIsolation: siblings are scoped to the SAME
+// (category, subcategory) lane. A full in one subcategory does not flag a
+// missing in a different subcategory of the same category/language.
+func TestParitySubcategoryIsolation(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.q.framework.backend", "q", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.q.framework.ui", "q", "http_framework", "ui_frontend", "auth_coverage:missing"),
+	}}
+	if got := computeParity(reg, "", 2, true).Findings; len(got) != 0 {
+		t.Fatalf("cross-subcategory comparison must not flag, got %+v", got)
+	}
+}
+
+// TestParityGroupedAndFrameworkSpecificCells exercises the non-flat
+// carriers: a grouped flagship and a framework_specific trailing cell are
+// both flattened by AllCapabilitiesIncludingFrameworkSpecific and compared.
+func TestParityGroupedCells(t *testing.T) {
+	flagship := Record{
+		ID: "lang.g.framework.a", Language: "g", Category: "http_framework", Subcategory: "http_backend", Label: "A",
+		Groups: map[string]map[string]Capability{
+			"Auth": {"auth_coverage": {Status: StatusFull}},
+		},
+	}
+	sibling := Record{
+		ID: "lang.g.framework.b", Language: "g", Category: "http_framework", Subcategory: "http_backend", Label: "B",
+		Groups: map[string]map[string]Capability{
+			"Auth": {"auth_coverage": {Status: StatusMissing}},
+		},
+	}
+	r := computeParity(&Registry{Records: []Record{flagship, sibling}}, "", 2, true)
+	f := findFinding(r, "auth_coverage")
+	if f == nil {
+		t.Fatal("grouped flagship vs grouped sibling should produce a finding")
+	}
+	if got := ids(f.TrailingIn); len(got) != 1 || got[0] != "lang.g.framework.b" {
+		t.Fatalf("trailing sibling mismatch: %v", got)
+	}
+}
+
+// TestParityLanguageFilter restricts the scan to one language.
+func TestParityLanguageFilter(t *testing.T) {
+	reg := &Registry{Records: []Record{
+		rec("lang.a.framework.x", "a", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.a.framework.y", "a", "http_framework", "http_backend", "auth_coverage:missing"),
+		rec("lang.b.framework.x", "b", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.b.framework.y", "b", "http_framework", "http_backend", "auth_coverage:missing"),
+	}}
+	r := computeParity(reg, "a", 2, true)
+	if len(r.Findings) != 1 || r.Findings[0].Language != "a" {
+		t.Fatalf("language filter should yield only language a, got %+v", r.Findings)
+	}
+}
+
+// TestParityCmdStrictExit asserts the CLI contract: without --strict the
+// command succeeds (informational) even with findings; with --strict it
+// exits non-zero when findings exist; JSON is well-formed.
+func TestParityCmdStrictExit(t *testing.T) {
+	out, _, err := runCmd(t, "parity", "--file", fixturePath(t))
+	if err != nil {
+		t.Fatalf("parity (non-strict) must not error: %v", err)
+	}
+	if !strings.Contains(out, "coverage parity probe") {
+		t.Fatalf("unexpected text output:\n%s", out)
+	}
+
+	// JSON output decodes into a ParityReport.
+	jout, _, err := runCmd(t, "parity", "--file", fixturePath(t), "--json")
+	if err != nil {
+		t.Fatalf("parity --json: %v", err)
+	}
+	var report ParityReport
+	if err := json.Unmarshal([]byte(jout), &report); err != nil {
+		t.Fatalf("parity --json did not produce valid ParityReport JSON: %v\n%s", err, jout)
+	}
+
+	// --strict exits non-zero iff there is at least one finding.
+	_, _, serr := runCmd(t, "parity", "--file", fixturePath(t), "--strict")
+	if len(report.Findings) > 0 && serr == nil {
+		t.Fatal("parity --strict must exit non-zero when findings exist")
+	}
+	if len(report.Findings) == 0 && serr != nil {
+		t.Fatalf("parity --strict must succeed when no findings: %v", serr)
+	}
+}
+
+// TestParityDeterministic: the report ordering is stable across runs
+// regardless of record input order.
+func TestParityDeterministic(t *testing.T) {
+	a := []Record{
+		rec("lang.d.framework.a", "d", "http_framework", "http_backend", "auth_coverage:full"),
+		rec("lang.d.framework.b", "d", "http_framework", "http_backend", "auth_coverage:missing", "request_validation:missing"),
+		rec("lang.d.framework.c", "d", "http_framework", "http_backend", "request_validation:full"),
+	}
+	b := []Record{a[2], a[0], a[1]}
+	r1 := computeParity(&Registry{Records: a}, "", 2, true)
+	r2 := computeParity(&Registry{Records: b}, "", 2, true)
+	if len(r1.Findings) != len(r2.Findings) {
+		t.Fatalf("finding count differs by input order: %d vs %d", len(r1.Findings), len(r2.Findings))
+	}
+	for i := range r1.Findings {
+		if r1.Findings[i].Capability != r2.Findings[i].Capability {
+			t.Fatalf("finding order not deterministic at %d: %q vs %q", i, r1.Findings[i].Capability, r2.Findings[i].Capability)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3876

## What

Adds `coverage parity`, a **read-only** probe that catches the meta-pattern the per-language audits (#3883/85/86/…) spotted by hand: a framework-agnostic capability is **credited (full/partial) on one framework in a language but left missing on its same-language siblings** — a likely BUILT-UNCREDITED gap (the extractor already handles it; the sibling record just was never re-verified).

## How the asymmetry detection works

- **Grouping:** records are grouped by `(language, category, subcategory)` — genuine sibling cohorts (e.g. JVM HTTP backends in Java).
- **Per capability** within a group, split the frameworks into `full` / `partial` / `missing` (using `AllCapabilitiesIncludingFrameworkSpecific`, so flat, grouped, and `framework_specific` cells all count).
- **Emit a finding only on real asymmetry:** `>=1 credited` (full or partial) **AND** `>=1 missing`, with the cohort size `>= --min-group` (default 2). `not_applicable` is neutral — neither flagship nor gap.

## Scaffold suppression (the stale-audit trap)

The `http_framework`+`orm` matrix seeds **every** framework with the same all-`missing` lane cells as a scaffold default. Those uniform-missing cohorts have **no flagship to trail**, so they produce **zero findings** — and are tallied under `suppressed_uniform_scaffold` so the report proves it saw and ignored them rather than silently missing them. All-credited cohorts likewise yield nothing.

## Read-only + CI gate

Never mutates `registry.json`. Findings are informational by default; `--strict` exits non-zero on any gap (CI gate, mirrors `fmt --check`). Text + `--json` output, fully deterministic (stable sort by language → category → subcategory → capability).

## Tests (value-asserting fixtures, not the live registry)

11 unit tests assert the logic directly:
- 1-full + 2-missing → **one** finding naming **both** trailing siblings + correct group size
- uniform scaffold (all-missing) → **0** findings, suppression counted
- all-full → 0; partial flagship exposes gap (and `--include-partial=false` suppresses it)
- min-group threshold; `not_applicable` neutrality; subcategory isolation; grouped/`framework_specific` carriers; language filter; `--strict` exit; determinism under input reorder

`gofmt` clean, `go vet` clean, `go test ./tools/coverage/...` green.

## Live-registry sanity (informational — these feed future grind waves)

- **465 findings**, **197 uniform-scaffold cells correctly suppressed** (the matrix is NOT flagged).
- Reproduces the **acceptance criterion** without hand-curation: `(java, http_framework, jvm_backend)` with `spring-boot` as sole flagship and **15 JVM siblings trailing** (e.g. `feature_flag_gating`, `view_rendering`).
- Top trailing breadth: Python `http_backend` `endpoint_deprecation_versioning` / `feature_flag_gating` (18 trailing), JS/TS `orm_mapper` `model_lifecycle_extraction` (17), Go `http_backend` DI capabilities (16).
- By language: jsts 85, java 55, go 47, kotlin 46, csharp 37, … — concrete per-language trailing-lists for the audit children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)