### PR TITLE
[python] query_attribution parity: Beanie + MongoEngine MongoDB ODM query topology

### DIFF
--- a/internal/engine/orm_queries_python.go
+++ b/internal/engine/orm_queries_python.go
@@ -54,31 +54,68 @@ var pyTortoisePeeweeRe = regexp.MustCompile(
 	`\b([A-Z][A-Za-z0-9_]*)\.(select|get|filter|all|create|update|delete|insert|save|count|exists|first|annotate|prefetch_related|where|join)\s*\(`,
 )
 
+// Beanie (async MongoDB ODM): document-class queries `<Model>.<verb>(...)`.
+// Beanie's surface is method calls on the Document subclass itself —
+// `User.find(User.age > 18)`, `User.find_one(...)`, `User.get(id)`,
+// `User.find_all()`, `User.aggregate([...])`, `User.insert_many([...])`,
+// `User.count()`. The verb list is Beanie-specific (find_all / find_one /
+// insert_many are not Tortoise/Peewee verbs) so canonicalOp() flattens it
+// to find/create/aggregate/etc.
+var pyBeanieRe = regexp.MustCompile(
+	`\b([A-Z][A-Za-z0-9_]*)\.(find_one|find_all|find_many|find|get|aggregate|insert_many|insert|count|delete_all|delete)\s*\(`,
+)
+
+// MongoEngine (sync MongoDB ODM): the `objects` QuerySet manager is invoked
+// either DIRECTLY as a call — `User.objects(name="x")` — or chained with a
+// verb — `User.objects.filter(...)` / `.get(...)` / `.first()` / `.count()`
+// / `.delete()` / `.update(...)`. The direct-call form is the idiom the
+// Django matcher (which requires `.objects.<verb>`) does not cover, so this
+// matcher anchors on `<Model>.objects` and inspects what follows.
+var pyMongoEngineRe = regexp.MustCompile(
+	`\b([A-Z][A-Za-z0-9_]*)\.objects\b`,
+)
+
+// pyMongoEngineVerbRe recovers the chained verb after `<Model>.objects.`
+// when present (anchored at the char immediately after `.objects`).
+var pyMongoEngineVerbRe = regexp.MustCompile(
+	`^\.(get|filter|all|first|count|exists|delete|update|order_by|only|exclude|aggregate|create|insert|save)\b`,
+)
+
 // scanPythonORM walks `src` and emits QUERIES edges for every detected
 // ORM call site.
 func scanPythonORM(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	// MongoEngine reuses Django's `<Model>.objects.<verb>` chain shape but is
+	// a MongoDB ODM, not Django. When a file imports mongoengine and NOT
+	// django, route `<Model>.objects.*` exclusively through the MongoEngine
+	// block below so the QUERIES edge is credited orm=mongoengine instead of
+	// a fabricated orm=django (and never double-emitted).
+	mongoEngineOnly := (strings.Contains(src, "from mongoengine") || strings.Contains(src, "import mongoengine")) &&
+		!(strings.Contains(src, "from django") || strings.Contains(src, "import django"))
+
 	// Django ORM
-	for _, m := range pyDjangoOrmRe.FindAllStringSubmatchIndex(src, -1) {
-		if len(m) < 6 {
-			continue
+	if !mongoEngineOnly {
+		for _, m := range pyDjangoOrmRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 6 {
+				continue
+			}
+			model := src[m[2]:m[3]]
+			verb := src[m[4]:m[5]]
+			caller := enclosingFuncAt(funcs, m[0])
+			argsBlob := extractCallArgs(src, m[5])
+			filterKeys := parseFilterKeys(argsBlob)
+			isJoin := pythonIsJoinDjango(verb, argsBlob)
+			// Promote terminal chain verbs to the emitted operation. Django
+			// idioms like `User.objects.filter(id=1).delete()` express the
+			// intent on the trailing call, not the queryset builder. We scan
+			// the tail of the statement for a recognised terminal verb and
+			// override the canonical op when one is present.
+			tail := lookAheadChain(src, m[5], 256)
+			op := canonicalOp(verb)
+			if t := promoteTerminalDjangoOp(tail); t != "" {
+				op = t
+			}
+			emit(caller, model, op, filterKeys, "django", isJoin)
 		}
-		model := src[m[2]:m[3]]
-		verb := src[m[4]:m[5]]
-		caller := enclosingFuncAt(funcs, m[0])
-		argsBlob := extractCallArgs(src, m[5])
-		filterKeys := parseFilterKeys(argsBlob)
-		isJoin := pythonIsJoinDjango(verb, argsBlob)
-		// Promote terminal chain verbs to the emitted operation. Django
-		// idioms like `User.objects.filter(id=1).delete()` express the
-		// intent on the trailing call, not the queryset builder. We scan
-		// the tail of the statement for a recognised terminal verb and
-		// override the canonical op when one is present.
-		tail := lookAheadChain(src, m[5], 256)
-		op := canonicalOp(verb)
-		if t := promoteTerminalDjangoOp(tail); t != "" {
-			op = t
-		}
-		emit(caller, model, op, filterKeys, "django", isJoin)
 	}
 
 	// SQLAlchemy classic
@@ -117,6 +154,69 @@ func scanPythonORM(src string, funcs []funcSpan, emit emitORMQueryFn) {
 			op = "aggregate"
 		}
 		emit(caller, model, op, filterKeys, "sqlalchemy", isJoin)
+	}
+
+	// Beanie (async MongoDB ODM). Gate on import-presence — the matcher is
+	// broad (`<Capitalised>.<verb>(`) and would otherwise over-fire on
+	// ordinary static-method calls. Beanie document queries target the
+	// Document subclass directly, so the model name is the regex capture.
+	if strings.Contains(src, "from beanie") || strings.Contains(src, "import beanie") {
+		for _, m := range pyBeanieRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 6 {
+				continue
+			}
+			model := src[m[2]:m[3]]
+			verb := src[m[4]:m[5]]
+			caller := enclosingFuncAt(funcs, m[0])
+			argsBlob := extractCallArgs(src, m[5])
+			filterKeys := parseFilterKeys(argsBlob)
+			emit(caller, model, canonicalOp(verb), filterKeys, "beanie", false)
+		}
+	}
+
+	// MongoEngine (sync MongoDB ODM). Gate on import-presence. The Django
+	// matcher already covers `<Model>.objects.<verb>(...)` for a fixed verb
+	// list but credits it as orm=django; MongoEngine needs its OWN provider
+	// label plus the direct-call form `<Model>.objects(...)` that Django's
+	// `.objects.<verb>` shape never matches. We anchor on `<Model>.objects`
+	// and classify what follows.
+	if strings.Contains(src, "from mongoengine") || strings.Contains(src, "import mongoengine") {
+		for _, m := range pyMongoEngineRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			model := src[m[2]:m[3]]
+			caller := enclosingFuncAt(funcs, m[0])
+			rest := src[m[1]:] // text immediately after `<Model>.objects`
+			switch {
+			case strings.HasPrefix(rest, "("):
+				// Direct manager call: `User.objects(name="x")` — a find with
+				// the kwargs as filter keys.
+				argsBlob := extractCallArgs(src, m[1])
+				filterKeys := parseFilterKeys(argsBlob)
+				emit(caller, model, "find", filterKeys, "mongoengine", false)
+			default:
+				// Chained verb: `User.objects.filter(...)` etc.
+				vm := pyMongoEngineVerbRe.FindStringSubmatchIndex(rest)
+				if vm == nil {
+					continue
+				}
+				verb := rest[vm[2]:vm[3]]
+				// Locate the verb's call args: the verb sits at rest[vm[2]:vm[3]]
+				// which maps to src offset m[1]+vm[3]; args start there.
+				argsBlob := extractCallArgs(src, m[1]+vm[3])
+				filterKeys := parseFilterKeys(argsBlob)
+				op := canonicalOp(verb)
+				// Promote a terminal CRUD verb on the chain, mirroring Django:
+				// `Article.objects.filter(...).delete()` expresses delete intent
+				// on the trailing call, not the queryset builder.
+				tail := lookAheadChain(src, m[1]+vm[3], 256)
+				if t := promoteTerminalDjangoOp(tail); t != "" {
+					op = t
+				}
+				emit(caller, model, op, filterKeys, "mongoengine", false)
+			}
+		}
 	}
 
 	// Tortoise / Peewee. Gate on import-presence: the matcher is broad

