### PR TITLE
parity-grind-kotlin

### DIFF
--- a/internal/custom/java/kotlin_port_test.go
+++ b/internal/custom/java/kotlin_port_test.go
@@ -564,6 +564,51 @@ data class Customer(
 	}
 }
 
+// TestKotlinHibernate_SchemaTableName_Parity3872 is the value-asserting parity
+// test for schema_extraction on lang.kotlin.orm.hibernate and
+// lang.kotlin.orm.spring-data. It drives the real ExtractHibernate dispatch on
+// Kotlin source for BOTH the "hibernate" and "spring_data_jpa" frameworks and
+// asserts the EXACT table_name property emitted from @Table(name=...) on a
+// Kotlin data class — proving the schema layer dispatches live for Kotlin and
+// is not a generic SCOPE.Schema presence check.
+func TestKotlinHibernate_SchemaTableName_Parity3872(t *testing.T) {
+	source := `
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "orders")
+data class Order(
+    val id: Long = 0,
+    val total: Double = 0.0
+)
+`
+	for _, fw := range []string{"hibernate", "spring_data_jpa"} {
+		r := ExtractHibernate(PatternContext{
+			Source:    source,
+			Language:  "kotlin",
+			Framework: fw,
+			FilePath:  "Order.kt",
+		})
+		var got string
+		var foundSchema bool
+		for _, e := range r.Entities {
+			if e.Kind == "SCOPE.Schema" && e.Name == "Order" {
+				foundSchema = true
+				if tn, ok := e.Properties["table_name"].(string); ok {
+					got = tn
+				}
+			}
+		}
+		if !foundSchema {
+			t.Fatalf("[parity#3872 %s] no SCOPE.Schema entity named Order emitted for Kotlin", fw)
+		}
+		if got != "orders" {
+			t.Errorf("[parity#3872 %s] table_name = %q, want %q", fw, got, "orders")
+		}
+	}
+}
+
 // TestKotlinHibernate_Associations_Issue3274 verifies @OneToMany / @ManyToOne
 // produce DEPENDS_ON relationships.
 func TestKotlinHibernate_Associations_Issue3274(t *testing.T) {


### PR DESCRIPTION
Closes #4166

Part of epic #3872. DEPLOY-DEFERRED.

## What
Parity-probe-driven gap grind for Kotlin. `covtool parity --language kotlin` flagged `orm/orm_mapper schema_extraction` with `lang.kotlin.orm.hibernate` and `lang.kotlin.orm.spring-data` MISSING while their true ORM peers (exposed/ktorm/room/sqldelight) are full.

Verify-first proved the capability already DISPATCHES live: `ExtractHibernate` (`internal/custom/java/hibernate.go:61`) gates on `(java||kotlin) && hibernateFrameworks[Framework]` and emits `SCOPE.Schema` entities carrying the `table_name` property from `@Table(name=...)` on Kotlin data classes. The cells were stale at `missing`.

## Cells fixed (before -> after)
- `lang.kotlin.orm.hibernate` Models.schema_extraction: **missing -> partial**
- `lang.kotlin.orm.spring-data` Models.schema_extraction: **missing -> partial**

Both mirror the Java siblings (`java.orm.hibernate`, `java.orm.spring-data-jpa` are `partial`). Partial is honest — Kotlin-specific JPA idioms not all captured.

## Test
`TestKotlinHibernate_SchemaTableName_Parity3872` (internal/custom/java/kotlin_port_test.go) drives the real `ExtractHibernate` dispatch on a Kotlin `@Entity @Table(name="orders") data class Order` for BOTH `hibernate` and `spring_data_jpa` frameworks, and asserts the exact emitted property `table_name == "orders"` on the `SCOPE.Schema` entity (not a `len>0` check).

## Skipped as N/A
The other 45 parity findings are whole-group taxonomy asymmetries (#3628-class): trailing siblings dagger-hilt/koin (DI containers), kotlinx-serialization, graphql-kotlin (GraphQL builder), retrofit (HTTP client) trail on HTTP-backend caps they have no surface for. Not credited.

## Gates
- `covtool fmt --check`: canonical
- `covtool validate`: ok (658 records)
- `go test ./internal/custom/kotlin/ ./internal/custom/java/ ./internal/extractors/ ./tools/coverage/`: pass
- `gofmt -l`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)