### PR TITLE
feat(csharp/dataflow): seed FastEndpoints request DTO for request_sink_dataflow

### DIFF
--- a/internal/substrate/dataflow_csharp.go
+++ b/internal/substrate/dataflow_csharp.go
@@ -92,6 +92,30 @@ var dfCSharpAnyFromAttrRe = regexp.MustCompile(
 	`\[\s*From(?:Body|Query|Form|Header|Route)\b`,
 )
 
+// dfCSharpFastEndpointSignalRe is a file-level presence check for a FastEndpoints
+// endpoint: a `: Endpoint<` base-class declaration or a `using FastEndpoints`
+// import. Mirrors engine/http_endpoint_csharp_minor.go fastEndpointsHasSignal so
+// the dataflow seed only fires on genuine FastEndpoints files. Required because a
+// FastEndpoints handler carries no per-parameter [From*] attribute — the whole
+// typed request DTO is request-derived.
+var dfCSharpFastEndpointSignalRe = regexp.MustCompile(
+	`using\s+FastEndpoints\b|:\s*Endpoint\s*<`,
+)
+
+// dfCSharpFEHandlerRe matches a FastEndpoints handler method header —
+// `HandleAsync(` or `ExecuteAsync(` (FastEndpoints' fixed handler-method names).
+// Group 1 = the method name. The enclosing class's typed request DTO is bound to
+// the FIRST parameter of this method, so that parameter is the request-derived
+// root (a CancellationToken second parameter is never seeded).
+var dfCSharpFEHandlerRe = regexp.MustCompile(
+	`\b(HandleAsync|ExecuteAsync)\s*\(`,
+)
+
+// dfCSharpCancellationTokenRe recognises a CancellationToken parameter so the
+// FastEndpoints seed never taints it even when it is the first parameter (a
+// parameterless-request `EndpointWithoutRequest` handler takes only `(CancellationToken ct)`).
+var dfCSharpCancellationTokenRe = regexp.MustCompile(`\bCancellationToken\b`)
+
 // dfCSharpRequestAccessRe matches an in-body request accessor whose key literal
 // is the source field: `Request.Query["x"]`, `Request.Form["x"]`,
 // `Request.RouteValues["id"]`, `Request.Headers["x"]`, `Request.Cookies["x"]`.
@@ -169,6 +193,9 @@ func sniffDataFlowCSharpEx(content string) DataFlowResult {
 	}
 	lines := strings.Split(content, "\n")
 	bodies := csharpFuncBodies(content, lines)
+	// A FastEndpoints file binds the whole typed request DTO to the first
+	// parameter of HandleAsync/ExecuteAsync; compute the file-level signal once.
+	feFile := dfCSharpFastEndpointSignalRe.MatchString(content)
 
 	var res DataFlowResult
 	for _, b := range bodies {
@@ -180,7 +207,16 @@ func sniffDataFlowCSharpEx(content string) DataFlowResult {
 		}
 		// Seed [From*] action params as request-derived roots so a
 		// [FromBody] dto / [FromQuery] string q parameter is tainted on entry.
+		// In a FastEndpoints file, also seed the HandleAsync/ExecuteAsync
+		// request DTO (first parameter) as a whole-object request root.
 		seed := csharpRequestParamTaints(lines, b)
+		if feFile {
+			for k, v := range csharpFastEndpointReqTaint(lines, b) {
+				if _, ok := seed[k]; !ok {
+					seed[k] = v
+				}
+			}
+		}
 		r := walkCSharpBody(ctx, b, seed)
 		res.Flows = append(res.Flows, r.Flows...)
 		res.Boundaries = append(res.Boundaries, r.Boundaries...)
@@ -735,6 +771,50 @@ func csharpRequestParamTaints(lines []string, b csharpFuncBody) map[string]taint
 		}
 		out[name] = taintInfo{field: field, line: b.Start}
 	}
+	return out
+}
+
+// csharpFastEndpointReqTaint returns the taint seed for a FastEndpoints handler.
+// FastEndpoints binds the endpoint's typed request DTO to the FIRST parameter of
+// the fixed handler method (`HandleAsync(MyRequest req, CancellationToken ct)` /
+// `ExecuteAsync(MyRequest req, ...)`), so that parameter is request-derived as a
+// whole object (field "" — recovered later from a `req.Property` access, exactly
+// like an ASP.NET [FromBody] whole-object root). A CancellationToken parameter is
+// never seeded, so a parameterless `EndpointWithoutRequest` handler whose only
+// parameter is `CancellationToken ct` yields no root. Returns an empty map for a
+// non-handler method so injected services and helper methods are unaffected.
+//
+// The caller restricts this to files carrying a FastEndpoints signal
+// (dfCSharpFastEndpointSignalRe), so a stray `HandleAsync` in an unrelated file
+// is not treated as a request source.
+func csharpFastEndpointReqTaint(lines []string, b csharpFuncBody) map[string]taintInfo {
+	out := map[string]taintInfo{}
+	if b.Start < 1 || b.Start > len(lines) {
+		return out
+	}
+	if !dfCSharpFEHandlerRe.MatchString(lines[b.Start-1]) {
+		return out
+	}
+	open := strings.IndexByte(lines[b.Start-1], '(')
+	if open < 0 {
+		return out
+	}
+	sig := jstsCallArgs(lines, b.Start, open)
+	params := jstsSplitArgs(sig)
+	if len(params) == 0 {
+		return out
+	}
+	first := params[0]
+	// Never seed a CancellationToken (the only param of a request-less handler).
+	if dfCSharpCancellationTokenRe.MatchString(first) {
+		return out
+	}
+	name := csharpParamIdent(first)
+	if name == "" {
+		return out
+	}
+	// Whole-object request root: field "" until a property access lifts a field.
+	out[name] = taintInfo{field: "", line: b.Start}
 	return out
 }
 

