### PR TITLE
feat(scala): endpoint_deprecation_versioning (http4s/akka-http/pekko-http) #4141

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -71288,8 +71288,11 @@
       "capabilities": {
         "Routing": {
           "endpoint_deprecation_versioning": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/scala/endpoint_deprecation.go","internal/custom/scala/endpoint_deprecation_test.go"],
+            "issue": "4141",
+            "notes": "#4141 (child of #3628) Scala port: deprecated/deprecation_source(+deprecated_since/deprecated_replacement)+path-derived api_version stamped at the SOURCE on a SCOPE.Pattern/deprecation marker. Scala HTTP endpoints are SCOPE.Operation custom-extractor entities the engine resolveEndpointDeprecation pass (gated on http_endpoint_definition) cannot reach, so the contract is stamped in the custom-extractor stage (PHP/Kotlin precedent). The Scala stdlib @deprecated(message, since) annotation on an akka/pekko verb directive (NOTE: Scala arg order is message-FIRST since-SECOND, the reverse of Java) credits deprecated=true+deprecated_since+deprecated_replacement; a Scaladoc @deprecated tag, a // DEPRECATED banner, and a Sunset/Deprecation response header (RFC 8594) also fire. api_version is path-derived from the akka/pekko path-DSL (path(\"v1\" / ...), \"api\" / \"v2\") prefering the DSL form over a /api/vN literal in the deprecation message. Identical property contract to the flagship. Value-asserted TestScalaDep_AkkaAnnotationVerb (since=1.5, replacement=v2, api_version=1) + TestScalaDep_PekkoAnnotation; negatives TestScalaDep_VersionlessNoApiVersion + TestScalaDep_NonRouteDeprecatedUnaffected.",
+            "verified_at": "2026-06-03"
           },
           "endpoint_pagination_posture": {
             "status": "missing",
@@ -72900,8 +72903,11 @@
       "capabilities": {
         "Routing": {
           "endpoint_deprecation_versioning": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/scala/endpoint_deprecation.go","internal/custom/scala/endpoint_deprecation_test.go"],
+            "issue": "4141",
+            "notes": "#4141 (child of #3628) Scala port: deprecated/deprecation_source(+deprecated_since/deprecated_replacement)+path-derived api_version stamped at the SOURCE on a SCOPE.Pattern/deprecation marker. http4s endpoints are SCOPE.Operation custom-extractor entities the engine resolveEndpointDeprecation pass (gated on http_endpoint_definition) cannot reach, so the contract is stamped in the custom-extractor stage (PHP/Kotlin precedent). The Scala stdlib @deprecated(message, since) annotation on a `case GET -\u003e Root / ...` route branch (NOTE: Scala arg order is message-FIRST since-SECOND, the reverse of Java) credits deprecated=true+deprecated_since+deprecated_replacement; a Scaladoc @deprecated tag, a // DEPRECATED banner, and a Sunset/Deprecation response header (RFC 8594, e.g. Header.Raw(ci\"Sunset\", ...)) also fire. api_version is path-derived from the http4s path-DSL (Root / \"api\" / \"v2\") prefering the DSL form over a /api/vN literal in the deprecation message. Identical property contract to the flagship. Value-asserted TestScalaDep_Http4sAnnotation (since=2.0, replacement=/api/v2/users, api_version=1), TestScalaDep_Http4sDSLVersion (api_version=2), TestScalaDep_ScaladocTag, TestScalaDep_BannerComment, TestScalaDep_SunsetHeader; negatives TestScalaDep_NonDeprecatedNone + TestScalaDep_VersionlessNoApiVersion.",
+            "verified_at": "2026-06-03"
           },
           "endpoint_pagination_posture": {
             "status": "missing",
@@ -73553,8 +73559,11 @@
       "capabilities": {
         "Routing": {
           "endpoint_deprecation_versioning": {
-            "status": "missing",
-            "issue": "3628"
+            "status": "full",
+            "cites": ["internal/custom/scala/endpoint_deprecation.go","internal/custom/scala/endpoint_deprecation_test.go"],
+            "issue": "4141",
+            "notes": "#4141 (child of #3628) Scala port: deprecated/deprecation_source(+deprecated_since/deprecated_replacement)+path-derived api_version stamped at the SOURCE on a SCOPE.Pattern/deprecation marker. Pekko HTTP endpoints are SCOPE.Operation custom-extractor entities the engine resolveEndpointDeprecation pass (gated on http_endpoint_definition) cannot reach, so the contract is stamped in the custom-extractor stage (PHP/Kotlin precedent). The Scala stdlib @deprecated(message, since) annotation on a pekko verb directive (NOTE: Scala arg order is message-FIRST since-SECOND, the reverse of Java) credits deprecated=true+deprecated_since+deprecated_replacement; a Scaladoc @deprecated tag, a // DEPRECATED banner, and a Sunset/Deprecation response header (RFC 8594) also fire. detectScalaFramework labels org.apache.pekko files pekko-http distinctly from akka-http. api_version is path-derived from the pekko path-DSL (path(\"api\" / \"v1\" / ...)) prefering the DSL form over a /api/vN literal in the deprecation message. Identical property contract to the flagship. Value-asserted TestScalaDep_PekkoAnnotation (framework=pekko-http, since=4.0, api_version=1); negatives TestScalaDep_VersionlessNoApiVersion + TestScalaDep_NonRouteDeprecatedUnaffected.",
+            "verified_at": "2026-06-03"
           },
           "endpoint_pagination_posture": {
             "status": "missing",

--- a/internal/custom/scala/endpoint_deprecation.go
+++ b/internal/custom/scala/endpoint_deprecation.go
@@ -1,0 +1,499 @@
+// endpoint_deprecation.go — endpoint API-version + deprecation stamping for
+// Scala web frameworks (#4141, child of #3628 Routing/endpoint_deprecation_versioning).
+//
+// Scala greenfield: prior to this pass every scala framework cell for
+// endpoint_deprecation_versioning was `missing`. The flagship engine pass
+// (internal/engine/http_endpoint_deprecation.go, resolveEndpointDeprecation)
+// stamps the contract on synthesised `http_endpoint_definition` entities — but
+// Scala HTTP endpoints are emitted as `SCOPE.Operation` entities by the custom
+// .scala extractors (akka.go `path(...)` / `route:METHOD`, tapir.go
+// `tapir:METHOD:path`), so the engine pass — gated on
+// Kind==http_endpoint_definition — can never reach them. This is the SAME
+// situation PHP Symfony/API-Platform (internal/custom/php) and Kotlin Ktor
+// (internal/custom/kotlin) faced; the resolution is identical: stamp the
+// contract in the CUSTOM-EXTRACTOR stage from the framework's own idioms.
+//
+// Scala sibling of the PHP custom-stage deprecation (#3628) and the Scala
+// rate_limit.go marker pass (#4105). It emits a `SCOPE.Pattern/deprecation`
+// marker per detected deprecation site carrying the IDENTICAL flat property
+// contract the flagship stamps, so the graph answers "which Scala endpoints are
+// deprecated, since when, replaced by what, and on which api version?":
+//
+//	deprecated             — "true" (present only when a marker was found)
+//	deprecated_since       — version/date from the marker, when available
+//	deprecated_replacement — the suggested replacement, when the marker names one
+//	deprecation_source     — the signal that fired (evidence for the dashboard)
+//	api_version            — "1" | "2" | … the numeric version (no leading 'v'),
+//	                         from a /api/vN or /vN route path segment, when present
+//
+// Recognised Scala deprecation idioms (all four credit deprecated=true):
+//
+//	@deprecated("use /api/v2/users", "2.0") — the Scala stdlib annotation. NOTE
+//	    the Scala arg order is (message, since) — message FIRST, since SECOND —
+//	    the OPPOSITE of Java's `@Deprecated(since=)`. The 2nd positional/`since=`
+//	    arg is the version; the 1st `message` arg yields the replacement hint and
+//	    a `since X` fallback. Sits on the route handler (an http4s
+//	    `case GET -> Root / "v1" / "users"` branch, an akka/pekko verb directive,
+//	    a tapir endpoint val, or the def that implements it).
+//	@deprecated <msg>  — a Scaladoc tag in the `/** … */` comment block above the
+//	    route handler (message yields since/replacement).
+//	// DEPRECATED <msg> — a banner line comment at the route (cross-language).
+//	Sunset / Deprecation response header (RFC 8594) — `Header("Sunset", …)`,
+//	    `Header.Raw(ci"Deprecation", …)`, `headers = Headers("Sunset" -> …)` set
+//	    in a route response (runtime deprecation signal).
+//
+// api_version is path-derived (language-agnostic, mirrors the flagship
+// applyEndpointAPIVersion): a `/api/vN` or `/vN` segment in either a quoted
+// route literal (`"/api/v1/users"`, scalatra/cask/play colon paths) or the
+// http4s/akka/zio path-DSL (`Root / "api" / "v2"`, `path("v1" / "users")`).
+//
+// Marker model (mirrors rate_limit.go): like the Scala rate-limit pass, the
+// deprecation/version semantic is projected onto a `SCOPE.Pattern/deprecation`
+// marker rather than a per-route endpoint op — Scala's akka/http4s endpoints are
+// emitted as un-composed `path(...)`/`route:METHOD` fragments (akka.go), so there
+// is no single composed endpoint op to attach to without fabricating a route
+// binding. The marker carries the full contract as evidence; MergeWithCustom
+// dedups by Name. One marker per deprecation site.
+//
+// Honest-partial (NEVER fabricated):
+//   - a route handler with NO deprecation marker → no marker emitted;
+//   - a deprecation marker with no resolvable since/replacement → those props
+//     are omitted (only deprecated + deprecation_source stamped);
+//   - a deprecation site whose enclosing route carries no explicit version
+//     segment → no api_version.
+//
+// Refs #4141.
+package scala
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_endpoint_deprecation", &scalaEndpointDeprecationExtractor{})
+}
+
+type scalaEndpointDeprecationExtractor struct{}
+
+func (e *scalaEndpointDeprecationExtractor) Language() string {
+	return "custom_scala_endpoint_deprecation"
+}
+
+var (
+	// reScalaDeprecatedAnno matches the Scala stdlib `@deprecated` annotation.
+	// Group 1 = the (optional) parenthesised argument body. Scala's annotation is
+	// `@deprecated(message, since)` — message FIRST, since SECOND (the reverse of
+	// Java). A no-arg `@deprecated` (or `@deprecatedInheritance`/`@deprecatedName`
+	// — excluded by the `\b` boundary below) still credits deprecated=true.
+	reScalaDeprecatedAnno = regexp.MustCompile(`@deprecated\b(?:\s*\(([^)]{0,300})\))?`)
+
+	// reScalaDeprecatedScaladoc matches a Scaladoc `@deprecated <message>` tag
+	// (lowercase, inside a /** … */ block). Group 1 = the trailing message up to
+	// end-of-line / next tag.
+	reScalaDeprecatedScaladoc = regexp.MustCompile(`@deprecated\b([^\n*@]{1,200})`)
+
+	// reScalaDeprecatedComment matches a `// DEPRECATED` / `/* DEPRECATED` /
+	// `* DEPRECATED` banner comment (case-insensitive). Group 1 = trailing message.
+	reScalaDeprecatedComment = regexp.MustCompile(`(?i)(?://|/\*|\*)\s*DEPRECATED\b([^\n*]{0,200})`)
+
+	// reScalaSinceArg pulls an explicit `since = "X"` named arg out of a
+	// @deprecated(...) body.
+	reScalaSinceArg = regexp.MustCompile(`\bsince\s*=\s*"([^"]{0,80})"`)
+
+	// reScalaMessageArg pulls an explicit `message = "X"` named arg out of a
+	// @deprecated(...) body.
+	reScalaMessageArg = regexp.MustCompile(`\bmessage\s*=\s*"([^"]{0,300})"`)
+
+	// reScalaStringArg matches a quoted string-literal argument.
+	reScalaStringArg = regexp.MustCompile(`"([^"]{0,300})"`)
+
+	// reScalaSunsetHeader matches a Sunset / Deprecation response-header write in
+	// a Scala route response. Covers `Header("Sunset", …)`, `Header.Raw(ci"Sunset",
+	// …)`, `"Deprecation" -> …`, `Headers("Sunset" -> …)`, akka
+	// `RawHeader("Sunset", …)`. Group 1 = the header name.
+	reScalaSunsetHeader = regexp.MustCompile(`(?i)["'\(]?\s*(?:ci)?["']\s*(sunset|deprecation)\s*["']`)
+
+	// reScalaVersionLiteral matches an `/api/vN` or `/vN` version segment inside a
+	// quoted route literal. Group 1 (api/v form) or group 2 (bare /v form) = the
+	// numeric version.
+	reScalaVersionLiteralAPI = regexp.MustCompile(`(?i)/api/v(\d+)(?:/|"|$)`)
+	reScalaVersionLiteralV   = regexp.MustCompile(`(?i)/v(\d+)(?:/|"|$)`)
+
+	// reScalaVersionDSLAPI matches the http4s / akka path-DSL version segment
+	// `"api" / "v2"` (api segment then a vN segment). Group 1 = numeric version.
+	reScalaVersionDSLAPI = regexp.MustCompile(`(?i)"api"\s*/\s*"v(\d+)"`)
+
+	// reScalaVersionDSLV matches a bare path-DSL version segment `"v1"`. Group 1 =
+	// numeric version.
+	reScalaVersionDSLV = regexp.MustCompile(`(?i)"v(\d+)"`)
+)
+
+const (
+	scalaAPIVersionMin = 1
+	scalaAPIVersionMax = 99
+)
+
+// depSiteFinder marks a route-bearing line so a deprecation marker can anchor on
+// the route region around it. We treat as a route-anchor: an http4s
+// `case ... -> ...` route branch, an akka/pekko verb directive (`get { … }`),
+// a `path(...)` / `pathPrefix(...)` directive, a tapir `endpoint` builder, a
+// scalatra/cask/play verb-with-path, and a `@deprecated`-annotated def.
+var reScalaRouteAnchor = regexp.MustCompile(
+	`(?m)(?:` +
+		`case\s+\w+\s*->` + // http4s route branch: case GET -> Root / ...
+		`|\b(?:get|post|put|delete|patch|head|options)\s*[\({]` + // akka verb directive / scalatra verb
+		`|\bpath(?:Prefix|End|EndOrSingleSlash)?\s*\(` + // akka path directive
+		`|@cask\.\w+` + // cask route
+		`|\bendpoint\b` + // tapir endpoint builder
+		`)`)
+
+func (e *scalaEndpointDeprecationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_endpoint_deprecation.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Fast guard: the file must mention a deprecation OR a Sunset/Deprecation
+	// header idiom; otherwise there is nothing to stamp.
+	if !strings.Contains(src, "deprecated") && !strings.Contains(src, "DEPRECATED") &&
+		!strings.Contains(src, "Sunset") && !strings.Contains(src, "sunset") &&
+		!strings.Contains(src, "Deprecation") {
+		return nil, nil
+	}
+
+	framework := detectScalaFramework(src)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, m := range e.findDeprecationSites(src) {
+		ln := lineOf(src, m.offset)
+		name := "deprecation:" + m.source + ":" + strconv.Itoa(ln)
+		ent := makeEntity(name, "SCOPE.Pattern", "deprecation", file.Path, file.Language, ln)
+		setProps(&ent,
+			"framework", framework,
+			"kind", "deprecation",
+			"provenance", "INFERRED_FROM_SCALA_DEPRECATION",
+			"deprecated", "true",
+			"deprecation_source", m.source,
+		)
+		if m.since != "" {
+			ent.Properties["deprecated_since"] = m.since
+		}
+		if m.replacement != "" {
+			ent.Properties["deprecated_replacement"] = m.replacement
+		}
+		if v, ok := scalaAPIVersionNear(src, m.offset); ok {
+			ent.Properties["api_version"] = strconv.Itoa(v)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// depSite is a resolved deprecation site: the byte offset of the marker, the
+// evidence source, and the honest-partial since/replacement.
+type depSite struct {
+	offset      int
+	source      string
+	since       string
+	replacement string
+}
+
+// findDeprecationSites scans the source for every deprecation marker. The four
+// signals are checked in priority order (annotation richest → Scaladoc → banner
+// comment → response header); each MATCH yields one site. A `@deprecated`
+// annotation and a sibling Scaladoc tag at the same place are de-duplicated by
+// offset so the richer annotation wins.
+func (e *scalaEndpointDeprecationExtractor) findDeprecationSites(src string) []depSite {
+	var out []depSite
+	claimed := make(map[int]bool) // line numbers already claimed by a richer signal
+
+	claim := func(off int) bool {
+		ln := lineOf(src, off)
+		if claimed[ln] {
+			return false
+		}
+		claimed[ln] = true
+		return true
+	}
+
+	// 1. @deprecated annotation (Scala stdlib). Must be a route-relevant
+	//    deprecation — gate on a route anchor within a small window so a
+	//    @deprecated on a non-route helper class does not leak.
+	for _, m := range reScalaDeprecatedAnno.FindAllStringSubmatchIndex(src, -1) {
+		// Exclude @deprecatedName / @deprecatedInheritance / @deprecatedOverriding:
+		// the `\b` after `deprecated` already blocks them (next char is a letter),
+		// but FindAllStringSubmatchIndex on the optional group can still match the
+		// bare `@deprecated` prefix of those — re-check the char right after.
+		after := m[1]
+		if after < len(src) {
+			c := src[after]
+			if c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' {
+				continue
+			}
+		}
+		// A `@deprecated` occurrence that is actually a Scaladoc tag (inside a
+		// /** … */ block) is handled by the Scaladoc pass below, which parses its
+		// free-text message; skip it here so the richer message-parse wins.
+		if scalaIsScaladocTag(src, m[0]) {
+			continue
+		}
+		if !scalaNearRouteAnchor(src, m[0]) {
+			continue
+		}
+		if !claim(m[0]) {
+			continue
+		}
+		since, repl := scalaParseAnnoArgs(src, m)
+		out = append(out, depSite{offset: m[0], source: "@deprecated", since: since, replacement: repl})
+	}
+
+	// 2. Scaladoc `@deprecated <msg>` tag inside a doc comment. Only when the
+	//    matched occurrence is a doc tag (preceded on its line by a `*` or `/**`),
+	//    not the annotation already claimed above.
+	for _, m := range reScalaDeprecatedScaladoc.FindAllStringSubmatchIndex(src, -1) {
+		if !scalaIsScaladocTag(src, m[0]) {
+			continue
+		}
+		if !scalaNearRouteAnchor(src, m[0]) {
+			continue
+		}
+		if !claim(m[0]) {
+			continue
+		}
+		msg := strings.TrimSpace(strings.Trim(src[m[2]:m[3]], " \t*/"))
+		since, repl := parseScalaDeprecationMessage(msg)
+		out = append(out, depSite{offset: m[0], source: "@deprecated scaladoc", since: since, replacement: repl})
+	}
+
+	// 3. `// DEPRECATED` banner comment at a route.
+	for _, m := range reScalaDeprecatedComment.FindAllStringSubmatchIndex(src, -1) {
+		if !scalaNearRouteAnchor(src, m[0]) {
+			continue
+		}
+		if !claim(m[0]) {
+			continue
+		}
+		msg := strings.TrimSpace(strings.Trim(src[m[2]:m[3]], " \t*/"))
+		since, repl := parseScalaDeprecationMessage(msg)
+		out = append(out, depSite{offset: m[0], source: "comment // DEPRECATED", since: since, replacement: repl})
+	}
+
+	// 4. Sunset / Deprecation response header (RFC 8594). A runtime deprecation
+	//    signal — credited regardless of an annotation. Gated on a route anchor so
+	//    an unrelated `"Deprecation"` string elsewhere does not leak.
+	for _, m := range reScalaSunsetHeader.FindAllStringSubmatchIndex(src, -1) {
+		if !scalaNearRouteAnchor(src, m[0]) {
+			continue
+		}
+		if !claim(m[0]) {
+			continue
+		}
+		hdr := titleScalaHeader(src[m[2]:m[3]])
+		out = append(out, depSite{offset: m[0], source: hdr + " response header"})
+	}
+
+	return out
+}
+
+// scalaParseAnnoArgs extracts since + replacement from a @deprecated(...) arg
+// body. Scala arg order is (message, since): the FIRST positional string is the
+// message (→ replacement hint + since fallback), the SECOND positional string is
+// the since version. Named `message =` / `since =` args override positionally.
+func scalaParseAnnoArgs(src string, m []int) (since, replacement string) {
+	if m[2] < 0 { // no argument list (bare @deprecated)
+		return "", ""
+	}
+	body := src[m[2]:m[3]]
+
+	var message string
+	// Named args take priority.
+	if sm := reScalaSinceArg.FindStringSubmatch(body); sm != nil {
+		since = sm[1]
+	}
+	if mm := reScalaMessageArg.FindStringSubmatch(body); mm != nil {
+		message = mm[1]
+	}
+	// Positional fallback: first quoted = message, second quoted = since.
+	if message == "" || since == "" {
+		strs := reScalaStringArg.FindAllStringSubmatch(body, -1)
+		if message == "" && len(strs) >= 1 {
+			message = strs[0][1]
+		}
+		if since == "" && len(strs) >= 2 {
+			since = strs[1][1]
+		}
+	}
+	// The message yields the replacement hint, and a `since X` fallback when no
+	// explicit since arg was given.
+	s, r := parseScalaDeprecationMessage(message)
+	replacement = r
+	if since == "" {
+		since = s
+	}
+	return since, replacement
+}
+
+// scalaNearRouteAnchor reports whether a route anchor (an http4s route branch,
+// an akka/scalatra verb directive, a path directive, a tapir endpoint builder,
+// or a cask route) appears within a small byte window around off. Keeps a
+// `@deprecated` on a non-route helper from emitting a route-deprecation marker.
+func scalaNearRouteAnchor(src string, off int) bool {
+	const win = 600
+	lo := off - win
+	if lo < 0 {
+		lo = 0
+	}
+	hi := off + win
+	if hi > len(src) {
+		hi = len(src)
+	}
+	return reScalaRouteAnchor.MatchString(src[lo:hi])
+}
+
+// scalaIsScaladocTag reports whether the `@deprecated` occurrence at off is a
+// Scaladoc tag (its line, trimmed, starts with `*` or `/**`) rather than a
+// code-level annotation.
+func scalaIsScaladocTag(src string, off int) bool {
+	ls := lineStartOffsetScala(src, off)
+	prefix := strings.TrimSpace(src[ls:off])
+	return strings.HasPrefix(prefix, "*") || strings.HasPrefix(prefix, "/**") || prefix == "*"
+}
+
+// lineStartOffsetScala returns the byte offset of the start of the line
+// containing off.
+func lineStartOffsetScala(src string, off int) int {
+	if off > len(src) {
+		off = len(src)
+	}
+	i := strings.LastIndexByte(src[:off], '\n')
+	if i < 0 {
+		return 0
+	}
+	return i + 1
+}
+
+// scalaAPIVersionNear resolves a path-derived api_version from the route region
+// around a deprecation site. It scans a window around off for a `/api/vN` or
+// `/vN` version segment in either a quoted route literal or the http4s/akka path
+// DSL (`"api" / "v2"`, `"v1"`). Honest-partial: no version segment → (0,false).
+func scalaAPIVersionNear(src string, off int) (int, bool) {
+	const win = 600
+	lo := off - win
+	if lo < 0 {
+		lo = 0
+	}
+	hi := off + win
+	if hi > len(src) {
+		hi = len(src)
+	}
+	region := src[lo:hi]
+
+	// The deprecation MESSAGE often names the replacement path
+	// (`@deprecated("use /api/v2/users", …)`), which would otherwise be mistaken
+	// for the route's own version. Scan the path-DSL form FIRST — `Root / "api" /
+	// "vN"` and `path("vN" / …)` are unambiguously the route's structure, never
+	// part of a quoted message — and only fall back to a quoted `/api/vN` literal
+	// when no DSL version segment is present (covers scalatra/cask/play colon
+	// paths whose route IS a quoted literal).
+	if m := reScalaVersionDSLAPI.FindStringSubmatch(region); m != nil {
+		if v, ok := scalaParseVersion(m[1]); ok {
+			return v, true
+		}
+	}
+	if m := reScalaVersionDSLV.FindStringSubmatch(region); m != nil {
+		if v, ok := scalaParseVersion(m[1]); ok {
+			return v, true
+		}
+	}
+	// Quoted-literal /api/vN (route IS a string literal, e.g. scalatra
+	// get("/api/v1/users")). Only reached when the DSL form is absent.
+	if m := reScalaVersionLiteralAPI.FindStringSubmatch(region); m != nil {
+		if v, ok := scalaParseVersion(m[1]); ok {
+			return v, true
+		}
+	}
+	if m := reScalaVersionLiteralV.FindStringSubmatch(region); m != nil {
+		if v, ok := scalaParseVersion(m[1]); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func scalaParseVersion(s string) (int, bool) {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	if v < scalaAPIVersionMin || v > scalaAPIVersionMax {
+		return 0, false
+	}
+	return v, true
+}
+
+// titleScalaHeader normalises a lower-cased header name to title case
+// (sunset → Sunset, deprecation → Deprecation).
+func titleScalaHeader(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// --- Shared message parsing (mirrors the flagship parseDeprecationMessage) ---
+
+// reScalaDepSince extracts a "since X" / "as of X" version/date from a free-text
+// deprecation message.
+var reScalaDepSince = regexp.MustCompile(`(?i)\b(?:since|as of)\s+([vV]?\d[\w.\-]*)`)
+
+// reScalaDepReplacement extracts a "use X" / "replaced by X" / "prefer X"
+// replacement hint from a free-text message.
+var reScalaDepReplacement = regexp.MustCompile("(?i)\\b(?:use|replaced by|prefer|see)\\s+`?([A-Za-z0-9_./{}\\-]+)`?")
+
+// parseScalaDeprecationMessage pulls an optional since-version + replacement hint
+// out of a free-text deprecation message. Both honest-partial (empty when
+// absent, never fabricated). Mirrors the flagship parser exactly.
+func parseScalaDeprecationMessage(msg string) (since, replacement string) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return "", ""
+	}
+	if m := reScalaDepSince.FindStringSubmatch(msg); m != nil {
+		since = m[1]
+	}
+	if m := reScalaDepReplacement.FindStringSubmatch(msg); m != nil {
+		replacement = strings.TrimSuffix(m[1], ".")
+	}
+	return since, replacement
+}

--- a/internal/custom/scala/endpoint_deprecation_test.go
+++ b/internal/custom/scala/endpoint_deprecation_test.go
@@ -1,0 +1,319 @@
+package scala_test
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// custom_scala_endpoint_deprecation — endpoint deprecation + api_version
+// stamping (#4141, child of #3628). Value-asserting: each test pins the SPECIFIC
+// deprecated/deprecated_since/deprecated_replacement/deprecation_source/
+// api_version resolved on the SPECIFIC Scala idiom. A "≥1 entity" check is NEVER
+// used. Negatives required (non-deprecated → none; versionless → no api_version).
+// ---------------------------------------------------------------------------
+
+const depKey = "custom_scala_endpoint_deprecation"
+
+// findDep returns the first deprecation marker matching deprecation_source.
+func findDep(ents []entitySummary, source string) (entitySummary, bool) {
+	for _, e := range ents {
+		if e.Subtype == "deprecation" && e.Props["deprecation_source"] == source {
+			return e, true
+		}
+	}
+	return entitySummary{}, false
+}
+
+// TestScalaDep_Http4sAnnotation: the flagship case from the ticket — a
+// @deprecated("use /api/v2/users", "2.0") annotation on an http4s route in a v1
+// path resolves the full contract (deprecated + since=2.0 + replacement +
+// api_version=1 + source).
+func TestScalaDep_Http4sAnnotation(t *testing.T) {
+	src := `
+import org.http4s._
+import org.http4s.dsl.io._
+
+val routes = HttpRoutes.of[IO] {
+  @deprecated("use /api/v2/users", "2.0")
+  case GET -> Root / "api" / "v1" / "users" => Ok("legacy")
+}
+`
+	ents := extract(t, depKey, fi("Routes.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["deprecated"] != "true" {
+		t.Errorf("deprecated = %q, want true", e.Props["deprecated"])
+	}
+	if e.Props["deprecated_since"] != "2.0" {
+		t.Errorf("deprecated_since = %q, want 2.0", e.Props["deprecated_since"])
+	}
+	if e.Props["deprecated_replacement"] != "/api/v2/users" {
+		t.Errorf("deprecated_replacement = %q, want /api/v2/users", e.Props["deprecated_replacement"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+	if e.Props["framework"] != "http4s" {
+		t.Errorf("framework = %q, want http4s", e.Props["framework"])
+	}
+}
+
+// TestScalaDep_Http4sDSLVersion: api_version resolved from the http4s path-DSL
+// `Root / "api" / "v2"` (no quoted /api/vN literal).
+func TestScalaDep_Http4sDSLVersion(t *testing.T) {
+	src := `
+import org.http4s._
+
+val routes = HttpRoutes.of[IO] {
+  @deprecated("superseded", "3.1")
+  case GET -> Root / "api" / "v2" / "orders" => Ok("o")
+}
+`
+	ents := extract(t, depKey, fi("Orders.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["api_version"] != "2" {
+		t.Errorf("api_version = %q, want 2", e.Props["api_version"])
+	}
+	if e.Props["deprecated_since"] != "3.1" {
+		t.Errorf("deprecated_since = %q, want 3.1", e.Props["deprecated_since"])
+	}
+}
+
+// TestScalaDep_AkkaAnnotationVerb: akka-http verb directive deprecated via the
+// stdlib annotation, version from the path DSL.
+func TestScalaDep_AkkaAnnotationVerb(t *testing.T) {
+	src := `
+import akka.http.scaladsl.server.Directives._
+
+val route =
+  path("v1" / "users") {
+    @deprecated("use v2", "1.5")
+    get {
+      complete("legacy")
+    }
+  }
+`
+	ents := extract(t, depKey, fi("AkkaRoutes.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["deprecated_since"] != "1.5" {
+		t.Errorf("deprecated_since = %q, want 1.5", e.Props["deprecated_since"])
+	}
+	if e.Props["deprecated_replacement"] != "v2" {
+		t.Errorf("deprecated_replacement = %q, want v2", e.Props["deprecated_replacement"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+	if e.Props["framework"] != "akka-http" {
+		t.Errorf("framework = %q, want akka-http", e.Props["framework"])
+	}
+}
+
+// TestScalaDep_PekkoAnnotation: pekko-http (org.apache.pekko) detected as its own
+// framework on a deprecated route.
+func TestScalaDep_PekkoAnnotation(t *testing.T) {
+	src := `
+import org.apache.pekko.http.scaladsl.server.Directives._
+
+val route =
+  path("api" / "v1" / "items") {
+    @deprecated("removed soon", "4.0")
+    get { complete("x") }
+  }
+`
+	ents := extract(t, depKey, fi("PekkoRoutes.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["framework"] != "pekko-http" {
+		t.Errorf("framework = %q, want pekko-http", e.Props["framework"])
+	}
+	if e.Props["deprecated_since"] != "4.0" {
+		t.Errorf("deprecated_since = %q, want 4.0", e.Props["deprecated_since"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+}
+
+// TestScalaDep_ScaladocTag: a Scaladoc @deprecated tag above an http4s route.
+func TestScalaDep_ScaladocTag(t *testing.T) {
+	src := `
+import org.http4s._
+
+/**
+ * Legacy lookup endpoint.
+ * @deprecated since 2.0 use /api/v2/lookup instead
+ */
+val route = HttpRoutes.of[IO] {
+  case GET -> Root / "api" / "v1" / "lookup" => Ok("l")
+}
+`
+	ents := extract(t, depKey, fi("Lookup.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated scaladoc")
+	if !ok {
+		t.Fatalf("expected @deprecated scaladoc marker; got: %+v", ents)
+	}
+	if e.Props["deprecated"] != "true" {
+		t.Errorf("deprecated = %q, want true", e.Props["deprecated"])
+	}
+	if e.Props["deprecated_since"] != "2.0" {
+		t.Errorf("deprecated_since = %q, want 2.0", e.Props["deprecated_since"])
+	}
+	if e.Props["deprecated_replacement"] != "/api/v2/lookup" {
+		t.Errorf("deprecated_replacement = %q, want /api/v2/lookup", e.Props["deprecated_replacement"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+}
+
+// TestScalaDep_BannerComment: a `// DEPRECATED` banner at a route.
+func TestScalaDep_BannerComment(t *testing.T) {
+	src := `
+import org.http4s._
+
+val route = HttpRoutes.of[IO] {
+  // DEPRECATED use /v2 instead
+  case GET -> Root / "v1" / "ping" => Ok("pong")
+}
+`
+	ents := extract(t, depKey, fi("Ping.scala", "scala", src))
+	e, ok := findDep(ents, "comment // DEPRECATED")
+	if !ok {
+		t.Fatalf("expected banner-comment marker; got: %+v", ents)
+	}
+	if e.Props["deprecated"] != "true" {
+		t.Errorf("deprecated = %q, want true", e.Props["deprecated"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+}
+
+// TestScalaDep_SunsetHeader: a Sunset response header (RFC 8594) on a route.
+func TestScalaDep_SunsetHeader(t *testing.T) {
+	src := `
+import org.http4s._
+import org.http4s.headers._
+
+val route = HttpRoutes.of[IO] {
+  case GET -> Root / "api" / "v1" / "report" =>
+    Ok("r").map(_.putHeaders(Header.Raw(ci"Sunset", "Wed, 11 Nov 2026 23:59:59 GMT")))
+}
+`
+	ents := extract(t, depKey, fi("Report.scala", "scala", src))
+	e, ok := findDep(ents, "Sunset response header")
+	if !ok {
+		t.Fatalf("expected Sunset header marker; got: %+v", ents)
+	}
+	if e.Props["deprecated"] != "true" {
+		t.Errorf("deprecated = %q, want true", e.Props["deprecated"])
+	}
+	if e.Props["api_version"] != "1" {
+		t.Errorf("api_version = %q, want 1", e.Props["api_version"])
+	}
+}
+
+// TestScalaDep_NamedSinceArg: the named `@deprecated(message = .., since = ..)`
+// form resolves the same as positional.
+func TestScalaDep_NamedSinceArg(t *testing.T) {
+	src := `
+import org.http4s._
+
+val route = HttpRoutes.of[IO] {
+  @deprecated(message = "use the new search", since = "5.2")
+  case GET -> Root / "api" / "v1" / "search" => Ok("s")
+}
+`
+	ents := extract(t, depKey, fi("Search.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["deprecated_since"] != "5.2" {
+		t.Errorf("deprecated_since = %q, want 5.2", e.Props["deprecated_since"])
+	}
+}
+
+// --- Negatives -------------------------------------------------------------
+
+// TestScalaDep_NonDeprecatedNone: a plain route with NO deprecation marker emits
+// no deprecation entity.
+func TestScalaDep_NonDeprecatedNone(t *testing.T) {
+	src := `
+import org.http4s._
+
+val route = HttpRoutes.of[IO] {
+  case GET -> Root / "api" / "v1" / "health" => Ok("ok")
+}
+`
+	ents := extract(t, depKey, fi("Health.scala", "scala", src))
+	for _, e := range ents {
+		if e.Subtype == "deprecation" {
+			t.Fatalf("expected NO deprecation marker on a non-deprecated route; got: %+v", e)
+		}
+	}
+}
+
+// TestScalaDep_VersionlessNoApiVersion: a deprecated route with no /vN segment
+// carries deprecated=true but NO api_version (honest-partial).
+func TestScalaDep_VersionlessNoApiVersion(t *testing.T) {
+	src := `
+import org.http4s._
+
+val route = HttpRoutes.of[IO] {
+  @deprecated("going away", "1.0")
+  case GET -> Root / "users" => Ok("u")
+}
+`
+	ents := extract(t, depKey, fi("Users.scala", "scala", src))
+	e, ok := findDep(ents, "@deprecated")
+	if !ok {
+		t.Fatalf("expected @deprecated marker; got: %+v", ents)
+	}
+	if e.Props["deprecated"] != "true" {
+		t.Errorf("deprecated = %q, want true", e.Props["deprecated"])
+	}
+	if v, present := e.Props["api_version"]; present {
+		t.Errorf("api_version should be ABSENT on a versionless route; got %q", v)
+	}
+}
+
+// TestScalaDep_NonRouteDeprecatedUnaffected: a @deprecated on a non-route helper
+// class (no route anchor nearby) does NOT emit a route-deprecation marker.
+func TestScalaDep_NonRouteDeprecatedUnaffected(t *testing.T) {
+	src := `
+import org.http4s._
+
+@deprecated("legacy model", "1.0")
+case class OldUser(id: Long, name: String)
+
+object Helpers {
+  @deprecated("use newFormat", "2.0")
+  def oldFormat(x: Int): String = x.toString
+}
+`
+	ents := extract(t, depKey, fi("Models.scala", "scala", src))
+	for _, e := range ents {
+		if e.Subtype == "deprecation" {
+			t.Fatalf("expected NO route-deprecation marker for non-route @deprecated; got: %+v", e)
+		}
+	}
+}
+
+// TestScalaDep_NonScalaSkipped: a non-scala file is skipped entirely.
+func TestScalaDep_NonScalaSkipped(t *testing.T) {
+	src := `@deprecated("x", "1.0") case GET -> Root / "v1" => Ok("x")`
+	ents := extract(t, depKey, fi("Routes.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-scala file; got: %+v", ents)
+	}
+}


### PR DESCRIPTION
Closes #4141 (child of epic #3628). **DEPLOY-DEFERRED** — live daemon untouched; deploy pending.

## Endpoint-shape finding (VERIFY-FIRST)
Scala HTTP endpoints are emitted as **`SCOPE.Operation`** entities by the custom `.scala` extractors (`akka.go` `path(...)`/`route:METHOD`, `tapir.go` `tapir:METHOD:path`), **not** `http_endpoint_definition`. The engine `resolveEndpointDeprecation` pass is gated on `Kind==http_endpoint_definition`, so it cannot reach Scala endpoints — the SAME situation PHP Symfony/API-Platform and Kotlin Ktor faced. **Resolution: stamp the contract in the CUSTOM-EXTRACTOR stage** (PHP/Kotlin precedent), confirmed by kotlin #4139's note.

## Stage / model
New `internal/custom/scala/endpoint_deprecation.go` (`custom_scala_endpoint_deprecation`, auto-dispatched for `.scala` via the `custom_scala_` prefix in `custom_dispatch.go`). Emits a **`SCOPE.Pattern/deprecation`** marker per deprecation site — the sibling of `rate_limit.go`'s `SCOPE.Pattern/rate_limit` model, since Scala's akka/http4s endpoints are emitted as un-composed `path(...)`/`route:METHOD` fragments with no single composed op to attach to without fabricating a route binding.

## Flagship shape matched (EXACTLY)
`deprecated="true"`, `deprecated_since`, `deprecated_replacement`, `deprecation_source`, `api_version`. Honest-partial throughout.

## Idioms covered
- **`@deprecated("use /api/v2/users", "2.0")`** Scala stdlib annotation — NOTE arg order is **message-FIRST, since-SECOND** (the reverse of Java's `@Deprecated(since=)`); named `message=`/`since=` also handled.
- **Scaladoc `@deprecated <msg>`** tag.
- **`// DEPRECATED`** banner comment.
- **`Sunset`/`Deprecation` response header** (RFC 8594) — `Header.Raw(ci"Sunset", …)` etc.
- **api_version** path-derived from the http4s/akka/pekko path-DSL (`Root / "api" / "v2"`, `path("v1" / …)`), **preferring the DSL form over a `/api/vN` literal inside the deprecation message** (so a replacement-path in the message is not mistaken for the route version).

## Exact deprecation/version asserted (value-asserting tests)
- `TestScalaDep_Http4sAnnotation` — `@deprecated("use /api/v2/users","2.0")` on `case GET -> Root / "api" / "v1" / "users"` → `deprecated_since=2.0`, `deprecated_replacement=/api/v2/users`, `api_version=1`.
- `TestScalaDep_Http4sDSLVersion` — `Root / "api" / "v2"` → `api_version=2`.
- `TestScalaDep_AkkaAnnotationVerb` — `since=1.5`, `replacement=v2`, `api_version=1`, `framework=akka-http`.
- `TestScalaDep_PekkoAnnotation` — `framework=pekko-http`, `since=4.0`, `api_version=1`.
- `TestScalaDep_ScaladocTag`, `TestScalaDep_BannerComment`, `TestScalaDep_SunsetHeader`, `TestScalaDep_NamedSinceArg`.
- **Negatives**: `TestScalaDep_NonDeprecatedNone`, `TestScalaDep_VersionlessNoApiVersion` (no `api_version`), `TestScalaDep_NonRouteDeprecatedUnaffected` (non-route `@deprecated` does not leak), `TestScalaDep_NonScalaSkipped`.

## Registry
`http4s` / `akka-http` / `pekko-http` cells flipped to **full** honestly (each cites the extractor + test, `verified_at=2026-06-03`, `issue=4141`). Other Scala frameworks (scalatra/cask/play/finatra/lagom/zio-http/tapir/sttp/caliban) remain **missing** — no value-asserted path yet. `go run ./tools/coverage fmt --check` → canonical.

## What's left missing (honest)
- Per-route binding: the marker carries the contract but isn't joined to a specific verb+path endpoint op (same honest limitation as `rate_limit.go`).
- Frameworks not flipped above have no value-asserted deprecation path in this PR.

## Tests
`go test ./internal/custom/scala/ ./internal/engine/ ./internal/extractors/ ./tools/coverage/ ./internal/types/` all **ok**. gofmt/vet clean. Worktree-isolated; main untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)