### PR TITLE
fix(mcp): archigraph_effective_contract returns empty on all ViewSets — wire to MRO contract data (deploy-9 item-4)

### DIFF
--- a/cmd/archigraph/effective_contract_pipeline_test.go
+++ b/cmd/archigraph/effective_contract_pipeline_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// effective_contract_pipeline_test.go — LAYER 1 of the deploy-9 item-4 fix
+// (archigraph_effective_contract returns empty on all ViewSets). These run the
+// FULL indexer pipeline (cmd/archigraph.Index via runIndexerOn) on real DRF
+// fixtures and assert the graph the MCP tool consumes carries the data it
+// needs:
+//
+//  1. A ROUTER-REGISTERED ModelViewSet stamps the per-verb effective contract
+//     (effective_kind / effective_source_class / effective_status /
+//     effective_error_statuses) onto its router-expanded route entities — the
+//     props the tool projects.
+//  2. An UNROUTED ModelViewSet emits the ViewSet class declaration + its
+//     EXTENDS edge to ModelViewSet but NO router-expanded routes — the exact
+//     live-daemon shape where the tool used to return empty and where the
+//     class-fallback (LAYER 2) must synthesize the contract from EXTENDS+pack.
+
+// routerExpandedRoutes returns the router-expanded route entities in doc.
+func routerExpandedRoutes(doc *graph.Document) []graph.Entity {
+	var out []graph.Entity
+	for _, e := range doc.Entities {
+		if e.Properties["pattern_type"] == "drf_router_expanded" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestPipeline_RoutedViewSet_StampsEffectiveContract asserts the routed fixture
+// carries the stamped per-verb contract the tool projects (the data exists in
+// the full-pipeline graph).
+func TestPipeline_RoutedViewSet_StampsEffectiveContract(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/drf_attribution_fixture", "drf_routed", nil)
+
+	routes := routerExpandedRoutes(doc)
+	if len(routes) == 0 {
+		t.Fatalf("expected router-expanded routes for ThingViewSet; got none")
+	}
+
+	var create *graph.Entity
+	for i := range routes {
+		if routes[i].Properties["drf_view_method"] == "ThingViewSet.create" {
+			create = &routes[i]
+			break
+		}
+	}
+	if create == nil {
+		t.Fatalf("no router-expanded route for ThingViewSet.create; routes=%v", routes)
+	}
+	p := create.Properties
+	if p["effective_kind"] != "inherited" {
+		t.Errorf("create effective_kind=%q; want inherited", p["effective_kind"])
+	}
+	if p["effective_source_class"] != "CreateModelMixin" {
+		t.Errorf("create effective_source_class=%q; want CreateModelMixin", p["effective_source_class"])
+	}
+	if p["effective_status"] != "201" {
+		t.Errorf("create effective_status=%q; want 201", p["effective_status"])
+	}
+	if p["effective_error_statuses"] != "400" {
+		t.Errorf("create effective_error_statuses=%q; want 400 (#278)", p["effective_error_statuses"])
+	}
+}
+
+// TestPipeline_UnroutedViewSet_NoRoutesButExtendsEdge asserts the unrouted
+// fixture is the live-daemon empty shape: a ViewSet class + EXTENDS-to-
+// ModelViewSet, but zero router-expanded routes. This is the data the
+// class-fallback resolves from.
+func TestPipeline_UnroutedViewSet_NoRoutesButExtendsEdge(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/drf_unrouted_viewset_fixture", "drf_unrouted", nil)
+
+	if rs := routerExpandedRoutes(doc); len(rs) != 0 {
+		t.Fatalf("expected NO router-expanded routes for an unrouted ViewSet; got %d: %+v", len(rs), rs)
+	}
+
+	// The ViewSet class declaration must be indexed.
+	var cls *graph.Entity
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Name == "WidgetViewSet" {
+			cls = e
+			break
+		}
+	}
+	if cls == nil {
+		t.Fatalf("WidgetViewSet class entity not indexed")
+	}
+
+	// And it must carry an EXTENDS edge whose base resolves to ModelViewSet.
+	found := false
+	for _, r := range doc.Relationships {
+		if r.Kind != "EXTENDS" || r.FromID != cls.ID {
+			continue
+		}
+		base := r.Properties["base_name"]
+		if strings.Contains(base, "ModelViewSet") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("WidgetViewSet has no EXTENDS edge to ModelViewSet — class-fallback would have nothing to resolve")
+	}
+}

--- a/cmd/archigraph/testdata/drf_unrouted_viewset_fixture/myapp/views.py
+++ b/cmd/archigraph/testdata/drf_unrouted_viewset_fixture/myapp/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets
+
+
+class WidgetViewSet(viewsets.ModelViewSet):
+    """A DRF ModelViewSet that is NOT registered with any router.
+
+    The router-expansion pass therefore emits NO router-expanded route
+    entities for it — but the class declaration and its EXTENDS edge to
+    ModelViewSet are indexed, so the inherited CRUD contract is still
+    MRO-resolvable (the get_source path). This is the upvate live-daemon
+    shape that made archigraph_effective_contract return empty.
+    """
+
+    queryset = []
+    serializer_class = None

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -1286,12 +1286,20 @@ routes carry it.
 `error_statuses`, `serializer`, `pagination`, `permissions`, `auth_required`,
 `behaviour`.
 
+**MRO wiring.** The tool does not depend solely on the engine-stamped
+`effective_*` props. It resolves the same MRO + baseknowledge-pack data
+`archigraph_get_source` reads, so it returns a contract wherever `get_source`
+can: (1) a router-expanded route whose `effective_*` fields are absent is
+**backfilled** from the inherited-endpoint MRO resolution → the pack (stamped
+values always win), and (2) when **no** router-expanded routes exist for the
+ViewSet, the per-verb contract is **synthesized from the ViewSet class entity's
+`EXTENDS` edges + the pack** (e.g. a `ModelViewSet` subclass yields its six CRUD
+verbs), exactly as `get_source` does.
+
 **Honest-partial.** A verb whose backing route carries no resolvable contract
 field simply omits that field (`default_status` 0, empty `error_statuses`) — it
-is never fabricated. A ViewSet with no router-expanded routes returns an empty
-`groups` list with a `note` (the contract is stamped by the T5 #3964 DRF
-expansion pass — an index predating that stamping requires a **reindex** to
-populate it).
+is never fabricated. A ViewSet with neither router-expanded routes nor a
+pack-resolvable `EXTENDS` chain returns an empty `groups` list with a `note`.
 
 ---
 

--- a/internal/mcp/effective_contract_mro_3964_test.go
+++ b/internal/mcp/effective_contract_mro_3964_test.go
@@ -1,0 +1,211 @@
+package mcp
+
+// effective_contract_mro_3964_test.go — LAYER 2 of the deploy-9 item-4 fix:
+// archigraph_effective_contract returned EMPTY on every DRF ViewSet because it
+// read ONLY the engine-stamped effective_* props on router-expanded routes, and
+// on a real index those routes either (a) lacked the stamped contract fields, or
+// (b) were not emitted at all for a ViewSet whose routing the expansion pass did
+// not materialise — even though the SAME contract is MRO-resolvable from the
+// ViewSet's EXTENDS edges + the baseknowledge pack (the path get_source uses and
+// that the report confirmed WORKS).
+//
+// These tests load graphs THROUGH graph.fb (the daemon's real load path) and
+// call handleEffectiveContract directly. The class-fallback test replicates the
+// EXACT full-pipeline shape captured from cmd/archigraph (Kind="View",
+// subtype="", an EXTENDS edge base_name="viewsets.ModelViewSet", and ZERO
+// router-expanded routes) — the live-daemon empty case. It MUST fail before the
+// fix and pass after.
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// callEffContractFB writes doc to graph.fb, loads it back via the production
+// loader, builds a server, and calls the handler — exercising the full daemon
+// serving path (FB round-trip + handler).
+func callEffContractFB(t *testing.T, doc *graph.Document, entityID string) effectiveContractResult {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write fb: %v", err)
+	}
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("load fb: %v", err)
+	}
+	srv := newTestServer(t, loaded)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": entityID}
+	res, err := srv.handleEffectiveContract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handler IsError: %s", resultText(res))
+	}
+	var out effectiveContractResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, resultText(res))
+	}
+	return out
+}
+
+// unroutedViewSetDoc replicates the full-pipeline shape of the unrouted
+// WidgetViewSet fixture (verified in cmd/archigraph Layer 1):
+//   - the ViewSet declaration is Kind="View", subtype="" (NOT isClassEntity).
+//   - it has an EXTENDS edge to an external ModelViewSet base (base_name carries
+//     "viewsets.ModelViewSet"); the pack resolves the CRUD contract from it.
+//   - there are ZERO router-expanded route entities.
+func unroutedViewSetDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "widgetvs", Name: "WidgetViewSet", QualifiedName: "myapp.views.WidgetViewSet",
+				Kind: "View", Subtype: "", SourceFile: "myapp/views.py", StartLine: 4, EndLine: 16,
+				Language: "python"},
+			{ID: "ext:viewsets", Name: "viewsets", Kind: "ExternalSymbol", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "widgetvs", ToID: "ext:viewsets", Kind: "EXTENDS",
+				Properties: map[string]string{"base_name": "viewsets.ModelViewSet"}},
+		},
+	}
+}
+
+// TestEffectiveContract_ClassFallback_UnroutedViewSet_ThroughFB is the
+// regression for the deploy-9 empty bug: a ModelViewSet with NO router-expanded
+// routes must still yield its inherited CRUD contract, resolved from EXTENDS +
+// the baseknowledge pack — the same data get_source reads. FAILS before the
+// class-fallback, PASSES after.
+func TestEffectiveContract_ClassFallback_UnroutedViewSet_ThroughFB(t *testing.T) {
+	out := callEffContractFB(t, unroutedViewSetDoc(), "WidgetViewSet")
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected 1 group synthesized from EXTENDS+pack, got %d (note=%q)", len(out.Groups), out.Note)
+	}
+	g := out.Groups[0]
+	if g.Class != "WidgetViewSet" {
+		t.Errorf("group class=%q; want WidgetViewSet", g.Class)
+	}
+	// ModelViewSet contributes the six CRUD verbs.
+	byMember := map[string]effectiveContract{}
+	for _, h := range g.Handlers {
+		byMember[leafAfterDot(h.Handler)] = h
+	}
+	for _, want := range []string{"create", "retrieve", "update", "partial_update", "destroy", "list"} {
+		if _, ok := byMember[want]; !ok {
+			t.Errorf("missing inherited verb %q in synthesized contract; got %v", want, g.Handlers)
+		}
+	}
+	// The #278 fact must be present on create — resolved purely from the pack.
+	create := byMember["create"]
+	if create.Kind != "inherited" {
+		t.Errorf("create kind=%q; want inherited", create.Kind)
+	}
+	if create.SourceClass == "" || leafAfterDot(create.SourceClass) != "CreateModelMixin" {
+		t.Errorf("create source_class=%q; want ...CreateModelMixin", create.SourceClass)
+	}
+	if create.DefaultStatus != 201 {
+		t.Errorf("create default_status=%d; want 201", create.DefaultStatus)
+	}
+	if len(create.ErrorStatuses) != 1 || create.ErrorStatuses[0] != 400 {
+		t.Errorf("create error_statuses=%v; want [400] (#278)", create.ErrorStatuses)
+	}
+	// list is paginated per the pack.
+	if !byMember["list"].Pagination {
+		t.Errorf("list should be marked paginated by the pack")
+	}
+}
+
+// routedViewSetThroughFBDoc replicates the routed ThingViewSet full-pipeline
+// shape (Kind="http_endpoint_definition", stamped effective_* props).
+func routedViewSetThroughFBDoc() *graph.Document {
+	route := func(id, verb, path, dvm, kind, src, status, errs string) graph.Entity {
+		p := map[string]string{
+			"pattern_type":           "drf_router_expanded",
+			"framework":              "django",
+			"verb":                   verb,
+			"path":                   path,
+			"drf_view_method":        dvm,
+			"effective_kind":         kind,
+			"effective_source_class": src,
+		}
+		if status != "" {
+			p["effective_status"] = status
+		}
+		if errs != "" {
+			p["effective_error_statuses"] = errs
+		}
+		return graph.Entity{ID: id, Name: id, Kind: "http_endpoint_definition", Language: "python", Properties: p}
+	}
+	return &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			route("e1", "POST", "/api/v1/things", "ThingViewSet.create", "inherited", "CreateModelMixin", "201", "400"),
+			route("e2", "GET", "/api/v1/things", "ThingViewSet.list", "explicit", "ThingViewSet", "200", ""),
+		},
+	}
+}
+
+// TestEffectiveContract_RoutedViewSet_ThroughFB confirms the router-expanded
+// path still works end-to-end through FB (no regression of the stamped path).
+func TestEffectiveContract_RoutedViewSet_ThroughFB(t *testing.T) {
+	out := callEffContractFB(t, routedViewSetThroughFBDoc(), "ThingViewSet")
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected 1 group from router-expanded routes, got %d (note=%q)", len(out.Groups), out.Note)
+	}
+	if len(out.Groups[0].Handlers) != 2 {
+		t.Fatalf("expected 2 handlers (create,list), got %d", len(out.Groups[0].Handlers))
+	}
+}
+
+// unstampedRouteDoc is a router-expanded create route MISSING the effective_*
+// stamp (older index) but carrying provenance=inherited + defining_class — the
+// shape get_source resolves. The tool must backfill the contract from the pack.
+func unstampedRouteDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "r1", Name: "r1", Kind: "http_endpoint_definition", Language: "python",
+				Properties: map[string]string{
+					"pattern_type":    "drf_router_expanded",
+					"framework":       "django",
+					"verb":            "POST",
+					"path":            "/api/v1/things",
+					"drf_view_method": "ThingViewSet.create",
+					// No effective_* — but the inherited provenance + defining
+					// mixin ARE present (what resolveInheritedEndpoint needs).
+					"provenance":     "inherited",
+					"defining_class": "rest_framework.mixins.CreateModelMixin",
+				}},
+		},
+	}
+}
+
+// TestEffectiveContract_BackfillUnstampedRoute_ThroughFB asserts a router-
+// expanded route with NO stamped effective_* still surfaces the full per-verb
+// contract, backfilled from the MRO/pack resolution get_source uses.
+func TestEffectiveContract_BackfillUnstampedRoute_ThroughFB(t *testing.T) {
+	out := callEffContractFB(t, unstampedRouteDoc(), "ThingViewSet")
+	if len(out.Groups) != 1 || len(out.Groups[0].Handlers) != 1 {
+		t.Fatalf("expected 1 group/1 handler, got %d groups (note=%q)", len(out.Groups), out.Note)
+	}
+	h := out.Groups[0].Handlers[0]
+	if h.Kind != "inherited" {
+		t.Errorf("kind=%q; want inherited (backfilled)", h.Kind)
+	}
+	if h.DefaultStatus != 201 {
+		t.Errorf("default_status=%d; want 201 (backfilled from pack)", h.DefaultStatus)
+	}
+	if len(h.ErrorStatuses) != 1 || h.ErrorStatuses[0] != 400 {
+		t.Errorf("error_statuses=%v; want [400] (backfilled #278)", h.ErrorStatuses)
+	}
+}

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -19,16 +19,31 @@ package mcp
 // source_class:CreateModelMixin, default_status:201, error_statuses:[400] even
 // though the ViewSet body is empty).
 //
