### PR TITLE
[ruby][credit] feature_flag_gating: Unleash is_enabled? / Rollout / Flipper subscript+feature() + 8-sibling credit

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -63675,8 +63675,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -63949,8 +63952,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -64225,8 +64231,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -64504,8 +64513,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -64785,8 +64797,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -65066,8 +65081,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -65362,8 +65380,8 @@
             "status": "full",
             "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
             "issue": "3706",
-            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic)",
-            "verified_at": "2026-06-02"
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (LaunchDarkly/Unleash/Unleash-React/OpenFeature/Flipper/Flagsmith/Split.io/generic); Ruby idioms: Flipper symbol/subscript/feature(), Unleash is_enabled? predicate, Rollout active?, LaunchDarkly variation",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -65653,8 +65671,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -65938,8 +65959,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "4140",
+            "notes": "Ruby flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (Flipper symbol/subscript/feature() + Unleash is_enabled? + Rollout active? + LaunchDarkly variation); framework-agnostic engine pass, value-asserted Ruby unit tests",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",

--- a/internal/engine/feature_flag_edges.go
+++ b/internal/engine/feature_flag_edges.go
@@ -27,10 +27,14 @@
 //   - FeatureManagement (.NET) : _featureManager.IsEnabledAsync("key") /
 //     IsEnabled("key") / the [FeatureGate("key")] attribute on an MVC
 //     controller/action (Microsoft.FeatureManagement)
-//   - Unleash      : unleash.isEnabled("key") / isFeatureEnabled("key")
+//   - Unleash      : unleash.isEnabled("key") / isFeatureEnabled("key") /
+//     (Ruby) unleash.is_enabled?("key") — the `?`-suffixed predicate form
 //   - OpenFeature  : client.getBooleanValue("key", false) /
 //     getStringValue / getNumberValue / getObjectValue
-//   - Flipper      : Flipper.enabled?(:key) / :key.to_sym (Ruby)
+//   - Flipper      : (Ruby) Flipper.enabled?(:key) / Flipper[:key].enabled? /
+//     Flipper.feature(:key).enabled? — symbol or string key
+//   - Rollout      : (Ruby) $rollout.active?(:key, user) — receiver-gated on
+//     the `rollout` gem instance
 //   - Flagsmith    : flagsmith.has_feature("key") / is_feature_enabled("key")
 //   - FF4j (Java)  : ff4j.check("key")
 //   - Split.io     : client.getTreatment("split-name") /
