### PR TITLE
vuln-finding-sibling-sweep

### DIFF
--- a/internal/substrate/substrate_golang_graphql_gqlgen_test.go
+++ b/internal/substrate/substrate_golang_graphql_gqlgen_test.go
@@ -130,6 +130,57 @@ func TestSubstrate_Go_Gqlgen_TaintSinkFires(t *testing.T) {
 	}
 }
 
+// gqlgenSanitizerSrc is a gqlgen generated-resolver module that cleanses its
+// input before use: an html.EscapeString XSS sanitizer and a parameterised
+// db.Query (placeholder + trailing arg) SQL sanitizer, both inside the
+// `func (r *mutationResolver) CreateTodo(…)` resolver method.
+const gqlgenSanitizerSrc = `
+package graph
+
+import (
+	"context"
+	"html"
+)
+
+// CreateTodo is the resolver for the createTodo field.
+func (r *mutationResolver) CreateTodo(ctx context.Context, input NewTodo) (*Todo, error) {
+	text := input.Text
+	safe := html.EscapeString(text)
+	db := r.DB
+	rows, _ := db.Query("SELECT * FROM todos WHERE text = ?", safe)
+	_ = rows
+	return &Todo{Text: safe}, nil
+}
+`
+
+// TestSubstrate_Go_Gqlgen_SanitizerFires proves sanitizer_recognition for
+// gqlgen: the framework-blind Go sanitizer detectors fire on the generated
+// resolver body — html.EscapeString is recognised as an XSS sanitizer and the
+// parameterised db.Query(sql, ?args) as a SQL sanitizer — and BOTH attribute to
+// the resolver method CreateTodo (so taint_flow.go can cleanse paths through
+// it). This mirrors the #3918 taint-sink credit: the security-relevant
+// sanitizer primitives are detected per-LANGUAGE regardless of framework.
+func TestSubstrate_Go_Gqlgen_SanitizerFires(t *testing.T) {
+	ms := sniffTaintGo(gqlgenSanitizerSrc)
+	if !hasTaintGoInFn(ms, TaintKindSanitizer, TaintCategoryXSS, "CreateTodo") {
+		t.Errorf("sanitizer: expected an XSS sanitizer (html.EscapeString) attributed to CreateTodo, got %+v", ms)
+	}
+	if !hasTaintGoInFn(ms, TaintKindSanitizer, TaintCategorySQL, "CreateTodo") {
+		t.Errorf("sanitizer: expected a SQL sanitizer (parameterised db.Query) attributed to CreateTodo, got %+v", ms)
+	}
+}
+
+// hasTaintGoInFn reports whether a TaintMatch of kind+category attributed to fn
+// is present.
+func hasTaintGoInFn(ms []TaintMatch, kind TaintKind, cat TaintCategory, fn string) bool {
+	for _, m := range ms {
+		if m.Kind == kind && m.Category == cat && m.Function == fn {
+			return true
+		}
+	}
+	return false
+}
+
 // --- gqlgen negative probes (honest non-credit) -----------------------------
 
 // TestSubstrate_Go_Gqlgen_TaintSourceDoesNotFire documents WHY

