### PR TITLE
fix(nestjs): recognize @UseGuards/@RequirePage auth so auth_coverage stops reporting covered:0 (deploy-9)

### DIFF
--- a/cmd/archigraph/deploy9_nestjs_auth_coverage_test.go
+++ b/cmd/archigraph/deploy9_nestjs_auth_coverage_test.go
@@ -1,0 +1,286 @@
+package main
+
+// deploy9_nestjs_auth_coverage_test.go — two-layer regression guard for the
+// deploy-9 finding: on core-backend-v2 (upvate-v2), archigraph_auth_coverage
+// reported `covered: 0 / overall_coverage: 0` for ALL 305 endpoints because the
+// app gates routes with a GLOBAL guard + metadata decorators (@RequirePage /
+// @Authenticated / @Public ...) rather than @UseGuards — and the JS/TS auth
+// resolver only recognised @UseGuards. The fix teaches the resolver the
+// metadata-decorator family (method + class level, with @Public opt-out).
+//
+// The fixture (testdata/deploy9_nestauth) copies the REAL controller shapes
+// (buildings.controller.ts → devices.controller.ts; auth.controller.ts) and the
+// REAL decorators (shared/auth.decorators.ts), not edited in core-backend-v2.
+//
+// LAYER 1 — FULL PIPELINE: Index() → graph.{fb,json} → assert each guarded
+// endpoint carries the auth signal (auth_required=true + auth_guard + the page),
+// and the @Public endpoints carry auth_required=false (NOT protected).
+//
+// LAYER 2 — MCP: load the pipeline graph into the REAL archigraph_auth_coverage
+// handler via mcp.NewServer + GetTool(...).Handler and assert covered > 0 and
+// the @Public endpoints are correctly flagged no-auth.
+//
+// Fail-before/pass-after: before the fix every endpoint resolves to
+// method="unknown" (no auth_required, no auth_guard) → covered == 0; after the
+// fix the six guarded routes carry the signal → covered == 6.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// deploy9GuardedRoutes are the endpoints the fixture protects via a metadata
+// decorator (method- or class-level). Each must carry the auth signal after the
+// fix. `page` is the literal page/permission the decorator names ("" when the
+// decorator carries none, e.g. @Authenticated / @InternalKeyOrAuth / inherited).
+var deploy9GuardedRoutes = []struct {
+	verb, path, page string
+}{
+	{"GET", "/api/v1/devices", "devices.read"},                      // @RequirePage('devices.read')
+	{"POST", "/api/v1/devices", "devices.write"},                    // @RequirePage('devices.write')
+	{"GET", "/api/v1/devices/summary", "devices.read,reports.read"}, // @AnyPage('devices.read','reports.read')
+	{"GET", "/api/v1/devices/{id}/notes", ""},                       // @Authenticated()
+	{"DELETE", "/api/v1/devices/{id}", "devices.write"},             // @RequirePage('devices.write')
+	{"PATCH", "/api/v1/devices/{id}", "devices.write"},              // @RequirePage('devices.write')
+	{"POST", "/api/v1/auth/webhook", ""},                            // @InternalKeyOrAuth()
+	{"GET", "/api/v1/auth/me", ""},                                  // inherits class-level @Authenticated()
+}
+
+// deploy9PublicRoutes are the genuinely-public routes (@Public()). They must NOT
+// be flagged protected, and archigraph_auth_coverage must report them no-auth.
+var deploy9PublicRoutes = []struct{ verb, path string }{
+	{"GET", "/api/v1/devices/health"}, // method-level @Public()
+	{"POST", "/api/v1/auth/login"},    // @Public() overriding class @Authenticated()
+	{"POST", "/api/v1/auth/register"}, // @Public()
+}
+
+func deploy9FindEndpoint(eps []*graph.Entity, verb, path string) *graph.Entity {
+	for _, e := range eps {
+		if e.Properties == nil {
+			continue
+		}
+		if e.Properties["verb"] == verb && e.Properties["path"] == path {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestDeploy9_NestJSMetadataAuth_FullPipelineAndMCP is the two-layer test.
+func TestDeploy9_NestJSMetadataAuth_FullPipelineAndMCP(t *testing.T) {
+	// Isolate per-repo state in a temp dir (never touch ~/.archigraph).
+	stateDir := t.TempDir()
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", stateDir)
+
+	fixture, err := filepath.Abs("testdata/deploy9_nestauth")
+	if err != nil {
+		t.Fatalf("abs fixture: %v", err)
+	}
+
+	// FULL PIPELINE: empty outPath → Index writes per-repo state (graph.fb +
+	// graph.json) under ARCHIGRAPH_DAEMON_ROOT at daemon.GraphPathForRepo(fixture).
+	// The MCP server discovers the SAME artifact via FindGraphFileAnyRef(fixture),
+	// so both layers read the identical pipeline output.
+	if err := Index(fixture, "", "deploy9_nestauth", nil, false, false,
+		WithExportJSON(true)); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	graphPath, _ := daemon.FindGraphFileAnyRef(fixture)
+	if graphPath == "" {
+		t.Fatal("pipeline graph not discoverable under daemon state dir")
+	}
+	doc, err := graph.LoadGraphFromDir(filepath.Dir(graphPath))
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+
+	var eps []*graph.Entity
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "http_endpoint_definition" {
+			eps = append(eps, &doc.Entities[i])
+		}
+	}
+	if len(eps) == 0 {
+		t.Fatal("no http_endpoint_definition entities emitted — pipeline did not see the NestJS controllers")
+	}
+
+	// ---- LAYER 1: auth stamping on the producer endpoints ----------------
+	t.Run("Layer1_FullPipeline_AuthStamping", func(t *testing.T) {
+		for _, r := range deploy9GuardedRoutes {
+			ep := deploy9FindEndpoint(eps, r.verb, r.path)
+			if ep == nil {
+				t.Errorf("guarded endpoint %s %s not emitted", r.verb, r.path)
+				continue
+			}
+			if ep.Properties["auth_required"] != "true" {
+				t.Errorf("%s %s: auth_required=%q, want true (fail-before: empty)",
+					r.verb, r.path, ep.Properties["auth_required"])
+			}
+			// MCP signal-1 key must be present so auth_coverage's cheap property
+			// check fires.
+			if ep.Properties["auth_guard"] == "" {
+				t.Errorf("%s %s: no auth_guard signal-1 key stamped", r.verb, r.path)
+			}
+			if r.page != "" {
+				if got := ep.Properties["auth_page"]; got != r.page {
+					t.Errorf("%s %s: auth_page=%q, want %q", r.verb, r.path, got, r.page)
+				}
+				if got := ep.Properties["auth_permissions"]; got != r.page {
+					t.Errorf("%s %s: auth_permissions=%q, want %q", r.verb, r.path, got, r.page)
+				}
+			}
+		}
+		for _, r := range deploy9PublicRoutes {
+			ep := deploy9FindEndpoint(eps, r.verb, r.path)
+			if ep == nil {
+				t.Errorf("public endpoint %s %s not emitted", r.verb, r.path)
+				continue
+			}
+			if ep.Properties["auth_required"] == "true" {
+				t.Errorf("%s %s: auth_required=true, want false/unset (@Public must not be flagged protected)",
+					r.verb, r.path)
+			}
+			if ep.Properties["auth_guard"] != "" {
+				t.Errorf("%s %s: auth_guard=%q stamped on a @Public route",
+					r.verb, r.path, ep.Properties["auth_guard"])
+			}
+		}
+	})
+
+	// ---- LAYER 2: archigraph_auth_coverage MCP handler -------------------
+	t.Run("Layer2_MCP_AuthCoverage_CoveredGreaterThanZero", func(t *testing.T) {
+		// Point a registry at the pipeline-produced graph (graph.fb in outDir).
+		regPath := filepath.Join(t.TempDir(), "registry.json")
+		reg := map[string]any{
+			"groups": map[string]any{
+				"deploy9": map[string]any{
+					"repos": map[string]any{
+						"deploy9_nestauth": map[string]any{
+							"path": fixture,
+						},
+					},
+				},
+			},
+		}
+		regBytes, err := json.Marshal(reg)
+		if err != nil {
+			t.Fatalf("marshal registry: %v", err)
+		}
+		if err := os.WriteFile(regPath, regBytes, 0o644); err != nil {
+			t.Fatalf("write registry: %v", err)
+		}
+
+		srv, err := mcp.NewServer(mcp.Config{RegistryPath: regPath})
+		if err != nil {
+			t.Fatalf("mcp.NewServer: %v", err)
+		}
+		st := srv.MCP.GetTool("archigraph_auth_coverage")
+		if st == nil {
+			t.Fatal("archigraph_auth_coverage not registered")
+		}
+
+		req := mcpapi.CallToolRequest{}
+		req.Params.Name = "archigraph_auth_coverage"
+		req.Params.Arguments = map[string]any{"group": "deploy9", "format": "full"}
+		res, err := st.Handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if res == nil || res.IsError {
+			t.Fatalf("tool returned error: %+v", res)
+		}
+
+		out := extractDeploy9JSON(t, res)
+
+		// overall_coverage > 0 and total covered > 0 (fail-before: both 0).
+		summaries, _ := out["repo_summaries"].([]any)
+		if len(summaries) == 0 {
+			t.Fatalf("no repo_summaries in result: %v", out)
+		}
+		totalCovered := 0
+		for _, s := range summaries {
+			sm, _ := s.(map[string]any)
+			if c, ok := sm["covered"].(float64); ok {
+				totalCovered += int(c)
+			}
+		}
+		if totalCovered == 0 {
+			t.Fatalf("covered == 0 (the deploy-9 bug): NestJS metadata-decorator auth not recognised")
+		}
+		if oc, _ := out["overall_coverage"].(float64); oc == 0 {
+			t.Fatalf("overall_coverage == 0 (the deploy-9 bug)")
+		}
+		// Exactly the 8 guarded routes are covered.
+		if totalCovered != len(deploy9GuardedRoutes) {
+			t.Errorf("covered=%d, want %d (the guarded routes)", totalCovered, len(deploy9GuardedRoutes))
+		}
+
+		// The @Public endpoints must be present and flagged no-auth.
+		endpoints, _ := out["endpoints"].([]any)
+		byPath := map[string]map[string]any{}
+		for _, raw := range endpoints {
+			ep, _ := raw.(map[string]any)
+			if ep == nil {
+				continue
+			}
+			verb, _ := ep["method"].(string)
+			path, _ := ep["path"].(string)
+			byPath[verb+" "+path] = ep
+		}
+		for _, r := range deploy9PublicRoutes {
+			ep, ok := byPath[r.verb+" "+r.path]
+			if !ok {
+				t.Errorf("public endpoint %s %s missing from auth_coverage results", r.verb, r.path)
+				continue
+			}
+			if ha, _ := ep["has_auth"].(bool); ha {
+				t.Errorf("%s %s (@Public): has_auth=true, want false", r.verb, r.path)
+			}
+		}
+		// And every guarded route must report has_auth=true.
+		for _, r := range deploy9GuardedRoutes {
+			ep, ok := byPath[r.verb+" "+r.path]
+			if !ok {
+				t.Errorf("guarded endpoint %s %s missing from results", r.verb, r.path)
+				continue
+			}
+			if ha, _ := ep["has_auth"].(bool); !ha {
+				t.Errorf("%s %s: has_auth=false, want true", r.verb, r.path)
+			}
+		}
+	})
+}
+
+// extractDeploy9JSON pulls the JSON object out of an MCP tool result's first
+// text content block.
+func extractDeploy9JSON(t *testing.T, res *mcpapi.CallToolResult) map[string]any {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatal("empty result content")
+	}
+	var text string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			text = tc.Text
+			break
+		}
+	}
+	if text == "" {
+		t.Fatalf("no TextContent in result: %T", res.Content[0])
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("unmarshal result JSON: %v\n%s", err, text)
+	}
+	return out
+}

