### PR TITLE
feat(jsts): endpoint_response_codes for sibling HTTP backends (parity grind)

### DIFF
--- a/internal/engine/http_endpoint_response_codes.go
+++ b/internal/engine/http_endpoint_response_codes.go
@@ -40,6 +40,10 @@
 //     exception → code mapping); default success 200.
 //   - Express / Nest (JS/TS): `res.status(201)`; `res.sendStatus(204)`;
 //     `@HttpCode(201)`; `throw new NotFoundException()` (Nest exc → code).
+//   - Sibling JS/TS backends: fastify `reply.code(201)`; hapi
+//     `h.response(x).code(201)`; koa `ctx.status = 201`; hono `c.json(x, 201)` /
+//     `c.status(201)`; restify `res.send(201, body)`; polka `res.writeHead(204)`;
+//     sails/adonis status helpers `res.created()` / `res.notFound()` (→ code).
 //   - Spring (Java/Kotlin): `@ResponseStatus(HttpStatus.CREATED)`;
 //     `ResponseEntity.status(404)` / `.ok()` (200) / `.notFound()` (404) /
 //     `.created(...)` (201); `throw new ResponseStatusException(NOT_FOUND)`.
@@ -571,6 +575,68 @@ var nestExceptionCodes = map[string]int{
 	"GatewayTimeoutException":       504,
 }
 
