### PR TITLE
iac-dependency-cell-flip-4202

### DIFF
--- a/internal/engine/cdk_edges_test.go
+++ b/internal/engine/cdk_edges_test.go
@@ -221,6 +221,53 @@ export class AppStack extends cdk.Stack {
 	}
 }
 
+// TestCDK_DependencyAttribution_Cell is the cell anchor for the
+// platform/app_topology `dependency_attribution` capability on
+// infra.resource.aws-cdk (issue #4202). It drives the REAL edge-emitter
+// (applyCDKEdges) and asserts the EXACT grant DEPENDS_ON edge together with its
+// attribution properties — iac_tool=aws-cdk, reason=grant, and the grant method
+// recorded under the `grant` key — proving the attribution metadata the cell is
+// credited for, not merely that an edge exists.
+func TestCDK_DependencyAttribution_Cell(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+export class AttribStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const dataBucket = new s3.Bucket(this, 'DataBucket', {});
+    const reader = new lambda.Function(this, 'Reader', { runtime: 'x', handler: 'h', code: 'c' });
+    dataBucket.grantReadWrite(reader);
+  }
+}
+`
+	_, rels := runCDKDetect(t, "typescript", "lib/attrib-stack.ts", src)
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var found *relResult
+	for i := range deps {
+		if deps[i].from == "SCOPE.InfraResource:Reader" && deps[i].to == "SCOPE.InfraResource:DataBucket" {
+			found = &deps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected DEPENDS_ON Reader→DataBucket, got %+v", deps)
+	}
+	if found.kind != "DEPENDS_ON" {
+		t.Errorf("edge kind = %q, want DEPENDS_ON", found.kind)
+	}
+	if found.props["iac_tool"] != "aws-cdk" {
+		t.Errorf("attribution iac_tool = %q, want aws-cdk", found.props["iac_tool"])
+	}
+	if found.props["reason"] != "grant" {
+		t.Errorf("attribution reason = %q, want grant", found.props["reason"])
+	}
+	if found.props["grant"] != "grantReadWrite" {
+		t.Errorf("attribution grant = %q, want grantReadWrite", found.props["grant"])
+	}
+}
+
 // TestCDK_NonCDKFileEmitsNothing asserts the pre-filter gate: a plain TS file
 // with a `new X(this,'id',…)` idiom but no CDK import emits nothing.
 func TestCDK_NonCDKFileEmitsNothing(t *testing.T) {

--- a/internal/engine/kubernetes_edges_test.go
+++ b/internal/engine/kubernetes_edges_test.go
@@ -242,6 +242,44 @@ spec:
 	}
 }
 
+// TestKubernetesEdges_DependencyAttribution_Cell is the cell anchor for the
+// platform/app_topology `dependency_attribution` capability on
+// infra.resource.kubernetes (issue #4202). It drives the REAL edge pass
+// (applyKubernetesEdges) on an HPA→Deployment manifest and asserts the EXACT
+// DEPENDS_ON edge together with its attribution properties — k8s_edge=hpa_target
+// and synthesis=kubernetes_edges — proving the attribution metadata the cell is
+// credited for, not merely that an edge exists.
+func TestKubernetesEdges_DependencyAttribution_Cell(t *testing.T) {
+	const path = "k8s/attrib.yaml"
+	src := `
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 1
+  maxReplicas: 5
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/HorizontalPodAutoscaler/api-hpa"
+	to := prefix + "resource/Deployment/api"
+	e := k8sFindEdge(rels, from, to, "DEPENDS_ON")
+	if e == nil {
+		t.Fatalf("missing HPA→Deployment DEPENDS_ON edge (%s → %s); rels=%+v", from, to, rels)
+	}
+	if e.Properties["k8s_edge"] != "hpa_target" {
+		t.Errorf("attribution k8s_edge = %q, want hpa_target", e.Properties["k8s_edge"])
+	}
+	if e.Properties["synthesis"] != "kubernetes_edges" {
+		t.Errorf("attribution synthesis = %q, want kubernetes_edges", e.Properties["synthesis"])
+	}
+}
+
 func TestKubernetesEdges_OwnerReference(t *testing.T) {
 	const path = "k8s/owner.yaml"
 	src := `

--- a/internal/engine/pulumi_edges_test.go
+++ b/internal/engine/pulumi_edges_test.go
@@ -93,6 +93,44 @@ const fn = new aws.lambda.Function("fn", {
 	}
 }
 
+// TestPulumiTS_DependencyAttribution_Cell is the cell anchor for the
+// platform/app_topology `dependency_attribution` capability on
+// infra.resource.pulumi (issue #4202). It drives the REAL edge-emitter
+// (applyPulumiEdges) and asserts the EXACT explicit-`dependsOn` DEPENDS_ON edge
+// together with its attribution properties — iac_tool=pulumi and reason=
+// depends_on — proving the attribution metadata the cell is credited for.
+func TestPulumiTS_DependencyAttribution_Cell(t *testing.T) {
+	src := `import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const queue = new aws.sqs.Queue("queue", {});
+
+const worker = new aws.lambda.Function("worker", {
+    runtime: "nodejs20.x",
+    handler: "h",
+}, { dependsOn: [queue] });
+`
+	_, rels := runPulumiDetect(t, "typescript", "index.ts", src)
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var found *relResult
+	for i := range deps {
+		if deps[i].from == "SCOPE.InfraResource:worker" && deps[i].to == "SCOPE.InfraResource:queue" &&
+			deps[i].props["reason"] == "depends_on" {
+			found = &deps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected DEPENDS_ON worker→queue (depends_on), got %+v", deps)
+	}
+	if found.kind != "DEPENDS_ON" {
+		t.Errorf("edge kind = %q, want DEPENDS_ON", found.kind)
+	}
+	if found.props["iac_tool"] != "pulumi" {
+		t.Errorf("attribution iac_tool = %q, want pulumi", found.props["iac_tool"])
+	}
+}
+
 // TestPulumiTS_DependsOnAndStackRef asserts an explicit `dependsOn: [queue]`
 // list produces a DEPENDS_ON edge, and a StackReference yields a cross-stack
 // node + edge.


### PR DESCRIPTION
Closes #4202 (epic #4194). **DEPLOY-DEFERRED** — live-daemon reindex is a separate coordinated step.

## What
Cell-flip ONLY (no dictionary edit — `dependency_attribution` already exists as a platform/app_topology capability). Credits the existing `dependency_attribution` capability for IaC `app_topology` records whose edge-emitting extractor genuinely produces DEPENDS_ON-class edges.

**Verify-first:** read each cited engine edge-emitter and proved it emits a DEPENDS_ON (or equivalent) edge before crediting.

## Per-record before → after
| Record | Before | After | Edge basis |
|---|---|---|---|
| `infra.resource.aws-cdk` | (missing) | **partial** | `applyCDKEdges` → `DEPENDS_ON` via `emitDependsOn`: grant / event_source / props_ref; props `iac_tool=aws-cdk` |
| `infra.resource.pulumi` | (missing) | **partial** | `applyPulumiEdges` → `DEPENDS_ON`: output_ref / depends_on / cross-stack; props `iac_tool=pulumi` |
| `infra.resource.kubernetes` | (missing) | **partial** | `applyKubernetesEdges` → `DEPENDS_ON`: hpa_target / networkpolicy_podselector / pdb_selector / servicemonitor_selector / owner_reference; props `synthesis=kubernetes_edges` |
| `infra.resource.helm` | (missing) | **LEFT MISSING** | see below |

### Helm — honestly left missing
`internal/extractors/yaml/helm.go` emits only **IMPORTS** (`importsRel`, kind `helm_dependency` for chart→subchart), **OVERRIDES** (values), **BINDS** (.Values refs), and **INCLUDES** (named templates). None are DEPENDS_ON-class infra dependency edges. Helm's dependency semantics are chart-packaging (subchart IMPORTS), not topological DEPENDS_ON, so it does not qualify for `dependency_attribution`. Not credited on faith.

## Tests added (value-asserting, drive the real emitter, exact edge — never len>0)
- `TestCDK_DependencyAttribution_Cell` — asserts `DEPENDS_ON` Reader→DataBucket with `iac_tool=aws-cdk`, `reason=grant`, `grant=grantReadWrite`.
- `TestPulumiTS_DependencyAttribution_Cell` — asserts `DEPENDS_ON` worker→queue with `reason=depends_on`, `iac_tool=pulumi`.
- `TestKubernetesEdges_DependencyAttribution_Cell` — asserts `DEPENDS_ON` HPA api-hpa→Deployment api with `k8s_edge=hpa_target`, `synthesis=kubernetes_edges`.

## Gates
- `covtool fmt --check`: canonical ✔
- `covtool validate`: ok (658 records; only pre-existing unrelated warnings) ✔
- `go test ./internal/engine/`: pass ✔
- `gofmt -l` + `go vet ./internal/engine/`: clean ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)