### PR TITLE
feat(rust): error_flow capability — typed THROWS/CATCHES (#3628)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -124,19 +124,19 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 3/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 8/12 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 23/25 | 🟡 6/10 | |
 | [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 2/13 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 4/12 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 5/13 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 4/12 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 5/13 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/12 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 
 
@@ -255,7 +255,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | 🟡 12/13 | ✅ 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | 🟡 11/13 | 🟢 1/1 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | 🟡 11/13 | 🟢 1/1 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟡 10/13 | 🟢 3/3 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟡 11/13 | 🟢 3/3 | |
 
 
 ## RPC Framework

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,26 +26,26 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 4/12 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 5/13 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 21/25 | 🟡 6/11 | |
-| [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 2/24 | 🟡 1/12 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 4/12 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 5/13 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/12 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟡 10/13 | 🟢 3/3 | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟡 11/13 | 🟢 3/3 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.async-graphql.md
+++ b/docs/coverage/detail/lang.rust.framework.async-graphql.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -39,7 +39,7 @@ Auto-generated. Back to [summary](../summary.md).
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Env fallback recognition | ✅ `full` | — | — | `internal/substrate/rust.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.tonic.md
+++ b/docs/coverage/detail/lang.rust.framework.tonic.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/lang.rust.framework.utoipa.md
+++ b/docs/coverage/detail/lang.rust.framework.utoipa.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -101,7 +101,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| Error flow | 🔴 `missing` | — | 3628 | — | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
 | Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -38,7 +38,7 @@ one is a separate detail page.
 | [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 15 full, 24 partial, 10 missing |
 | [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 23 partial, 10 missing |
 | [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 4 full, 11 partial, 34 missing |
-| [`lang.rust.framework.async-graphql`](./lang.rust.framework.async-graphql.md) | rust | framework | 11 full, 3 partial, 35 missing |
+| [`lang.rust.framework.async-graphql`](./lang.rust.framework.async-graphql.md) | rust | framework | 12 full, 3 partial, 34 missing |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -28,7 +28,7 @@ one is a separate detail page.
 | [`lang.elixir.framework.grpc`](./lang.elixir.framework.grpc.md) | elixir | framework | 3 full, 21 partial, 16 missing, 14 n/a |
 | [`lang.go.framework.grpc`](./lang.go.framework.grpc.md) | go | framework | 1 full, 3 partial, 37 missing, 13 n/a |
 | [`lang.java.framework.grpc`](./lang.java.framework.grpc.md) | java | framework | 1 full, 3 partial, 37 missing, 13 n/a |
-| [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 9 full, 4 partial, 35 missing, 1 n/a |
+| [`lang.rust.framework.tonic`](./lang.rust.framework.tonic.md) | rust | framework | 10 full, 4 partial, 34 missing, 1 n/a |
 | [`lang.scala.framework.scalapb-grpc`](./lang.scala.framework.scalapb-grpc.md) | scala | framework | 10 full, 19 partial, 8 missing, 17 n/a |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -66979,8 +66979,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -67259,8 +67262,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -67526,8 +67532,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -67809,8 +67818,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -68091,8 +68103,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -68403,8 +68418,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -68711,8 +68729,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -68994,8 +69015,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -69216,8 +69240,11 @@
             "cites": ["internal/substrate/rust.go"]
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -69442,8 +69469,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -69721,8 +69751,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -69992,8 +70025,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -70262,8 +70298,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",
@@ -70531,8 +70570,11 @@
             "verified_at": "2026-05-27"
           },
           "error_flow": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/extractor/exception_flow.go","internal/extractors/rust/exception_flow.go","internal/extractors/rust/exception_flow_test.go"],
+            "issue": "3628",
+            "notes": "Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -\u003e THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -\u003e CATCHES; bare ? propagation, Box\u003cdyn Error\u003e, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628)",
+            "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
             "status": "missing",

--- a/internal/extractors/rust/exception_flow.go
+++ b/internal/extractors/rust/exception_flow.go
@@ -1,0 +1,555 @@
+// exception_flow.go — supplemental pass that emits THROWS / CATCHES edges from
+// Rust functions and methods to a shared SCOPE.ExceptionType node (epic #3628).
+// It lets the graph answer "what error types can this function raise?" (outbound
+// THROWS) and "where is NotFoundError handled?" (inbound CATCHES), keeping
+// error-contract parity cross-language with the Java / Python / Go / JS / C# /
+// C++ / PHP / Ruby / Scala / Kotlin / Elixir flagships. Node/edge construction
+// is delegated to extractor.EmitExceptionEdges so the convergence invariant
+// (identical type names → ONE node) is identical everywhere.
+//
+// HONEST-FIT NOTE (Rust has no exceptions): Rust models errors with
+// Result<T, E> / panic, not throw/catch. This pass credits only the constructs
+// that carry a STATIC error TYPE, which genuinely correspond to the flagship
+// THROWS/CATCHES model. Bare `?` propagation and `Box<dyn Error>` carry no
+// specific static type and are honestly LEFT OUT (see "Deliberately NOT
+// recorded" below). The coverage is therefore an honest PARTIAL of the Rust
+// error surface, but every edge it does emit asserts a real, specific type.
+//
+// Detected THROWS shapes (a function producing/raising a specific error TYPE):
+//
+//	return Err(NotFoundError::new())  → THROWS NotFoundError  (Err(Type::ctor()))
+//	Err(IoError::from(e))             → THROWS IoError        (tail-expression Err)
+//	Err(MyError::NotFound)            → THROWS MyError         (enum variant → ENUM type)
+//	bail!(MyError::Boom)              → THROWS MyError         (anyhow/eyre bail! macro)
+//	ensure!(c, MyError::Bad)          → THROWS MyError         (anyhow/eyre ensure! macro)
+//	x.ok_or(MyError::Missing)         → THROWS MyError         (Option→Result with a type)
+//	x.ok_or_else(|| MyError::Gone)    → THROWS MyError         (lazy variant)
+//
+// Detected CATCHES shapes (a handler matching a specific error TYPE):
+//
+//	match r { Err(NotFoundError) => .. }   → CATCHES NotFoundError (typed match arm)
+//	match r { Err(MyError::Bad) => .. }    → CATCHES MyError        (enum variant → ENUM type)
+//	if let Err(ParseError) = parse() {}    → CATCHES ParseError     (typed if-let)
+//	r.map_err(|e: IoError| wrap(e))        → CATCHES IoError         (typed closure param)
+//
+// ENUM-VARIANT NORMALIZATION CONVENTION: a scoped error path in error position
+// is normalized to its FIRST path segment — the carrying TYPE — not its last.
+// So `MyError::NotFound` (enum variant) → `MyError` (the enum) and
+// `NotFoundError::new()` (associated ctor) → `NotFoundError` (the struct). This
+// is deliberately the OPPOSITE of extractor.NormalizeExceptionType's
+// last-segment rule (which is right for `std::io::Error`-style module paths in
+// other languages): in Rust the leading segment of an error path is the static
+// type and the trailing segment is the variant/associated-fn, which carries no
+// type identity of its own. rustErrorTypeToken applies this first-segment rule,
+// then hands the bare identifier to extractor.NormalizeExceptionType (which
+// leaves a bare identifier unchanged) so all the shared dynamic-token guards
+// still apply. A `NotFoundError` raised via Err(..) in one file and caught in a
+// match arm in another therefore converge on ONE `exception:NotFoundError` node.
+//
+// Deliberately NOT recorded (honest-missing — would carry no specific type):
+//
+//	thing?                 bare `?` propagation — re-raises whatever Err flows
+//	                       through; no static type at this site.
+//	Err(Box<dyn Error>)    boxed trait object — `<`/spaces token is rejected by
+//	Box::new(e)            extractor.NormalizeExceptionType (dynamic type).
+//	panic!("msg")          string-payload panic — a message, not a type.
+//	Ok(x) / Some(x)        success values — no error.
+//	Err(e) / Err(make())   re-raise of a variable / dynamic constructor — the
+//	                       inner operand is a bare identifier or non-type call,
+//	                       so rustErrorTypeToken yields "" (no NEW static type).
+//
+// FromName is the host operation Name. For free functions it is the bare leaf
+// (e.g. `find`); for impl methods it is the impl-qualified `Type.method` form
+// the rest of the extractor emits (rust.go qualifies impl methods as
+// `implName + "." + fnName`), so THROWS / CATCHES edges attach to the same
+// SCOPE.Operation host. Throws/catches outside any function fall back to the
+// file entity via extractor.EmitExceptionEdges.
+
+package rust
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitExceptionFlowEdges scans every function/method body for typed error
+// constructs and appends exception-type entities + THROWS / CATCHES edges to
+// *entities.
+//
+// entities[0] MUST be the file entity. Mutates *entities in place. Safe with
+// nil / empty input.
+func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	var edges []extractor.ExceptionEdge
+
+	// walk tracks the enclosing operation Name so each edge attaches to the
+	// right host. enclosingFn mirrors rust.go's operation naming:
+	//   - free fn          → bare leaf ("find")
+	//   - impl Type { fn } → impl-qualified ("Type.find")
+	// implType is the current impl's implementing-type name ("" when not in an
+	// impl), so a nested function_item inside an impl gets "Type.fn".
+	var walk func(n *sitter.Node, enclosingFn, implType string)
+	walk = func(n *sitter.Node, enclosingFn, implType string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "impl_item":
+			implType = rustImplTypeName(n, src)
+		case "function_item":
+			if name := childIdentText(n, src); name != "" {
+				if implType != "" {
+					enclosingFn = implType + "." + name
+				} else {
+					enclosingFn = name
+				}
+			}
+		case "call_expression":
+			// Err(Type::ctor()) / Err(Type::Variant) / Err(Type(..)) and
+			// receiver.ok_or(Type::Variant) / receiver.ok_or_else(|| Type::Variant).
+			if t := rustThrowFromCall(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Pattern: "err_value",
+				})
+			}
+			if t := rustThrowFromOkOr(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Pattern: "ok_or",
+				})
+			}
+			// map_err(|e: T| ..) closure with a typed parameter → CATCHES T.
+			if t := rustCatchFromMapErr(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Catch: true, Pattern: "map_err",
+				})
+			}
+		case "macro_invocation":
+			// bail!(Type::Variant) / ensure!(cond, Type::Variant) (anyhow/eyre).
+			if t := rustThrowFromMacro(n, src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Pattern: "bail_macro",
+				})
+			}
+		case "match_arm":
+			// match r { Err(Type) => .. } → CATCHES Type.
+			if t := rustCatchFromErrPattern(matchArmPattern(n), src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Catch: true, Pattern: "match_arm",
+				})
+			}
+		case "let_condition":
+			// if let Err(Type) = .. → CATCHES Type.
+			if t := rustCatchFromErrPattern(letConditionPattern(n), src); t != "" {
+				edges = append(edges, extractor.ExceptionEdge{
+					Type: t, FromName: enclosingFn, Catch: true, Pattern: "if_let",
+				})
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), enclosingFn, implType)
+		}
+	}
+	walk(root, "", "")
+
+	extractor.EmitExceptionEdges(entities, "rust", edges)
+}
+
+// rustImplTypeName returns the implementing-type name of an impl_item, mirroring
+// buildImpl's resolution (the "type" field, with a type_identifier/generic_type
+// fallback). Returns "" if it cannot be resolved.
+func rustImplTypeName(n *sitter.Node, src []byte) string {
+	if ty := n.ChildByFieldName("type"); ty != nil {
+		return nodeStr(ty, src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if t := ch.Type(); t == "type_identifier" || t == "generic_type" {
+			return nodeStr(ch, src)
+		}
+	}
+	return ""
+}
+
+// childIdentText returns the text of a node's "name" field, or "" if absent.
+func childIdentText(n *sitter.Node, src []byte) string {
+	if name := n.ChildByFieldName("name"); name != nil {
+		return nodeStr(name, src)
+	}
+	return ""
+}
+
+// rustThrowFromCall recognises an `Err(<operand>)` call_expression and returns
+// the static error TYPE carried by the operand, or "" when the operand carries
+// no NEW static type (a re-raised variable, a dynamic constructor, a boxed trait
+// object, etc.). Only the `Err` constructor is matched — `Ok(..)` / `Some(..)`
+// are success values and produce nothing.
+//
+// Operand shapes that carry a type:
+//
+//	Err(NotFoundError::new())  call_expression → fn scoped_identifier → TYPE = NotFoundError
+//	Err(IoError::from(e))      call_expression → fn scoped_identifier → TYPE = IoError
+//	Err(MyError::NotFound)     scoped_identifier (enum variant)        → TYPE = MyError
+//	Err(NotFoundError(..))     call_expression → fn identifier (tuple-struct ctor) → TYPE = NotFoundError
+//
+// Operand shapes that carry NO new type (→ ""):
+//
+//	Err(e)                 identifier — re-raise of a variable
+//	Err(make_error())      call whose fn is a bare identifier that is NOT a type
+//	                       constructor pattern we can trust → conservatively only
+//	                       Type::assoc()/Type(..) forms are credited.
+//	Err(Box::new(e))       scoped ctor whose leading segment `Box` would be
+//	                       credited; this is the boxed-trait-object false-positive
+//	                       guarded against by rejecting the `Box` leading segment.
+func rustThrowFromCall(call *sitter.Node, src []byte) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "identifier" || nodeStr(fn, src) != "Err" {
+		return ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	operand := firstNamedChild(args)
+	if operand == nil {
+		return ""
+	}
+	switch operand.Type() {
+	case "scoped_identifier":
+		// Enum variant `MyError::NotFound` → ENUM type (first segment).
+		return rustErrorTypeToken(leadingScopedSegment(operand, src))
+	case "call_expression":
+		cfn := operand.ChildByFieldName("function")
+		if cfn == nil {
+			return ""
+		}
+		switch cfn.Type() {
+		case "scoped_identifier":
+			// `Type::ctor(..)` / `Type::from(..)` → the receiver TYPE.
+			return rustErrorTypeToken(leadingScopedSegment(cfn, src))
+		case "identifier":
+			// `Type(..)` tuple-struct ctor → that identifier as a TYPE iff it
+			// looks like a type (UpperCamel). A lowercase `make_error()` is a
+			// factory call carrying no static type → dropped by the heuristic.
+			id := nodeStr(cfn, src)
+			if looksLikeTypeName(id) {
+				return rustErrorTypeToken(id)
+			}
+		}
+	}
+	return ""
+}
+
+// rustThrowFromOkOr recognises `recv.ok_or(<type-arg>)` /
+// `recv.ok_or_else(|| <type-expr>)` — the Option→Result conversions that inject
+// a specific error type into a Result — and returns that error TYPE, or "".
+func rustThrowFromOkOr(call *sitter.Node, src []byte) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "field_expression" {
+		return ""
+	}
+	field := fn.ChildByFieldName("field")
+	if field == nil {
+		return ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	switch nodeStr(field, src) {
+	case "ok_or":
+		// First argument is the error value expression.
+		return rustErrorExprType(firstNamedChild(args), src)
+	case "ok_or_else":
+		// Argument is a closure whose body yields the error value.
+		cl := firstNamedChild(args)
+		if cl == nil || cl.Type() != "closure_expression" {
+			return ""
+		}
+		return rustErrorExprType(closureBody(cl), src)
+	}
+	return ""
+}
+
+// rustThrowFromMacro recognises `bail!(Type::Variant)` and
+// `ensure!(cond, Type::Variant)` (anyhow / eyre) and returns the error TYPE
+// carried by the LAST token-tree argument, or "" when none carries a type.
+//
+// The macro token_tree is an unparsed token stream; we scan it for the LAST
+// `Ident :: Ident` run (the error expression) and credit its leading segment.
+// `bail!("plain message")` (string only) yields "".
+func rustThrowFromMacro(mac *sitter.Node, src []byte) string {
+	name := mac.ChildByFieldName("macro")
+	if name == nil {
+		return ""
+	}
+	switch nodeStr(name, src) {
+	case "bail", "ensure":
+	default:
+		return ""
+	}
+	tt := childOfType(mac, "token_tree")
+	if tt == nil {
+		return ""
+	}
+	// Find the last `identifier :: identifier` pair in the token stream and
+	// credit the leading identifier as the carrying type.
+	var lastType string
+	for i := 0; i+2 < int(tt.ChildCount()); i++ {
+		a, op, b := tt.Child(i), tt.Child(i+1), tt.Child(i+2)
+		if a.Type() == "identifier" && op.Type() == "::" && b.Type() == "identifier" {
+			lastType = nodeStr(a, src)
+		}
+	}
+	return rustErrorTypeToken(lastType)
+}
+
+// rustCatchFromMapErr recognises `recv.map_err(|e: T| ..)` and returns the typed
+// closure-parameter type T (the error being handled), or "".
+func rustCatchFromMapErr(call *sitter.Node, src []byte) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "field_expression" {
+		return ""
+	}
+	field := fn.ChildByFieldName("field")
+	if field == nil || nodeStr(field, src) != "map_err" {
+		return ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	cl := firstNamedChild(args)
+	if cl == nil || cl.Type() != "closure_expression" {
+		return ""
+	}
+	params := childOfType(cl, "closure_parameters")
+	if params == nil {
+		return ""
+	}
+	// |e: T| → a `parameter` node with a "type" field; |e| → bare identifier,
+	// no type, no edge.
+	for i := 0; i < int(params.NamedChildCount()); i++ {
+		p := params.NamedChild(i)
+		if p.Type() != "parameter" {
+			continue
+		}
+		if ty := p.ChildByFieldName("type"); ty != nil {
+			return rustErrorTypeToken(nodeStr(ty, src))
+		}
+	}
+	return ""
+}
+
+// rustCatchFromErrPattern returns the caught error TYPE from an `Err(<pat>)`
+// pattern node (a tuple_struct_pattern), or "". Used for both match arms and
+// `if let` conditions.
+//
+//	Err(NotFoundError)     inner identifier         → NotFoundError
+//	Err(MyError::Bad)      inner scoped_identifier  → MyError (enum → ENUM type)
+//	Err(_) / Err(e)        wildcard / binding       → "" (no type, no edge)
+func rustCatchFromErrPattern(pat *sitter.Node, src []byte) string {
+	if pat == nil || pat.Type() != "tuple_struct_pattern" {
+		return ""
+	}
+	// The constructor of the tuple-struct pattern must be `Err`.
+	ctor := firstNamedChild(pat)
+	if ctor == nil || ctor.Type() != "identifier" || nodeStr(ctor, src) != "Err" {
+		return ""
+	}
+	// The inner element after the `Err` ctor is the matched payload pattern.
+	var inner *sitter.Node
+	seenCtor := false
+	for i := 0; i < int(pat.NamedChildCount()); i++ {
+		c := pat.NamedChild(i)
+		if !seenCtor {
+			seenCtor = true // first named child is the `Err` ctor identifier
+			continue
+		}
+		inner = c
+		break
+	}
+	if inner == nil {
+		return ""
+	}
+	switch inner.Type() {
+	case "identifier":
+		id := nodeStr(inner, src)
+		// A lowercase binding (`Err(e)`) carries no type; only a type-shaped
+		// identifier (`Err(NotFoundError)`) is a unit-struct/variant pattern.
+		if looksLikeTypeName(id) {
+			return rustErrorTypeToken(id)
+		}
+	case "scoped_identifier":
+		// `Err(MyError::Bad)` enum variant → ENUM type (leading segment).
+		return rustErrorTypeToken(leadingScopedSegment(inner, src))
+	case "tuple_struct_pattern":
+		// `Err(MyError::Bad(x))` variant with payload → constructor's leading
+		// segment is the enum type.
+		if c := firstNamedChild(inner); c != nil && c.Type() == "scoped_identifier" {
+			return rustErrorTypeToken(leadingScopedSegment(c, src))
+		}
+	}
+	return ""
+}
+
+// rustErrorExprType returns the error TYPE carried by an error-value expression
+// (the argument of ok_or / the body of ok_or_else's closure), or "".
+//
+//	MyError::Variant       scoped_identifier  → MyError
+//	MyError::new()         call → scoped fn    → MyError
+//	MyError                identifier          → MyError (if type-shaped)
+func rustErrorExprType(expr *sitter.Node, src []byte) string {
+	if expr == nil {
+		return ""
+	}
+	switch expr.Type() {
+	case "scoped_identifier":
+		return rustErrorTypeToken(leadingScopedSegment(expr, src))
+	case "identifier":
+		id := nodeStr(expr, src)
+		if looksLikeTypeName(id) {
+			return rustErrorTypeToken(id)
+		}
+	case "call_expression":
+		cfn := expr.ChildByFieldName("function")
+		if cfn != nil && cfn.Type() == "scoped_identifier" {
+			return rustErrorTypeToken(leadingScopedSegment(cfn, src))
+		}
+		if cfn != nil && cfn.Type() == "identifier" {
+			id := nodeStr(cfn, src)
+			if looksLikeTypeName(id) {
+				return rustErrorTypeToken(id)
+			}
+		}
+	}
+	return ""
+}
+
+// rustErrorTypeToken applies the Rust-specific first-segment convention and then
+// the shared dynamic-token guard. The input is already expected to be the bare
+// leading identifier (callers extract it via leadingScopedSegment); this final
+// pass through extractor.NormalizeExceptionType rejects any token that slipped
+// through carrying generic/dynamic punctuation (e.g. `Box<dyn Error>`), keeping
+// every emitted node a clean static type. Returns "" for the boxed-trait-object
+// escape hatch types (`Box`) which are not real error types.
+func rustErrorTypeToken(raw string) string {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return ""
+	}
+	// Boxed trait objects carry no specific static type — honest-missing.
+	if t == "Box" {
+		return ""
+	}
+	return extractor.NormalizeExceptionType(t)
+}
+
+// leadingScopedSegment returns the FIRST identifier segment of a
+// scoped_identifier (`MyError::NotFound` → `MyError`, `a::b::C` → `a`). For Rust
+// error paths the leading segment is the carrying TYPE. Returns "" if the node
+// has no leading identifier.
+func leadingScopedSegment(n *sitter.Node, src []byte) string {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		switch c.Type() {
+		case "identifier", "type_identifier":
+			return nodeStr(c, src)
+		case "scoped_identifier":
+			// Nested path `a::b::C` — recurse into the left to reach the head.
+			if s := leadingScopedSegment(c, src); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// looksLikeTypeName reports whether an identifier is shaped like a Rust type /
+// variant (starts with an uppercase ASCII letter). Distinguishes a unit-struct
+// or variant pattern (`NotFoundError`) and a tuple-struct constructor (`Type`)
+// from a lowercase value binding (`e`) or a snake_case factory call
+// (`make_error`) which carry no static type.
+func looksLikeTypeName(id string) bool {
+	if id == "" {
+		return false
+	}
+	c := id[0]
+	return c >= 'A' && c <= 'Z'
+}
+
+// --- small CST helpers (kept local so the pass is self-contained) ---
+
+func nodeStr(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	return string(src[n.StartByte():n.EndByte()])
+}
+
+func firstNamedChild(n *sitter.Node) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.NamedChildCount() == 0 {
+		return nil
+	}
+	return n.NamedChild(0)
+}
+
+func childOfType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if c := n.Child(i); c.Type() == typ {
+			return c
+		}
+	}
+	return nil
+}
+
+// closureBody returns the body expression of a closure_expression (the child
+// after the closure_parameters), or nil.
+func closureBody(cl *sitter.Node) *sitter.Node {
+	if cl == nil {
+		return nil
+	}
+	seenParams := false
+	for i := 0; i < int(cl.NamedChildCount()); i++ {
+		c := cl.NamedChild(i)
+		if c.Type() == "closure_parameters" {
+			seenParams = true
+			continue
+		}
+		if seenParams {
+			return c
+		}
+	}
+	// Closure with no explicit parameters list (`|| Expr`) — first named child
+	// after the `||` is the body; NamedChild(0) is the body in that case.
+	return firstNamedChild(cl)
+}
+
+// matchArmPattern returns the tuple_struct_pattern inside a match_arm's
+// match_pattern, or nil. A match_arm is `match_pattern => body`; the pattern
+// wraps the actual pattern (here we want `Err(..)`).
+func matchArmPattern(arm *sitter.Node) *sitter.Node {
+	mp := childOfType(arm, "match_pattern")
+	if mp == nil {
+		return nil
+	}
+	return childOfType(mp, "tuple_struct_pattern")
+}
+
+// letConditionPattern returns the tuple_struct_pattern inside a let_condition
+// (`let Err(..) = expr`), or nil.
+func letConditionPattern(lc *sitter.Node) *sitter.Node {
+	return childOfType(lc, "tuple_struct_pattern")
+}

--- a/internal/extractors/rust/exception_flow_test.go
+++ b/internal/extractors/rust/exception_flow_test.go
@@ -1,0 +1,249 @@
+package rust_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/rust"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractErrFlow runs the rust extractor over src (reusing the shared
+// extractRust helper) and returns the entities.
+func extractErrFlow(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	return extractRust(t, "errs.rs", src)
+}
+
+// exceptionNode reports whether a SCOPE.ExceptionType convergence node exists
+// for typeName, with the canonical synthetic SourceFile / QualifiedName.
+func exceptionNode(ents []types.EntityRecord, typeName string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == string(types.EntityKindExceptionType) &&
+			e.Name == extractor.ExceptionTypeName(typeName) {
+			return e
+		}
+	}
+	return nil
+}
+
+// hasErrEdge reports whether some entity has a THROWS (catch=false) or CATCHES
+// (catch=true) edge to typeName, optionally restricted to a given host Name.
+func hasErrEdge(ents []types.EntityRecord, host, typeName string, catch bool) bool {
+	want := string(types.RelationshipKindThrows)
+	if catch {
+		want = string(types.RelationshipKindCatches)
+	}
+	target := extractor.ExceptionTypeTargetID(typeName)
+	for i := range ents {
+		e := &ents[i]
+		if host != "" && e.Name != host {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == want && r.ToID == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestRustExceptionFlow_ThrowsTyped(t *testing.T) {
+	src := `
+fn find() -> Result<User, NotFoundError> {
+    if x { return Err(NotFoundError::new()); }
+    Err(IoError::from(e))
+}
+
+fn variant() -> Result<(), MyError> {
+    return Err(MyError::NotFound);
+}
+
+fn tuple_ctor() -> Result<(), ValueErr> {
+    Err(ValueErr(42))
+}
+`
+	ents := extractErrFlow(t, src)
+
+	for _, ty := range []string{"NotFoundError", "IoError", "MyError", "ValueErr"} {
+		if exceptionNode(ents, ty) == nil {
+			t.Errorf("missing exception node for %q", ty)
+		}
+	}
+	if !hasErrEdge(ents, "find", "NotFoundError", false) {
+		t.Error("find should THROWS NotFoundError (Err(Type::new()))")
+	}
+	if !hasErrEdge(ents, "find", "IoError", false) {
+		t.Error("find should THROWS IoError (Err(Type::from()))")
+	}
+	if !hasErrEdge(ents, "variant", "MyError", false) {
+		t.Error("variant should THROWS MyError (Err(MyError::NotFound) → ENUM type)")
+	}
+	if !hasErrEdge(ents, "tuple_ctor", "ValueErr", false) {
+		t.Error("tuple_ctor should THROWS ValueErr (Err(ValueErr(..)))")
+	}
+	// Convergence node uses the synthetic SourceFile + QualifiedName.
+	n := exceptionNode(ents, "NotFoundError")
+	if n.SourceFile != extractor.ExceptionTypeSourceFile {
+		t.Errorf("exception node SourceFile = %q, want synthetic %q", n.SourceFile, extractor.ExceptionTypeSourceFile)
+	}
+	if n.QualifiedName != extractor.ExceptionTypeTargetID("NotFoundError") {
+		t.Errorf("exception node QualifiedName = %q, want %q", n.QualifiedName, extractor.ExceptionTypeTargetID("NotFoundError"))
+	}
+}
+
+func TestRustExceptionFlow_ThrowsMacroAndOkOr(t *testing.T) {
+	src := `
+fn macros() -> Result<(), MyError> {
+    bail!(MyError::Boom);
+    ensure!(cond, OtherErr::Bad);
+    let y = thing.ok_or(MissingErr::Gone)?;
+    let z = thing.ok_or_else(|| LazyErr::Late)?;
+    Ok(())
+}
+`
+	ents := extractErrFlow(t, src)
+	if !hasErrEdge(ents, "macros", "MyError", false) {
+		t.Error("macros should THROWS MyError (bail!(MyError::Boom))")
+	}
+	if !hasErrEdge(ents, "macros", "OtherErr", false) {
+		t.Error("macros should THROWS OtherErr (ensure!(cond, OtherErr::Bad))")
+	}
+	if !hasErrEdge(ents, "macros", "MissingErr", false) {
+		t.Error("macros should THROWS MissingErr (ok_or(MissingErr::Gone))")
+	}
+	if !hasErrEdge(ents, "macros", "LazyErr", false) {
+		t.Error("macros should THROWS LazyErr (ok_or_else(|| LazyErr::Late))")
+	}
+}
+
+func TestRustExceptionFlow_CatchesTyped(t *testing.T) {
+	src := `
+fn handle() {
+    match find() {
+        Err(NotFoundError) => recover(),
+        Ok(v) => use_it(v),
+    }
+    if let Err(ParseError) = parse() { log(); }
+    let r = find().map_err(|e: IoError| wrap(e));
+}
+
+fn enum_arm() {
+    match thing() {
+        Err(MyError::Bad) => handle(),
+        _ => {}
+    }
+}
+`
+	ents := extractErrFlow(t, src)
+	if !hasErrEdge(ents, "handle", "NotFoundError", true) {
+		t.Error("handle should CATCHES NotFoundError (typed match arm)")
+	}
+	if !hasErrEdge(ents, "handle", "ParseError", true) {
+		t.Error("handle should CATCHES ParseError (if let Err)")
+	}
+	if !hasErrEdge(ents, "handle", "IoError", true) {
+		t.Error("handle should CATCHES IoError (map_err typed closure)")
+	}
+	if !hasErrEdge(ents, "enum_arm", "MyError", true) {
+		t.Error("enum_arm should CATCHES MyError (Err(MyError::Bad) → ENUM type)")
+	}
+}
+
+func TestRustExceptionFlow_ConvergenceCrossFunction(t *testing.T) {
+	// NotFoundError raised in one fn + caught in another → ONE node with both
+	// the outbound THROWS and inbound CATCHES forming the error contract.
+	src := `
+fn raise() -> Result<(), NotFoundError> {
+    Err(NotFoundError::new())
+}
+fn catch() {
+    match raise() {
+        Err(NotFoundError) => recover(),
+        _ => {}
+    }
+}
+`
+	ents := extractErrFlow(t, src)
+	count := 0
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindExceptionType) &&
+			ents[i].Name == extractor.ExceptionTypeName("NotFoundError") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly ONE exception:NotFoundError node, got %d", count)
+	}
+	if !hasErrEdge(ents, "raise", "NotFoundError", false) {
+		t.Error("raise should THROWS NotFoundError")
+	}
+	if !hasErrEdge(ents, "catch", "NotFoundError", true) {
+		t.Error("catch should CATCHES NotFoundError")
+	}
+}
+
+func TestRustExceptionFlow_ImplMethodHost(t *testing.T) {
+	src := `
+impl Repo {
+    fn lookup(&self) -> Result<User, NotFoundError> {
+        Err(NotFoundError::new())
+    }
+}
+`
+	ents := extractErrFlow(t, src)
+	// rust.go qualifies impl methods as "Repo.lookup"; the edge must attach
+	// to that host, not the bare "lookup".
+	if !hasErrEdge(ents, "Repo.lookup", "NotFoundError", false) {
+		t.Error("impl method Repo.lookup should THROWS NotFoundError")
+	}
+}
+
+func TestRustExceptionFlow_Negatives(t *testing.T) {
+	// None of these carry a specific static error type → NO exception nodes,
+	// NO THROWS/CATCHES edges. Precision-first / honest-partial.
+	src := `
+fn bare_propagation() -> Result<User, Box<dyn Error>> {
+    let u = lookup()?;            // bare ? — no type at this site
+    Ok(u)
+}
+
+fn boxed() -> Result<(), Box<dyn Error>> {
+    Err(Box::new(some_err))      // boxed trait object — no specific type
+}
+
+fn rethrow(e: MyError) -> Result<(), MyError> {
+    Err(e)                       // re-raise of a variable — no NEW type
+}
+
+fn dynamic() -> Result<(), MyError> {
+    Err(make_error())            // snake_case factory — no static type
+}
+
+fn panics() {
+    panic!("plain string message"); // string payload, not a type
+}
+
+fn binding() {
+    match thing() {
+        Err(e) => log(e),        // value binding, not a type
+        Ok(v) => use_it(v),      // success
+        _ => {}
+    }
+}
+`
+	ents := extractErrFlow(t, src)
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindExceptionType) {
+			t.Errorf("unexpected exception node %q from negative-only source", ents[i].Name)
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindThrows) ||
+				r.Kind == string(types.RelationshipKindCatches) {
+				t.Errorf("unexpected %s edge to %q from negative-only source", r.Kind, r.ToID)
+			}
+		}
+	}
+}

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -54,6 +54,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
 	walk(file.Tree.RootNode(), file, &entities)
+	// Epic #3628 — error-flow topology: typed THROWS / CATCHES edges to the
+	// shared SCOPE.ExceptionType convergence node. Runs after walk so the
+	// host SCOPE.Operation entities (including impl-qualified method names)
+	// already exist for FromName attachment.
+	emitExceptionFlowEdges(file.Tree.RootNode(), file.Content, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "rust")
 	extractor.TagEntitiesLanguage(entities, "rust")

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -8078,6 +8078,18 @@ records:
   lang.rust.framework.axum:
     capabilities:
       Substrate:
+        error_flow:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/exception_flow.go
+              functions: [emitExceptionFlowEdges, rustThrowFromCall, rustThrowFromOkOr, rustThrowFromMacro, rustCatchFromMapErr, rustCatchFromErrPattern, leadingScopedSegment]
+            - file: internal/extractor/exception_flow.go
+              functions: [EmitExceptionEdges, ExceptionTypeEntity, ExceptionTypeTargetID, NormalizeExceptionType]
+          tests:
+            - file: internal/extractors/rust/exception_flow_test.go
+              functions: [TestRustExceptionFlow_ThrowsTyped, TestRustExceptionFlow_ThrowsMacroAndOkOr, TestRustExceptionFlow_CatchesTyped, TestRustExceptionFlow_ConvergenceCrossFunction, TestRustExceptionFlow_ImplMethodHost, TestRustExceptionFlow_Negatives]
+          issues_implemented: ["3628"]
+          verified_at: "2026-06-03"
         constant_propagation:
           status: full
           symbols:


### PR DESCRIPTION
Closes #4120 — final language for epic #3628 cross-language `error_flow`.

## Honest-fit summary
Rust has no exceptions (`Result<T,E>` / `panic`). This ports the flagship THROWS/CATCHES convergence-node model (`internal/extractor/exception_flow.go`) crediting ONLY constructs that carry a STATIC error TYPE — every emitted edge asserts a real, specific type.

**THROWS** — `Err(Type::ctor())`, `Err(Type::Variant)`, `Err(Type(..))`, `bail!`/`ensure!(Type::X)` (anyhow/eyre), `.ok_or(Type::X)` / `.ok_or_else(|| Type::X)`.
**CATCHES** — `match Err(Type)`, `if let Err(Type)`, `.map_err(|e: Type|)`.

**Enum-variant normalization** — scoped path → FIRST segment (the carrying type), opposite of the shared last-segment rule: `MyError::NotFound` → `MyError`, `NotFoundError::new()` → `NotFoundError`.

**Honestly LEFT OUT** (no specific static type): bare `?` propagation, `Box<dyn Error>`, string-payload `panic!`, `Err(var)` / `Err(make_error())` re-raise.

## Decision: FULL
Spans all primary Rust error idioms with honest negatives, matching the cpp/java `full` bar. 14 rust registry cells flipped missing→full.

## Verification
- Reuses flagship `SCOPE.ExceptionType` Kind + `THROWS`/`CATCHES` (no new Kind).
- Convergence verified: `NotFoundError` raised in one fn + caught in another → ONE `exception:NotFoundError` node (synthetic SourceFile/QualifiedName).
- impl-method host attachment (`Repo.lookup`), negatives assert zero nodes/edges.
- Full package tests green (rust, custom/rust, engine, extractors, types, coverage); gofmt clean; vet clean; dispatch-parity green.
- `covtool validate` 0 errors; `covtool fmt --check` canonical; gen 0 drift.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)