--- a/internal/substrate/substrate_java_graphql_taint_test.go
+++ b/internal/substrate/substrate_java_graphql_taint_test.go
@@ -1,0 +1,167 @@
+package substrate
+
+import "testing"
+
+// substrate_java_graphql_taint_test.go — issue: vuln-finding sibling sweep
+// (epic #3872). Verify-first proof that the framework-BLIND, per-LANGUAGE Java
+// taint sniffer (taint_sites_java.go, registered via RegisterTaintSniffer("java",
+// …), dispatched solely by file extension through LanguageForPath: ".java" ->
+// "java") fires on Netflix DGS and Spring-for-GraphQL resolver-method bodies.
+//
+// This is the Java analog of the gqlgen (#3918), Pothos/TypeGraphQL (#3903) and
+// PHP-Lighthouse GraphQL verify-first taint credits. taint_sites_java.go contains
+// zero framework references: its SQL-injection sink (javaSinkSQLRe), HTML/SQL
+// sanitizers (javaSanitizerHTMLRe / javaSanitizerSQLRe) and the @Valid sanitizer
+// match on any Java method body and attribute to the enclosing method via
+// scanJavaFuncHeaders, which accepts an annotation-prefixed header
+// (`@DgsQuery public List<Show> shows(…)` / `@QueryMapping public Book …`).
+//
+// VERIFY-FIRST findings encoded as assertions:
+//
+//  1. taint_sink_detection (PARTIAL credit): the raw-Statement SQL sink
+//     (`stmt.executeQuery("… '" + arg + "'")`) is flagged sql_injection and
+//     attributes to the DGS / Spring-GraphQL resolver method.
+//  2. sanitizer_recognition (PARTIAL credit): a PreparedStatement
+//     (parameterised-SQL) sanitizer AND an HtmlUtils.htmlEscape XSS sanitizer
+//     both fire and attribute to the same resolver method.
+//
+//  HONEST NEGATIVE (vulnerability_finding stays MISSING): the Java taint SOURCE
+//  regexes key on the servlet API (request.getParameter/Header), Spring MVC
+//  request annotations (@RequestParam/@PathVariable/@RequestBody),
+//  System.getenv/getProperty and ObjectInputStream.readObject. A DGS /
+//  Spring-GraphQL resolver receives untrusted input via the GraphQL-specific
+//  @InputArgument / @Argument typed parameters, which are NOT among the
+//  recognised request-input sources — so no taint SOURCE fires on the
+//  resolver-arg idiom, and taint_flow.go (which only seeds its source→sink BFS
+//  from a TaintKindSource match) emits no SecurityFinding. Proven by the
+//  *_TaintSourceDoesNotFire tests below. vulnerability_finding therefore stays
+//  honestly missing for both Java GraphQL siblings.
+
+// dgsResolverSrc is a representative Netflix DGS data-fetcher: the canonical
+// `@DgsComponent` class with a `@DgsQuery`-annotated resolver method that reads
+// the @InputArgument, builds a raw concatenated SQL string into a Statement
+// sink, then demonstrates both a PreparedStatement (parameterised) and an
+// HtmlUtils.htmlEscape sanitizer.
+const dgsResolverSrc = `
+package com.example.shows;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.InputArgument;
+import org.springframework.web.util.HtmlUtils;
+
+@DgsComponent
+public class ShowsDataFetcher {
+
+    @DgsQuery
+    public List<Show> shows(@InputArgument String titleFilter) throws Exception {
+        String sql = "SELECT * FROM shows WHERE title = '" + titleFilter + "'";
+        ResultSet rs = stmt.executeQuery(sql);
+        String safe = HtmlUtils.htmlEscape(titleFilter);
+        PreparedStatement ps = conn.prepareStatement("SELECT * FROM shows WHERE title = ?");
+        return parse(rs, safe);
+    }
+}
+`
+
+// springGraphQLResolverSrc is a representative Spring-for-GraphQL controller:
+// the canonical `@Controller` class with a `@QueryMapping` resolver method that
+// reads the @Argument, builds a raw concatenated SQL string into a Statement
+// sink, then demonstrates both a PreparedStatement and HtmlUtils.htmlEscape
+// sanitizer.
+const springGraphQLResolverSrc = `
+package com.example.book;
+
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.util.HtmlUtils;
+
+@Controller
+public class BookController {
+
+    @QueryMapping
+    public Book bookByName(@Argument String name) throws Exception {
+        String sql = "SELECT * FROM book WHERE name = '" + name + "'";
+        ResultSet rs = stmt.executeQuery(sql);
+        String safe = HtmlUtils.htmlEscape(name);
+        PreparedStatement ps = conn.prepareStatement("SELECT * FROM book WHERE name = ?");
+        return map(rs, safe);
+    }
+}
+`
+
+// hasTaintInFn asserts a TaintMatch of the given kind+category exists AND is
+// attributed to method fn (so taint_flow.go can bind it to a graph entity).
+func hasTaintInFn(t *testing.T, ms []TaintMatch, kind TaintKind, cat TaintCategory, fn string) {
+	t.Helper()
+	for _, m := range ms {
+		if m.Kind == kind && m.Category == cat && m.Function == fn {
+			return
+		}
+	}
+	t.Errorf("expected taint %s/%s attributed to %q; got %+v", kind, cat, fn, ms)
+}
+
+// --- Netflix DGS ------------------------------------------------------------
+
+// TestSubstrate_Java_DGS_TaintSinkFires proves taint_sink_detection for DGS: the
+// raw-Statement SQL sink fires on the @DgsQuery resolver body and attributes to
+// the resolver method `shows`.
+func TestSubstrate_Java_DGS_TaintSinkFires(t *testing.T) {
+	ms := sniffTaintJava(dgsResolverSrc)
+	hasTaintInFn(t, ms, TaintKindSink, TaintCategorySQL, "shows")
+}
+
+// TestSubstrate_Java_DGS_SanitizerFires proves sanitizer_recognition for DGS:
+// both the PreparedStatement (parameterised-SQL) sanitizer and the
+// HtmlUtils.htmlEscape XSS sanitizer fire and attribute to `shows`.
+func TestSubstrate_Java_DGS_SanitizerFires(t *testing.T) {
+	ms := sniffTaintJava(dgsResolverSrc)
+	hasTaintInFn(t, ms, TaintKindSanitizer, TaintCategorySQL, "shows")
+	hasTaintInFn(t, ms, TaintKindSanitizer, TaintCategoryXSS, "shows")
+}
+
+// TestSubstrate_Java_DGS_TaintSourceDoesNotFire documents WHY
+// vulnerability_finding is left missing for DGS: the Java taint SOURCE regexes
+// key on servlet / Spring-MVC request accessors, System.getenv and
+// ObjectInputStream.readObject. A DGS resolver reads its untrusted input via the
+// @InputArgument typed parameter, which is NOT a recognised source — so no taint
+// source fires, hence no source→sink SecurityFinding.
+func TestSubstrate_Java_DGS_TaintSourceDoesNotFire(t *testing.T) {
+	ms := sniffTaintJava(dgsResolverSrc)
+	if n := countTaint(ms, TaintKindSource, TaintCategoryGeneric); n != 0 {
+		t.Errorf("expected NO taint source (resolver reads @InputArgument typed arg, not request.getParameter/@RequestParam); got %d: %+v", n, ms)
+	}
+}
+
+// --- Spring for GraphQL -----------------------------------------------------
+
+// TestSubstrate_Java_SpringGraphQL_TaintSinkFires proves taint_sink_detection
+// for Spring-for-GraphQL: the raw-Statement SQL sink fires on the @QueryMapping
+// resolver body and attributes to `bookByName`.
+func TestSubstrate_Java_SpringGraphQL_TaintSinkFires(t *testing.T) {
+	ms := sniffTaintJava(springGraphQLResolverSrc)
+	hasTaintInFn(t, ms, TaintKindSink, TaintCategorySQL, "bookByName")
+}
+
+// TestSubstrate_Java_SpringGraphQL_SanitizerFires proves sanitizer_recognition
+// for Spring-for-GraphQL: both the PreparedStatement (parameterised-SQL)
+// sanitizer and the HtmlUtils.htmlEscape XSS sanitizer fire and attribute to
+// `bookByName`.
+func TestSubstrate_Java_SpringGraphQL_SanitizerFires(t *testing.T) {
+	ms := sniffTaintJava(springGraphQLResolverSrc)
+	hasTaintInFn(t, ms, TaintKindSanitizer, TaintCategorySQL, "bookByName")
+	hasTaintInFn(t, ms, TaintKindSanitizer, TaintCategoryXSS, "bookByName")
+}
+
+// TestSubstrate_Java_SpringGraphQL_TaintSourceDoesNotFire documents WHY
+// vulnerability_finding is left missing for Spring-for-GraphQL: the @Argument
+// typed parameter is not a recognised taint source, so no source fires and no
+// source→sink SecurityFinding is emitted.
+func TestSubstrate_Java_SpringGraphQL_TaintSourceDoesNotFire(t *testing.T) {
+	ms := sniffTaintJava(springGraphQLResolverSrc)
+	if n := countTaint(ms, TaintKindSource, TaintCategoryGeneric); n != 0 {
+		t.Errorf("expected NO taint source (resolver reads @Argument typed arg, not request.getParameter/@RequestParam); got %d: %+v", n, ms)
+	}
+}

