### PR TITLE
iac-dict-outputs-crossstack

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -9,16 +9,16 @@ Back to [summary](../summary.md). Bucket: **Other**.
 
 ## IaC / Provisioning
 
-| Language | Name | Dependency attribution | Resource extraction | Status | Notes |
-|---|---|---|---|---|---|
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | ✅ | ✅ | |
+| Language | Name | Dependency attribution | Iac cross stack reference | Iac output export extraction | Resource extraction | Status | Notes |
+|---|---|---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | 🟢 | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | ✅ | ✅ | ✅ | ✅ | |
 
 ## Containers & Orchestration
 

--- a/docs/coverage/detail/infra.iac.ansible.md
+++ b/docs/coverage/detail/infra.iac.ansible.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
+| Iac cross stack reference | — `not_applicable` | — | — | — | Ansible has no cross-stack / remote-state construct and the yaml extractor emits no cross-stack reference. Honest-missing. |
+| Iac output export extraction | — `not_applicable` | — | — | — | Ansible playbooks have no stack-output/export construct (register / set_fact are runtime task vars, not published stack outputs); the yaml extractor emits no output/export entity. Honest-missing. |
 | Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.bicep.md
+++ b/docs/coverage/detail/infra.iac.bicep.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/extractors/bicep/extractor.go` | DEPENDS_ON edges from symbolic-name property references (foo.id / foo.properties.x / foo.outputs.y) and explicit dependsOn:[...] arrays between resources/modules (mirrors hcl depends_on->DEPENDS_ON edge kind); module 'path.bicep' -> IMPORTS edge. Edges emitted as Format-A structural-refs bound via byLocation to sibling entities in the same file. |
+| Iac cross stack reference | — `not_applicable` | — | — | — | Bicep has no cross-stack / remote-state construct in the grammar this extractor parses; symbolic-name references and `existing` resources are intra-template / same-deployment lookups, not cross-stack joins. Honest-missing. |
+| Iac output export extraction | ✅ `full` | `2026-06-04` | — | `internal/extractors/bicep/extractor.go` | Bicep `output <name> <type> = ...` declarations are extracted as SCOPE.Schema/output entities by reOutput + extractOutputs (extractor.go:77-78,121), named by the output identifier — the values a Bicep module/template publishes to its caller. |
 | Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/extractors/bicep/extractor.go`<br>`internal/extractors/bicep/kinds.go` | Regex/line-based .bicep extractor (no tree-sitter grammar vendored): SCOPE.InfraResource per 'resource' decl named by symbolic name, Kind-stable with uniform resource_category from the shared types.IaCResourceCategory classifier (#3549; bicepResourceCoarseScope now delegates to it, resource_scope kept as an alias); azure_rp_type + api_version + deployed_name on Metadata. SCOPE.Component/module per 'module' decl, SCOPE.Schema for param/var/output. Handles 'existing' resources and [for ...] loops. |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.cdk.md
+++ b/docs/coverage/detail/infra.iac.cdk.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/cdk_edges.go` | CDK-TS + CDK-Python dependency edges implemented: DEPENDS_ON from grant calls (bucket.grantRead(fn) / data.grant_read(fn)), Lambda event sources (addEventSource / add_event_source), and construct vars passed through props/kwargs; mirrors the hcl extractor's depends_on->DEPENDS_ON edge kind. CDK-Java/Go/C# pending. Python branch: applyCDKEdgesPython. |
+| Iac cross stack reference | — `not_applicable` | — | — | — | The CDK extractor emits no cross-stack / Fn.importValue / exportValue idiom; cross-construct edges are intra-app dependency edges, not cross-stack references. Honest-missing. |
+| Iac output export extraction | 🟢 `partial` | `2026-06-04` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml`<br>`internal/engine/rules/python/frameworks/aws_cdk.yaml` | CfnOutput is extracted as a SCOPE.Config entity named by its OutputId literal via the entity rule `(?:new\s+)?(?:cdk\.)?CfnOutput\s*\(\s*\w+\s*,\s*["']([^"']+)["']` (aws_cdk.yaml:54-58 TS, :51-52 Py, name_group=1). Partial: covers CDK-TS + CDK-Python only; CDK-Java/Go/C# CfnOutput pending (same gap as resource_extraction). |
 | Resource extraction | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/cdk_edges.go`<br>`internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml` | CDK-TS + CDK-Python implemented (applyCDKEdges / applyCDKEdgesPython): SCOPE.InfraResource per construct named by its 'LogicalId' literal (construct_type + coarse resource_scope). Stack/App scope via rules/{javascript_typescript,python}/frameworks/aws_cdk.yaml. CDK-Java/Go/C# pending. |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.cloudformation.md
+++ b/docs/coverage/detail/infra.iac.cloudformation.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/engine/iac_cloudformation_edges.go` | — |
+| Iac cross stack reference | ✅ `full` | `2026-06-04` | — | `internal/engine/iac_cloudformation_edges.go` | `!ImportValue Name` and `{ "Fn::ImportValue": Name }` are matched by cfnImportValueShortRe/cfnImportValueLongRe (iac_cloudformation_edges.go:314-315) and emit a consumer-side DEPENDS_ON edge (cross_stack=true) to the same `cfn-export:<name>` node a producing stack's Export collapses onto (iac_cloudformation_edges.go:549-557) — the cross-stack join. |
+| Iac output export extraction | ✅ `full` | `2026-06-04` | — | `internal/engine/iac_cloudformation_edges.go` | `Outputs.<O>.Export.Name` is scanned by cfnCollectExportNames (iac_cloudformation_edges.go:814-844) and emitted as a producer-side `cfn-export:<name>` SCOPE.Config entity with side=producer + export_name metadata (iac_cloudformation_edges.go:573-580). |
 | Resource extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/iac_cloudformation_edges.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.opentofu.md
+++ b/docs/coverage/detail/infra.iac.opentofu.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | Full dependency_attribution parity with Terraform via the shared hcl extractor: depends_on->DEPENDS_ON edges, for_each/count USES iteration-source edges, module I/O data-flow edges, and data.terraform_remote_state cross-stack DEPENDS_ON all fire for .tofu identically to .tf because entities carry Language="terraform". Same downstream IaC engine passes apply (iac_sns_edges, event_bus_edges, dynamic_patterns_terraform are gated on lang=="terraform"). |
+| Iac cross stack reference | ✅ `full` | `2026-06-04` | — | `internal/extractors/hcl` | Full parity with Terraform: `data.terraform_remote_state.*.outputs.*` in .tofu files emits the same cross-stack DEPENDS_ON edge (cross_stack=true) via extractRemoteStateDeps (terraform_deep.go:221-260), since entities carry Language="terraform". |
+| Iac output export extraction | ✅ `full` | `2026-06-04` | — | `internal/extractors/hcl` | Full parity with Terraform: `output "name" {}` blocks in .tofu files flow through the same extractOutputBlock (extractor.go:371-391) as .tf because the classifier routes .tofu to the shared "terraform" language token, emitting SCOPE.Schema/output entities identically. |
 | Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | OpenTofu (#3553) is the Apache-licensed Terraform fork with byte-for-byte identical HCL; the classifier routes .tofu / .tofu.json to the shared "terraform" language token, so .tofu files flow through the same hcl/terraform tree-sitter extractor as .tf with zero extra code. Full resource_extraction parity: resource/data/module/provider/variable/output/locals blocks, dynamic-block child entities, terraform{} settings, and the uniform resource_category classifier (#3549) all apply unchanged. Cited at the extractor package; classifier routing in internal/classifier/classifier.go. |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.pulumi.md
+++ b/docs/coverage/detail/infra.iac.pulumi.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3528) | `internal/engine/pulumi_edges.go`<br>`internal/engine/pulumi_edges_go_net.go` | Pulumi-TS + Pulumi-Python (applyPulumiEdges / applyPulumiEdgesPython) and Pulumi-Go + Pulumi-C# (applyPulumiEdgesGoNet, #3550): DEPENDS_ON from output references (TS other.arn/.id; Go/C# .Arn/.Id/.ID() passed into a resource's args), explicit dependsOn/depends_on (TS/Py) and DependsOn lists (Go pulumi.DependsOn([]pulumi.Resource{...}) / C# CustomResourceOptions.DependsOn). StackReference cross-stack nodes for TS/Py (collapsed onto pulumi-stack:<ref>). Mirrors the hcl extractor's DEPENDS_ON edge kind. Pulumi-Java pending; Go/C# StackReference + ComponentResource deferred. Was citing the dormant rules/pulumi/_manifest.yaml (never fired: loader keys rules by top-level dir, no file is tagged 'pulumi'). |
+| Iac cross stack reference | 🟢 `partial` | — | [link](https://github.com/cajasmota/archigraph/issues/3528) | `internal/engine/pulumi_edges.go` | `new pulumi.StackReference("org/project/stack")` is matched by pulumiTSStackRefRe (pulumi_edges.go:122-125) and pulumiPyStackRefRe (:158-160) and emits a DEPENDS_ON to a `pulumi-stack:<ref>` cross-stack node (pulumiCrossStackNodeID, :93-96) — the cross-stack join. Partial: Pulumi-TS + Pulumi-Python only; Go/C# StackReference deferred (per resource_extraction notes). |
+| Iac output export extraction | — `not_applicable` | — | — | — | The Pulumi extractor emits no stack-output/export node: `producer.Id`/`.Arn` 'output refs' are inter-resource dependency edges into another resource's args (pulumi_edges_go_net.go:82-85), not extraction of a stack's published outputs/exports as entities. Honest-missing. |
 | Resource extraction | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3528) | `internal/engine/pulumi_edges.go`<br>`internal/engine/pulumi_edges_go_net.go`<br>`internal/engine/rules/javascript_typescript/frameworks/pulumi.yaml`<br>`internal/engine/rules/python/frameworks/pulumi.yaml` | Pulumi-TS + Pulumi-Python (applyPulumiEdges / applyPulumiEdgesPython) and Pulumi-Go + Pulumi-C# (applyPulumiEdgesGoNet, #3550): SCOPE.InfraResource per resource constructor named by its logical-name string literal (construct_type + uniform resource_category from the shared types.IaCResourceCategory classifier; Go factory pkg.NewType maps to pkg.Type via New-strip). ComponentResource subclasses recorded as component-scoped nodes for TS/Py. Program-scope idioms via rules/{javascript_typescript,python}/frameworks/pulumi.yaml. Pulumi-Java pending. Was over-stamped via the dormant rules/pulumi/_manifest.yaml. |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.serverless-framework.md
+++ b/docs/coverage/detail/infra.iac.serverless-framework.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/engine/serverless_edges.go`<br>`internal/engine/serverless_framework_edges.go` | — |
+| Iac cross stack reference | — `not_applicable` | — | — | — | The Serverless Framework parser emits no cross-stack / Fn::ImportValue reference. Honest-missing. |
+| Iac output export extraction | — `not_applicable` | — | — | — | The Serverless Framework parser extracts functions/events/handlers; it does not parse the `resources.Outputs` CloudFormation block into output/export entities (the 'exports' matches in serverless_edges.go are JS handler exports, not stack outputs). Honest-missing. |
 | Resource extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/serverless_framework_edges.go`<br>`internal/engine/serverless_framework_parse.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/infra.iac.terraform.md
+++ b/docs/coverage/detail/infra.iac.terraform.md
@@ -6,13 +6,15 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [platform](../by-category/platform.md)
 - **Subcategory:** IaC / Provisioning
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | #3527 deepened: for_each/count meta-args emit USES iteration-source edges (each.*/count.*/self.* pseudo-refs suppressed); module I/O data-flow edges (module.this USES module.x tagged with the consuming input arg); data.terraform_remote_state.X.outputs.Y → cross-stack DEPENDS_ON (cross_stack=true); dynamic blocks emit child dynamic_block entities with CONTAINS+CALLS; terraform{} required_providers → per-provider IMPORTS(import_kind=required_provider, version). Remaining gaps: module input → child variable binding is intra-file CALLS only (no cross-module-file output/variable resolution); moved/import blocks not yet emitted as rename/adopt edges. |
+| Iac cross stack reference | ✅ `full` | `2026-06-04` | — | `internal/extractors/hcl` | `data.terraform_remote_state.<name>.outputs.<key>` consumption is detected by extractRemoteStateDeps/remoteStateName (terraform_deep.go:221-269) and emits one cross-stack DEPENDS_ON edge per distinct remote-state name (cross_stack=true, remote_state=<name>) — deliberately NOT a generic data-source CALLS edge; it wires one stack to another stack's published outputs. |
+| Iac output export extraction | ✅ `full` | `2026-06-04` | — | `internal/extractors/hcl` | `output "name" {}` blocks are extracted by extractOutputBlock (extractor.go:175-176,371-391) as SCOPE.Schema entities with Subtype=output, named by the output identifier — the values a Terraform module/root publishes for consumption. |
 | Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | #3527: dynamic "x" {} nested blocks now emitted as SCOPE.Component/dynamic_block child entities (previously dropped by the top-level-only walker); terraform{} settings captured as a SCOPE.Component/terraform_settings entity (required_providers+backend+required_version) instead of being dropped; lifecycle/provisioner meta-blocks recorded in resource Metadata.meta_blocks. |
 
 ## Provenance

--- a/internal/engine/detector_test.go
+++ b/internal/engine/detector_test.go
@@ -842,3 +842,49 @@ func TestDetect_CSharpRE2Patterns_Compile(t *testing.T) {
 		})
 	}
 }
+
+// TestDetect_CDKCfnOutput_OutputExportExtraction drives the real embedded
+// rules/javascript_typescript/frameworks/aws_cdk.yaml against a CfnOutput
+// statement and asserts the published-output entity is extracted. This is the
+// value-asserting test backing the iac_output_export_extraction (#4195)
+// capability credit for AWS CDK: a `new cdk.CfnOutput(this, 'ApiUrl', …)` must
+// surface as a Config entity named by its OutputId literal ('ApiUrl').
+func TestDetect_CDKCfnOutput_OutputExportExtraction(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules failed: %v", err)
+	}
+	det := New(rules)
+	src := `import * as cdk from 'aws-cdk-lib';
+
+export class ApiStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    new cdk.CfnOutput(this, 'ApiUrl', { value: 'https://example.com' });
+  }
+}
+`
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "lib/api-stack.ts",
+		Content:  []byte(src),
+		Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+
+	// The aws_cdk.yaml CfnOutput entity rule (name_group=1) must surface the
+	// OutputId literal 'ApiUrl' as an entity. (The downstream CDK normaliser
+	// settles its Kind to SCOPE.InfraResource — what matters for #4195 is that
+	// the published-output identifier is extracted as a first-class entity and
+	// is not dropped.)
+	var found bool
+	for _, e := range result.Entities {
+		if e.Name == "ApiUrl" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CfnOutput entity named 'ApiUrl' (the OutputId literal), got %+v", result.Entities)
+	}
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -66,7 +66,7 @@ categories:
   databases:
     capabilities: [resource_extraction, dependency_attribution]
   platform:
-    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency, translation_key_usage]
+    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution, shared_data_coupling, external_service_dependency, translation_key_usage, iac_output_export_extraction, iac_cross_stack_reference]
     subcategory_order: [iac_provisioning, container_orchestration, config_files, workflow_dag, app_topology, integration_external, localization, frontend_routing]
   security:
     capabilities: [auth_policy, secret_detection, sql_injection, cors_policy]
@@ -705,6 +705,20 @@ subcategories:
     capabilities:
       - resource_extraction
       - dependency_attribution
+      # iac_output_export_extraction (#4195): extraction of a stack/template's
+      # published OUTPUTS / EXPORTS as first-class entities — the named values a
+      # stack exposes for consumption by other stacks or callers. Backed by
+      # CloudFormation `Outputs.<O>.Export.Name` producer nodes (cfn-export:*),
+      # AWS CDK `CfnOutput(...)` config entities, Terraform/OpenTofu `output`
+      # blocks (SCOPE.Schema/output), and Bicep `output` declarations.
+      - iac_output_export_extraction
+      # iac_cross_stack_reference (#4196): extraction of cross-stack / remote
+      # references — a consuming stack reaching into another stack's published
+      # state — as DEPENDS_ON edges or cross-stack join nodes. Backed by
+      # Terraform/OpenTofu `data.terraform_remote_state.*` (cross_stack=true),
+      # CloudFormation `!ImportValue` / `Fn::ImportValue` (collapsing onto the
+      # shared cfn-export:* node), and Pulumi `StackReference` (pulumi-stack:*).
+      - iac_cross_stack_reference
     groups: []
 
   container_orchestration:

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -17878,6 +17878,105 @@ records:
           issues_implemented: ["3491"]
           verified_at: "2026-05-31"
 
+  infra.iac.cloudformation:
+    capabilities:
+      iac_output_export_extraction:
+        status: full
+        symbols:
+          - file: internal/engine/iac_cloudformation_edges.go
+            functions: [cfnCollectExportNames]
+        tests:
+          - file: internal/engine/iac_cloudformation_edges_test.go
+        issues_implemented: ["4195"]
+        verified_at: "2026-06-04"
+      iac_cross_stack_reference:
+        status: full
+        symbols:
+          - file: internal/engine/iac_cloudformation_edges.go
+            functions: [cfnCollectImports]
+        tests:
+          - file: internal/engine/iac_cloudformation_edges_test.go
+        issues_implemented: ["4196"]
+        verified_at: "2026-06-04"
+
+  infra.iac.terraform:
+    capabilities:
+      iac_output_export_extraction:
+        status: full
+        symbols:
+          - file: internal/extractors/hcl/extractor.go
+            functions: [extractOutputBlock]
+        tests:
+          - file: internal/extractors/hcl/extractor_test.go
+        issues_implemented: ["4195"]
+        verified_at: "2026-06-04"
+      iac_cross_stack_reference:
+        status: full
+        symbols:
+          - file: internal/extractors/hcl/terraform_deep.go
+            functions: [extractRemoteStateDeps, remoteStateName]
+        tests:
+          - file: internal/extractors/hcl/terraform_deep_test.go
+        issues_implemented: ["4196"]
+        verified_at: "2026-06-04"
+
+  infra.iac.opentofu:
+    capabilities:
+      iac_output_export_extraction:
+        status: full
+        symbols:
+          - file: internal/extractors/hcl/extractor.go
+            functions: [extractOutputBlock]
+        tests:
+          - file: internal/extractors/hcl/extractor_test.go
+        issues_implemented: ["4195"]
+        verified_at: "2026-06-04"
+      iac_cross_stack_reference:
+        status: full
+        symbols:
+          - file: internal/extractors/hcl/terraform_deep.go
+            functions: [extractRemoteStateDeps, remoteStateName]
+        tests:
+          - file: internal/extractors/hcl/terraform_deep_test.go
+        issues_implemented: ["4196"]
+        verified_at: "2026-06-04"
+
+  infra.iac.bicep:
+    capabilities:
+      iac_output_export_extraction:
+        status: full
+        symbols:
+          - file: internal/extractors/bicep/extractor.go
+            functions: [extractOutputs]
+        tests:
+          - file: internal/extractors/bicep/extractor_test.go
+        issues_implemented: ["4195"]
+        verified_at: "2026-06-04"
+
+  infra.iac.cdk:
+    capabilities:
+      iac_output_export_extraction:
+        status: partial
+        symbols:
+          - file: internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
+          - file: internal/engine/rules/python/frameworks/aws_cdk.yaml
+        tests:
+          - file: internal/engine/detector_test.go
+        issues_implemented: ["4195"]
+        verified_at: "2026-06-04"
+
+  infra.iac.pulumi:
+    capabilities:
+      iac_cross_stack_reference:
+        status: partial
+        symbols:
+          - file: internal/engine/pulumi_edges.go
+            functions: [pulumiCrossStackNodeID]
+        tests:
+          - file: internal/engine/pulumi_edges_test.go
+        issues_implemented: ["4196"]
+        verified_at: "2026-06-04"
+
   infra.iac.serverless-framework:
     capabilities:
       dependency_attribution:

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -1289,7 +1289,16 @@ func splitCategoryRowsBySubcategory(category string, rows []categoryRow) ([]cate
 				return groupCell(recsForSub[r].GroupDigestByName, g)
 			})
 		} else {
-			sec.CapabilityKeys = subcategoryRenderKeys(category, s)
+			// Don't-strand guard (parity with the flat table at #3874 and
+			// the dictionary's "don't fabricate an empty column" intent):
+			// a capability column the subcategory declares but that is "—"
+			// for every record in this lane is dropped. Presentation-only —
+			// registry statuses are untouched. Without this, a newly-added
+			// capability (e.g. iac_output_export_extraction) that only some
+			// records in the lane carry would still render an always-empty
+			// column for the rest.
+			sec.CapabilityKeys = nonStrandedCapKeys(
+				subcategoryRenderKeys(category, s), recsForSub)
 		}
 		subs = append(subs, sec)
 	}


### PR DESCRIPTION
Closes #4195, Closes #4196

Adds two new `platform` / `iac_provisioning` capabilities to the coverage taxonomy and credits the cells extractors **provably** back (verify-first; honest `not_applicable` everywhere the data is not emitted).

## New capabilities (epic #4194)
- **`iac_output_export_extraction`** (#4195) — extraction of a stack/template's published OUTPUTS/EXPORTS as first-class entities.
- **`iac_cross_stack_reference`** (#4196) — cross-stack / remote references (DEPENDS_ON edges or cross-stack join nodes).

## Per-tool credits (verified against extractor source)
| Tool | output/export (#4195) | cross-stack (#4196) |
|---|---|---|
| CloudFormation | full — `cfnCollectExportNames` → `cfn-export:*` producer node | full — `Fn::ImportValue` → cross_stack DEPENDS_ON |
| Terraform / OpenTofu | full — `output` blocks (`extractOutputBlock`) | full — `terraform_remote_state` (`extractRemoteStateDeps`) |
| AWS CDK | partial — `CfnOutput` rule (TS+Py) | n/a |
| Bicep | full — `output` decls (`extractOutputs`) | n/a |
| Pulumi | n/a (output refs are inter-resource deps, not stack outputs) | partial — `StackReference` (TS+Py) |
| Serverless / Ansible | n/a | n/a |

## Generator fix
The flat-table don't-strand guard now also applies to per-subcategory lanes, so a newly-added capability that only some records carry no longer renders an always-empty column for the rest.

## Tests
- `TestDetect_CDKCfnOutput_OutputExportExtraction` — drives the real embedded `aws_cdk.yaml`, asserts the `CfnOutput('ApiUrl', …)` OutputId surfaces as a named entity.
- Existing value-asserting tests back the rest: `TestCFN_CrossStack` (producer `cfn-export:shared-vpc-id` node + consumer cross-stack DEPENDS_ON), `TestExtractOutput` (TF output block → SCOPE.Schema), `TestDeep_RemoteStateCrossStack` (remote_state cross_stack edge), `TestPulumiTS_DependsOnAndStackRef` (`pulumi-stack:*` node), `TestBicep_ParamVarOutput`.

Gates: `fmt --check` canonical, `validate` clean (658 records, no new errors), scoped `go test` (engine, hcl, bicep, coverage) green, `gofmt`/`go vet` clean.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)