### PR TITLE
coverage(java): credit spring-data-jpa association/relationship_extraction (built-but-stale sibling)

### DIFF
--- a/internal/extractors/custom_java_patterns_smoke_test.go
+++ b/internal/extractors/custom_java_patterns_smoke_test.go
@@ -560,3 +560,68 @@ public class PhoneValidator implements ConstraintValidator<ValidPhone, String> {
 		t.Errorf("custom validator validated_type = %q, want String", got)
 	}
 }
+
+// TestJavaPatternsSpringDataJpaAssociationLive proves that Spring Data JPA
+// entities — not just plain JPA/Hibernate ones — reach the graph through the
+// live dispatch path with their @OneToMany/@ManyToOne associations intact.
+//
+// Spring Data JPA entities are ordinary jakarta.persistence @Entity classes, so
+// the same hibernate.go extractor handles them. The framework gate
+// hibernateFrameworks already admits the "spring_data_jpa" token, and
+// frameworkMarkers maps "org.springframework.data.jpa" -> "spring_data_jpa", so
+// a file importing the Spring Data JPA package is dispatched into ExtractHibernate.
+// This test asserts the association emerges as a directed DEPENDS_ON edge with
+// association_kind=OneToMany, which is exactly what association_extraction and
+// relationship_extraction credit for the sibling jpa/hibernate ORM records.
+func TestJavaPatternsSpringDataJpaAssociationLive(t *testing.T) {
+	src := `
+package com.example.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.OneToMany;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @OneToMany
+    private List<LineItem> items;
+}
+`
+	path := "src/main/java/com/example/model/Order.java"
+	recs := runJavaPatterns(t, path, src)
+
+	order := findRecord(recs, "SCOPE.Schema", "Order")
+	if order == nil {
+		t.Fatalf("expected SCOPE.Schema Order entity to emit live for spring_data_jpa; got %v", names(recs))
+	}
+	if got := order.Properties["table_name"]; got != "orders" {
+		t.Errorf("Order table_name = %q, want orders", got)
+	}
+
+	// relationship_extraction: the @OneToMany association Order -> LineItem must
+	// emit as a directed DEPENDS_ON edge, identical to the plain-JPA path.
+	wantTarget := "scope:schema:hibernate_entity:" + path + ":LineItem"
+	if !hasRel(order, "DEPENDS_ON", wantTarget) {
+		t.Errorf("expected DEPENDS_ON association edge Order -> LineItem (%s) for spring_data_jpa; got rels %v",
+			wantTarget, order.Relationships)
+	}
+
+	// association_extraction: the edge must carry association_kind=OneToMany so
+	// the association classifier (not merely "some dependency") is satisfied.
+	foundKind := false
+	for _, r := range order.Relationships {
+		if r.Kind == "DEPENDS_ON" && r.ToID == wantTarget {
+			if r.Properties["association_kind"] != "OneToMany" {
+				t.Errorf("association_kind = %q, want OneToMany", r.Properties["association_kind"])
+			}
+			foundKind = true
+		}
+	}
+	if !foundKind {
+		t.Errorf("expected the Order -> LineItem DEPENDS_ON edge to carry association_kind=OneToMany; got rels %v",
+			order.Relationships)
+	}
+}


### PR DESCRIPTION
## Summary

`covtool parity --language java` (base main `11bc6dc12`, uniform-scaffold suppressed) flagged **spring-data-jpa** as the single MISSING sibling for both `association_extraction` and `relationship_extraction` in the `orm/orm_mapper` group, while `jpa` / `hibernate` / `eclipselink` / `ebean` are all `full`.

**VERIFY-FIRST verdict: genuine built-but-not-surfacing (stale registry cell), not a build gap.** Spring Data JPA entities are ordinary `jakarta.persistence` `@Entity` classes:

- `internal/custom/java/hibernate.go` `hibernateFrameworks` **already admits** `spring_data_jpa`.
- `internal/custom/java/patterns_dispatch.go` `frameworkMarkers` maps `org.springframework.data.jpa -> spring_data_jpa`, so the file dispatches into `ExtractHibernate` through the live `RunCustomExtractors` path.
- `@OneToMany`/`@ManyToOne`/`@OneToOne`/`@ManyToMany` associations emit `DEPENDS_ON` edges with `association_kind` — identical to the `full` siblings.

The registry cells were stale-marked `missing` (cited #3586) even though the capability fires live.

## Changes

- **Live smoke test** `TestJavaPatternsSpringDataJpaAssociationLive` — drives the full `RunCustomExtractors` dispatch on a Spring Data JPA `@Entity` (imports `org.springframework.data.jpa.repository.JpaRepository`); value-asserts the `Order -> LineItem` `DEPENDS_ON` edge carries `association_kind=OneToMany` (mirrors `TestJavaPatternsJpaEntityLive`, never `len > 0`).
- **Registry** — flip `association_extraction` + `relationship_extraction` for `lang.java.orm.spring-data-jpa` `missing -> full`, mirroring the `jpa` cell shape/cites. Surgical 2-cell edit, no re-serialization.

## Quality gates

- `covtool fmt --check`: **canonical** (the only fmt delta was `> -> >` HTML-escape on my two notes lines, matching the sibling jpa cell).
- `covtool validate`: **ok** (the `association/relationship_extraction has no mapping entry` warning is pre-existing and uniform across every ORM Relationships cell in all languages — not introduced here; standard dictionary keys, no custom-key dispatch).
- Full package tests pass: `internal/custom/java`, `internal/extractors`, `tools/coverage`.
- Post-fix parity: spring-data-jpa now `full` for both caps; the only remaining ORM MISSING is the uniform `migration_schema_ops` group gap (#3628 territory, out of scope).

## Findings assessed
- **Fixed (genuine):** spring-data-jpa `association_extraction` + `relationship_extraction`.
- **Skipped as honest-N/A:** the `guice` single-MISSING gaps (auth_coverage/route_extraction/request_shape/handler_attribution/transaction_propagation/endpoint_synthesis) — guice is a DI container, not an HTTP framework; HTTP/routing/handler caps are N/A by design.
- **Skipped as uniform-group / #3628-cap:** migration_schema_ops, transaction_function_stamping, model_lifecycle — whole-group gaps, not sibling-trailing.

Closes #4162. Part of epic #3872.

**DEPLOY-DEFERRED** — registry credit + test only; live daemon rebuild/reindex deferred to the next coordinated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)