### PR TITLE
fix(drf): stamp get_permissions resolved page key as auth_permissions on per-action endpoints (deploy-9 item-3)

### DIFF
--- a/cmd/archigraph/drf_get_permissions_pagekey_pipeline_test.go
+++ b/cmd/archigraph/drf_get_permissions_pagekey_pipeline_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions is the deploy-9
+// item-3 full-pipeline guard for the DRF get_permissions() per-action page-key.
+//
+// # The bug
+//
+// A DRF ViewSet whose get_permissions() branches on self.action and returns
+// CustomPagePermissionCheck(PERMISSION_PAGES["<KEY>"]) guards PER ACTION
+// resolves the page key correctly inside the engine pass
+// (django_drf_get_permissions.go: parseDRFActionPermissions /
+// mergeGetPermissionsBranches), and the engine-level ApplyDjangoDRFRoutes test
+// (internal/engine/django_drf_get_permissions_test.go) already proves the
+// resolved key reaches the endpoint posture's permissionPages. BUT through the
+// FULL index pipeline (cmd/archigraph Indexer.Run — the path the daemon runs on
+// rebuild) the synthesized per-action endpoint did NOT carry `auth_permissions`:
+// inspect(get_inspection_types, fields=[auth_permissions]) came back empty even
+// though get_source resolved the page key. This is the #2670-class meta-bug
+// (engine unit test green, real build drops the property somewhere downstream).
+//
+// # The fixture
+//
+// testdata/drf_get_permissions_pagekey_fixture mirrors the real
+// upvate_core/core/views/jurisdiction_viewset.py shape: a router-registered
+// JurisdictionViewSet whose get_permissions() resolves
+//   - get_inspection_types → PERMISSION_PAGES["JURISDICTIONS"]
+//   - email                → PERMISSION_PAGES["EMAIL_TEMPLATES"]
+// via the assign-then-return-comprehension idiom.
+//
+// # The assertions
+//
+// Endpoint side (the #3978 stamping — already green, kept as a regression guard):
+//
+//  1. The synthesized endpoint for GET /jurisdictions/inspection_types carries
+//     auth_permissions=JURISDICTIONS (the resolved page key).
+//  2. The synthesized endpoint for the `email` @action carries
+//     auth_permissions=EMAIL_TEMPLATES — a DISTINCT key, proving no bleed.
+//  3. A third action with no page-key guard
+//     (at_least_one_jurisdiction_has_maintenance_evaluation → CustomActionPermissionCheck)
+//     carries NO auth_permissions (honest-partial).
+//
+// Handler-Operation side (THE deploy-9 item-3 fix — fails before, passes after):
+//
+//  4. The action method Operation `JurisdictionViewSet.get_inspection_types`
+//     (the symbol archigraph_inspect / get_source resolve) carries
+//     auth_permissions=JURISDICTIONS — propagated from its endpoint.
+//  5. The `JurisdictionViewSet.email` Operation carries
+//     auth_permissions=EMAIL_TEMPLATES — distinct, no bleed across handlers.
+//  6. The no-page-key action's Operation carries NO auth_permissions.
+func TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/drf_get_permissions_pagekey_fixture", "drf_get_permissions_pagekey_fixture", nil)
+
+	type endpoint struct {
+		path       string
+		verb       string
+		authPerms  string
+		sourceFile string
+	}
+	var got []endpoint
+	for _, e := range doc.Entities {
+		if e.Kind != "http_endpoint" && e.Kind != "http_endpoint_definition" {
+			continue
+		}
+		got = append(got, endpoint{
+			path:       e.Properties["path"],
+			verb:       e.Properties["verb"],
+			authPerms:  e.Properties["auth_permissions"],
+			sourceFile: e.SourceFile,
+		})
+	}
+	if len(got) == 0 {
+		t.Fatalf("no http_endpoint entities emitted by indexer")
+	}
+
+	find := func(verb, path string) *endpoint {
+		for i := range got {
+			if got[i].verb == verb && got[i].path == path {
+				return &got[i]
+			}
+		}
+		return nil
+	}
+
+	// ---- Endpoint side (regression guard for #3978) ----
+
+	// (1) inspection_types → JURISDICTIONS.
+	insp := find("GET", "/jurisdictions/inspection_types")
+	if insp == nil {
+		t.Fatalf("missing GET /jurisdictions/inspection_types — got endpoints: %+v", got)
+	}
+	if insp.authPerms != "JURISDICTIONS" {
+		t.Errorf("GET /jurisdictions/inspection_types auth_permissions=%q; want %q",
+			insp.authPerms, "JURISDICTIONS")
+	}
+
+	// (2) email → EMAIL_TEMPLATES (distinct key, no bleed). The `email` @action
+	// has detail=True so the route carries the lookup placeholder; assert on the
+	// page key regardless of verb (the action declares patch+put).
+	var emailEP *endpoint
+	for i := range got {
+		if got[i].path == "/jurisdictions/{pk}/email" {
+			emailEP = &got[i]
+			break
+		}
+	}
+	if emailEP == nil {
+		t.Fatalf("missing /jurisdictions/{pk}/email — got endpoints: %+v", got)
+	}
+	if emailEP.authPerms != "EMAIL_TEMPLATES" {
+		t.Errorf("/jurisdictions/{pk}/email auth_permissions=%q; want %q (distinct from inspection_types — no bleed)",
+			emailEP.authPerms, "EMAIL_TEMPLATES")
+	}
+
+	// (3) the no-page-key action carries NO auth_permissions (honest-partial).
+	noKey := find("GET", "/jurisdictions/at_least_one_jurisdiction_has_maintenance_evaluation")
+	if noKey == nil {
+		t.Fatalf("missing GET /jurisdictions/at_least_one_jurisdiction_has_maintenance_evaluation — got endpoints: %+v", got)
+	}
+	if noKey.authPerms != "" {
+		t.Errorf("GET /jurisdictions/at_least_one_jurisdiction_has_maintenance_evaluation auth_permissions=%q; want empty (CustomActionPermissionCheck has no page key)",
+			noKey.authPerms)
+	}
+
+	// ---- Handler-Operation side (THE deploy-9 item-3 fix) ----
+	//
+	// archigraph_inspect / get_source resolve the @action by its method symbol
+	// (a SCOPE.Operation named "<ViewSet>.<method>"), NOT the http_endpoint. The
+	// page key MUST reach that Operation or auth_coverage starting from the
+	// handler shows nothing. The views.py JurisdictionViewSet duplicates the same
+	// method names; assert on the views.py fixture file to avoid cross-fixture
+	// ambiguity (both files resolve identically — page key per action is stable).
+	opAuthPerms := func(method string) (string, bool) {
+		want := "JurisdictionViewSet." + method
+		for _, e := range doc.Entities {
+			if e.Kind != "SCOPE.Operation" || e.Name != want {
+				continue
+			}
+			if e.SourceFile == "" || filepathSuffix(e.SourceFile) != "views.py" {
+				continue
+			}
+			return e.Properties["auth_permissions"], true
+		}
+		return "", false
+	}
+
+	// (4) get_inspection_types Operation → JURISDICTIONS (the core bug).
+	if ap, ok := opAuthPerms("get_inspection_types"); !ok {
+		t.Fatalf("missing SCOPE.Operation JurisdictionViewSet.get_inspection_types in views.py")
+	} else if ap != "JURISDICTIONS" {
+		t.Errorf("Operation get_inspection_types auth_permissions=%q; want %q "+
+			"(page key resolved onto endpoint but NOT propagated to the handler symbol — deploy-9 item-3)",
+			ap, "JURISDICTIONS")
+	}
+
+	// (5) email Operation → EMAIL_TEMPLATES (distinct — no bleed across handlers).
+	if ap, ok := opAuthPerms("email"); !ok {
+		t.Fatalf("missing SCOPE.Operation JurisdictionViewSet.email in views.py")
+	} else if ap != "EMAIL_TEMPLATES" {
+		t.Errorf("Operation email auth_permissions=%q; want %q (distinct from inspection_types — no bleed)",
+			ap, "EMAIL_TEMPLATES")
+	}
+
+	// (6) no-page-key action Operation → empty (honest-partial preserved).
+	if ap, ok := opAuthPerms("at_least_one_jurisdiction_has_maintenance_evaluation"); !ok {
+		t.Fatalf("missing SCOPE.Operation JurisdictionViewSet.at_least_one_jurisdiction_has_maintenance_evaluation in views.py")
+	} else if ap != "" {
+		t.Errorf("Operation at_least_one_jurisdiction_has_maintenance_evaluation auth_permissions=%q; want empty",
+			ap)
+	}
+}
+
+// filepathSuffix returns the final path component of p (the basename), using
+// both separators so the test is OS-agnostic without importing path/filepath
+// for a single basename.
+func filepathSuffix(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' || p[i] == '\\' {
+			return p[i+1:]
+		}
+	}
+	return p
+}

