### PR TITLE
wave1-structural-jstsrust

### DIFF
--- a/internal/patterns/typealias_w1jr_graphql_clients_test.go
+++ b/internal/patterns/typealias_w1jr_graphql_clients_test.go
@@ -1,0 +1,92 @@
+package patterns
+
+// Wave1-structural (epic #3872): prove the language-level TS type_alias
+// extractor fires on the real idioms of the GraphQL-flavoured jsts records
+// — pothos, type-graphql, graphql-client. The extractor switches on
+// language "typescript"/"javascript" (unconditional per-language, no
+// framework gate; see typeAliasExtractor.Detect), so a flip of
+// type_alias_extraction missing -> full on these records is justified iff
+// the framework's idiomatic .ts source yields type_alias entities with
+// the EXACT alias_name / alias_of properties. Assertions check exact prop
+// values — never len>0 alone.
+
+import "testing"
+
+// findAliasW1jr returns the type_alias entity with the given alias_name,
+// or nil. Used to assert exact alias_name/alias_of pairs.
+func findAliasW1jr(results []entityRecordAlias, name string) map[string]string {
+	for _, p := range results {
+		if p["alias_name"] == name {
+			return p
+		}
+	}
+	return nil
+}
+
+type entityRecordAlias = map[string]string
+
+func propsOfW1jr(t *testing.T, src string) []entityRecordAlias {
+	t.Helper()
+	d := &typeAliasExtractor{}
+	out := []entityRecordAlias{}
+	for _, e := range d.Detect("schema.ts", "typescript", src) {
+		out = append(out, e.Properties)
+	}
+	return out
+}
+
+// Pothos code-first schemas alias the SchemaBuilder's generic type map —
+// `type Types = { Scalars: { ... } }` and field-shape aliases are routine.
+func TestW1jr_TypeAlias_PothosSchemaBuilderTypes(t *testing.T) {
+	src := `import SchemaBuilder from '@pothos/core';
+type UserId = string;
+type Types = { Scalars: { ID: { Input: UserId; Output: UserId } } };
+const builder = new SchemaBuilder<Types>({});`
+	props := propsOfW1jr(t, src)
+	a := findAliasW1jr(props, "UserId")
+	if a == nil {
+		t.Fatalf("expected UserId type_alias, got %+v", props)
+	}
+	if a["alias_of"] != "string" {
+		t.Fatalf("expected UserId alias_of=string, got %q", a["alias_of"])
+	}
+	if findAliasW1jr(props, "Types") == nil {
+		t.Fatalf("expected Types type_alias (Pothos builder generic), got %+v", props)
+	}
+}
+
+// type-graphql codebases alias resolver context / arg-shape unions.
+func TestW1jr_TypeAlias_TypeGraphqlContextAlias(t *testing.T) {
+	src := `import { Resolver } from 'type-graphql';
+type MyContext = BaseContext & RequestContext;
+@Resolver()
+class RecipeResolver {}`
+	props := propsOfW1jr(t, src)
+	a := findAliasW1jr(props, "MyContext")
+	if a == nil {
+		t.Fatalf("expected MyContext type_alias, got %+v", props)
+	}
+	// Intersection-type context alias — the extractor captures the full
+	// RHS up to the statement terminator.
+	if a["alias_of"] != "BaseContext & RequestContext" {
+		t.Fatalf("expected MyContext alias_of intersection, got %q", a["alias_of"])
+	}
+}
+
+// graphql-client operations alias variable/result shapes for typed calls.
+func TestW1jr_TypeAlias_GraphqlClientOperationShape(t *testing.T) {
+	src := `import { request } from 'graphql-request';
+type UserVars = { id: string };
+type UserResult = { user: { name: string } };`
+	props := propsOfW1jr(t, src)
+	v := findAliasW1jr(props, "UserVars")
+	if v == nil {
+		t.Fatalf("expected UserVars type_alias, got %+v", props)
+	}
+	if v["alias_of"] != "{ id: string }" {
+		t.Fatalf("expected UserVars alias_of, got %q", v["alias_of"])
+	}
+	if findAliasW1jr(props, "UserResult") == nil {
+		t.Fatalf("expected UserResult type_alias, got %+v", props)
+	}
+}

