### PR TITLE
[php] feature_flag_gating: Laravel Pennant + Flagception (framework-agnostic engine pass)

### DIFF
--- a/internal/engine/feature_flag_edges.go
+++ b/internal/engine/feature_flag_edges.go
@@ -53,6 +53,12 @@
 //     — receiver-gated on the `FunWithFlags` module; atom key normalized
 //   - Flippant      : (Elixir) Flippant.enabled?("key", actor) — receiver-gated
 //     on the `Flippant` module; string or (normalized) atom key
+//   - Laravel Pennant: (PHP) Feature::active("key") / Feature::inactive("key") /
+//     Feature::for($u)->active("key") (facade) + the global feature("key")
+//     helper — receiver-gated on the capital `Feature::` facade (the helper is
+//     case-sensitive lowercase to avoid collision)
+//   - Flagception   : (PHP/Symfony) $featureManager->isActive("key") —
+//     receiver-gated on a flag/feature receiver token
 //   - Generic/custom : getFlag("key") / feature_enabled("key") /
 //     featureEnabled("key") / isFeatureEnabled("key") — FF-specific custom
 //     wrappers, distinct enough from arbitrary code to attribute
@@ -92,7 +98,7 @@ const featureFlagPatternType = "feature_flag_gating"
 // flagHit is one detected flag-check call site.
 type flagHit struct {
 	key    string // literal flag key (symbol leading ':' already stripped)
-	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | rollout | flagsmith | ff4j | split | growthbook | configcat | funwithflags | flippant | custom
+	sdk    string // detecting SDK: launchdarkly | featuremanagement | unleash | unleash-react | openfeature | flipper | rollout | flagsmith | ff4j | split | growthbook | configcat | funwithflags | flippant | laravel-pennant | flagception | custom
 	method string // the SDK call/method observed
 	caller string // enclosing-function name ("" → file scope)
 	line   int    // 1-indexed source line
@@ -389,6 +395,64 @@ var flagSDKMatchers = []flagSDKMatcher{
 		),
 		sdk:    "unleash",
 		method: "Unleash.enabled?",
+	},
+
+	// Laravel Pennant facade (PHP). `Feature::active('new-checkout')` /
+	// `Feature::inactive('old-ui')` — the Pennant `Feature` facade exposes the
+	// gating check as `active`/`inactive` static-style calls via `::`. The
+	// scoped form `Feature::for($user)->active('beta-ui')` resolves a scope
+	// first, then calls `active`/`inactive`; the `Feature::for(...)->` prefix is
+	// matched optionally so both the bare facade call and the scoped call attach
+	// to the same matcher. Receiver-gated on the capital-`Feature` facade token
+	// reached via `::` — case-SENSITIVE so an ordinary `$model->active('x')` (no
+	// `Feature::` receiver) cannot false-positive. The Pennant `active`/`inactive`
+	// method pair is the gating predicate; `value()`/`for()` lookups are not
+	// matched (no gating decision). Literal key only (a dynamic
+	// `Feature::active($flagName)` yields no hit).
+	{
+		re: regexp.MustCompile(
+			`\bFeature::(?:for\s*\([^)]*\)\s*->\s*)?(?:active|inactive)\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "laravel-pennant",
+		method: "Feature::active",
+	},
+
+	// Laravel Pennant global helper (PHP). `feature('dark-mode')` — the
+	// framework-provided `feature()` helper resolves the Pennant manager and
+	// checks the flag in one bare call. Case-SENSITIVE lowercase `feature(` so it
+	// cannot collide with the capital-`Feature::` facade above nor with the
+	// generic `feature_enabled`/`featureEnabled` wrappers (which require an
+	// `_?enabled` suffix the bare helper does not have). A receiver-qualified
+	// `->feature(...)` / `::feature(...)` is excluded via the leading `\b` plus a
+	// negative check on a preceding member-access operator, so an unrelated
+	// `$repo->feature('x')` lookup is not misattributed. Literal key only.
+	{
+		re: regexp.MustCompile(
+			`(?:^|[^>:\w$])feature\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "laravel-pennant",
+		method: "feature",
+	},
+
+	// Symfony Flagception (PHP). `$featureManager->isActive('promo')` — the
+	// Flagception manager exposes the gating check as `isActive('key')`. The bare
+	// `isActive` method name is too generic to attribute on its own (any model
+	// could expose `isActive`), so a flag/feature-flavoured receiver token is
+	// required: the receiver variable name must contain `flag` or `feature`
+	// (e.g. `$featureManager`, `$flagManager`, `$this->flagception` via a
+	// `flag`-named member). Same receiver-gated discipline used for
+	// FF4j/Rollout/GrowthBook. Case-insensitive on the receiver token so
+	// `featureManager`/`FeatureManager`/`flagception` all qualify. Literal key
+	// only.
+	{
+		re: regexp.MustCompile(
+			`(?i)\$?\w*(?:flag|feature)\w*\s*->\s*isActive\s*\(\s*` +
+				`(?:"([^"\\]+)"|'([^'\\]+)')`,
+		),
+		sdk:    "flagception",
+		method: "isActive",
 	},
 
 	// Generic / custom feature-flag wrappers. getFlag("key") /

--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -1502,3 +1502,161 @@ end
 		t.Errorf("dynamic FunWithFlags key should yield no output, got flags=%v edges=%v", flags, edges)
 	}
 }
