### PR TITLE
fix(mongo): lift $lookup.from JOINS_COLLECTION through get_collection helper-indirection (deploy-9 REFUTED item-1)

### DIFF
--- a/cmd/archigraph/mongo_helper_indirection_test.go
+++ b/cmd/archigraph/mongo_helper_indirection_test.go
@@ -1,0 +1,151 @@
+// Full-pipeline integration test for the Mongo `$lookup → JOINS_COLLECTION`
+// helper-indirection real shape (deploy-9 REFUTED item-1).
+//
+// The rewrite agent reported that on upvate-core the `$lookup.from` collection
+// literals never reach JOINS_COLLECTION edges. The prior tests were
+// extraction-only on crafted fixtures and missed it twice because the REAL
+// access shape combines FOUR things together that no single crafted fixture
+// exercised end-to-end:
+//
+//  1. The aggregating collection comes through a CONNECTION-HELPER indirection
+//     — `MongoDBConnection.get_collection(INSPECTIONS)` — bound to a local
+//     `inspections_cln` variable, not a direct `db.coll`.
+//  2. The collection name is a MODULE-LEVEL CONSTANT (`INSPECTIONS`) imported
+//     from a sibling module, not a quoted string at the call site.
+//  3. The pipeline is built by a SEPARATE builder function in `queries.py`,
+//     imported via a MULTI-LINE `from ... import (...)` clause, and passed as a
+//     DIRECT CALL argument: `inspections_cln.aggregate(builder(params))`.
+//  4. The builder ASSEMBLES the pipeline imperatively — `pipeline = [ ... ]`
+//     then `pipeline.append({...})` / `pipeline.extend([ ... ])` — with both
+//     top-level and NESTED correlated `$lookup` stages, then `return pipeline`.
+//
+// Two fixtures drive the entire production index pipeline (the same
+// Indexer.Run the daemon invokes on rebuild):
+//
+//   - testdata/mongo_helper_indirection      — a minimal hand-written fixture
+//     isolating the four conditions above with a nested correlated lookup.
+//   - testdata/mongo_helper_indirection_real — the VERBATIM upvate-core source
+//     (queries.py / service.py / mongo_helper.py / mongodb_collections.py) that
+//     was REFUTED, copied read-only so the regression is pinned to the exact
+//     bytes the rewrite agent saw.
+//
+// Both assert JOINS_COLLECTION edges to the SPECIFIC named collections survive
+// all the way to the final graph.Document. An extraction-only unit test is
+// explicitly NOT sufficient — that is what missed this twice.
+package main
+
+import "testing"
+
+// TestMongoLookupHelperIndirection_MinimalShape pins the four-condition shape
+// in a small hand-written fixture so a future regression points straight at the
+// offending stage rather than drowning in the 1300-line real file.
+func TestMongoLookupHelperIndirection_MinimalShape(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/mongo_helper_indirection", "mongo_helper_indirection", nil)
+
+	type edge struct{ from, to string }
+	var joins []edge
+	for _, r := range doc.Relationships {
+		if r.Kind == "JOINS_COLLECTION" {
+			joins = append(joins, edge{from: r.FromID, to: r.ToID})
+		}
+	}
+
+	if len(joins) == 0 {
+		kindCounts := map[string]int{}
+		for _, r := range doc.Relationships {
+			kindCounts[r.Kind]++
+		}
+		t.Logf("graph stats: entities=%d relationships=%d", len(doc.Entities), len(doc.Relationships))
+		t.Logf("relationship kinds in graph: %v", kindCounts)
+		t.Fatalf("deploy-9 item-1: expected JOINS_COLLECTION edges from the helper-indirection aggregate shape, got 0 — the $lookup.from literals never reached the graph")
+	}
+
+	// Every join originates at the resolved aggregating collection
+	// (Class:Inspection), NOT a phantom (Class:INSPECTIONS / a mangled var
+	// name). Receiver flow: inspections_cln -> get_collection(INSPECTIONS) ->
+	// "inspections" -> capitalisedSingular -> "Inspection".
+	const wantFrom = "Class:Inspection"
+
+	wantTargets := map[string]bool{
+		"Class:Inspection_group":       false, // top-level "inspection_groups"
+		"Class:M_device":               false, // top-level "m_devices"
+		"Class:M_contract":             false, // top-level "m_contracts"
+		"Class:M_group_device_setting": false, // NESTED "m_group_device_settings"
+	}
+	for _, j := range joins {
+		if _, ok := wantTargets[j.to]; ok {
+			wantTargets[j.to] = true
+			if j.from != wantFrom {
+				t.Errorf("JOINS_COLLECTION to %s has FromID %q, want %q (aggregating collection must resolve through the get_collection helper indirection)", j.to, j.from, wantFrom)
+			}
+		}
+	}
+	for target, seen := range wantTargets {
+		if !seen {
+			t.Errorf("deploy-9 item-1: missing JOINS_COLLECTION edge %s -> %s; observed joins: %+v", wantFrom, target, joins)
+		}
+	}
+}
+
+// TestMongoLookupHelperIndirection_RealUpvateSource indexes the VERBATIM
+// upvate-core building-service source that was reported REFUTED at deploy-9 and
+// asserts that every DISTINCT `$lookup.from` collection in the real builder
+// (15 of them, spanning top-level and nested correlated lookups, multi-line
+// extend-assembled pipelines, and four builder functions) becomes a
+// JOINS_COLLECTION edge from Class:Inspection through to the final graph.json.
+func TestMongoLookupHelperIndirection_RealUpvateSource(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/mongo_helper_indirection_real", "upvate_building", nil)
+
+	const wantFrom = "Class:Inspection"
+	got := map[string]bool{}
+	for _, r := range doc.Relationships {
+		if r.Kind != "JOINS_COLLECTION" {
+			continue
+		}
+		if r.FromID != wantFrom {
+			t.Errorf("real source: JOINS_COLLECTION to %s has FromID %q, want %q — the get_collection(INSPECTIONS) helper indirection did not resolve to the real collection node", r.ToID, r.FromID, wantFrom)
+		}
+		got[r.ToID] = true
+	}
+
+	// The 15 distinct collections joined by the real builder's $lookup stages
+	// (`grep -oE '"from": "[a-z_]+"' queries.py | sort -u`). Includes the two
+	// real (mis)spellings of the alternate-address collection, the nested
+	// correlated m_group_device_settings, and the extend-assembled targets.
+	want := []string{
+		"Class:Inspection_group",             // inspection_groups
+		"Class:Inspections_history",          // inspections_history
+		"Class:M_building_alternate_address", // m_building_alternate_addresses
+		"Class:M_building_alternate_adress",  // m_building_alternate_adresses (real typo)
+		"Class:M_building",                   // m_buildings
+		"Class:M_client",                     // m_clients
+		"Class:M_contract",                   // m_contracts
+		"Class:M_device_equipment_type",      // m_device_equipment_types
+		"Class:M_device",                     // m_devices
+		"Class:M_group_device_setting",       // m_group_device_settings (nested)
+		"Class:M_jurisdiction",               // m_jurisdictions
+		"Class:M_user",                       // m_users
+		"Class:Me_page_version",              // me_page_versions
+		"Class:Me_page",                      // me_pages
+		"Class:Me_report_inspections_group",  // me_report_inspections_group
+	}
+
+	if len(got) == 0 {
+		kindCounts := map[string]int{}
+		for _, r := range doc.Relationships {
+			kindCounts[r.Kind]++
+		}
+		t.Logf("graph stats: entities=%d relationships=%d", len(doc.Entities), len(doc.Relationships))
+		t.Logf("relationship kinds in graph: %v", kindCounts)
+		t.Fatalf("deploy-9 item-1 (REAL source): expected JOINS_COLLECTION edges from the real upvate building service, got 0")
+	}
+	gotList := make([]string, 0, len(got))
+	for k := range got {
+		gotList = append(gotList, k)
+	}
+	for _, target := range want {
+		if !got[target] {
+			t.Errorf("deploy-9 item-1 (REAL source): missing JOINS_COLLECTION edge %s -> %s; got targets: %v", wantFrom, target, gotList)
+		}
+	}
+}

--- a/cmd/archigraph/testdata/mongo_helper_indirection/core/helper/mongo_helper.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection/core/helper/mongo_helper.py
@@ -1,0 +1,19 @@
+from pymongo import MongoClient
+from pymongo.collection import Collection
+
+
+class MongoDBConnection:
+    _client = None
+
+    @classmethod
+    def get_client(cls):
+        if cls._client is None:
+            cls._client = MongoClient("mongodb://localhost:27017")
+        return cls._client
+
+    @classmethod
+    def get_collection(cls, collection_name, db_name="app"):
+        client = cls.get_client()
+        db = client[db_name]
+        collection = db[collection_name]
+        return collection