--- a/cmd/archigraph/testdata/deploy9_nestauth/package.json
+++ b/cmd/archigraph/testdata/deploy9_nestauth/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "deploy9-nestauth-fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0"
+  }
+}

--- a/cmd/archigraph/testdata/deploy9_nestauth/src/auth/auth.controller.ts
+++ b/cmd/archigraph/testdata/deploy9_nestauth/src/auth/auth.controller.ts
@@ -1,0 +1,31 @@
+// Deploy-9 fixture — mirrors the REAL core-backend-v2 auth.controller.ts shape:
+// @Public() sits ABOVE the @Post verb decorator on each login/register route,
+// plus one @InternalKeyOrAuth() route and a class-level @Authenticated() default
+// with a per-method @Public() override (exercising getAllAndOverride precedence).
+import { Controller, Get, Post } from '@nestjs/common';
+import { Authenticated, Public, InternalKeyOrAuth } from '../shared/auth.decorators';
+
+// Class-level default: every method is @Authenticated() unless it overrides.
+@Authenticated()
+@Controller('api/v1/auth')
+export class AuthController {
+  // Explicit public login route — overrides the class-level @Authenticated().
+  @Public()
+  @Post('login')
+  login() {}
+
+  // Explicit public registration.
+  @Public()
+  @Post('register')
+  register() {}
+
+  // Internal-key-or-auth gated webhook (protected).
+  @InternalKeyOrAuth()
+  @Post('webhook')
+  webhook() {}
+
+  // No method-level decorator → inherits the class-level @Authenticated()
+  // (protected). Exercises class-level inheritance.
+  @Get('me')
+  me() {}
+}