+// MRO WIRING (deploy-9 item-4): the tool no longer depends SOLELY on the
+// engine-stamped effective_* props. It resolves the same MRO/baseknowledge-pack
+// data get_source reads, so it returns a contract wherever get_source can:
+//   - BACKFILL: a router-expanded route whose effective_* fields are absent (an
+//     index that predates the stamping pass, or an honest-partial stamp) is
+//     filled from resolveInheritedEndpoint -> the pack (stamped values always
+//     win — never clobbered).
+//   - CLASS FALLBACK: when NO router-expanded routes exist for the ViewSet (a
+//     real DRF app whose routing the expansion pass did not materialise — the
+//     live-daemon empty case), the per-verb contract is synthesized from the
+//     ViewSet CLASS entity's EXTENDS edges + the pack, exactly as resolveMember
+//     does for get_source.
+//
 // HONEST-PARTIAL: a verb whose backing route carries no resolvable contract
 // field simply omits that field (projectEffectiveContract leaves it zero/empty)
-// — nothing is fabricated. A ViewSet with no router-expanded routes in the
-// index returns an empty handlers list with a note, not an error.
+// — nothing is fabricated. A ViewSet with neither router-expanded routes nor a
+// pack-resolvable EXTENDS chain returns an empty handlers list with a note, not
+// an error.
 
 import (
 	"context"
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/frameworks/baseknowledge"
 	"github.com/cajasmota/archigraph/internal/graph"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
@@ -146,6 +161,13 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 			if !ok {
 				continue
 			}
+			// #3964 follow-up: when the route carries no stamped per-verb
+			// contract (effective_kind/effective_status absent because the
+			// index predates the stamping pass, or the stamp was honest-partial),
+			// backfill from the SAME MRO/pack resolution get_source uses
+			// (resolveInheritedEndpoint). This is what keeps the tool and
+			// get_source from disagreeing on an inherited verb's contract.
+			backfillEffectiveContractFromMRO(r, e, &c)
 			key := groupKey{repo: r.Repo, class: vs}
 			g, exists := groups[key]
 			if !exists {
@@ -158,6 +180,38 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
+		}
+	}
+
+	// CLASS FALLBACK (deploy-9 item-4): when NO router-expanded route entities
+	// were found for the ViewSet — the live-daemon empty case on a real DRF app
+	// whose routing the expansion pass didn't materialise — synthesize the
+	// per-verb contract from the ViewSet CLASS entity's EXTENDS edges + the
+	// baseknowledge pack, exactly as get_source's resolveMember does. The data
+	// the tool needs is the same MRO-reachable data get_source reads; this makes
+	// the tool return it wherever get_source can.
+	if len(groups) == 0 {
+		for _, r := range reposToConsider(lg, nil) {
+			if r.Doc == nil {
+				continue
+			}
+			cls := findViewSetClassEntity(r, wantVS)
+			if cls == nil {
+				continue
+			}
+			handlers := synthesizeClassEffectiveContracts(r, cls)
+			if len(handlers) == 0 {
+				continue
+			}
+			key := groupKey{repo: r.Repo, class: leafAfterDot(cls.Name)}
+			g := &effectiveContractGroup{
+				Class:     leafAfterDot(cls.Name),
+				Framework: classFramework(cls),
+				Repo:      r.Repo,
+			}
+			g.Handlers = handlers
+			groups[key] = g
+			order = append(order, key)
 		}
 	}
 