--- a/cmd/archigraph/testdata/mongo_helper_indirection/core/mongodb_collections.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection/core/mongodb_collections.py
@@ -1,0 +1,2 @@
+INSPECTIONS = "inspections"
+INSPECTIONS_GROUP = "inspection_groups"

--- a/cmd/archigraph/testdata/mongo_helper_indirection/core/services/building/queries.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection/core/services/building/queries.py
@@ -1,0 +1,55 @@
+from pymongo import ASCENDING, DESCENDING
+
+
+def get_inspection_devices_pipeline(params: dict):
+    building_id = params.get("building_id")
+    user_groups = params.get("user_groups")
+
+    pipeline = [
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "localField": "inspectionGroupId",
+                "foreignField": "_id",
+                "as": "inspections_group",
+            }
+        },
+        {"$unwind": {"path": "$inspections_group", "preserveNullAndEmptyArrays": True}},
+        {"$match": {"building_id": building_id, "group_id": {"$in": user_groups}}},
+        {
+            "$lookup": {
+                "from": "m_devices",
+                "let": {"device_id": "$device_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$device_id"]}}},
+                    {
+                        "$lookup": {
+                            "from": "m_group_device_settings",
+                            "let": {"device_id": "$$device_id"},
+                            "pipeline": [
+                                {"$match": {"$expr": {"$eq": ["$device_id", "$$device_id"]}}},
+                            ],
+                            "as": "group_device_settings",
+                        }
+                    },
+                ],
+                "as": "device",
+            }
+        },
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_contracts",
+                "localField": "contractId",
+                "foreignField": "_id",
+                "as": "contract",
+            }
+        },
+        {
+            "$project": {
+                "_id": 1,
+                "contractId": 1,
+            }
+        },
+    ]
+    return pipeline

