### PR TITLE
[php] feature_flag_gating: Laravel Pennant + Flagception idioms (framework-agnostic engine pass)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -51989,8 +51989,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "3706",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY edge (framework-agnostic engine pass, fires for every PHP file). Laravel Pennant idioms verified \u0026 attributed to the enclosing controller action/method: Feature::active(\"key\") / Feature::inactive(\"key\") / Feature::for($user)-\u003eactive(\"key\") facade + global feature(\"key\") helper. Cross-language SDKs also fire for PHP $var-\u003emethod idioms: Unleash $u-\u003eisEnabled(\"key\"), OpenFeature $c-\u003egetBooleanValue(\"key\",false), LaunchDarkly $c-\u003evariation(\"key\",...). Honest-partial: dynamic keys (Feature::active($k)) + non-Pennant $model-\u003eactive(\"x\") emit nothing (receiver-gated on the Feature facade).",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -52556,8 +52559,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "3706",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (framework-agnostic PHP engine pass). Laravel Pennant idioms (Lumen shares the Laravel facade/helper) attribute to the enclosing method: Feature::active/inactive(\"key\"), Feature::for($u)-\u003eactive(\"key\"), feature(\"key\") helper; cross-language Unleash/OpenFeature/LaunchDarkly $var idioms also fire. Honest-partial: dynamic keys + non-Pennant -\u003eactive() miss (receiver-gated).",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -53421,8 +53427,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "partial",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "3706",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (framework-agnostic PHP engine pass, fires regardless of framework). Slim hosts no first-party flag facade, but the cross-language SDK matchers fire for $var idioms: Unleash $u-\u003eisEnabled(\"key\"), OpenFeature $c-\u003egetBooleanValue(\"key\",false), LaunchDarkly $c-\u003evariation(\"key\",...), plus the Laravel feature(\"key\")/Pennant + Flagception matchers should a Slim app pull them in. Honest-partial: dynamic keys + non-flag receivers miss.",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",
@@ -53721,8 +53730,11 @@
             "verified_at": "2026-06-03"
           },
           "feature_flag_gating": {
-            "status": "missing",
-            "issue": "feature_flag_gating:#3706-not-yet-extracted"
+            "status": "full",
+            "cites": ["internal/engine/feature_flag_edges.go","internal/engine/feature_flag_edges_test.go","internal/engine/orm_queries.go"],
+            "issue": "3706",
+            "notes": "flag-check call sites -\u003e feature:\u003ckey\u003e + GATED_BY (framework-agnostic PHP engine pass). Symfony Flagception idiom verified \u0026 attributed to the enclosing method: $manager-\u003eisActive(\"key\") (receiver-gated on a flag/feature token, e.g. $this-\u003eflagception / $featureManager). Cross-language Unleash $u-\u003eisEnabled, OpenFeature $c-\u003egetBooleanValue, LaunchDarkly $c-\u003evariation $var idioms also fire. Honest-partial: dynamic keys + non-Flagception $model-\u003eisActive(\"x\") emit nothing.",
+            "verified_at": "2026-06-03"
           },
           "fs_effect": {
             "status": "partial",

--- a/internal/engine/feature_flag_edges.go
+++ b/internal/engine/feature_flag_edges.go
@@ -38,6 +38,11 @@
 //     Split-specific)
 //   - Unleash-React: useFlag("key") / useFlagsStatus — the @unleash/proxy-client
 //     React hook
+//   - Laravel Pennant (PHP) : Feature::active("key") / Feature::inactive("key") /
+//     Feature::for($u)->active("key") (facade), plus the global feature("key")
+//     helper
+//   - Flagception (Symfony/PHP) : $featureManager->isActive("key") —
+//     receiver-gated on a flag/feature receiver token
 //   - Generic/custom : getFlag("key") / feature_enabled("key") /
 //     featureEnabled("key") / isFeatureEnabled("key") — FF-specific custom
 //     wrappers, distinct enough from arbitrary code to attribute
@@ -77,7 +82,7 @@ const featureFlagPatternType = "feature_flag_gating"
 // flagHit is one detected flag-check call site.
 type flagHit struct {
 	key    string // literal flag key (symbol leading ':' already stripped)
-	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | flagsmith | ff4j | split | custom
+	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | flagsmith | ff4j | split | laravel-pennant | flagception | custom
 	method string // the SDK call/method observed
 	caller string // enclosing-function name ("" → file scope)
 	line   int    // 1-indexed source line
@@ -248,6 +253,58 @@ var flagSDKMatchers = []flagSDKMatcher{
 		),
 		sdk:    "ff4j",
 		method: "ff4j.check",
+	},
+
+	// Laravel Pennant (PHP). The Pennant facade exposes
+	// `Feature::active('flag')` / `Feature::inactive('flag')`, plus the scoped
+	// form `Feature::for($user)->active('flag')`. The check is receiver-gated on
+	// the capital-`Feature` facade reached via `::`, which is Pennant-specific,
+	// so a generic `->active(...)` on an arbitrary model (e.g.
+	// `$model->active('x')`) is NOT matched — only calls flowing from the
+	// `Feature` facade are. The optional `for(...)->` scope segment lets the
+	// per-scope idiom resolve to the same flag node. Case-SENSITIVE: the
+	// `Feature` class name is conventionally capitalised, and lower-casing it
+	// would collide with the bare `feature('key')` helper matcher below.
+	{
+		re: regexp.MustCompile(
+			`\bFeature::(?:for\s*\([^)]*\)\s*->\s*)?(?:active|inactive)\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "laravel-pennant",
+		method: "Feature::active",
+	},
+
+	// Laravel `feature('flag')` helper (PHP). Pennant ships a global
+	// `feature()` helper that is the function-call twin of the `Feature`
+	// facade. Case-SENSITIVE lowercase `feature(` so it matches the helper
+	// without colliding with the capitalised `Feature::` facade above or the
+	// `feature_enabled`/`featureEnabled` generic wrappers below (those carry a
+	// trailing `_enabled`/`Enabled` token, so `feature\s*\(` cannot match
+	// them). The `\b` before `feature` keeps `hasFeature(`/`getFeature(`
+	// (no word boundary mid-identifier) from matching.
+	{
+		re: regexp.MustCompile(
+			`\bfeature\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "laravel-pennant",
+		method: "feature",
+	},
+
+	// Symfony Flagception (PHP). The Flagception FeatureManager exposes
+	// `$manager->isActive('flag')`. `isActive` is generic on its own, so the
+	// receiver is gated to a token containing `flag` or `feature`
+	// (case-insensitive) — e.g. `$this->flagception`, `$featureManager`,
+	// `$features` — which captures the Flagception idiom while rejecting an
+	// arbitrary `$model->isActive('x')`. The receiver may arrive via `->` (an
+	// object property/var) or `::` (a static facade).
+	{
+		re: regexp.MustCompile(
+			`(?i)\$?\w*(?:flag|feature)\w*\s*(?:->|::)\s*isActive\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "flagception",
+		method: "isActive",
 	},
 
 	// Generic / custom feature-flag wrappers. getFlag("key") /

--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -1031,3 +1031,298 @@ public class Widget
 		t.Errorf("non-FeatureManager IsEnabled property should yield no output, got flags=%v edges=%v", flags, edges)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PHP (#4143) — Laravel Pennant facade/helper + Symfony Flagception, plus the
+// cross-language SDKs (LaunchDarkly/Unleash/OpenFeature) verified to already
+// fire for PHP `->`/`::` + `$var` idioms. Mirrors the go #3919 / ruby #4140
+// node/edge shape: `feature:<key>` node, `GATED_BY` edge from the enclosing
+// PHP function.
+// ---------------------------------------------------------------------------
+
+// Laravel Pennant: Feature::active('new-checkout') in a controller action →
+// checkout GATED_BY feature:new-checkout, SDK subtype "laravel-pennant".
+func TestFeatureFlag_PHP_Pennant_FeatureActive(t *testing.T) {
+	src := `<?php
+class CheckoutController
+{
+    public function checkout($cart)
+    {
+        if (Feature::active('new-checkout')) {
+            return $this->newCheckout($cart);
+        }
+        return $this->legacyCheckout($cart);
+    }
+}
+`
+	flags, edges := runFlagPass("php", "CheckoutController.php", src)
+
+	flag, ok := findFlag(flags, "new-checkout")
+	if !ok {
+		t.Fatalf("expected feature:new-checkout entity, got flags=%v", flags)
+	}
+	if flag.ID != "feature:new-checkout" {
+		t.Errorf("flag ID = %q, want feature:new-checkout", flag.ID)
+	}
+	if flag.Subtype != "laravel-pennant" {
+		t.Errorf("flag SDK subtype = %q, want laravel-pennant", flag.Subtype)
+	}
+
+	g, ok := findGate(edges, "new-checkout")
+	if !ok {
+		t.Fatalf("expected GATED_BY edge for new-checkout, got %v", edges)
+	}
+	if g.From != "Function:checkout" {
+		t.Errorf("GATED_BY FromID = %q, want Function:checkout", g.From)
+	}
+	if g.To != "feature:new-checkout" {
+		t.Errorf("GATED_BY ToID = %q, want feature:new-checkout", g.To)
+	}
+	if g.SDK != "laravel-pennant" {
+		t.Errorf("GATED_BY sdk = %q, want laravel-pennant", g.SDK)
+	}
+}
+
+// Laravel Pennant scoped form: Feature::for($user)->active('beta-ui') →
+// feature:beta-ui, SDK subtype "laravel-pennant", attributed to the enclosing
+// PHP method.
+func TestFeatureFlag_PHP_Pennant_FeatureForScoped(t *testing.T) {
+	src := `<?php
+class Dashboard
+{
+    public function show($user)
+    {
+        if (Feature::for($user)->active('beta-ui')) {
+            return $this->betaDashboard();
+        }
+        return $this->classicDashboard();
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Dashboard.php", src)
+	flag, ok := findFlag(flags, "beta-ui")
+	if !ok {
+		t.Fatalf("expected feature:beta-ui entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "laravel-pennant" {
+		t.Errorf("flag SDK subtype = %q, want laravel-pennant", flag.Subtype)
+	}
+	g, ok := findGate(edges, "beta-ui")
+	if !ok {
+		t.Fatalf("expected GATED_BY for beta-ui, got %v", edges)
+	}
+	if g.From != "Function:show" || g.To != "feature:beta-ui" {
+		t.Errorf("edge = %+v, want From=Function:show To=feature:beta-ui", g)
+	}
+}
+
+// Laravel `feature('dark-mode')` helper → feature:dark-mode, SDK subtype
+// "laravel-pennant", attributed to the enclosing PHP function.
+func TestFeatureFlag_PHP_Laravel_FeatureHelper(t *testing.T) {
+	src := `<?php
+class Theme
+{
+    public function render($user)
+    {
+        if (feature('dark-mode')) {
+            return $this->dark();
+        }
+        return $this->light();
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Theme.php", src)
+	flag, ok := findFlag(flags, "dark-mode")
+	if !ok {
+		t.Fatalf("expected feature:dark-mode entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "laravel-pennant" {
+		t.Errorf("flag SDK subtype = %q, want laravel-pennant", flag.Subtype)
+	}
+	g, ok := findGate(edges, "dark-mode")
+	if !ok {
+		t.Fatalf("expected GATED_BY for dark-mode, got %v", edges)
+	}
+	if g.From != "Function:render" || g.To != "feature:dark-mode" {
+		t.Errorf("edge = %+v, want From=Function:render To=feature:dark-mode", g)
+	}
+}
+
+// Symfony Flagception: $this->flagception->isActive('promo') → feature:promo,
+// SDK subtype "flagception". The receiver token contains `flagception`, so the
+// receiver gate fires.
+func TestFeatureFlag_PHP_Flagception_isActive(t *testing.T) {
+	src := `<?php
+class PromoService
+{
+    public function run()
+    {
+        if ($this->flagception->isActive('promo')) {
+            return $this->showPromo();
+        }
+        return null;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "PromoService.php", src)
+	flag, ok := findFlag(flags, "promo")
+	if !ok {
+		t.Fatalf("expected feature:promo entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "flagception" {
+		t.Errorf("flag SDK subtype = %q, want flagception", flag.Subtype)
+	}
+	g, ok := findGate(edges, "promo")
+	if !ok {
+		t.Fatalf("expected GATED_BY for promo, got %v", edges)
+	}
+	if g.From != "Function:run" || g.To != "feature:promo" {
+		t.Errorf("edge = %+v, want From=Function:run To=feature:promo", g)
+	}
+}
+
+// PHP CREDIT — the cross-language Unleash matcher already fires for the
+// Unleash-php `$unleash->isEnabled('beta')` idiom. SDK subtype "unleash".
+func TestFeatureFlag_PHP_Unleash_isEnabled_Credited(t *testing.T) {
+	src := `<?php
+class Gate
+{
+    public function run()
+    {
+        if ($unleash->isEnabled('beta')) {
+            return 1;
+        }
+        return 0;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Gate.php", src)
+	flag, ok := findFlag(flags, "beta")
+	if !ok {
+		t.Fatalf("expected feature:beta entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "unleash" {
+		t.Errorf("flag SDK subtype = %q, want unleash", flag.Subtype)
+	}
+	g, ok := findGate(edges, "beta")
+	if !ok || g.From != "Function:run" || g.To != "feature:beta" {
+		t.Errorf("edge = %+v ok=%v, want From=Function:run To=feature:beta", g, ok)
+	}
+}
+
+// PHP CREDIT — the cross-language OpenFeature matcher already fires for
+// `$client->getBooleanValue('new-ui', false)`. SDK subtype "openfeature".
+func TestFeatureFlag_PHP_OpenFeature_getBooleanValue_Credited(t *testing.T) {
+	src := `<?php
+class Gate
+{
+    public function run()
+    {
+        $v = $client->getBooleanValue('new-ui', false);
+        return $v;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Gate.php", src)
+	flag, ok := findFlag(flags, "new-ui")
+	if !ok {
+		t.Fatalf("expected feature:new-ui entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "openfeature" {
+		t.Errorf("flag SDK subtype = %q, want openfeature", flag.Subtype)
+	}
+	if g, ok := findGate(edges, "new-ui"); !ok || g.From != "Function:run" {
+		t.Errorf("edge = %+v ok=%v, want From=Function:run", g, ok)
+	}
+}
+
+// PHP CREDIT — the LaunchDarkly variation family fires for
+// `$client->variation('ld-flag', $context, false)`. SDK subtype "launchdarkly".
+func TestFeatureFlag_PHP_LaunchDarkly_variation_Credited(t *testing.T) {
+	src := `<?php
+class Gate
+{
+    public function run($context)
+    {
+        $v = $client->variation('ld-flag', $context, false);
+        return $v;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Gate.php", src)
+	flag, ok := findFlag(flags, "ld-flag")
+	if !ok {
+		t.Fatalf("expected feature:ld-flag entity, got flags=%v", flags)
+	}
+	if flag.Subtype != "launchdarkly" {
+		t.Errorf("flag SDK subtype = %q, want launchdarkly", flag.Subtype)
+	}
+	if g, ok := findGate(edges, "ld-flag"); !ok || g.From != "Function:run" {
+		t.Errorf("edge = %+v ok=%v, want From=Function:run", g, ok)
+	}
+}
+
+// PHP NEGATIVE (receiver gate) — `$model->active('x')` is an ordinary
+// Eloquent-style `active()` call on a NON-Pennant receiver, so the Pennant
+// matcher (gated on the `Feature::` facade) does NOT fire. No output.
+func TestFeatureFlag_PHP_NonPennantActive_NoFabrication(t *testing.T) {
+	src := `<?php
+class Repo
+{
+    public function run($model)
+    {
+        if ($model->active('x')) {
+            return 1;
+        }
+        return 0;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Repo.php", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("non-Pennant ->active() should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// PHP NEGATIVE (receiver gate) — `$model->isActive('x')` on a receiver with no
+// flag/feature token is NOT attributed to Flagception. No output.
+func TestFeatureFlag_PHP_NonFlagceptionIsActive_NoFabrication(t *testing.T) {
+	src := `<?php
+class Repo
+{
+    public function run($model)
+    {
+        if ($model->isActive('x')) {
+            return 1;
+        }
+        return 0;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Repo.php", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("non-Flagception isActive should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// PHP NEGATIVE (honest-partial) — a dynamic Pennant key
+// `Feature::active($flagName)` is a non-literal argument, so no flag entity is
+// fabricated and no edge is emitted.
+func TestFeatureFlag_PHP_Pennant_DynamicKey_NoFabrication(t *testing.T) {
+	src := `<?php
+class Gate
+{
+    public function run($flagName)
+    {
+        if (Feature::active($flagName)) {
+            return 1;
+        }
+        return 0;
+    }
+}
+`
+	flags, edges := runFlagPass("php", "Gate.php", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("dynamic Pennant key should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}


### PR DESCRIPTION
Closes #4143 (epic #3628 area #17). **DEPLOY-DEFERRED** — live daemon untouched; reindex + re-bench after the next coordinated deploy.

## Verify-first (live registry main 8e152b9fa)
Probed real PHP against the current `internal/engine/feature_flag_edges.go` matcher table BEFORE any change:

| PHP idiom | SDK | Fired before? | After |
|---|---|---|---|
| `$client->getBooleanValue('new-ui', false)` (OpenFeature) | openfeature | **YES** | credited |
| `$unleash->isEnabled('beta')` (Unleash-php) | unleash | **YES** | credited |
| `$client->variation('ld-flag', $ctx, false)` (LaunchDarkly-php) | launchdarkly | **YES** | credited |
| `Feature::active('new-checkout')` (Laravel Pennant) | laravel-pennant | NO | **added** |
| `Feature::for($u)->active('beta-ui')` (Pennant scoped) | laravel-pennant | NO | **added** |
| `feature('dark-mode')` (Laravel helper) | laravel-pennant | NO | **added** |
| `$this->flagception->isActive('promo')` (Symfony Flagception) | flagception | NO | **added** |

## Added matchers (genuinely missed; mirror go #3919 / ruby #4140 shape)
- **Laravel Pennant facade** — `Feature::active|inactive('key')` + scoped `Feature::for($u)->active('key')`. Receiver-gated on the capital-`Feature` facade via `::`.
- **Laravel `feature('key')` helper** — bare-call form, case-SENSITIVE lowercase so it can't collide with the `Feature::` facade or the `feature_enabled`/`featureEnabled` generic wrappers.
- **Symfony Flagception** — `$mgr->isActive('key')`, receiver-gated on a `flag`/`feature` receiver token.

Each emits the `feature:<key>` node + `GATED_BY` edge from the enclosing PHP function (`indexEnclosingFunctions` already supports PHP).

## False-positive guards (value-asserted negatives)
- `$model->active('x')` (non-Pennant receiver) → nothing (facade gate).
- `$model->isActive('x')` (no flag/feature token) → nothing (receiver gate).
- `Feature::active($flagName)` / `feature($k)` (dynamic key) → nothing (honest-partial: literal-only).
- `$svc->getFeature('x')` → nothing; `$svc->hasFeature('x')` correctly stays the existing Flagsmith matcher (unchanged).

## Tests
10 new value-asserting PHP tests (exact `feature:<key>` node + `GATED_BY` FromID + SDK subtype; 3 negatives). Full suites pass:
`go test ./internal/engine/ ./internal/extractors/ ./tools/coverage/` + `./internal/types/` guardrail + `go vet`.

## Registry credit (surgical, canonical)
`docs/coverage/registry.json` `Substrate.feature_flag_gating` for PHP frameworks — credited by-fixture/by-idiom discipline (not blind bulk-copy, per #3919):
- `laravel` **full**, `lumen` **full** (Pennant facade+helper), `symfony` **full** (Flagception), `slim` **partial** (generic SDKs only, no first-party facade).
- Surgical line-range edits, `go run ./tools/coverage fmt --check` → canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)