@@ -176,11 +230,160 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 	}
 
 	if len(out.Groups) == 0 {
-		out.Note = "no router-expanded routes found for this ViewSet. " +
-			"The effective contract is stamped by the DRF expansion pass (T5 #3964); " +
-			"if the index predates that stamping a reindex is required to populate it."
+		out.Note = "no effective contract resolvable for this ViewSet: neither " +
+			"router-expanded routes nor a ViewSet class entity with EXTENDS edges to " +
+			"a known framework base (e.g. ModelViewSet) were found in the index. " +
+			"Confirm the target is a DRF ViewSet and that its class is indexed; if the " +
+			"index predates the DRF expansion pass (#3964) a reindex may help."
 	}
 	return jsonResult(out), nil
+}
+
+// backfillEffectiveContractFromMRO fills the per-verb contract fields a
+// router-expanded route left empty (the stamp omitted them, or the index
+// predates the stamping pass) from the SAME MRO resolution get_source uses:
+// resolveInheritedEndpoint -> the baseknowledge pack contract. It never
+// OVERWRITES a stamped value — stamped props win — so an index that already
+// carries effective_* is byte-identical to before. Honest-partial: when the MRO
+// can't resolve the verb, the empty fields stay empty.
+func backfillEffectiveContractFromMRO(r *LoadedRepo, e *graph.Entity, c *effectiveContract) {
+	// Only inherited routes carry a pack-resolvable framework contract; explicit
+	// bodies and @action verbs have no framework default to backfill.
+	res, ok := resolveInheritedEndpoint(r, e)
+	if !ok || res.Contract == nil {
+		return
+	}
+	applyPackContract(res, c)
+}
+
+// applyPackContract maps a pack-resolved memberResolution into the per-verb
+// effectiveContract, filling ONLY the fields the caller left zero/empty so a
+// stamped value is never clobbered.
+func applyPackContract(res memberResolution, c *effectiveContract) {
+	m := res.Contract
+	if c.Kind == "" {
+		c.Kind = "inherited"
+	}
+	if c.SourceClass == "" {
+		c.SourceClass = res.DefiningClass
+	}
+	if c.Verb == "" {
+		c.Verb = m.HTTPVerb
+	}
+	if c.DefaultStatus == 0 && m.DefaultStatus != baseknowledge.StatusUnknown {
+		c.DefaultStatus = m.DefaultStatus
+	}
+	if len(c.ErrorStatuses) == 0 && len(m.ErrorStatuses) > 0 {
+		c.ErrorStatuses = append([]int(nil), m.ErrorStatuses...)
+	}
+	if c.Behaviour == "" {
+		c.Behaviour = m.Behaviour
+	}
+}
+
+// findViewSetClassEntity returns the ViewSet declaration entity whose leaf name
+// (lower-cased) matches wantVS, used by the class-fallback synthesis when no
+// router-expanded routes exist for the ViewSet.
+//
+// It accepts not only isClassEntity nodes (SCOPE.Component / class subtype) but
+// any entity that owns at least one EXTENDS/IMPLEMENTS edge — because the Python
+// extractor emits a DRF ViewSet as Kind="View" with an empty subtype (so
+// isClassEntity is false for it) yet still records the inheritance edge to
+// ModelViewSet that the synthesis walks. Restricting to "has an EXTENDS edge"
+// keeps this from matching unrelated same-named non-class entities.
+func findViewSetClassEntity(r *LoadedRepo, wantVS string) *graph.Entity {
+	if r.Doc == nil {
+		return nil
+	}
+	var fallback *graph.Entity
+	for i := range r.Doc.Entities {
+		e := &r.Doc.Entities[i]
+		if strings.ToLower(leafAfterDot(e.Name)) != wantVS {
+			continue
+		}
+		if isClassEntity(e) {
+			return e
+		}
+		if fallback == nil && len(extendsBases(r, e)) > 0 {
+			fallback = e
+		}
+	}
+	return fallback
+}
+
+// classFramework reports the route framework leaf for a ViewSet class entity,
+// from its framework property when set, defaulting to "django" for a
+// pack-recognised DRF base. Empty when neither is known.
+func classFramework(cls *graph.Entity) string {
+	if fw := cls.Properties["framework"]; fw != "" {
+		return fw
+	}
+	return "django"
+}
+
+// synthesizeClassEffectiveContracts builds the per-verb effective contract for a
+// ViewSet class entity directly from its EXTENDS edges + the baseknowledge pack
+// — the same resolution get_source performs on a ViewSet's inherited method
+// entity. For each known base (e.g. ModelViewSet, ListModelMixin), every member
+// the base contributes is emitted as one inherited per-verb contract. Returns
+// nil when the class extends no pack-known base (honest-partial: nothing
+// synthesized rather than a fabricated contract).
+func synthesizeClassEffectiveContracts(r *LoadedRepo, cls *graph.Entity) []effectiveContract {
+	reg := baseknowledge.Default()
+	owning := leafAfterDot(cls.Name)
+	serializer := cls.Properties["serializer_class"]
+
+	// BFS the EXTENDS graph so a ViewSet that subclasses an in-repo base which
+	// itself extends ModelViewSet still resolves the inherited verbs.
+	type byVerb struct {
+		member        baseknowledge.Member
+		definingClass string
+	}
+	resolved := map[string]byVerb{} // member name -> contract (first match wins)
+	visited := map[string]bool{cls.ID: true}
+	frontier := extendsBases(r, cls)
+	for len(frontier) > 0 {
+		var next []baseRef
+		for _, b := range frontier {
+			for name, m := range reg.MembersOf(b.name) {
+				if _, seen := resolved[name]; seen {
+					continue
+				}
+				dc := m.DefiningClass
+				if dc == "" {
+					dc = canonicalBaseFQN(reg, b.name)
+				}
+				resolved[name] = byVerb{member: m, definingClass: dc}
+			}
+			if b.entity != nil && !visited[b.entity.ID] {
+				visited[b.entity.ID] = true
+				next = append(next, extendsBases(r, b.entity)...)
+			}
+		}
+		frontier = next
+	}
+	if len(resolved) == 0 {
+		return nil
+	}
+
+	out := make([]effectiveContract, 0, len(resolved))
+	for _, v := range resolved {
+		c := effectiveContract{
+			Handler:    owning + "." + v.member.Name,
+			Serializer: serializer,
+		}
+		res := memberResolution{
+			Provenance:    provInheritedExternal,
+			Member:        v.member.Name,
+			OwningClass:   owning,
+			DefiningClass: v.definingClass,
+			Contract:      &v.member,
+		}
+		applyPackContract(res, &c)
+		c.Pagination = v.member.PaginationApplicable
+		out = append(out, c)
+	}
+	return out
 }
 
 // sortEffectiveContracts orders per-verb contracts deterministically by path