--- a/internal/substrate/substrate_w1jr_graphql_clientschema_defuse_test.go
+++ b/internal/substrate/substrate_w1jr_graphql_clientschema_defuse_test.go
@@ -1,0 +1,94 @@
+package substrate
+
+import "testing"
+
+// Wave1-structural (epic #3872): prove the language-level jsts def-use
+// sniffer fires on the real idioms of the GraphQL-flavoured jsts records
+// — pothos (code-first builder), type-graphql (decorator classes), and
+// graphql-client (operation builders). The sniffer registers on the
+// "jsts" slug (see init() in def_use_jsts.go) and is framework-agnostic,
+// so a flip of def_use_chain_extraction missing/partial -> partial on
+// these records is justified iff the framework's idiomatic source yields
+// concrete (function, var) def/use pairs. Each assertion below names the
+// EXACT enclosing function and variable — never len>0 alone.
+
+// Pothos code-first: the canonical factoring extracts a field's resolver
+// into a top-level arrow `const resolveUser = (parent, args, ctx) => {...}`
+// then wires it into `t.field({ resolve: resolveUser })`. We assert the
+// precise def/use of `userId` and `safe` inside `resolveUser`.
+func TestW1jr_DefUseJSTS_PothosResolveBody(t *testing.T) {
+	src := `
+import { builder } from './builder';
+
+const resolveUser = (parent, args, ctx) => {
+  let userId = args.id;
+  let safe = userId + 1;
+  return ctx.loadUser(safe);
+};
+
+builder.queryField('user', (t) =>
+  t.field({ type: 'User', resolve: resolveUser }),
+);
+`
+	defs, uses := sniffDefUseJSTS(src)
+	if !containsVarDef(defs, "resolveUser", "userId") {
+		t.Fatalf("expected def of userId in resolveUser, got %+v", defs)
+	}
+	if !containsVarDef(defs, "resolveUser", "safe") {
+		t.Fatalf("expected def of safe in resolveUser, got %+v", defs)
+	}
+	// `userId` is defined then read into `safe` — a real def->use chain.
+	if !containsVarUse(uses, "resolveUser", "userId") {
+		t.Fatalf("expected use of userId in resolveUser, got %+v", uses)
+	}
+}
+
+// type-graphql decorator class: a @Resolver method binds locals. Assert
+// def/use of `total` inside the resolver method `activeRecipes`.
+func TestW1jr_DefUseJSTS_TypeGraphqlResolverMethod(t *testing.T) {
+	src := `
+@Resolver(() => Recipe)
+class RecipeResolver {
+  @Query(() => [Recipe])
+  async activeRecipes(parent, args, ctx) {
+    let total = args.limit;
+    let bounded = total + 5;
+    return ctx.recipes.slice(0, bounded);
+  }
+}
+`
+	defs, uses := sniffDefUseJSTS(src)
+	if !containsVarDef(defs, "activeRecipes", "total") {
+		t.Fatalf("expected def of total in activeRecipes, got %+v", defs)
+	}
+	if !containsVarDef(defs, "activeRecipes", "bounded") {
+		t.Fatalf("expected def of bounded in activeRecipes, got %+v", defs)
+	}
+	if !containsVarUse(uses, "activeRecipes", "total") {
+		t.Fatalf("expected use of total in activeRecipes, got %+v", uses)
+	}
+}
+
+// graphql-client operation builder: a request function binds the
+// composed query variables. Assert def/use of `variables` in `fetchUser`.
+func TestW1jr_DefUseJSTS_GraphqlClientOperation(t *testing.T) {
+	src := `
+import { gql, request } from 'graphql-request';
+
+async function fetchUser(endpoint, id) {
+  let variables = { userId: id };
+  let merged = variables;
+  return request(endpoint, USER_QUERY, merged);
+}
+`
+	defs, uses := sniffDefUseJSTS(src)
+	if !containsVarDef(defs, "fetchUser", "variables") {
+		t.Fatalf("expected def of variables in fetchUser, got %+v", defs)
+	}
+	if !containsVarDef(defs, "fetchUser", "merged") {
+		t.Fatalf("expected def of merged in fetchUser, got %+v", defs)
+	}
+	if !containsVarUse(uses, "fetchUser", "variables") {
+		t.Fatalf("expected use of variables in fetchUser, got %+v", uses)
+	}
+}

