### PR TITLE
Go endpoint_response_codes parity: credit buffalo, build hertz/fasthttp (#3818)

### DIFF
--- a/internal/engine/http_endpoint_response_codes.go
+++ b/internal/engine/http_endpoint_response_codes.go
@@ -624,8 +624,9 @@ func jsResponseCodes(region, body string) responseCodesVerdict {
 // ---------------------------------------------------------------------------
 //
 // The status idioms differ by framework but all resolve to a literal int or a
-// well-known package constant suffix (http.StatusXxx / fiber.StatusXxx). The
-// constant suffix → code mapping is shared with response_shape_go.go's
+// well-known package constant suffix (http.StatusXxx / fiber.StatusXxx /
+// consts.StatusXxx / fasthttp.StatusXxx — the latter two mirror the stdlib code
+// values). The constant suffix → code mapping is shared with response_shape_go.go's
 // goHTTPStatusFromName, extended here with the full set of codes endpoints
 // commonly return.
 //
@@ -638,6 +639,11 @@ func jsResponseCodes(region, body string) responseCodesVerdict {
 //     http.Error(w, msg, http.StatusBadRequest) (2nd/3rd arg is the code).
 //   - fiber:       c.Status(fiber.StatusOK).JSON(x); c.SendStatus(204);
 //     fiber.NewError(fiber.StatusNotFound, ...).
+//   - buffalo:     c.Render(http.StatusCreated, r.JSON(x)) — the stdlib
+//     constant via Render (already resolved by the Render verb + http.Status*).
+//   - hertz:       c.JSON(consts.StatusCreated, x) / c.JSON(201, x);
+//     c.SetStatusCode(consts.StatusNoContent) (#3818).
+//   - fasthttp:    ctx.SetStatusCode(fasthttp.StatusCreated) (#3818).
 //
 // HONEST-PARTIAL: a status expressed through a variable (`c.JSON(code, x)`,
 // `w.WriteHeader(myStatus)`) is not a literal and is skipped — we still record
@@ -647,9 +653,15 @@ func jsResponseCodes(region, body string) responseCodesVerdict {
 // goStatusCallRe matches the call shapes whose FIRST argument is the HTTP
 // status: c.JSON / c.IndentedJSON / c.PureJSON / c.XML / c.Status / c.String /
 // c.Data / c.AbortWithStatus / c.AbortWithStatusJSON / c.SendStatus /
-// w.WriteHeader / ctx.NoContent / echo.NewHTTPError / fiber.NewError.
+// w.WriteHeader / ctx.NoContent / echo.NewHTTPError / fiber.NewError /
+// c.SetStatusCode (Hertz / fasthttp).
+//
+// The status constant may be a net/http (http.Status*), fiber (fiber.Status*),
+// CloudWeGo/Hertz (consts.Status*) or fasthttp (fasthttp.Status*) suffix — all
+// four families mirror the stdlib code values, so a single suffix→code table
+// resolves them (#3818).
 var goStatusFirstArgRe = regexp.MustCompile(
-	`\b\w+\s*\.\s*(?:JSON|IndentedJSON|PureJSON|SecureJSON|AsciiJSON|XML|YAML|ProtoBuf|Status|String|Data|HTML|Render|AbortWithStatus|AbortWithStatusJSON|SendStatus|WriteHeader|NoContent|NewHTTPError|NewError)\s*\(\s*(\d{3}|http\.Status[A-Z][A-Za-z]+|fiber\.Status[A-Z][A-Za-z]+|echo\.[A-Z][A-Za-z]+)`,
+	`\b\w+\s*\.\s*(?:JSON|IndentedJSON|PureJSON|SecureJSON|AsciiJSON|XML|YAML|ProtoBuf|Status|String|Data|HTML|Render|AbortWithStatus|AbortWithStatusJSON|SendStatus|SetStatusCode|WriteHeader|NoContent|NewHTTPError|NewError)\s*\(\s*(\d{3}|(?:http|fiber|consts|fasthttp)\.Status[A-Z][A-Za-z]+|echo\.[A-Z][A-Za-z]+)`,
 )
 
 // goHTTPErrorRe matches `http.Error(w, msg, http.StatusBadRequest)` /
@@ -659,9 +671,10 @@ var goHTTPErrorRe = regexp.MustCompile(
 )
 
 // goStatusTokenRe parses a single resolved status token into either a numeric
-// literal (group 1) or a constant suffix (group 2), accepting the http.Status*
-// and fiber.Status* constant families (which share the stdlib code values).
-var goStatusTokenRe = regexp.MustCompile(`^(?:(\d{3})|(?:http|fiber)\.Status([A-Z][A-Za-z]+))$`)
+// literal (group 1) or a constant suffix (group 2), accepting the http.Status*,
+// fiber.Status*, consts.Status* (Hertz/CloudWeGo) and fasthttp.Status*
+// constant families (all four share the stdlib code values).
+var goStatusTokenRe = regexp.MustCompile(`^(?:(\d{3})|(?:http|fiber|consts|fasthttp)\.Status([A-Z][A-Za-z]+))$`)
 
 // goResponseCodes resolves the literal status-code set returned by a Go
 // handler. The handler body is located via the endpoint's source_handler
@@ -700,8 +713,9 @@ func goResponseCodes(content string, e *types.EntityRecord) responseCodesVerdict
 }
 
 // goResolveStatusToken resolves a status token (a 3-digit literal or an
-// http.Status*/fiber.Status* constant) to its numeric code. An `echo.X`
-// constant is a non-status echo symbol and is rejected (returns false).
+// http.Status*/fiber.Status*/consts.Status*/fasthttp.Status* constant) to its
+// numeric code. An `echo.X` constant is a non-status echo symbol and is
+// rejected (returns false).
 func goResolveStatusToken(tok string) (int, bool) {
 	tok = strings.TrimSpace(tok)
 	m := goStatusTokenRe.FindStringSubmatch(tok)
@@ -720,9 +734,10 @@ func goResolveStatusToken(tok string) (int, bool) {
 	return 0, false
 }
 
-// goStatusConstCode maps the net/http (and fiber, which mirrors it) status
-// constant suffix to its numeric code. Superset of response_shape_go.go's
-// goHTTPStatusFromName, covering the codes endpoints commonly return.
+// goStatusConstCode maps the net/http (and fiber / Hertz-consts / fasthttp,
+// which all mirror it) status constant suffix to its numeric code. Superset of
+// response_shape_go.go's goHTTPStatusFromName, covering the codes endpoints
+// commonly return.
 func goStatusConstCode(name string) int {
 	if c, ok := goStatusConstCodes[name]; ok {
 		return c

--- a/internal/engine/http_endpoint_response_codes_test.go
+++ b/internal/engine/http_endpoint_response_codes_test.go
@@ -404,6 +404,172 @@ func reg() {
 }
 
 // ---------------------------------------------------------------------------
+// Go HTTP-framework siblings: buffalo / hertz / fasthttp (#3818)
+//
+// The goResponseCodes idiom set (status-first-arg call verbs + the stdlib code
+// table) already covers these frameworks once the constant family / verb is in
+// scope — route synthesis sets source_handler the same way for every Go
+// framework, so the handler body is reachable identically. These are
+// value-asserting parity tests for the trailing siblings the coverage parity
+// probe flagged as MISSING against the flagship gin/echo/chi cohort.
+// ---------------------------------------------------------------------------
+
+// buffalo renders with the stdlib http.Status* constant via c.Render — already
+// matched by the Render verb + http.Status* family (CREDIT, no new idiom). The
+// happy path is 201, the validation branch 400.
+func TestResponseCodes_Go_Buffalo_RenderStatus(t *testing.T) {
+	src := `
+package actions
+
+import (
+	"net/http"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+)
+
+var r = render.New(render.Options{})
+
+func UsersCreate(c buffalo.Context) error {
+	if c.Param("bad") != "" {
+		return c.Render(http.StatusBadRequest, r.JSON(map[string]string{"e": "bad"}))
+	}
+	return c.Render(http.StatusCreated, r.JSON(map[string]int{"id": 1}))
+}
+
+func setup(app *buffalo.App) {
+	app.POST("/users", UsersCreate)
+}
+`
+	eps := deprecProps(t, "go", "main.go", src)
+	e := mustEndpoint(t, eps, "POST /users")
+	if got := e.Properties["response_codes"]; got != "201,400" {
+		t.Fatalf("response_codes=%q want 201,400 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "201" {
+		t.Fatalf("success_code=%q want 201", got)
+	}
+	if got := e.Properties["response_codes_source"]; got != "status call" {
+		t.Fatalf("response_codes_source=%q want 'status call'", got)
+	}
+}
+
+// hertz (CloudWeGo) returns via c.JSON(consts.StatusXxx, x) and
+// c.SetStatusCode(consts.StatusXxx). The consts.Status* family mirrors the
+// net/http code values; resolving it is the #3818 build for hertz. Mix a numeric
+// literal in too (also valid hertz) to assert both paths land in the set.
+func TestResponseCodes_Go_Hertz_ConstsStatus(t *testing.T) {
+	src := `
+package main
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+)
+
+func CreateUser(ctx context.Context, c *app.RequestContext) {
+	if bad(c) {
+		c.JSON(400, map[string]string{"e": "bad"})
+		return
+	}
+	c.SetStatusCode(consts.StatusNoContent)
+	c.JSON(consts.StatusCreated, map[string]int{"id": 1})
+}
+
+func main() {
+	h := server.Default()
+	h.POST("/users", CreateUser)
+	h.Spin()
+}
+`
+	eps := deprecProps(t, "go", "main.go", src)
+	e := mustEndpoint(t, eps, "POST /users")
+	if got := e.Properties["response_codes"]; got != "201,204,400" {
+		t.Fatalf("response_codes=%q want 201,204,400 (props: %v)", got, e.Properties)
+	}
+	// Two distinct 2xx codes (201 + 204) ⇒ success_code is ambiguous, omitted.
+	if got := e.Properties["success_code"]; got != "" {
+		t.Fatalf("success_code=%q want absent (two 2xx codes ⇒ ambiguous)", got)
+	}
+	if got := e.Properties["response_codes_source"]; got != "status call" {
+		t.Fatalf("response_codes_source=%q want 'status call'", got)
+	}
+}
+
+// fasthttp sets the status with ctx.SetStatusCode(fasthttp.StatusXxx). The
+// fasthttp.Status* family also mirrors net/http; this is the #3818 build for
+// fasthttp (the SetStatusCode verb + fasthttp.Status* family).
+func TestResponseCodes_Go_Fasthttp_SetStatusCode(t *testing.T) {
+	src := `
+package main
+
+import (
+	"github.com/fasthttp/router"
+	"github.com/valyala/fasthttp"
+)
+
+func CreateUser(ctx *fasthttp.RequestCtx) {
+	if !valid(ctx) {
+		ctx.SetStatusCode(fasthttp.StatusUnprocessableEntity)
+		return
+	}
+	ctx.SetStatusCode(fasthttp.StatusCreated)
+}
+
+func main() {
+	r := router.New()
+	r.POST("/users", CreateUser)
+	fasthttp.ListenAndServe(":8080", r.Handler)
+}
+`
+	eps := deprecProps(t, "go", "main.go", src)
+	e := mustEndpoint(t, eps, "POST /users")
+	if got := e.Properties["response_codes"]; got != "201,422" {
+		t.Fatalf("response_codes=%q want 201,422 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "201" {
+		t.Fatalf("success_code=%q want 201", got)
+	}
+}
+
+// Negative: a hertz handler whose status is a dynamic variable
+// (c.SetStatusCode(code)) yields NO literal — response_codes stays absent, the
+// framework default 200 is not fabricated. Asserts the consts.Status* addition
+// did not loosen the honest-partial boundary.
+func TestResponseCodes_Go_Hertz_DynamicStatusAbsent(t *testing.T) {
+	src := `
+package main
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+)
+
+func Status(ctx context.Context, c *app.RequestContext) {
+	code := pick()
+	c.SetStatusCode(code)
+	c.JSON(code, map[string]bool{"ok": true})
+}
+
+func main() {
+	h := server.Default()
+	h.GET("/status", Status)
+	h.Spin()
+}
+`
+	eps := deprecProps(t, "go", "main.go", src)
+	e := mustEndpoint(t, eps, "GET /status")
+	if got := e.Properties["response_codes"]; got != "" {
+		t.Fatalf("response_codes=%q want absent (dynamic status var, no literal)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Async siblings: sanic / starlette / quart / litestar (#3913)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Closes #4157 (epic #3872 — per-language coverage parity audit). Closes #3818 for the buffalo/hertz/fasthttp `endpoint_response_codes` siblings.

`covtool parity --language go` (on main `11bc6dc12`, uniform-scaffold suppressed) flagged `endpoint_response_codes` MISSING for **buffalo / fasthttp / hertz** against the FULL gin/echo/chi/fiber/net-http/gorilla-mux flagship cohort. Verify-first probing the existing `goResponseCodes` extractor (which locates the handler body via `source_handler`, identically for every Go framework) classified each finding as genuine:

| sibling | before | classification | fix |
|---|---|---|---|
| **buffalo** | MISSING | extractor **already fires** — `c.Render(http.StatusCreated, r.JSON(x))` matched by the `Render` verb + `http.Status*` family | **CREDIT** — registry cell was wrongly MISSING, no code change |
| **hertz** | MISSING | fired only on numeric `c.JSON(400,x)`; named `consts.Status*` unresolved | **BUILD** — add `consts.Status*` family + `SetStatusCode` verb |
| **fasthttp** | MISSING | `ctx.SetStatusCode(fasthttp.StatusCreated)` unresolved | **BUILD** — add `fasthttp.Status*` family + `SetStatusCode` verb |

`consts.Status*` (CloudWeGo) and `fasthttp.Status*` both mirror the net/http code values, so the single shared suffix→code table resolves them — exactly mirroring how `fiber.Status*` is already handled.

## Verification (value-asserting, with negatives)

- `TestResponseCodes_Go_Buffalo_RenderStatus` → `response_codes=201,400`, `success_code=201`, `source=status call`
- `TestResponseCodes_Go_Hertz_ConstsStatus` → `201,204,400`; two 2xx ⇒ `success_code` **omitted as ambiguous**
- `TestResponseCodes_Go_Fasthttp_SetStatusCode` → `201,422`, `success_code=201`
- `TestResponseCodes_Go_Hertz_DynamicStatusAbsent` (negative) → dynamic status var ⇒ `response_codes` **absent** (no default-200 fabrication; honest-partial boundary held)

`go test ./internal/engine/` (full package) and `go test ./tools/coverage/` both pass. Post-fix `covtool parity --language go` shows buffalo/fasthttp/hertz now `full`.

## Registry

3 cells flipped `missing`→`full` surgically (id-verified per framework, no re-serialization). `covtool fmt --check` → canonical. No custom registry key added (dispatch-parity N/A).

Remaining `endpoint_response_codes` MISSING siblings (beego/iris/go-zero/kratos/revel/huma) stay tracked under #3818 — route-synthesis-gated or non-stdlib status mechanisms (separate work); fx/wire/gqlgen are honest-N/A (DI / GraphQL).

## DEPLOY-DEFERRED

Live daemon rebuild + upvate reindex NOT performed in this sandbox (`ARCHIGRAPH_DAEMON_ROOT` isolated). Requires a coordinated daemon rebuild to surface in the live graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)