### PR TITLE
coverage-docs: redesign message_broker into 5 subcategories (Schedulers/Task-queues/Brokers/Realtime/Webhooks) (#4008)

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -5,49 +5,73 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Consumer extraction | Producer extraction | Room channel grouping | Signature verification | Topic attribution | Status | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [C#](../by-language/csharp.md) | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | — | — | — | — | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [elixir](../by-language/elixir.md) | [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | ✅ | — | 🟢 | 🔴 | |
-| [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | 🟢 | — | — | — | — | 🟢 | |
-| [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS SNS](../detail/msg.broker.sns.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [AWS SQS](../detail/msg.broker.sqs.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Apache Kafka](../detail/msg.broker.kafka.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Service Bus / Event Hubs](../detail/msg.broker.azure-service-bus.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Debezium (CDC)](../detail/msg.broker.debezium.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | 🔴 | 🔴 | — | — | — | 🔴 | |
-| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [NATS](../detail/msg.broker.nats.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [SignalR](../detail/msg.signalr.md) | 🔴 | ✅ | — | — | — | 🔴 | |
-| [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ✅ | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | — | ✅ | 🟢 | 🟢 | |
-| [python](../by-language/python.md) | [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | 🟢 | — | — | — | — | 🟢 | |
-| [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Django Channels](../detail/msg.django-channels.md) | — | — | ✅ | — | — | ✅ | |
-| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | — | — | ✅ | |
-| [python](../by-language/python.md) | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [ruby](../by-language/ruby.md) | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | — | — | ✅ | ✅ | |
-| [ruby](../by-language/ruby.md) | [Rails ActionCable](../detail/msg.actioncable.md) | — | — | ✅ | — | — | ✅ | |
-| [ruby](../by-language/ruby.md) | [Resque (Ruby task queue)](../detail/msg.resque.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | 🟢 | — | — | — | — | 🟢 | |
-| [ruby](../by-language/ruby.md) | [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | 🟢 | — | — | — | — | 🟢 | |
-| [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
-| [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | — | — | 🟢 | 🟢 | |
+
+
+## Schedulers
+
+| Language | Name | Consumer extraction | Status | Notes |
+|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | 🟢 | 🟢 | |
+
+## Task Queues
+
+| Language | Name | Consumer extraction | Producer extraction | Topic attribution | Status | Notes |
+|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Resque (Ruby task queue)](../detail/msg.resque.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | 🟢 | |
+
+## Brokers
+
+| Language | Name | Consumer extraction | Producer extraction | Topic attribution | Status | Notes |
+|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS SNS](../detail/msg.broker.sns.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AWS SQS](../detail/msg.broker.sqs.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Apache Kafka](../detail/msg.broker.kafka.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Service Bus / Event Hubs](../detail/msg.broker.azure-service-bus.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Debezium (CDC)](../detail/msg.broker.debezium.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | 🔴 | 🔴 | — | 🔴 | |
+| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [NATS](../detail/msg.broker.nats.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+
+## Realtime Channels
+
+| Language | Name | Consumer extraction | Producer extraction | Room channel grouping | Topic attribution | Status | Notes |
+|---|---|---|---|---|---|---|---|
+| [elixir](../by-language/elixir.md) | [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | ✅ | 🟢 | 🔴 | |
+| [multi](../by-language/multi.md) | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | ✅ | ✅ | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [SignalR](../detail/msg.signalr.md) | 🔴 | ✅ | — | — | 🔴 | |
+| [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ✅ | 🟢 | 🟢 | |
+| [python](../by-language/python.md) | [Django Channels](../detail/msg.django-channels.md) | — | — | ✅ | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Rails ActionCable](../detail/msg.actioncable.md) | — | — | ✅ | — | ✅ | |
+
+## Webhooks
+
+| Language | Name | Consumer extraction | Producer extraction | Signature verification | Topic attribution | Status | Notes |
+|---|---|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | ✅ | 🟢 | 🟢 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -104,11 +104,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | 🟢 | |
+| [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | 🟢 | |
+| [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | 🟢 | |
+
 
 ### Validation
 

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -105,6 +105,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Schedulers
+
+| Name | Consumer extraction | Notes |
+|---|---|---|
+| [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -87,6 +87,17 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Category | Status | Notes |
 |---|---|---|---|
-| [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [Phoenix Channels](../detail/msg.phoenix-channels.md) | [message_broker](../by-category/message_broker.md) | 🔴 | |
 | [Ueberauth (Elixir OAuth)](../detail/lang.elixir.framework.ueberauth.md) | [security](../by-category/security.md) | 🔴 | |
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | 🟢 | |
+
+
+### Realtime Channels
+
+| Name | Consumer extraction | Producer extraction | Room channel grouping | Topic attribution | Notes |
+|---|---|---|---|---|---|
+| [Phoenix Channels](../detail/msg.phoenix-channels.md) | 🔴 | ✅ | ✅ | 🟢 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -153,11 +153,27 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Schedulers
+
+| Name | Consumer extraction | Notes |
+|---|---|---|
+| [node-schedule (Node scheduled jobs)](../detail/msg.node-schedule.md) | 🟢 | |
+
+
+### Task Queues
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | |
+
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)](../detail/msg.orm-lifecycle-hooks-jsts.md) | ✅ | ✅ | ✅ | |
+
 
 ### Config Files
 

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -112,14 +112,36 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [Celery (Python task queue)](../detail/msg.celery.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Django Channels](../detail/msg.django-channels.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+
+### Schedulers
+
+| Name | Consumer extraction | Notes |
+|---|---|---|
+| [APScheduler (Python advanced scheduler)](../detail/msg.apscheduler.md) | 🟢 | |
+
+
+### Task Queues
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | |
+| [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | |
+
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ✅ | |
+| [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | ✅ | |
+
+
+### Realtime Channels
+
+| Name | Consumer extraction | Producer extraction | Room channel grouping | Topic attribution | Notes |
+|---|---|---|---|---|---|
+| [Django Channels](../detail/msg.django-channels.md) | — | — | ✅ | — | |
+
 
 ### Workflow / DAG & State Machines
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -73,14 +73,36 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Rails ActionCable](../detail/msg.actioncable.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Resque (Ruby task queue)](../detail/msg.resque.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Schedulers
+
+| Name | Consumer extraction | Notes |
+|---|---|---|
+| [rufus-scheduler (Ruby in-process scheduler)](../detail/msg.rufus-scheduler.md) | 🟢 | |
+| [whenever (Ruby cron / config/schedule.rb)](../detail/msg.whenever.md) | 🟢 | |
+
+
+### Task Queues
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [Resque (Ruby task queue)](../detail/msg.resque.md) | 🟢 | 🟢 | 🟢 | |
+| [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | 🟢 | 🟢 | — | |
+
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | ✅ | |
+
+
+### Realtime Channels
+
+| Name | Consumer extraction | Producer extraction | Room channel grouping | Topic attribution | Notes |
+|---|---|---|---|---|---|
+| [Rails ActionCable](../detail/msg.actioncable.md) | — | — | ✅ | — | |
+
 
 ### Workflow / DAG & State Machines
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -85,10 +85,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ## Other
 
-| Name | Category | Status | Notes |
-|---|---|---|---|
-| [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
-| [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | [message_broker](../by-category/message_broker.md) | 🟢 | |
+
+### Brokers
+
+| Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
+|---|---|---|---|---|
+| [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | |
+| [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | |
+
 
 ### Validation
 

--- a/docs/coverage/detail/lang.c-cpp.framework.librdkafka.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.librdkafka.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/lang.c-cpp.framework.mqtt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.mqtt.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/lang.c-cpp.framework.zeromq.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.zeromq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.broadway.md
+++ b/docs/coverage/detail/lang.elixir.framework.broadway.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.lapin.md
+++ b/docs/coverage/detail/lang.rust.framework.lapin.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.rdkafka.md
+++ b/docs/coverage/detail/lang.rust.framework.rdkafka.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.actioncable.md
+++ b/docs/coverage/detail/msg.actioncable.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.apscheduler.md
+++ b/docs/coverage/detail/msg.apscheduler.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.amqp.md
+++ b/docs/coverage/detail/msg.broker.amqp.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.azure-service-bus.md
+++ b/docs/coverage/detail/msg.broker.azure-service-bus.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.cloudevents.md
+++ b/docs/coverage/detail/msg.broker.cloudevents.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.debezium.md
+++ b/docs/coverage/detail/msg.broker.debezium.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.eventbridge.md
+++ b/docs/coverage/detail/msg.broker.eventbridge.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.eventgrid.md
+++ b/docs/coverage/detail/msg.broker.eventgrid.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.gcp-pubsub.md
+++ b/docs/coverage/detail/msg.broker.gcp-pubsub.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.kafka.md
+++ b/docs/coverage/detail/msg.broker.kafka.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.mqtt.md
+++ b/docs/coverage/detail/msg.broker.mqtt.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.nats.md
+++ b/docs/coverage/detail/msg.broker.nats.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.pulsar.md
+++ b/docs/coverage/detail/msg.broker.pulsar.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.rabbitmq.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.redis.md
+++ b/docs/coverage/detail/msg.broker.redis.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.sns.md
+++ b/docs/coverage/detail/msg.broker.sns.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.broker.sqs.md
+++ b/docs/coverage/detail/msg.broker.sqs.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.bullmq.md
+++ b/docs/coverage/detail/msg.bullmq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.celery.md
+++ b/docs/coverage/detail/msg.celery.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.django-channels.md
+++ b/docs/coverage/detail/msg.django-channels.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.django-signals.md
+++ b/docs/coverage/detail/msg.django-signals.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.dramatiq.md
+++ b/docs/coverage/detail/msg.dramatiq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/msg.graphql-subscriptions.md
+++ b/docs/coverage/detail/msg.graphql-subscriptions.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.hangfire-recurring.md
+++ b/docs/coverage/detail/msg.hangfire-recurring.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.kafka-streams.md
+++ b/docs/coverage/detail/msg.kafka-streams.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/msg.node-schedule.md
+++ b/docs/coverage/detail/msg.node-schedule.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.orm-lifecycle-hooks-jsts.md
+++ b/docs/coverage/detail/msg.orm-lifecycle-hooks-jsts.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.orm-lifecycle-hooks-py.md
+++ b/docs/coverage/detail/msg.orm-lifecycle-hooks-py.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.orm-lifecycle-hooks-ruby.md
+++ b/docs/coverage/detail/msg.orm-lifecycle-hooks-ruby.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.phoenix-channels.md
+++ b/docs/coverage/detail/msg.phoenix-channels.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/msg.resque.md
+++ b/docs/coverage/detail/msg.resque.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.rufus-scheduler.md
+++ b/docs/coverage/detail/msg.rufus-scheduler.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/msg.sidekiq.md
+++ b/docs/coverage/detail/msg.sidekiq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
 - **Capability cells:** 2
 
 ## Capabilities

--- a/docs/coverage/detail/msg.signalr.md
+++ b/docs/coverage/detail/msg.signalr.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.sse.md
+++ b/docs/coverage/detail/msg.sse.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 3
 
 ## Capabilities

--- a/docs/coverage/detail/msg.webhook.md
+++ b/docs/coverage/detail/msg.webhook.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Webhooks
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/msg.websocket.md
+++ b/docs/coverage/detail/msg.websocket.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Realtime Channels
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/msg.whenever.md
+++ b/docs/coverage/detail/msg.whenever.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -5172,6 +5172,7 @@
     {
       "id": "lang.c-cpp.framework.librdkafka",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "c-cpp",
       "label": "librdkafka (C/C++ Kafka client)",
       "capabilities": {
@@ -5473,6 +5474,7 @@
     {
       "id": "lang.c-cpp.framework.mqtt",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "c-cpp",
       "label": "MQTT (Paho C/C++ / Mosquitto)",
       "capabilities": {
@@ -7656,6 +7658,7 @@
     {
       "id": "lang.c-cpp.framework.zeromq",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "c-cpp",
       "label": "ZeroMQ (libzmq/cppzmq)",
       "capabilities": {
@@ -14590,6 +14593,7 @@
     {
       "id": "lang.elixir.framework.broadway",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "elixir",
       "label": "Broadway (Elixir data pipelines)",
       "capabilities": {
@@ -68186,6 +68190,7 @@
     {
       "id": "lang.rust.framework.lapin",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "rust",
       "label": "lapin (AMQP/RabbitMQ)",
       "capabilities": {
@@ -68498,6 +68503,7 @@
     {
       "id": "lang.rust.framework.rdkafka",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "rust",
       "label": "rdkafka (Kafka)",
       "capabilities": {
@@ -76936,6 +76942,7 @@
     {
       "id": "msg.actioncable",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "ruby",
       "label": "Rails ActionCable",
       "capabilities": {
@@ -76951,6 +76958,7 @@
     {
       "id": "msg.apscheduler",
       "category": "message_broker",
+      "subcategory": "schedulers",
       "language": "python",
       "label": "APScheduler (Python advanced scheduler)",
       "capabilities": {
@@ -76965,6 +76973,7 @@
     {
       "id": "msg.broker.amqp",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "AMQP (generic)",
       "capabilities": {
@@ -76988,6 +76997,7 @@
     {
       "id": "msg.broker.azure-service-bus",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Azure Service Bus / Event Hubs",
       "capabilities": {
@@ -77011,6 +77021,7 @@
     {
       "id": "msg.broker.cloudevents",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "CloudEvents",
       "capabilities": {
@@ -77034,6 +77045,7 @@
     {
       "id": "msg.broker.debezium",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Debezium (CDC)",
       "capabilities": {
@@ -77057,6 +77069,7 @@
     {
       "id": "msg.broker.eventbridge",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "AWS EventBridge",
       "capabilities": {
@@ -77080,6 +77093,7 @@
     {
       "id": "msg.broker.eventgrid",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Azure Event Grid",
       "capabilities": {
@@ -77103,6 +77117,7 @@
     {
       "id": "msg.broker.gcp-pubsub",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "GCP Pub/Sub",
       "capabilities": {
@@ -77126,6 +77141,7 @@
     {
       "id": "msg.broker.kafka",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Apache Kafka",
       "capabilities": {
@@ -77149,6 +77165,7 @@
     {
       "id": "msg.broker.mqtt",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "MQTT",
       "capabilities": {
@@ -77172,6 +77189,7 @@
     {
       "id": "msg.broker.nats",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "NATS",
       "capabilities": {
@@ -77195,6 +77213,7 @@
     {
       "id": "msg.broker.pulsar",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Apache Pulsar",
       "capabilities": {
@@ -77219,6 +77238,7 @@
     {
       "id": "msg.broker.rabbitmq",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "RabbitMQ",
       "capabilities": {
@@ -77243,6 +77263,7 @@
     {
       "id": "msg.broker.redis",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Redis pub/sub \u0026 streams",
       "capabilities": {
@@ -77266,6 +77287,7 @@
     {
       "id": "msg.broker.sns",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "AWS SNS",
       "capabilities": {
@@ -77289,6 +77311,7 @@
     {
       "id": "msg.broker.sqs",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "AWS SQS",
       "capabilities": {
@@ -77312,6 +77335,7 @@
     {
       "id": "msg.bullmq",
       "category": "message_broker",
+      "subcategory": "task_queues",
       "language": "jsts",
       "label": "BullMQ / bull (Node task queue)",
       "capabilities": {
@@ -77336,6 +77360,7 @@
     {
       "id": "msg.celery",
       "category": "message_broker",
+      "subcategory": "task_queues",
       "language": "python",
       "label": "Celery (Python task queue)",
       "capabilities": {
@@ -77359,6 +77384,7 @@
     {
       "id": "msg.django-channels",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "python",
       "label": "Django Channels",
       "capabilities": {
@@ -77374,6 +77400,7 @@
     {
       "id": "msg.django-signals",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "python",
       "label": "Django signals (intra-repo pub/sub)",
       "capabilities": {
@@ -77398,6 +77425,7 @@
     {
       "id": "msg.dramatiq",
       "category": "message_broker",
+      "subcategory": "task_queues",
       "language": "python",
       "label": "Dramatiq (Python task queue)",
       "capabilities": {
@@ -77418,6 +77446,7 @@
     {
       "id": "msg.graphql-subscriptions",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "multi",
       "label": "GraphQL subscriptions",
       "capabilities": {
@@ -77441,6 +77470,7 @@
     {
       "id": "msg.hangfire-recurring",
       "category": "message_broker",
+      "subcategory": "schedulers",
       "language": "csharp",
       "label": "Hangfire RecurringJob (.NET scheduled jobs)",
       "capabilities": {
@@ -77455,6 +77485,7 @@
     {
       "id": "msg.kafka-streams",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "multi",
       "label": "Kafka Streams / Faust",
       "capabilities": {
@@ -77473,6 +77504,7 @@
     {
       "id": "msg.node-schedule",
       "category": "message_broker",
+      "subcategory": "schedulers",
       "language": "jsts",
       "label": "node-schedule (Node scheduled jobs)",
       "capabilities": {
@@ -77487,6 +77519,7 @@
     {
       "id": "msg.orm-lifecycle-hooks-jsts",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "jsts",
       "label": "ORM model lifecycle-hook → handler TRIGGERS (TypeORM, Sequelize, Mongoose)",
       "capabilities": {
@@ -77510,6 +77543,7 @@
     {
       "id": "msg.orm-lifecycle-hooks-py",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "python",
       "label": "ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)",
       "capabilities": {
@@ -77533,6 +77567,7 @@
     {
       "id": "msg.orm-lifecycle-hooks-ruby",
       "category": "message_broker",
+      "subcategory": "brokers",
       "language": "ruby",
       "label": "ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)",
       "capabilities": {
@@ -77556,6 +77591,7 @@
     {
       "id": "msg.phoenix-channels",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "elixir",
       "label": "Phoenix Channels",
       "capabilities": {
@@ -77588,6 +77624,7 @@
     {
       "id": "msg.resque",
       "category": "message_broker",
+      "subcategory": "task_queues",
       "language": "ruby",
       "label": "Resque (Ruby task queue)",
       "capabilities": {
@@ -77614,6 +77651,7 @@
     {
       "id": "msg.rufus-scheduler",
       "category": "message_broker",
+      "subcategory": "schedulers",
       "language": "ruby",
       "label": "rufus-scheduler (Ruby in-process scheduler)",
       "capabilities": {
@@ -77628,6 +77666,7 @@
     {
       "id": "msg.sidekiq",
       "category": "message_broker",
+      "subcategory": "task_queues",
       "language": "ruby",
       "label": "Sidekiq (Ruby task queue)",
       "capabilities": {
@@ -77648,6 +77687,7 @@
     {
       "id": "msg.signalr",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "multi",
       "label": "SignalR",
       "capabilities": {
@@ -77670,6 +77710,7 @@
     {
       "id": "msg.sse",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "multi",
       "label": "Server-Sent Events",
       "capabilities": {
@@ -77692,6 +77733,7 @@
     {
       "id": "msg.webhook",
       "category": "message_broker",
+      "subcategory": "webhooks",
       "language": "multi",
       "label": "Webhooks",
       "capabilities": {
@@ -77721,6 +77763,7 @@
     {
       "id": "msg.websocket",
       "category": "message_broker",
+      "subcategory": "realtime_channels",
       "language": "multi",
       "label": "WebSocket",
       "capabilities": {
@@ -77753,6 +77796,7 @@
     {
       "id": "msg.whenever",
       "category": "message_broker",
+      "subcategory": "schedulers",
       "language": "ruby",
       "label": "whenever (Ruby cron / config/schedule.rb)",
       "capabilities": {

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -56,6 +56,7 @@ categories:
     subcategory_order: [orm_mapper]
   message_broker:
     capabilities: [producer_extraction, consumer_extraction, topic_attribution, room_channel_grouping, signature_verification]
+    subcategory_order: [schedulers, task_queues, brokers, realtime_channels, webhooks]
   observability:
     capabilities: [trace_extraction, metric_extraction, log_extraction]
   build_system:
@@ -772,4 +773,61 @@ subcategories:
     capabilities:
       - resource_extraction
       - dependency_attribution
+    groups: []
+
+  # message_broker subcategories (#4008, B5 epic #3871). The 44 records mix
+  # five behaviourally distinct mechanisms, so the flat by-category pivot was
+  # a 7-wide union in which room_channel_grouping (carried by 4 records) and
+  # signature_verification (carried by 1) were near-empty columns — 104 "—"
+  # cells the #4007 column-strand guard could not touch (every column carries
+  # ≥1 real cell category-wide). These lanes carve the category into coherent
+  # subgroups, each declaring only the capability columns its records actually
+  # carry, so every per-subgroup pivot is dense (no group taxonomy: per-
+  # capability columns; the don't-strand guard is N/A within each lane). The
+  # registry subcategory field on each record routes it here; cells still
+  # validate against the message_broker category-level allow-list (status
+  # fields unchanged — presentation/taxonomy only).
+  schedulers:
+    display: "Schedulers"
+    parent_category: message_broker
+    capabilities:
+      - consumer_extraction
+    groups: []
+
+  task_queues:
+    display: "Task Queues"
+    parent_category: message_broker
+    capabilities:
+      - consumer_extraction
+      - producer_extraction
+      - topic_attribution
+    groups: []
+
+  brokers:
+    display: "Brokers"
+    parent_category: message_broker
+    capabilities:
+      - consumer_extraction
+      - producer_extraction
+      - topic_attribution
+    groups: []
+
+  realtime_channels:
+    display: "Realtime Channels"
+    parent_category: message_broker
+    capabilities:
+      - consumer_extraction
+      - producer_extraction
+      - room_channel_grouping
+      - topic_attribution
+    groups: []
+
+  webhooks:
+    display: "Webhooks"
+    parent_category: message_broker
+    capabilities:
+      - consumer_extraction
+      - producer_extraction
+      - signature_verification
+      - topic_attribution
     groups: []

--- a/tools/coverage/message_broker_subcategory_test.go
+++ b/tools/coverage/message_broker_subcategory_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// msgBrokerReg builds an in-memory registry covering the message_broker
+// subcategory lanes (#4008, B5 epic #3871). Before the split, the 44
+// records rendered one 7-wide union pivot in which room_channel_grouping
+// (4 records) and signature_verification (1 record) were near-empty
+// columns — 104 "—" cells the #4007 column-strand guard could not touch
+// (every column carried ≥1 real cell category-wide). The fixture includes
+// one representative per lane plus the two columns that were sparse so the
+// tests can assert each carved lane declares only its own dense columns.
+func msgBrokerReg() *Registry {
+	rec := func(id, sub, label string, caps map[string]string) Record {
+		c := map[string]Capability{}
+		for k, s := range caps {
+			c[k] = Capability{Status: s}
+		}
+		return Record{
+			ID: id, Category: "message_broker", Subcategory: sub,
+			Language: "multi", Label: label, Capabilities: c,
+		}
+	}
+	return &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			// Schedulers (consumer-only)
+			rec("msg.whenever", "schedulers", "whenever (Ruby cron)",
+				map[string]string{"consumer_extraction": "full"}),
+			rec("msg.apscheduler", "schedulers", "APScheduler",
+				map[string]string{"consumer_extraction": "full"}),
+			// Task Queues (consumer + producer [+ topic])
+			rec("msg.sidekiq", "task_queues", "Sidekiq (Ruby task queue)",
+				map[string]string{"consumer_extraction": "partial", "producer_extraction": "partial"}),
+			rec("msg.celery", "task_queues", "Celery (Python task queue)",
+				map[string]string{"consumer_extraction": "full", "producer_extraction": "full", "topic_attribution": "full"}),
+			// Brokers (consumer + producer + topic)
+			rec("msg.broker.kafka", "brokers", "Apache Kafka",
+				map[string]string{"consumer_extraction": "full", "producer_extraction": "full", "topic_attribution": "full"}),
+			rec("msg.broker.rabbitmq", "brokers", "RabbitMQ",
+				map[string]string{"consumer_extraction": "full", "producer_extraction": "full", "topic_attribution": "full"}),
+			// Realtime Channels (room/channel grouping; some lack it)
+			rec("msg.actioncable", "realtime_channels", "Rails ActionCable",
+				map[string]string{"room_channel_grouping": "full"}),
+			rec("msg.websocket", "realtime_channels", "WebSocket",
+				map[string]string{"consumer_extraction": "full", "producer_extraction": "full", "room_channel_grouping": "full", "topic_attribution": "partial"}),
+			rec("msg.signalr", "realtime_channels", "SignalR",
+				map[string]string{"consumer_extraction": "missing", "producer_extraction": "full"}),
+			// Webhooks (signature verification)
+			rec("msg.webhook", "webhooks", "Webhooks",
+				map[string]string{"consumer_extraction": "full", "producer_extraction": "full", "signature_verification": "full", "topic_attribution": "partial"}),
+		},
+	}
+}
+
+// TestMessageBrokerSubcategoryLanes asserts the #4008 redesign: the
+// message_broker by-category page is split into five behaviourally
+// distinct subcategory lanes, each declaring ONLY the capability columns
+// its records actually carry (no 5-wide union sprawl). This is the fix
+// that kills the 104-em-dash flat pivot.
+func TestMessageBrokerSubcategoryLanes(t *testing.T) {
+	root := t.TempDir()
+	if err := generate(msgBrokerReg(), root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	page := readFile(t, filepath.Join(root, "docs/coverage/by-category/message_broker.md"))
+
+	// Each lane renders as its own section heading, in the dictionary's
+	// declared subcategory_order.
+	wantOrder := []string{
+		"## Schedulers",
+		"## Task Queues",
+		"## Brokers",
+		"## Realtime Channels",
+		"## Webhooks",
+	}
+	prev := -1
+	for _, h := range wantOrder {
+		i := strings.Index(page, h)
+		if i < 0 {
+			t.Errorf("message_broker.md missing subcategory section %q\n%s", h, page)
+			continue
+		}
+		if i < prev {
+			t.Errorf("subcategory section %q out of declared order", h)
+		}
+		prev = i
+	}
+
+	// Per-lane column sets: each lane header carries exactly the capability
+	// columns its records declare, and NONE of the columns that belong only
+	// to other lanes (the sparse-union leak the redesign removes).
+	cases := []struct {
+		lane    string
+		want    []string // columns that MUST appear in this lane's header
+		notWant []string // columns that MUST NOT appear (other lanes' vocab)
+		rec     string
+	}{
+		{
+			"## Schedulers",
+			[]string{"Consumer extraction"},
+			[]string{"Producer extraction", "Topic attribution", "Room channel grouping", "Signature verification"},
+			"msg.whenever",
+		},
+		{
+			"## Task Queues",
+			[]string{"Consumer extraction", "Producer extraction", "Topic attribution"},
+			[]string{"Room channel grouping", "Signature verification"},
+			"msg.sidekiq",
+		},
+		{
+			"## Brokers",
+			[]string{"Consumer extraction", "Producer extraction", "Topic attribution"},
+			[]string{"Room channel grouping", "Signature verification"},
+			"msg.broker.kafka",
+		},
+		{
+			"## Realtime Channels",
+			[]string{"Consumer extraction", "Producer extraction", "Room channel grouping", "Topic attribution"},
+			[]string{"Signature verification"},
+			"msg.actioncable",
+		},
+		{
+			"## Webhooks",
+			[]string{"Consumer extraction", "Producer extraction", "Signature verification", "Topic attribution"},
+			[]string{"Room channel grouping"},
+			"msg.webhook",
+		},
+	}
+	for _, c := range cases {
+		body := sectionBody(page, c.lane)
+		if !strings.Contains(body, c.rec) {
+			t.Errorf("lane %q should contain record %s\n%s", c.lane, c.rec, body)
+		}
+		header := firstTableHeader(body)
+		if header == "" {
+			t.Errorf("lane %q has no table header\n%s", c.lane, body)
+			continue
+		}
+		for _, col := range c.want {
+			if !strings.Contains(header, col) {
+				t.Errorf("lane %q header missing its own column %q: %s", c.lane, col, header)
+			}
+		}
+		for _, col := range c.notWant {
+			if strings.Contains(header, col) {
+				t.Errorf("lane %q header carries foreign column %q (sparse-union leak): %s", c.lane, col, header)
+			}
+		}
+	}
+
+	// Signature verification lives ONLY on the Webhooks lane and Room
+	// channel grouping ONLY on Realtime — the two columns that were
+	// near-empty in the old flat union are now confined to where they apply.
+	if strings.Count(page, "Signature verification") != 1 {
+		t.Errorf("Signature verification column should appear in exactly one lane (Webhooks)")
+	}
+	if strings.Count(page, "Room channel grouping") != 1 {
+		t.Errorf("Room channel grouping column should appear in exactly one lane (Realtime Channels)")
+	}
+
+	// No structurally-always-empty column: every declared lane column is
+	// backed by ≥1 non-"—" cell. This is the core anti-sprawl invariant.
+	assertNoAlwaysEmptyColumn(t, page)
+}
+
+// TestMessageBrokerSubcategoriesDeclared pins the dictionary taxonomy for
+// message_broker so a future edit can't silently drop a lane or reorder it.
+func TestMessageBrokerSubcategoriesDeclared(t *testing.T) {
+	want := []string{"schedulers", "task_queues", "brokers", "realtime_channels", "webhooks"}
+	got := dict().SubcategoriesByCategory("message_broker")
+	if len(got) != len(want) {
+		t.Fatalf("SubcategoriesByCategory(message_broker) = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("SubcategoriesByCategory(message_broker)[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+		if !dict().HasSubcategory("message_broker", want[i]) {
+			t.Errorf("dictionary missing message_broker subcategory %q", want[i])
+		}
+	}
+
+	// Per-lane allow-lists declare only the keys that lane's records carry.
+	laneKeys := map[string][]string{
+		"schedulers":        {"consumer_extraction"},
+		"task_queues":       {"consumer_extraction", "producer_extraction", "topic_attribution"},
+		"brokers":           {"consumer_extraction", "producer_extraction", "topic_attribution"},
+		"realtime_channels": {"consumer_extraction", "producer_extraction", "room_channel_grouping", "topic_attribution"},
+		"webhooks":          {"consumer_extraction", "producer_extraction", "signature_verification", "topic_attribution"},
+	}
+	for lane, wantKeys := range laneKeys {
+		got := map[string]bool{}
+		for _, k := range dict().SubcategoryCapabilities(lane) {
+			got[k] = true
+		}
+		if len(got) != len(wantKeys) {
+			t.Errorf("lane %q capabilities = %v, want %v", lane, dict().SubcategoryCapabilities(lane), wantKeys)
+		}
+		for _, k := range wantKeys {
+			if !got[k] {
+				t.Errorf("lane %q missing declared capability %q", lane, k)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #4008 · Epic #3871 · Program #3628

## What

The `message_broker` by-category page rendered one flat **7-wide union pivot** in which `room_channel_grouping` (carried by 4 records) and `signature_verification` (1 record) were near-empty columns — **104 "—" cells** the #4007 non-stranded column-drop could not touch, because every union column carries ≥1 real cell *category-wide*. The B5 audit (#3874) verdict was a **registry subcategory split**, not a column drop. This PR delivers it.

Carve the 44 records into five behaviourally distinct lanes, each declaring **only** the capability columns its records actually carry (no empty-column union), mirroring the `http_framework` / platform (#3861) subcategory model.

## Per-record subgroup assignment (44)

| Lane | Columns | Records |
|---|---|---|
| **Schedulers** | Consumer | apscheduler, hangfire-recurring, node-schedule, rufus-scheduler, whenever |
| **Task Queues** | Consumer · Producer · Topic | bullmq, celery, dramatiq, resque, sidekiq |
| **Brokers** | Consumer · Producer · Topic | kafka, rabbitmq, nats, sns, sqs, pulsar, redis, eventbridge, gcp-pubsub, azure-service-bus, eventgrid, amqp, mqtt, cloudevents, debezium, kafka-streams, django-signals, orm-lifecycle-hooks-{jsts,py,ruby}, librdkafka, rdkafka, lapin, c-cpp mqtt, zeromq, broadway |
| **Realtime Channels** | Consumer · Producer · Room channel grouping · Topic | actioncable, django-channels, phoenix-channels, websocket, signalr, sse, graphql-subscriptions |
| **Webhooks** | Consumer · Producer · Signature verification · Topic | webhook |

## Implementation

- **`registry.json`** — surgically set `subcategory` on each of the 44 records (purely additive: 44 insertions, 0 deletions; no status/cell touched). The existing `splitCategoryRowsBySubcategory` render path picks them up.
- **`capability-dictionary.yaml`** — declare the 5 subcategories + per-lane column allow-lists + `subcategory_order`.
- **`generate.go`** — *no change*; the subcategory-split machinery already groups any category whose records carry a subcategory (same path platform/http_framework use).
- New value-asserting `message_broker_subcategory_test.go` — pins the 5 lane headings + order, per-lane column sets (asserts foreign columns are absent), record placement, the no-always-empty-column invariant, `Signature verification`/`Room channel grouping` confined to one lane each, and the dictionary taxonomy.

## Sparsity before → after (`message_broker.md` em-dash cells)

**105 → 15.** The 15 remaining are honest per-lane gaps (e.g. sidekiq/dramatiq have no topic; sse/signalr/graphql-subscriptions have no room grouping). The two formerly near-empty union columns are now confined to the lane where they apply.

## Presentation-only / quality

- Every cell's **status is unchanged** — JSON status-diff across all 3843 status cells is **empty**; the registry diff is 44 additive `subcategory` lines only.
- `gen` **idempotent** (run twice → 0 drift).
- `go test ./tools/coverage/...` green · `coverage validate` **0 errors** · `fmt --check` canonical · `gofmt -l` empty · `go vet` clean.

DEPLOY-DEFERRED: docs + generator-config only, no runtime/indexer path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)