### PR TITLE
ruby: Elasticsearch driver topology (build) + Neo4j query_attribution (credit)

### DIFF
--- a/internal/engine/orm_queries_drivers_other.go
+++ b/internal/engine/orm_queries_drivers_other.go
@@ -28,6 +28,7 @@
 //     C#     : .Index("products")
 //     PHP    : ['index' => 'products']
 //     Python : es.search(index='products')
+//     Ruby   : client.search(index: 'products')
 //   - Cassandra (CQL FROM/INTO/UPDATE table — reuses extractSQLTable)
 //     any lang: session.execute("SELECT ... FROM events")
 //
@@ -412,6 +413,19 @@ func mentionsRubyCassandra(src string) bool {
 	return strings.Contains(src, "cassandra") || strings.Contains(src, "Cassandra.cluster")
 }
 
+// mentionsRubyElastic reports whether the file references the elasticsearch-ruby
+// client (the `elasticsearch` gem / `Elasticsearch::Client`) or the OpenSearch
+// fork (`opensearch-ruby` / `OpenSearch::Client`), which share the identical
+// `client.search(index: 'x', ...)` call shape. The import gate keeps the broad
+// `index:` literal surface (esIndexKeyRe) from firing on unrelated Ruby hashes.
+func mentionsRubyElastic(src string) bool {
+	return strings.Contains(src, "Elasticsearch::Client") ||
+		strings.Contains(src, "elasticsearch") ||
+		strings.Contains(src, "Elasticsearch") ||
+		strings.Contains(src, "OpenSearch::Client") ||
+		strings.Contains(src, "opensearch")
+}
+
 func scanRubyDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 	if mentionsRubyMongo(src) {
 		for _, m := range rubyMongoCollRe.FindAllStringSubmatchIndex(src, -1) {
@@ -434,6 +448,15 @@ func scanRubyDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 	}
 	if mentionsRubyCassandra(src) {
 		emitCQLTargets(src, funcs, emit, rubyCqlRe)
+	}
+	// Elasticsearch (elasticsearch-ruby / opensearch-ruby): the dominant Ruby
+	// ES idiom is `client.search(index: 'users', body: {...})`, whose index
+	// literal is captured by the shared esIndexKeyRe and attributed to the
+	// resource by the language-agnostic emitElasticTargets — exactly as the
+	// C#/PHP/Python driver passes do (#3645). Dynamic index names (a variable)
+	// are honest-skipped because esIndexKeyRe only captures quoted literals.
+	if mentionsRubyElastic(src) {
+		emitElasticTargets(src, funcs, emit)
 	}
 }
 

--- a/internal/engine/orm_queries_drivers_other_test.go
+++ b/internal/engine/orm_queries_drivers_other_test.go
@@ -336,3 +336,58 @@ end
 		t.Errorf("expected orm=dynamodb, got %q", e.ORM)
 	}
 }