--- a/cmd/archigraph/testdata/drf_get_permissions_pagekey_fixture/myapp/urls.py
+++ b/cmd/archigraph/testdata/drf_get_permissions_pagekey_fixture/myapp/urls.py
@@ -1,0 +1,10 @@
+from rest_framework import routers
+
+from . import views
+
+
+router = routers.DefaultRouter()
+router.register(r"jurisdictions", views.JurisdictionViewSet, basename="jurisdiction")
+
+
+urlpatterns = router.urls

--- a/cmd/archigraph/testdata/drf_get_permissions_pagekey_fixture/myapp/views.py
+++ b/cmd/archigraph/testdata/drf_get_permissions_pagekey_fixture/myapp/views.py
@@ -1,0 +1,53 @@
+# Real-shape DRF ViewSet mirroring upvate_core core/views/jurisdiction_viewset.py.
+# get_permissions() branches on self.action and returns CustomPagePermissionCheck
+# guards keyed by PERMISSION_PAGES["<KEY>"] PER ACTION. The resolved page key must
+# reach the @action's synthesized endpoint as `auth_permissions` through the FULL
+# index pipeline (not merely the engine-level ApplyDjangoDRFRoutes pass).
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+# Stand-ins for upvate_core.settings.PERMISSION_PAGES and the custom guards.
+PERMISSION_PAGES = {
+    "JURISDICTIONS": "jurisdictions",
+    "EMAIL_TEMPLATES": "email_templates",
+}
+DEFAULT_VIEWSET_ACTIONS = ["list", "retrieve", "create", "update", "partial_update", "destroy"]
+
+
+class CustomPagePermissionCheck:
+    def __init__(self, page):
+        self.page = page
+
+
+class CustomActionPermissionCheck:
+    pass
+
+
+class JurisdictionViewSet(viewsets.ModelViewSet):
+    serializer_class = None
+    http_method_names = ["get", "post", "put", "patch", "delete"]
+
+    @action(methods=["get"], detail=False, url_path="inspection_types")
+    def get_inspection_types(self, request, *arg, **kwargs):
+        return Response({})
+
+    @action(methods=["patch", "put"], detail=True)
+    def email(self, request, pk, *args, **kwargs):
+        return Response({})
+
+    @action(methods=["get"], detail=False)
+    def at_least_one_jurisdiction_has_maintenance_evaluation(self, request, *args, **kwargs):
+        return Response({})
+
+    def get_permissions(self):
+        if self.action in DEFAULT_VIEWSET_ACTIONS:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])]
+        elif self.action in ["get_jurisdiction_setting", "get_inspection_types"]:
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["JURISDICTIONS"])]
+        elif self.action == "email":
+            permission_classes = [IsAuthenticated, CustomPagePermissionCheck(PERMISSION_PAGES["EMAIL_TEMPLATES"])]
+        else:
+            permission_classes = [IsAuthenticated, CustomActionPermissionCheck]
+        return [permission() for permission in permission_classes]

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -484,6 +484,24 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 				"framework":    propOr(r, "framework", ""),
 			},
 		})