+
+// PHP — Laravel Pennant facade: `Feature::active('new-checkout')` →
+// feature:new-checkout, SDK subtype "laravel-pennant", attributed to the
+// enclosing PHP function.
+func TestFeatureFlag_PHP_Pennant_Active(t *testing.T) {
+	src := `<?php
+function checkout() {
+    if (Feature::active('new-checkout')) {
+        return newCheckout();
+    }
+    return legacyCheckout();
+}
+`
+	flags, edges := runFlagPass("php", "checkout.php", src)
+	flag, ok := findFlag(flags, "new-checkout")
+	if !ok {
+		t.Fatalf("expected feature:new-checkout entity, got %v", flags)
+	}
+	if flag.ID != "feature:new-checkout" {
+		t.Errorf("flag ID = %q, want feature:new-checkout", flag.ID)
+	}
+	if flag.Subtype != "laravel-pennant" {
+		t.Errorf("flag SDK = %q, want laravel-pennant", flag.Subtype)
+	}
+	g, ok := findGate(edges, "new-checkout")
+	if !ok {
+		t.Fatalf("expected GATED_BY for new-checkout, got %v", edges)
+	}
+	if g.From != "Function:checkout" || g.To != "feature:new-checkout" {
+		t.Errorf("edge = %+v, want From=Function:checkout To=feature:new-checkout", g)
+	}
+	if g.SDK != "laravel-pennant" {
+		t.Errorf("edge sdk = %q, want laravel-pennant", g.SDK)
+	}
+}
+
+// PHP — Laravel Pennant `inactive` predicate and the scoped
+// `Feature::for($u)->active('key')` form both attribute to the laravel-pennant
+// subtype.
+func TestFeatureFlag_PHP_Pennant_Inactive_And_Scoped(t *testing.T) {
+	src := `<?php
+function render($u) {
+    if (Feature::inactive('old-ui')) {
+        return null;
+    }
+    if (Feature::for($u)->active('beta-ui')) {
+        return beta();
+    }
+}
+`
+	flags, edges := runFlagPass("php", "render.php", src)
+	if f, ok := findFlag(flags, "old-ui"); !ok || f.Subtype != "laravel-pennant" {
+		t.Fatalf("expected feature:old-ui laravel-pennant entity, got %v", flags)
+	}
+	if f, ok := findFlag(flags, "beta-ui"); !ok || f.Subtype != "laravel-pennant" {
+		t.Fatalf("expected feature:beta-ui laravel-pennant entity, got %v", flags)
+	}
+	g1, ok := findGate(edges, "old-ui")
+	if !ok || g1.From != "Function:render" || g1.To != "feature:old-ui" {
+		t.Errorf("old-ui edge = %+v ok=%v, want Function:render -> feature:old-ui", g1, ok)
+	}
+	g2, ok := findGate(edges, "beta-ui")
+	if !ok || g2.From != "Function:render" || g2.To != "feature:beta-ui" {
+		t.Errorf("beta-ui edge = %+v ok=%v, want Function:render -> feature:beta-ui", g2, ok)
+	}
+}
+
+// PHP — Laravel Pennant global helper: `feature('dark-mode')` →
+// feature:dark-mode, laravel-pennant. The bare lowercase helper is distinct
+// from the capital-`Feature::` facade and from the generic feature_enabled
+// wrapper.
+func TestFeatureFlag_PHP_Pennant_Helper(t *testing.T) {
+	src := `<?php
+function nav() {
+    if (feature('dark-mode')) {
+        return darkNav();
+    }
+    return lightNav();
+}
+`
+	flags, edges := runFlagPass("php", "nav.php", src)
+	flag, ok := findFlag(flags, "dark-mode")
+	if !ok || flag.Subtype != "laravel-pennant" {
+		t.Fatalf("expected feature:dark-mode laravel-pennant entity, got %v", flags)
+	}
+	g, ok := findGate(edges, "dark-mode")
+	if !ok || g.From != "Function:nav" || g.To != "feature:dark-mode" {
+		t.Errorf("edge = %+v ok=%v, want Function:nav -> feature:dark-mode", g, ok)
+	}
+	if g.SDK != "laravel-pennant" {
+		t.Errorf("edge sdk = %q, want laravel-pennant", g.SDK)
+	}
+}
+
+// PHP — Symfony Flagception: `$featureManager->isActive('promo')` →
+// feature:promo, SDK subtype "flagception". Receiver-gated on a flag/feature
+// receiver token.
+func TestFeatureFlag_PHP_Flagception_IsActive(t *testing.T) {
+	src := `<?php
+class PromoController {
+    public function show() {
+        if ($this->featureManager->isActive('promo')) {
+            return $this->promoView();
+        }
+    }
+}
+`
+	flags, edges := runFlagPass("php", "promo.php", src)
+	flag, ok := findFlag(flags, "promo")
+	if !ok {
+		t.Fatalf("expected feature:promo entity, got %v", flags)
+	}
+	if flag.Subtype != "flagception" {
+		t.Errorf("flag SDK = %q, want flagception", flag.Subtype)
+	}
+	g, ok := findGate(edges, "promo")
+	if !ok || g.To != "feature:promo" {
+		t.Fatalf("expected GATED_BY for promo, got %v", edges)
+	}
+	if g.From != "Function:show" {
+		t.Errorf("edge From = %q, want Function:show", g.From)
+	}
+	if g.SDK != "flagception" {
+		t.Errorf("edge sdk = %q, want flagception", g.SDK)
+	}
+}
+
+// PHP NEGATIVE — `$model->active('x')` (no Pennant `Feature::` facade) and
+// `$model->isActive('x')` (no flag/feature receiver token) are ordinary
+// model predicates, NOT feature-flag checks: no entity, no edge.
+func TestFeatureFlag_PHP_NonFlagPredicates_NoFabrication(t *testing.T) {
+	src := `<?php
+function f($model, $user) {
+    $a = $model->active('x');     // not Feature:: facade — skipped
+    $b = $user->isActive('y');    // no flag/feature receiver — skipped
+    $c = $repo->feature('z');     // member-call feature(), not the helper — skipped
+}
+`
+	flags, edges := runFlagPass("php", "f.php", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("non-flag PHP predicates should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}
+
+// PHP NEGATIVE — a dynamic (non-literal) flag key must NOT fabricate a flag
+// entity or edge (honest-partial, mirrors the other languages).
+func TestFeatureFlag_PHP_DynamicKey_NoFabrication(t *testing.T) {
+	src := `<?php
+function gate($flagName, $k) {
+    if (Feature::active($flagName)) { return; }
+    if (feature($k)) { return; }
+}
+`
+	flags, edges := runFlagPass("php", "gate.php", src)
+	if len(flags) != 0 || len(edges) != 0 {
+		t.Errorf("dynamic PHP flag key should yield no output, got flags=%v edges=%v", flags, edges)
+	}
+}


### PR DESCRIPTION
Closes #4154 (epic #3628 area #17). **DEPLOY-DEFERRED** — live daemon untouched; reindex + re-bench after the next coordinated deploy.

## Verify-first (live registry main 8a48915df)
Probed real PHP against the current `internal/engine/feature_flag_edges.go` matcher table BEFORE any change:

| PHP idiom | SDK | Fired before? | After |
|---|---|---|---|
| `$client->getBooleanValue('new-ui', false)` (OpenFeature) | openfeature | **YES** | credited |
| `$unleash->isEnabled('beta')` (Unleash-php) | unleash | **YES** | credited |
| `$client->variation('ld-flag', $ctx, false)` (LaunchDarkly-php) | launchdarkly | **YES** | credited |
| `Feature::active('new-checkout')` (Laravel Pennant) | laravel-pennant | NO | **added** |
| `Feature::inactive('old-ui')` (Pennant) | laravel-pennant | NO | **added** |
| `Feature::for($u)->active('beta-ui')` (Pennant scoped) | laravel-pennant | NO | **added** |
| `feature('dark-mode')` (Laravel helper) | laravel-pennant | NO | **added** |
| `$featureManager->isActive('promo')` (Symfony Flagception) | flagception | NO | **added** |

## Added matchers (genuinely missed; mirror go #3919 / ruby #4140 shape)
- **Laravel Pennant facade** — `Feature::active|inactive('key')` + scoped `Feature::for($u)->active('key')`. Receiver-gated on the capital-`Feature` facade via `::`, case-SENSITIVE.
- **Laravel `feature('key')` helper** — bare-call form, case-SENSITIVE lowercase so it cannot collide with the `Feature::` facade or the generic `feature_enabled`/`featureEnabled` wrappers. A member-access `->feature(...)` / `::feature(...)` is excluded.
- **Symfony Flagception** — `$featureManager->isActive('key')`, receiver-gated on a `flag`/`feature` receiver token.

Each emits the `feature:<key>` node + `GATED_BY` edge from the enclosing PHP function (`indexEnclosingFunctions` already supports PHP).

## False-positive guards (value-asserted negatives)
- `$model->active('x')` (non-Pennant receiver) → nothing (facade gate).
- `$user->isActive('x')` (no flag/feature token) → nothing (receiver gate).
- `$repo->feature('x')` / `Repo::feature('x')` (member/static call) → nothing (helper is bare-call only).
- `Feature::active($flagName)` / `feature($k)` (dynamic key) → nothing (honest-partial: literal-only).

## Tests
6 value-asserting PHP tests (exact `feature:<key>` node + `GATED_BY` From/To + SDK subtype; 2 negatives). Full suites pass:
`go test ./internal/engine/ ./internal/extractors/ ./tools/coverage/ ./internal/types/` + `go vet`.

## Registry credit (surgical, canonical)
`docs/coverage/registry.json` `Substrate.feature_flag_gating` for PHP frameworks — credited by-idiom (not blind bulk-copy):
- `laravel` **full**, `lumen` **full** (Pennant facade+helper), `symfony` **full** (Flagception).
- The other 13 PHP frameworks → **partial** (generic cross-language SDKs fire framework-agnostically; no first-party facade).
- Surgical line-range edits, `go run ./tools/coverage fmt --check` → canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)