### PR TITLE
C/C++ rate_limit_stamping for Drogon (greenfield #4115)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -15,7 +15,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 | [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 | [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/11 | |
 | [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
 | [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | — | ✅ 4/4 | ✅ 1/1 | 🟡 22/25 | 🟡 3/8 | |
 | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 7/11 | |
 | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
 | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |
 | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/25 | 🟡 6/11 | |

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | 4115 | `internal/custom/cpp/rate_limit.go` | #4115: Drogon is the ONE C++ framework with a genuine in-code rate-limit idiom. Stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/rate_limit_name/limit/period) for (1) the drogon::RateLimiter::newRateLimiter(capacity, std::chrono::window) token-bucket factory — human rate resolved from a literal capacity + chrono window (chrono::seconds(n) and the 60s/2min user-defined-literal spellings), engine-scope; and (2) a rate-limit HttpFilter subclass + its FILTER_ADD route binding (route-scope) / registerFilter<X> registration (engine-scope), gated on a throttle-named filter so a plain auth/logging filter is not mis-stamped. Partial: regex heuristic, no cross-TU filter resolution, no RateLimiter-instance to route binding. Negatives proven (auth filter, external/nginx delegation). |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/restinio_middleware.go` | non_matched_request_handler, make_chain<H1,H2,...>, request_handler chaining detected; regex/partial |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🔴 `missing` | — | 4115 | — | #4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern. |
 
 ### Schema
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3530,8 +3530,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -3817,8 +3817,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -4103,9 +4103,11 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "partial",
+            "cites": ["internal/custom/cpp/rate_limit.go"],
+            "issue": "4115",
+            "notes": "#4115: Drogon is the ONE C++ framework with a genuine in-code rate-limit idiom. Stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/rate_limit_name/limit/period) for (1) the drogon::RateLimiter::newRateLimiter(capacity, std::chrono::window) token-bucket factory — human rate resolved from a literal capacity + chrono window (chrono::seconds(n) and the 60s/2min user-defined-literal spellings), engine-scope; and (2) a rate-limit HttpFilter subclass + its FILTER_ADD route binding (route-scope) / registerFilter\u003cX\u003e registration (engine-scope), gated on a throttle-named filter so a plain auth/logging filter is not mis-stamped. Partial: regex heuristic, no cross-TU filter resolution, no RateLimiter-instance to route binding. Negatives proven (auth filter, external/nginx delegation).",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {
@@ -5620,8 +5622,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -5907,8 +5909,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -6194,8 +6196,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -6970,8 +6972,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {
@@ -7257,8 +7259,8 @@
           },
           "rate_limit_stamping": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "issue": "4115",
+            "notes": "#4115 (verify-first): C++ rate limiting for this framework is predominantly external/middleware (nginx/envoy/API gateway) or hand-rolled — there is no framework-native, statically-detectable rate-limit primitive (unlike Drogon's drogon::RateLimiter / rate-limit HttpFilter). Honestly left missing rather than fabricating coverage for an externally-enforced concern."
           }
         },
         "Schema": {

--- a/internal/custom/cpp/rate_limit.go
+++ b/internal/custom/cpp/rate_limit.go
@@ -1,0 +1,314 @@
+package cpp
+
+// rate_limit.go — endpoint rate-limit / throttle stamping for C/C++ HTTP
+// frameworks (#4115, child of #3628 Middleware/rate_limit_stamping).
+//
+// C/C++ greenfield: prior to this pass EVERY C/C++ HTTP-framework cell for
+// rate_limit_stamping was `missing`. This pass is deliberately NARROW because
+// the honest, verify-first finding is that C++ web frameworks predominantly
+// delegate rate limiting to EXTERNAL infrastructure (nginx / envoy / an API
+// gateway) — there is no in-code primitive to detect for most of them:
+//
+//	oatpp / Crow / Pistache / POCO / Restbed / RESTinio / cpprestsdk
+//	  — no framework-native rate-limit type. Rate limiting, when present, is
+//	    either external middleware or a bespoke token-bucket the project rolled
+//	    itself. Those remain honestly `missing` (see registry notes); inventing
+//	    a "rate_limited" stamp for a hand-rolled counter would be fabrication.
+//
+// The ONE C++ framework with a genuine, statically-detectable rate-limit idiom
+// is Drogon, which ships a first-class rate limiter:
+//
+//	1. drogon::RateLimiter factory — the token-bucket primitive:
+//	     auto limiter = drogon::RateLimiter::newRateLimiter(
+//	         100, std::chrono::seconds(60));
+//	   Group: capacity (the request cap) + a std::chrono window. We resolve the
+//	   cap + window/seconds → human rate "100/60s" when both are literal. The
+//	   RateLimiterPtr type alias usage is the same signal.
+//
+//	2. A Drogon HttpFilter whose name marks it a rate limiter, bound to routes:
+//	     class RateLimitFilter : public HttpFilter<RateLimitFilter> { ... };
+//	     FILTER_ADD("RateLimitFilter");   // per-controller route binding
+//	     app().registerFilter<RateLimitFilter>();
+//	   A filter is Drogon's per-route middleware hook, so a rate-limit filter
+//	   bound via FILTER_ADD is route-scoped throttling. The filter CLASS itself
+//	   (scope=engine until bound) and each FILTER_ADD binding (scope=route) are
+//	   stamped, naming the filter as evidence. Only filters whose name carries a
+//	   rate-limit signal (RateLimit / Throttle / RateLimiter) are stamped — a
+//	   plain auth/logging filter is NOT a throttle (that stays auth_middleware's
+//	   job and is the negative here).
+//
+// Shared flat contract (same keys every other language stamps so the graph
+// answers "which surfaces are throttled and at what rate?"):
+//
+//	rate_limited      — "true" when a throttle applies.
+//	rate_limit        — human rate "100/60s" when statically resolvable from a
+//	                    literal capacity + literal std::chrono window; OMITTED
+//	                    (honest-partial) otherwise.
+//	rate_limit_scope  — "route"  (a RateLimitFilter bound via FILTER_ADD)
+//	                    | "engine" (a RateLimiter factory / a rate-limit filter
+//	                      class definition not yet bound to a route in-file).
+//	rate_limit_source — the recognised idiom: "drogon_ratelimiter" (the factory)
+//	                    | "drogon_filter" (a rate-limit HttpFilter / binding).
+//	rate_limit_name   — the filter class name (evidence) when from a filter.
+//	limit / period    — the resolved numeric cap + window-seconds (when literal).
+//
+// Every surface adds a SCOPE.Pattern/rate_limit marker (the multi-line Drogon
+// idioms do not reduce to a single route op the way a decorator does), mirroring
+// the csharp/elixir marker model.
+//
+// Honesty: partial — heuristic regex on source text. We capture the concrete
+// limiter capacity/window and the concrete filter symbol within a file, but do
+// NOT resolve a filter class defined in another translation unit, nor bind a
+// RateLimiter instance to a specific route. Negatives proven: a non-throttle
+// filter and an external/nginx comment do not stamp.
+//
+// Refs #4115.
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_rate_limit", &cppRateLimitExtractor{})
+}
+
+type cppRateLimitExtractor struct{}
+
+func (e *cppRateLimitExtractor) Language() string { return "custom_cpp_rate_limit" }
+
+var (
+	// drogon::RateLimiter::newRateLimiter(100, std::chrono::seconds(60))
+	// drogon::RateLimiter::newRateLimiter(50, 30s)                       (chrono literal)
+	// Group 1 = capacity literal. The window is parsed separately from the
+	// remainder of the call args by reChronoWindow so both the std::chrono::X(n)
+	// spelling and the `30s`/`2min` chrono-literal suffix spelling are handled.
+	reDrogonRateLimiterNew = regexp.MustCompile(
+		`\bRateLimiter::newRateLimiter\s*\(\s*(\d+)\s*,\s*([^)]*\)?[^,)]*)\)`)
+
+	// std::chrono::seconds(60) / chrono::minutes(2) / std::chrono::hours(1)
+	// — the explicit-duration window spelling. Group 1 = unit, group 2 = count.
+	reChronoDuration = regexp.MustCompile(
+		`chrono::(seconds|minutes|hours|milliseconds)\s*\(\s*(\d+)\s*\)`)
+
+	// `60s` / `2min` / `1h` / `500ms` — the C++14 chrono user-defined-literal
+	// window spelling. Group 1 = count, group 2 = unit suffix.
+	reChronoLiteral = regexp.MustCompile(`\b(\d+)\s*(ms|s|min|h)\b`)
+
+	// The Drogon HttpFilter-class / FILTER_ADD / registerFilter<X> regexes are
+	// already declared (identically) in auth_middleware.go in this same package
+	// — reDrogonFilterClass, reDrogonFilterAdd, reDrogonRegisterFilter — and are
+	// reused here. We additionally gate each match through cppNameIsRateLimit so
+	// only a throttle-named filter is stamped as a rate limit (a plain auth /
+	// logging filter stays auth_middleware's concern and is the negative here).
+)
+
+// cppNameIsRateLimit reports whether a filter/class symbol name reads as a
+// rate-limit / throttle primitive (so a plain auth/logging filter is NOT
+// mis-stamped as a throttle). Conservative on purpose: only the unambiguous
+// rate-limit vocabulary qualifies.
+func cppNameIsRateLimit(name string) bool {
+	l := strings.ToLower(name)
+	return strings.Contains(l, "ratelimit") ||
+		strings.Contains(l, "rate_limit") ||
+		strings.Contains(l, "throttle") ||
+		strings.Contains(l, "ratelimiter")
+}
+
+// cppChronoSeconds converts a std::chrono duration unit + count to whole
+// seconds. A sub-second (milliseconds) window returns 0 so the caller reports
+// the rate in ms rather than rounding a sub-second window to 0s.
+func cppChronoSeconds(unit string, n int) (secs int, subSecondMs int) {
+	switch unit {
+	case "seconds", "s":
+		return n, 0
+	case "minutes", "min":
+		return n * 60, 0
+	case "hours", "h":
+		return n * 3600, 0
+	case "milliseconds", "ms":
+		return 0, n
+	}
+	return 0, 0
+}
+
+// cppResolveWindow extracts the window (in seconds, or sub-second ms) from the
+// trailing-args text of a newRateLimiter(...) call. Returns (secs, ms, ok).
+// Prefers the explicit std::chrono::unit(n) spelling; falls back to the chrono
+// user-defined-literal (`60s`) spelling.
+func cppResolveWindow(argsText string) (secs int, ms int, ok bool) {
+	if m := reChronoDuration.FindStringSubmatch(argsText); m != nil {
+		n, _ := strconv.Atoi(m[2])
+		s, sub := cppChronoSeconds(m[1], n)
+		return s, sub, true
+	}
+	if m := reChronoLiteral.FindStringSubmatch(argsText); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		s, sub := cppChronoSeconds(m[2], n)
+		return s, sub, true
+	}
+	return 0, 0, false
+}
+
+// cppHumanRate builds the shared "<limit>/<window>" rate from a cap + a window
+// expressed in seconds (or, for a sub-second window, milliseconds). Returns ""
+// when the window is unresolved.
+func cppHumanRate(limit, secs, ms int) string {
+	switch {
+	case secs > 0:
+		return strconv.Itoa(limit) + "/" + strconv.Itoa(secs) + "s"
+	case ms > 0:
+		return strconv.Itoa(limit) + "/" + strconv.Itoa(ms) + "ms"
+	}
+	return ""
+}
+
+func (e *cppRateLimitExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_rate_limit.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "cpp" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: must mention one of the recognised Drogon rate-limit idioms.
+	if !strings.Contains(src, "RateLimiter") &&
+		!strings.Contains(src, "HttpFilter") &&
+		!strings.Contains(src, "FILTER_ADD") &&
+		!strings.Contains(src, "registerFilter") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// ---------------------------------------------------------------------
+	// 1. drogon::RateLimiter::newRateLimiter(capacity, chrono-window)
+	//    The token-bucket factory. Engine-scope (a limiter instance is not
+	//    bound to a named route in-file). Resolves the human rate when the
+	//    capacity + window are both literal.
+	// ---------------------------------------------------------------------
+	for _, m := range reDrogonRateLimiterNew.FindAllStringSubmatchIndex(src, -1) {
+		cap, _ := strconv.Atoi(src[m[2]:m[3]])
+		argsText := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := "drogon_ratelimiter:" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_RATELIMITER",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "engine",
+			"rate_limit_source", "drogon_ratelimiter")
+		if cap > 0 {
+			ent.Properties["limit"] = strconv.Itoa(cap)
+		}
+		if secs, ms, ok := cppResolveWindow(argsText); ok {
+			if secs > 0 {
+				ent.Properties["period"] = strconv.Itoa(secs)
+			}
+			if cap > 0 {
+				if rate := cppHumanRate(cap, secs, ms); rate != "" {
+					ent.Properties["rate_limit"] = rate
+				}
+			}
+		}
+		add(ent)
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. Rate-limit HttpFilter subclasses + their route bindings.
+	//    A filter whose name reads as a throttle is a Drogon rate-limit
+	//    middleware. The class definition is engine-scope (not yet bound); a
+	//    FILTER_ADD("X") / registerFilter<X>() binding naming a rate-limit
+	//    filter is route-scope throttling.
+	// ---------------------------------------------------------------------
+
+	// 2a. The filter class definition (engine scope).
+	for _, m := range reDrogonFilterClass.FindAllStringSubmatchIndex(src, -1) {
+		fname := src[m[2]:m[3]]
+		if !cppNameIsRateLimit(fname) {
+			continue // a plain auth/logging filter — not a throttle (negative).
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity("drogon_ratelimit_filter:"+fname, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_RATELIMIT_FILTER",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "engine",
+			"rate_limit_source", "drogon_filter",
+			"rate_limit_name", fname)
+		add(ent)
+	}
+
+	// 2b. FILTER_ADD("X") — per-route binding (route scope) of a rate-limit filter.
+	for _, m := range reDrogonFilterAdd.FindAllStringSubmatchIndex(src, -1) {
+		fname := src[m[2]:m[3]]
+		if !cppNameIsRateLimit(fname) {
+			continue
+		}
+		line := lineOf(src, m[0])
+		name := "drogon_ratelimit_bind:" + fname + ":" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_RATELIMIT_FILTER",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "route",
+			"rate_limit_source", "drogon_filter",
+			"rate_limit_name", fname,
+			"rate_limit_binding", "FILTER_ADD")
+		add(ent)
+	}
+
+	// 2c. registerFilter<X>() — global registration (engine scope) of a rate-limit filter.
+	for _, m := range reDrogonRegisterFilter.FindAllStringSubmatchIndex(src, -1) {
+		fname := src[m[2]:m[3]]
+		if !cppNameIsRateLimit(fname) {
+			continue
+		}
+		line := lineOf(src, m[0])
+		name := "drogon_ratelimit_register:" + fname + ":" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_RATELIMIT_FILTER",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "engine",
+			"rate_limit_source", "drogon_filter",
+			"rate_limit_name", fname,
+			"rate_limit_binding", "registerFilter")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/rate_limit_test.go
+++ b/internal/custom/cpp/rate_limit_test.go
@@ -1,0 +1,243 @@
+package cpp_test
+
+// rate_limit_test.go — value-asserting fixtures for the C++ (Drogon)
+// rate_limit_stamping pass (#4115). Proves the flat contract
+// (rate_limited / rate_limit / rate_limit_scope / rate_limit_source /
+// rate_limit_name / limit / period) fires for the genuine Drogon idioms and
+// proves the negatives (non-throttle filter, external/nginx rate limiting,
+// non-Drogon C++ frameworks) do NOT stamp.
+
+import "testing"
+
+// findRateLimit returns the first SCOPE.Pattern/rate_limit entity whose
+// rate_limit_name (or, when absent, Name) matches, or nil.
+func findRateLimit(ents []entitySummary, pred func(entitySummary) bool) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Subtype == "rate_limit" && pred(ents[i]) {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func anyRateLimit(ents []entitySummary) bool {
+	return findRateLimit(ents, func(entitySummary) bool { return true }) != nil
+}
+
+// --- 1. drogon::RateLimiter factory with std::chrono::seconds window -------
+
+func TestCppRateLimit_DrogonRateLimiterChronoSeconds(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+#include <drogon/utils/RateLimiter.h>
+using namespace drogon;
+void setup() {
+    auto limiter = drogon::RateLimiter::newRateLimiter(100, std::chrono::seconds(60));
+}`
+	ents := extract(t, "custom_cpp_rate_limit", fi("svc.cc", "cpp", src))
+	e := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "drogon_ratelimiter"
+	})
+	if e == nil {
+		t.Fatalf("expected drogon_ratelimiter rate-limit entity, got %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if e.Props["limit"] != "100" {
+		t.Errorf("limit = %q, want 100", e.Props["limit"])
+	}
+	if e.Props["period"] != "60" {
+		t.Errorf("period = %q, want 60", e.Props["period"])
+	}
+	if e.Props["rate_limit"] != "100/60s" {
+		t.Errorf("rate_limit = %q, want 100/60s", e.Props["rate_limit"])
+	}
+	if e.Props["rate_limit_scope"] != "engine" {
+		t.Errorf("rate_limit_scope = %q, want engine", e.Props["rate_limit_scope"])
+	}
+}
+
+// --- 2. drogon::RateLimiter factory with chrono user-defined literal (2min) -
+
+func TestCppRateLimit_DrogonRateLimiterChronoLiteral(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+using namespace std::chrono_literals;
+auto rl = drogon::RateLimiter::newRateLimiter(30, 2min);`
+	ents := extract(t, "custom_cpp_rate_limit", fi("svc.cc", "cpp", src))
+	e := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "drogon_ratelimiter"
+	})
+	if e == nil {
+		t.Fatalf("expected drogon_ratelimiter entity, got %+v", ents)
+	}
+	if e.Props["limit"] != "30" {
+		t.Errorf("limit = %q, want 30", e.Props["limit"])
+	}
+	if e.Props["period"] != "120" { // 2min -> 120s
+		t.Errorf("period = %q, want 120", e.Props["period"])
+	}
+	if e.Props["rate_limit"] != "30/120s" {
+		t.Errorf("rate_limit = %q, want 30/120s", e.Props["rate_limit"])
+	}
+}
+
+// --- 3. RateLimiter with a non-literal window → honest-partial (rate omitted) -
+
+func TestCppRateLimit_DrogonRateLimiterPartialWindow(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+auto rl = drogon::RateLimiter::newRateLimiter(200, windowFromConfig());`
+	ents := extract(t, "custom_cpp_rate_limit", fi("svc.cc", "cpp", src))
+	e := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "drogon_ratelimiter"
+	})
+	if e == nil {
+		t.Fatalf("expected drogon_ratelimiter entity, got %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if e.Props["limit"] != "200" {
+		t.Errorf("limit = %q, want 200", e.Props["limit"])
+	}
+	if e.Props["rate_limit"] != "" {
+		t.Errorf("rate_limit = %q, want omitted (non-literal window)", e.Props["rate_limit"])
+	}
+	if e.Props["period"] != "" {
+		t.Errorf("period = %q, want omitted (non-literal window)", e.Props["period"])
+	}
+}
+
+// --- 4. Rate-limit HttpFilter class + FILTER_ADD route binding -------------
+
+func TestCppRateLimit_DrogonFilterAndBinding(t *testing.T) {
+	src := `
+#include <drogon/HttpFilter.h>
+using namespace drogon;
+class RateLimitFilter : public HttpFilter<RateLimitFilter> {
+  public:
+    void doFilter(const HttpRequestPtr &req, FilterCallback &&fcb, FilterChainCallback &&ccb) override;
+};
+class ApiController : public drogon::HttpController<ApiController> {
+  public:
+    METHOD_LIST_BEGIN
+    ADD_METHOD_TO(ApiController::list, "/api/items", Get);
+    METHOD_LIST_END
+    void list(...) {
+        FILTER_ADD("RateLimitFilter");
+    }
+};`
+	ents := extract(t, "custom_cpp_rate_limit", fi("ctrl.cc", "cpp", src))
+
+	cls := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_name"] == "RateLimitFilter" && s.Props["rate_limit_scope"] == "engine"
+	})
+	if cls == nil {
+		t.Fatalf("expected engine-scope rate-limit filter class entity, got %+v", ents)
+	}
+	if cls.Props["rate_limit_source"] != "drogon_filter" {
+		t.Errorf("class source = %q, want drogon_filter", cls.Props["rate_limit_source"])
+	}
+
+	bind := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_name"] == "RateLimitFilter" && s.Props["rate_limit_scope"] == "route"
+	})
+	if bind == nil {
+		t.Fatalf("expected route-scope FILTER_ADD binding entity, got %+v", ents)
+	}
+	if bind.Props["rate_limit_binding"] != "FILTER_ADD" {
+		t.Errorf("binding = %q, want FILTER_ADD", bind.Props["rate_limit_binding"])
+	}
+	if bind.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", bind.Props["rate_limited"])
+	}
+}
+
+// --- 5. registerFilter<X>() global registration ----------------------------
+
+func TestCppRateLimit_DrogonRegisterFilter(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+int main() {
+    drogon::app().registerFilter<ThrottleFilter>();
+    drogon::app().run();
+}`
+	ents := extract(t, "custom_cpp_rate_limit", fi("main.cc", "cpp", src))
+	e := findRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_binding"] == "registerFilter"
+	})
+	if e == nil {
+		t.Fatalf("expected registerFilter throttle entity, got %+v", ents)
+	}
+	if e.Props["rate_limit_name"] != "ThrottleFilter" {
+		t.Errorf("rate_limit_name = %q, want ThrottleFilter", e.Props["rate_limit_name"])
+	}
+	if e.Props["rate_limit_scope"] != "engine" {
+		t.Errorf("scope = %q, want engine", e.Props["rate_limit_scope"])
+	}
+}
+
+// --- NEGATIVE 6: a plain auth filter is NOT a throttle ---------------------
+
+func TestCppRateLimit_NegativeAuthFilterNotThrottle(t *testing.T) {
+	src := `
+#include <drogon/HttpFilter.h>
+class JwtAuthFilter : public drogon::HttpFilter<JwtAuthFilter> {
+    void doFilter(...) override;
+};
+void setup() {
+    FILTER_ADD("JwtAuthFilter");
+    drogon::app().registerFilter<LoginRequiredFilter>();
+}`
+	ents := extract(t, "custom_cpp_rate_limit", fi("auth.cc", "cpp", src))
+	if anyRateLimit(ents) {
+		t.Fatalf("auth/login filters must NOT stamp rate_limit; got %+v", ents)
+	}
+}
+
+// --- NEGATIVE 7: external (nginx/envoy) rate limiting is not in-code -------
+
+func TestCppRateLimit_NegativeExternalRateLimit(t *testing.T) {
+	// A Drogon service whose rate limiting is delegated to nginx — only a
+	// comment mentions it; nothing statically detectable in app code.
+	src := `
+#include <drogon/drogon.h>
+// Rate limiting is enforced by nginx (limit_req_zone) in front of this service.
+int main() {
+    drogon::app().registerHandler("/ping", [](const drogon::HttpRequestPtr &,
+        std::function<void(const drogon::HttpResponsePtr &)> &&cb) { /* ... */ });
+    drogon::app().run();
+}`
+	ents := extract(t, "custom_cpp_rate_limit", fi("main.cc", "cpp", src))
+	if anyRateLimit(ents) {
+		t.Fatalf("external/nginx rate limiting must NOT stamp; got %+v", ents)
+	}
+}
+
+// --- NEGATIVE 8: non-Drogon C++ frameworks have no detectable idiom --------
+
+func TestCppRateLimit_NegativeNonDrogonFrameworks(t *testing.T) {
+	// oatpp-style interceptor + a hand-rolled counter: no framework-native
+	// rate-limit primitive, so nothing is stamped (honest-missing).
+	src := `
+#include <oatpp/web/server/interceptor/RequestInterceptor.hpp>
+class MyInterceptor : public oatpp::web::server::interceptor::RequestInterceptor {
+    int requestCount = 0; // hand-rolled, not a framework primitive
+};`
+	ents := extract(t, "custom_cpp_rate_limit", fi("interceptor.cpp", "cpp", src))
+	if anyRateLimit(ents) {
+		t.Fatalf("non-Drogon C++ frameworks must NOT stamp rate_limit; got %+v", ents)
+	}
+}
+
+// --- NEGATIVE 9: wrong language gate (a .rs file mislabeled) ---------------
+
+func TestCppRateLimit_NegativeWrongLanguage(t *testing.T) {
+	src := `drogon::RateLimiter::newRateLimiter(100, std::chrono::seconds(60));`
+	ents := extract(t, "custom_cpp_rate_limit", fi("svc.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Fatalf("non-cpp language must yield no entities; got %+v", ents)
+	}
+}


### PR DESCRIPTION
Closes #4115. Child of #3628 (Middleware/rate_limit_stamping).

## Verify-first finding
C++ web frameworks predominantly delegate rate limiting to **external infrastructure** (nginx/envoy/API gateway) or hand-roll it — there is no framework-native, statically-detectable rate-limit primitive for most of them. **Drogon is the ONE framework with a genuine in-code idiom**, so this pass is deliberately narrow and honest rather than fabricating coverage.

| Framework | Result |
|---|---|
| **Drogon** | `partial` — real idiom credited |
| cpprestsdk / crow / oatpp / pistache / poco / restbed / restinio | honestly `missing` (external/middleware) |

## What ships
`internal/custom/cpp/rate_limit.go` (`custom_cpp_rate_limit`, auto-dispatched via the existing `custom_cpp_` prefix — no dispatch-parity change). Stamps the shared flat contract (`rate_limited`/`rate_limit`/`rate_limit_scope`/`rate_limit_source`/`rate_limit_name`/`limit`/`period`) for:

1. **`drogon::RateLimiter::newRateLimiter(capacity, std::chrono::window)`** token-bucket factory — human rate resolved from a literal capacity + chrono window (both the `chrono::seconds(n)` and the `60s`/`2min` user-defined-literal spellings); engine-scope; honest-partial (rate omitted) when the window is non-literal.
2. A **rate-limit `HttpFilter` subclass** + its **`FILTER_ADD`** route binding (route-scope) / **`registerFilter<X>`** registration (engine-scope), gated on a throttle-named filter so a plain auth/logging filter is **not** mis-stamped.

## Honesty / negatives
Partial — regex heuristic; no cross-TU filter resolution, no RateLimiter-instance→route binding. 4 negatives proven: a plain auth filter, external/nginx-delegated limiting, a non-Drogon framework, and a wrong-language file all yield **no** stamp.

## Registry
Drogon `rate_limit_stamping` missing→partial (cites `rate_limit.go`); the 7 externally-delegating frameworks keep `missing` with an accurate verify-first note. Derived coverage docs regenerated.

## Validation
- Full package tests green: `internal/custom/cpp`, `internal/engine`, `internal/extractors`, `tools/coverage`
- `covtool validate` 0 errors; `covtool fmt --check` canonical; `covtool gen` 0 drift
- gofmt clean; go vet clean

**DEPLOY-DEFERRED** (no live-daemon rebuild/reindex in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)