+		// deploy-9 item-3 — propagate the synthetic endpoint's resolved
+		// fine-grained authorisation identity onto the handler Operation so a
+		// symbol-keyed query (archigraph_inspect / get_source on the @action
+		// method, e.g. `JurisdictionViewSet.get_inspection_types`) surfaces the
+		// SAME `auth_permissions` page-key the endpoint carries. The DRF
+		// get_permissions per-action page-key pass (#3978) stamps
+		// `auth_permissions` (e.g. JURISDICTIONS) on the synthesized
+		// http_endpoint, but auth_coverage / endpoint_posture consumers that
+		// start from the handler method saw nothing because the property never
+		// reached the handler entity. We copy it here — at the one resolution
+		// site that knows BOTH the endpoint (page-key source) and its handler —
+		// rather than re-deriving it. Honest-partial: when the endpoint carries
+		// no `auth_permissions` (dynamic / unresolvable page key, or a guard
+		// with no PERMISSION_PAGES subscript) nothing is stamped. First write
+		// wins so a handler shared by several verb-routes (the email PATCH/PUT
+		// pair) is not churned, and an explicit value already on the handler is
+		// never overwritten.
+		propagateHandlerAuthPermissions(handler, r)
 		// #2678 — rebind the synthetic's source_file / start_line / end_line
 		// to the resolved handler so the endpoint points at the method body,
 		// not the routing/registration site. Mirrors the DRF fix (#2677): for
@@ -836,6 +854,45 @@ func itoaSmall(n int) string {
 		n /= 10
 	}
 	return string(b[p:])