--- a/cmd/archigraph/testdata/mongo_helper_indirection/core/services/building/service.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection/core/services/building/service.py
@@ -1,0 +1,15 @@
+from core.mongodb_collections import INSPECTIONS, INSPECTIONS_GROUP
+from core.helper.mongo_helper import MongoDBConnection
+from core.services.building.queries import (
+    get_inspection_devices_pipeline,
+)
+
+
+def get_inspection_devices(params: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    data = inspections_cln.aggregate(get_inspection_devices_pipeline(params)).next()
+
+    if not data:
+        return None
+
+    return data

--- a/cmd/archigraph/testdata/mongo_helper_indirection_real/core/helper/mongo_helper.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection_real/core/helper/mongo_helper.py
@@ -1,0 +1,194 @@
+from pymongo import MongoClient, ASCENDING, InsertOne
+from django.conf import settings
+from pymongo.errors import PyMongoError
+from pymongo.collection import Collection
+import os
+
+
+class MongoDBConnection:
+    _client = None
+    _pid = None
+
+    @classmethod
+    def get_client(cls):
+        pid = os.getpid()
+        if cls._pid != pid:
+            cls._client = None
+
+        if cls._client is None:
+            mongo_user = settings.MONGO_DB_USER
+            mongo_password = settings.MONGO_DB_PASSWORD
+            mongo_host = settings.MONGO_DB_HOST
+            mongo_db_name = settings.MONGO_DB_NAME
+            cls._client = MongoClient(
+                f"mongodb+srv://{mongo_user}:{mongo_password}@{mongo_host}/{mongo_db_name}?retryWrites=true&w=majority&tlsInsecure=true"
+            )
+            cls._pid = pid
+        return cls._client
+
+    @classmethod
+    def get_collection(cls, collection_name, db_name=settings.MONGO_DB_NAME):
+        client = cls.get_client()
+        db = client[db_name]
+        collection = db[collection_name]
+
+        if isinstance(collection, Collection):
+            # Save original methods
+            original_insert_one = collection.insert_one
+            original_insert_many = collection.insert_many
+            original_bulk_write = collection.bulk_write
+
+            # insert_one override
+            def custom_insert_one(data, *args, **kwargs):
+                if "id" not in data:
+                    data["id"] = cls.get_next_sequence(collection_name)
+                return original_insert_one(data, *args, **kwargs)
+
+            # insert_many override
+            def custom_insert_many(data_list, *args, **kwargs):
+                for item in data_list:
+                    if "id" not in item:
+                        item["id"] = cls.get_next_sequence(collection_name)
+                return original_insert_many(data_list, *args, **kwargs)
+
+            # bulk_write override
+            def custom_bulk_write(operations, *args, **kwargs):
+                updated_ops = []
+                for op in operations:
+                    if isinstance(op, InsertOne):
+                        doc = op._doc
+                        if "id" not in doc:
+                            doc["id"] = cls.get_next_sequence(collection_name)
+                        updated_ops.append(InsertOne(doc))
+                    else:
+                        updated_ops.append(op)
+                return original_bulk_write(updated_ops, *args, **kwargs)
+
+            # Apply patches safely
+            collection.insert_one = custom_insert_one
+            collection.insert_many = custom_insert_many
+            collection.bulk_write = custom_bulk_write
+        return collection
+
+    @classmethod
+    def get_all_database(cls):
+        client = cls.get_client()
+        return client.list_database_names()
+
+    @classmethod
+    def get_all_collections(cls, db_name):
+        client = cls.get_client()
+        db = client[db_name]
+        return db.list_collection_names()
+
+    @classmethod
+    def insert_one(cls, collection_name, data):
+        if "id" not in data:
+            data["id"] = cls.get_next_sequence(collection_name)
+        collection = cls.get_collection(collection_name)
+        return collection.insert_one(data)
+
+    @classmethod
+    def insert_many(cls, collection_name, data):
+        for item in data:
+            if "id" not in item:
+                item["id"] = cls.get_next_sequence(collection_name)
+        collection = cls.get_collection(collection_name)
+        return collection.insert_many(data)
+
+    @classmethod
+    def find_one(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.find_one(query)
+
+    @classmethod
+    def find_many(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.find(query)
+
+    @classmethod
+    def update_one(cls, collection_name, query, new_values, **args):
+        collection = cls.get_collection(collection_name)
+        return collection.update_one(query, new_values, **args)
+
+    @classmethod
+    def update_many(cls, collection_name, query, new_values):
+        collection = cls.get_collection(collection_name)
+        return collection.update_many(query, new_values)
+
+    @classmethod
+    def delete_one(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.delete_one(query)
+    
+    @classmethod
+    def count_documents(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.count_documents(query)
+
+    @classmethod
+    def delete_many(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.delete_many(query)
+    
+    @classmethod
+    def find_one_and_delete(cls, collection_name, query):
+        collection = cls.get_collection(collection_name)
+        return collection.find_one_and_delete(query)
+    
+    @classmethod
+    def find_one_and_update(cls, collection_name, query, new_values):
+        collection = cls.get_collection(collection_name)
+        return collection.find_one_and_update(query, new_values)
+
+    @classmethod
+    def drop_collection(cls, collection_name):
+        collection = cls.get_collection(collection_name)
+        return collection.drop()
+
+    @classmethod
+    def drop_database(cls, db_name):
+        client = cls.get_client()
+        return client.drop_database(db_name)
+
+    @classmethod
+    def close_connection(cls):
+        if cls._client is not None:
+            cls._client.close()
+            cls._client = None
+
+    @classmethod
+    def empty_collection(cls, collection_name):
+        collection = cls.get_collection(collection_name)
+        collection.delete_many({})
+        print(f"All documents in the '{collection_name}' collection have been deleted.")
+
+    @classmethod
+    def create_index(cls, collection_name, field_name):
+        """
+        Creates an index on the specified field in the given collection.
+
+        :param collection_name: The name of the collection to create the index on.
+        :param field_name: The field to index.
+        """
+        try:
+            collection = cls.get_collection(collection_name)
+            index_name = collection.create_index([(field_name, ASCENDING)])
+            print(
+                f"Index '{index_name}' created on field '{field_name}' in collection '{collection_name}'."
+            )
+        except PyMongoError as e:
+            print(
+                f"Error creating index on field '{field_name}' in collection '{collection_name}': {str(e)}"
+            )
+    
+    @classmethod
+    def get_next_sequence(cls, sequence_name):
+        counters_collection = cls.get_collection("counters")
+        result = counters_collection.find_one_and_update(
+            {"_id": sequence_name},
+            {"$inc": {"sequence_value": 1}},
+            upsert=True,
+            return_document=True
+        )
+        return result["sequence_value"]

--- a/cmd/archigraph/testdata/mongo_helper_indirection_real/core/mongodb_collections.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection_real/core/mongodb_collections.py
@@ -1,0 +1,8 @@
+INSPECTIONS = "inspections"
+INSPECTIONS_HISTORY = "inspections_history"
+INSPECTIONS_GROUP = "inspection_groups"
+ME_PAGES = "me_pages"
+ME_PAGE_VERSIONS = "me_page_versions"
+ME_REPORT_INSPECTIONS_GROUP = "me_report_inspections_group"
+NOTIFICATIONS = "notifications"
+PERMITS = "permits"

--- a/cmd/archigraph/testdata/mongo_helper_indirection_real/core/services/building/queries.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection_real/core/services/building/queries.py
@@ -1,0 +1,1344 @@
+from pymongo import ASCENDING, DESCENDING
+
+
+def get_inspection_devices_pipeline(params: dict):
+
+    building_id = params.get("building_id")
+    user_groups = params.get("user_groups")
+    devices = params.get("devices")
+    clients = params.get("clients")
+    statuses = params.get("statuses")
+    elv3_compliance_status = params.get("elv3_compliance_status")
+    aoc_compliance_status = params.get("aoc_compliance_report_status")
+    inspection_types = params.get("inspection_types")
+    offset = params.get("offset")
+    limit = params.get("limit")
+    sort = params.get("field")
+    order = params.get("order")
+    order = DESCENDING if order == "descend" else ASCENDING
+
+    pipeline = [
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "localField": "inspectionGroupId",
+                "foreignField": "_id",
+                "as": "inspections_group",
+            }
+        },
+        {"$unwind": {"path": "$inspections_group", "preserveNullAndEmptyArrays": True}},
+        {"$set": {"building_id": "$inspections_group.buildingId", "group_id": "$inspections_group.groupId"}},
+        {"$match": {"building_id": building_id, "group_id": {"$in": user_groups}}},
+        {
+            "$project": {
+                "_id": 1,
+                "contractId": 1,
+                "contractNumber": 1,
+                "contractType": 1,
+                "inspectionGroupId": 1,
+                "device_id": 1,
+                "device_name": 1,
+                "fsotDate": 1,
+                "result": 1,
+                "status": 1,
+                "reason": 1,
+                "inspection_date": 1,
+                "is_reinspected": 1,
+                "inspections_group": 1,
+                "inspection_checklists": {"$first": "$inspection_checklists"},
+                "elv3": 1,
+                "aoc": 1,
+                "aoc_filed_date": 1,
+            }
+        },
+        {
+            "$set": {
+                "users_to_lookup": [
+                    "$inspections_group.inspectorId",
+                    "$inspections_group.performingInspectorId",
+                    "$inspections_group.witnessingInspectorId",
+                    "$inspections_group.performingDirectorId",
+                    "$inspections_group.witnessingDirectorId",
+                ]
+            }
+        },
+        {
+            "$lookup": {
+                "from": "m_devices",
+                "let": {"device_id": "$device_id", "group_id": "$group_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$device_id"]}}},
+                    {"$limit": 1},
+                    {
+                        "$lookup": {
+                            "from": "m_group_device_settings",
+                            "let": {"device_id": "$$device_id", "group_id": "$$group_id"},
+                            "pipeline": [
+                                {
+                                    "$match": {
+                                        "$expr": {
+                                            "$and": [
+                                                {"$eq": ["$device_id", "$$device_id"]},
+                                                {"$eq": ["$group_id", "$$group_id"]},
+                                            ]
+                                        }
+                                    }
+                                },
+                                {"$limit": 1},
+                                {
+                                    "$project": {
+                                        "_id": 0,
+                                        "name": 1,
+                                    }
+                                },
+                            ],
+                            "as": "group_device_settings",
+                        }
+                    },
+                    {"$unwind": {"path": "$group_device_settings", "preserveNullAndEmptyArrays": True}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "name": {"$ifNull": ["$group_device_settings.name", "$name"]},
+                        }
+                    },
+                ],
+                "as": "device",
+            }
+        },
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_users",
+                "let": {"ids": "$users_to_lookup"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$in": ["$postgresql_id", "$$ids"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "first_name": 1, "last_name": 1}},
+                ],
+                "as": "users",
+            }
+        },
+        {
+            "$set": {
+                "inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.inspectorId"]},
+                        }
+                    }
+                },
+                "performing_inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.performingInspectorId"]},
+                        }
+                    }
+                },
+                "performing_director": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.performingDirectorId"]},
+                        }
+                    }
+                },
+                "witnessing_inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.witnessingInspectorId"]},
+                        }
+                    }
+                },
+                "witnessing_director": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.witnessingDirectorId"]},
+                        }
+                    }
+                },
+            }
+        },
+        {
+            "$lookup": {
+                "from": "m_contracts",
+                "let": {"contract_id": "$contractId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$contract_id"]}}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "contract_number": 1,
+                            "contract_type": 1,
+                            "selected_address_type": 1,
+                            "selected_address": 1,
+                            "client_id": 1,
+                        }
+                    },
+                    {"$limit": 1},
+                ],
+                "as": "contract",
+            }
+        },
+        {"$unwind": {"path": "$contract", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_building_alternate_adresses",
+                "localField": "selected_address",
+                "foreignField": "postgresql_id",
+                "as": "alternate_adresses",
+            }
+        },
+        {"$unwind": {"path": "$alternate_adresses", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_buildings",
+                "let": {"building_id": "$inspections_group.buildingId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$building_id"]}}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "name": 1,
+                            "physical_address": 1,
+                            "premises_address": 1,
+                        }
+                    },
+                    {"$limit": 1},
+                ],
+                "as": "building",
+            }
+        },
+        {"$unwind": {"path": "$building", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_clients",
+                "let": {"client_id": {"$ifNull": ["$inspections_group.clientId", "$contract.client_id"]}},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$client_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                    {"$limit": 1},
+                ],
+                "as": "client",
+            }
+        },
+        {"$unwind": {"path": "$client", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_jurisdictions",
+                "let": {"jurisdiction_id": "$inspections_group.jurisdictionId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$jurisdiction_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                    {"$limit": 1},
+                ],
+                "as": "jurisdiction",
+            }
+        },
+        {"$unwind": {"path": "$jurisdiction", "preserveNullAndEmptyArrays": True}},
+        {
+            "$set": {
+                "client_id": "$client.id",
+                "checklist_id": "$inspection_checklists.id",
+                "checklist_type": "$inspection_checklists.type",
+                "elv3_compliance_status": {"$first": "$elv3.status"},
+                "aoc_compliance_status": {"$first": "$aoc.compliance_report_status"},
+                "computed_building_address": {
+                    "$cond": {
+                        "if": {"$eq": ["$contract.selected_address_type", "Premises Address"]},
+                        "then": {"$ifNull": ["$building.premises_address", "$building.physical_address"]},
+                        "else": {"$ifNull": ["$alternate_adresses.address", "$building.physical_address"]},
+                    }
+                },
+            }
+        },
+    ]
+
+    if statuses:
+        pipeline.append({"$match": {"status": {"$in": statuses}}})
+
+    if inspection_types:
+        pipeline.append({"$match": {"checklist_type": {"$in": list(map(int, inspection_types))}}})
+
+    if clients:
+        pipeline.append({"$match": {"client_id": {"$in": list(map(int, clients))}}})
+
+    if devices:
+        pipeline.append({"$match": {"device_id": {"$in": list(map(int, devices))}}})
+
+    if elv3_compliance_status:
+        pipeline.append({"$match": {"elv3_compliance_status": {"$in": elv3_compliance_status}}})
+
+    if aoc_compliance_status:
+        pipeline.append({"$match": {"aoc_compliance_status": {"$in": aoc_compliance_status}}})
+
+    pipeline.extend(
+        [
+            {
+                "$lookup": {
+                    "from": "inspections_history",
+                    "let": {
+                        "inspection_id": "$_id",
+                        "client_name": "$client.name",
+                        "checklist_id": "$checklist_id",
+                        "checklist_type": "$checklist_type",
+                        "inspection_date": "$inspection_date",
+                        "inspector_id": "$inspector_id",
+                        "contract_id": "$contract.id",
+                        "contract_type": "$contract.contract_type",
+                        "contract_number": "$contract.contract_number",
+                        "building_address": "$computed_building_address",
+                        "performing_inspector_id": "$performing_inspector.id",
+                        "performing_director_id": "$performing_director.id",
+                        "witnessing_inspector_id": "$witnessing_inspector.id",
+                        "witnessing_director_id": "$witnessing_director.id",
+                        "elevator_company_id": "$elevator_company.id",
+                        "witnessing_company_id": "$witnessing_company.id",
+                        "scheduled_date": "$inspections_group.startDate",
+                    },
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$parent_id", "$$inspection_id"]}}},
+                        {
+                            "$project": {
+                                "_id": 0,
+                                "id": {"$toString": "$_id"},
+                                "contractId": 1,
+                                "contractNumber": 1,
+                                "contractType": 1,
+                                "device_id": 1,
+                                "device_name": 1,
+                                "fsotDate": 1,
+                                "result": 1,
+                                "status": 1,
+                                "reason": 1,
+                                "inspection_date": "$$inspection_date",
+                                "inspection_files": 1,
+                                "inspection_emails": 1,
+                                "inspection_notes": 1,
+                                "inspection_checklists": 1,
+                                "client_name": "$$client_name",
+                                "checklist_id": "$$checklist_id",
+                                "checklist_type": "$$checklist_type",
+                                "contract_id": "$$contract_id",
+                                "contract_type": "$$contract_type",
+                                "contract_number": "$$contract_number",
+                                "building_address": "$$building_address",
+                                "inspector_id": "$$inspector_id",
+                                "scheduled_date": "$$scheduled_date",
+                                "performing_inspector_id": "$$performing_inspector_id",
+                                "performing_director_id": "$$performing_director_id",
+                                "witnessing_inspector_id": "$$witnessing_inspector_id",
+                                "witnessing_director_id": "$$witnessing_director_id",
+                                "elevator_company_id": "$$elevator_company_id",
+                                "witnessing_company_id": "$$witnessing_company_id",
+                                "elv3": 1,
+                                "aoc": 1,
+                            }
+                        },
+                        {"$limit": 1},
+                    ],
+                    "as": "history",
+                }
+            },
+            {
+                "$project": {
+                    "_id": 0,
+                    "id": {"$toString": "$_id"},
+                    "inspections_group_id": {"$toString": "$inspections_group._id"},
+                    "device_id": "$device.id",
+                    "device_name": "$device.name",
+                    "status": "$status",
+                    "scheduled_date": "$inspections_group.startDate",
+                    "fsot_date": {"$ifNull": ["$inspections_group.fsotDate", None]},
+                    "result": "$result",
+                    "inspection_date": "$inspection_date",
+                    "checklist_id": "$checklist_id",
+                    "checklist_type": "$checklist_type",
+                    "is_reinspected": {"$ifNull": ["$is_reinspected", False]},
+                    "inspector_id": {"$ifNull": ["$inspector.id", "$inspections_group.inspectorId"]},
+                    "inspector_name": {
+                        "$trim": {"input": {"$concat": ["$inspector.first_name", " ", "$inspector.last_name"]}}
+                    },
+                    "performing_inspector_id": {"$ifNull": ["$performing_inspector.id", None]},
+                    "performing_inspector_name": {
+                        "$trim": {
+                            "input": {
+                                "$concat": ["$performing_inspector.first_name", " ", "$performing_inspector.last_name"]
+                            }
+                        }
+                    },
+                    "performing_director_id": {
+                        "$ifNull": ["$performing_director.id", "$inspections_group.performingDirectorId"]
+                    },
+                    "performing_director_name": {
+                        "$cond": {
+                            "if": "$performing_director.id",
+                            "then": {
+                                "$trim": {
+                                    "input": {
+                                        "$concat": [
+                                            "$performing_director.first_name",
+                                            " ",
+                                            "$performing_director.last_name",
+                                        ]
+                                    }
+                                }
+                            },
+                            "else": None,
+                        }
+                    },
+                    "witnessing_inspector_id": {
+                        "$ifNull": ["$witnessing_inspector.id", "$inspections_group.witnessingInspectorId"]
+                    },
+                    "witnessing_inspector_name": {
+                        "$trim": {
+                            "input": {
+                                "$concat": ["$witnessing_inspector.first_name", " ", "$witnessing_inspector.last_name"]
+                            }
+                        }
+                    },
+                    "witnessing_director_id": {
+                        "$ifNull": ["$witnessing_director.id", "$inspections_group.witnessingDirectorId"]
+                    },
+                    "witnessing_director_name": {
+                        "$trim": {
+                            "input": {
+                                "$concat": ["$witnessing_director.first_name", " ", "$witnessing_director.last_name"]
+                            }
+                        }
+                    },
+                    "witnessing_company_id": {"$ifNull": ["$inspections_group.witnessingCompanyId", None]},
+                    "elevator_company_id": {"$ifNull": ["$inspections_group.elevator_company_id", None]},
+                    "jurisdiction_id": "$jurisdiction.id",
+                    "jurisdiction_name": "$jurisdiction.name",
+                    "building_id": "$building.id",
+                    "building_address": "$computed_building_address",
+                    "client_id": "$client.id",
+                    "client_name": {"$ifNull": ["$client.name", "$inspections_group.clientName"]},
+                    "contract_id": "$contract.id",
+                    "contract_number": "$contract.contract_number",
+                    "contract_type": "$contract.contract_type",
+                    "aoc_filed_date": "$aoc_filed_date",
+                    "children": {
+                        "$cond": [{"$gt": [{"$size": {"$ifNull": ["$history", []]}}, 0]}, "$history", "$$REMOVE"]
+                    },
+                    "aoc": {"$ifNull": ["$aoc", []]},
+                    "elv3": {"$ifNull": ["$elv3", []]},
+                }
+            },
+            {
+                "$facet": {
+                    "results": [
+                        {"$sort": {sort: order}},
+                        {"$skip": offset},
+                        {"$limit": limit},
+                    ],
+                    "count": [{"$count": "total"}],
+                }
+            },
+            {"$project": {"results": 1, "count": {"$arrayElemAt": ["$count.total", 0]}}},
+        ]
+    )
+
+    return pipeline
+
+
+def get_inspection_devices_filters_pipeline(params: dict):
+
+    building_id = params.get("building_id")
+    user_groups = params.get("user_groups")
+
+    return [
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "localField": "inspectionGroupId",
+                "foreignField": "_id",
+                "as": "inspections_group",
+            }
+        },
+        {"$unwind": {"path": "$inspections_group", "preserveNullAndEmptyArrays": True}},
+        {"$set": {"building_id": "$inspections_group.buildingId", "group_id": "$inspections_group.groupId"}},
+        {"$match": {**({"building_id": building_id} if building_id else {}), "group_id": {"$in": user_groups}}},
+        {
+            "$project": {
+                "_id": 1,
+                "device_id": 1,
+                "device_name": 1,
+                "status": 1,
+                "inspections_group": 1,
+                "inspection_checklists": {"$first": "$inspection_checklists"},
+                "aoc": {"$first": "$aoc"},
+                "elv3": {"$first": "$elv3"},
+            }
+        },
+        {
+            "$lookup": {
+                "from": "m_clients",
+                "let": {"client_id": "$inspections_group.clientId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$client_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                    {"$limit": 1},
+                ],
+                "as": "client",
+            }
+        },
+        {"$unwind": {"path": "$client", "preserveNullAndEmptyArrays": True}},
+        {"$set": {"users_to_lookup": ["$inspections_group.inspectorId", "$inspections_group.witnessingInspectorId"]}},
+        {
+            "$lookup": {
+                "from": "m_users",
+                "let": {"ids": "$users_to_lookup"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$in": ["$postgresql_id", "$$ids"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "first_name": 1, "last_name": 1}},
+                ],
+                "as": "users",
+            }
+        },
+        {
+            "$set": {
+                "inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.inspectorId"]},
+                        }
+                    }
+                },
+                "witnessing_inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.witnessingInspectorId"]},
+                        }
+                    }
+                },
+            }
+        },
+        {
+            "$project": {
+                "_id": 0,
+                "device_id": "$device_id",
+                "device_name": "$device_name",
+                "status": "$status",
+                "result": "$result",
+                "client_id": "$client.id",
+                "client_name": "$client.name",
+                "inspector_id": {"$ifNull": ["$inspector.id", None]},
+                "inspector_name": {
+                    "$trim": {
+                        "input": {
+                            "$concat": [
+                                {"$ifNull": ["$inspector.first_name", ""]},
+                                " ",
+                                {"$ifNull": ["$inspector.last_name", ""]},
+                            ]
+                        }
+                    }
+                },
+                "witnessing_inspector_id": {"$ifNull": ["$witnessing_inspector.id", None]},
+                "witnessing_inspector_name": {
+                    "$trim": {
+                        "input": {
+                            "$concat": [
+                                {"$ifNull": ["$witnessing_inspector.first_name", ""]},
+                                " ",
+                                {"$ifNull": ["$witnessing_inspector.last_name", ""]},
+                            ]
+                        }
+                    }
+                },
+                "elv3_compliance_status": {"$ifNull": ["$elv3.status", None]},
+                "aoc_compliance_status": {"$ifNull": ["$aoc.compliance_report_status", None]},
+            }
+        },
+        {
+            "$facet": {
+                "devices": [
+                    {"$match": {"device_id": {"$ne": None}, "device_name": {"$ne": None}, "device_name": {"$ne": ""}}},
+                    {"$group": {"_id": "$device_id", "text": {"$first": "$device_name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+                "clients": [
+                    {"$match": {"client_id": {"$ne": None}, "client_name": {"$ne": None}, "client_name": {"$ne": ""}}},
+                    {"$group": {"_id": "$client_id", "text": {"$first": "$client_name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+                "statuses": [
+                    {"$match": {"status": {"$ne": None}, "status": {"$ne": ""}}},
+                    {"$group": {"_id": "$status"}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": "$_id"}},
+                    {"$sort": {"text": 1}},
+                ],
+                "inspectors": [
+                    {
+                        "$match": {
+                            "$or": [
+                                {"inspector_id": {"$ne": None}},
+                                {"witnessing_inspector_id": {"$ne": None}},
+                            ]
+                        }
+                    },
+                    {
+                        "$project": {
+                            "inspector_options": [
+                                {"id": "$inspector_id", "name": "$inspector_name"},
+                                {"id": "$witnessing_inspector_id", "name": "$witnessing_inspector_name"},
+                            ]
+                        }
+                    },
+                    {"$unwind": "$inspector_options"},
+                    {"$match": {"inspector_options.id": {"$nin": [None, "", 0]}}},
+                    {"$group": {"_id": "$inspector_options.id", "text": {"$first": "$inspector_options.name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+                "elv3_compliance_status": [
+                    {"$match": {"elv3_compliance_status": {"$nin": [None, ""]}}},
+                    {"$group": {"_id": "$elv3_compliance_status"}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": "$_id"}},
+                    {"$sort": {"text": 1}},
+                ],
+                "aoc_compliance_status": [
+                    {"$match": {"aoc_compliance_status": {"$nin": [None, ""]}}},
+                    {"$group": {"_id": "$aoc_compliance_status"}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": "$_id"}},
+                    {"$sort": {"text": 1}},
+                ],
+            }
+        },
+    ]
+
+
+def get_maintenance_evaluations_pipeline(params: dict):
+    building_id = params.get("building_id")
+    user_groups = params.get("user_groups")
+    statuses = params.get("statuses")
+    devices = params.get("devices")
+    inspectors = params.get("inspectors")
+    inspection_year = params.get("inspection_year")
+    offset = params.get("offset")
+    limit = params.get("limit")
+    sort = params.get("field")
+    order = params.get("order")
+    order = DESCENDING if order == "descend" else ASCENDING
+    search = params.get("search")
+    checklist_id = params.get("checklist_id")
+
+    if not building_id:
+        statuses = ["Results Reviewed", "Assembling Report"]
+
+    pipeline = [
+        {
+            "$project": {
+                "_id": 1,
+                "inspectionGroupId": 1,
+                "contractId": 1,
+                "device_id": 1,
+                "result": 1,
+                "status": 1,
+                "checklist_id": {"$first": "$inspection_checklists.id"},
+                "checklist_type": {"$first": "$inspection_checklists.type"},
+                "inspection_year": {"$year": "$inspection_date"},
+            }
+        },
+        {"$match": {"checklist_type": 4}},
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "let": {"inspections_group_id": "$inspectionGroupId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$_id", "$$inspections_group_id"]}}},
+                    {
+                        "$project": {
+                            "_id": 1,
+                            "groupId": 1,
+                            "buildingId": 1,
+                            "inspectorId": 1,
+                            "clientId": 1,
+                            "witnessingInspectorId": 1,
+                            "startDate": 1,
+                        }
+                    },
+                    {"$limit": 1},
+                ],
+                "as": "inspections_group",
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$inspections_group",
+                "preserveNullAndEmptyArrays": True,
+            }
+        },
+    ]
+
+    if building_id:
+        pipeline.append(
+            {
+                "$match": {
+                    "inspections_group.buildingId": building_id,
+                }
+            }
+        )
+
+    pipeline.extend([
+        {
+            "$match": {
+                "inspections_group.groupId": {"$in": user_groups},
+            }
+        },
+        {
+            "$set": {
+                "users_to_lookup": [
+                    "$inspections_group.inspectorId",
+                    "$inspections_group.witnessingInspectorId",
+                ]
+            }
+        },
+        {
+            "$lookup": {
+                "from": "m_users",
+                "let": {"ids": "$users_to_lookup"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$in": ["$postgresql_id", "$$ids"]}}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "first_name": 1,
+                            "last_name": 1,
+                        }
+                    },
+                ],
+                "as": "users",
+            }
+        },
+        {
+            "$set": {
+                "inspector": {
+                    "$ifNull": [
+                        {
+                            "$first": {
+                                "$filter": {
+                                    "input": "$users",
+                                    "as": "u",
+                                    "cond": {
+                                        "$eq": [
+                                            "$$u.id",
+                                            "$inspections_group.inspectorId",
+                                        ]
+                                    },
+                                }
+                            }
+                        },
+                        None,
+                    ]
+                },
+                "witnessing_inspector": {
+                    "$ifNull": [
+                        {
+                            "$first": {
+                                "$filter": {
+                                    "input": "$users",
+                                    "as": "u",
+                                    "cond": {
+                                        "$eq": [
+                                            "$$u.id",
+                                            "$inspections_group.witnessingInspectorId",
+                                        ]
+                                    },
+                                }
+                            }
+                        },
+                        None,
+                    ]
+                },
+            }
+        },
+        {
+            "$lookup": {
+                "from": "m_devices",
+                "let": {
+                    "device_id": "$device_id",
+                    "group_id": "$inspections_group.groupId",
+                },
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$device_id"]}}},
+                    {
+                        "$lookup": {
+                            "from": "m_group_device_settings",
+                            "let": {
+                                "device_id": "$$device_id",
+                                "group_id": "$$group_id",
+                            },
+                            "pipeline": [
+                                {
+                                    "$match": {
+                                        "$expr": {
+                                            "$and": [
+                                                {"$eq": ["$device_id", "$$device_id"]},
+                                                {"$eq": ["$group_id", "$$group_id"]},
+                                            ]
+                                        }
+                                    }
+                                },
+                                {"$limit": 1},
+                                {
+                                    "$project": {
+                                        "_id": 0,
+                                        "machine_number": 1,
+                                        "car_number": 1,
+                                        "equipment_type_id": 1,
+                                    }
+                                },
+                            ],
+                            "as": "settings",
+                        }
+                    },
+                    {
+                        "$unwind": {
+                            "path": "$settings",
+                            "preserveNullAndEmptyArrays": True,
+                        }
+                    },
+                    {
+                        "$lookup": {
+                            "from": "m_device_equipment_types",
+                            "let": {"equipment_type_id": "$settings.equipment_type_id"},
+                            "pipeline": [
+                                {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$equipment_type_id"]}}},
+                                {"$project": {"_id": 0, "category": 1, "alias": 1}},
+                                {"$limit": 1},
+                            ],
+                            "as": "equipment_type",
+                        }
+                    },
+                    {"$unwind": {"path": "$equipment_type", "preserveNullAndEmptyArrays": True}},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "name": {"$ifNull": ["$name", "$settings.name"]},
+                            "machine_number": "$settings.machine_number",
+                            "car_number": "$settings.car_number",
+                            "equipment_type": {
+                                "$cond": {
+                                    "if": {"$ne": ["$equipment_type", None]},
+                                    "then": {"$concat": ["$equipment_type.category", "-", "$equipment_type.alias"]},
+                                    "else": None,
+                                }
+                            },
+                        }
+                    },
+                ],
+                "as": "device",
+            }
+        },
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_buildings",
+                "let": {"building_id": "$inspections_group.buildingId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$building_id"]}}},
+                    {"$limit": 1},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "name": 1,
+                            "premises_address": 1,
+                        }
+                    },
+                ],
+                "as": "building",
+            }
+        },
+        {"$unwind": {"path": "$building", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_contracts",
+                "let": {"contract_id": "$contractId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$contract_id"]}}},
+                    {"$limit": 1},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "client_id": 1,
+                            "contract_number": 1,
+                            "contract_type": 1,
+                            "selected_address_type": 1,
+                            "selected_address_id": 1,
+                        }
+                    },
+                ],
+                "as": "contract",
+            }
+        },
+        {"$unwind": {"path": "$contract", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_clients",
+                "let": {"client_id": "$contract.client_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$client_id"]}}},
+                    {"$limit": 1},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "id": "$postgresql_id",
+                            "name": 1,
+                        }
+                    },
+                ],
+                "as": "client",
+            }
+        },
+        {"$unwind": {"path": "$client", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_building_alternate_addresses",
+                "let": {"alt_addr_id": "$contract.selected_address_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$alt_addr_id"]}}},
+                    {"$limit": 1},
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "address": 1,
+                        }
+                    },
+                ],
+                "as": "alt_address",
+            }
+        },
+        {"$unwind": {"path": "$alt_address", "preserveNullAndEmptyArrays": True}},
+        {
+            "$set": {
+                "alternate_address": {
+                    "$cond": [
+                        {"$eq": ["$contract.selected_address_type", "Premises Address"]},
+                        "$building.premises_address",
+                        {"$ifNull": ["$alt_address.address", None]},
+                    ]
+                }
+            }
+        },
+    ])
+
+    pipeline.extend(
+        [
+            {
+                "$lookup": {
+                    "from": "me_report_inspections_group",
+                    "let": {"inspection_id": "$_id"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$in": ["$$inspection_id", "$inspections"]}}},
+                        {"$project": {"_id": 1}},
+                        {"$limit": 1},
+                    ],
+                    "as": "assembled_report",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$assembled_report",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {"$set": {"assembled_report_id": {"$ifNull": ["$assembled_report._id", None]}}},
+            {
+                "$group": {
+                    "_id": {"$ifNull": ["$assembled_report_id", "$_id"]},
+                    "building_id": {"$first": "$building.id"},
+                    "building_name": {"$first": "$building.name"},
+                    "alternate_address": {"$first": "$alternate_address"},
+                    "contract_number": {"$first": "$contract.contract_number"},
+                    "contract_type": {"$first": "$contract.contract_type"},
+                    "client_id": {"$first": "$client.id"},
+                    "client_name": {"$first": "$client.name"},
+                    "inspection_year": {"$first": "$inspection_year"},
+                    "inspector": {"$first": "$inspector"},
+                    "witnessing_inspector": {"$first": "$witnessing_inspector"},
+                    "checklist_id": {"$first": "$checklist_id"},
+                    "checklist_type": {"$first": "$checklist_type"},
+                    "status": {"$first": "$status"},
+                    "devices": {
+                        "$push": {
+                            "id": "$device_id",
+                            "name": "$device.name",
+                            "machine_number": "$device.machine_number",
+                            "car_number": "$device.car_number",
+                            "inspection_id": {"$toString": "$_id"},
+                        }
+                    },
+                    "device": {
+                        "$first": {
+                            "$cond": [
+                                {"$eq": ["$assembled_report_id", None]},
+                                "$device",
+                                None,
+                            ]
+                        }
+                    },
+                }
+            },
+            {"$sort": {"_id": -1}},
+            {
+                "$lookup": {
+                    "from": "me_pages",
+                    "let": {"inspections_group_id": "$_id"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$inspections_group_id", "$$inspections_group_id"]}}},
+                        {"$limit": 1},
+                    ],
+                    "as": "me_page",
+                }
+            },
+            {"$unwind": {"path": "$me_page", "preserveNullAndEmptyArrays": True}},
+            {
+                "$lookup": {
+                    "from": "me_page_versions",
+                    "let": {"current_version_id": "$me_page.current_version"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$_id", "$$current_version_id"]}}},
+                        {"$limit": 1},
+                        {
+                            "$project": {
+                                "_id": 0,
+                                "id": {"$toString": "$_id"},
+                                "name": "$name",
+                                "version_number": "$version_number",
+                            }
+                        },
+                    ],
+                    "as": "current_version",
+                }
+            },
+            {"$unwind": {"path": "$current_version", "preserveNullAndEmptyArrays": True}},
+            {
+                "$project": {
+                    "_id": 0,
+                    "id": {"$toString": "$_id"},
+                    "row_type": {
+                        "$cond": [{"$eq": ["$device", None]}, "group", "inspection"]
+                    },
+                    "building_id": "$building_id",
+                    "building_name": "$building_name",
+                    "alternate_address": "$alternate_address",
+                    "contract_number": "$contract_number",
+                    "contract_type": "$contract_type",
+                    "client_id": "$client_id",
+                    "client_name": "$client_name",
+                    "checklist_id": "$checklist_id",
+                    "checklist_type": "$checklist_type",
+                    "inspection_year": "$inspection_year",
+                    "status": "$status",
+                    "inspector_id": {"$ifNull": ["$inspector.id", None]},
+                    "inspector_name": {
+                        "$trim": {
+                            "input": {
+                                "$concat": [
+                                    "$inspector.first_name",
+                                    " ",
+                                    "$inspector.last_name",
+                                ]
+                            }
+                        }
+                    },
+                    "witnessing_inspector_id": {"$ifNull": ["$witnessing_inspector.id", None]},
+                    "witnessing_inspector_name": {
+                        "$trim": {
+                            "input": {
+                                "$concat": [
+                                    "$witnessing_inspector.first_name",
+                                    " ",
+                                    "$witnessing_inspector.last_name",
+                                ]
+                            }
+                        }
+                    },
+                    "device": "$device",
+                    "devices": "$devices",
+                    "current_version": "$current_version",
+                }
+            },
+        ]
+    )
+
+    if statuses:
+        pipeline.append({"$match": {"status": {"$in": statuses}}})
+
+    if devices:
+        pipeline.append({"$match": {"devices.id": {"$in": list(map(int, devices))}}})
+
+    if inspectors:
+        sanitize_inspectors = list(map(int, inspectors))
+        pipeline.append(
+            {
+                "$match": {
+                    "$or": [
+                        {"inspector_id": {"$in": sanitize_inspectors}},
+                        {"witnessing_inspector_id": {"$in": sanitize_inspectors}},
+                    ]
+                }
+            }
+        )
+
+    if inspection_year:
+        pipeline.append({"$match": {"inspection_year": {"$in": list(map(int, inspection_year))}}})
+
+    if search:
+        search_regex = {"$regex": search, "$options": "i"}
+        pipeline.append(
+            {
+                "$match": {
+                    "$or": [
+                        {"alternate_address": search_regex},
+                        {"client_name": search_regex},
+                        {"devices.name": search_regex},
+                    ]
+                }
+            }
+        )
+
+    if checklist_id:
+        pipeline.append({"$match": {"checklist_id": {"$in": list(map(int, checklist_id))}}})
+
+    pipeline.extend(
+        [
+            {
+                "$facet": {
+                    "results": [{"$sort": {sort: order}}, {"$skip": offset}, {"$limit": limit}],
+                    "count": [{"$count": "total"}],
+                }
+            },
+            {"$project": {"results": 1, "count": {"$arrayElemAt": ["$count.total", 0]}}},
+        ]
+    )
+
+    return pipeline
+
+
+def get_maintenance_evaluations_filters_pipeline(params: dict):
+    building_id = params.get("building_id")
+    user_groups = params.get("user_groups")
+
+    pipeline = [
+        {
+            "$project": {
+                "_id": 1,
+                "inspectionGroupId": 1,
+                "device_id": 1,
+                "status": 1,
+                "inspection_date": 1,
+                "inspection_year": {"$year": "$inspection_date"},
+                "checklist_type": {"$first": "$inspection_checklists.type"},
+            }
+        },
+        {"$match": {"checklist_type": 4}},
+        {
+            "$lookup": {
+                "from": "inspection_groups",
+                "let": {"inspections_group_id": "$inspectionGroupId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$_id", "$$inspections_group_id"]}}},
+                    {
+                        "$project": {
+                            "_id": 1,
+                            "groupId": 1,
+                            "buildingId": 1,
+                            "inspectorId": 1,
+                            "clientId": 1,
+                            "witnessingInspectorId": 1,
+                        }
+                    },
+                    {"$limit": 1},
+                ],
+                "as": "inspections_group",
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$inspections_group",
+                "preserveNullAndEmptyArrays": True,
+            }
+        },
+    ]
+
+    if building_id:
+        pipeline.append({"$match": {"inspections_group.buildingId": building_id}})
+    else:
+        pipeline.append({"$match": {"status": {"$in": ["Results Reviewed", "Assembling Report"]}}})
+
+    pipeline.extend([
+        {"$match": {"inspections_group.groupId": {"$in": user_groups}}},
+        {
+            "$lookup": {
+                "from": "m_devices",
+                "let": {"device_id": "$device_id"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$device_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                    {"$limit": 1},
+                ],
+                "as": "device",
+            }
+        },
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "m_clients",
+                "let": {"client_id": "$inspections_group.clientId"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$eq": ["$postgresql_id", "$$client_id"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "name": 1}},
+                    {"$limit": 1},
+                ],
+                "as": "client",
+            }
+        },
+        {"$unwind": {"path": "$client", "preserveNullAndEmptyArrays": True}},
+        {"$set": {"users_to_lookup": ["$inspections_group.inspectorId", "$inspections_group.witnessingInspectorId"]}},
+        {
+            "$lookup": {
+                "from": "m_users",
+                "let": {"ids": "$users_to_lookup"},
+                "pipeline": [
+                    {"$match": {"$expr": {"$in": ["$postgresql_id", "$$ids"]}}},
+                    {"$project": {"_id": 0, "id": "$postgresql_id", "first_name": 1, "last_name": 1}},
+                ],
+                "as": "users",
+            }
+        },
+        {
+            "$set": {
+                "inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.inspectorId"]},
+                        }
+                    }
+                },
+                "witnessing_inspector": {
+                    "$first": {
+                        "$filter": {
+                            "input": "$users",
+                            "as": "u",
+                            "cond": {"$eq": ["$$u.id", "$inspections_group.witnessingInspectorId"]},
+                        }
+                    }
+                },
+            }
+        },
+        {
+            "$project": {
+                "_id": 0,
+                "device_id": "$device.id",
+                "device_name": "$device.name",
+                "status": "$status",
+                "inspection_year": "$inspection_year",
+                "client_id": "$client.id",
+                "client_name": "$client.name",
+                "inspector_id": {"$ifNull": ["$inspector.id", None]},
+                "inspector_name": {
+                    "$trim": {
+                        "input": {
+                            "$concat": [
+                                {"$ifNull": ["$inspector.first_name", ""]},
+                                " ",
+                                {"$ifNull": ["$inspector.last_name", ""]},
+                            ]
+                        }
+                    }
+                },
+                "witnessing_inspector_id": {"$ifNull": ["$witnessing_inspector.id", None]},
+                "witnessing_inspector_name": {
+                    "$trim": {
+                        "input": {
+                            "$concat": [
+                                {"$ifNull": ["$witnessing_inspector.first_name", ""]},
+                                " ",
+                                {"$ifNull": ["$witnessing_inspector.last_name", ""]},
+                            ]
+                        }
+                    }
+                },
+            }
+        },
+        {
+            "$facet": {
+                "devices": [
+                    {"$match": {"device_id": {"$ne": None}, "device_name": {"$ne": None}, "device_name": {"$ne": ""}}},
+                    {"$group": {"_id": "$device_id", "text": {"$first": "$device_name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+                "clients": [
+                    {"$match": {"client_id": {"$ne": None}, "client_name": {"$ne": None}, "client_name": {"$ne": ""}}},
+                    {"$group": {"_id": "$client_id", "text": {"$first": "$client_name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+                "statuses": [
+                    {"$match": {"status": {"$ne": None}, "status": {"$ne": ""}}},
+                    {"$group": {"_id": "$status"}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": "$_id"}},
+                    {"$sort": {"text": 1}},
+                ],
+                "inspection_years": [
+                    {"$match": {"inspection_year": {"$ne": None}}},
+                    {"$group": {"_id": "$inspection_year"}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": {"$toString": "$_id"}}},
+                    {"$sort": {"value": -1}},
+                ],
+                "inspectors": [
+                    {
+                        "$match": {
+                            "$or": [
+                                {"inspector_id": {"$ne": None}},
+                                {"witnessing_inspector_id": {"$ne": None}},
+                            ]
+                        }
+                    },
+                    {
+                        "$project": {
+                            "inspector_options": [
+                                {"id": "$inspector_id", "name": "$inspector_name"},
+                                {"id": "$witnessing_inspector_id", "name": "$witnessing_inspector_name"},
+                            ]
+                        }
+                    },
+                    {"$unwind": "$inspector_options"},
+                    {"$match": {"inspector_options.id": {"$nin": [None, "", 0]}}},
+                    {"$group": {"_id": "$inspector_options.id", "text": {"$first": "$inspector_options.name"}}},
+                    {"$project": {"_id": 0, "value": "$_id", "text": 1}},
+                    {"$sort": {"text": 1}},
+                ],
+            }
+        },
+    ])
+
+    return pipeline

--- a/cmd/archigraph/testdata/mongo_helper_indirection_real/core/services/building/service.py
+++ b/cmd/archigraph/testdata/mongo_helper_indirection_real/core/services/building/service.py
@@ -1,0 +1,248 @@
+from bson import ObjectId
+from django.db.models import Count, Q
+from core.models.checklist import Checklist
+from core.models.contract import Contract
+from core.mongodb_collections import INSPECTIONS, INSPECTIONS_GROUP, ME_REPORT_INSPECTIONS_GROUP
+from core.helper.mongo_helper import MongoDBConnection
+from core.services.building.queries import (
+    get_inspection_devices_pipeline,
+    get_inspection_devices_filters_pipeline,
+    get_maintenance_evaluations_pipeline,
+    get_maintenance_evaluations_filters_pipeline,
+)
+
+
+def get_inspection_devices(params: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    data = inspections_cln.aggregate(get_inspection_devices_pipeline(params)).next()
+
+    if not data:
+        return None
+
+    return data
+
+
+def get_inspection_devices_filters(params: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    data = inspections_cln.aggregate(get_inspection_devices_filters_pipeline(params)).next()
+
+    if not data:
+        return None
+
+    return data
+
+
+def get_maintenance_evaluations(params: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    data = inspections_cln.aggregate(get_maintenance_evaluations_pipeline(params)).next()
+    
+    if not data:
+        return None
+
+    try:
+        results = data.get("results", [])
+        for result in results:
+            checklist_id = result.get("checklist_id")
+            checklist = Checklist.objects.filter(id=checklist_id).first()
+            result["checklist_name"] = checklist.name if checklist else None
+    except Exception:
+        pass
+
+    return data
+
+
+def get_maintenance_evaluations_filters(params: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    data = inspections_cln.aggregate(get_maintenance_evaluations_filters_pipeline(params)).next()
+
+    if not data:
+        return None
+
+    return data
+
+
+def update_maintenance_evaluations(data: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    me_report_group_cln = MongoDBConnection.get_collection(ME_REPORT_INSPECTIONS_GROUP)
+
+    source_id = ObjectId(data.get("source_id"))
+    destination_raw_id = data.get("destination_id")
+    destination_id = ObjectId(destination_raw_id) if destination_raw_id != "new" else None
+    inspections_ids = [ObjectId(inspection_id) for inspection_id in data.get("inspections")]
+
+    try:
+        pull_result = me_report_group_cln.update_one(
+            {"_id": source_id},
+            {"$pull": {"inspections": {"$in": inspections_ids}}},
+        )
+
+        if pull_result.modified_count <= 0:
+            raise Exception("No inspections were removed from source")
+
+        if destination_id is None:
+            inspections_cln.update_many(
+                {"_id": {"$in": inspections_ids}},
+                {"$set": {"status": "Results Reviewed"}},
+            )
+
+            source_doc = me_report_group_cln.find_one({"_id": source_id})
+            if source_doc and len(source_doc.get("inspections", [])) == 0:
+                me_report_group_cln.delete_one({"_id": source_id})
+
+            return pull_result
+
+        push_result = me_report_group_cln.update_one(
+            {"_id": destination_id},
+            {"$addToSet": {"inspections": {"$each": inspections_ids}}},
+        )
+
+        if push_result.modified_count <= 0:
+            me_report_group_cln.update_one(
+                {"_id": source_id},
+                {"$addToSet": {"inspections": {"$each": inspections_ids}}},
+            )
+            raise Exception("No inspections were added to destination")
+
+        source_doc = me_report_group_cln.find_one({"_id": source_id})
+        if source_doc and len(source_doc.get("inspections", [])) == 0:
+            me_report_group_cln.delete_one({"_id": source_id})
+
+        return push_result
+
+    except Exception as e:
+        raise Exception(f"There was an error updating the inspections: {str(e)}")
+
+
+def delete_maintenance_evaluations(data: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    me_report_group_cln = MongoDBConnection.get_collection(ME_REPORT_INSPECTIONS_GROUP)
+
+    inspections_group_id = data.get("inspections_group_id")
+
+    if not inspections_group_id:
+        raise ValueError("inspections_group_id is required")
+
+    try:
+        source_group_id = ObjectId(inspections_group_id)
+
+        me_report_group = me_report_group_cln.find_one({"_id": source_group_id})
+        if not me_report_group:
+            raise ValueError(f"ME report inspections group {inspections_group_id} not found")
+
+        inspections_ids = me_report_group.get("inspections", [])
+
+        if inspections_ids:
+            inspections_cln.update_many(
+                {"_id": {"$in": inspections_ids}},
+                {"$set": {"status": "Results Reviewed"}},
+            )
+
+        deleted_result = me_report_group_cln.delete_one({"_id": source_group_id})
+        if deleted_result.deleted_count <= 0:
+            raise Exception("No ME report inspections group was deleted")
+
+        return deleted_result
+
+    except Exception as e:
+        raise Exception(f"There was an error deleting the inspections group: {str(e)}")
+
+
+def merge_maintenance_evaluations(data: dict):
+    inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)
+    inspections_group_cln = MongoDBConnection.get_collection(INSPECTIONS_GROUP)
+    me_report_group_cln = MongoDBConnection.get_collection(ME_REPORT_INSPECTIONS_GROUP)
+
+    inspections = data.get("inspections")
+    if not inspections:
+        raise ValueError("No inspections provided")
+
+    inspections_ids = [ObjectId(inspection["id"]) for inspection in inspections]
+
+    first_inspection_doc = inspections_cln.find_one({"_id": inspections_ids[0]})
+    if not first_inspection_doc:
+        raise ValueError(f"Inspection {inspections_ids[0]} not found")
+
+    inspections_group = inspections_group_cln.find_one({"_id": first_inspection_doc["inspectionGroupId"]})
+    if not inspections_group:
+        raise ValueError("Inspections group not found for the selected inspection")
+
+    me_report_doc = {
+        "building_id": inspections_group.get("buildingId"),
+        "client_id": inspections_group.get("clientId"),
+        "contract_id": inspections_group.get("contractId"),
+        "group_id": inspections_group.get("groupId"),
+        "jurisdiction_id": inspections_group.get("jurisdictionId"),
+        "inspections": inspections_ids,
+    }
+
+    insert_result = me_report_group_cln.insert_one(me_report_doc)
+    if not insert_result.inserted_id:
+        raise Exception("Failed to create ME report inspections group")
+
+    try:
+        updated_result = inspections_cln.update_many(
+            {"_id": {"$in": inspections_ids}},
+            {"$set": {"status": "Assembling Report"}},
+        )
+
+        if updated_result.modified_count <= 0:
+            me_report_group_cln.delete_one({"_id": insert_result.inserted_id})
+            raise Exception("No inspections were updated")
+
+        return str(insert_result.inserted_id)
+
+    except Exception:
+        me_report_group_cln.delete_one({"_id": insert_result.inserted_id})
+        raise Exception("There was an error updating the inspections.")
+
+
+def get_building_contract_conunters(params: dict):
+    contracts = Contract.objects.filter(
+        building_id=params.get("building_id"),
+        group_id=params.get("group_id"),
+    )
+
+    counters = contracts.aggregate(
+        all=Count("id"),
+        active=Count("id", filter=Q(status="active")),
+        proposal=Count("id", filter=Q(status="proposal")),
+        expired=Count("id", filter=Q(status="expired")),
+        canceled=Count("id", filter=Q(status__in=["cancelled", "canceled"])),
+    )
+
+    return {
+        "all": counters.get("all", 0),
+        "active": counters.get("active", 0),
+        "proposal": counters.get("proposal", 0),
+        "expired": counters.get("expired", 0),
+        "canceled": counters.get("canceled", 0),
+    }
+
+
+def get_building_contract_filters(params: dict):
+    contracts = Contract.objects.filter(
+        building_id=params.get("building_id"),
+        group_id=params.get("group_id"),
+    )
+
+    contract_filters = [
+        {"text": contract.get("contract_number"), "value": contract.get("id")}
+        for contract in contracts.exclude(contract_number__isnull=True)
+        .exclude(contract_number="")
+        .values("id", "contract_number")
+        .order_by("contract_number")
+    ]
+
+    status_filters = [
+        {"text": contract_status, "value": contract_status}
+        for contract_status in contracts.exclude(status__isnull=True)
+        .exclude(status="")
+        .values_list("status", flat=True)
+        .distinct()
+        .order_by("status")
+    ]
+
+    return {
+        "contracts": contract_filters,
+        "statuses": status_filters,
+    }


### PR DESCRIPTION
## deploy-9 REFUTED item-1 — Mongo \$lookup → JOINS_COLLECTION on the real helper-indirection shape

### The exact real-shape gap
The rewrite agent reported (deploy-8, deploy-9) that on upvate-core the Mongo `\$lookup.from` collection literals never reach JOINS_COLLECTION edges. The real access path in `core/services/building/` combines **four** conditions together that no prior crafted fixture exercised end-to-end:

1. **Helper indirection** — `inspections_cln = MongoDBConnection.get_collection(INSPECTIONS)` bound to a local var, not a direct `db.coll`.
2. **Constant collection name** — `INSPECTIONS` is a module-level constant imported from `core.mongodb_collections`, not a quoted string at the call site.
3. **Cross-file builder via multi-line import** — the pipeline is built by `get_inspection_devices_pipeline` in `queries.py`, imported via `from core.services.building.queries import (\n  ...\n)` and passed as a **direct call argument**: `inspections_cln.aggregate(get_inspection_devices_pipeline(params))`.
4. **Imperatively-assembled pipeline** — `pipeline = [...]; pipeline.extend([...]); pipeline.append({...}); return pipeline`, with both top-level and **nested correlated** `\$lookup` stages.

### Root-cause finding (honest)
Driving the **full production index pipeline** (`Indexer.Run`, the same surface the daemon invokes on rebuild) over the **verbatim** upvate building-service source emits **all 15 distinct** JOINS_COLLECTION edges from `Class:Inspection` — `inspection_groups`, `m_devices`, `m_contracts`, `m_clients`, `m_users`, `inspections_history`, the nested `m_group_device_settings`, etc. **The extractor at `origin/main` already resolves all four conditions** (via the merged #3866 / #3928 / #3969 / #3994). The deploy-9 REFUTED status reflects a **stale deployed daemon binary** (built before #3994 merged), not a code gap — consistent with the known undeployed-fix bundle awaiting a coordinated daemon rebuild.

What was genuinely missing is a **full-pipeline regression guard**. The prior tests were extraction-only on crafted fixtures, so they could not catch (a) a downstream pass dropping the edges, (b) an unresolved `RepoRoot`, or (c) a stale build — and they missed the real combined shape twice.

### How the fix bridges builder-pipeline → aggregating-collection across the helper
No production-code change is warranted (the bridge already works): the receiver follows `inspections_cln` → `get_collection(INSPECTIONS)` → constant resolves cross-module to `inspections` → `Class:Inspection`; the pipeline argument is a direct builder call, resolved cross-file through the multi-line import to `queries.py`, whose imperative `pipeline.extend/append` + nested `\$lookup` stages are all lifted. This PR **locks that behaviour in** with the integration test the suite lacked.

### The test + fail-before/pass-after proof
Two full-pipeline integration tests in `cmd/archigraph/mongo_helper_indirection_test.go`:
- `_MinimalShape` — minimal hand-written fixture isolating the four conditions with a nested correlated lookup.
- `_RealUpvateSource` — the **verbatim upvate-core source** (`queries.py` / `service.py` / `mongo_helper.py` / `mongodb_collections.py`) copied read-only; asserts all 15 distinct `\$lookup.from` collections become JOINS_COLLECTION edges from `Class:Inspection` in the final `graph.json`.

**Proof the guard has teeth:** removing the #3994 multi-line-import scan makes `_RealUpvateSource` go **red** (all 15 joins vanish — the builder import no longer resolves); restoring it makes it **green**. Full package suites green: `cmd/archigraph`, `internal/engine`, `internal/resolve`, `internal/types`.

### What's honestly still missing
- This proves the **code** is correct; it does **not** fix the live daemon. The deploy-9 graph stays REFUTED until the daemon is rebuilt+restarted on a binary that includes #3994 (the undeployed-bundle deploy step). **DEPLOY-DEFERRED.**
- Negatives are covered implicitly (`\$match`/`\$project` produce no join; non-literal `from` produces no edge — no fabrication). Cross-module builders that themselves re-import another builder, and dynamic builder dispatch, remain honest-partial as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)