### PR TITLE
fix(nestjs): controller constructor-DI INJECTED_INTO lost in pipeline dedup/resolve (deploy-9 REFUTED item-2)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -121,6 +121,22 @@ type Indexer struct {
 	incremental         bool
 	incrementalStateDir string // directory that holds file-index.json
 
+	// incrementalCarryForwardEntities holds the previous-graph entities sourced
+	// from UNCHANGED files during an incremental reindex. buildDocument seeds the
+	// resolver index with their (name, kind) → stable-ID identity so that
+	// bare-name edge endpoints emitted by the freshly re-extracted changed files
+	// — most importantly the NestJS/Angular constructor-DI INJECTED_INTO edge,
+	// whose FromID is the provider *name* ("FooService") attached to the consumer
+	// (controller) record — resolve to the provider's stable entity ID even when
+	// the provider file is out of the changed-file extraction scope. Without this
+	// the edge's FromID stays a bare name, never matches survivingIDs in
+	// mergeIncrementalPrevDoc, and the controller's inbound DI edge is silently
+	// dropped from the persisted graph (deploy-9 REFUTED item-2). The IDs are
+	// stable across runs (EntityID = hash(repo,kind,name,sourceFile)), so an
+	// edge rewritten to a carried-forward entity's ID points at a node that
+	// mergeIncrementalPrevDoc re-adds to the merged document. Nil on full runs.
+	incrementalCarryForwardEntities []types.EntityRecord
+
 	// exportFB is a deprecated no-op field retained for back-compat with
 	// existing callers that pass WithExportFB(true). graph.fb is now
 	// always written; setting exportFB has no additional effect.
@@ -792,6 +808,33 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				for _, f := range changed {
 					incrementalChange[filepath.ToSlash(f)] = true
 				}
+				// Seed buildDocument's resolver index with the prev-graph
+				// entities from UNCHANGED files so cross-file bare-name edge
+				// endpoints emitted by the re-extracted changed files (e.g. the
+				// constructor-DI INJECTED_INTO provider name on a controller)
+				// resolve to their stable provider IDs even though the provider
+				// file is out of this run's extraction scope. Only real,
+				// source-bearing entities are carried (ext:* synthetics are
+				// regenerated downstream and have no stable provider identity).
+				cf := make([]types.EntityRecord, 0, len(prev.Entities))
+				for ei := range prev.Entities {
+					pe := &prev.Entities[ei]
+					if pe.SourceFile == "" {
+						continue
+					}
+					if incrementalChange[filepath.ToSlash(pe.SourceFile)] {
+						continue
+					}
+					cf = append(cf, types.EntityRecord{
+						ID:         pe.ID,
+						Name:       pe.Name,
+						Kind:       pe.Kind,
+						Subtype:    pe.Subtype,
+						SourceFile: pe.SourceFile,
+						Properties: pe.Properties,
+					})
+				}
+				i.incrementalCarryForwardEntities = cf
 			}
 		}
 	}
@@ -3831,7 +3874,24 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 			importStats.ReferencesRewritten, importStats.ReferencesConsidered)
 	}
 
-	idx := resolve.BuildIndex(merged)
+	// Incremental resolver-scope augmentation (deploy-9 REFUTED item-2):
+	// seed the resolver index with the carried-forward (unchanged-file) prev
+	// entities so cross-file bare-name edge endpoints emitted by the
+	// re-extracted changed files — notably the constructor-DI INJECTED_INTO
+	// provider name attached to a controller — resolve to their stable
+	// provider IDs. The carry-forward entities are used for index lookups
+	// ONLY; they are NOT appended to `merged` (mergeIncrementalPrevDoc
+	// re-adds the unchanged-file entities to the persisted document, so
+	// adding them here too would double-emit). IDs are stable across runs,
+	// so an edge rewritten to a carried-forward entity's ID resolves to a
+	// node that survives into the final graph.
+	indexEntities := merged
+	if len(i.incrementalCarryForwardEntities) > 0 {
+		indexEntities = make([]types.EntityRecord, 0, len(merged)+len(i.incrementalCarryForwardEntities))
+		indexEntities = append(indexEntities, merged...)
+		indexEntities = append(indexEntities, i.incrementalCarryForwardEntities...)
+	}
+	idx := resolve.BuildIndex(indexEntities)
 	// #2049 — Django string-FK late-binding: rewrite scope:component:ref:python:*
 	// stubs on REFERENCES edges with django_rel set, using app-label-aware
 	// byPackageComponent lookup. Runs after BuildIndex (needs the component

