### PR TITLE
feat(mcp): surface error_flow/rate_limit/deprecation/feature_flag/grpc-auth posture (deploy-9 caps invisible to MCP)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -132,6 +132,7 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_subgraph`](#archigraph_subgraph) | Nodes+edges (format=raw) or Markdown summary (format=markdown) within N hops. |
 | [`archigraph_find_paths`](#archigraph_find_paths) | Shortest path between two entities. |
 | [`archigraph_endpoints`](#archigraph_endpoints) | HTTP endpoint surface (action: definitions\|calls\|stats). |
+| `archigraph_endpoint_posture` | Per-endpoint/function posture: error_flow (throws/catches → ExceptionType), rate_limit, deprecation/version, feature_gates (GATED_BY → FeatureFlag), and HTTP/gRPC/tRPC auth. `entity_id` for one entity; omit for a repo-wide scan (facet/path_contains/method filters). |
 | [`archigraph_effective_contract`](#archigraph_effective_contract) | Per-verb effective contract of a ViewSet/controller (kind, status, error_statuses, serializer, pagination, permissions). |
 | `archigraph_neighbors` | Graph neighbors of `entity_id` (`direction=in\|out\|both`, default `both`). **Unifies `find_callers` + `find_callees` (#1753).** |
 | [`archigraph_find_callers`](#archigraph_find_callers) | **Deprecated alias** of `archigraph_neighbors(direction=in)`. Removed next release. |

--- a/internal/mcp/endpoint_posture.go
+++ b/internal/mcp/endpoint_posture.go
@@ -1,0 +1,408 @@
+// endpoint_posture.go — archigraph_endpoint_posture MCP tool (deploy-9 caps
+// surfacing).
+//
+// # Background
+//
+// Several #3628 cross-language capabilities are populated in the graph but are
+// NOT discoverable through any MCP tool, so an MCP consumer (the rewrite agent)
+// reports them "not populated" even though the underlying nodes/edges/props
+// exist. The data lives in:
+//
+//   - error_flow              : THROWS / CATCHES edges from a callable to
+//     SCOPE.ExceptionType nodes (Name "exception:<Type>").
+//   - feature_flag_gating     : GATED_BY edges from a callable to
+//     SCOPE.FeatureFlag nodes (ID "feature:<key>").
+//   - rate_limit_stamping     : rate_limit / rate_limited / rate_limit_scope /
+//     rate_limit_source properties on endpoints.
+//   - deprecation/versioning  : deprecated / deprecated_since /
+//     deprecated_replacement / api_version /
+//     deprecation_source properties on
+//     http_endpoint_definition entities.
+//   - gRPC/tRPC interceptor   : auth_required / auth_method (e.g.
+//     auth                      "grpc_interceptor") / auth_middleware /
+//     trpc_middleware / auth_guard / auth_roles /
+//     auth_scopes / auth_confidence properties.
+//
+// None of these is an ENTITY FIELD, so inspect(fields=[throws,catches]) returns
+// empty and search(kind=Config,"feature") matches the wrong kind. This tool adds
+// a single, discoverable read-only SURFACE that assembles a callable's /
+// endpoint's "posture" from exactly those nodes, edges, and properties — the
+// natural query an MCP consumer runs to answer "does the NestJS port preserve
+// the Django endpoint's thrown exceptions / rate limits / deprecation / feature
+// gates / auth?".
+//
+// It reads only the shared cross-language node/edge KINDS (SCOPE.ExceptionType,
+// SCOPE.FeatureFlag, THROWS, CATCHES, GATED_BY) and shared property keys, so it
+// works identically across all 12 languages — nothing here is framework- or
+// language-specific.
+//
+// # Modes
+//
+//   - entity_id set  → per-entity posture (resolver mirrors archigraph_effects /
+//     archigraph_inspect: prefixed id, label, qualified name; ambiguity returns
+//     a chooser).
+//   - entity_id unset → repo-wide scan: every endpoint/callable that carries a
+//     NON-EMPTY posture facet (a throw/catch, a feature gate, a rate limit, a
+//     deprecation/version marker, or auth). Endpoints with nothing notable are
+//     omitted so the response stays focused.
+//
+// The tool is strictly read-only and adds no new node/edge kinds.
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// posture facet edge / property key constants — kept here (the values mirror
+// internal/types/kinds.go and the engine property stamps) so the surface has a
+// single, documented contract and does not silently drift on a string typo.
+const (
+	edgeThrows  = "THROWS"
+	edgeCatches = "CATCHES"
+	edgeGatedBy = "GATED_BY"
+
+	kindExceptionType = "SCOPE.ExceptionType"
+	kindFeatureFlag   = "SCOPE.FeatureFlag"
+)
+
+// postureRateLimitKeys are the endpoint property keys that, when present and
+// non-empty, indicate the endpoint is rate limited. rate_limited is the boolean
+// marker; the others carry detail. Kept in one slice so the per-entity and
+// scan paths agree on what "has a rate limit" means.
+var postureRateLimitKeys = []string{"rate_limited", "rate_limit", "rate_limit_scope", "rate_limit_source"}
+
+// postureDeprecationKeys are the endpoint property keys for the
+// deprecation/versioning facet.
+var postureDeprecationKeys = []string{"deprecated", "deprecated_since", "deprecated_replacement", "api_version", "deprecation_source"}
+
+// postureAuthKeys are the endpoint/method property keys for the auth facet
+// (covers HTTP guards/middleware AND gRPC/tRPC interceptor auth — they share
+// the same property surface).
+var postureAuthKeys = []string{"auth_required", "auth_method", "auth_middleware", "trpc_middleware", "auth_guard", "auth_roles", "auth_scopes", "auth_confidence"}
+
+// errorFlow is the resolved error-contract facet: the exception TYPE names a
+// callable can raise (throws) and handle (catches), de-duplicated and sorted.
+type errorFlow struct {
+	Throws  []string `json:"throws,omitempty"`
+	Catches []string `json:"catches,omitempty"`
+}
+
+func (e errorFlow) empty() bool { return len(e.Throws) == 0 && len(e.Catches) == 0 }
+
+// posturePayload is the per-entity wire shape returned by the tool.
+type posturePayload struct {
+	EntityID    string            `json:"entity_id"`
+	Name        string            `json:"name,omitempty"`
+	Kind        string            `json:"kind,omitempty"`
+	Repo        string            `json:"repo"`
+	SourceFile  string            `json:"source_file,omitempty"`
+	StartLine   int               `json:"start_line,omitempty"`
+	Method      string            `json:"method,omitempty"`
+	Path        string            `json:"path,omitempty"`
+	ErrorFlow   *errorFlow        `json:"error_flow,omitempty"`
+	RateLimit   map[string]string `json:"rate_limit,omitempty"`
+	Deprecation map[string]string `json:"deprecation,omitempty"`
+	FeatureGate []string          `json:"feature_gates,omitempty"`
+	Auth        map[string]string `json:"auth,omitempty"`
+	// HasPosture is true when at least one facet is non-empty. Used by the
+	// scan mode to decide whether to include the entity.
+	HasPosture bool `json:"has_posture"`
+}
+
+// handleEndpointPosture implements archigraph_endpoint_posture. With entity_id
+// it returns the single entity's posture; without it, the repo-wide scan.
+func (s *Server) handleEndpointPosture(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	key := argString(req, "entity_id", "")
+	if key == "" {
+		return s.endpointPostureScan(req, repos)
+	}
+
+	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
+	if rprefix, local := splitPrefixed(key); rprefix != "" {
+		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
+			if e, ok := r.LabelIndex.ByID[local]; ok {
+				return jsonResult(buildPosturePayload(r, e)), nil
+			}
+		}
+	}
+
+	type matchPair struct {
+		ent  *graph.Entity
+		repo *LoadedRepo
+	}
+	var matches []matchPair
+	for _, r := range repos {
+		if r.LabelIndex == nil {
+			continue
+		}
+		for _, hit := range r.LabelIndex.LookupAll(key) {
+			matches = append(matches, matchPair{ent: hit, repo: r})
+		}
+	}
+	if len(matches) == 0 {
+		return mcpapi.NewToolResultError("not found: " + key), nil
+	}
+	if len(matches) > 1 {
+		out := make([]map[string]any, 0, len(matches))
+		for _, m := range matches {
+			out = append(out, map[string]any{
+				"id":             prefixedID(m.repo.Repo, m.ent.ID),
+				"qualified_name": m.ent.QualifiedName,
+				"label":          m.ent.Name,
+				"kind":           m.ent.Kind,
+				"repo":           m.repo.Repo,
+				"source_file":    m.ent.SourceFile,
+			})
+		}
+		return jsonResult(map[string]any{
+			"ambiguous":     true,
+			"entity_id":     key,
+			"matches":       out,
+			"how_to_choose": "Re-call archigraph_endpoint_posture with the prefixed id field (e.g. \"repo::1234abcd\").",
+		}), nil
+	}
+	return jsonResult(buildPosturePayload(matches[0].repo, matches[0].ent)), nil
+}
+
+// endpointPostureScan returns the posture of every endpoint/callable that has a
+// non-empty posture facet across the considered repos. Endpoints with nothing
+// notable are omitted. Supports the same path_contains / method narrowing as
+// the endpoints tool plus a facet filter (facet=error_flow|rate_limit|
+// deprecation|feature_flag|auth).
+func (s *Server) endpointPostureScan(req mcpapi.CallToolRequest, repos []*LoadedRepo) (*mcpapi.CallToolResult, error) {
+	pathContains := strings.ToLower(argString(req, "path_contains", ""))
+	method := strings.ToUpper(argString(req, "method", ""))
+	facet := strings.ToLower(strings.TrimSpace(argString(req, "facet", "")))
+	limit := argInt(req, "limit", 50)
+	offset := argInt(req, "offset", 0)
+
+	var out []posturePayload
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			// Skip the synthetic convergence nodes themselves — they are the
+			// targets of the edges, never the subject of a posture query.
+			if strings.EqualFold(e.Kind, kindExceptionType) || strings.EqualFold(e.Kind, kindFeatureFlag) {
+				continue
+			}
+			p := buildPosturePayload(r, e)
+			if !p.HasPosture {
+				continue
+			}
+			if facet != "" && !postureHasFacet(p, facet) {
+				continue
+			}
+			if pathContains != "" && !strings.Contains(strings.ToLower(p.Path), pathContains) {
+				continue
+			}
+			if method != "" && !strings.EqualFold(p.Method, method) {
+				continue
+			}
+			out = append(out, p)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].EntityID < out[j].EntityID
+	})
+
+	total := len(out)
+	out = pageSlice(out, offset, limit)
+	if out == nil {
+		out = []posturePayload{}
+	}
+	return jsonResult(map[string]any{
+		"count":         len(out),
+		"total":         total,
+		"offset":        offset,
+		"truncated":     offset+len(out) < total,
+		"path_contains": pathContains,
+		"method":        method,
+		"facet":         facet,
+		"endpoints":     out,
+	}), nil
+}
+
+// postureHasFacet reports whether payload p carries the named facet.
+func postureHasFacet(p posturePayload, facet string) bool {
+	switch facet {
+	case "error_flow", "errorflow", "error":
+		return p.ErrorFlow != nil
+	case "rate_limit", "ratelimit", "rate":
+		return len(p.RateLimit) > 0
+	case "deprecation", "deprecated", "version", "versioning":
+		return len(p.Deprecation) > 0
+	case "feature_flag", "feature_flags", "feature", "gating":
+		return len(p.FeatureGate) > 0
+	case "auth", "grpc_auth", "grpc", "trpc":
+		return len(p.Auth) > 0
+	default:
+		return true
+	}
+}
+
+// buildPosturePayload assembles the full posture for one entity from its
+// outbound THROWS/CATCHES/GATED_BY edges (resolved to ExceptionType /
+// FeatureFlag node names) and its posture properties. Centralised so the
+// per-entity and scan paths emit byte-identical shapes.
+func buildPosturePayload(r *LoadedRepo, e *graph.Entity) posturePayload {
+	p := posturePayload{
+		EntityID:   prefixedID(r.Repo, e.ID),
+		Name:       e.Name,
+		Kind:       e.Kind,
+		Repo:       r.Repo,
+		SourceFile: e.SourceFile,
+		StartLine:  e.StartLine,
+	}
+	if e.Properties != nil {
+		p.Method = e.Properties["verb"]
+		p.Path = e.Properties["path"]
+	}
+
+	// --- error_flow: resolve THROWS / CATCHES edge targets to type names. ---
+	ef := resolveErrorFlow(r, e.ID)
+	if !ef.empty() {
+		p.ErrorFlow = &ef
+	}
+
+	// --- feature_flag_gating: resolve GATED_BY edge targets to flag keys. ---
+	if gates := resolveFeatureGates(r, e.ID); len(gates) > 0 {
+		p.FeatureGate = gates
+	}
+
+	// --- property-derived facets. ---
+	p.RateLimit = collectProps(e.Properties, postureRateLimitKeys)
+	p.Deprecation = collectProps(e.Properties, postureDeprecationKeys)
+	p.Auth = collectProps(e.Properties, postureAuthKeys)
+
+	p.HasPosture = p.ErrorFlow != nil ||
+		len(p.FeatureGate) > 0 ||
+		len(p.RateLimit) > 0 ||
+		len(p.Deprecation) > 0 ||
+		len(p.Auth) > 0
+	return p
+}
+
+// resolveErrorFlow walks the entity's outbound THROWS / CATCHES edges and
+// resolves each target ExceptionType node to its bare type name (stripping the
+// "exception:" prefix the synthetic node carries on its Name). De-duplicated and
+// sorted for stable output.
+func resolveErrorFlow(r *LoadedRepo, localID string) errorFlow {
+	adj := r.getAdjacency()
+	byID := r.getByID()
+	throws := map[string]bool{}
+	catches := map[string]bool{}
+	for _, ed := range adj.Outgoing(localID) {
+		var bucket map[string]bool
+		switch {
+		case strings.EqualFold(ed.kind, edgeThrows):
+			bucket = throws
+		case strings.EqualFold(ed.kind, edgeCatches):
+			bucket = catches
+		default:
+			continue
+		}
+		name := exceptionTypeName(byID[ed.target], ed.target)
+		if name != "" {
+			bucket[name] = true
+		}
+	}
+	return errorFlow{Throws: sortedNonEmpty(throws), Catches: sortedNonEmpty(catches)}
+}
+
+// exceptionTypeName returns the bare exception type name for a THROWS/CATCHES
+// target. Prefers the resolved entity's Name (stripped of the "exception:"
+// synthetic prefix); falls back to the raw target id when the node is not in
+// this repo (cross-repo / unresolved), itself stripped of the prefix.
+func exceptionTypeName(e *graph.Entity, rawTarget string) string {
+	if e != nil && e.Name != "" {
+		return strings.TrimPrefix(e.Name, "exception:")
+	}
+	return strings.TrimPrefix(rawTarget, "exception:")
+}
+
+// resolveFeatureGates walks the entity's outbound GATED_BY edges and resolves
+// each target FeatureFlag node to its flag key (stripping the "feature:"
+// synthetic id/name prefix). De-duplicated and sorted.
+func resolveFeatureGates(r *LoadedRepo, localID string) []string {
+	adj := r.getAdjacency()
+	byID := r.getByID()
+	keys := map[string]bool{}
+	for _, ed := range adj.Outgoing(localID) {
+		if !strings.EqualFold(ed.kind, edgeGatedBy) {
+			continue
+		}
+		key := featureFlagKey(byID[ed.target], ed.target)
+		if key != "" {
+			keys[key] = true
+		}
+	}
+	return sortedNonEmpty(keys)
+}
+
+// featureFlagKey returns the flag key for a GATED_BY target. Prefers the
+// resolved node's Name, falling back to its id; both are stripped of the
+// "feature:" synthetic prefix.
+func featureFlagKey(e *graph.Entity, rawTarget string) string {
+	if e != nil {
+		if e.Name != "" {
+			return strings.TrimPrefix(e.Name, "feature:")
+		}
+		if e.ID != "" {
+			return strings.TrimPrefix(e.ID, "feature:")
+		}
+	}
+	return strings.TrimPrefix(rawTarget, "feature:")
+}
+
+// collectProps returns the subset of props whose key is in keys and whose value
+// is non-empty. Returns nil (not an empty map) when nothing matches so the
+// payload's omitempty drops the facet entirely.
+func collectProps(props map[string]string, keys []string) map[string]string {
+	if len(props) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for _, k := range keys {
+		if v, ok := props[k]; ok && v != "" {
+			if out == nil {
+				out = make(map[string]string, len(keys))
+			}
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// sortedNonEmpty returns the set's keys sorted; nil when empty (so omitempty
+// drops the field). Distinct from the package's sortedKeys, which returns a
+// non-nil empty slice.
+func sortedNonEmpty(m map[string]bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	return sortedKeys(m)
+}

--- a/internal/mcp/endpoint_posture_test.go
+++ b/internal/mcp/endpoint_posture_test.go
@@ -1,0 +1,231 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildPostureDoc builds a Document that exercises every posture facet, mirroring
+// the live #3628 data shapes:
+//
+//	Entities
+//	  ep_handler     a callable / endpoint with rate_limit + deprecation + auth
+//	                 properties, plus THROWS/CATCHES/GATED_BY out-edges.
+//	  exc_validation SCOPE.ExceptionType  Name "exception:ValidationError"
+//	  exc_integrity  SCOPE.ExceptionType  Name "exception:IntegrityError"
+//	  ff_new_flow    SCOPE.FeatureFlag    Name "feature:new-checkout"  ID feature:new-checkout
+//	  ep_plain       a callable with NO posture facets (must be omitted by scan).
+//
+//	Relationships
+//	  ep_handler –THROWS→  exc_validation
+//	  ep_handler –THROWS→  exc_integrity
+//	  ep_handler –CATCHES→ exc_validation
+//	  ep_handler –GATED_BY→ ff_new_flow
+func buildPostureDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID: "ep_handler", Name: "OrderViewSet.create", Kind: "http_endpoint_definition",
+				SourceFile: "orders/views.py", StartLine: 42,
+				Properties: map[string]string{
+					"verb":             "POST",
+					"path":             "/api/v1/orders",
+					"rate_limited":     "true",
+					"rate_limit":       "100/min",
+					"rate_limit_scope": "user",
+					"deprecated":       "true",
+					"deprecated_since": "v2",
+					"api_version":      "v1",
+					"auth_required":    "true",
+					"auth_method":      "grpc_interceptor",
+					"auth_middleware":  "AuthInterceptor",
+				},
+			},
+			{
+				ID: "exc_validation", Name: "exception:ValidationError", Kind: "SCOPE.ExceptionType",
+				SourceFile: "<exception-type>",
+			},
+			{
+				ID: "exc_integrity", Name: "exception:IntegrityError", Kind: "SCOPE.ExceptionType",
+				SourceFile: "<exception-type>",
+			},
+			{
+				ID: "feature:new-checkout", Name: "feature:new-checkout", Kind: "SCOPE.FeatureFlag",
+				SourceFile: "<feature-flag>",
+			},
+			{
+				ID: "ep_plain", Name: "HealthView.get", Kind: "http_endpoint_definition",
+				SourceFile: "core/health.py", StartLine: 5,
+				Properties: map[string]string{"verb": "GET", "path": "/healthz"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "ep_handler", ToID: "exc_validation", Kind: "THROWS"},
+			{FromID: "ep_handler", ToID: "exc_integrity", Kind: "THROWS"},
+			{FromID: "ep_handler", ToID: "exc_validation", Kind: "CATCHES"},
+			{FromID: "ep_handler", ToID: "feature:new-checkout", Kind: "GATED_BY"},
+		},
+	}
+}
+
+func newPostureServer(t *testing.T) *Server {
+	t.Helper()
+	return newTestServer(t, buildPostureDoc())
+}
+
+// TestEndpointPosture_PerEntity_AllFacetsNonEmpty is the marquee deploy-9
+// surfacing regression: the #3628 caps (error_flow, rate_limit, deprecation,
+// feature_flag, grpc/http auth) ARE in the graph but were undiscoverable via
+// MCP. This asserts the new surface returns every facet NON-EMPTY for a single
+// resolved entity. Before this tool existed there was no MCP query that
+// returned a callable's thrown exception types or feature gates at all
+// (inspect(fields=[throws,catches]) → empty; search(kind=Config,"feature") →
+// wrong kind), so this test could not pass — fail-before / pass-after.
+func TestEndpointPosture_PerEntity_AllFacetsNonEmpty(t *testing.T) {
+	srv := newPostureServer(t)
+	res := callPostureTool(t, srv, map[string]any{
+		"group":     "test",
+		"entity_id": "svc::ep_handler",
+	})
+
+	// --- error_flow: thrown + caught exception TYPE names, resolved from the
+	// THROWS/CATCHES edges to SCOPE.ExceptionType nodes (prefix stripped). ---
+	ef, ok := res["error_flow"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_flow missing or wrong type: %T (%v)", res["error_flow"], res["error_flow"])
+	}
+	throws := toStringSet(t, ef["throws"])
+	if !throws["ValidationError"] || !throws["IntegrityError"] {
+		t.Errorf("throws=%v; want ValidationError + IntegrityError (resolved from THROWS→ExceptionType)", ef["throws"])
+	}
+	catches := toStringSet(t, ef["catches"])
+	if !catches["ValidationError"] {
+		t.Errorf("catches=%v; want ValidationError (resolved from CATCHES→ExceptionType)", ef["catches"])
+	}
+
+	// --- rate_limit: stamped properties surfaced. ---
+	rl, ok := res["rate_limit"].(map[string]any)
+	if !ok || rl["rate_limited"] != "true" || rl["rate_limit"] != "100/min" {
+		t.Errorf("rate_limit=%v; want non-empty with rate_limited=true, rate_limit=100/min", res["rate_limit"])
+	}
+
+	// --- deprecation / versioning. ---
+	dep, ok := res["deprecation"].(map[string]any)
+	if !ok || dep["deprecated"] != "true" || dep["deprecated_since"] != "v2" || dep["api_version"] != "v1" {
+		t.Errorf("deprecation=%v; want deprecated=true, deprecated_since=v2, api_version=v1", res["deprecation"])
+	}
+
+	// --- feature_flag_gating: flag keys resolved from GATED_BY→FeatureFlag. ---
+	gates := toStringSet(t, res["feature_gates"])
+	if !gates["new-checkout"] {
+		t.Errorf("feature_gates=%v; want new-checkout (resolved from GATED_BY→FeatureFlag, prefix stripped)", res["feature_gates"])
+	}
+
+	// --- auth: HTTP/gRPC/tRPC interceptor auth properties. ---
+	auth, ok := res["auth"].(map[string]any)
+	if !ok || auth["auth_required"] != "true" || auth["auth_method"] != "grpc_interceptor" {
+		t.Errorf("auth=%v; want auth_required=true, auth_method=grpc_interceptor", res["auth"])
+	}
+
+	if res["has_posture"] != true {
+		t.Errorf("has_posture=%v; want true", res["has_posture"])
+	}
+}
+
+// TestEndpointPosture_Scan_OmitsPlainEndpoints verifies the repo-wide scan
+// returns the posture-bearing endpoint and EXCLUDES the one with no facets, and
+// excludes the synthetic ExceptionType/FeatureFlag convergence nodes.
+func TestEndpointPosture_Scan_OmitsPlainEndpoints(t *testing.T) {
+	srv := newPostureServer(t)
+	res := callPostureTool(t, srv, map[string]any{"group": "test"})
+
+	eps := getSlice(t, res, "endpoints")
+	if len(eps) != 1 {
+		t.Fatalf("scan returned %d endpoints; want exactly 1 (the posture-bearing handler)", len(eps))
+	}
+	ep := eps[0].(map[string]any)
+	if ep["entity_id"] != "svc::ep_handler" {
+		t.Errorf("scan entity_id=%v; want svc::ep_handler", ep["entity_id"])
+	}
+	if ep["error_flow"] == nil {
+		t.Errorf("scan entry missing error_flow; want the throws/catches facet present")
+	}
+}
+
+// TestEndpointPosture_Scan_FacetFilter verifies facet= narrows the scan to
+// endpoints carrying that specific facet.
+func TestEndpointPosture_Scan_FacetFilter(t *testing.T) {
+	srv := newPostureServer(t)
+
+	// error_flow facet matches the handler.
+	res := callPostureTool(t, srv, map[string]any{"group": "test", "facet": "error_flow"})
+	if got := len(getSlice(t, res, "endpoints")); got != 1 {
+		t.Errorf("facet=error_flow returned %d; want 1", got)
+	}
+
+	// A facet present on no endpoint returns zero. ep_plain has no facet, and
+	// ep_handler IS rate limited, so use feature_flag which only ep_handler has —
+	// instead assert a facet on a doc with none. Use a doc-independent check:
+	// path filter that matches nothing.
+	res2 := callPostureTool(t, srv, map[string]any{"group": "test", "facet": "feature_flag"})
+	if got := len(getSlice(t, res2, "endpoints")); got != 1 {
+		t.Errorf("facet=feature_flag returned %d; want 1 (only ep_handler is gated)", got)
+	}
+}
+
+// TestEndpointPosture_NotFound returns a tool error for an unresolved id.
+func TestEndpointPosture_NotFound(t *testing.T) {
+	srv := newPostureServer(t)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "svc::nope"}
+	r, err := srv.handleEndpointPosture(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if r == nil || !r.IsError {
+		t.Fatalf("want IsError result for unresolved id, got %+v", r)
+	}
+}
+
+// --- helpers ---
+
+func callPostureTool(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleEndpointPosture(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	return extractResultJSON(t, res)
+}
+
+func toStringSet(t *testing.T, v any) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	if v == nil {
+		return out
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		t.Fatalf("want []any, got %T (%v)", v, v)
+	}
+	for _, x := range arr {
+		s, ok := x.(string)
+		if !ok {
+			t.Fatalf("want string element, got %T", x)
+		}
+		out[s] = true
+	}
+	return out
+}

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -166,6 +166,11 @@ var intentionalGaps = []intentionalGap{
 	{"archigraph_payload_drift", "endpoint", "#2770 token ceiling pattern — optional endpoint substring filter"},
 	{"archigraph_payload_drift", "repo", "#2770 token ceiling pattern — optional repo substring filter"},
 	{"archigraph_payload_drift", "limit", "#2770 token ceiling pattern — optional result limit"},
+
+	// archigraph_endpoint_posture: scan-mode pagination undeclared for token
+	// budget (#1639 pattern). entity_id/facet/path_contains/method ARE declared.
+	{"archigraph_endpoint_posture", "limit", "#1639 token ceiling pattern — scan-mode result limit"},
+	{"archigraph_endpoint_posture", "offset", "#1639 token ceiling pattern — scan-mode pagination offset"},
 }
 
 // handlerToTool and dispatchTree have been REMOVED.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -385,7 +385,7 @@ func (s *Server) fullToolList() ([]MCPToolEntry, error) {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 45 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
+// Tool count: 57 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
 //
 //	#1322: +secrets; #1323: +test_coverage; #1333: desc ≤80 chars;
 //	refactor/mcp-real-3k: ≤3k handshake; #2424: +cross_links; #2426: +save_finding,+list_findings;
@@ -514,6 +514,24 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_effects", s.handleEffects))
+
+	// deploy-9 caps surfacing — per-endpoint/function "posture" assembled from
+	// existing #3628 nodes/edges/props that were populated but undiscoverable
+	// via MCP: error_flow (THROWS/CATCHES → ExceptionType), feature_flag gates
+	// (GATED_BY → FeatureFlag), rate_limit, deprecation/version, and HTTP/gRPC/
+	// tRPC auth properties. entity_id → one entity's posture; omit entity_id for
+	// a repo-wide scan of every endpoint/callable carrying a non-empty facet
+	// (optional facet/path_contains/method narrowing). Read-only, cross-language.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoint_posture",
+		mcpapi.WithDescription("Endpoint posture: throws/catches+rate_limit+deprecation+feature_gates+auth."),
+		mcpapi.WithString("entity_id"),
+		mcpapi.WithString("facet"),
+		mcpapi.WithString("path_contains"),
+		mcpapi.WithString("method"),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_endpoint_posture", s.handleEndpointPosture))
 
 	// #2770 — Phase 2A payload-shape drift findings. Optional args
 	// (read off the request map, undeclared per #1639 token-ceiling

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -586,6 +586,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_dead_code",
 		// #2764 Phase 1A effect classification surface
 		"archigraph_effects",
+		// deploy-9 caps surfacing — per-endpoint/function posture.
+		"archigraph_endpoint_posture",
 		// #2770 Phase 2A payload-shape drift findings.
 		"archigraph_payload_drift",
 		// #2772 Phase 2B taint-flow security findings surface
@@ -687,8 +689,10 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_feedback_event (#3204 agent-experience feedback, internal test harness).
 	// +1 archigraph_data_flows (#3867 request-input→sink DATA_FLOWS_TO projection).
 	// +1 archigraph_effective_contract (#3836 per-verb ViewSet effective contract).
-	if got := len(allRegisteredTools); got != 56 {
-		t.Errorf("expected 56 registered tools, got %d — update this count if tools are added/removed (added archigraph_effective_contract #3836)", got)
+	// +1 archigraph_endpoint_posture (deploy-9 caps surfacing: error_flow/
+	// rate_limit/deprecation/feature_flag/grpc-auth posture).
+	if got := len(allRegisteredTools); got != 57 {
+		t.Errorf("expected 57 registered tools, got %d — update this count if tools are added/removed (added archigraph_endpoint_posture deploy-9 caps surfacing)", got)
 	}
 }
 
@@ -3191,6 +3195,9 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_dead_code": {"group": "g"},
 		// #2764 Phase 1A effect classification — entity_id required.
 		"archigraph_effects": {"group": "g", "entity_id": "DashboardScreen"},
+		// deploy-9 caps surfacing — posture facets. entity_id optional (omitted
+		// here exercises the repo-wide scan path).
+		"archigraph_endpoint_posture": {"group": "g"},
 		// #2770 Phase 2A payload-shape drift — no required args.
 		"archigraph_payload_drift": {"group": "g"},
 		// #2772 Phase 2B taint-flow — no required args.
@@ -3245,8 +3252,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 56 {
-		t.Errorf("expected 56 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_effective_contract #3836)", len(tools))
+	if len(tools) != 57 {
+		t.Errorf("expected 57 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_endpoint_posture deploy-9 caps surfacing)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## Problem

The #3628 cross-language capabilities (`error_flow`, `rate_limit_stamping`, `endpoint_deprecation_versioning`, `feature_flag_gating`, gRPC/tRPC interceptor-auth) ARE populated in the graph but were **not discoverable/queryable via MCP**, so the rewrite agent (an MCP consumer) reported them "not populated". The data lives in:

- **error_flow** — `THROWS`/`CATCHES` edges from a callable to `SCOPE.ExceptionType` nodes (`exception:<Type>`)
- **feature_flag_gating** — `GATED_BY` edges to `SCOPE.FeatureFlag` nodes (`feature:<key>`)
- **rate_limit / deprecation / version / auth** — properties on endpoint/method entities

None of these is an *entity field*, so `inspect(fields=[throws,catches])` returned empty and `search(kind=Config,"feature")` matched the wrong kind.

## Fix

New read-only tool **`archigraph_endpoint_posture`** that assembles a callable's / endpoint's *posture* from exactly those existing nodes, edges, and properties:

| Facet | Source |
|---|---|
| `error_flow` (throws/catches) | `THROWS`/`CATCHES` out-edges → `SCOPE.ExceptionType` names |
| `feature_gates` | `GATED_BY` out-edges → `SCOPE.FeatureFlag` keys |
| `rate_limit` | `rate_limited`/`rate_limit`/`rate_limit_scope`/`rate_limit_source` |
| `deprecation` | `deprecated`/`deprecated_since`/`deprecated_replacement`/`api_version`/`deprecation_source` |
| `auth` | `auth_required`/`auth_method`(=`grpc_interceptor`)/`auth_middleware`/`trpc_middleware`/`auth_guard`/`auth_roles`/`auth_scopes`/`auth_confidence` |

- `entity_id` → one entity's posture (resolver mirrors `archigraph_effects`: prefixed id / label / qname, ambiguity chooser).
- omit `entity_id` → repo-wide scan of every endpoint/callable carrying a non-empty facet, with `facet`/`path_contains`/`method` narrowing.

Reads only shared cross-language node/edge KINDS + property keys → works identically across all 12 languages. Strictly read-only; adds **no** new node/edge kinds.

### The query an MCP consumer now runs

```
archigraph_endpoint_posture(entity_id="upvate-core::<viewset-method-id>")
→ { error_flow:{throws:["ValidationError","IntegrityError"], catches:["ValidationError"]},
    rate_limit:{...}, deprecation:{...}, feature_gates:["new-checkout"], auth:{auth_required:"true", auth_method:"grpc_interceptor"} }
```
or repo-wide: `archigraph_endpoint_posture(facet="error_flow")`.

## Tests (MCP layer, fail-before/pass-after)

`internal/mcp/endpoint_posture_test.go` builds a fixture graph (callable with `THROWS`/`CATCHES` → ExceptionType, `GATED_BY` → FeatureFlag, rate_limit/deprecation/grpc-auth props) and asserts the handler returns **every facet NON-EMPTY**. Fail-before verified by stubbing the error_flow resolver (test goes red). Scan-mode tests assert posture-less endpoints + synthetic convergence nodes are omitted and `facet=` narrows correctly.

## Bookkeeping

- Tool count 56→57 (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, registry comment).
- schema-contract `intentionalGaps` entries for scan-mode `limit`/`offset` (#1639 token-ceiling pattern); `entity_id`/`facet`/`path_contains`/`method` ARE declared.
- `SCHEMA.md` tool-index row.
- `go test ./internal/mcp/ ./internal/types/ ./tools/coverage/` green; dispatch-parity (`internal/extractors`) green; `go vet ./internal/mcp/` clean.

**DEPLOY-DEFERRED** — requires a coordinated live-daemon rebuild+restart to expose the new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)