--- a/cmd/archigraph/testdata/deploy9_nestauth/src/devices/devices.controller.ts
+++ b/cmd/archigraph/testdata/deploy9_nestauth/src/devices/devices.controller.ts
@@ -1,0 +1,46 @@
+// Deploy-9 fixture controller — mirrors the REAL core-backend-v2
+// buildings.controller.ts decorator layout: a global PermissionsGuard +
+// AuthenticationGuard (registered as APP_GUARD elsewhere) enforce auth; each
+// route declares its requirement with a SetMetadata-based decorator. There is
+// NO @UseGuards in this app — the pre-fix resolver therefore saw no auth.
+import { Controller, Get, Post, Delete, Patch } from '@nestjs/common';
+import { RequirePage, Authenticated, AnyPage, Public } from '../shared/auth.decorators';
+
+@Controller('api/v1/devices')
+export class DevicesController {
+  // Page-gated read — the dominant case (@RequirePage on a @Get method).
+  @Get()
+  @RequirePage('devices.read')
+  list() {}
+
+  // Page-gated write (sensitive verb + page).
+  @Post()
+  @RequirePage('devices.write')
+  create() {}
+
+  // OR-over-pages requirement.
+  @Get('summary')
+  @AnyPage('devices.read', 'reports.read')
+  summary() {}
+
+  // Authenticated-only (no RBAC matrix) — still protected (401 before handler).
+  @Get(':id/notes')
+  @Authenticated()
+  notes() {}
+
+  // Page-gated destructive verb.
+  @Delete(':id')
+  @RequirePage('devices.write')
+  remove() {}
+
+  // Page-gated update.
+  @Patch(':id')
+  @RequirePage('devices.write')
+  update() {}
+
+  // Genuinely public (legacy AllowAny) — must NOT be flagged as protected, and
+  // must be reported as no-auth by archigraph_auth_coverage.
+  @Public()
+  @Get('health')
+  health() {}
+}

