### PR TITLE
parity-grind-php

### DIFF
--- a/internal/custom/php/apiplatform.go
+++ b/internal/custom/php/apiplatform.go
@@ -81,16 +81,20 @@ func (e *apiPlatformExtractor) Language() string { return "custom_php_api_platfo
 var (
 	// `#[ApiResource(...)]` — the resource attribute. Group 1 is the full
 	// argument body (may be empty for a bare `#[ApiResource]`).
-	reAPResource = regexp.MustCompile(`#\[ApiResource\b\s*(?:\((?P<body>(?:[^()]|\([^()]*\))*)\))?\s*\]`)
+	// The body sub-pattern tolerates up to TWO levels of nested parentheses so a
+	// security expression call — `new Delete(security: "is_granted('ROLE')")` —
+	// inside an `operations: [...]` list inside `#[ApiResource(...)]` still
+	// matches (the inner is_granted(...) is the second level). #3872.
+	reAPResource = regexp.MustCompile(`#\[ApiResource\b\s*(?:\((?P<body>(?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\))?\s*\]`)
 	// `class Foo` — the class the attribute decorates. Group 1 is the class name.
 	reAPClass = regexp.MustCompile(`(?m)^\s*(?:final\s+|abstract\s+)*class\s+([A-Za-z_]\w*)`)
 	// A standalone per-class operation attribute: #[Get], #[GetCollection],
 	// #[Post(...)], #[Put], #[Patch], #[Delete]. Group 1 is the operation name,
 	// group 2 the optional argument body.
-	reAPOpAttr = regexp.MustCompile(`#\[(Get|GetCollection|Post|Put|Patch|Delete)\b\s*(?:\((?P<body>(?:[^()]|\([^()]*\))*)\))?\s*\]`)
+	reAPOpAttr = regexp.MustCompile(`#\[(Get|GetCollection|Post|Put|Patch|Delete)\b\s*(?:\((?P<body>(?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\))?\s*\]`)
 	// `new Get()` / `new GetCollection(...)` — operation constructors inside an
 	// `operations: [ ... ]` list. Group 1 is the operation name, group 2 body.
-	reAPOpNew = regexp.MustCompile(`new\s+(Get|GetCollection|Post|Put|Patch|Delete)\s*\((?P<body>(?:[^()]|\([^()]*\))*)\)`)
+	reAPOpNew = regexp.MustCompile(`new\s+(Get|GetCollection|Post|Put|Patch|Delete)\s*\((?P<body>(?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\)`)
 	// `uriTemplate: '/path'` inside an operation body. Group 1 is the path.
 	reAPUriTemplate = regexp.MustCompile(`uriTemplate\s*:\s*['"]([^'"]+)['"]`)
 	// `#[ApiFilter(SearchFilter::class, ...)]` — a query filter. Group 1 is the
@@ -100,6 +104,14 @@ var (
 	// marker, valid on #[ApiResource] (resource-wide) and on a single operation
 	// (new Get(deprecationReason: '...')). Group 1 is the message (epic #3628).
 	reAPDeprecationReason = regexp.MustCompile(`(?i)deprecationReason\s*:\s*['"]([^'"]{0,200})['"]`)
+	// `security: "is_granted('ROLE_ADMIN')"` — the Symfony security expression on
+	// #[ApiResource] (resource-wide) or on a single REST operation. Mirrors the
+	// api-platform-graphql sibling's auth parse (apiplatform_graphql.go, #3872).
+	// Group 1 is the raw double-quoted expression.
+	reAPSecurity = regexp.MustCompile(`\bsecurity\s*:\s*"((?:[^"\\]|\\.)*)"`)
+	// `is_granted('ROLE_ADMIN')` inside a security expression. Group 1 is the
+	// granted attribute (typically a ROLE_* string, any literal captured).
+	reAPIsGranted = regexp.MustCompile(`is_granted\s*\(\s*['"]([^'"]+)['"]`)
 )
 
 // apOperation describes one generated REST operation: its HTTP method and
@@ -259,6 +271,7 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 			op  apOperation
 			uri string
 			dep string // per-operation deprecationReason message, "" when none
+			sec string // per-operation security expression, "" when none
 		}
 		addOp := func(name, body string) {
 			meta, ok := apOperationMeta(name)
@@ -273,11 +286,16 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 			if dm := reAPDeprecationReason.FindStringSubmatch(body); dm != nil {
 				dep = dm[1]
 			}
+			sec := ""
+			if sm := reAPSecurity.FindStringSubmatch(body); sm != nil {
+				sec = sm[1]
+			}
 			explicit = append(explicit, struct {
 				op  apOperation
 				uri string
 				dep string
-			}{meta, uri, dep})
+				sec string
+			}{meta, uri, dep, sec})
 		}
 		// operations: [ new Get(), new GetCollection() ] inside the resource body.
 		if strings.Contains(resBody, "operations") {
@@ -302,7 +320,14 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 		if dm := reAPDeprecationReason.FindStringSubmatch(apStripOperationsList(resBody)); dm != nil {
 			resDep = dm[1]
 		}
-		emit := func(opName, method, path string, collection bool, depReason string) {
+		// Resource-wide `security:` on #[ApiResource(...)] guards every generated
+		// operation (a per-operation security overrides it). Strip the
+		// operations:[...] sub-list so a per-op security isn't read as resource-wide.
+		resSec := ""
+		if sm := reAPSecurity.FindStringSubmatch(apStripOperationsList(resBody)); sm != nil {
+			resSec = sm[1]
+		}
+		emit := func(opName, method, path string, collection bool, depReason, secExpr string) {
 			name := method + " " + path
 			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, line)
 			setProps(&ent, "framework", "api-platform",
@@ -320,6 +345,22 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 				since, repl := parseDeprecationMessage(depReason)
 				stampDeprecation(&ent, "deprecationReason", since, repl)
 			}
+			// Auth (#3872): a `security:` expression makes the REST operation
+			// auth-protected; is_granted('ROLE_*') clauses become auth_roles.
+			// Mirrors the api-platform-graphql sibling's auth property shape.
+			if secExpr != "" {
+				setProps(&ent, "auth_required", "true",
+					"auth_method", "expression",
+					"auth_confidence", "high",
+					"auth_expression", secExpr)
+				var roles []string
+				for _, gm := range reAPIsGranted.FindAllStringSubmatch(secExpr, -1) {
+					roles = append(roles, gm[1])
+				}
+				if len(roles) > 0 {
+					setProps(&ent, "auth_roles", strings.Join(roles, ","))
+				}
+			}
 			add(ent)
 		}
 
@@ -331,7 +372,7 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 				if !op.collection {
 					path = basePath + "/{id}"
 				}
-				emit(op.name, op.method, path, op.collection, resDep)
+				emit(op.name, op.method, path, op.collection, resDep, resSec)
 			}
 		} else {
 			for _, x := range ops {
@@ -347,7 +388,12 @@ func (e *apiPlatformExtractor) Extract(ctx context.Context, file extractor.FileI
 				if dep == "" {
 					dep = resDep
 				}
-				emit(x.op.name, x.op.method, path, x.op.collection, dep)
+				// Per-operation security wins; otherwise inherit the resource-wide one.
+				sec := x.sec
+				if sec == "" {
+					sec = resSec
+				}
+				emit(x.op.name, x.op.method, path, x.op.collection, dep, sec)
 			}
 		}
 

--- a/internal/custom/php/apiplatform_test.go
+++ b/internal/custom/php/apiplatform_test.go
@@ -133,6 +133,89 @@ class Book {}
 	}
 }
 