--- a/internal/engine/orm_queries_test.go
+++ b/internal/engine/orm_queries_test.go
@@ -156,6 +156,143 @@ async def get_post_with_author(session, post_id):
 }
 
 // ---------------------------------------------------------------------------
+// Python: Beanie (async MongoDB ODM) — #3645 sibling parity
+// ---------------------------------------------------------------------------
+
+func TestORM_BeanieDocumentQueries(t *testing.T) {
+	src := `from beanie import Document
+
+class User(Document):
+    name: str
+    age: int
+
+async def get_user(user_id):
+    return await User.get(user_id)
+
+async def list_adults():
+    return await User.find(User.age >= 18).to_list()
+
+async def find_one_user(name):
+    return await User.find_one(User.name == name)
+
+async def add_users(users):
+    return await User.insert_many(users)
+
+async def remove_user(user_id):
+    await User.find_one(User.id == user_id).delete()
+
+async def report():
+    return await User.aggregate([{"$group": {"_id": "$age"}}]).to_list()
+`
+	edges := detectORM(t, "python", "app/repo.py", src)
+
+	// find: get_user resolves to op=find, orm=beanie (the .get verb).
+	e := assertEdgeExists(t, edges, "Function:get_user", "Class:User", "find")
+	if e.ORM != "beanie" {
+		t.Errorf("expected orm=beanie, got %q", e.ORM)
+	}
+
+	// find: list_adults via User.find(...).
+	assertEdgeExists(t, edges, "Function:list_adults", "Class:User", "find")
+	// find: find_one_user via User.find_one(...).
+	assertEdgeExists(t, edges, "Function:find_one_user", "Class:User", "find")
+	// create: insert_many flattens to create.
+	ec := assertEdgeExists(t, edges, "Function:add_users", "Class:User", "create")
+	if ec.ORM != "beanie" {
+		t.Errorf("expected orm=beanie for insert_many, got %q", ec.ORM)
+	}
+	// aggregate: pipeline call flattens to aggregate.
+	assertEdgeExists(t, edges, "Function:report", "Class:User", "aggregate")
+}
+
+// Negative: a Beanie-shaped call in a file that does NOT import beanie must
+// not fabricate a QUERIES edge — the matcher is import-gated.
+func TestORM_BeanieNotImportedNoEdge(t *testing.T) {
+	src := `class Helper:
+    pass
+
+def run():
+    # Looks Beanie-ish but no beanie import: must stay silent.
+    return Helper.find(x=1)
+`
+	edges := detectORM(t, "python", "app/util.py", src)
+	for _, e := range edges {
+		if e.ORM == "beanie" {
+			t.Errorf("did not expect a beanie edge without import, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python: MongoEngine (sync MongoDB ODM) — #3645 sibling parity
+// ---------------------------------------------------------------------------
+
+func TestORM_MongoEngineDirectAndChained(t *testing.T) {
+	src := `from mongoengine import Document, StringField
+
+class Article(Document):
+    title = StringField()
+
+def find_by_title(title):
+    # Direct manager-call form Django's matcher never covers.
+    return Article.objects(title=title)
+
+def filter_published():
+    return Article.objects.filter(published=True).order_by("-created")
+
+def get_one(article_id):
+    return Article.objects.get(id=article_id)
+
+def purge():
+    Article.objects.filter(stale=True).delete()
+`
+	edges := detectORM(t, "python", "app/articles.py", src)
+
+	// Direct-call form: Article.objects(title=...) → find, orm=mongoengine,
+	// with the kwarg captured as a filter key.
+	e := assertEdgeExists(t, edges, "Function:find_by_title", "Class:Article", "find")
+	if e.ORM != "mongoengine" {
+		t.Errorf("expected orm=mongoengine, got %q", e.ORM)
+	}
+	if !strings.Contains(e.FilterKeys, "title") {
+		t.Errorf("expected filter_keys to contain title, got %q", e.FilterKeys)
+	}
+
+	// Chained verb forms.
+	ef := assertEdgeExists(t, edges, "Function:filter_published", "Class:Article", "find")
+	if ef.ORM != "mongoengine" {
+		t.Errorf("expected orm=mongoengine for .objects.filter, got %q", ef.ORM)
+	}
+	assertEdgeExists(t, edges, "Function:get_one", "Class:Article", "find")
+	assertEdgeExists(t, edges, "Function:purge", "Class:Article", "delete")
+
+	// Exclusivity: a mongoengine-only file must NOT also emit an orm=django
+	// edge for the same `.objects.<verb>` call site (no double-emit /
+	// mis-attribution).
+	for _, ed := range edges {
+		if ed.ORM == "django" {
+			t.Errorf("mongoengine-only file should not emit a django edge, got %+v", ed)
+		}
+	}
+}
+
+// Negative: a MongoEngine-shaped call in a file that does NOT import
+// mongoengine must not fabricate a mongoengine edge. (It may still match the
+// Django matcher if `.objects.<verb>` is present, which is correct Django
+// behaviour — we only assert no mongoengine edge here.)
+func TestORM_MongoEngineNotImportedNoEdge(t *testing.T) {
+	src := `def run():
+    return Article.objects(title="x")
+`
+	edges := detectORM(t, "python", "app/util.py", src)
+	for _, e := range edges {
+		if e.ORM == "mongoengine" {
+			t.Errorf("did not expect a mongoengine edge without import, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // JS/TS: Prisma
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`covtool parity --language python` (on main `11bc6dc12`) flagged `lang.python.orm.beanie` and `lang.python.orm.mongoengine` as **trailing siblings** (MISSING) in the `orm/orm_mapper → query_attribution` group of 18 siblings — while 13 siblings including the flagships `django`, `sqlalchemy`, `sqlmodel` and the `mongodb` driver were already `full`.

## VERIFY-FIRST (genuine build gap, not a credit)

The prior registry note — *"YAML detection-only; dead custom_extractor never ran in Go; no native query-topology extractor"* — was honest. `scanPythonORM` had Django / SQLAlchemy / Tortoise / Peewee matchers but **no Beanie or MongoEngine matcher**, and the pymongo driver matcher (`scanPythonDrivers`, `db.get_collection('x')` / subscript shape) does **not** fire on document-class queries. So this is a real extractor gap, not an already-firing-but-uncredited case.

## Build (`internal/engine/orm_queries_python.go`, import-gated)

- **Beanie** (async MongoDB ODM): matches `<Model>.find / find_one / find_all / find_many / get / aggregate / insert_many / insert / count / delete_all / delete (...)` → QUERIES edge `Function:<caller> → Class:<Model>`, canonical operation (find / create / aggregate / update / delete) + parsed `filter_keys`, `orm=beanie`. Gated on a `beanie` import.
- **MongoEngine** (sync MongoDB ODM): matches BOTH the **direct manager-call** form `<Model>.objects(field=...)` — the idiom Django's `.objects.<verb>` matcher never covered — and **chained** verbs `<Model>.objects.filter / get / all / first / count / delete / update / ...`, with terminal-CRUD promotion (`.filter(...).delete()` → `delete`), `orm=mongoengine`. Gated on a `mongoengine` import. MongoEngine-only files **suppress the Django matcher** so each `.objects.*` call site is credited exactly once as `orm=mongoengine` (no double-emit / mis-attribution).

## Tests (value-asserting + negatives)

- `TestORM_BeanieDocumentQueries` — asserts find/create/aggregate ops, `orm=beanie`, correct caller/model IDs.
- `TestORM_BeanieNotImportedNoEdge` — import-gate negative (no fabricated edge without a beanie import).
- `TestORM_MongoEngineDirectAndChained` — asserts direct-call + chained forms, filter-key capture, terminal-verb promotion, and **no double-emitted django edge** in a mongoengine-only file.
- `TestORM_MongoEngineNotImportedNoEdge` — import-gate negative.

Full `internal/engine` package suite green (31s). `go vet` clean.

## Registry

`beanie` and `mongoengine` `query_attribution` cells flipped `missing → full` with cites + value-asserting notes. **`covtool fmt --check` canonical** (surgical 2-cell edit; the only canonicalization was the encoder's `<`→`<` escaping on the two new notes lines — no whole-file re-serialization). `covtool validate` exit 0; the residual `query_attribution has no mapping entry` warning is a **pre-existing baseline** shared identically by the `django`/`sqlalchemy` flagships in this same lane — new cells mirror the flagship treatment exactly. No new custom capability key → no dispatch-parity change.

Post-fix parity: both ODMs now `full`, no longer trailing siblings (only `neo4j` remains, a genuinely different Cypher-topology gap left honest).

## Deploy

**DEPLOY-DEFERRED** — registry + extractor change; live-daemon rebuild handled separately.

Closes #4156 (epic #3872)

🤖 Generated with [Claude Code](https://claude.com/claude-code)