--- a/cmd/archigraph/testdata/deploy9_nestauth/src/shared/auth.decorators.ts
+++ b/cmd/archigraph/testdata/deploy9_nestauth/src/shared/auth.decorators.ts
@@ -1,0 +1,22 @@
+// Trimmed copy of core-backend-v2 src/shared/auth/permissions/permissions.decorators.ts
+// (deploy-9 fixture — REAL idioms, not edited in place). Each decorator records a
+// PermissionRequirement as route metadata; a single GLOBAL PermissionsGuard reads
+// it via Reflector.getAllAndOverride([handler, class]).
+import { SetMetadata } from '@nestjs/common';
+
+export const PERMISSIONS_METADATA = 'upvate:permissions' as const;
+
+export const Public = (): MethodDecorator & ClassDecorator =>
+  SetMetadata(PERMISSIONS_METADATA, { kind: 'public' });
+
+export const Authenticated = (): MethodDecorator & ClassDecorator =>
+  SetMetadata(PERMISSIONS_METADATA, { kind: 'authenticated' });
+
+export const RequirePage = (slug: string): MethodDecorator & ClassDecorator =>
+  SetMetadata(PERMISSIONS_METADATA, { kind: 'page', pages: [slug] });
+
+export const AnyPage = (...slugs: string[]): MethodDecorator & ClassDecorator =>
+  SetMetadata(PERMISSIONS_METADATA, { kind: 'any-page', pages: slugs });
+
+export const InternalKeyOrAuth = (): MethodDecorator & ClassDecorator =>
+  SetMetadata(PERMISSIONS_METADATA, { kind: 'internal-key' });

--- a/internal/engine/http_endpoint_jsts_auth.go
+++ b/internal/engine/http_endpoint_jsts_auth.go
@@ -242,7 +242,13 @@ type jsAuthContext struct {
 	// default). Endpoints inherit it unless they opt out with `auth: false`.
 	hapiServerDefaultAuth bool
 	hapiServerDefaultLine int
-	file                  string
+	// classMetaAuth is the controller class-level metadata-decorator posture
+	// (@RequirePage / @Authenticated / @Public ... on the @Controller class).
+	// It applies to every method without its own override (deploy-9). nestMetaNone
+	// when no controller in the file carries a class-level metadata decorator.
+	classMetaAuth     nestMetaAuthResult
+	classMetaAuthLine int
+	file              string
 }
 
 // resolveJSTSFileAuth scans a file once and returns its app/router-level and
@@ -291,6 +297,14 @@ func resolveJSTSFileAuth(content, file string) jsAuthContext {
 			File: file,
 			Line: lineAtOffset(content, m[0]),
 		})
+	}
+
+	// Nest class-level metadata-decorator posture (deploy-9): @RequirePage /
+	// @Authenticated / @Public ... on the @Controller class. Applies to every
+	// method that lacks its own metadata override.
+	if cls := resolveNestClassMetadataAuth(content); cls.kind != nestMetaNone {
+		ctx.classMetaAuth = cls
+		ctx.classMetaAuthLine = nestFirstControllerLine(content)
 	}
 
 	// Hapi server-wide default auth strategy.