+
+func TestDriver_RubyElasticIndex(t *testing.T) {
+	src := `require 'elasticsearch'
+class LogSearch
+  def search
+    client = Elasticsearch::Client.new
+    client.search(index: 'logs', body: { query: { match_all: {} } })
+  end
+end
+`
+	edges := detectORM(t, "ruby", "log_search.rb", src)
+	e := assertEdgeExists(t, edges, "Function:search", "Class:Log", "find")
+	if e.ORM != "elastic" {
+		t.Errorf("expected orm=elastic, got %q", e.ORM)
+	}
+}
+
+// Dynamic-index negative: an index name bound to a variable is not a static
+// literal, so esIndexKeyRe must not capture it — no hallucinated edge.
+func TestDriver_RubyElasticDynamicIndexSkipped(t *testing.T) {
+	src := `require 'elasticsearch'
+class LogSearch
+  def search(idx)
+    client = Elasticsearch::Client.new
+    client.search(index: idx, body: {})
+  end
+end
+`
+	edges := detectORM(t, "ruby", "log_search.rb", src)
+	for _, e := range edges {
+		if e.ORM == "elastic" {
+			t.Errorf("expected no elastic edge for dynamic index, got %+v", e)
+		}
+	}
+}
+
+// Neo4j Ruby: the language-agnostic datastore-infra pass (scanDatastoreInfraDrivers,
+// run for Ruby in applyORMQueries) attributes `session.run("MATCH (n:Label) ...")`
+// Cypher to the node label. This asserts the Ruby neo4j-ruby-driver call shape
+// genuinely fires the cross-language Cypher emitter — the basis for crediting
+// lang.ruby.driver.neo4j query_attribution.
+func TestDriver_RubyNeo4jCypher(t *testing.T) {
+	src := `require 'neo4j/driver'
+class UserGraph
+  def find_users
+    session.run("MATCH (u:User) RETURN u")
+  end
+end
+`
+	edges := detectORM(t, "ruby", "user_graph.rb", src)
+	e := assertEdgeExists(t, edges, "Function:find_users", "Class:User", "find")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}


### PR DESCRIPTION
## What

`covtool parity --language ruby` (main `11bc6dc12`, uniform-scaffold suppressed → REAL findings) flagged the `orm/orm_mapper · query_attribution` group: 8 sibling Ruby drivers are `full` (cassandra/dynamodb/mongodb/mysql/postgres/redis/sqlite + activerecord) while two trail as `MISSING`. VERIFY-FIRST showed one is a genuine build and one a genuine credit.

### 1. Elasticsearch — genuine BUILD
`scanRubyDrivers` covered Mongo/Dynamo/Cassandra but never wired the shared, language-agnostic `emitElasticTargets` (already used by the C#/PHP/Python driver passes), despite:
- `esIndexKeyRe` already matching the Ruby `index: 'logs'` idiom, and
- `elasticsearch-ruby` (`Elasticsearch::Client#search`) being the dominant Ruby ES client.

Added a `mentionsRubyElastic` import gate and wired `emitElasticTargets`, so `client.search(index: 'logs', ...)` emits the **same** canonical `QUERIES → Class:<Index>` edge as the sibling languages. Dynamic (variable) index names are honest-skipped.

### 2. Neo4j — genuine CREDIT (no code change)
Ruby already runs the language-agnostic datastore-infra pass (`scanDatastoreInfraDrivers → emitCypherTargets`) in `applyORMQueries`, so `session.run("MATCH (u:User) ...")` Cypher already attributes to the node label. The registry cell was stale-`MISSING` ("no native query-topology extractor"). A value-asserting test confirms the cross-language Cypher emitter fires for the Ruby driver → credited to `full`.

## VERIFY-FIRST rigor
The elastic positive test was proven non-vacuous: with the wiring disabled it FAILS (`got: Class:Client` / `orm=""`), with it enabled it PASSES (`Function:search -find-> Class:Log`, `orm=elastic`).

## Tests (value-asserting, not len>0)
- `TestDriver_RubyElasticIndex` → `Function:search -find-> Class:Log` (`orm=elastic`)
- `TestDriver_RubyElasticDynamicIndexSkipped` → no edge for a variable index (negative)
- `TestDriver_RubyNeo4jCypher` → `Function:find_users -find-> Class:User` (`orm=neo4j`)

## Result
- `lang.ruby.driver.{elastic,neo4j}` `query_attribution`: `MISSING → full`
- Parity findings 32 → 31 (the `query_attribution` trailing-sibling group is fully closed)
- `covtool fmt --check`: canonical ✅ (only the 2 edited cells changed)
- Full `internal/engine` + `tools/coverage` package tests pass; `go vet` + `gofmt` clean
- No new custom registry key (reused existing `query_attribution` capability) → no dispatch-parity change

DEPLOY-DEFERRED.

Closes #4170 (epic #3872), family #3645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)