--- a/cmd/archigraph/nestjs_controller_di_pipeline_test.go
+++ b/cmd/archigraph/nestjs_controller_di_pipeline_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestNestJSControllerDIPipeline_FullIndex is the baseline FULL-PIPELINE
+// integration test: a NestJS controller's constructor-DI INJECTED_INTO edge
+// (provider service -> consumer controller) must survive resolution + dedup
+// into the persisted graph with RESOLVED hashed entity IDs (not bare names)
+// on a from-scratch full index.
+//
+// This guards the extraction + resolve + buildDocument path (#3970/#3979). It
+// passes on main; the regression that deploy-9 REFUTED lives on the INCREMENTAL
+// path — see TestNestJSControllerDIPipeline_Incremental below.
+func TestNestJSControllerDIPipeline_FullIndex(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	repo, ctrlPath := writeNestJSDIFixture(t)
+	gitInitCommit(t, repo)
+
+	out := filepath.Join(repo, ".ag", "graph.json")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Index(repo, out, "nestjs-di", nil, true, false); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+	_ = ctrlPath
+	assertControllerDIResolved(t, filepath.Dir(out))
+}
+
+// TestNestJSControllerDIPipeline_Incremental is the regression test for the
+// deploy-9 REFUTED item: the NestJS controller constructor-DI INJECTED_INTO
+// edge is LOST on an incremental reindex that touches ONLY the controller file
+// (the provider service file is unchanged, hence out of the changed-file
+// resolver scope).
+//
+// Root cause: the edge is extractor-emitted on the CONTROLLER record with a
+// bare-NAME FromID ("FooService"). On a full index the resolver index contains
+// the provider entity so the name binds to its hashed ID; on an incremental
+// index of the controller alone, the unchanged provider is absent from the
+// resolver scope, the FromID stays a bare name, never matches survivingIDs in
+// mergeIncrementalPrevDoc, and the controller's inbound DI edge silently
+// disappears from the persisted graph — controller-specific because controller
+// files are edited far more often than the services they consume.
+//
+// The fix seeds buildDocument's resolver index with carried-forward
+// (unchanged-file) prev entities. This test MUST FAIL before that fix (the
+// re-extracted edge keeps a bare-name FromID) and PASS after.
+func TestNestJSControllerDIPipeline_Incremental(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	repo, ctrlPath := writeNestJSDIFixture(t)
+	gitInitCommit(t, repo)
+
+	out := filepath.Join(repo, ".ag", "graph.json")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Dir(out)
+
+	// Initial full index (first incremental run has no manifest -> full).
+	if err := Index(repo, out, "nestjs-di", nil, true, false, WithIncremental(stateDir)); err != nil {
+		t.Fatalf("initial index: %v", err)
+	}
+	assertControllerDIResolved(t, stateDir) // sanity: baseline is correct.
+
+	// Edit ONLY the controller; leave it UNCOMMITTED so `git diff HEAD`
+	// reports it as the sole changed file (the editor-save scenario the
+	// daemon reacts to). The provider service file stays unchanged and is
+	// therefore excluded from this run's extraction scope.
+	orig, err := os.ReadFile(ctrlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ctrlPath, append(orig, []byte("\n// touched to trigger incremental reindex\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Index(repo, out, "nestjs-di", nil, true, false, WithIncremental(stateDir)); err != nil {
+		t.Fatalf("incremental index: %v", err)
+	}
+
+	assertControllerDIResolved(t, stateDir)
+}
+
+// writeNestJSDIFixture lays down a tiny NestJS repo: an @Injectable() provider
+// service and an @Controller consumer with constructor DI of that service, in
+// sibling files. Returns the repo dir and the controller file path.
+func writeNestJSDIFixture(t *testing.T) (repo, ctrlPath string) {
+	t.Helper()
+	repo = t.TempDir()
+	srcDir := filepath.Join(repo, "src", "modules", "foo")
+	if err := os.MkdirAll(filepath.Join(srcDir, "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcDir, "application"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	serviceTS := `import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FooService {
+  listFoos(): string[] {
+    return ['a', 'b'];
+  }
+}
+`
+	controllerTS := `import { Controller, Get } from '@nestjs/common';
+import { FooService } from '../application/foo.service';
+
+@Controller('api/v1/foos')
+export class FooController {
+  constructor(private readonly fooService: FooService) {}
+
+  @Get()
+  list(): string[] {
+    return this.fooService.listFoos();
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "application", "foo.service.ts"), []byte(serviceTS), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctrlPath = filepath.Join(srcDir, "api", "foo.controller.ts")
+	if err := os.WriteFile(ctrlPath, []byte(controllerTS), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo, ctrlPath
+}
+
+func gitInitCommit(t *testing.T, repo string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"-c", "user.email=t@t.t", "-c", "user.name=t", "add", "-A"},
+		{"-c", "user.email=t@t.t", "-c", "user.name=t", "commit", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// assertControllerDIResolved loads the persisted graph from dir and asserts
+// that an INJECTED_INTO edge exists between the RESOLVED FooService entity ID
+// and the RESOLVED FooController entity ID — i.e. every INJECTED_INTO edge into
+// the controller carries the hashed provider ID, never a bare name.
+func assertControllerDIResolved(t *testing.T, dir string) {
+	t.Helper()
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	var controllerID, serviceID string
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		switch e.Name {
+		case "FooController":
+			if controllerID == "" || isComponentish(e.Kind) {
+				controllerID = e.ID
+			}
+		case "FooService":
+			if serviceID == "" || isComponentish(e.Kind) {
+				serviceID = e.ID
+			}
+		}
+	}
+	if controllerID == "" {
+		t.Fatalf("FooController entity not found in graph")
+	}
+	if serviceID == "" {
+		t.Fatalf("FooService entity not found in graph")
+	}
+
+	resolved := false
+	var sawBareName bool
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "INJECTED_INTO" || r.ToID != controllerID {
+			continue
+		}
+		if r.FromID == serviceID {
+			resolved = true
+		} else if !isHex16ID(r.FromID) {
+			// A bare, unresolved provider name survived into the graph — the
+			// exact deploy-9 REFUTED symptom.
+			sawBareName = true
+			t.Logf("unresolved INJECTED_INTO into FooController: FromID=%q (want resolved serviceID=%s)", r.FromID, serviceID)
+		}
+	}
+
+	// A bare-name FromID surviving is itself the bug, even if a separate
+	// resolved edge also happens to be present (e.g. a carried-forward copy
+	// from a previous run): the unresolved edge is what persists once the
+	// resolved copy ages out, and it is invisible to inspect / neighbors /
+	// trace because buildAdjacency keys it under a phantom node.
+	if sawBareName {
+		t.Fatalf("controller constructor-DI INJECTED_INTO edge survived with a BARE-NAME FromID instead of the resolved FooService ID %s — provider name not resolved against the out-of-scope (unchanged) provider file", serviceID)
+	}
+	if !resolved {
+		t.Fatalf("NO INJECTED_INTO edge from the resolved FooService ID %s to the resolved FooController ID %s survived the pipeline", serviceID, controllerID)
+	}
+}
+
+func isComponentish(kind string) bool {
+	switch kind {
+	case "SCOPE.Component", "Class", "Component":
+		return true
+	}
+	return false
+}
+
+func isHex16ID(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

The NestJS controller constructor-DI `INJECTED_INTO` edge (provider service → consumer controller) is **absent from the live graph** despite deploy #9 carrying the #3979 extraction fix. REFUTED across deploy-8 and deploy-9; prior fixes had extraction-only unit tests (which pass), but the edge is lost in the FULL pipeline.

## Exact root cause — name-resolution scope (NOT dedup-clobber)

The edge is extractor-emitted on the **controller** record with a bare-NAME `FromID` (e.g. `"DevicesService"`), resolved to the provider's hashed ID by `buildDocument`'s `resolve.BuildIndex`.

In **incremental** reindex mode, `Run()` sets `files = changed`, so Pass-1 extraction **and** `buildDocument`'s `resolve.BuildIndex(merged)` see ONLY the changed-file records. When an editor save touches **only the controller** (controller files churn far more than the services they consume), the unchanged provider file is out of scope — the resolver index has no entry for `"DevicesService"`, the `FromID` stays a bare name, never matches `survivingIDs` in `mergeIncrementalPrevDoc` (cmd/archigraph/index.go:4162), and the controller's inbound DI edge is silently dropped. This is controller-specific purely because of the controller-vs-service edit-frequency asymmetry, and invisible to extraction-only tests (which always see both files).

Code location: `cmd/archigraph/index.go` — `idx := resolve.BuildIndex(merged)` inside `buildDocument`, with `merged` scoped to changed files in incremental mode.

## Fix

Seed `buildDocument`'s resolver index with the **carried-forward (unchanged-file) prev-graph entities** so cross-file bare-name edge endpoints resolve to their stable provider IDs. The carry-forward entities are used for index lookups ONLY — they are NOT appended to `merged` (the emitted set), since `mergeIncrementalPrevDoc` already re-adds the unchanged-file entities. Entity IDs are stable across runs (`hash(repo,kind,name,sourceFile)`), so an edge rewritten to a carried-forward entity's ID resolves to a node that survives into the final graph. Generic across every cross-file bare-name edge endpoint; mirrors how full-index DI edges already resolve. Service DI and controller routing/endpoints are unaffected.

## Integration test (fail-before / pass-after)

`TestNestJSControllerDIPipeline_Incremental` — FULL-PIPELINE test via the real `Index()` entrypoint on an on-disk NestJS fixture (`@Injectable() FooService` + `@Controller` `FooController` with `constructor(private readonly fooService: FooService)` in sibling files): full index, then **controller-only** incremental reindex. Asserts no `INJECTED_INTO` edge into the controller carries a bare-name `FromID` (every one must use the resolved `FooService` hashed ID).
- **FAILS before** the fix: re-extracted edge survives with `FromID="FooService"` (bare name).
- **PASSES after**: `FromID` resolves to the stable provider ID.

`TestNestJSControllerDIPipeline_FullIndex` guards the from-scratch path.

## Verification

- `go test ./cmd/archigraph/ ./internal/extractors/javascript/ ./internal/resolve/ ./internal/engine/ ./internal/types/` — 0 test-level failures. (The pre-existing `#2083 leak-detector` failure in cmd/archigraph also fails on pristine main and is unrelated to this change.)
- Dispatch-parity green (`internal/extractors` TestDispatch*).
- Confirmed on the real upvate files (`devices-read.controller.ts` + `devices.service.ts`, up to the full 507-file core-backend-v2 `src/`): the edge survives on a full index — the loss is incremental-only, matching the live symptom.

## DEPLOY-DEFERRED

Needs deploy #10 + a full reindex (or an incremental reindex of the affected controllers) of upvate to surface the edge live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)