--- a/internal/substrate/substrate_jsts_graphql_codefirst_test.go
+++ b/internal/substrate/substrate_jsts_graphql_codefirst_test.go
@@ -153,6 +153,45 @@ func TestSubstrate_JSTS_Pothos_TaintFires(t *testing.T) {
 	}
 }
 
+// pothosSanitizerSrc is a Pothos module whose helper cleanses input before use:
+// a DOMPurify.sanitize XSS sanitizer and a parameterised db.query(sql, [params])
+// SQL sanitizer, both inside the `persistUser` helper wired into a builder
+// mutation field.
+const pothosSanitizerSrc = `
+import { builder } from './builder';
+import DOMPurify from 'dompurify';
+
+async function persistUser(name) {
+  const clean = DOMPurify.sanitize(name);
+  const rows = await db.query('SELECT * FROM users WHERE name = ?', [clean]);
+  return clean;
+}
+
+builder.mutationField('createUser', (t) =>
+  t.field({
+    type: 'User',
+    args: { name: t.arg.string({ required: true }) },
+    resolve: (root, args) => persistUser(args.name),
+  }),
+);
+`
+
+// TestSubstrate_JSTS_Pothos_SanitizerFires proves sanitizer_recognition for
+// Pothos: the framework-blind jsts sanitizer detectors fire — DOMPurify.sanitize
+// as an XSS sanitizer and the parameterised db.query(sql, [params]) as a SQL
+// sanitizer — and BOTH attribute to the persistUser helper. Mirrors the #3903
+// taint-sink credit (security-relevant primitives detected per-LANGUAGE
+// regardless of framework).
+func TestSubstrate_JSTS_Pothos_SanitizerFires(t *testing.T) {
+	ms := sniffTaintJSTS(pothosSanitizerSrc)
+	if !hasTaintJstsInFn(ms, TaintKindSanitizer, TaintCategoryXSS, "persistUser") {
+		t.Errorf("sanitizer: expected an XSS sanitizer (DOMPurify.sanitize) attributed to persistUser, got %+v", ms)
+	}
+	if !hasTaintJstsInFn(ms, TaintKindSanitizer, TaintCategorySQL, "persistUser") {
+		t.Errorf("sanitizer: expected a SQL sanitizer (parameterised db.query) attributed to persistUser, got %+v", ms)
+	}
+}
+
 // --- TypeGraphQL ------------------------------------------------------------
 
 func TestSubstrate_JSTS_TypeGraphQL_DefUseAttributes(t *testing.T) {
@@ -179,6 +218,53 @@ func TestSubstrate_JSTS_TypeGraphQL_TaintFires(t *testing.T) {
 	if countTaint(ms, TaintKindSink, TaintCategorySQL) == 0 {
 		t.Errorf("taint: expected a SQL-injection sink (raw query concat), got %+v", ms)
 	}
+}
+
+// typeGraphQLSanitizerSrc is a TypeGraphQL module whose service helper cleanses
+// input before use: a validator.escape XSS sanitizer and a parameterised
+// db.query(sql, [params]) SQL sanitizer, both inside the persistAccount helper
+// called from an @Resolver method.
+const typeGraphQLSanitizerSrc = `
+import { Resolver, Mutation, Arg } from 'type-graphql';
+import validator from 'validator';
+
+async function persistAccount(email) {
+  const safe = validator.escape(email);
+  const rows = await db.query('SELECT * FROM accounts WHERE email = ?', [safe]);
+  return safe;
+}
+
+@Resolver()
+export class UserResolver {
+  @Mutation(() => User)
+  async createUser(@Arg('email') email: string) {
+    return persistAccount(email);
+  }
+}
+`
+
+// TestSubstrate_JSTS_TypeGraphQL_SanitizerFires proves sanitizer_recognition for
+// TypeGraphQL: validator.escape (XSS) and the parameterised db.query(sql,
+// [params]) (SQL) sanitizers fire and attribute to persistAccount.
+func TestSubstrate_JSTS_TypeGraphQL_SanitizerFires(t *testing.T) {
+	ms := sniffTaintJSTS(typeGraphQLSanitizerSrc)
+	if !hasTaintJstsInFn(ms, TaintKindSanitizer, TaintCategoryXSS, "persistAccount") {
+		t.Errorf("sanitizer: expected an XSS sanitizer (validator.escape) attributed to persistAccount, got %+v", ms)
+	}
+	if !hasTaintJstsInFn(ms, TaintKindSanitizer, TaintCategorySQL, "persistAccount") {
+		t.Errorf("sanitizer: expected a SQL sanitizer (parameterised db.query) attributed to persistAccount, got %+v", ms)
+	}
+}
+
+// hasTaintJstsInFn reports whether a TaintMatch of kind+category attributed to
+// fn is present.
+func hasTaintJstsInFn(ms []TaintMatch, kind TaintKind, cat TaintCategory, fn string) bool {
+	for _, m := range ms {
+		if m.Kind == kind && m.Category == cat && m.Function == fn {
+			return true
+		}
+	}
+	return false
 }
 
 // --- Negative: request_sink_dataflow does NOT fire (honest non-credit) -------


### PR DESCRIPTION
Closes #4181 (epic #3872). DEPLOY-DEFERRED.

Verify-first sweep of the `vulnerability_finding` / `taint_sink_detection` / `sanitizer_recognition` flagship→sibling asymmetry across **go / java / jsts** GraphQL siblings.

## Root finding
The per-LANGUAGE taint sniffers (`taint_sites_{golang,java,jsts}.go`) detect SINK and SANITIZER primitives **framework-blind** and attribute them to the enclosing method/function via the per-language func-header scanners, which already accept GraphQL-resolver header forms. So a set of `sanitizer_recognition` cells (and, for java, the never-credited `taint_sink_detection`) on GraphQL siblings were **stale-missing** → now `partial` with value-asserting live tests.

`vulnerability_finding` stays **honestly missing** for every GraphQL server sibling: a SecurityFinding needs a source→sink path and `taint_flow.go` seeds its BFS only from a recognised `TaintKindSource`; the GraphQL request-input idiom (typed resolver args) is not a seeded source. Proven by negative `*_TaintSourceDoesNotFire` tests.

## Cells flipped (missing → partial)
| lang | record | cell |
|---|---|---|
| go | gqlgen | `sanitizer_recognition` |
| java | dgs | `taint_sink_detection`, `sanitizer_recognition` |
| java | spring-graphql | `taint_sink_detection`, `sanitizer_recognition` |
| jsts | pothos | `sanitizer_recognition` |
| jsts | type-graphql | `sanitizer_recognition` |

(java dgs/spring-graphql `taint_source_detection` + `vulnerability_finding` notes were also updated to document the honest-negative under #3872.)

## Honest-N/A (left missing)
- DI containers **fx**, **wire** (go, #3628 group cap), **Guice** (java) — no request-input surface.
- **GraphQL Client** (jsts frontend Apollo/urql/Relay) — consumer, no server request-input surface.
- `vulnerability_finding` for every GraphQL server sibling — resolver-arg source not seeded.

## Tests (value-asserting, non-vacuous)
New `internal/substrate/substrate_java_graphql_taint_test.go` + additions to the existing go/jsts GraphQL substrate tests. Each asserts the EXACT `(kind, category, function)` attribution (not `len>0`):
- `TestSubstrate_Go_Gqlgen_SanitizerFires` — sanitizer/xss (html.EscapeString) AND sanitizer/sql_injection (parameterised db.Query) attributed to `CreateTodo`.
- `TestSubstrate_Java_DGS_TaintSinkFires` — sink/sql_injection (`stmt.executeQuery` concat) attributed to `shows`.
- `TestSubstrate_Java_DGS_SanitizerFires` — sanitizer/sql_injection (PreparedStatement) AND sanitizer/xss (HtmlUtils.htmlEscape) attributed to `shows`.
- `TestSubstrate_Java_DGS_TaintSourceDoesNotFire` — zero sources (negative).
- `TestSubstrate_Java_SpringGraphQL_TaintSinkFires` / `_SanitizerFires` / `_TaintSourceDoesNotFire` — same, attributed to `bookByName`.
- `TestSubstrate_JSTS_Pothos_SanitizerFires` — sanitizer/xss (DOMPurify.sanitize) AND sanitizer/sql_injection (parameterised db.query) attributed to `persistUser`.
- `TestSubstrate_JSTS_TypeGraphQL_SanitizerFires` — same (validator.escape) attributed to `persistAccount`.

Non-vacuousness confirmed: miscategorising the java XSS sanitizer makes `_SanitizerFires` FAIL; restoring it passes.

## Gates
- `covtool fmt --check` canonical; `covtool validate` ok.
- `go test ./internal/substrate/ ./internal/links/ ./tools/coverage/` pass; `gofmt -l` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)