+// TestAPIPlatform_PerOperationSecurity asserts a per-operation `security:`
+// expression stamps the EXACT auth properties on that REST endpoint and that an
+// operation WITHOUT security is left unsecured (auth parity with the
+// api-platform-graphql sibling; epic #3872).
+func TestAPIPlatform_PerOperationSecurity(t *testing.T) {
+	src := `<?php
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Delete;
+
+#[ApiResource(operations: [
+    new Get(),
+    new Delete(security: "is_granted('ROLE_ADMIN')"),
+])]
+class Book {}
+`
+	ents := extractRecords(t, "custom_php_api_platform", fi("Book.php", "php", src))
+	del := findRecord(ents, "SCOPE.Operation", "DELETE /books/{id}")
+	if del == nil {
+		t.Fatal("expected DELETE /books/{id} endpoint")
+	}
+	if got := prop(t, del, "auth_required"); got != "true" {
+		t.Errorf("auth_required = %q, want true", got)
+	}
+	if got := prop(t, del, "auth_roles"); got != "ROLE_ADMIN" {
+		t.Errorf("auth_roles = %q, want ROLE_ADMIN", got)
+	}
+	if got := prop(t, del, "auth_method"); got != "expression" {
+		t.Errorf("auth_method = %q, want expression", got)
+	}
+	if got := prop(t, del, "auth_expression"); got != "is_granted('ROLE_ADMIN')" {
+		t.Errorf("auth_expression = %q, want is_granted('ROLE_ADMIN')", got)
+	}
+	// The Get() op has no security: → must NOT be auth_required (negative).
+	get := findRecord(ents, "SCOPE.Operation", "GET /books/{id}")
+	if get == nil {
+		t.Fatal("expected GET /books/{id} endpoint")
+	}
+	if got := get.Properties["auth_required"]; got != "" {
+		t.Errorf("unsecured GET leaked auth_required = %q", got)
+	}
+}
+
+// TestAPIPlatform_ResourceWideSecurity asserts a resource-wide `security:` on
+// #[ApiResource(...)] guards every generated default-CRUD endpoint, and that a
+// per-operation security overrides the resource-wide expression.
+func TestAPIPlatform_ResourceWideSecurity(t *testing.T) {
+	src := `<?php
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Delete;
+
+#[ApiResource(
+    security: "is_granted('ROLE_USER')",
+    operations: [
+        new Get(),
+        new Delete(security: "is_granted('ROLE_ADMIN', object)"),
+    ]
+)]
+class Book {}
+`
+	ents := extractRecords(t, "custom_php_api_platform", fi("Book.php", "php", src))
+	// Get inherits the resource-wide ROLE_USER expression.
+	get := findRecord(ents, "SCOPE.Operation", "GET /books/{id}")
+	if get == nil {
+		t.Fatal("expected GET /books/{id} endpoint")
+	}
+	if got := prop(t, get, "auth_required"); got != "true" {
+		t.Errorf("inherited auth_required = %q, want true", got)
+	}
+	if got := prop(t, get, "auth_roles"); got != "ROLE_USER" {
+		t.Errorf("inherited auth_roles = %q, want ROLE_USER", got)
+	}
+	// Delete's per-operation security overrides the resource-wide one.
+	del := findRecord(ents, "SCOPE.Operation", "DELETE /books/{id}")
+	if del == nil {
+		t.Fatal("expected DELETE /books/{id} endpoint")
+	}
+	if got := prop(t, del, "auth_roles"); got != "ROLE_ADMIN" {
+		t.Errorf("per-op override auth_roles = %q, want ROLE_ADMIN", got)
+	}
+}
+
 // TestAPIPlatform_NoMatch verifies the extractor is a no-op on plain PHP.
 func TestAPIPlatform_NoMatch(t *testing.T) {
 	src := `<?php class Plain { public function go() { return 1; } }`

--- a/internal/extractors/php/config_consumer_test.go
+++ b/internal/extractors/php/config_consumer_test.go
@@ -112,3 +112,44 @@ function read(string $name): void {
 		t.Errorf("dynamic key must be skipped; got %v", keys)
 	}
 }