@@ -345,6 +359,9 @@ func applyJSTSAuthPolicy(content, path string, entities []types.EntityRecord, be
 	// Index Nest method-level guards by handler symbol (the decorator sits
 	// immediately above the @Get/@Post method; we attribute by nearest method).
 	methodGuards := indexNestMethodGuards(content, path)
+	// Index Nest method-level metadata-decorator auth (@RequirePage / @Public /
+	// @Authenticated ...) by handler method symbol (deploy-9).
+	methodMetaAuth := indexNestMethodMetadataAuth(content)
 	// Index Hapi per-route auth from the route object bodies.
 	hapiRouteAuth := indexHapiRouteAuth(content, path)
 	// Index Adonis route-chain middleware by canonical path.
@@ -375,7 +392,7 @@ func applyJSTSAuthPolicy(content, path string, entities []types.EntityRecord, be
 
 		policy := resolveEndpointAuth(
 			framework, key, e.Properties["source_handler"],
-			ctx, routeAuth, methodGuards, hapiRouteAuth, adonisRouteAuth, marbleRouteAuth,
+			ctx, routeAuth, methodGuards, methodMetaAuth, hapiRouteAuth, adonisRouteAuth, marbleRouteAuth,
 		)
 		stampAuthPolicy(e.Properties, policy)
 	}
@@ -395,6 +412,7 @@ func resolveEndpointAuth(
 	ctx jsAuthContext,
 	routeAuth map[string][]AuthSignal,
 	methodGuards map[string][]AuthSignal,
+	methodMetaAuth map[string]nestMetaAuthResult,
 	hapiRouteAuth map[string]hapiAuth,
 	adonisRouteAuth map[string][]AuthSignal,
 	marbleRouteAuth map[string][]AuthSignal,
@@ -418,6 +436,13 @@ func resolveEndpointAuth(
 				Scopes:      scopesFromSignals(sigs),
 				SourceChain: sigs,
 			}
+		}
+		// 1b'. Nest method-level metadata decorator (@RequirePage / @Public /
+		// @Authenticated ...). A method-level verdict — protective OR explicitly
+		// public — overrides the class-level default, mirroring NestJS
+		// `Reflector.getAllAndOverride([handler, class])` precedence (deploy-9).
+		if res, ok := methodMetaAuth[handler]; ok && res.kind != nestMetaNone {
+			return nestMetaPolicy(res, "high", ctx.file, 0)
 		}
 	}
 	// 1c. Hapi per-route auth.
@@ -465,6 +490,13 @@ func resolveEndpointAuth(
 			Scopes:      scopesFromSignals(ctx.classGuards),
 			SourceChain: ctx.classGuards,
 		}
+	}
+	// 3'. Nest class-level metadata decorator (@RequirePage / @Public /
+	// @Authenticated ... on the @Controller class). Applies to every method
+	// without its own override — MEDIUM confidence (class scope). A class-level
+	// @Public is an explicit public verdict for the whole controller (deploy-9).
+	if framework == "nestjs" && ctx.classMetaAuth.kind != nestMetaNone {
+		return nestMetaPolicy(ctx.classMetaAuth, "medium", ctx.file, ctx.classMetaAuthLine)
 	}
 	if ctx.hapiServerDefaultAuth && framework == "hapi" {
 		return AuthPolicy{
@@ -577,6 +609,14 @@ func stampAuthPolicy(props map[string]string, policy AuthPolicy) {
 		case "middleware", "config", "framework_default":
 			props["auth_middleware"] = authEvidenceSymbol(head.Text)
 		}
+	}
+	// #deploy-9 — surface the NestJS metadata-decorator permission page(s) under
+	// a dedicated key so archigraph_auth_coverage answers "what page does this
+	// route require?" without re-deriving it from auth_permissions.
+	if policy.Required && len(policy.Permissions) > 0 {
+		pages := append([]string(nil), policy.Permissions...)
+		sort.Strings(pages)
+		props["auth_page"] = strings.Join(pages, ",")
 	}
 }
 

