### PR TITLE
feat(engine): Elixir feature_flag_gating — FunWithFlags / Flippant / Unleash bare enabled?

### DIFF
--- a/internal/engine/feature_flag_edges.go
+++ b/internal/engine/feature_flag_edges.go
@@ -28,7 +28,8 @@
 //     IsEnabled("key") / the [FeatureGate("key")] attribute on an MVC
 //     controller/action (Microsoft.FeatureManagement)
 //   - Unleash      : unleash.isEnabled("key") / isFeatureEnabled("key") /
-//     (Ruby) unleash.is_enabled?("key") — the `?`-suffixed predicate form
+//     (Ruby) unleash.is_enabled?("key") — the `?`-suffixed predicate form /
+//     (Elixir) Unleash.enabled?("key") — the bare `enabled?` predicate
 //   - OpenFeature  : client.getBooleanValue("key", false) /
 //     getStringValue / getNumberValue / getObjectValue
 //   - Flipper      : (Ruby) Flipper.enabled?(:key) / Flipper[:key].enabled? /
@@ -47,6 +48,11 @@
 //     gb/growthbook)
 //   - ConfigCat     : configCatClient.getValue("key", default) /
 //     getValueAsync / getValueDetails (receiver-gated on configCat*)
+//   - FunWithFlags  : (Elixir) FunWithFlags.enabled?(:key) /
+//     FunWithFlags.enabled?(:key, for: actor) / FunWithFlags.enabled?("key")
+//     — receiver-gated on the `FunWithFlags` module; atom key normalized
+//   - Flippant      : (Elixir) Flippant.enabled?("key", actor) — receiver-gated
+//     on the `Flippant` module; string or (normalized) atom key
 //   - Generic/custom : getFlag("key") / feature_enabled("key") /
 //     featureEnabled("key") / isFeatureEnabled("key") — FF-specific custom
 //     wrappers, distinct enough from arbitrary code to attribute
