### PR TITLE
observability-attribution-sweep

### DIFF
--- a/internal/custom/golang/observability.go
+++ b/internal/custom/golang/observability.go
@@ -75,7 +75,9 @@ func (e *observabilityExtractor) Language() string { return "custom_go_observabi
 // the Go HTTP framework family (issue #3215). The markers are reused verbatim
 // from the middleware/auth extender (middleware_auth_extend.go) so a file is
 // attributed to the same framework across every framework-agnostic pass.
-// net-http is placed last because its `http.*` markers are the broadest.
+// net-http is placed near-last because its `http.*` markers are the broadest;
+// gqlgen (GraphQL resolver modules, issue #3613) is appended after net-http so
+// that any concrete HTTP-server framework still wins attribution.
 var obsFrameworkMarkers = []struct {
 	name string
 	re   *regexp.Regexp
@@ -92,12 +94,24 @@ var obsFrameworkMarkers = []struct {
 	{"revel", regexp.MustCompile(`\brevel\.(?:Result|Controller|Intercept(?:Func|Method)|BEFORE|AFTER)\b`)},
 	{"fasthttp", regexp.MustCompile(`\bfasthttp\.(?:RequestCtx|RequestHandler|ListenAndServe)\b`)},
 	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ListenAndServe|ListenAndServeTLS)\b`)},
+	// gqlgen (GraphQL) — issue #3613 / observability-attribution-sweep. gqlgen
+	// resolver modules emit the same framework-agnostic observability signals
+	// (zap/slog/zerolog setup, prometheus collectors, otel tracer/span) detected
+	// by obsSignals, but carry no gin/echo/fiber/chi/net-http request-context
+	// marker, so they previously attributed to framework="" and were dropped
+	// (leaving gqlgen's log/metric/trace cells stale-missing while the HTTP
+	// siblings are partial/full). The marker is the canonical gqlgen import plus
+	// the generated resolver receiver types (mirrors the http_endpoint_synthesis
+	// gqlgen signal). Placed LAST — after net-http — so a file that ALSO uses a
+	// concrete HTTP-server framework still attributes to that server (the
+	// server marker wins in declaration order), exactly like the rust utoipa fix.
+	{"gqlgen", regexp.MustCompile(`github\.com/99designs/gqlgen\b|\b(?:query|mutation|subscription)Resolver\b`)},
 }
 
 // detectObsFramework returns the framework the file belongs to, or "" when no
 // recognised framework marker is present. First match wins in declaration
 // order (gin→echo→fiber→chi→beego→iris→hertz→buffalo→gorilla-mux→revel→
-// fasthttp→net-http).
+// fasthttp→net-http→gqlgen).
 func detectObsFramework(src string) string {
 	for _, m := range obsFrameworkMarkers {
 		if m.re.MatchString(src) {

--- a/internal/custom/golang/observability_gqlgen_attribution_test.go
+++ b/internal/custom/golang/observability_gqlgen_attribution_test.go
@@ -1,0 +1,146 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// observability-attribution-sweep (issue #3613): gqlgen resolver modules emit
+// the same framework-agnostic observability signals as the HTTP-server
+// frameworks, but previously lacked an import marker in obsFrameworkMarkers, so
+// they attributed to framework="" and were dropped — leaving gqlgen's
+// log/metric/trace coverage cells stale-`missing` while its siblings are
+// partial/full. These tests prove the gqlgen marker now credits those signals,
+// asserting the EXACT entity id, observability props, and framework=gqlgen.
+//
+// Non-vacuousness: without the gqlgen marker in obsFrameworkMarkers, the file
+// has no recognised framework, detectObsFramework returns "" and the extractor
+// returns nil — so every assertion below fails. (Verified by reverting the
+// marker addition.)
+
+// gqlgen resolver file using the canonical generated receiver type, with all
+// three observability families present. This is the value-asserting case.
+func TestObservabilityGqlgenAttribution(t *testing.T) {
+	src := `package resolvers
+
+import "go.uber.org/zap"
+
+type mutationResolver struct{ *Resolver }
+
+var requestsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{Name: "graphql_resolver_requests_total"},
+	[]string{"field"},
+)
+
+func (r *mutationResolver) CreateUser(ctx context.Context) error {
+	logger := zap.NewProduction()
+	tracer := otel.Tracer("graphql")
+	ctx, span := tracer.Start(ctx, "resolver.createUser")
+	_ = logger
+	_ = span
+	return nil
+}`
+	ents := extractFull(t, "custom_go_observability", fi("schema.resolvers.go", "go", src))
+
+	got := obsEntities(ents)
+	if len(got) == 0 {
+		t.Fatalf("expected gqlgen observability entities, got none")
+	}
+
+	// logging: zap setup attributed to gqlgen.
+	logE := findObs(ents, "logging", "zap")
+	if logE == nil {
+		t.Fatalf("missing logging/zap entity; got %+v", got)
+	}
+	if logE.Props["framework"] != "gqlgen" {
+		t.Errorf("logging framework=%q want gqlgen", logE.Props["framework"])
+	}
+
+	// metrics: prometheus collector with EXACT metric name + entity name + provenance.
+	m := findObs(ents, "metrics", "prometheus")
+	if m == nil {
+		t.Fatalf("missing metrics/prometheus entity; got %+v", got)
+	}
+	if m.Name != "obs:metrics:prometheus:graphql_resolver_requests_total" {
+		t.Errorf("metric entity name=%q want obs:metrics:prometheus:graphql_resolver_requests_total", m.Name)
+	}
+	if m.Props["metric_name"] != "graphql_resolver_requests_total" {
+		t.Errorf("metric_name=%q want graphql_resolver_requests_total", m.Props["metric_name"])
+	}
+	if m.Props["framework"] != "gqlgen" {
+		t.Errorf("metric framework=%q want gqlgen", m.Props["framework"])
+	}
+	if m.Props["provenance"] != "INFERRED_FROM_GQLGEN_METRICS" {
+		t.Errorf("metric provenance=%q want INFERRED_FROM_GQLGEN_METRICS", m.Props["provenance"])
+	}
+
+	// tracing: span start with EXACT span name + entity name + framework.
+	span := findObs(ents, "tracing", "span_start")
+	if span == nil {
+		t.Fatalf("missing tracing/span_start entity; got %+v", got)
+	}
+	if span.Name != "obs:tracing:span_start:resolver.createUser" {
+		t.Errorf("span entity name=%q want obs:tracing:span_start:resolver.createUser", span.Name)
+	}
+	if span.Props["span_name"] != "resolver.createUser" {
+		t.Errorf("span_name=%q want resolver.createUser", span.Props["span_name"])
+	}
+	if span.Props["framework"] != "gqlgen" {
+		t.Errorf("span framework=%q want gqlgen", span.Props["framework"])
+	}
+
+	// every emitted entity must be attributed to gqlgen.
+	for _, e := range got {
+		if e.Props["framework"] != "gqlgen" {
+			t.Errorf("entity %q framework=%q want gqlgen", e.Name, e.Props["framework"])
+		}
+	}
+}
+
+// The canonical gqlgen import alone (no generated receiver type) is sufficient
+// to attribute a resolver/server-wiring file.
+func TestObservabilityGqlgenImportMarker(t *testing.T) {
+	src := `package graph
+
+import "github.com/99designs/gqlgen/graphql/handler"
+
+func newServer() {
+	tracer := otel.Tracer("graphql")
+	_, span := tracer.Start(ctx, "graphql.exec")
+	_ = span
+}`
+	ents := extractFull(t, "custom_go_observability", fi("server.go", "go", src))
+	span := findObs(ents, "tracing", "span_start")
+	if span == nil {
+		t.Fatalf("missing tracing/span_start; got %+v", obsEntities(ents))
+	}
+	if span.Props["framework"] != "gqlgen" {
+		t.Errorf("framework=%q want gqlgen", span.Props["framework"])
+	}
+}
+
+// SELF-AUDIT: marker ordering must not let gqlgen steal attribution from a
+// concrete HTTP-server framework. A file that imports a gqlgen receiver type
+// AND uses a gin request context must attribute to gin (gin's marker precedes
+// gqlgen in obsFrameworkMarkers declaration order — mirrors the rust utoipa
+// LAST-placement fix).
+func TestObservabilityGqlgenDoesNotStealFromServerFramework(t *testing.T) {
+	src := `package main
+
+type queryResolver struct{}
+
+func run() {
+	r := gin.Default()
+	tracer := otel.Tracer("svc")
+	_, span := tracer.Start(ctx, "http.handle")
+	_ = r
+	_ = span
+}`
+	ents := extractFull(t, "custom_go_observability", fi("main.go", "go", src))
+	span := findObs(ents, "tracing", "span_start")
+	if span == nil {
+		t.Fatalf("missing tracing/span_start; got %+v", obsEntities(ents))
+	}
+	if span.Props["framework"] != "gin" {
+		t.Errorf("framework=%q want gin (server framework must win over gqlgen)", span.Props["framework"])
+	}
+}


### PR DESCRIPTION
Closes #4186 (epic #3872).

## Summary

Observability-attribution parity sweep over languages whose obs extractor detects tracing/metrics/log idioms **framework-blind** and then credits a framework via a separate import-marker list (the rust utoipa pattern, #4175).

**Genuine gap found & fixed: Go / gqlgen.** The Go obs scanner (`internal/custom/golang/observability.go`) fires framework-blind (zap/slog/logrus/zerolog setup, prometheus collectors, otel `Tracer()`/`Start()`), then attributes via `detectObsFramework`/`obsFrameworkMarkers`. `gqlgen` was missing from that marker list, so gqlgen resolver modules attributed to `framework=""` and were dropped — leaving gqlgen's three Observability cells `missing` while its HTTP siblings (gin/echo/fiber/chi/…) are partial/partial/full.

### Change
- Append a `gqlgen` import marker, ordered LAST (after net-http), so a file that also uses a concrete HTTP-server framework still attributes to that server. Marker = `github.com/99designs/gqlgen` import OR generated `query/mutation/subscriptionResolver` receiver types (mirrors the existing gqlgen signal in `http_endpoint_synthesis.go`).
- Registry cells flipped to match flagship siblings: `log_extraction` partial, `metric_extraction` partial, `trace_extraction` full (same cites/notes shape as gin/chi).

### Cells fixed (before → after)
| record | capability | before | after |
|---|---|---|---|
| lang.go.framework.gqlgen | log_extraction | missing | partial |
| lang.go.framework.gqlgen | metric_extraction | missing | partial |
| lang.go.framework.gqlgen | trace_extraction | missing | full |

### Tests (`observability_gqlgen_attribution_test.go`, all value-asserting)
- `TestObservabilityGqlgenAttribution` — asserts exact metric entity name `obs:metrics:prometheus:graphql_resolver_requests_total` + `metric_name=graphql_resolver_requests_total` + `provenance=INFERRED_FROM_GQLGEN_METRICS`; exact span entity `obs:tracing:span_start:resolver.createUser` + `span_name=resolver.createUser`; logging/zap entity; every entity `framework=gqlgen`.
- `TestObservabilityGqlgenImportMarker` — canonical import alone credits to gqlgen.
- `TestObservabilityGqlgenDoesNotStealFromServerFramework` (self-audit) — gin+gqlgen file attributes to **gin**, proving marker ordering is safe.

Non-vacuousness verified: removing the gqlgen marker fails both positive tests (no entities emitted).

### N/A — not genuine gaps this sweep
- **Go fx / wire** (MISSING siblings in same group): dependency-injection containers, not request-handling/obs-bearing surfaces — out of the rust-pattern shape; left missing.
- **csharp / ruby / php / kotlin / java**: their obs extractors do NOT use the rust-style "framework-blind scan + import-marker attribution list". csharp credits by logging/metric *library* name (`log_framework`/`metric_framework`), not by HTTP-framework import; java/kotlin gate on a passed-in `ctx.Framework` allowlist (`obsFrameworks`) set by the router rather than detecting from imports. Flipping their GraphQL/DI siblings would require router/allowlist work + live-indexer verification (forbidden in this isolated wave) — deferred.

## Gates
- `covtool fmt --check`: canonical ✅
- `covtool validate`: ok (pre-existing unrelated capability-map warnings only) ✅
- `go test ./internal/custom/golang/`: pass ✅
- `gofmt -l` + `go vet ./internal/custom/golang/`: clean ✅
- parity --language go: gqlgen finding closed ✅

DEPLOY-DEFERRED — graph not reindexed in this isolated wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)