--- a/internal/engine/http_endpoint_jsts_nest_metadata_auth.go
+++ b/internal/engine/http_endpoint_jsts_nest_metadata_auth.go
@@ -1,0 +1,250 @@
+// NestJS metadata-decorator auth recognition (deploy-9).
+//
+// Many production NestJS apps do NOT gate routes with `@UseGuards(...)` on each
+// controller/method. Instead they register a single authentication guard and a
+// single RBAC `PermissionsGuard` GLOBALLY (`{ provide: APP_GUARD, ... }`) and
+// declare each route's requirement with a thin `SetMetadata`-based decorator —
+// e.g. `@RequirePage('devices.read')`, `@Authenticated()`, `@AnyPage(...)` — that
+// the global guard reads via `Reflector.getAllAndOverride([handler, class])`.
+// `@Public()` is the explicit opt-out (legacy AllowAny).
+//
+// The pre-existing #2852 resolver only recognised `@UseGuards`, so on such an
+// app EVERY endpoint resolved to method="unknown" and archigraph_auth_coverage
+// reported `covered: 0` for genuinely-protected routes (the deploy-9 finding on
+// core-backend-v2 / upvate-v2: 0 / 305).
+//
+// This pass recognises the metadata-decorator family at BOTH method level (binds
+// to that handler) and class level (the controller-level default applies to all
+// its methods, mirroring `getAllAndOverride([handler, class])` precedence:
+// method overrides class). A protective decorator → auth_required=true with
+// method="guard" (the route IS gated by the metadata-driven guard) and the page
+// /permission carried as auth_permissions + auth_page. `@Public()`/`@AllowAnonymous`
+// → an explicit public verdict that suppresses inheritance, so the tool does NOT
+// mislabel a genuinely-public login route as protected.
+//
+// Honest-partial: a route carrying NO recognised metadata decorator at method or
+// class level is left to the existing resolver chain (it may still be gated by a
+// truly global APP_GUARD declared in another file — cross-file, not visible to
+// this per-file pass). In core-backend-v2 every route carries a per-route or
+// per-class decorator (154 verb decorators ↔ 153 auth decorators), so this pass
+// greens the real numbers without fabricating coverage.
+//
+// Refs deploy-9.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// nestMetaAuthKind classifies a recognised metadata decorator.
+type nestMetaAuthKind int
+
+const (
+	nestMetaNone      nestMetaAuthKind = iota
+	nestMetaPublic                     // @Public() / @AllowAnonymous() — explicit opt-out
+	nestMetaProtected                  // any protective requirement decorator
+)
+
+// nestMetaAuthResult is the resolved metadata-decorator posture for a method or
+// class, with the page/permission slugs the decorator names (when literal).
+type nestMetaAuthResult struct {
+	kind        nestMetaAuthKind
+	decorator   string   // canonical decorator text for the source chain (e.g. "@RequirePage('buildings')")
+	permissions []string // literal page/permission slugs (RequirePage/AnyPage/HasPage/OwnerAndPage)
+	roles       []string // literal role names (@Roles)
+}
+
+// nestPublicDecoratorRe matches the explicit public opt-out decorators. These
+// are the metadata equivalents of DRF AllowAny — the route skips authentication
+// entirely, so it must NOT inherit a class-level or global requirement.
+var nestPublicDecoratorRe = regexp.MustCompile(`@(?:Public|AllowAnonymous|AllowAny|SkipAuth|NoAuth)\s*\(`)
+
+// nestProtectiveMetaDecoratorRe matches the metadata-driven requirement
+// decorators recognised across the common RBAC conventions. The set covers the
+// core-backend-v2 family (@RequirePage / @Authenticated / @AnyPage / @OwnerOnly /
+// @OwnerAndPage / @HasPage / @RequireAction / @InternalKeyOrAuth) plus the
+// generic nest-access-control / casl spellings (@Permissions / @RequirePermission(s)
+// / @CheckPolicies / @UseRoles). Group 1 = decorator name, group 2 = raw args.
+var nestProtectiveMetaDecoratorRe = regexp.MustCompile(
+	`@(RequirePage|Authenticated|AnyPage|OwnerOnly|OwnerAndPage|HasPage|HasPermission|RequireAction|InternalKeyOrAuth|RequirePermissions|RequirePermission|Permissions|CheckPermissions|CheckPolicies|UseRoles|RequireScopes|RequireScope|Scopes)\s*\(([^)]*)\)`,
+)
+
+// nestPageBearingDecorators are the protective decorators whose quoted argument
+// names a permission page / slug we surface as auth_permissions + auth_page.
+var nestPageBearingDecorators = map[string]bool{
+	"RequirePage":        true,
+	"AnyPage":            true,
+	"OwnerAndPage":       true,
+	"HasPage":            true,
+	"HasPermission":      true,
+	"RequirePermissions": true,
+	"RequirePermission":  true,
+	"Permissions":        true,
+	"CheckPermissions":   true,
+	"RequireScopes":      true,
+	"RequireScope":       true,
+	"Scopes":             true,
+}
+
+// recognizeNestMetadataAuth classifies a decorator block (the contiguous run of
+// `@...` lines above a method or class). `@Public` wins outright (explicit
+// opt-out). Otherwise the first protective metadata decorator decides, carrying
+// any literal page/permission slugs. A block with neither yields nestMetaNone so
+// the caller falls through to the existing resolver chain (honest-partial).
+func recognizeNestMetadataAuth(block string) nestMetaAuthResult {
+	if block == "" {
+		return nestMetaAuthResult{kind: nestMetaNone}
+	}
+	// Explicit public opt-out takes precedence over any sibling requirement —
+	// stacking @Public with a page decorator is a contradiction; the public
+	// marker is the safe (auth-skipping) reading.
+	if nestPublicDecoratorRe.MatchString(block) {
+		return nestMetaAuthResult{kind: nestMetaPublic, decorator: "@Public()"}
+	}
+	res := nestMetaAuthResult{kind: nestMetaNone}
+	for _, m := range nestProtectiveMetaDecoratorRe.FindAllStringSubmatch(block, -1) {
+		name := m[1]
+		args := strings.TrimSpace(m[2])
+		res.kind = nestMetaProtected
+		if res.decorator == "" {
+			res.decorator = "@" + name + "(" + args + ")"
+		}
+		if nestPageBearingDecorators[name] {
+			for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(args, -1) {
+				if tok := strings.TrimSpace(q[1]); tok != "" {
+					res.permissions = append(res.permissions, tok)
+				}
+			}
+		}
+	}
+	// @Roles can co-occur with a metadata requirement (or stand alone as the
+	// requirement). Capture its literal roles.
+	if rm := jsRolesDecoratorRe.FindStringSubmatch(block); rm != nil {
+		for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(rm[1], -1) {
+			if tok := strings.TrimSpace(q[1]); tok != "" {
+				res.roles = append(res.roles, tok)
+			}
+		}
+		if res.kind == nestMetaNone {
+			res.kind = nestMetaProtected
+			res.decorator = "@Roles(" + strings.TrimSpace(rm[1]) + ")"
+		}
+	}
+	return res
+}
+
+// indexNestMethodMetadataAuth attributes each handler method's own preceding
+// decorator block to that method, recognising the metadata-decorator family
+// (and @Public). Returns a map keyed by bare method name. Mirrors
+// indexNestMethodGuards but for the SetMetadata RBAC decorators rather than
+// @UseGuards. A method whose block carries a verb decorator but no recognised
+// auth metadata yields no entry (it may inherit the class-level decorator).
+func indexNestMethodMetadataAuth(content string) map[string]nestMetaAuthResult {
+	out := map[string]nestMetaAuthResult{}
+	if !nestHasMetadataAuthMarker(content) {
+		return out
+	}
+	for _, loc := range nestHandlerMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		method := content[loc[2]:loc[3]]
+		block := precedingDecoratorBlock(content, loc[0])
+		if block == "" || !nestVerbDecoratorRe.MatchString(block) {
+			continue
+		}
+		if res := recognizeNestMetadataAuth(block); res.kind != nestMetaNone {
+			out[method] = res
+		}
+	}
+	return out
+}
+
+// resolveNestClassMetadataAuth scans the controller class declarations and
+// returns the class-level metadata posture (the controller-level default that
+// applies to every method without its own override). When a file declares
+// multiple controllers we keep the FIRST protective/public verdict found —
+// per-method overrides still win at resolve time, so a coarse file-level class
+// verdict is a safe medium-confidence fallback. Returns nestMetaNone when no
+// controller carries a class-level metadata decorator.
+func resolveNestClassMetadataAuth(content string) nestMetaAuthResult {
+	if !nestHasMetadataAuthMarker(content) {
+		return nestMetaAuthResult{kind: nestMetaNone}
+	}
+	for _, m := range jsClassDeclRe.FindAllStringSubmatchIndex(content, -1) {
+		block := precedingDecoratorBlock(content, m[0])
+		if block == "" {
+			continue
+		}
+		if res := recognizeNestMetadataAuth(block); res.kind != nestMetaNone {
+			return res
+		}
+	}
+	return nestMetaAuthResult{kind: nestMetaNone}
+}
+
+// nestFirstControllerLine returns the 1-based line of the first @Controller
+// declaration (for the class-level source-chain entry). 0 when absent.
+func nestFirstControllerLine(content string) int {
+	if i := strings.Index(content, "@Controller"); i >= 0 {
+		return lineAtOffset(content, i)
+	}
+	return 0
+}
+
+// nestHasMetadataAuthMarker is the cheap substring fast-path: skip the regex
+// passes unless the file mentions at least one recognised metadata decorator.
+func nestHasMetadataAuthMarker(content string) bool {
+	for _, marker := range []string{
+		"@RequirePage", "@Authenticated", "@AnyPage", "@OwnerOnly", "@OwnerAndPage",
+		"@HasPage", "@HasPermission", "@RequireAction", "@InternalKeyOrAuth",
+		"@RequirePermission", "@Permissions", "@CheckPermissions", "@CheckPolicies",
+		"@UseRoles", "@RequireScope", "@Scopes", "@Roles",
+		"@Public", "@AllowAnonymous", "@AllowAny", "@SkipAuth", "@NoAuth",
+	} {
+		if strings.Contains(content, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// nestMetaPolicy builds an AuthPolicy from a resolved metadata posture at the
+// given confidence. A protective verdict carries method="guard" (the route is
+// gated by the metadata-driven global guard) with the page/permission slugs as
+// permissions; a public verdict is an explicit Required=false config verdict.
+func nestMetaPolicy(res nestMetaAuthResult, confidence, file string, line int) AuthPolicy {
+	if res.kind == nestMetaPublic {
+		return AuthPolicy{
+			Required: false, Method: "config", Confidence: confidence,
+			SourceChain: []AuthSignal{{
+				Kind: "config", Text: res.decorator + " (explicit public)", File: file, Line: line,
+			}},
+		}
+	}
+	return AuthPolicy{
+		Required: true, Method: "guard", Confidence: confidence,
+		Roles:       dedupeNonEmpty(res.roles),
+		Permissions: dedupeNonEmpty(res.permissions),
+		SourceChain: []AuthSignal{{
+			Kind: "guard", Text: res.decorator, File: file, Line: line,
+		}},
+	}
+}
+
+// dedupeNonEmpty returns a stable de-duplicated copy of in with empties removed,
+// or nil when nothing remains (so an empty slice never sets an empty property).
+func dedupeNonEmpty(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem (deploy-9)

On **core-backend-v2 / upvate-v2** (NestJS), `archigraph_auth_coverage` reported `covered: 0 / overall_coverage: 0` for **all 305 endpoints** — flagging genuinely-protected routes as no-auth.

Root cause: the JS/TS auth resolver (`internal/engine/http_endpoint_jsts_auth.go`, #2852) only recognised NestJS **`@UseGuards(...)`**. This app uses none. It registers a single `AuthenticationGuard` + RBAC `PermissionsGuard` **globally** as `APP_GUARD` and declares each route's requirement with a thin `SetMetadata`-based decorator read via `Reflector.getAllAndOverride([handler, class])`:

| decorator | count | meaning |
|---|---|---|
| `@RequirePage('slug')` | 111 | page-gated (the dominant case) |
| `@Authenticated()` | 44 | IsAuthenticated-only |
| `@Public()` | 17 | explicit AllowAny (opt-out) |
| `@InternalKeyOrAuth()` | 4 | auth-or-internal-key |
| + `@AnyPage / @OwnerOnly / @OwnerAndPage / @HasPage / @RequireAction` | | RBAC variants |

154 verb decorators ↔ 153 auth decorators — essentially every route carries one. With no `@UseGuards`, every endpoint resolved to `method="unknown"` and `auth_coverage` counted zero coverage.

## Fix

`internal/engine/http_endpoint_jsts_nest_metadata_auth.go` (new) + wiring into the existing resolver:

- Recognise the metadata-decorator family at **method level** (binds to the handler) and **class level** (controller default applies to every method), with **method overriding class** — mirroring `getAllAndOverride([handler, class])`.
- A protective decorator → `auth_required=true`, `auth_method=guard`, **`auth_guard`** (MCP signal-1 key auth_coverage counts), plus **`auth_page` / `auth_permissions`** for page-bearing decorators (`@RequirePage`/`@AnyPage`/`@HasPage`/`@OwnerAndPage`).
- **`@Public()` / `@AllowAnonymous` → explicit public verdict** that suppresses class/global inheritance, so login/public routes are not mislabelled protected.
- **Honest-partial**: a route with no recognised decorator at method or class level is left to the existing resolver chain (a truly global cross-file `APP_GUARD` is not visible to this per-file pass).

Also covers the generic nest-access-control / casl spellings (`@RequirePermissions`, `@Permissions`, `@CheckPolicies`, `@UseRoles`, `@RequireScopes`).

## Two-layer test (mandatory, fail-before/pass-after)

`cmd/archigraph/deploy9_nestjs_auth_coverage_test.go` over `testdata/deploy9_nestauth` — a fixture **copied from the real controller shapes** (`buildings.controller.ts` → `devices.controller.ts`, `auth.controller.ts`, `shared/auth.decorators.ts`; core-backend-v2 was not edited):

- **Layer 1 — full pipeline** (`Index()` → `graph.{fb,json}`): each guarded endpoint carries `auth_required=true` + `auth_guard` + the page; each `@Public` endpoint carries neither.
- **Layer 2 — real MCP handler** (`mcp.NewServer` → `archigraph_auth_coverage`): `covered == 8` (> 0) and the three `@Public` routes report `has_auth=false`.
- **Fail-before** (recogniser disabled): `auth_required=""` + `covered == 0` — reproduces the deploy-9 bug exactly. **Pass-after**: green.

## Tests

`go test` green for `cmd/archigraph` (full), `internal/engine`, `internal/mcp`, `internal/extractors/javascript`, `internal/custom/javascript`, `tools/coverage`, and `internal/extractors` (dispatch-parity). The one `internal/mcp` flake (`TestGetSource_FsnotifyWatcher_CompletesQuickly`, a macOS fsevents kernel stall) passes in isolation and is unrelated.

## DEPLOY-DEFERRED

Requires a coordinated live-daemon rebuild + reindex of core-backend-v2 to take effect — do not disturb the running deploy-9 daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)