### PR TITLE
feat(kotlin): port endpoint_deprecation_versioning to Kotlin (Ktor + Spring) (#4136)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -46095,8 +46095,11 @@
       "capabilities": {
         "Routing": {
           "endpoint_deprecation_versioning": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/endpoint_deprecation.go","internal/custom/kotlin/endpoint_deprecation_test.go"],
+            "issue": "4136",
+            "notes": "#4136 (epic #3628): greenfield Kotlin port. Ktor producer endpoints are SCOPE.Operation custom-extractor entities (ktor_routes.go), so the flagship engine pass (http_endpoint_deprecation.go) cannot reach them; this custom extractor stamps the IDENTICAL flat contract at the source. A Ktor verb handler get/post/...(\"/path\"){} carrying @Deprecated(\"use /api/v2/x\", ReplaceWith(\"/v2/x\")) or a KDoc @deprecated tag in the region above the call -\u003e deprecated=true + deprecated_replacement (+ deprecated_since from 'since X') + deprecation_source=@Deprecated|KDoc @deprecated; a call.response.header(\"Sunset\"/\"Deprecation\", ...) in the handler lambda -\u003e deprecation_source=\u003cHeader\u003e response header. api_version is path-derived from an explicit /api/v{N} or /v{N} segment, composing enclosing route(\"/prefix\") prefixes. Value-asserted in endpoint_deprecation_test.go. Honest-partial: a versionless non-deprecated route is not stamped (left to ktor_routes.go); /apiv2something is not a version segment; a config-/variable-driven marker is not resolved.",
+            "verified_at": "2026-06-03"
           },
           "endpoint_pagination_posture": {
             "status": "missing",
@@ -47338,8 +47341,11 @@
       "capabilities": {
         "Routing": {
           "endpoint_deprecation_versioning": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/kotlin/endpoint_deprecation.go","internal/custom/kotlin/endpoint_deprecation_test.go"],
+            "issue": "4136",
+            "notes": "#4136 (epic #3628): greenfield Kotlin port. Spring-Boot-Kotlin producer endpoints are SCOPE.Operation custom-extractor entities (routing.go), so the flagship engine pass cannot reach them; this custom extractor stamps the IDENTICAL flat contract at the source. A @\u003cVerb\u003eMapping handler in a @RestController/@Controller carrying @Deprecated(\"use /api/v2/x\", ReplaceWith(...)) or a KDoc @deprecated above the mapping -\u003e deprecated=true + deprecated_replacement (+ deprecated_since) + deprecation_source=@Deprecated|KDoc @deprecated; a response.setHeader(\"Sunset\"/\"Deprecation\", ...) in the fun body -\u003e deprecation_source=\u003cHeader\u003e response header. api_version is path-derived from the composed class @RequestMapping + method path (/api/v{N} or /v{N} segment). Endpoint Name matches routing.go so the stamp merges onto the plain route op. Value-asserted in endpoint_deprecation_test.go (Spring annotated/Deprecation-header + versionless-negative). Honest-partial: a versionless non-deprecated handler is not stamped; a config-/variable-driven marker is not resolved.",
+            "verified_at": "2026-06-03"
           },
           "endpoint_pagination_posture": {
             "status": "full",

--- a/internal/custom/kotlin/endpoint_deprecation.go
+++ b/internal/custom/kotlin/endpoint_deprecation.go
@@ -1,0 +1,527 @@
+// endpoint_deprecation.go — endpoint deprecation + API-version stamping for
+// Kotlin web frameworks (#4136, child of epic #3628 cross-language fan-out).
+//
+// Greenfield: Kotlin carried NO endpoint_deprecation_versioning coverage.
+// Kotlin sibling of the engine flagship pass
+// (internal/engine/http_endpoint_deprecation.go) and the PHP custom-extractor
+// port (internal/custom/php/helpers.go). The flagship engine pass stamps a flat
+// property contract on synthesised http_endpoint_definition endpoints; Kotlin
+// producer endpoints are SCOPE.Operation entities emitted by the custom .kt
+// route extractors (ktor_routes.go / routing.go) instead, so the engine pass
+// cannot reach them. To keep the Kotlin deprecation surface complete and
+// consistent, this extractor stamps the IDENTICAL property contract at the
+// source from the Kotlin framework idioms.
+//
+// Property contract (mirrors the flagship http_endpoint_deprecation.go EXACTLY):
+//
+//	deprecated             — "true" (present only when a marker was found)
+//	deprecated_since       — version/date from the marker, when available
+//	deprecated_replacement — the suggested replacement, when the marker names one
+//	deprecation_source     — the signal that fired (evidence for the dashboard)
+//	api_version            — "1" | "2" | … numeric version from the route path
+//
+// Two recognised Kotlin surfaces (same as rate_limit_endpoint.go, so the
+// stamped endpoint op merges onto the plain route op by Name):
+//
+//	Ktor DSL — a verb handler get/post/...("/path") { … } inside a routing{} /
+//	           route("/prefix"){} block. Deprecation is read from the
+//	           @Deprecated("use /api/v2/...", ReplaceWith(...)) annotation or a
+//	           KDoc `* @deprecated …` tag in the doc/annotation region
+//	           immediately ABOVE the verb call, OR from a
+//	           call.response.header("Sunset"/"Deprecation", …) write in the
+//	           handler lambda body. Enclosing route("/prefix") prefixes compose
+//	           into the canonical path (same naming as ktor_routes.go).
+//
+//	Spring-Boot-Kotlin — a @<Verb>Mapping handler inside a @RestController /
+//	           @Controller. Deprecation is read from the @Deprecated annotation /
+//	           KDoc @deprecated above the @<Verb>Mapping, OR a
+//	           response.setHeader("Sunset"/"Deprecation", …) in the fun body.
+//	           Class-level @RequestMapping prefix composes (same naming as
+//	           routing.go's Spring extractor).
+//
+// api_version is path-derived for BOTH surfaces: an explicit /api/v{N} or /v{N}
+// segment in the composed canonical path pins api_version (mirrors the flagship
+// apiVersionFromPath). Honest-partial: a versionless route carries no
+// api_version; a route with no deprecation marker carries no `deprecated` (never
+// fabricated — `deprecated=false` is never written).
+//
+// Like the sibling rate-limit pass this adds NO new node kind beyond the
+// endpoint op it re-emits with the contract attached; MergeWithCustom /
+// downstream dedup folds it onto the plain route op sharing the same Name.
+//
+// Refs #4136, #3628.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_endpoint_deprecation", &kotlinEndpointDeprecationExtractor{})
+}
+
+type kotlinEndpointDeprecationExtractor struct{}
+
+func (e *kotlinEndpointDeprecationExtractor) Language() string {
+	return "custom_kotlin_endpoint_deprecation"
+}
+
+// --- shared message parsing (mirrors flagship depSinceRe / depReplacementRe) --
+
+// ktDepSinceRe extracts a "since X" / "as of X" version/date from a free-text
+// deprecation message (mirrors the flagship depSinceRe).
+var ktDepSinceRe = regexp.MustCompile(`(?i)\b(?:since|as of)\s+([vV]?\d[\w.\-]*)`)
+
+// ktDepReplacementRe extracts a "use X instead" / "replaced by X" hint (mirrors
+// the flagship depReplacementRe).
+var ktDepReplacementRe = regexp.MustCompile("(?i)\\b(?:use|replaced by|prefer|see)\\s+`?([A-Za-z0-9_./{}\\-]+)`?")
+
+// ktParseDeprecationMessage pulls an optional since-version and replacement hint
+// out of a free-text deprecation message. Both are honest-partial: an absent
+// signal yields an empty string (never fabricated). Mirrors the flagship parser.
+func ktParseDeprecationMessage(msg string) (since, replacement string) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return "", ""
+	}
+	if m := ktDepSinceRe.FindStringSubmatch(msg); m != nil {
+		since = m[1]
+	}
+	if m := ktDepReplacementRe.FindStringSubmatch(msg); m != nil {
+		replacement = strings.TrimSuffix(m[1], ".")
+	}
+	return since, replacement
+}
+
+// --- api_version (path-derived, mirrors flagship apiVersionFromPath) ---------
+
+const (
+	ktAPIVersionMin = 1
+	ktAPIVersionMax = 99
+)
+
+// ktAPIVersionPatterns recognise an explicit API version SEGMENT in a canonical
+// route path. First-match-wins. The trailing `(?:/|$)` anchor keeps
+// `/apiv2something` (no segment boundary) from matching — a version is only a
+// version when it is its own path segment. Mirrors endpointAPIVersionPatterns.
+var ktAPIVersionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)/api/v(\d+)(?:/|$)`),
+	regexp.MustCompile(`(?i)/v(\d+)(?:/|$)`),
+}
+
+// ktAPIVersionFromPath returns the numeric API version named by an explicit
+// version segment in path, and whether one was found in range.
+func ktAPIVersionFromPath(path string) (int, bool) {
+	for _, re := range ktAPIVersionPatterns {
+		m := re.FindStringSubmatch(path)
+		if m == nil {
+			continue
+		}
+		v, err := strconv.Atoi(m[1])
+		if err != nil {
+			return 0, false
+		}
+		if v < ktAPIVersionMin || v > ktAPIVersionMax {
+			return 0, false
+		}
+		return v, true
+	}
+	return 0, false
+}
+
+// --- deprecation marker recognition -----------------------------------------
+
+// ktDeprecatedAnnotationRe matches a Kotlin @Deprecated annotation with its
+// optional message + ReplaceWith argument list. Group 1 = the argument body
+// (the "message", ReplaceWith("..."), level=…). Kotlin's stdlib @Deprecated has
+// the shape @Deprecated("msg", ReplaceWith("expr"), level=…).
+var ktDeprecatedAnnotationRe = regexp.MustCompile(`@Deprecated\b(?:\s*\(([^)]{0,400})\))?`)
+
+// ktDeprecatedMsgRe / ktReplaceWithRe pull the human message and the
+// ReplaceWith expression out of a @Deprecated argument body.
+var (
+	ktDeprecatedMsgRe = regexp.MustCompile(`^\s*"([^"]{0,300})"`)
+	ktReplaceWithRe   = regexp.MustCompile(`ReplaceWith\s*\(\s*"([^"]{0,300})"`)
+)
+
+// ktKDocDeprecatedRe matches a KDoc `@deprecated <message>` tag (lowercase), the
+// Kotlin doc-comment deprecation convention, with its trailing message.
+var ktKDocDeprecatedRe = regexp.MustCompile(`@deprecated\b([^\n*]{0,300})`)
+
+// ktDeprecationHeaderRe matches a handler setting a Sunset / Deprecation HTTP
+// response header (RFC 8594). Covers the Kotlin shapes:
+// `call.response.header("Sunset", …)` (Ktor) and
+// `response.setHeader("Deprecation", …)` / `headers.add("Sunset", …)` (Spring),
+// plus a bracket/quote form. Mirrors the flagship deprecationHeaderRe shape.
+var ktDeprecationHeaderRe = regexp.MustCompile(`(?i)["'\(\[]\s*(sunset|deprecation)\s*["'\)\]]`)
+
+// ktDepVerdict is the resolved deprecation state for one endpoint (mirrors the
+// flagship deprecationVerdict).
+type ktDepVerdict struct {
+	deprecated  bool
+	since       string
+	replacement string
+	source      string
+}
+
+// ktResolveAnnotationDeprecation inspects a doc/annotation region (the lines
+// immediately above a handler) for a @Deprecated annotation or a KDoc
+// @deprecated tag and returns the resolved verdict. Honest-partial: no marker →
+// (zero, false).
+func ktResolveAnnotationDeprecation(region string) (ktDepVerdict, bool) {
+	if m := ktDeprecatedAnnotationRe.FindStringSubmatch(region); m != nil {
+		v := ktDepVerdict{deprecated: true, source: "@Deprecated"}
+		args := m[1]
+		if args != "" {
+			// Human message (first positional string literal).
+			if msgM := ktDeprecatedMsgRe.FindStringSubmatch(args); msgM != nil {
+				s, r := ktParseDeprecationMessage(msgM[1])
+				v.since = s
+				v.replacement = r
+			}
+			// ReplaceWith("expr") is the canonical Kotlin replacement hint and
+			// wins over a free-text "use X" parse when present.
+			if rwM := ktReplaceWithRe.FindStringSubmatch(args); rwM != nil {
+				v.replacement = strings.TrimSpace(rwM[1])
+			}
+		}
+		// A KDoc @deprecated tag in the same region can carry a since/replacement
+		// the annotation omitted (honest-partial fill, never overwrite).
+		if jm := ktKDocDeprecatedRe.FindStringSubmatch(region); jm != nil {
+			s, r := ktParseDeprecationMessage(strings.TrimSpace(strings.Trim(jm[1], " \t*/")))
+			if v.since == "" {
+				v.since = s
+			}
+			if v.replacement == "" {
+				v.replacement = r
+			}
+		}
+		return v, true
+	}
+	if jm := ktKDocDeprecatedRe.FindStringSubmatch(region); jm != nil {
+		v := ktDepVerdict{deprecated: true, source: "KDoc @deprecated"}
+		v.since, v.replacement = ktParseDeprecationMessage(strings.TrimSpace(strings.Trim(jm[1], " \t*/")))
+		return v, true
+	}
+	return ktDepVerdict{}, false
+}
+
+// ktResolveHeaderDeprecation inspects a handler body window for a Sunset /
+// Deprecation response-header write. Honest-partial: no header → (zero, false).
+func ktResolveHeaderDeprecation(body string) (ktDepVerdict, bool) {
+	if m := ktDeprecationHeaderRe.FindStringSubmatch(body); m != nil {
+		return ktDepVerdict{
+			deprecated: true,
+			source:     ktTitleHeader(m[1]) + " response header",
+		}, true
+	}
+	return ktDepVerdict{}, false
+}
+
+// ktTitleHeader upper-cases the first rune of a lower-cased header name
+// ("sunset" → "Sunset"). Mirrors the flagship titleHeaderName.
+func ktTitleHeader(s string) string {
+	s = strings.ToLower(s)
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// ktStampDeprecation writes the flat deprecation contract onto an endpoint
+// entity from a resolved verdict. since/replacement are honest-partial (omitted
+// when empty). No-op when the verdict is not deprecated.
+func ktStampDeprecation(e *types.EntityRecord, v ktDepVerdict) {
+	if !v.deprecated {
+		return
+	}
+	setProps(e, "deprecated", "true")
+	if v.source != "" {
+		setProps(e, "deprecation_source", v.source)
+	}
+	if v.since != "" {
+		setProps(e, "deprecated_since", v.since)
+	}
+	if v.replacement != "" {
+		setProps(e, "deprecated_replacement", v.replacement)
+	}
+}
+
+// ktStampAPIVersion writes api_version onto an endpoint entity from its path,
+// when an explicit version segment is present. Honest-partial: no segment →
+// no-op.
+func ktStampAPIVersion(e *types.EntityRecord, path string) {
+	if v, ok := ktAPIVersionFromPath(path); ok {
+		setProps(e, "api_version", strconv.Itoa(v))
+	}
+}
+
+// --- extractor entry point ---------------------------------------------------
+
+func (e *kotlinEndpointDeprecationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_endpoint_deprecation.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: a deprecation/version surface must mention a marker OR a
+	// versioned path. We only stamp a marker-bearing endpoint, but api_version
+	// can apply even without a deprecation marker, so allow a /v{N} path through.
+	hasMarker := strings.Contains(src, "@Deprecated") ||
+		strings.Contains(src, "@deprecated") ||
+		strings.Contains(src, "Sunset") ||
+		strings.Contains(src, "Deprecation")
+	hasVersion := strings.Contains(src, "/v") || strings.Contains(src, "/api/v")
+	if !hasMarker && !hasVersion {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, ent := range e.extractKtor(src, file) {
+		add(ent)
+	}
+	for _, ent := range e.extractSpring(src, file) {
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ktDepVerbRe matches a Ktor verb handler get/post/...("/path"); group 1 = verb,
+// group 2 = leaf path. Same verb set as ktor_routes.go.
+var ktDepVerbRe = regexp.MustCompile(
+	`\b(get|post|put|delete|patch|head|options)\s*\(\s*"([^"]*)"`)
+
+// ktDepRouteRe matches an enclosing route("/prefix") { opener; group 1 = prefix.
+var ktDepRouteRe = regexp.MustCompile(`\broute\s*\(\s*"([^"]*)"\s*\)\s*\{`)
+
+// extractKtor walks every Ktor verb handler, composing enclosing route("/prefix")
+// prefixes, and stamps deprecation (from the @Deprecated/KDoc region above the
+// verb call or a Sunset/Deprecation header in the handler lambda body) and
+// api_version (path-derived). Only marker-bearing OR version-bearing handlers
+// are emitted; a plain handler is skipped so it does not shadow the route op.
+func (e *kotlinEndpointDeprecationExtractor) extractKtor(src string, file extractor.FileInput) []types.EntityRecord {
+	// Gate on a Ktor routing signal so we no-op on Spring-only files.
+	if !strings.Contains(src, "routing") && !ktDepRouteRe.MatchString(src) {
+		return nil
+	}
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for _, v := range ktDepVerbRe.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToUpper(src[v[2]:v[3]])
+		leaf := src[v[4]:v[5]]
+		prefix := ktDepEnclosingRoutePrefix(src, v[0])
+		fullPath := joinKtRoutePaths(prefix, leaf)
+		name := verb + " " + fullPath
+		if seen[name] {
+			continue
+		}
+
+		// Deprecation: annotation/KDoc region above the verb call, then a
+		// Sunset/Deprecation header in the handler lambda body.
+		region := ktDocAnnotationRegion(src, v[0])
+		verdict, dep := ktResolveAnnotationDeprecation(region)
+		if !dep {
+			body := ktHandlerBodyWindow(src, v[1])
+			verdict, dep = ktResolveHeaderDeprecation(body)
+		}
+		_, ver := ktAPIVersionFromPath(fullPath)
+		if !dep && !ver {
+			// Nothing to stamp — leave the plain route op to ktor_routes.go.
+			continue
+		}
+		seen[name] = true
+
+		ln := lineOf(src, v[0])
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, "kotlin", ln)
+		setProps(&ent,
+			"framework", "ktor",
+			"http_method", verb,
+			"path", fullPath,
+			"provenance", "INFERRED_FROM_KTOR_DEPRECATION",
+		)
+		ktStampDeprecation(&ent, verdict)
+		ktStampAPIVersion(&ent, fullPath)
+		out = append(out, ent)
+	}
+	return out
+}
+
+// ktDepEnclosingRoutePrefix returns the composed route("/prefix") prefix path
+// that brace-encloses the verb call at byte offset verbOff. Walks every
+// route("/p"){ opener whose brace-balanced block contains verbOff, joining the
+// prefixes outermost-first. Returns "" when no enclosing route. Reuses the
+// shared brace matcher (ktRLMatchBrace) from rate_limit_endpoint.go.
+func ktDepEnclosingRoutePrefix(src string, verbOff int) string {
+	var prefix string
+	for _, rm := range ktDepRouteRe.FindAllStringSubmatchIndex(src, -1) {
+		bodyStart := rm[1] // past the opening brace
+		bodyEnd, ok := ktRLMatchBrace(src, bodyStart)
+		if !ok {
+			continue
+		}
+		if rm[0] < verbOff && verbOff < bodyEnd {
+			prefix = joinKtRoutePaths(prefix, src[rm[2]:rm[3]])
+		}
+	}
+	return prefix
+}
+
+// --- Spring-Kotlin surface ---------------------------------------------------
+
+var (
+	// ktDepSpringController gates the Spring surface on a controller annotation.
+	ktDepSpringController = regexp.MustCompile(`@(?:Rest)?Controller\b`)
+
+	// ktDepSpringClassMapping matches a class-level @RequestMapping prefix
+	// (positional / value= / path=). Mirrors reKtSpringClassMapping.
+	ktDepSpringClassMapping = regexp.MustCompile(
+		`@RequestMapping\s*(?:\(\s*(?:value\s*=\s*|path\s*=\s*)?"([^"]*)"\s*\))?`)
+
+	// ktDepSpringVerb matches a method-level verb mapping with optional path.
+	// Mirrors reKtSpringVerbMapping.
+	ktDepSpringVerb = regexp.MustCompile(
+		`@(Get|Post|Put|Delete|Patch|Head|Options)Mapping\s*(?:\(\s*(?:value\s*=\s*|path\s*=\s*)?"([^"]*)"\s*\))?`)
+)
+
+var ktDepSpringVerbMap = map[string]string{
+	"Get": "GET", "Post": "POST", "Put": "PUT", "Delete": "DELETE",
+	"Patch": "PATCH", "Head": "HEAD", "Options": "OPTIONS",
+}
+
+// extractSpring stamps deprecation + api_version on the endpoint op of a
+// @<Verb>Mapping handler inside a @RestController/@Controller. Endpoint Name
+// matches routing.go's Spring extractor so they merge. Only marker-bearing OR
+// version-bearing handlers are emitted.
+func (e *kotlinEndpointDeprecationExtractor) extractSpring(src string, file extractor.FileInput) []types.EntityRecord {
+	if !ktDepSpringController.MatchString(src) {
+		return nil
+	}
+	classPrefix := ""
+	if m := ktDepSpringClassMapping.FindStringSubmatchIndex(src); m != nil && m[2] >= 0 {
+		classPrefix = src[m[2]:m[3]]
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for _, m := range ktDepSpringVerb.FindAllStringSubmatchIndex(src, -1) {
+		verb := ktDepSpringVerbMap[src[m[2]:m[3]]]
+		methodPath := ""
+		if m[4] >= 0 {
+			methodPath = src[m[4]:m[5]]
+		}
+		fullPath := joinKtRoutePaths(classPrefix, methodPath)
+		if fullPath == "" {
+			fullPath = "/"
+		}
+		name := verb + " " + fullPath
+		if seen[name] {
+			continue
+		}
+
+		// Deprecation: @Deprecated/KDoc region above the @<Verb>Mapping, then a
+		// Sunset/Deprecation header in the fun body that follows the mapping.
+		region := ktDocAnnotationRegion(src, m[0])
+		verdict, dep := ktResolveAnnotationDeprecation(region)
+		if !dep {
+			body := ktHandlerBodyWindow(src, m[1])
+			verdict, dep = ktResolveHeaderDeprecation(body)
+		}
+		_, ver := ktAPIVersionFromPath(fullPath)
+		if !dep && !ver {
+			continue
+		}
+		seen[name] = true
+
+		ln := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, "kotlin", ln)
+		setProps(&ent,
+			"framework", "spring-boot",
+			"http_method", verb,
+			"path", fullPath,
+			"provenance", "INFERRED_FROM_SPRING_DEPRECATION",
+		)
+		ktStampDeprecation(&ent, verdict)
+		ktStampAPIVersion(&ent, fullPath)
+		out = append(out, ent)
+	}
+	return out
+}
+
+// --- shared region helpers ---------------------------------------------------
+
+// ktDocAnnotationRegion returns the contiguous run of annotation (`@`), KDoc
+// (`/**`, `*`, `*/`) and line-comment (`//`) lines immediately ABOVE the handler
+// at byte offset handlerOff, where a @Deprecated annotation / KDoc @deprecated
+// tag lives. Mirrors the flagship handlerDecoratorRegion (annotation/comment
+// walk-up), scoped to the lines preceding handlerOff.
+func ktDocAnnotationRegion(src string, handlerOff int) string {
+	if handlerOff <= 0 || handlerOff > len(src) {
+		return ""
+	}
+	lines := strings.Split(src[:handlerOff], "\n")
+	// The last element is the (partial) handler line; walk upward over the
+	// preceding annotation/comment lines.
+	end := len(lines) - 1
+	top := end
+	for top > 0 {
+		prev := strings.TrimSpace(lines[top-1])
+		if prev == "" ||
+			strings.HasPrefix(prev, "@") ||
+			strings.HasPrefix(prev, "//") ||
+			strings.HasPrefix(prev, "*") ||
+			strings.HasPrefix(prev, "/*") {
+			top--
+			continue
+		}
+		break
+	}
+	// Include the handler line itself so an inline annotation on the same line is
+	// in scope.
+	return strings.Join(lines[top:], "\n")
+}
+
+// ktHandlerBodyWindow returns a bounded window of the handler body starting just
+// after the verb/mapping match. Kept small (1000 bytes) to avoid attributing a
+// sibling handler's header write to this endpoint. Mirrors the flagship
+// handlerBodyWindow size.
+func ktHandlerBodyWindow(src string, bodyStart int) string {
+	if bodyStart < 0 || bodyStart >= len(src) {
+		return ""
+	}
+	end := bodyStart + 1000
+	if end > len(src) {
+		end = len(src)
+	}
+	return src[bodyStart:end]
+}

--- a/internal/custom/kotlin/endpoint_deprecation_test.go
+++ b/internal/custom/kotlin/endpoint_deprecation_test.go
@@ -1,0 +1,387 @@
+package kotlin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Kotlin endpoint_deprecation_versioning port (#4136, epic #3628).
+//
+// Mirrors the flagship property contract EXACTLY: deprecated / deprecated_since
+// / deprecated_replacement / deprecation_source / api_version.
+// ---------------------------------------------------------------------------
+
+func runKtDeprecation(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&kotlinEndpointDeprecationExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: path, Language: "kotlin", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("endpoint_deprecation extract: %v", err)
+	}
+	return ents
+}
+
+func ktDepByName(ents []types.EntityRecord) map[string]types.EntityRecord {
+	out := map[string]types.EntityRecord{}
+	for _, e := range ents {
+		out[e.Name] = e
+	}
+	return out
+}
+
+func ktDepMust(t *testing.T, byName map[string]types.EntityRecord, name string) types.EntityRecord {
+	t.Helper()
+	e, ok := byName[name]
+	if !ok {
+		keys := make([]string, 0, len(byName))
+		for k := range byName {
+			keys = append(keys, k)
+		}
+		t.Fatalf("endpoint %q not stamped (got: %v)", name, keys)
+	}
+	return e
+}
+
+// --- Ktor surface -----------------------------------------------------------
+
+// The flagship value-asserting probe, Ktor form: a verb handler with
+// @Deprecated("use /api/v2/users") in route /api/v1/users →
+// deprecated=true + deprecated_replacement + api_version=1 + deprecation_source.
+func TestKtDeprecation_KtorAnnotatedVersionedRoute(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        route("/api/v1") {
+            @Deprecated("use /api/v2/users")
+            get("/users") {
+                call.respondText("users")
+            }
+            get("/health") {
+                call.respondText("ok")
+            }
+        }
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "App.kt", src))
+
+	dep := ktDepMust(t, byName, "GET /api/v1/users")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "@Deprecated" {
+		t.Errorf("deprecation_source=%q, want @Deprecated", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/api/v2/users" {
+		t.Errorf("deprecated_replacement=%q, want /api/v2/users", got)
+	}
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1 (path-derived)", got)
+	}
+	if got := dep.Properties["http_method"]; got != "GET" {
+		t.Errorf("http_method=%q, want GET", got)
+	}
+
+	// Negative-ish: the non-deprecated sibling under /api/v1 still pins
+	// api_version (versioned path) but carries NO deprecated flag.
+	live := ktDepMust(t, byName, "GET /api/v1/health")
+	if _, ok := live.Properties["deprecated"]; ok {
+		t.Fatalf("GET /api/v1/health deprecation leaked, want absent (props: %v)", live.Properties)
+	}
+	if got := live.Properties["api_version"]; got != "1" {
+		t.Errorf("GET /api/v1/health api_version=%q, want 1", got)
+	}
+}
+
+// ReplaceWith(...) is the canonical Kotlin replacement hint and wins; a
+// `since 2.0` message pins deprecated_since.
+func TestKtDeprecation_KtorReplaceWithAndSince(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        route("/v2") {
+            @Deprecated("since 2.0", ReplaceWith("/v3/reports"))
+            get("/reports") {
+                call.respondText("reports")
+            }
+        }
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "App.kt", src))
+	dep := ktDepMust(t, byName, "GET /v2/reports")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true", dep.Properties["deprecated"])
+	}
+	if got := dep.Properties["deprecated_since"]; got != "2.0" {
+		t.Errorf("deprecated_since=%q, want 2.0", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/v3/reports" {
+		t.Errorf("deprecated_replacement=%q, want /v3/reports (ReplaceWith wins)", got)
+	}
+	if got := dep.Properties["api_version"]; got != "2" {
+		t.Errorf("api_version=%q, want 2", got)
+	}
+}
+
+// A Sunset response header written via call.response.header(...) in the Ktor
+// handler lambda body is the runtime deprecation signal.
+func TestKtDeprecation_KtorSunsetResponseHeader(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        get("/payments") {
+            call.response.header("Sunset", "Sat, 31 Dec 2025 23:59:59 GMT")
+            call.respondText("paid")
+        }
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "App.kt", src))
+	dep := ktDepMust(t, byName, "GET /payments")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "Sunset response header" {
+		t.Errorf("deprecation_source=%q, want 'Sunset response header'", got)
+	}
+}
+
+// A KDoc `* @deprecated use /api/v2/x` tag above a Ktor verb handler marks it
+// deprecated (the Kotlin doc-comment convention).
+func TestKtDeprecation_KtorKDocDeprecated(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        /**
+         * @deprecated use /api/v2/orders instead
+         */
+        get("/api/v1/orders") {
+            call.respondText("orders")
+        }
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "App.kt", src))
+	dep := ktDepMust(t, byName, "GET /api/v1/orders")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "KDoc @deprecated" {
+		t.Errorf("deprecation_source=%q, want 'KDoc @deprecated'", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/api/v2/orders" {
+		t.Errorf("deprecated_replacement=%q, want /api/v2/orders", got)
+	}
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1", got)
+	}
+}
+
+// --- Spring-Kotlin surface --------------------------------------------------
+
+// The flagship probe, Spring-Kotlin form: @Deprecated on a @GetMapping handler
+// in a @RestController with class @RequestMapping("/api/v1") →
+// deprecated + replacement + api_version=1 + source.
+func TestKtDeprecation_SpringAnnotatedVersionedRoute(t *testing.T) {
+	src := `@RestController
+@RequestMapping("/api/v1")
+class UserController {
+    @Deprecated("use /api/v2/users")
+    @GetMapping("/users")
+    fun users(): String = "users"
+
+    @GetMapping("/health")
+    fun health(): String = "ok"
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "UserController.kt", src))
+
+	dep := ktDepMust(t, byName, "GET /api/v1/users")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "@Deprecated" {
+		t.Errorf("deprecation_source=%q, want @Deprecated", got)
+	}
+	if got := dep.Properties["deprecated_replacement"]; got != "/api/v2/users" {
+		t.Errorf("deprecated_replacement=%q, want /api/v2/users", got)
+	}
+	if got := dep.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1", got)
+	}
+	if got := dep.Properties["framework"]; got != "spring-boot" {
+		t.Errorf("framework=%q, want spring-boot", got)
+	}
+
+	// Non-deprecated sibling: api_version pinned, no deprecation fabricated.
+	live := ktDepMust(t, byName, "GET /api/v1/health")
+	if _, ok := live.Properties["deprecated"]; ok {
+		t.Fatalf("GET /api/v1/health deprecation leaked (props: %v)", live.Properties)
+	}
+	if got := live.Properties["api_version"]; got != "1" {
+		t.Errorf("api_version=%q, want 1", got)
+	}
+}
+
+// A Deprecation response header via response.setHeader(...) in a Spring-Kotlin
+// fun body is the runtime signal.
+func TestKtDeprecation_SpringDeprecationResponseHeader(t *testing.T) {
+	src := `@RestController
+@RequestMapping("/api/v2")
+class ReportController {
+    @GetMapping("/reports")
+    fun reports(response: HttpServletResponse): String {
+        response.setHeader("Deprecation", "true")
+        return "reports"
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "ReportController.kt", src))
+	dep := ktDepMust(t, byName, "GET /api/v2/reports")
+	if dep.Properties["deprecated"] != "true" {
+		t.Fatalf("deprecated=%q, want true (props: %v)", dep.Properties["deprecated"], dep.Properties)
+	}
+	if got := dep.Properties["deprecation_source"]; got != "Deprecation response header" {
+		t.Errorf("deprecation_source=%q, want 'Deprecation response header'", got)
+	}
+	if got := dep.Properties["api_version"]; got != "2" {
+		t.Errorf("api_version=%q, want 2", got)
+	}
+}
+
+// --- Honest-partial negatives -----------------------------------------------
+
+// A versionless, non-deprecated Ktor route is NOT emitted at all (the plain
+// route op is left to ktor_routes.go) — neither api_version nor deprecated is
+// fabricated.
+func TestKtDeprecation_KtorVersionlessNonDeprecatedNotStamped(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        get("/status") {
+            call.respondText("ok")
+        }
+    }
+}
+`
+	ents := runKtDeprecation(t, "App.kt", src)
+	if len(ents) != 0 {
+		t.Fatalf("versionless non-deprecated route stamped %d entities, want 0: %v", len(ents), ents)
+	}
+}
+
+// A Spring-Kotlin versionless non-deprecated handler is likewise not stamped.
+func TestKtDeprecation_SpringVersionlessNonDeprecatedNotStamped(t *testing.T) {
+	src := `@RestController
+@RequestMapping("/status")
+class StatusController {
+    @GetMapping("/ping")
+    fun ping(): String = "pong"
+}
+`
+	ents := runKtDeprecation(t, "Status.kt", src)
+	if len(ents) != 0 {
+		t.Fatalf("versionless non-deprecated Spring handler stamped %d, want 0: %v", len(ents), ents)
+	}
+}
+
+// `/apiv2something` is NOT a version segment — no api_version (segment-anchor
+// negative, mirrors the flagship TestAPIVersion_NoFalseSegment).
+func TestKtDeprecation_NoFalseVersionSegment(t *testing.T) {
+	src := `fun Application.module() {
+    routing {
+        @Deprecated("gone")
+        get("/apiv2something/x") {
+            call.respondText("x")
+        }
+    }
+}
+`
+	byName := ktDepByName(runKtDeprecation(t, "App.kt", src))
+	dep := ktDepMust(t, byName, "GET /apiv2something/x")
+	if got, ok := dep.Properties["api_version"]; ok {
+		t.Fatalf("api_version=%q fabricated on non-segment path, want absent", got)
+	}
+	if dep.Properties["deprecated"] != "true" {
+		t.Errorf("deprecated=%q, want true (annotation still fires)", dep.Properties["deprecated"])
+	}
+}
+
+// A non-Kotlin file is a no-op.
+func TestKtDeprecation_NonKotlinNoOp(t *testing.T) {
+	src := `@Deprecated("x") @GetMapping("/api/v1/x")`
+	ents, err := (&kotlinEndpointDeprecationExtractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "x.java", Language: "java", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("non-kotlin file stamped %d entities, want 0", len(ents))
+	}
+}
+
+// --- unit: ktAPIVersionFromPath ---------------------------------------------
+
+func TestKtAPIVersionFromPath(t *testing.T) {
+	cases := []struct {
+		path   string
+		wantV  int
+		wantOK bool
+	}{
+		{"/api/v1/users", 1, true},
+		{"/api/v2", 2, true},
+		{"/v3/orders", 3, true},
+		{"/v10/x", 10, true},
+		{"/apiv2something/x", 0, false},
+		{"/users", 0, false},
+		{"/api/v0/x", 0, false},   // below min
+		{"/api/v100/x", 0, false}, // above max
+	}
+	for _, c := range cases {
+		v, ok := ktAPIVersionFromPath(c.path)
+		if ok != c.wantOK || (ok && v != c.wantV) {
+			t.Errorf("ktAPIVersionFromPath(%q)=(%d,%v), want (%d,%v)", c.path, v, ok, c.wantV, c.wantOK)
+		}
+	}
+}
+
+// --- unit: ktResolveAnnotationDeprecation -----------------------------------
+
+func TestKtResolveAnnotationDeprecation(t *testing.T) {
+	cases := []struct {
+		name       string
+		region     string
+		wantDep    bool
+		wantSource string
+		wantRepl   string
+		wantSince  string
+	}{
+		{"bare @Deprecated", "@Deprecated", true, "@Deprecated", "", ""},
+		{"msg replacement", `@Deprecated("use /api/v2/x")`, true, "@Deprecated", "/api/v2/x", ""},
+		{"ReplaceWith wins", `@Deprecated("old", ReplaceWith("/v2/y"))`, true, "@Deprecated", "/v2/y", ""},
+		{"since msg", `@Deprecated("since 1.5")`, true, "@Deprecated", "", "1.5"},
+		{"kdoc only", "* @deprecated use /v2/z", true, "KDoc @deprecated", "/v2/z", ""},
+		{"no marker", "// plain comment", false, "", "", ""},
+	}
+	for _, c := range cases {
+		v, ok := ktResolveAnnotationDeprecation(c.region)
+		if ok != c.wantDep {
+			t.Errorf("%s: ok=%v, want %v", c.name, ok, c.wantDep)
+			continue
+		}
+		if !c.wantDep {
+			continue
+		}
+		if v.source != c.wantSource {
+			t.Errorf("%s: source=%q, want %q", c.name, v.source, c.wantSource)
+		}
+		if v.replacement != c.wantRepl {
+			t.Errorf("%s: replacement=%q, want %q", c.name, v.replacement, c.wantRepl)
+		}
+		if v.since != c.wantSince {
+			t.Errorf("%s: since=%q, want %q", c.name, v.since, c.wantSince)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4136 (child of epic #3628 cross-language fan-out).

## Problem
`endpoint_deprecation_versioning` is full in java/jsts/python/go/csharp/ruby/php but was **missing in Kotlin**. Verified empirically: Kotlin producer endpoints are `SCOPE.Operation` entities emitted by the custom `.kt` extractors (`ktor_routes.go` / `routing.go`), **not** engine-synthesized `http_endpoint_definition`, so the flagship engine pass (`internal/engine/http_endpoint_deprecation.go`) cannot reach them. (A Ktor/Spring-Kotlin `.kt` file yields zero `http_endpoint_definition` through `engine.Detect`.) Same architecture PHP solved by stamping the identical flat contract in the custom-extractor stage (`internal/custom/php/helpers.go`).

## Change
New greenfield custom extractor `internal/custom/kotlin/endpoint_deprecation.go` (sibling of `rate_limit_endpoint.go`). Re-emits the endpoint op (`Name = "VERB path"`, merges onto the plain route op by Name) stamping the flagship flat contract **exactly**:

| prop | example |
|---|---|
| `deprecated` | `"true"` (only when a marker fires) |
| `deprecated_since` | `2.0` (from `since X` / KDoc) |
| `deprecated_replacement` | `/api/v2/users` (from `use X` / `ReplaceWith(...)`) |
| `deprecation_source` | `@Deprecated` \| `KDoc @deprecated` \| `Sunset response header` |
| `api_version` | `1` (path-derived) |

### Idioms covered
- **Ktor**: `@Deprecated("use /api/v2/x", ReplaceWith("/v2/x"))` / KDoc `@deprecated` above a verb handler; `call.response.header("Sunset"/"Deprecation", ...)`; api_version from `/api/v{N}` or `/v{N}`, composing enclosing `route("/prefix")` prefixes.
- **Spring-Kotlin**: `@Deprecated` / KDoc `@deprecated` on a `@<Verb>Mapping` in a `@RestController`; `response.setHeader("Sunset"/"Deprecation", ...)`; api_version from composed class `@RequestMapping` + method path.

### Honest-partial / negatives (asserted)
- Versionless non-deprecated route → **not** stamped (left to the plain route extractor); no fabricated `deprecated=false`.
- `/apiv2something` is **not** a version segment → no `api_version`.
- A config-/variable-driven marker is not resolved.
- Non-`.kt` file → no-op.

### Fires live on .kt
Verified end-to-end through the real `RunCustomExtractors` dispatch (`custom_kotlin_` prefix): `GET /api/v1/users` → `deprecated=true, deprecated_replacement=/api/v2/users, api_version=1, deprecation_source=@Deprecated`.

## Coverage
Flips Ktor + Spring Boot (Kotlin) `Routing` cells to **full** with cites + notes. Non-route Kotlin frameworks (Arrow/Koin/Retrofit/coroutines/serialization/graphql-kotlin) stay missing — they are not route producers (flipping them would be dishonest).

## Tests
12 value-asserting tests in `endpoint_deprecation_test.go` (Ktor annotated/ReplaceWith+since/Sunset-header/KDoc; Spring annotated/Deprecation-header; versionless negatives; no-false-segment; non-kotlin no-op; api-version + annotation-verdict unit tables). Full package tests green: `internal/custom/kotlin/ internal/engine/ internal/extractors/ tools/coverage/`. `covtool fmt --check` canonical.

## Deploy
DEPLOY-DEFERRED: engine/extractor logic only; takes effect on the next live daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)