### PR TITLE
feat(engine): jsts ORM lifecycle hooks — add MikroORM entity decorators

### DIFF
--- a/internal/engine/orm_lifecycle_hook_edges.go
+++ b/internal/engine/orm_lifecycle_hook_edges.go
@@ -23,6 +23,7 @@
 //	TypeORM (jsts)               @AfterInsert() method  /  @EventSubscriber afterInsert
 //	Sequelize (jsts)             User.afterCreate((user)=>{...})  /  hooks:{afterCreate}
 //	Mongoose (jsts)              schema.post('save', fn)  /  schema.pre('save', fn)
+//	MikroORM (jsts)              @BeforeCreate() method  /  @OnLoad() method
 //
 // Honest-partial discipline: a dynamic / missing model (e.g. @receiver with no
 // sender, an all-models signal), a dynamic event name, or an anonymous /
@@ -138,6 +139,28 @@ var tsEntityClassRe = regexp.MustCompile(
 // method. Group 1 = decorator name (e.g. AfterInsert); Group 2 = method name.
 var tsLifecycleMethodRe = regexp.MustCompile(
 	`(?m)@(BeforeInsert|AfterInsert|BeforeUpdate|AfterUpdate|BeforeRemove|AfterRemove|BeforeSoftRemove|AfterSoftRemove|BeforeRecover|AfterRecover|AfterLoad)\s*\(\s*\)(?:\s*\n\s*@[^\n]*)*\s*\n\s*(?:async\s+)?(\w+)\s*\(`,
+)
+
+// mikroORMDecoratorEvents maps a MikroORM lifecycle hook decorator to its
+// event name. These are the MikroORM-EXCLUSIVE decorators: @BeforeUpdate /
+// @AfterUpdate / @AfterLoad share their decorator name with TypeORM and are
+// already handled (with the same event name) by tsLifecycleMethodRe, so
+// including them here would double-emit. Restricting this set to the
+// MikroORM-only decorators keeps emissions disjoint from the TypeORM branch.
+// Ref: MikroORM lifecycle hooks (@BeforeCreate/@AfterCreate/@BeforeUpsert/
+// @AfterUpsert/@BeforeDelete/@AfterDelete/@OnInit/@OnLoad).
+var mikroORMDecoratorEvents = map[string]string{
+	"BeforeCreate": "beforeCreate", "AfterCreate": "afterCreate",
+	"BeforeUpsert": "beforeUpsert", "AfterUpsert": "afterUpsert",
+	"BeforeDelete": "beforeDelete", "AfterDelete": "afterDelete",
+	"OnInit": "onInit", "OnLoad": "onLoad",
+}
+
+// mikroLifecycleMethodRe matches a MikroORM-exclusive lifecycle decorator
+// directly above a method. Group 1 = decorator name; Group 2 = method name.
+// Scoped, like the TypeORM matcher, to @Entity class bodies by the caller.
+var mikroLifecycleMethodRe = regexp.MustCompile(
+	`(?m)@(BeforeCreate|AfterCreate|BeforeUpsert|AfterUpsert|BeforeDelete|AfterDelete|OnInit|OnLoad)\s*\(\s*\)(?:\s*\n\s*@[^\n]*)*\s*\n\s*(?:async\s+)?(\w+)\s*\(`,
 )
 
 // sequelizeHookEvents is the set of Sequelize hook method / option names.
@@ -337,7 +360,8 @@ func synthesizeRubyARCallbacks(src string, emit func(model, event, handler, fram
 }
 
 // synthesizeJSTSORMHooks handles TypeORM entity lifecycle decorators,
-// Sequelize hook registrations, and Mongoose pre/post middleware.
+// MikroORM entity lifecycle decorators, Sequelize hook registrations, and
+// Mongoose pre/post middleware.
 func synthesizeJSTSORMHooks(src string, emit func(model, event, handler, framework string, line int), lineAt func(int) int) {
 	// --- TypeORM: @AfterInsert() etc. methods inside an @Entity class -------
 	if strings.Contains(src, "@Entity") {
@@ -369,6 +393,16 @@ func synthesizeJSTSORMHooks(src string, emit func(model, event, handler, framewo
 				method := body[lm[4]:lm[5]]
 				event := typeormDecoratorEvents[decorator]
 				emit(sp.name, event, method, "typeorm", lineAt(sp.bodyStart+lm[0]))
+			}
+			// MikroORM-exclusive lifecycle decorators on the same @Entity
+			// classes (@BeforeCreate/@AfterCreate/@BeforeUpsert/@AfterUpsert/
+			// @BeforeDelete/@AfterDelete/@OnInit/@OnLoad). Disjoint from the
+			// TypeORM decorator set above, so no double-emit.
+			for _, lm := range mikroLifecycleMethodRe.FindAllStringSubmatchIndex(body, -1) {
+				decorator := body[lm[2]:lm[3]]
+				method := body[lm[4]:lm[5]]
+				event := mikroORMDecoratorEvents[decorator]
+				emit(sp.name, event, method, "mikro-orm", lineAt(sp.bodyStart+lm[0]))
 			}
 		}
 	}

--- a/internal/engine/orm_lifecycle_hook_edges_test.go
+++ b/internal/engine/orm_lifecycle_hook_edges_test.go
@@ -239,6 +239,88 @@ export class Order {
 }
 
 // ---------------------------------------------------------------------------
+// MikroORM entity lifecycle hooks
+// ---------------------------------------------------------------------------
+
+// MikroORM-exclusive decorators (@BeforeCreate/@AfterCreate/@BeforeDelete/
+// @AfterDelete/@OnInit/@OnLoad/@BeforeUpsert/@AfterUpsert) on an @Entity class
+// each become a SCOPE.ModelEvent node + TRIGGERS edge to the named method.
+func TestORMHook_MikroORM_LifecycleDecorators(t *testing.T) {
+	src := `import { Entity, BeforeCreate, AfterCreate, BeforeDelete, OnLoad } from '@mikro-orm/core';
+
+@Entity()
+export class User {
+  @BeforeCreate()
+  async hashPassword() {}
+
+  @AfterCreate()
+  sendWelcome() {}
+
+  @BeforeDelete()
+  cleanup() {}
+
+  @OnLoad()
+  decorate() {}
+}
+`
+	ents, rels := runORMHookDetect(t, "typescript", "user.entity.ts", src)
+	const bc = "SCOPE.ModelEvent:User.beforeCreate"
+	const ac = "SCOPE.ModelEvent:User.afterCreate"
+	const bd = "SCOPE.ModelEvent:User.beforeDelete"
+	const ol = "SCOPE.ModelEvent:User.onLoad"
+	if !hasModelEvent(ents, bc, "User.beforeCreate") {
+		t.Fatalf("missing %s; ents=%+v", bc, ents)
+	}
+	if !hasTriggers(rels, bc, "hashPassword") {
+		t.Fatalf("missing TRIGGERS %s -> hashPassword", bc)
+	}
+	if !hasTriggers(rels, ac, "sendWelcome") {
+		t.Fatalf("missing TRIGGERS %s -> sendWelcome", ac)
+	}
+	if !hasTriggers(rels, bd, "cleanup") {
+		t.Fatalf("missing TRIGGERS %s -> cleanup", bd)
+	}
+	if !hasTriggers(rels, ol, "decorate") {
+		t.Fatalf("missing TRIGGERS %s -> decorate", ol)
+	}
+	// framework prop must be mikro-orm (not mislabeled typeorm).
+	for _, e := range ents {
+		if e.ID == bc && e.Properties["framework"] != "mikro-orm" {
+			t.Fatalf("framework for %s = %q, want mikro-orm", bc, e.Properties["framework"])
+		}
+	}
+}
+
+// Negative: a plain @Property() (non-lifecycle decorator) on a method-like
+// member produces no lifecycle event.
+func TestORMHook_MikroORM_NonLifecycleDecorator_NoEvent(t *testing.T) {
+	src := `@Entity()
+export class User {
+  @Property()
+  fullName() {}
+}
+`
+	ents, _ := runORMHookDetect(t, "typescript", "user.entity.ts", src)
+	if countModelEvents(ents) != 0 {
+		t.Fatalf("non-lifecycle decorator produced events: %+v", ents)
+	}
+}
+
+// Negative: MikroORM lifecycle decorator on a class with NO @Entity is not an
+// entity → out of scope (the @Entity gate is what scopes hook attribution).
+func TestORMHook_MikroORM_NoEntity_Skipped(t *testing.T) {
+	src := `export class Helper {
+  @BeforeCreate()
+  hashPassword() {}
+}
+`
+	ents, rels := runORMHookDetect(t, "typescript", "helper.ts", src)
+	if countModelEvents(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("non-entity class produced output: ents=%+v rels=%+v", ents, rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Sequelize hooks
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4118 — Refs #3872 (per-language coverage parity epic), #3628.

## Summary
Extends the jsts ORM lifecycle-hook TRIGGERS pass (`internal/engine/orm_lifecycle_hook_edges.go`) to cover **MikroORM** entity lifecycle decorators — the one jsts ORM with genuine before/after insert/update/delete/load hooks not yet covered.

## VERIFY-FIRST findings (corrected the probe's framing)
- The registry capability **`model_lifecycle_extraction`** is **data-lifecycle traits** (soft-delete / timestamps / audit-columns) in `internal/lifecycle/lifecycle.go` — NOT before/after hooks. jsts already has it `full` for **two** ORMs (typeorm + sequelize).
- The actual before/after **hooks** are a separate engine pass, already covering jsts **TypeORM**, **Sequelize**, and **Mongoose** (with honesty negatives). The genuine gap was **MikroORM**.

## What changed
- `mikroORMDecoratorEvents` + `mikroLifecycleMethodRe` for the MikroORM-**exclusive** decorators: `@BeforeCreate`/`@AfterCreate`/`@BeforeUpsert`/`@AfterUpsert`/`@BeforeDelete`/`@AfterDelete`/`@OnInit`/`@OnLoad`, scoped to `@Entity` class bodies, attributed `framework=mikro-orm`.
- The shared-named decorators (`@BeforeUpdate`/`@AfterUpdate`/`@AfterLoad`) were already handled by the TypeORM matcher; the new set is disjoint, so **no double-emit**.
- Result shape (matches flagship): `@BeforeCreate() hashPassword()` on `@Entity User` → `SCOPE.ModelEvent:User.beforeCreate` --TRIGGERS--> `Function:hashPassword`, framework=`mikro-orm`.

## Tests (value-asserting, with negatives)
- `TestORMHook_MikroORM_LifecycleDecorators` — asserts concrete `SCOPE.ModelEvent:User.beforeCreate/afterCreate/beforeDelete/onLoad` nodes + TRIGGERS edges to named handlers + `framework=mikro-orm`.
- Negatives: non-lifecycle `@Property()` → no event; lifecycle decorator on a non-`@Entity` class → skipped.

## Not changed (honest)
- No registry cell flips: `model_lifecycle_extraction` is traits, not hooks — flipping it would be dishonest. covtool `fmt --check` confirms registry canonical, `validate` 0 errors, `gen` 0 drift.
- No new entity Kind (reuses `SCOPE.ModelEvent`). No extractor dispatch touched.
- Prisma `$use` (query middleware, no per-model event identity) and Drizzle/Knex/Objection (no lifecycle-hook idiom) correctly remain absent.

## Validation
`go test ./internal/engine/ ./internal/types/ ./internal/extractors/ ./internal/lifecycle/ ./internal/custom/javascript/ ./tools/coverage/` all green; `gofmt -l` empty; `go vet` clean; covtool `validate`/`gen`/`fmt --check` clean.

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)