+// --- Sibling JS/TS HTTP backends (fastify / hono / koa / hapi / restify /
+//     polka / adonis / sails) -------------------------------------------------
+//
+// These frameworks do not share Express's `res.status(NNN)` everywhere; each has
+// a canonical status idiom that the Express-only regexes above miss. The cases
+// below are literal-only — a status passed through a variable stays honest-partial
+// exactly as for Express/Nest (no fabrication).
+
+// jsReplyCodeRe matches the fastify canonical idiom `reply.code(201)` (and the
+// `.code(NNN)` chained on a hapi response: `h.response(x).code(201)`). The
+// receiver name is not constrained so `reply.code`, `res.code`, `response.code`
+// and a chained `.code(` all match; only a 3-digit literal argument resolves.
+var jsReplyCodeRe = regexp.MustCompile(`\.\s*code\s*\(\s*(\d{3})\s*\)`)
+
+// jsWriteHeadRe matches the Node/polka idiom `res.writeHead(204)` (the first
+// argument is the status; an optional 2nd headers arg is ignored).
+var jsWriteHeadRe = regexp.MustCompile(`\.\s*writeHead\s*\(\s*(\d{3})\b`)
+
+// jsCtxStatusAssignRe matches the koa idiom `ctx.status = 201` (Express's
+// `.statusCode = NNN` is already covered by jsStatusCodeAssignRe; koa exposes the
+// status as `.status` rather than `.statusCode`).
+var jsCtxStatusAssignRe = regexp.MustCompile(`\.\s*status\s*=\s*(\d{3})\b`)
+
+// jsCtxStatusGetterRe matches the hono body-returning idiom where the status is
+// the 2nd positional argument: `c.json(x, 201)`, `c.text('ok', 404)`,
+// `c.body(buf, 204)`, `c.html(s, 200)`. A leading numeric (status-only) form
+// `c.status(201)` is already covered by jsResStatusRe.
+var jsHonoBodyStatusRe = regexp.MustCompile(`\.\s*(?:json|text|body|html)\s*\(\s*[^,()]*?,\s*(\d{3})\s*[),]`)
+
+// jsRestifySendCodeRe matches restify's `res.send(201, body)` / `res.send(204)`
+// where the FIRST argument is a 3-digit status literal (restify overloads send:
+// `res.send(body)` has no status — only a leading numeric resolves).
+var jsRestifySendCodeRe = regexp.MustCompile(`\.\s*send\s*\(\s*(\d{3})\s*[),]`)
+
+// jsResponseHelperRe matches the named status-helper methods exposed by sails
+// (`res.ok()`, `res.created()`, `res.notFound()`, `res.badRequest()`,
+// `res.forbidden()`, `res.serverError()`) and adonis (`response.created()`,
+// `response.noContent()`, `response.notFound()`, …). The method name maps to a
+// fixed code via jsResponseHelperCodes.
+var jsResponseHelperRe = regexp.MustCompile(`\.\s*(ok|created|accepted|noContent|notFound|badRequest|unauthorized|forbidden|conflict|unprocessableEntity|tooManyRequests|serverError|internalServerError|notImplemented|badGateway|serviceUnavailable|gatewayTimeout)\s*\(`)
+
+// jsResponseHelperCodes maps a sails/adonis status helper to its HTTP code.
+var jsResponseHelperCodes = map[string]int{
+	"ok":                  200,
+	"created":             201,
+	"accepted":            202,
+	"noContent":           204,
+	"badRequest":          400,
+	"unauthorized":        401,
+	"forbidden":           403,
+	"notFound":            404,
+	"conflict":            409,
+	"unprocessableEntity": 422,
+	"tooManyRequests":     429,
+	"serverError":         500,
+	"internalServerError": 500,
+	"notImplemented":      501,
+	"badGateway":          502,
+	"serviceUnavailable":  503,
+	"gatewayTimeout":      504,
+}
+
 func jsResponseCodes(region, body string) responseCodesVerdict {
 	var v responseCodesVerdict
 
@@ -612,6 +678,36 @@ func jsResponseCodes(region, body string) responseCodesVerdict {
 			v.add(c)
 			if v.source == "" {
 				v.source = "Nest exception"
+			}
+		}
+	}
+
+	// Sibling-framework literal status idioms in the body. Each block resolves a
+	// 3-digit literal only; dynamic statuses stay honest-partial. The source label
+	// records the FIRST sibling idiom that fired (Express idioms above win when
+	// present, preserving the flagship evidence string).
+	jsSiblingLiteral := func(re *regexp.Regexp, source string) {
+		for _, m := range re.FindAllStringSubmatch(body, -1) {
+			if c, err := strconv.Atoi(m[1]); err == nil {
+				v.add(c)
+				if v.source == "" {
+					v.source = source
+				}
+			}
+		}
+	}
+	jsSiblingLiteral(jsReplyCodeRe, "reply.code()")     // fastify / hapi .code()
+	jsSiblingLiteral(jsWriteHeadRe, "res.writeHead()")  // polka / node
+	jsSiblingLiteral(jsCtxStatusAssignRe, "ctx.status") // koa
+	jsSiblingLiteral(jsHonoBodyStatusRe, "c.json(x,NNN)")
+	jsSiblingLiteral(jsRestifySendCodeRe, "res.send(NNN)") // restify
+
+	// sails / adonis named status helpers → fixed code.
+	for _, m := range jsResponseHelperRe.FindAllStringSubmatch(body, -1) {
+		if c, ok := jsResponseHelperCodes[m[1]]; ok {
+			v.add(c)
+			if v.source == "" {
+				v.source = "res." + m[1] + "()"
 			}
 		}
 	}

