### PR TITLE
parity-grind-rust

### DIFF
--- a/internal/custom/rust/observability.go
+++ b/internal/custom/rust/observability.go
@@ -98,6 +98,14 @@ var rustObsFrameworkMarkers = []struct {
 	// unchanged — these markers only affect attribution.
 	{"tonic", regexp.MustCompile(`\buse\s+tonic\b|tonic::`)},
 	{"async-graphql", regexp.MustCompile(`\buse\s+async_graphql\b|async_graphql::`)},
+	// Issue (parity-grind-rust) — utoipa is an OpenAPI-documentation layer that
+	// annotates handlers with #[utoipa::path]/#[derive(ToSchema)]. Such handler
+	// modules emit the same framework-agnostic observability signals (tracing
+	// spans / metrics / #[instrument]). The marker is appended LAST so that a
+	// file importing both a server framework (axum/actix/…) and utoipa is still
+	// attributed to the actual HTTP framework; the utoipa marker only catches
+	// utoipa-only handler/doc modules that would otherwise be framework="".
+	{"utoipa", regexp.MustCompile(`\buse\s+utoipa\b|utoipa::`)},
 }
 
 func detectRustObsFramework(src string) string {

--- a/internal/custom/rust/observability_auth_test.go
+++ b/internal/custom/rust/observability_auth_test.go
@@ -353,6 +353,66 @@ func TestRustObs_WrongLang(t *testing.T) {
 	}
 }
 
+// TestRustObs_FrameworkAttribution_Utoipa is the VALUE-ASSERTING probe for the
+// parity-grind-rust fix. utoipa is an OpenAPI-documentation layer: handler
+// modules annotated with #[utoipa::path]/#[derive(ToSchema)] emit the same
+// framework-agnostic observability signals (tracing span / metric / log macro)
+// recognised by rustObsSignals. Before the utoipa import marker was added, a
+// utoipa-only handler module's observability entities were emitted with
+// framework="" and so were NOT credited to the per-framework metric/trace/log
+// cells. This probe drives a utoipa-only file through the live scanner and
+// asserts (a) the EXACT metric/span/log entity is emitted and (b) each carries
+// framework="utoipa" — the property the per-framework coverage cells depend on.
+func TestRustObs_FrameworkAttribution_Utoipa(t *testing.T) {
+	src := `
+use utoipa::OpenApi;
+use utoipa::ToSchema;
+use tracing::{info, info_span};
+
+#[utoipa::path(get, path = "/users/{id}", responses((status = 200, body = User)))]
+async fn get_user(id: i32) -> User {
+    let _s = info_span!("utoipa_get_user");
+    metrics::counter!("utoipa_requests_total", 1);
+    tracing::info!("serving documented endpoint");
+    User::default()
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("utoipa_handler.rs", "rust", src))
+	if len(ents) == 0 {
+		t.Fatal("expected observability entities from utoipa handler module, got none")
+	}
+
+	// (a) the exact span / metric / log entities must be present.
+	wantNames := []string{
+		"obs:tracing:tracing_level_span:info:utoipa_get_user",        // trace_extraction
+		"obs:metrics:metrics_macro:counter:utoipa_requests_total",    // metric_extraction
+		"obs:logging:tracing_macro:info:serving documented endpoint", // log_extraction
+	}
+	for _, n := range wantNames {
+		if !containsEntity(ents, "SCOPE.Pattern", n) {
+			t.Errorf("expected observability entity %q", n)
+		}
+	}
+
+	// (b) the captured concrete names are asserted by value (never len>0).
+	if got := obsNameOf(ents, "obs:metrics:metrics_macro:counter:utoipa_requests_total"); got != "utoipa_requests_total" {
+		t.Errorf("metric observability_name = %q, want %q", got, "utoipa_requests_total")
+	}
+	if got := obsNameOf(ents, "obs:tracing:tracing_level_span:info:utoipa_get_user"); got != "utoipa_get_user" {
+		t.Errorf("span observability_name = %q, want %q", got, "utoipa_get_user")
+	}
+
+	// (c) every emitted entity is attributed to the utoipa per-framework cell.
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Pattern" {
+			continue
+		}
+		if got := e.Props["framework"]; got != "utoipa" {
+			t.Errorf("entity %q: framework = %q, want %q", e.Name, got, "utoipa")
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Auth — JWT signals
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4174

DEPLOY-DEFERRED.

## Parity-probe-driven gap grind for Rust

`covtool parity --language rust` flagged `lang.rust.framework.utoipa` as the lone trailing sibling for the three Observability caps. Verify-first showed the observability scanner (`internal/custom/rust/observability.go`) is framework-agnostic — the signals dispatch live on every `.rs` file — but utoipa was missing from the import-marker attribution list (`rustObsFrameworkMarkers`), so utoipa-only handler/doc modules emitted entities with `framework=""`. Identical to the #3981 fix for tonic + async-graphql.

### Cells fixed (before → after)
| cell | before | after |
|---|---|---|
| `lang.rust.framework.utoipa` · metric_extraction | missing | **full** |
| `lang.rust.framework.utoipa` · trace_extraction | missing | **full** |
| `lang.rust.framework.utoipa` · log_extraction | missing | **partial** |

(full/full/partial mirrors every Rust HTTP-framework sibling exactly.)

### Change
- `internal/custom/rust/observability.go`: append `{"utoipa", use utoipa | utoipa::}` marker, ordered **last** so a file importing both a server framework and utoipa still attributes to the server framework.
- `internal/custom/rust/observability_auth_test.go`: `TestRustObs_FrameworkAttribution_Utoipa` — value-asserting, drives a utoipa-only file through the real scanner and asserts the exact entities + props (see below).
- `docs/coverage/registry.json`: surgical flip of the 3 cells (canonical 2-space, mirrors sibling notes).

### Test assertions (no `len>0`)
`TestRustObs_FrameworkAttribution_Utoipa` asserts:
- metric: entity `obs:metrics:metrics_macro:counter:utoipa_requests_total`, `observability_name="utoipa_requests_total"`
- trace: entity `obs:tracing:tracing_level_span:info:utoipa_get_user`, `observability_name="utoipa_get_user"`
- log: entity `obs:logging:tracing_macro:info:serving documented endpoint`
- every emitted `SCOPE.Pattern` entity carries `framework="utoipa"`

### Skipped as honest-N/A
- All `async-graphql` / `tonic` / `utoipa` trailing-sibling cells for REST-shaped HTTP caps (auth_coverage, middleware_coverage, request_validation, schema_drift_detection, rate_limit_stamping, *_effect, taint_*, etc.) — these are GraphQL-builder / gRPC / OpenAPI-doc surfaces, not REST handlers.
- sea-query Relationships (`association_extraction`, `foreign_key_extraction`, `lazy_loading_recognition`, `relationship_extraction`) + Migrations (`migration_parsing`): sea-query is a SQL query *builder*; `sea_query.go` emits zero relationship/FK/association/migration entities (verified). Correctly `missing`.

### Gates
- `covtool fmt --check`: canonical
- `covtool validate`: ok (658 records; pre-existing unrelated warnings only)
- `go test ./internal/custom/rust/ ./tools/coverage/...`: pass
- `gofmt -l`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)