--- a/internal/substrate/dataflow_csharp_test.go
+++ b/internal/substrate/dataflow_csharp_test.go
@@ -191,6 +191,106 @@ func TestDataFlowCSharp_ReturnBareTainted_Response(t *testing.T) {
 	}
 }
 
+// ---- FastEndpoints (typed request DTO bound to the handler's first param) ----
+
+// FastEndpoints binds the request DTO to HandleAsync's first parameter; a
+// `req.Email` property access lifts the field and the EF write is the sink.
+func TestDataFlowCSharp_FastEndpoints_HandleAsync_PropertyField_DBWrite(t *testing.T) {
+	src := "" +
+		"public class CreateUser : Endpoint<CreateUserReq> {\n" +
+		"    public override async Task HandleAsync(CreateUserReq req, CancellationToken ct) {\n" +
+		"        _context.Users.Add(new User { Email = req.Email });\n" +
+		"        await _context.SaveChangesAsync();\n" +
+		"    }\n" +
+		"}\n"
+	flows := sniffDataFlowCSharp(src)
+	got := findFlow(flows, func(f DataFlow) bool {
+		return f.Function == "HandleAsync" && f.SinkKind == DataFlowSinkDBWrite && f.SinkName == "_context.Users.Add"
+	})
+	if got == nil {
+		t.Fatalf("expected FastEndpoints EF db_write flow, got %+v", flows)
+	}
+	if got.SourceField != "Email" {
+		t.Errorf("source field = %q, want Email (from req.Email)", got.SourceField)
+	}
+	if got.HopVia != "" {
+		t.Errorf("expected intra-fn, got hop=%q", got.HopVia)
+	}
+}
+
+// The ExecuteAsync handler variant is equally seeded; a bare `return req;` is a
+// whole-object response sink with empty field.
+func TestDataFlowCSharp_FastEndpoints_ExecuteAsync_WholeObject_Response(t *testing.T) {
+	src := "" +
+		"public class Echo : Endpoint<EchoReq, EchoReq> {\n" +
+		"    public override async Task ExecuteAsync(EchoReq req, CancellationToken ct) {\n" +
+		"        return req;\n" +
+		"    }\n" +
+		"}\n"
+	flows := sniffDataFlowCSharp(src)
+	got := findFlow(flows, func(f DataFlow) bool {
+		return f.Function == "ExecuteAsync" && f.SinkKind == DataFlowSinkResponse && f.SinkName == "return"
+	})
+	if got == nil {
+		t.Fatalf("expected FastEndpoints response flow, got %+v", flows)
+	}
+	if got.SourceField != "" {
+		t.Errorf("source field = %q, want empty (whole-object req)", got.SourceField)
+	}
+}
+
+// The `using FastEndpoints;` import alone is a sufficient file signal even when
+// the base-class generic is written without a space (`:Endpoint<`).
+func TestDataFlowCSharp_FastEndpoints_UsingImport_Signal(t *testing.T) {
+	src := "" +
+		"using FastEndpoints;\n" +
+		"public class Save : Endpoint<SaveReq> {\n" +
+		"    public override async Task HandleAsync(SaveReq req, CancellationToken ct) {\n" +
+		"        await connection.ExecuteAsync(\"insert ...\", new { req.Name });\n" +
+		"    }\n" +
+		"}\n"
+	flows := sniffDataFlowCSharp(src)
+	got := findFlow(flows, func(f DataFlow) bool {
+		return f.Function == "HandleAsync" && f.SinkKind == DataFlowSinkDBWrite && f.SinkName == "connection.ExecuteAsync"
+	})
+	if got == nil {
+		t.Fatalf("expected FastEndpoints Dapper db_write flow, got %+v", flows)
+	}
+	if got.SourceField != "Name" {
+		t.Errorf("source field = %q, want Name (from req.Name)", got.SourceField)
+	}
+}
+
+// Negative: a CancellationToken-only handler (EndpointWithoutRequest) has no
+// request DTO, so its sole parameter is NOT seeded — no flow is fabricated.
+func TestDataFlowCSharp_FastEndpoints_Negative_NoRequestCancellationToken(t *testing.T) {
+	src := "" +
+		"public class Ping : EndpointWithoutRequest : Endpoint<object> {\n" +
+		"    public override async Task HandleAsync(CancellationToken ct) {\n" +
+		"        _context.Audits.Add(new Audit(ct));\n" +
+		"    }\n" +
+		"}\n"
+	flows := sniffDataFlowCSharp(src)
+	if len(flows) != 0 {
+		t.Fatalf("expected no flows for a CancellationToken-only handler, got %+v", flows)
+	}
+}
+
+// Negative: a HandleAsync method in a file with NO FastEndpoints signal is not
+// treated as a request handler (the first param is not seeded).
+func TestDataFlowCSharp_FastEndpoints_Negative_NoFileSignal(t *testing.T) {
+	src := "" +
+		"public class Worker {\n" +
+		"    public async Task HandleAsync(JobMessage req, CancellationToken ct) {\n" +
+		"        _context.Jobs.Add(new Job { Name = req.Name });\n" +
+		"    }\n" +
+		"}\n"
+	flows := sniffDataFlowCSharp(src)
+	if len(flows) != 0 {
+		t.Fatalf("expected no flows without a FastEndpoints signal, got %+v", flows)
+	}
+}
+
 // ---- multi-hop (one local-method hop) ----
 
 func TestDataFlowCSharp_OneHop_LocalMethod(t *testing.T) {


### PR DESCRIPTION
## csharp parity grind (epic #3872) — Closes #4164

Ran `covtool parity --language csharp` on main `11bc6dc12` (uniform-scaffold suppressed → real findings). The bulk of the 37 findings are `hotchocolate` (GraphQL) trailing-siblings against REST-oriented caps (honest-N/A — SKIP) and cross-language #3628 caps already done. After VERIFY-FIRST triage, **one genuine, high-value, buildable gap**:

### Gap built: `request_sink_dataflow` for `lang.csharp.framework.fastendpoints`

**Verify-first (genuine, not scaffold):** the C# dataflow sniffer (`internal/substrate/dataflow_csharp.go`, built in #3960) seeds request-derived taint roots ONLY from ASP.NET `[From*]` attributes and `Request.Query[...]` accessors. FastEndpoints carries **no per-parameter binding attribute** — it binds the entire typed request DTO to the FIRST parameter of the fixed handler method:

```csharp
public class CreateUser : Endpoint<CreateUserReq> {
    public override async Task HandleAsync(CreateUserReq req, CancellationToken ct) {
        _context.Users.Add(new User { Email = req.Email });   // req-derived → EF write
        await _context.SaveChangesAsync();
    }
}
```

So `req` was never seeded — `request_sink_dataflow` was genuinely `missing` (#3740) for fastendpoints while aspnet-core/mvc/carter were `partial`.

**Fix:** seed the FastEndpoints request DTO as a whole-object request root (field `""`, recovered from `req.Property` access, mirroring `[FromBody]`):
- file-scoped to a FastEndpoints signal (`dfCSharpFastEndpointSignalRe`: `using FastEndpoints` / `: Endpoint<`) — a stray `HandleAsync` elsewhere is not a request source;
- first param of `HandleAsync`/`ExecuteAsync` (`dfCSharpFEHandlerRe`) is the root; a `CancellationToken`-only handler (`EndpointWithoutRequest`) is never seeded (`csharpFastEndpointReqTaint`);
- reuses the existing intra-method taint, multi-hop local propagation, cross-file boundary emission, and the shared sink table (EF Core / Dapper / response / outbound HTTP) — no new dispatch.

### Artifacts asserted (5 new value-asserting tests, all green)
- `HandleAsync` + `req.Email` → EF `_context.Users.Add` db_write, **field=Email** (property-lifted, intra-fn)
- `ExecuteAsync` + `return req` → response, **field=""** (whole-object)
- `using FastEndpoints` import signal + `req.Name` → Dapper `connection.ExecuteAsync`, **field=Name**
- negative: `CancellationToken`-only handler (`EndpointWithoutRequest`) → **no flow** (token never seeded)
- negative: `HandleAsync` in a file with **no** FastEndpoints signal → **no flow**

Full `./internal/substrate/` package tests + `go vet` pass.

### Registry
`lang.csharp.framework.fastendpoints` `request_sink_dataflow`: `missing`(#3740) → `partial`(#4164). Surgical line-range edit (id-verified inside the fastendpoints block, 5 insert / 2 delete), `covtool fmt --check` reports **canonical**. No new capability key → no dispatch-parity change needed.

### Skipped (verified honest, NOT built)
- `nancyfx` / `servicestack` `request_sink_dataflow` — own request models (NancyFX `this.Bind<T>()`/`Request.Form`, ServiceStack typed DTOs via `Service.Request`); separate seeding, genuine-but-deferred under #3740.
- `hotchocolate` (all caps) — GraphQL, honest-N/A vs REST-oriented caps.
- `test.fluentassertions` `dependency_graph`/`target_extraction` — assertion DSL with no test-method/class structure of its own; correctly `missing` under #3828 (honest-N/A, SKIP).
- DI / rate_limit / error_flow siblings — DI-container honest-N/A and #3628 caps already done.

**DEPLOY-DEFERRED** (live daemon not rebuilt/reindexed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)