@@ -86,7 +92,7 @@ const featureFlagPatternType = "feature_flag_gating"
 // flagHit is one detected flag-check call site.
 type flagHit struct {
 	key    string // literal flag key (symbol leading ':' already stripped)
-	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | rollout | flagsmith | ff4j | split | growthbook | configcat | custom
+	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | rollout | flagsmith | ff4j | split | growthbook | configcat | funwithflags | flippant | custom
 	method string // the SDK call/method observed
 	caller string // enclosing-function name ("" → file scope)
 	line   int    // 1-indexed source line
@@ -334,6 +340,55 @@ var flagSDKMatchers = []flagSDKMatcher{
 		),
 		sdk:    "configcat",
 		method: "configCat.getValue",
+	},
+
+	// FunWithFlags (Elixir). FunWithFlags.enabled?(:flag) /
+	// FunWithFlags.enabled?(:flag, for: actor) / FunWithFlags.enabled?("flag").
+	// The bare `.enabled?` predicate is far too common in Elixir (any struct can
+	// expose an `enabled?/1` predicate) to attribute on its own, so the
+	// FunWithFlags module receiver is required — the same receiver-gated
+	// discipline used for Flipper / FF4j / Rollout. Elixir flag keys are
+	// idiomatically atoms (`:flag`); the leading `:` is stripped by the symbol
+	// sub-pattern so an atom key normalizes to the same node a string key
+	// (`"flag"`) of the same name would (mirroring Ruby's symbol normalization).
+	// The case-sensitive `FunWithFlags` receiver matches the canonical Elixir
+	// module name.
+	{
+		re: regexp.MustCompile(
+			`\bFunWithFlags\s*\.\s*enabled\?\s*\(\s*` +
+				`(?::([A-Za-z_]\w*[?!]?)|"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "funwithflags",
+		method: "FunWithFlags.enabled?",
+	},
+
+	// Flippant (Elixir). Flippant.enabled?("flag", actor) — string-key feature
+	// gate. As with FunWithFlags, the bare `.enabled?` predicate is receiver-
+	// gated on the `Flippant` module name to keep it from false-positiving on
+	// arbitrary `.enabled?` predicates. Flippant keys are conventionally
+	// strings; an atom key is accepted too (normalized) for symmetry.
+	{
+		re: regexp.MustCompile(
+			`\bFlippant\s*\.\s*enabled\?\s*\(\s*` +
+				`(?::([A-Za-z_]\w*[?!]?)|"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "flippant",
+		method: "Flippant.enabled?",
+	},
+
+	// Unleash (Elixir). Unleash.enabled?("flag"). The Elixir Unleash client
+	// exposes the check as a bare `enabled?` predicate rather than the
+	// `is_enabled?` form the Ruby SDK uses (handled by the Unleash matcher
+	// above), so this dedicated, receiver-gated matcher claims the Elixir idiom.
+	// The `Unleash` module receiver keeps the generic `.enabled?` predicate from
+	// false-positiving; atom or string key (atom normalized).
+	{
+		re: regexp.MustCompile(
+			`\bUnleash\s*\.\s*enabled\?\s*\(\s*` +
+				`(?::([A-Za-z_]\w*[?!]?)|"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "unleash",
+		method: "Unleash.enabled?",
 	},
 
 	// Generic / custom feature-flag wrappers. getFlag("key") /

--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -1340,3 +1340,165 @@ function pick(user) {
 		t.Errorf("expected exactly one flag/edge, got flags=%v edges=%v", flags, edges)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Elixir (#3628 area #17) — FunWithFlags / Flippant / Unleash bare `enabled?`.
+//
+// Elixir flag keys are idiomatically atoms (`:flag`); the leading `:` is
+// stripped so an atom key converges on the same `feature:<key>` node a string
+// key of the same name produces (mirroring Ruby symbol normalization). Elixir
+// has no enclosing-function index in indexEnclosingFunctions (orm_queries.go),
+// so the GATED_BY edge is file-scope-anchored (`File:<path>`) — the same
+// fallback used in any language where the enclosing def can't be resolved. The
+// FunWithFlags / Flippant / Unleash module receivers are required so the bare
+// `.enabled?` predicate (ubiquitous in Elixir) is only attributed when it is
+// the flag SDK API.
+// ---------------------------------------------------------------------------
+
+// ELIXIR — FunWithFlags.enabled?(:new_checkout, for: user): atom key normalized
+// (leading `:` stripped) → feature:new_checkout, SDK subtype "funwithflags".
+func TestFeatureFlag_Elixir_FunWithFlags_atom_for_actor(t *testing.T) {
+	src := `
+defmodule Checkout do
+  def run(cart, user) do
+    if FunWithFlags.enabled?(:new_checkout, for: user) do
+      new_flow(cart)
+    else
+      legacy(cart)
+    end
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "checkout.ex", src)
+
+	flag, ok := findFlag(flags, "new_checkout")
+	if !ok {
+		t.Fatalf("expected feature:new_checkout entity (atom normalized), got flags=%v", flags)
+	}
+	if flag.ID != "feature:new_checkout" {
+		t.Errorf("flag ID = %q, want feature:new_checkout", flag.ID)
+	}
+	if flag.Subtype != "funwithflags" {
+		t.Errorf("flag SDK subtype = %q, want funwithflags", flag.Subtype)
+	}
+
+	g, ok := findGate(edges, "new_checkout")
+	if !ok {
+		t.Fatalf("expected GATED_BY for new_checkout, got %v", edges)
+	}
+	if g.From != "File:checkout.ex" {
+		t.Errorf("GATED_BY FromID = %q, want File:checkout.ex (no Elixir enclosing-func index)", g.From)
+	}
+	if g.To != "feature:new_checkout" {
+		t.Errorf("GATED_BY ToID = %q, want feature:new_checkout", g.To)
+	}
+	if g.SDK != "funwithflags" {
+		t.Errorf("GATED_BY sdk = %q, want funwithflags", g.SDK)
+	}
+}
+
+// ELIXIR — FunWithFlags.enabled?("beta"): string-key form also fires.
+func TestFeatureFlag_Elixir_FunWithFlags_string_key(t *testing.T) {
+	src := `
+defmodule Page do
+  def render do
+    FunWithFlags.enabled?("beta")
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "page.ex", src)
+	flag, ok := findFlag(flags, "beta")
+	if !ok || flag.Subtype != "funwithflags" {
+		t.Fatalf("expected feature:beta funwithflags entity, got %v", flags)
+	}
+	if _, ok := findGate(edges, "beta"); !ok {
+		t.Fatalf("expected GATED_BY for beta, got %v", edges)
+	}
+}
+
+// ELIXIR — Flippant.enabled?("flag", actor): string key, receiver-gated.
+func TestFeatureFlag_Elixir_Flippant_enabled(t *testing.T) {
+	src := `
+defmodule Gate do
+  def call(actor) do
+    Flippant.enabled?("search_v2", actor)
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "gate.ex", src)
+	flag, ok := findFlag(flags, "search_v2")
+	if !ok {
+		t.Fatalf("expected feature:search_v2 entity, got %v", flags)
+	}
+	if flag.Subtype != "flippant" {
+		t.Errorf("flag SDK = %q, want flippant", flag.Subtype)
+	}
+	g, ok := findGate(edges, "search_v2")
+	if !ok {
+		t.Fatalf("expected GATED_BY for search_v2, got %v", edges)
+	}
+	if g.SDK != "flippant" {
+		t.Errorf("GATED_BY sdk = %q, want flippant", g.SDK)
+	}
+}
+
+// ELIXIR — Unleash.enabled?("beta"): the bare `enabled?` predicate (vs the Ruby
+// SDK's `is_enabled?`), receiver-gated on the Unleash module → SDK "unleash".
+func TestFeatureFlag_Elixir_Unleash_bare_enabled(t *testing.T) {
+	src := `
+defmodule Feed do
+  def show do
+    if Unleash.enabled?("beta") do
+      :new
+    else
+      :stable
+    end
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "feed.ex", src)
+	flag, ok := findFlag(flags, "beta")
+	if !ok {
+		t.Fatalf("expected feature:beta entity, got %v", flags)
+	}
+	if flag.Subtype != "unleash" {
+		t.Errorf("flag SDK = %q, want unleash", flag.Subtype)
+	}
+	if g, ok := findGate(edges, "beta"); !ok || g.SDK != "unleash" {
+		t.Errorf("expected GATED_BY beta sdk=unleash, got %+v ok=%v", g, ok)
+	}
+}
+
+// ELIXIR NEGATIVE — a bare `.enabled?` on a NON-FF receiver must NOT be
+// attributed: the FunWithFlags / Flippant / Unleash matchers each require their
+// module receiver, so `record.enabled?(:foo)` on an arbitrary struct emits
+// nothing (the ubiquitous Elixir predicate stays unattributed).
+func TestFeatureFlag_Elixir_NonFlagReceiver_NoFabrication(t *testing.T) {
+	src := `
+defmodule View do
+  def visible?(record) do
+    SomeMod.enabled?(:foo) and record.enabled?
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "view.ex", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("non-FF .enabled? receiver should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// ELIXIR NEGATIVE — a dynamic (non-literal) flag key must NOT fabricate a flag
+// entity or edge (honest-partial, mirrors the other languages).
+func TestFeatureFlag_Elixir_DynamicKey_NoFabrication(t *testing.T) {
+	src := `
+defmodule Gate do
+  def check(flag, user) do
+    FunWithFlags.enabled?(flag, for: user)
+  end
+end
+`
+	flags, edges := runFlagPass("elixir", "dyn.ex", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("dynamic FunWithFlags key should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}


### PR DESCRIPTION
## Summary
Extends the framework-agnostic `applyFeatureFlagEdges` engine pass (`internal/engine/feature_flag_edges.go`) to recognise the canonical **Elixir** flag-SDK idioms. Mirrors the go/ruby shape exactly: one `feature:<key>` node + a `GATED_BY` edge per (caller, flag).

## VERIFY-FIRST (base 62fb4bbeb, before any change)
Value-asserting probes on real Elixir:

| Idiom | Before | After |
|---|---|---|
| `Unleash.is_enabled?("beta")` | ✅ fired (Ruby `is_enabled?` matcher) | ✅ (unchanged) |
| `FunWithFlags.enabled?(:new_checkout, for: user)` | ❌ missed | ✅ `feature:new_checkout` (atom normalized) |
| `FunWithFlags.enabled?("beta")` | ❌ missed | ✅ `feature:beta` |
| `Flippant.enabled?("flag", actor)` | ❌ missed | ✅ `feature:flag` |
| `Unleash.enabled?("beta")` (bare predicate) | ❌ missed | ✅ `feature:beta` |

## Change
Three new receiver-gated matchers:
- `FunWithFlags.enabled?(:key \| "key", for: actor)` → sdk `funwithflags`
- `Flippant.enabled?("key", actor)` → sdk `flippant`
- `Unleash.enabled?("key")` → sdk `unleash` (the bare `enabled?` Elixir form vs Ruby `is_enabled?`)

Elixir atom keys (`:flag`) normalize to the same `feature:<key>` node a string key produces (leading `:` stripped, same disposition as Ruby symbols).

## False-positive guards
- Each matcher is **receiver-gated** on its module name (`FunWithFlags` / `Flippant` / `Unleash`) so the ubiquitous bare `.enabled?` Elixir predicate is only attributed when it is the flag SDK API.
- Negatives asserted: `SomeMod.enabled?(:x)` / `record.enabled?` (non-FF receiver) → nothing; `FunWithFlags.enabled?(flag)` (dynamic key) → nothing.

## Honest-partial
Elixir has no enclosing-function index in `indexEnclosingFunctions` (orm_queries.go), so GATED_BY edges are file-scope-anchored (`File:<path>`) — the standard fallback. Out of scope for this PR; noted in the registry cells.

## Tests
6 value-asserting Elixir unit tests (atom-for-actor normalization, string key, Flippant, bare Unleash, non-FF-receiver negative, dynamic-key negative). Full packages green: `go test ./internal/engine/ ./internal/extractors/ ./tools/coverage/`.

## Registry
14 `lang.elixir.framework.*` `feature_flag_gating` cells moved `missing → partial` via `covtool update` (canonical; `covtool fmt --check` passes, `covtool validate` ok).

## Deploy
DEPLOY-DEFERRED — live daemon untouched; ships with the next coordinated rebuild+reindex.

Closes #4149

🤖 Generated with [Claude Code](https://claude.com/claude-code)