### PR DESCRIPTION
## The disconnect (where the tool looked vs where the data is)

`archigraph_effective_contract` returned EMPTY on every DRF ViewSet (with the misleading "no router-expanded routes found ... a reindex is required" note) even on a fresh index, while `get_source` correctly synthesized the same per-verb inherited DRF mixin contract.

- **The tool** read ONLY the engine-stamped `effective_*` flat props on `pattern_type=="drf_router_expanded"` route entities (`projectEffectiveContract`).
- **`get_source`** resolves the contract LIVE at read-time from the ViewSet's `EXTENDS` edges + the baseknowledge pack (`resolveMember` / `resolveInheritedEndpoint`).

On a real DRF app whose routing the expansion pass does not materialise, the router-expanded route entities are absent — so the tool had nothing to iterate and returned zero groups — yet the contract was fully MRO-reachable (the exact data `get_source` reads). Verified with a full-pipeline probe: the routed fixture DOES stamp `effective_*`, and the unrouted ViewSet emits the class + `EXTENDS`-to-`ModelViewSet` but ZERO routes.

## The fix (wire the tool to the same MRO/pack data get_source uses)

1. **Backfill** — a router-expanded route missing `effective_*` (older index / honest-partial stamp) is filled from `resolveInheritedEndpoint` → the pack. Stamped values always win (already-stamped indexes are byte-identical).
2. **Class fallback** — when no router-expanded routes exist for the ViewSet, synthesize the per-verb contract from the ViewSet CLASS entity's `EXTENDS` edges + the pack (a `ModelViewSet` subclass yields its six CRUD verbs with the #278 statuses), exactly as `resolveMember` does for `get_source`. The real extractor emits a DRF ViewSet as `Kind="View"` `subtype=""` (not `isClassEntity`), so the class lookup also accepts any same-named entity that owns an `EXTENDS` edge.
3. Corrected the misleading empty-result note (reindex is no longer the only/primary cause) + updated `SCHEMA.md` and the package doc.