@@ -77,7 +81,7 @@ const featureFlagPatternType = "feature_flag_gating"
 // flagHit is one detected flag-check call site.
 type flagHit struct {
 	key    string // literal flag key (symbol leading ':' already stripped)
-	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | flagsmith | ff4j | split | custom
+	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | rollout | flagsmith | ff4j | split | custom
 	method string // the SDK call/method observed
 	caller string // enclosing-function name ("" → file scope)
 	line   int    // 1-indexed source line
@@ -159,11 +163,17 @@ var flagSDKMatchers = []flagSDKMatcher{
 	},
 
 	// Unleash. isEnabled("flag") / isFeatureEnabled("flag") /
-	// is_enabled("flag"). Also the Python decorator-ish `@app.feature("flag")`
-	// is handled by the generic feature() matcher below.
+	// is_enabled("flag"). The Ruby Unleash SDK exposes the same check as a
+	// `?`-suffixed predicate: `UNLEASH.is_enabled?("flag")` /
+	// `unleash.is_enabled?("flag")`. The optional `\??` before the argument
+	// paren accepts that Ruby predicate form without a separate matcher; the
+	// `is_enabled` / `is_feature_enabled` method names are FF-specific enough
+	// that admitting the trailing `?` does not introduce false positives. Also
+	// the Python decorator-ish `@app.feature("flag")` is handled by the generic
+	// feature() matcher below.
 	{
 		re: regexp.MustCompile(
-			`(?i)\bis(?:_)?(?:feature)?(?:_)?enabled\s*\(\s*` +
+			`(?i)\bis(?:_)?(?:feature)?(?:_)?enabled\??\s*\(\s*` +
 				`(?:"([^"\\]+)"|'([^'\\]+)')`,
 		),
 		sdk:    "unleash",
@@ -192,6 +202,38 @@ var flagSDKMatchers = []flagSDKMatcher{
 		),
 		sdk:    "flipper",
 		method: "Flipper.enabled?",
+	},
+
+	// Flipper (Ruby) feature-object forms. The gem also exposes the check via a
+	// feature object: `Flipper[:flag].enabled?` (subscript) and
+	// `Flipper.feature(:flag).enabled?`. The flag key is captured at the
+	// subscript / feature() argument; the trailing `.enabled?` confirms it is a
+	// gating check (not just a feature lookup). The `Flipper` receiver token
+	// keeps the bare `.enabled?` predicate from false-positiving on unrelated
+	// receivers. Symbol or string key.
+	{
+		re: regexp.MustCompile(
+			`\bFlipper(?:\[\s*|\.feature\s*\(\s*)` +
+				`(?::([A-Za-z_]\w*[?!]?)|"([^"\\]+)"|'([^'\\]+)')` +
+				`\s*[\])]\s*\.enabled\?`,
+		),
+		sdk:    "flipper",
+		method: "Flipper[].enabled?",
+	},
+
+	// Rollout (Ruby `rollout` gem). `$rollout.active?(:flag, user)` /
+	// `rollout.active?("flag", user)`. The generic `.active?` predicate is far
+	// too common to attribute on its own, so a `rollout` receiver is required
+	// (the canonical instance is a `$rollout` global or a `rollout` local),
+	// mirroring the receiver-gated discipline used for FF4j / FeatureManagement.
+	// Symbol or string key.
+	{
+		re: regexp.MustCompile(
+			`(?i)(?:\$rollout|\brollout)\s*\.\s*active\?\s*\(\s*` +
+				`(?::([A-Za-z_]\w*[?!]?)|"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "rollout",
+		method: "rollout.active?",
 	},
 
 	// Flagsmith. has_feature("flag") / is_feature_enabled("flag") /

--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -210,6 +210,177 @@ end
 	}
 }
 
+// RUBY — Unleash `?`-suffixed predicate: a Rails controller action calling
+// `UNLEASH.is_enabled?("beta")` → feature:beta, SDK subtype "unleash",
+// attributed to the enclosing Ruby method. The Ruby SDK uses the `?`-suffixed
+// predicate form `is_enabled?` which the JS/Python `is_enabled(` matcher misses
+// without the optional `\??`. #4140.
+func TestFeatureFlag_Ruby_Unleash_is_enabled_predicate(t *testing.T) {
+	src := `
+def index
+  if UNLEASH.is_enabled?("beta")
+    render_beta
+  else
+    render_stable
+  end
+end
+`
+	flags, edges := runFlagPass("ruby", "controller.rb", src)
+
+	flag, ok := findFlag(flags, "beta")
+	if !ok {
+		t.Fatalf("expected feature:beta entity, got flags=%v", flags)
+	}
+	if flag.ID != "feature:beta" {
+		t.Errorf("flag ID = %q, want feature:beta", flag.ID)
+	}
+	if flag.Subtype != "unleash" {
+		t.Errorf("flag SDK subtype = %q, want unleash", flag.Subtype)
+	}
+	g, ok := findGate(edges, "beta")
+	if !ok {
+		t.Fatalf("expected GATED_BY for beta, got %v", edges)
+	}
+	if g.From != "Function:index" {
+		t.Errorf("GATED_BY FromID = %q, want Function:index", g.From)
+	}
+	if g.To != "feature:beta" {
+		t.Errorf("GATED_BY ToID = %q, want feature:beta", g.To)
+	}
+	if g.SDK != "unleash" {
+		t.Errorf("GATED_BY sdk = %q, want unleash", g.SDK)
+	}
+}
+
+// RUBY — Flipper subscript form `Flipper[:new_dash].enabled?` → feature:new_dash
+// (symbol normalized, leading `:` stripped), SDK subtype "flipper", attributed
+// to the enclosing Ruby method. #4140.
+func TestFeatureFlag_Ruby_Flipper_subscript(t *testing.T) {
+	src := `
+def dashboard
+  return new_dashboard if Flipper[:new_dash].enabled?
+  legacy_dashboard
+end
+`
+	flags, edges := runFlagPass("ruby", "dash.rb", src)
+	flag, ok := findFlag(flags, "new_dash")
+	if !ok {
+		t.Fatalf("expected feature:new_dash entity (symbol normalized), got %v", flags)
+	}
+	if flag.ID != "feature:new_dash" {
+		t.Errorf("flag ID = %q, want feature:new_dash", flag.ID)
+	}
+	if flag.Subtype != "flipper" {
+		t.Errorf("flag SDK = %q, want flipper", flag.Subtype)
+	}
+	g, ok := findGate(edges, "new_dash")
+	if !ok || g.From != "Function:dashboard" || g.To != "feature:new_dash" {
+		t.Fatalf("edge = %+v ok=%v, want Function:dashboard -> feature:new_dash", g, ok)
+	}
+	if g.SDK != "flipper" {
+		t.Errorf("GATED_BY sdk = %q, want flipper", g.SDK)
+	}
+}
+
+// RUBY — Flipper feature-object form `Flipper.feature(:promo).enabled?` →
+// feature:promo, SDK subtype "flipper". #4140.
+func TestFeatureFlag_Ruby_Flipper_feature_object(t *testing.T) {
+	src := `
+def promo
+  Flipper.feature(:promo).enabled? ? show_promo : nil
+end
+`
+	flags, edges := runFlagPass("ruby", "promo.rb", src)
+	if _, ok := findFlag(flags, "promo"); !ok {
+		t.Fatalf("expected feature:promo entity, got %v", flags)
+	}
+	g, ok := findGate(edges, "promo")
+	if !ok || g.From != "Function:promo" || g.To != "feature:promo" || g.SDK != "flipper" {
+		t.Fatalf("edge = %+v ok=%v, want Function:promo -> feature:promo (flipper)", g, ok)
+	}
+}
+
+// RUBY — Rollout gem `$rollout.active?(:new_checkout, current_user)` →
+// feature:new_checkout (symbol normalized), SDK subtype "rollout", attributed to
+// the enclosing Ruby method. The receiver is the `$rollout` global. #4140.
+func TestFeatureFlag_Ruby_Rollout_active(t *testing.T) {
+	src := `
+def checkout
+  if $rollout.active?(:new_checkout, current_user)
+    new_checkout_flow
+  else
+    legacy_checkout
+  end
+end
+`
+	flags, edges := runFlagPass("ruby", "checkout.rb", src)
+	flag, ok := findFlag(flags, "new_checkout")
+	if !ok {
+		t.Fatalf("expected feature:new_checkout entity, got %v", flags)
+	}
+	if flag.ID != "feature:new_checkout" {
+		t.Errorf("flag ID = %q, want feature:new_checkout", flag.ID)
+	}
+	if flag.Subtype != "rollout" {
+		t.Errorf("flag SDK = %q, want rollout", flag.Subtype)
+	}
+	g, ok := findGate(edges, "new_checkout")
+	if !ok {
+		t.Fatalf("expected GATED_BY for new_checkout, got %v", edges)
+	}
+	if g.From != "Function:checkout" || g.To != "feature:new_checkout" {
+		t.Errorf("edge = %+v, want Function:checkout -> feature:new_checkout", g)
+	}
+	if g.SDK != "rollout" {
+		t.Errorf("GATED_BY sdk = %q, want rollout", g.SDK)
+	}
+}
+
+// RUBY NEGATIVE — a bare `record.enabled?` predicate on a non-flag receiver (an
+// ActiveRecord model) must NOT be attributed: there is no Flipper / Unleash /
+// Rollout SDK token, so the receiver-gated matchers correctly emit nothing.
+func TestFeatureFlag_Ruby_NonFlagPredicate_NoFabrication(t *testing.T) {
+	src := `
+def visible?
+  record.enabled? && record.published?
+end
+`
+	flags, edges := runFlagPass("ruby", "visible.rb", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("bare non-flag .enabled? predicate should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// RUBY NEGATIVE — a generic `.active?(:x)` on a NON-rollout receiver must NOT be
+// attributed: the Rollout matcher requires a `rollout` receiver, so a
+// `widget.active?(:on)` call on an arbitrary object emits nothing.
+func TestFeatureFlag_Ruby_NonRolloutActive_NoFabrication(t *testing.T) {
+	src := `
+def click
+  return unless widget.active?(:on)
+  handle_click
+end
+`
+	flags, edges := runFlagPass("ruby", "click.rb", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("non-rollout .active? should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// RUBY NEGATIVE — a dynamic (non-literal) key on the Rollout matcher must NOT
+// fabricate a flag entity or edge (honest-partial, mirrors the other langs).
+func TestFeatureFlag_Ruby_Rollout_DynamicKey_NoFabrication(t *testing.T) {
+	src := `
+def gate(flag_name, user)
+  $rollout.active?(flag_name, user)
+end
+`
+	flags, edges := runFlagPass("ruby", "gate.rb", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("dynamic Rollout key should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
 // Flagsmith: has_feature("promo-banner").
 func TestFeatureFlag_Flagsmith_has_feature(t *testing.T) {
 	src := `


### PR DESCRIPTION
Closes #4140 — parent #3628 (area #17, feature-flag topology). DEPLOY-DEFERRED (live daemon untouched).

Verify-and-credit the framework-agnostic `internal/engine/feature_flag_edges.go` pass for Ruby, mirroring the go #3919 / jsts #4137 node/edge shape (`feature:<key>` node, `GATED_BY` edge, symbol `:flag` normalized to `flag`, dynamic key → no fabrication).

## Verify-first (probed live registry, main 8e152b9fa)
| Ruby idiom | SDK | Before | After |
|---|---|---|---|
| `Flipper.enabled?(:beta, user)` | flipper | fires | fires |
| `c.variation("ld-flag", user, false)` | launchdarkly | fires | fires |
| `UNLEASH.is_enabled?("beta")` / `unleash.is_enabled?(...)` | unleash | **missed** | **fires** |
| `$rollout.active?(:chat, user)` | rollout | **missed** | **fires** |
| `Flipper[:new_dash].enabled?` | flipper | **missed** | **fires** |
| `Flipper.feature(:x).enabled?` | flipper | **missed** | **fires** |

## Matcher changes (engine)
- **Unleash**: optional `\??` before the arg paren so the Ruby `?`-suffixed predicate `is_enabled?(` fires. `is_enabled`/`is_feature_enabled` are FF-specific names, so admitting the `?` adds no false positives.
- **Flipper**: new feature-object matcher for subscript `Flipper[:flag].enabled?` and `Flipper.feature(:flag).enabled?`, `Flipper`-receiver-gated.
- **Rollout** (new SDK): `$rollout.active?(:flag, user)`, receiver-gated on `rollout` so generic `.active?` does not false-positive.

## False-positive guards (value-asserted negatives)
- `record.enabled?` (non-flag receiver, no SDK token) → none.
- `widget.active?(:x)` (generic `.active?` without `rollout` receiver) → none.
- Dynamic Rollout key (bare ident) → none (honest-partial).

## Tests
Value-asserting positives for each idiom (exact key, `Function:<caller>` FromID, `feature:<key>` ToID, SDK subtype) incl. symbol normalization (`:new_dash`→`new_dash`, `:new_checkout`→`new_checkout`) + 3 negatives. Full `internal/engine/ internal/extractors/ tools/coverage/` packages green; gofmt + vet clean.

## Registry credit
`feature_flag_gating` → **full** for the 8 Ruby web-framework siblings (sinatra, grape, hanami, roda, cuba, padrino, dry-rb, graphql-ruby) on the same evidence as the rails flagship (framework-agnostic engine pass + Ruby unit tests); rails notes refreshed. Surgical via `coverage update`; canonical (`coverage fmt --check` ok), `coverage validate` clean (new map warnings consistent with the pre-existing flagship-anchored map convention — 238 such sibling warnings already at baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)