--- a/internal/substrate/substrate_w1jr_rust_grpcgraphql_defuse_test.go
+++ b/internal/substrate/substrate_w1jr_rust_grpcgraphql_defuse_test.go
@@ -1,0 +1,87 @@
+package substrate
+
+import "testing"
+
+// Wave1-structural (epic #3872): prove the language-level rust def-use
+// sniffer fires on the real idioms of the rust records tonic (gRPC
+// service impls), async-graphql (resolver methods), and utoipa
+// (OpenAPI-annotated axum handlers). The sniffer registers on the "rust"
+// slug (init() in def_use_rust.go) and is framework-agnostic, so a flip
+// of def_use_chain_extraction missing -> partial on these records is
+// justified iff the framework's idiomatic .rs source yields concrete
+// (fn, var) def/use pairs. Each assertion names the EXACT enclosing fn
+// and variable.
+
+// tonic gRPC service: a #[tonic::async_trait] impl method binds locals
+// from the request. Assert def/use of `name` inside fn `say_hello`.
+func TestW1jr_DefUseRust_TonicServiceMethod(t *testing.T) {
+	src := `
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(&self, request: Request<HelloRequest>) -> Result<Response<HelloReply>, Status> {
+        let name = request.into_inner().name;
+        let greeting = name;
+        Ok(Response::new(HelloReply { message: greeting }))
+    }
+}
+`
+	defs, uses := sniffDefUseRust(src)
+	if !containsVarDef(defs, "say_hello", "name") {
+		t.Fatalf("expected def of name in say_hello, got %+v", defs)
+	}
+	if !containsVarDef(defs, "say_hello", "greeting") {
+		t.Fatalf("expected def of greeting in say_hello, got %+v", defs)
+	}
+	// `name` is bound then read into `greeting` — a real def->use chain.
+	if !containsVarUse(uses, "say_hello", "name") {
+		t.Fatalf("expected use of name in say_hello, got %+v", uses)
+	}
+}
+
+// async-graphql resolver: an #[Object] impl method binds query locals.
+// Assert def/use of `count` inside fn `users`.
+func TestW1jr_DefUseRust_AsyncGraphqlResolver(t *testing.T) {
+	src := `
+#[Object]
+impl QueryRoot {
+    async fn users(&self, ctx: &Context<'_>, limit: i32) -> Vec<User> {
+        let count = limit;
+        let bounded = count;
+        ctx.data_unchecked::<Db>().users(bounded)
+    }
+}
+`
+	defs, uses := sniffDefUseRust(src)
+	if !containsVarDef(defs, "users", "count") {
+		t.Fatalf("expected def of count in users, got %+v", defs)
+	}
+	if !containsVarDef(defs, "users", "bounded") {
+		t.Fatalf("expected def of bounded in users, got %+v", defs)
+	}
+	if !containsVarUse(uses, "users", "count") {
+		t.Fatalf("expected use of count in users, got %+v", uses)
+	}
+}
+
+// utoipa OpenAPI-annotated handler: a #[utoipa::path] axum handler binds
+// locals from the path. Assert def/use of `id` inside fn `get_item`.
+func TestW1jr_DefUseRust_UtoipaHandler(t *testing.T) {
+	src := `
+#[utoipa::path(get, path = "/item/{id}", responses((status = 200, body = Item)))]
+async fn get_item(Path(raw): Path<u64>) -> Json<Item> {
+    let id = raw;
+    let key = id;
+    Json(store::lookup(key))
+}
+`
+	defs, uses := sniffDefUseRust(src)
+	if !containsVarDef(defs, "get_item", "id") {
+		t.Fatalf("expected def of id in get_item, got %+v", defs)
+	}
+	if !containsVarDef(defs, "get_item", "key") {
+		t.Fatalf("expected def of key in get_item, got %+v", defs)
+	}
+	if !containsVarUse(uses, "get_item", "id") {
+		t.Fatalf("expected use of id in get_item, got %+v", uses)
+	}
+}


### PR DESCRIPTION
Closes #4192 (epic #3872).

Brings the 6 core **structural** capabilities to honest sibling-parity on the GraphQL/client jsts records and the gRPC/GraphQL rust records. All six are **language-level** with zero per-framework code — verified by reading the source:

| pass | location | dispatch |
|---|---|---|
| def_use_chain_extraction | `internal/substrate/def_use_{jsts,rust}.go` | `RegisterDefUseSniffer("jsts"/"rust", …)` |
| pure_function_tagging | `internal/links/pure_function_pass.go` | language-agnostic (reads effect props) |
| dead_code_detection / reachability_analysis | `internal/links/reachability.go` | BFS over CALLS/IMPORTS, language-agnostic |
| module_cycle_detection | `internal/links/module_cycle_pass.go` | Tarjan SCC over IMPORTS, language-agnostic |
| type_alias_extraction | `internal/patterns/type_alias_extractor.go` | switches on language (ts/js, rust), no framework gate |

### Flips (25, all sibling-mirrored, none vacuous)
- **jsts** `graphql-client`: 5 substrate missing→partial + type_alias missing→full
- **jsts** `pothos`, `type-graphql`: 4 substrate missing→partial (def_use already partial) + type_alias missing→full
- **jsts** `graphql-resolvers`: type_alias missing→full (substrate already partial)
- **rust** `tonic`, `async-graphql`, `utoipa`: 5 substrate missing→partial each (type_alias already full, #3980)

substrate caps land at **partial** (the honest level for line-regex sniffers, matching graphql-resolvers / actix); type_alias lands at **full** (unconditional extractor, matching 27 jsts siblings).

### Honest-missing: none
Every cap is language-level and the per-framework idiom provably exercises it. No invented flips; substrate intentionally stays `partial`, not `full`.

### Tests (drive the REAL sniffer on each framework's idiom, exact-value assertions)
- `internal/substrate/substrate_w1jr_graphql_clientschema_defuse_test.go` — Pothos arrow resolver, type-graphql decorator method, graphql-request operation: assert exact (fn,var) def/use pairs.
- `internal/substrate/substrate_w1jr_rust_grpcgraphql_defuse_test.go` — tonic service impl, async-graphql resolver, utoipa handler: assert exact (fn,var) def/use pairs.
- `internal/patterns/typealias_w1jr_graphql_clients_test.go` — Pothos builder generics, type-graphql context alias, graphql-client op shapes: assert exact `alias_name`/`alias_of`.

### Gates
- covtool `fmt --check`: canonical ✓ (surgical edits via covtool `update`, no re-serialization)
- covtool `validate`: ok (658 records) ✓
- `gofmt -l`: clean ✓ · `go vet`: clean ✓
- scoped `go test ./internal/substrate/ ./internal/patterns/`: pass ✓

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)