### PR TITLE
wave1-structural-kotlin

### DIFF
--- a/internal/substrate/structural_kotlin_wave1_test.go
+++ b/internal/substrate/structural_kotlin_wave1_test.go
@@ -1,0 +1,201 @@
+// Wave1 structural-kotlin coverage proofs (epic #3872).
+//
+// These tests prove the language-level Kotlin structural sniffers fire on
+// the *idiomatic* source of five DI / serialization / HTTP-client /
+// GraphQL Kotlin frameworks: dagger-hilt, koin, graphql-kotlin,
+// kotlinx-serialization, and retrofit. The registry cells for
+// def_use_chain_extraction, pure_function_tagging, dead_code_detection,
+// reachability_analysis, and module_cycle_detection are flipped
+// missing→partial off the back of these proofs.
+//
+// Substrate proven here:
+//   - def_use_chain_extraction: the Kotlin def-use sniffer lifts the exact
+//     local-variable def (attributed to its enclosing fun) from each
+//     framework's idiom — this is the same fact pure_function_tagging and
+//     dead_code_detection read downstream.
+//   - reachability_analysis / dead_code_detection: the Kotlin entry-point
+//     sniffer roots a library_export seed on each framework's public
+//     top-level surface (the Koin module fn, the Hilt provider, the
+//     graphql-kotlin query method, the kotlinx encode helper, the Retrofit
+//     service factory), which is exactly what the reachability BFS seeds on.
+//
+// Each subtest asserts an EXACT extracted symbol — never len>0.
+package substrate
+
+import "testing"
+
+// findDef returns true iff defs contains a def with the given Function +
+// Var, proving function-attributed def-use (not a bare match).
+func findDef(defs []VarDef, fn, varName string) bool {
+	for _, d := range defs {
+		if d.Function == fn && d.Var == varName {
+			return true
+		}
+	}
+	return false
+}
+
+// findEntry returns true iff eps contains an entry with the given Ident +
+// Kind, proving a reachability seed of the expected shape.
+func findEntry(eps []EntryPoint, ident string, kind EntryKind) bool {
+	for _, e := range eps {
+		if e.Ident == ident && e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStructuralKotlinWave1_DefUse drives the real Kotlin def-use sniffer
+// on each framework's idiom and asserts the exact (function, variable) def.
+func TestStructuralKotlinWave1_DefUse(t *testing.T) {
+	sniff := DefUseSnifferFor("kotlin")
+	if sniff == nil {
+		t.Fatal("expected def-use sniffer registered for kotlin")
+	}
+
+	cases := []struct {
+		framework string
+		source    string
+		wantFn    string
+		wantVar   string
+		wantUse   string
+	}{
+		{
+			// Koin DSL: a module-defining fun binding a single instance.
+			framework: "koin",
+			source: "fun appModule() = module {\n" +
+				"  single { val repo = UserRepository(get())\n" +
+				"    repo }\n" +
+				"}\n",
+			wantFn:  "appModule",
+			wantVar: "repo",
+			wantUse: "repo",
+		},
+		{
+			// Dagger-Hilt: an @Module object exposing a provider fun.
+			framework: "dagger-hilt",
+			source: "@Module\n" +
+				"object NetworkModule {\n" +
+				"  fun provideClient(): Client {\n" +
+				"    val client = Client()\n" +
+				"    return client\n" +
+				"  }\n" +
+				"}\n",
+			wantFn:  "provideClient",
+			wantVar: "client",
+			wantUse: "client",
+		},
+		{
+			// graphql-kotlin: a Query class with a resolver method.
+			framework: "graphql-kotlin",
+			source: "class BookQuery {\n" +
+				"  fun book(id: String): Book {\n" +
+				"    val found = repository.find(id)\n" +
+				"    return found\n" +
+				"  }\n" +
+				"}\n",
+			wantFn:  "book",
+			wantVar: "found",
+			wantUse: "found",
+		},
+		{
+			// kotlinx.serialization: a @Serializable class + encode helper.
+			framework: "kotlinx-serialization",
+			source: "@Serializable\n" +
+				"data class User(val name: String)\n" +
+				"fun encodeUser(u: User): String {\n" +
+				"  val text = Json.encodeToString(u)\n" +
+				"  return text\n" +
+				"}\n",
+			wantFn:  "encodeUser",
+			wantVar: "text",
+			wantUse: "text",
+		},
+		{
+			// Retrofit: a @GET service interface + a factory fun.
+			framework: "retrofit",
+			source: "interface ApiService {\n" +
+				"  @GET(\"users\")\n" +
+				"  suspend fun getUsers(): List<User>\n" +
+				"}\n" +
+				"fun buildService(): ApiService {\n" +
+				"  val service = retrofit.create(ApiService::class.java)\n" +
+				"  return service\n" +
+				"}\n",
+			wantFn:  "buildService",
+			wantVar: "service",
+			wantUse: "service",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.framework, func(t *testing.T) {
+			defs, uses := sniff(c.source)
+			if !findDef(defs, c.wantFn, c.wantVar) {
+				t.Errorf("%s: expected def {Function:%q Var:%q} in %v",
+					c.framework, c.wantFn, c.wantVar, defs)
+			}
+			if !containsUseVar(uses, c.wantUse) {
+				t.Errorf("%s: expected use %q in uses", c.framework, c.wantUse)
+			}
+		})
+	}
+}
+
+// TestStructuralKotlinWave1_ReachabilitySeed drives the real Kotlin
+// entry-point sniffer on each framework's idiom and asserts the exact
+// library_export seed the reachability / dead-code BFS roots on.
+func TestStructuralKotlinWave1_ReachabilitySeed(t *testing.T) {
+	sniff := EntryPointSnifferFor("kotlin")
+	if sniff == nil {
+		t.Fatal("expected entry-point sniffer registered for kotlin")
+	}
+
+	cases := []struct {
+		framework string
+		source    string
+		wantIdent string
+	}{
+		{
+			framework: "koin",
+			source:    "fun appModule() = module { single { UserRepository(get()) } }\n",
+			wantIdent: "appModule",
+		},
+		{
+			framework: "dagger-hilt",
+			source: "@Module\nobject NetworkModule {\n" +
+				"  fun provideClient(): Client = Client()\n}\n",
+			wantIdent: "provideClient",
+		},
+		{
+			framework: "graphql-kotlin",
+			source: "class BookQuery {\n" +
+				"  fun book(id: String): Book = repository.find(id)\n}\n",
+			wantIdent: "book",
+		},
+		{
+			framework: "kotlinx-serialization",
+			source:    "fun encodeUser(u: User): String = Json.encodeToString(u)\n",
+			wantIdent: "encodeUser",
+		},
+		{
+			framework: "retrofit",
+			source: "fun buildService(): ApiService =\n" +
+				"  retrofit.create(ApiService::class.java)\n",
+			wantIdent: "buildService",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.framework, func(t *testing.T) {
+			eps := sniff(c.source)
+			if !findEntry(eps, c.wantIdent, EntryKindLibraryExport) {
+				t.Errorf("%s: expected library_export seed %q in %v",
+					c.framework, c.wantIdent, eps)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4190 (epic #3872).

## What
Flip the language-level CORE STRUCTURAL caps missing→partial for 5 Kotlin framework records whose source is plain .kt and is dispatched by the **framework-blind** Kotlin sniffers (verified live — zero per-framework branching):

| Record | def_use | pure_func | dead_code | reachability | module_cycle | type_alias |
|---|---|---|---|---|---|---|
| dagger-hilt | →partial | →partial | →partial | →partial | →partial | **missing (honest)** |
| koin | →partial | →partial | →partial | →partial | →partial | **missing (honest)** |
| graphql-kotlin | →partial | →partial | →partial | →partial | →partial | **missing (honest)** |
| kotlinx-serialization | →partial | →partial | →partial | →partial | →partial | **missing (honest)** |
| retrofit | →partial | →partial | →partial | →partial | →partial | **missing (honest)** |

25 cells flipped, 5 honestly left missing.

## Why these flip
- `def_use_chain_extraction`: `RegisterDefUseSniffer("kotlin")` gates on file content only.
- `pure_function_tagging`: pure_function_pass.go is "zero per-language code" — walks every function entity.
- `dead_code_detection` / `reachability_analysis`: reachability.go BFS roots on the kotlin entry-point sniffer's library_export seeds (each framework exposes a public top-level fun/class).
- `module_cycle_detection`: module_cycle_pass.go is language-agnostic Tarjan over the common IMPORTS edge graph the kotlin extractor emits.

## Why type_alias is honestly missing
kotlin `typealias` is supported by the extractor, but it is **not idiomatic** to DI containers (Koin DSL / Hilt @Module), @Serializable data classes, Retrofit @GET interfaces, or graphql-kotlin schema classes. Flipping it would be inflation, so it stays missing.

## Proof (value-asserting, never len>0)
`internal/substrate/structural_kotlin_wave1_test.go` drives the REAL sniffers on each framework's idiom:
- `TestStructuralKotlinWave1_DefUse` — asserts the exact function-attributed local def + matching use per framework (e.g. koin → {appModule, repo}, hilt → {provideClient, client}, retrofit → {buildService, service}).
- `TestStructuralKotlinWave1_ReachabilitySeed` — asserts the exact library_export entry-point Ident per framework (appModule / provideClient / book / encodeUser / buildService).

## Gates
covtool `fmt --check` canonical; `validate` ok; `go test ./internal/substrate ./internal/links` pass; gofmt + go vet clean. Registry edit is surgical (10 hunks, all in the 5 records' Substrate regions) — no whole-file re-serialization.

DEPLOY-DEFERRED — registry + test only; no daemon rebuild in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)