### PR TITLE
feat(rust): rate_limit_stamping greenfield — tower-governor + actix-governor + tower RateLimitLayer

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -124,15 +124,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 4/6 | 🟢 1/1 | — | 🟢 1/1 | 🟡 24/25 | 🟡 8/12 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 2/5 | — | 🟢 1/1 | 🟢 1/1 | 🟡 23/25 | 🟡 6/10 | |
 | [ruby](../by-language/ruby.md) | [graphql-ruby (GraphQL)](../detail/lang.ruby.framework.graphql-ruby.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 10/24 | 🟡 2/13 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 4/12 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 5/13 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,15 +26,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [Tonic](../detail/lang.rust.framework.tonic.md) | 🟡 3/6 | 🔴 0/1 | 🟢 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 4/12 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 7/11 | |
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |
 | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 5/13 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/25 | 🟡 6/11 | |

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | custom Transform<S,ServiceRequest> impls + .wrap() registrations captured with middleware_name/middleware_trait |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/rust/rate_limit.go`<br>`internal/custom/rust/rate_limit_test.go` | #4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period/rate_limit_burst) for actix-governor — a .wrap(Governor::new(&conf)) on the App, resolving GovernorConfigBuilder::default().per_second(N).burst_size(M) when literal (scope=app, source=actix_governor). Partial: rate omitted when non-literal/cross-statement. Negatives: a plain route does not stamp. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/axum.go` | .layer/.route_layer + tower ServiceBuilder ordered layer chains enumerated in source order (layer_order + layer_order_list) |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/rust/rate_limit.go`<br>`internal/custom/rust/rate_limit_test.go` | #4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period/rate_limit_burst) for tower-governor on axum — a .layer(GovernorLayer{ config }) guarding the Router, resolving GovernorConfigBuilder::default().per_second(N).burst_size(M) when literal (scope=router, source=tower_governor). Partial: rate omitted when per_second/burst_size is non-literal or the builder is chained cross-statement. Negatives: a plain route and a non-rate layer (CorsLayer/TraceLayer) do not stamp. |
 
 ### Schema
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -46,7 +46,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | ServiceBuilder::new().layer(..).layer(..) chains enumerated in source order: per-layer layer_order plus a layer_chain entity with layer_count + layer_order_list |
-| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+| Rate limit stamping | 🟢 `partial` | `2026-06-03` | — | `internal/custom/rust/rate_limit.go`<br>`internal/custom/rust/rate_limit_test.go` | #4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) for the tower::limit RateLimitLayer::new(num, Duration::from_secs/from_millis(n)) — resolving limit/period + human rate when literal (scope=engine, source=tower_ratelimit). Partial when args are non-literal. Negatives: a non-rate tower layer (CorsLayer/TraceLayer) does not stamp. |
 
 ### Schema
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -66987,9 +66987,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "partial",
+            "cites": ["internal/custom/rust/rate_limit.go","internal/custom/rust/rate_limit_test.go"],
+            "notes": "#4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period/rate_limit_burst) for actix-governor — a .wrap(Governor::new(\u0026conf)) on the App, resolving GovernorConfigBuilder::default().per_second(N).burst_size(M) when literal (scope=app, source=actix_governor). Partial: rate omitted when non-literal/cross-statement. Negatives: a plain route does not stamp.",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {
@@ -67540,9 +67541,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "partial",
+            "cites": ["internal/custom/rust/rate_limit.go","internal/custom/rust/rate_limit_test.go"],
+            "notes": "#4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period/rate_limit_burst) for tower-governor on axum — a .layer(GovernorLayer{ config }) guarding the Router, resolving GovernorConfigBuilder::default().per_second(N).burst_size(M) when literal (scope=router, source=tower_governor). Partial: rate omitted when per_second/burst_size is non-literal or the builder is chained cross-statement. Negatives: a plain route and a non-rate layer (CorsLayer/TraceLayer) do not stamp.",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {
@@ -70035,9 +70037,10 @@
             "verified_at": "2026-05-30"
           },
           "rate_limit_stamping": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/3778",
-            "notes": "endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work."
+            "status": "partial",
+            "cites": ["internal/custom/rust/rate_limit.go","internal/custom/rust/rate_limit_test.go"],
+            "notes": "#4124 greenfield: custom_rust_rate_limit stamps the flat contract (rate_limited/rate_limit/rate_limit_scope/rate_limit_source/limit/period) for the tower::limit RateLimitLayer::new(num, Duration::from_secs/from_millis(n)) — resolving limit/period + human rate when literal (scope=engine, source=tower_ratelimit). Partial when args are non-literal. Negatives: a non-rate tower layer (CorsLayer/TraceLayer) does not stamp.",
+            "verified_at": "2026-06-03"
           }
         },
         "Schema": {

--- a/internal/custom/rust/rate_limit.go
+++ b/internal/custom/rust/rate_limit.go
@@ -1,0 +1,347 @@
+// rate_limit.go — endpoint rate-limit / throttle stamping for Rust web
+// frameworks (#4124, child of #3628 Middleware/rate_limit_stamping). Rust
+// greenfield: prior to this pass EVERY Rust HTTP-framework cell for
+// rate_limit_stamping was `missing` — an axum router guarded by a tower-governor
+// `GovernorLayer`, an actix app guarded by `Governor::new(&conf)`, or a tower
+// `RateLimitLayer`-wrapped service carried no rate-limit signal.
+//
+// Rust greenfield sibling of the Scala pass
+// (internal/custom/scala/rate_limit.go, #4105) and the C++ pass
+// (internal/custom/cpp/rate_limit.go, #4115). It stamps the SAME flat property
+// contract the other languages use so the graph answers "which surfaces are
+// throttled and at what rate?":
+//
+//	rate_limited      — "true" when a throttle applies.
+//	rate_limit        — human rate "5/s" / "100/60s" when statically resolvable
+//	                    from a literal rate; OMITTED (honest-partial) when the
+//	                    builder is chained cross-statement or non-literal.
+//	rate_limit_scope  — "router" (a tower-governor GovernorLayer is applied to a
+//	                    whole axum Router via .layer(...), not a named route)
+//	                    | "app"   (an actix Governor is .wrap(...)-ed onto the
+//	                      App/Scope, app-wide)
+//	                    | "engine" (a bare tower RateLimitLayer / a governor
+//	                      config builder not bound to a layer in-file).
+//	rate_limit_source — the recognised idiom: "tower_governor" (axum
+//	                    GovernorLayer) | "actix_governor" (actix Governor wrap)
+//	                    | "tower_ratelimit" (tower::limit RateLimitLayer).
+//	limit / period    — the resolved numeric cap + window-seconds (when literal).
+//	rate_limit_burst  — the resolved governor burst_size (when literal).
+//
+// Three recognised Rust surfaces:
+//
+//  1. tower-governor on axum —
+//     let conf = GovernorConfigBuilder::default()
+//     .per_second(5).burst_size(10).finish().unwrap();
+//     Router::new().route(...).layer(GovernorLayer { config: conf });
+//     The GovernorLayer is the tower middleware; per_second is the steady-state
+//     replenish rate (→ "<n>/s") and burst_size the bucket capacity. We resolve
+//     per_second/burst_size from the GovernorConfigBuilder chain anywhere in the
+//     file (the builder is conventionally assigned to a config value and then
+//     referenced by the layer). The layer guards the whole Router, so
+//     scope=router. A GovernorConfigBuilder with NO bound GovernorLayer in-file
+//     is engine-scope (config defined, binding not seen here).
+//
+//  2. actix-governor —
+//     let governor_conf = GovernorConfigBuilder::default()
+//     .per_second(2).burst_size(5).finish().unwrap();
+//     App::new().wrap(Governor::new(&governor_conf));
+//     Governor is actix-web middleware applied via .wrap(...) — app-wide
+//     (scope=app). Shares the GovernorConfigBuilder so per_second/burst_size are
+//     resolved the same way.
+//
+//  3. tower RateLimitLayer (tower::limit) —
+//     ServiceBuilder::new().layer(RateLimitLayer::new(100, Duration::from_secs(60)));
+//     RateLimitLayer::new(num, per) — num requests per the Duration window. The
+//     FIRST arg is the cap, the SECOND a std::time::Duration (from_secs(n) /
+//     from_millis(n)). Resolves limit/period + human rate "100/60s". It wraps a
+//     tower Service, not a named route → scope=engine.
+//
+// Like the sibling passes these surfaces add NO new node KIND beyond a marker
+// (`SCOPE.Pattern/rate_limit`) — a governor layer guards a whole Router/App and
+// a tower RateLimitLayer wraps a Service rather than a named route. The marker
+// carries the full throttle posture as evidence; MergeWithCustom dedups by Name.
+//
+// Honest-partial cases (rate_limited stamped, numeric rate OMITTED):
+//   - per_second / burst_size / RateLimitLayer args are non-literal (a config
+//     val / expression) or the builder is chained across statements we cannot
+//     statically join to the binding;
+//   - the Duration unit is unrecognised.
+//
+// Negatives proven: a plain axum/actix route with no governor/rate layer, and a
+// non-rate tower layer (CorsLayer / TraceLayer), do NOT stamp.
+//
+// Honesty: partial — heuristic regex on source text gated on a tower-governor /
+// actix-governor / tower-RateLimitLayer signal so a same-named symbol from
+// another crate is not mis-attributed.
+//
+// Refs #4124.
+package rust
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_rate_limit", &rustRateLimitExtractor{})
+}
+
+type rustRateLimitExtractor struct{}
+
+func (e *rustRateLimitExtractor) Language() string { return "custom_rust_rate_limit" }
+
+var (
+	// reGovernorLayer matches the tower-governor axum middleware binding:
+	//   .layer(GovernorLayer { config: conf })
+	//   .layer(GovernorLayer { config })          (field-init shorthand)
+	//   .layer(GovernorLayer::new(...))            (newer builder form)
+	// We only need the GovernorLayer token presence + its offset; the rate is
+	// resolved from the GovernorConfigBuilder chain (reGovernorPerSecond /
+	// reGovernorBurst) elsewhere in the file.
+	reGovernorLayer = regexp.MustCompile(`\bGovernorLayer\b`)
+
+	// reActixGovernorWrap matches the actix-governor middleware binding:
+	//   .wrap(Governor::new(&governor_conf))
+	//   .wrap(Governor::new(&conf))
+	reActixGovernorWrap = regexp.MustCompile(`\.wrap\s*\(\s*Governor::new\s*\(`)
+
+	// reGovernorConfigBuilder matches the shared governor config builder entry
+	// point so a builder with no bound layer in-file can still be stamped
+	// engine-scope.
+	reGovernorConfigBuilder = regexp.MustCompile(`\bGovernorConfigBuilder::default\s*\(\s*\)`)
+
+	// reGovernorPerSecond captures a literal .per_second(N) on the governor
+	// builder chain. Group 1 = the replenish rate (requests/second).
+	reGovernorPerSecond = regexp.MustCompile(`\.per_second\s*\(\s*(\d+)\s*\)`)
+
+	// reGovernorPerMillisecond captures a literal .per_millisecond(N) on the
+	// governor builder chain (sub-second replenish). Group 1 = ms-per-cell.
+	reGovernorPerMillisecond = regexp.MustCompile(`\.per_millisecond\s*\(\s*(\d+)\s*\)`)
+
+	// reGovernorBurst captures a literal .burst_size(M). Group 1 = bucket capacity.
+	reGovernorBurst = regexp.MustCompile(`\.burst_size\s*\(\s*(\d+)\s*\)`)
+
+	// reTowerRateLimitLayer matches the tower::limit RateLimitLayer:
+	//   RateLimitLayer::new(100, Duration::from_secs(60))
+	//   RateLimitLayer::new(50, Duration::from_millis(500))
+	// Group 1 = num (cap), group 2 = the trailing Duration args text (parsed by
+	// reDurationSecs / reDurationMillis).
+	reTowerRateLimitLayer = regexp.MustCompile(
+		`\bRateLimitLayer::new\s*\(\s*(\d+)\s*,\s*([^)]*\)?[^,)]*)\)`)
+
+	// reDurationSecs / reDurationMillis parse a std::time::Duration constructor
+	// from the trailing args of RateLimitLayer::new. Group 1 = count.
+	reDurationSecs   = regexp.MustCompile(`Duration::from_secs\s*\(\s*(\d+)\s*\)`)
+	reDurationMillis = regexp.MustCompile(`Duration::from_millis\s*\(\s*(\d+)\s*\)`)
+)
+
+// rustGovernorRate resolves the governor steady-state rate from the file's
+// GovernorConfigBuilder chain. Prefers .per_second(N) (→ "<n>/s", periodSecs=1);
+// falls back to .per_millisecond(N) (→ "1/<n>ms", sub-second, periodSecs unset).
+// Returns ("", 0, 0, false) when no literal replenish rate is present (the
+// builder is chained cross-statement or non-literal → honest-partial).
+func rustGovernorRate(src string) (rate string, limit int, periodSecs int, ok bool) {
+	if m := reGovernorPerSecond.FindStringSubmatch(src); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return strconv.Itoa(n) + "/s", n, 1, true
+	}
+	if m := reGovernorPerMillisecond.FindStringSubmatch(src); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		// per_millisecond(N) = one cell replenished every N ms.
+		return "1/" + strconv.Itoa(n) + "ms", 1, 0, true
+	}
+	return "", 0, 0, false
+}
+
+// rustGovernorBurst resolves a literal .burst_size(M) from the builder chain.
+func rustGovernorBurst(src string) (burst int, ok bool) {
+	if m := reGovernorBurst.FindStringSubmatch(src); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return n, true
+	}
+	return 0, false
+}
+
+// rustTowerWindowSecs parses the std::time::Duration window from the trailing
+// args of a RateLimitLayer::new(num, Duration) call. Returns (secs, ms, ok):
+// from_secs → (n, 0, true); from_millis → (0, n, true).
+func rustTowerWindowSecs(argsText string) (secs int, ms int, ok bool) {
+	if m := reDurationSecs.FindStringSubmatch(argsText); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return n, 0, true
+	}
+	if m := reDurationMillis.FindStringSubmatch(argsText); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return 0, n, true
+	}
+	return 0, 0, false
+}
+
+// rustTowerHumanRate builds "<num>/<secs>s" (or "<num>/<ms>ms" for a sub-second
+// window) from the tower RateLimitLayer cap + window; "" when window unresolved.
+func rustTowerHumanRate(num, secs, ms int) string {
+	switch {
+	case secs > 0:
+		return strconv.Itoa(num) + "/" + strconv.Itoa(secs) + "s"
+	case ms > 0:
+		return strconv.Itoa(num) + "/" + strconv.Itoa(ms) + "ms"
+	}
+	return ""
+}
+
+func (e *rustRateLimitExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_rate_limit.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: must mention one of the recognised idioms.
+	if !strings.Contains(src, "GovernorLayer") &&
+		!strings.Contains(src, "Governor::new") &&
+		!strings.Contains(src, "GovernorConfigBuilder") &&
+		!strings.Contains(src, "RateLimitLayer") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Resolve the shared governor config (builder is conventionally assigned to a
+	// config value and referenced by the layer/wrap; we resolve per_second /
+	// burst_size from the chain anywhere in the file). Applied to both the
+	// tower-governor (axum) and actix-governor surfaces.
+	govRate, govLimit, govPeriod, govRateOK := rustGovernorRate(src)
+	govBurst, govBurstOK := rustGovernorBurst(src)
+
+	applyGovernorProps := func(ent *types.EntityRecord) {
+		if govRateOK {
+			ent.Properties["rate_limit"] = govRate
+			ent.Properties["limit"] = strconv.Itoa(govLimit)
+			if govPeriod > 0 {
+				ent.Properties["period"] = strconv.Itoa(govPeriod)
+			}
+		}
+		if govBurstOK {
+			ent.Properties["rate_limit_burst"] = strconv.Itoa(govBurst)
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 1. tower-governor GovernorLayer on an axum Router (scope=router).
+	// ---------------------------------------------------------------------
+	layerBound := false
+	for _, m := range reGovernorLayer.FindAllStringIndex(src, -1) {
+		layerBound = true
+		line := lineOf(src, m[0])
+		name := "tower_governor:" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "axum",
+			"provenance", "INFERRED_FROM_TOWER_GOVERNOR",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "router",
+			"rate_limit_source", "tower_governor")
+		applyGovernorProps(&ent)
+		add(ent)
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. actix-governor Governor::new wrap (scope=app).
+	// ---------------------------------------------------------------------
+	wrapBound := false
+	for _, m := range reActixGovernorWrap.FindAllStringIndex(src, -1) {
+		wrapBound = true
+		line := lineOf(src, m[0])
+		name := "actix_governor:" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "actix-web",
+			"provenance", "INFERRED_FROM_ACTIX_GOVERNOR",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "app",
+			"rate_limit_source", "actix_governor")
+		applyGovernorProps(&ent)
+		add(ent)
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. A GovernorConfigBuilder with NO bound GovernorLayer / Governor::new
+	//    wrap in-file: the config is defined but its binding is not seen here.
+	//    Stamp engine-scope (still carries the resolved rate as evidence).
+	// ---------------------------------------------------------------------
+	if !layerBound && !wrapBound {
+		for _, m := range reGovernorConfigBuilder.FindAllStringIndex(src, -1) {
+			line := lineOf(src, m[0])
+			name := "governor_config:" + file.Path + ":" + strconv.Itoa(line)
+			ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+			setProps(&ent,
+				"framework", "tower-governor",
+				"provenance", "INFERRED_FROM_GOVERNOR_CONFIG",
+				"kind", "rate_limit",
+				"rate_limited", "true",
+				"rate_limit_scope", "engine",
+				"rate_limit_source", "tower_governor")
+			applyGovernorProps(&ent)
+			add(ent)
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. tower::limit RateLimitLayer::new(num, Duration) (scope=engine).
+	// ---------------------------------------------------------------------
+	for _, m := range reTowerRateLimitLayer.FindAllStringSubmatchIndex(src, -1) {
+		num, _ := strconv.Atoi(src[m[2]:m[3]])
+		argsText := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := "tower_ratelimit:" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "rate_limit", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "tower",
+			"provenance", "INFERRED_FROM_TOWER_RATELIMIT_LAYER",
+			"kind", "rate_limit",
+			"rate_limited", "true",
+			"rate_limit_scope", "engine",
+			"rate_limit_source", "tower_ratelimit")
+		if num > 0 {
+			ent.Properties["limit"] = strconv.Itoa(num)
+		}
+		if secs, ms, ok := rustTowerWindowSecs(argsText); ok {
+			if secs > 0 {
+				ent.Properties["period"] = strconv.Itoa(secs)
+			}
+			if rate := rustTowerHumanRate(num, secs, ms); rate != "" {
+				ent.Properties["rate_limit"] = rate
+			}
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/rate_limit_test.go
+++ b/internal/custom/rust/rate_limit_test.go
@@ -1,0 +1,259 @@
+package rust_test
+
+// rate_limit_test.go — value-asserting fixtures for the Rust rate_limit_stamping
+// pass (#4124, child of #3628). Proves the flat contract
+// (rate_limited / rate_limit / rate_limit_scope / rate_limit_source /
+// limit / period / rate_limit_burst) fires for the genuine Rust idioms
+// (tower-governor on axum, actix-governor, tower::limit RateLimitLayer) and
+// proves the negatives (plain route, non-rate tower layer) do NOT stamp.
+
+import "testing"
+
+// findRustRateLimit returns the first SCOPE.Pattern/rate_limit entity matching
+// pred, or nil.
+func findRustRateLimit(ents []entitySummary, pred func(entitySummary) bool) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Subtype == "rate_limit" && pred(ents[i]) {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func anyRustRateLimit(ents []entitySummary) bool {
+	return findRustRateLimit(ents, func(entitySummary) bool { return true }) != nil
+}
+
+// --- 1. tower-governor on axum: per_second(5) + burst_size(10) --------------
+
+func TestRustRateLimit_TowerGovernorAxum(t *testing.T) {
+	src := `
+use axum::Router;
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
+
+fn app() -> Router {
+    let conf = GovernorConfigBuilder::default()
+        .per_second(5)
+        .burst_size(10)
+        .finish()
+        .unwrap();
+    Router::new()
+        .route("/users", axum::routing::get(list))
+        .layer(GovernorLayer { config: conf })
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("main.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "tower_governor" && s.Props["rate_limit_scope"] == "router"
+	})
+	if e == nil {
+		t.Fatalf("expected tower_governor router rate-limit entity, got %+v", ents)
+	}
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if e.Props["rate_limit"] != "5/s" {
+		t.Errorf("rate_limit = %q, want 5/s", e.Props["rate_limit"])
+	}
+	if e.Props["limit"] != "5" {
+		t.Errorf("limit = %q, want 5", e.Props["limit"])
+	}
+	if e.Props["period"] != "1" {
+		t.Errorf("period = %q, want 1", e.Props["period"])
+	}
+	if e.Props["rate_limit_burst"] != "10" {
+		t.Errorf("rate_limit_burst = %q, want 10", e.Props["rate_limit_burst"])
+	}
+	if e.Props["framework"] != "axum" {
+		t.Errorf("framework = %q, want axum", e.Props["framework"])
+	}
+}
+
+// --- 2. actix-governor: per_second(2) + burst_size(5) -----------------------
+
+func TestRustRateLimit_ActixGovernor(t *testing.T) {
+	src := `
+use actix_web::{App, HttpServer};
+use actix_governor::{Governor, GovernorConfigBuilder};
+
+fn build() -> App<()> {
+    let governor_conf = GovernorConfigBuilder::default()
+        .per_second(2)
+        .burst_size(5)
+        .finish()
+        .unwrap();
+    App::new()
+        .wrap(Governor::new(&governor_conf))
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("server.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "actix_governor"
+	})
+	if e == nil {
+		t.Fatalf("expected actix_governor rate-limit entity, got %+v", ents)
+	}
+	if e.Props["rate_limit_scope"] != "app" {
+		t.Errorf("rate_limit_scope = %q, want app", e.Props["rate_limit_scope"])
+	}
+	if e.Props["rate_limit"] != "2/s" {
+		t.Errorf("rate_limit = %q, want 2/s", e.Props["rate_limit"])
+	}
+	if e.Props["limit"] != "2" {
+		t.Errorf("limit = %q, want 2", e.Props["limit"])
+	}
+	if e.Props["rate_limit_burst"] != "5" {
+		t.Errorf("rate_limit_burst = %q, want 5", e.Props["rate_limit_burst"])
+	}
+	if e.Props["framework"] != "actix-web" {
+		t.Errorf("framework = %q, want actix-web", e.Props["framework"])
+	}
+}
+
+// --- 3. tower::limit RateLimitLayer::new(100, Duration::from_secs(60)) -------
+
+func TestRustRateLimit_TowerRateLimitLayer(t *testing.T) {
+	src := `
+use tower::{ServiceBuilder, limit::RateLimitLayer};
+use std::time::Duration;
+
+fn svc() {
+    let _ = ServiceBuilder::new()
+        .layer(RateLimitLayer::new(100, Duration::from_secs(60)));
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("svc.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "tower_ratelimit"
+	})
+	if e == nil {
+		t.Fatalf("expected tower_ratelimit entity, got %+v", ents)
+	}
+	if e.Props["limit"] != "100" {
+		t.Errorf("limit = %q, want 100", e.Props["limit"])
+	}
+	if e.Props["period"] != "60" {
+		t.Errorf("period = %q, want 60", e.Props["period"])
+	}
+	if e.Props["rate_limit"] != "100/60s" {
+		t.Errorf("rate_limit = %q, want 100/60s", e.Props["rate_limit"])
+	}
+	if e.Props["rate_limit_scope"] != "engine" {
+		t.Errorf("rate_limit_scope = %q, want engine", e.Props["rate_limit_scope"])
+	}
+}
+
+// --- 4. tower RateLimitLayer with a sub-second from_millis window ------------
+
+func TestRustRateLimit_TowerRateLimitLayerMillis(t *testing.T) {
+	src := `
+use tower::limit::RateLimitLayer;
+use std::time::Duration;
+let layer = RateLimitLayer::new(50, Duration::from_millis(500));`
+	ents := extract(t, "custom_rust_rate_limit", fi("svc.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "tower_ratelimit"
+	})
+	if e == nil {
+		t.Fatalf("expected tower_ratelimit entity, got %+v", ents)
+	}
+	if e.Props["limit"] != "50" {
+		t.Errorf("limit = %q, want 50", e.Props["limit"])
+	}
+	if e.Props["rate_limit"] != "50/500ms" {
+		t.Errorf("rate_limit = %q, want 50/500ms", e.Props["rate_limit"])
+	}
+	// Sub-second window: period (whole seconds) is honestly omitted.
+	if _, ok := e.Props["period"]; ok {
+		t.Errorf("period unexpectedly set for sub-second window: %q", e.Props["period"])
+	}
+}
+
+// --- 5. honest-partial: governor config with non-literal per_second ---------
+
+func TestRustRateLimit_GovernorNonLiteralPartial(t *testing.T) {
+	src := `
+use axum::Router;
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
+
+fn app(rps: u64) -> Router {
+    let conf = GovernorConfigBuilder::default()
+        .per_second(rps)
+        .finish()
+        .unwrap();
+    Router::new().layer(GovernorLayer { config: conf })
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("main.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_source"] == "tower_governor"
+	})
+	if e == nil {
+		t.Fatalf("expected tower_governor entity, got %+v", ents)
+	}
+	// rate_limited is stamped; the numeric rate is honestly OMITTED (non-literal).
+	if e.Props["rate_limited"] != "true" {
+		t.Errorf("rate_limited = %q, want true", e.Props["rate_limited"])
+	}
+	if _, ok := e.Props["rate_limit"]; ok {
+		t.Errorf("rate_limit should be omitted for non-literal per_second, got %q", e.Props["rate_limit"])
+	}
+	if _, ok := e.Props["limit"]; ok {
+		t.Errorf("limit should be omitted for non-literal per_second, got %q", e.Props["limit"])
+	}
+}
+
+// --- 6. governor config builder with no bound layer/wrap -> engine scope -----
+
+func TestRustRateLimit_GovernorConfigUnbound(t *testing.T) {
+	src := `
+use tower_governor::governor::GovernorConfigBuilder;
+fn make_conf() {
+    let _conf = GovernorConfigBuilder::default()
+        .per_second(3)
+        .burst_size(7)
+        .finish()
+        .unwrap();
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("conf.rs", "rust", src))
+	e := findRustRateLimit(ents, func(s entitySummary) bool {
+		return s.Props["rate_limit_scope"] == "engine" && s.Props["rate_limit_source"] == "tower_governor"
+	})
+	if e == nil {
+		t.Fatalf("expected unbound governor config (engine scope), got %+v", ents)
+	}
+	if e.Props["rate_limit"] != "3/s" {
+		t.Errorf("rate_limit = %q, want 3/s", e.Props["rate_limit"])
+	}
+	if e.Props["rate_limit_burst"] != "7" {
+		t.Errorf("rate_limit_burst = %q, want 7", e.Props["rate_limit_burst"])
+	}
+}
+
+// --- 7. NEGATIVE: a plain axum route with no governor/rate layer ------------
+
+func TestRustRateLimit_PlainRouteNoStamp(t *testing.T) {
+	src := `
+use axum::{Router, routing::get};
+fn app() -> Router {
+    Router::new().route("/health", get(|| async { "ok" }))
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("main.rs", "rust", src))
+	if anyRustRateLimit(ents) {
+		t.Errorf("plain route must not stamp a rate limit, got %+v", ents)
+	}
+}
+
+// --- 8. NEGATIVE: a non-rate tower layer (CorsLayer / TraceLayer) -----------
+
+func TestRustRateLimit_NonRateLayerNoStamp(t *testing.T) {
+	src := `
+use axum::Router;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+fn app() -> Router {
+    Router::new()
+        .layer(CorsLayer::permissive())
+        .layer(TraceLayer::new_for_http())
+}`
+	ents := extract(t, "custom_rust_rate_limit", fi("main.rs", "rust", src))
+	if anyRustRateLimit(ents) {
+		t.Errorf("non-rate tower layer must not stamp a rate limit, got %+v", ents)
+	}
+}


### PR DESCRIPTION
Closes #4124. Refs #3628 (Middleware / rate_limit_stamping audit). **DEPLOY-DEFERRED.**

## What
Rust greenfield for `rate_limit_stamping`: prior to this pass EVERY rust HTTP-framework cell was `missing`. New `custom_rust_rate_limit` extractor stamps the shared flat contract — `rate_limited` / `rate_limit` / `rate_limit_scope` / `rate_limit_source` / `limit` / `period` / `rate_limit_burst` — mirroring the scala (#4105) and cpp (#4115) greenfield templates.

## Recognised idioms (value-asserting — exact rate/burst asserted, not len>0)
| idiom | example | stamp |
|---|---|---|
| **tower-governor** on axum | `.layer(GovernorLayer{ config })` + `GovernorConfigBuilder::default().per_second(5).burst_size(10)` | `rate_limited=true`, `rate_limit=5/s`, `limit=5`, `period=1`, `rate_limit_burst=10`, `scope=router`, `source=tower_governor` |
| **actix-governor** | `.wrap(Governor::new(&conf))` + `per_second(2).burst_size(5)` | `rate_limit=2/s`, `burst=5`, `scope=app`, `source=actix_governor` |
| **tower** `RateLimitLayer` | `RateLimitLayer::new(100, Duration::from_secs(60))` | `limit=100`, `period=60`, `rate_limit=100/60s`, `scope=engine`, `source=tower_ratelimit`; `from_millis(500)` → `50/500ms` (sub-second window, `period` honestly omitted) |

## Honest-partial
`rate_limited` stamped, numeric rate OMITTED when `per_second`/`burst_size`/`RateLimitLayer` args are non-literal (e.g. `per_second(rps)`) or builder-chained cross-statement we cannot join. A `GovernorConfigBuilder` with no bound layer in-file → engine-scope.

## Negatives (proven in tests)
- a plain axum/actix route → no stamp;
- a non-rate tower layer (`CorsLayer` / `TraceLayer`) → no stamp.

## Coverage
Flipped the rust `axum` / `actix` / `tower` `rate_limit_stamping` cells `missing → partial` (surgical line-range registry edits; other rust frameworks honestly stay `missing`). Other rust HTTP frameworks (rocket/poem/warp/tide/etc.) have no framework-native rate-limit primitive to detect → remain `missing`; tonic (gRPC) / async-graphql / utoipa are not HTTP-middleware surfaces.

## Gates
- Full package tests green: `internal/custom/rust/` (8 new value-asserting tests), `internal/extractors/rust/`, `internal/engine/`, `tools/coverage/`.
- Dispatch-parity green (`TestEveryRegisteredCustomKeyDispatches`); **live-fired** via `RunCustomExtractors` on a `.rs` file.
- `covtool validate` 0 errors (warning parity with the scala/cpp precedent); `fmt --check` canonical; `gen` 0 drift; `gofmt` clean; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)