+}
+
+// propagateHandlerAuthPermissions copies the resolved fine-grained
+// authorisation identity from a synthesized http_endpoint onto its handler
+// entity (deploy-9 item-3). The DRF get_permissions per-action page-key pass
+// (#3978) stamps `auth_permissions` (e.g. the PERMISSION_PAGES["JURISDICTIONS"]
+// constant key) on the endpoint, but symbol-keyed consumers — archigraph_inspect
+// / get_source on the @action method, archigraph_auth_coverage starting from the
+// handler — read the property off the handler Operation, which never carried it.
+// We copy it (plus `auth_required`, which a page-key guard always implies) at the
+// resolution site that already pairs an endpoint with its handler.
+//
+// First-write-wins: an existing value on the handler is preserved (an explicit
+// handler annotation, or the first of several verb-routes that share one handler
+// — the email PATCH/PUT pair). Honest-partial: an endpoint with no resolved
+// `auth_permissions` (dynamic / unresolvable page key) propagates nothing, so the
+// handler is not falsely marked as carrying a fine-grained grant.
+func propagateHandlerAuthPermissions(handler, endpoint *types.EntityRecord) {
+	if handler == nil || endpoint == nil {
+		return
+	}
+	perms := propOr(endpoint, "auth_permissions", "")
+	if perms == "" {
+		return
+	}
+	if handler.Properties == nil {
+		handler.Properties = map[string]string{}
+	}
+	if _, exists := handler.Properties["auth_permissions"]; !exists {
+		handler.Properties["auth_permissions"] = perms
+	}
+	// A fine-grained page-key guard always requires authentication; mirror the
+	// endpoint's auth_required so handler-keyed posture queries agree with the
+	// endpoint. Only set when absent (do not downgrade an existing value).
+	if _, exists := handler.Properties["auth_required"]; !exists {
+		if ar := propOr(endpoint, "auth_required", ""); ar != "" {
+			handler.Properties["auth_required"] = ar
+		}
+	}
 }
 
 // propOr returns r.Properties[k] or fallback if missing/nil.


### PR DESCRIPTION
## Problem (deploy-9 item-3)

The DRF `get_permissions()` per-action page-key resolution (#3978) works — `get_source(JurisdictionViewSet.get_permissions)` correctly resolves `get_inspection_types → PERMISSION_PAGES["JURISDICTIONS"]` and `email → EMAIL_TEMPLATES` — and the resolved key IS stamped as `auth_permissions` on the synthesized `http_endpoint`. **But it never reached the handler `SCOPE.Operation`** that `archigraph_inspect` / `get_source` resolve by symbol. So `inspect(get_inspection_types, fields=[auth_permissions])` came back empty, and `auth_coverage` queries that start from the handler method saw nothing.

### Where the page key was captured-but-not-stamped

- `django_drf_get_permissions.go` (#3978) resolves the per-action page key and `stampDRFEndpointPosture` writes `auth_permissions` onto the **endpoint** entity. ✅
- The handler **Operation** entity (`JurisdictionViewSet.get_inspection_types`) — the one symbol-keyed tools resolve — was never given the property. ❌

Root cause: case (a) — captured & attached to the endpoint, but not propagated to the per-action handler entity.

## Fix

In `ResolveHTTPEndpointHandlers` — the single pass that pairs a synthesized endpoint with its resolved handler and emits the `IMPLEMENTS` (handler → endpoint) edge — propagate the endpoint's resolved `auth_permissions` (and `auth_required`) onto the handler Operation via a new `propagateHandlerAuthPermissions` helper. Reuses the #3978 resolution; no re-derivation.

- **First-write-wins**: a handler shared by several verb-routes (the `email` PATCH/PUT pair) is not churned; an existing explicit handler value is never overwritten.
- **Honest-partial**: an endpoint with no resolved page key (dynamic / unresolvable, or a guard with no `PERMISSION_PAGES` subscript) propagates nothing — the handler is not falsely marked.

## Test (full pipeline — fail-before / pass-after)

`testdata/drf_get_permissions_pagekey_fixture` is a router-registered `JurisdictionViewSet` mirroring `core/views/jurisdiction_viewset.py` (assign-then-return-comprehension `get_permissions`, `@action` methods `get_inspection_types` / `email` / `at_least_one_..._evaluation`). `TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions` runs `cmd/archigraph` `Indexer.Run` and asserts:

| # | entity | assertion |
|---|--------|-----------|
| 1-3 | endpoints | `auth_permissions` JURISDICTIONS / EMAIL_TEMPLATES / none — **#3978 regression guard** |
| 4 | Operation `get_inspection_types` | `auth_permissions=JURISDICTIONS` — **the fix** |
| 5 | Operation `email` | `auth_permissions=EMAIL_TEMPLATES` — **distinct, no bleed across handlers** |
| 6 | Operation `at_least_one_..._evaluation` | empty — honest-partial preserved |

Confirmed **FAIL before** (4 & 5 empty), **PASS after**. No-bleed proven by 5 carrying a distinct key from 4.

## Validation
- `go test ./internal/engine/ ./internal/mcp/ ./tools/coverage/` — all pass
- `go test ./cmd/archigraph/` — passes (the pre-existing `~/.archigraph` store-leak-detector flake reproduced once non-deterministically; 3 subsequent reruns all `ok`; base-identical to origin/main, unrelated to this Python/DRF-only change)
- `go vet ./internal/engine/ ./cmd/archigraph/` — clean

Does not regress `get_source` or auth presence detection.

**DEPLOY-DEFERRED** — do not disturb the live deploy-9 daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)