## Two-layer test (fail-before / pass-after)

**Layer 1 — full pipeline** (`cmd/archigraph`, `runIndexerOn` → `Index`):
- `TestPipeline_RoutedViewSet_StampsEffectiveContract`: a router-registered `ModelViewSet` stamps `effective_kind=inherited` / `effective_source_class=CreateModelMixin` / `effective_status=201` / `effective_error_statuses=400` on its routes.
- `TestPipeline_UnroutedViewSet_NoRoutesButExtendsEdge` (new fixture): an unrouted `ModelViewSet` emits the class + `EXTENDS`-to-`ModelViewSet` but ZERO router-expanded routes — the live-daemon empty shape.

**Layer 2 — MCP handler through `graph.fb`** (`internal/mcp`, the daemon's real load path):
- `TestEffectiveContract_ClassFallback_UnroutedViewSet_ThroughFB`: the unrouted ViewSet now yields all six inherited CRUD verbs; `create` = inherited / `…CreateModelMixin` / 201 / `[400]`; `list` paginated. **FAILS before** (0 groups + the misleading note), **PASSES after**.
- `TestEffectiveContract_BackfillUnstampedRoute_ThroughFB`: an unstamped router-expanded route is backfilled from the pack (201 / `[400]`). **FAILS before**, **PASSES after**.
- `TestEffectiveContract_RoutedViewSet_ThroughFB`: the stamped router path is unregressed.

## Not regressed

`resolveMember` / `resolveInheritedEndpoint` are **reused, not modified** — the MRO/get_source epic is untouched. Full `./internal/mcp ./internal/engine ./internal/types ./cmd/archigraph` suites pass (one pre-existing, unrelated `~/.archigraph/store` leak-detector flake in `cmd/archigraph` reproduces on `origin/main` without these changes).

**DEPLOY-DEFERRED**: ships in the next coordinated live-daemon rebuild + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