--- a/internal/engine/http_endpoint_response_codes_test.go
+++ b/internal/engine/http_endpoint_response_codes_test.go
@@ -147,6 +147,181 @@ app.get('/dyn', (req, res) => {
 }
 
 // ---------------------------------------------------------------------------
+// Sibling JS/TS HTTP backends (fastify / koa / hono / restify / hapi / polka /
+// adonis). Each exercises the framework's CANONICAL status idiom that the
+// Express-only regexes miss, asserting the exact resolved code set + the
+// evidence source label.
+// ---------------------------------------------------------------------------
+
+func TestResponseCodes_Fastify_ReplyCode(t *testing.T) {
+	src := `
+const fastify = require('fastify')();
+
+fastify.post('/items', async (req, reply) => {
+    if (!req.body) {
+        return reply.code(400).send({ error: 'empty' });
+    }
+    return reply.code(201).send({ ok: true });
+});
+`
+	eps := deprecProps(t, "javascript", "routes/items.js", src)
+	e := mustEndpoint(t, eps, "POST /items")
+	if got := e.Properties["response_codes"]; got != "201,400" {
+		t.Fatalf("response_codes=%q want 201,400 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "201" {
+		t.Fatalf("success_code=%q want 201", got)
+	}
+	if got := e.Properties["response_codes_source"]; got != "reply.code()" {
+		t.Fatalf("response_codes_source=%q want reply.code()", got)
+	}
+}
+
+func TestResponseCodes_Koa_CtxStatusAssign(t *testing.T) {
+	src := `
+const Router = require('@koa/router');
+const router = new Router();
+
+router.get('/ping', async (ctx) => {
+    ctx.status = 200;
+    ctx.body = { ok: true };
+});
+`
+	eps := deprecProps(t, "javascript", "routes/ping.js", src)
+	e := mustEndpoint(t, eps, "GET /ping")
+	if got := e.Properties["response_codes"]; got != "200" {
+		t.Fatalf("response_codes=%q want 200 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "200" {
+		t.Fatalf("success_code=%q want 200", got)
+	}
+	if got := e.Properties["response_codes_source"]; got != "ctx.status" {
+		t.Fatalf("response_codes_source=%q want ctx.status", got)
+	}
+}
+
+func TestResponseCodes_Hono_BodyStatusArg(t *testing.T) {
+	src := `
+const app = new Hono();
+
+app.post('/create', (c) => {
+    return c.json({ ok: true }, 201);
+});
+`
+	eps := deprecProps(t, "javascript", "routes/create.js", src)
+	e := mustEndpoint(t, eps, "POST /create")
+	if got := e.Properties["response_codes"]; got != "201" {
+		t.Fatalf("response_codes=%q want 201 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["response_codes_source"]; got != "c.json(x,NNN)" {
+		t.Fatalf("response_codes_source=%q want c.json(x,NNN)", got)
+	}
+}
+
+func TestResponseCodes_Restify_SendCode(t *testing.T) {
+	src := `
+const restify = require('restify');
+const server = restify.createServer();
+
+server.post('/new', (req, res, next) => {
+    res.send(201, { ok: true });
+    return next();
+});
+`
+	eps := deprecProps(t, "javascript", "routes/new.js", src)
+	e := mustEndpoint(t, eps, "POST /new")
+	if got := e.Properties["response_codes"]; got != "201" {
+		t.Fatalf("response_codes=%q want 201 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["response_codes_source"]; got != "res.send(NNN)" {
+		t.Fatalf("response_codes_source=%q want res.send(NNN)", got)
+	}
+}
+
+func TestResponseCodes_Hapi_ResponseCode(t *testing.T) {
+	src := `
+server.route({
+    method: 'POST',
+    path: '/widgets',
+    handler: (request, h) => {
+        return h.response({ ok: true }).code(201);
+    }
+});
+`
+	eps := deprecProps(t, "javascript", "routes/widgets.js", src)
+	e := mustEndpoint(t, eps, "POST /widgets")
+	if got := e.Properties["response_codes"]; got != "201" {
+		t.Fatalf("response_codes=%q want 201 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "201" {
+		t.Fatalf("success_code=%q want 201", got)
+	}
+}
+
+func TestResponseCodes_Polka_WriteHead(t *testing.T) {
+	src := `
+const polka = require('polka');
+const app = polka();
+
+app.get('/health', (req, res) => {
+    res.writeHead(204);
+    res.end();
+});
+`
+	eps := deprecProps(t, "javascript", "routes/health.js", src)
+	e := mustEndpoint(t, eps, "GET /health")
+	if got := e.Properties["response_codes"]; got != "204" {
+		t.Fatalf("response_codes=%q want 204 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["response_codes_source"]; got != "res.writeHead()" {
+		t.Fatalf("response_codes_source=%q want res.writeHead()", got)
+	}
+}
+
+func TestResponseCodes_Adonis_StatusHelpers(t *testing.T) {
+	// Adonis named status helpers map to fixed codes: badRequest→400, created→201.
+	src := `
+const Route = use('Route');
+
+Route.post('/posts', async ({ request, response }) => {
+    if (!request.body) {
+        return response.badRequest({ error: 'empty' });
+    }
+    return response.created({ id: 1 });
+});
+`
+	eps := deprecProps(t, "javascript", "routes/posts.js", src)
+	e := mustEndpoint(t, eps, "POST /posts")
+	if got := e.Properties["response_codes"]; got != "201,400" {
+		t.Fatalf("response_codes=%q want 201,400 (props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["success_code"]; got != "201" {
+		t.Fatalf("success_code=%q want 201", got)
+	}
+}
+
+func TestResponseCodes_Sibling_DynamicStatusSkipped(t *testing.T) {
+	// A fastify reply.code(dynamicVar) must NOT fabricate a code; the literal 200
+	// alongside it still records. Mirrors the Express dynamic-skip guarantee.
+	src := `
+const fastify = require('fastify')();
+
+fastify.get('/dyn', async (req, reply) => {
+    const code = computeCode();
+    if (req.query.ok) {
+        return reply.code(200).send({});
+    }
+    return reply.code(code).send({});
+});
+`
+	eps := deprecProps(t, "javascript", "routes/dyn.js", src)
+	e := mustEndpoint(t, eps, "GET /dyn")
+	if got := e.Properties["response_codes"]; got != "200" {
+		t.Fatalf("response_codes=%q want 200 (dynamic var skipped) (props: %v)", got, e.Properties)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Spring (Java)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4158
Refs epic #3872, #3818
**DEPLOY-DEFERRED**

## Genuine gap (parity probe, uniform-scaffold suppressed)
`covtool parity --language jsts` on main `11bc6dc12` flagged `http_backend / Routing / endpoint_response_codes` as **full** only for `express` + `nestjs` (group of 14) — 10 real HTTP backend siblings MISSING. The Express-only regexes (`res.status(NNN)`, `res.sendStatus(NNN)`, `res.statusCode = NNN`) miss each sibling's canonical status idiom.

## VERIFY-FIRST (genuine build gap, not scaffold / not honest-N/A)
End-to-end probe through `applyHTTPEndpointSynthesis` confirmed the existing extractor only partially fired (shared `.status(NNN)`) and entirely missed:

| framework | canonical idiom | resolved now |
|---|---|---|
| fastify | `reply.code(201)` | `201,400` |
| koa | `ctx.status = 201` | `200` |
| hono | `c.json(x, 201)` | `201` |
| hapi | `h.response(x).code(201)` | `201` |
| restify | `res.send(201, body)` | `201` |
| polka | `res.writeHead(204)` | `204` |
| adonis | `response.created()`/`.badRequest()` (helper→code) | `201,400` |

## Build
- Extended `jsResponseCodes` (`internal/engine/http_endpoint_response_codes.go`) with literal-only regexes per idiom + a sails/adonis named-status-helper→code map, mirroring the Java `ResponseEntity` factory-helper pattern.
- **Honest-partial preserved**: dynamic statuses (`reply.code(var)`) never fabricated; Express evidence label still wins when present (flagship string unchanged).
- Credited **7 verified** frameworks `full`. Left **honest-MISSING**: sails/feathers/marblejs (handler bodies not inline-synthesised verifiably here), pothos/type-graphql (GraphQL schema-builders — N/A for HTTP response codes).

## Quality gates
- 10 value-asserting tests (exact code set + `success_code` + `response_codes_source` label + a sibling dynamic-skip negative).
- Full `internal/engine` (50s) and `tools/coverage` packages green.
- `covtool fmt --check` → canonical; registry edited surgically (35 ins / 14 del, 7 cells), semantically verified identical to hand-edit.
- `covtool validate` exit 0 (no new mapping-warning class — the 7 cells mirror the flagship express/nestjs exactly, which carry the same pre-existing mapping-entry status).
- No new custom capability key → no dispatch-parity change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)