+
+// Parity flip (epic #3872): the config-read pass is framework-agnostic — it
+// walks every PHP file regardless of framework. An API Platform GraphQL
+// resolver reads configuration with the same getenv/$_ENV/env()/config()
+// shapes, so config_consumption dispatches live for the api-platform-graphql
+// sibling exactly as it does for api-platform. Asserts the EXACT config key +
+// DEPENDS_ON_CONFIG edge from the resolver method (never len>0).
+func TestPHPConfigConsumer_APIPlatformGraphQLResolver(t *testing.T) {
+	src := `<?php
+namespace App\Resolver;
+
+use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
+
+final class BookResolver implements QueryItemResolverInterface
+{
+    public function __invoke(?object $item, array $context): object
+    {
+        $endpoint = getenv('GRAPHQL_ENDPOINT');
+        $rate = $_ENV['GRAPHQL_RATE_LIMIT'];
+        $secret = env('API_PLATFORM_SECRET');
+        $cache = config('api_platform.graphql.cache');
+        return $item;
+    }
+}
+`
+	recs := extractPHPRecords(t, src)
+	keys := phpConfigKeysFrom(recs, "BookResolver.__invoke")
+	for _, want := range []string{
+		"GRAPHQL_ENDPOINT",           // getenv
+		"GRAPHQL_RATE_LIMIT",         // $_ENV superglobal
+		"API_PLATFORM_SECRET",        // Laravel env()
+		"api_platform.graphql.cache", // Laravel config()
+	} {
+		if !keys[want] {
+			t.Errorf("expected DEPENDS_ON_CONFIG(BookResolver.__invoke → %s); got %v", want, keys)
+		}
+		if !phpHasConfigKeyEntity(recs, want) {
+			t.Errorf("expected SCOPE.Config/config_key entity for %s", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4168

DEPLOY-DEFERRED.

Verify-first PHP parity grind (epic #3872). Two genuine framework asymmetries from `covtool parity --language php`.

## Cells fixed (before → after)
| record | cap | before | after | kind |
|---|---|---|---|---|
| `lang.php.framework.api-platform` | `Auth/auth_coverage` | missing | full | genuine build gap |
| `lang.php.framework.api-platform-graphql` | `Substrate/config_consumption` | missing | full | stale-cell flip |

### api-platform auth_coverage (BUILD)
The REST `#[ApiResource]` extractor emitted endpoints but never parsed the Symfony `security:` expression. Built it (mirrors the api-platform-graphql sibling): resource-wide `security:` guards every generated op, per-op `security:` overrides. Stamps `auth_required`, `auth_method=expression`, `auth_confidence=high`, `auth_expression`, `auth_roles` (from `is_granted('ROLE_*')`). Also widened the resource/operation body regexes to two paren-nesting levels so `is_granted(...)` inside `new Delete(...)` inside `#[ApiResource(...)]` still matches (previously the whole attribute failed to match such bodies).

### api-platform-graphql config_consumption (FLIP)
`internal/extractors/php/config_consumer.go` runs unconditionally per PHP file (framework-agnostic `getenv`/`$_ENV`/`env()`/`config()` → `DEPENDS_ON_CONFIG` edges). GraphQL resolvers dispatch identically; cell was stale.

## Skipped as N/A
- `graphql-php` `auth_coverage` (sole remaining trailing sibling) — webonyx/graphql-php is a pure schema-builder library with no framework-level auth/security surface; auth is application-level. Honest N/A.
- `request_validation` / `type_extraction` / `tests_linkage` / `trace_extraction` — MISSING across the ENTIRE api-platform/GraphQL family (all 4), not single-sibling-trailing; whole-group (#3628) gaps.
- `di_*`, `view_rendering`, `endpoint_*` whole-row MISSING — whole-group/#3628 caps.

## Tests (exact edge/property asserted)
- `TestAPIPlatform_PerOperationSecurity` — `DELETE /books/{id}`: `auth_required=true`, `auth_roles=ROLE_ADMIN`, `auth_method=expression`, `auth_expression=is_granted('ROLE_ADMIN')`; negative: unsecured `GET /books/{id}` → empty `auth_required`.
- `TestAPIPlatform_ResourceWideSecurity` — resource-wide guard inherited onto `GET` (`auth_roles=ROLE_USER`); per-op override on `DELETE` (`auth_roles=ROLE_ADMIN`).
- `TestPHPConfigConsumer_APIPlatformGraphQLResolver` — resolver `__invoke` emits exact `DEPENDS_ON_CONFIG`/`SCOPE.Config` for `GRAPHQL_ENDPOINT`, `GRAPHQL_RATE_LIMIT`, `API_PLATFORM_SECRET`, `api_platform.graphql.cache`.

## Gates
`covtool fmt --check` canonical · `covtool validate` ok · `go test ./internal/custom/php/ ./internal/extractors/php/` pass · `gofmt -l` / `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)