### PR TITLE
extend-pagination-reader-idioms

### DIFF
--- a/internal/engine/http_endpoint_pagination.go
+++ b/internal/engine/http_endpoint_pagination.go
@@ -451,13 +451,37 @@ func pythonPaginationVerdict(region, body string) (paginationVerdict, bool) {
 // `request.query_params.get("name")` in the handler body.
 func pythonRequestQueryParams(body string) map[string]bool {
 	present := map[string]bool{}
+	// flask / sanic / quart / starlette / litestar: request.args.get / .query_params.get.
 	for _, m := range pyRequestQueryGetRe.FindAllStringSubmatch(body, -1) {
-		name := strings.ToLower(m[1])
-		if isPaginationParam(name) {
-			present[name] = true
+		addPaginationParam(present, m[1])
+	}
+	// bottle: request.query.<name> / request.query.get("name") / request.query["name"].
+	for _, m := range pyBottleQueryRe.FindAllStringSubmatch(body, -1) {
+		// Exactly one of the three capture groups is non-empty per match.
+		for _, g := range m[1:] {
+			if g != "" {
+				addPaginationParam(present, g)
+			}
 		}
 	}
+	// falcon: req.get_param("name") / req.get_param_as_int("name").
+	for _, m := range pyFalconGetParamRe.FindAllStringSubmatch(body, -1) {
+		addPaginationParam(present, m[1])
+	}
+	// tornado: self.get_query_argument("name") / self.get_argument("name").
+	for _, m := range pyTornadoArgRe.FindAllStringSubmatch(body, -1) {
+		addPaginationParam(present, m[1])
+	}
 	return present
+}
+
+// addPaginationParam lower-cases a candidate param name and records it iff it
+// is a recognised pagination param.
+func addPaginationParam(present map[string]bool, raw string) {
+	name := strings.ToLower(raw)
+	if isPaginationParam(name) {
+		present[name] = true
+	}
 }
 
 // pythonSignatureParams extracts the parameter identifiers from a (possibly
@@ -583,6 +607,18 @@ func jsQueryParams(src string) map[string]bool {
 			name = strings.TrimSpace(strings.Split(name, "=")[0])
 			if isPaginationParam(name) {
 				present[name] = true
+			}
+		}
+	}
+	// hono: c.req.query("limit")
+	for _, m := range jsHonoQueryRe.FindAllStringSubmatch(src, -1) {
+		addPaginationParam(present, m[1])
+	}
+	// adonisjs: request.input("limit") / request.qs().limit / request.qs()["offset"]
+	for _, m := range jsAdonisInputRe.FindAllStringSubmatch(src, -1) {
+		for _, g := range m[1:] {
+			if g != "" {
+				addPaginationParam(present, g)
 			}
 		}
 	}

--- a/internal/engine/http_endpoint_pagination_patterns.go
+++ b/internal/engine/http_endpoint_pagination_patterns.go
@@ -22,6 +22,26 @@ var (
 	// (`request.args.get(key)`) has no string literal and does not match.
 	pyRequestQueryGetRe = regexp.MustCompile(`\.\s*(?:args|query_params|GET)\s*(?:\.\s*get\s*\(|\[)\s*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
 
+	// pyBottleQueryRe matches Bottle's request-query reads:
+	//
+	//   request.query.limit               (FormsDict attribute access)
+	//   request.query.get("limit")        (.get with string literal)
+	//   request.query["limit"]            (bracket index)
+	//
+	// Group 1 is the attribute name, group 2 the .get/bracket literal name
+	// (exactly one of the two is non-empty per match). HONEST-PARTIAL: a
+	// dynamically-named read (`request.query.get(key)`) has no literal and does
+	// not match.
+	pyBottleQueryRe = regexp.MustCompile(`\.\s*query\s*(?:\.\s*get\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']|\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']|\.\s*([A-Za-z_][A-Za-z0-9_]*))`)
+
+	// pyFalconGetParamRe matches Falcon's `req.get_param("limit")` /
+	// `req.get_param_as_int("offset")` request-query reads. Group 1 is the name.
+	pyFalconGetParamRe = regexp.MustCompile(`\.\s*get_param(?:_as_\w+)?\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
+	// pyTornadoArgRe matches Tornado's `self.get_query_argument("limit")` /
+	// `self.get_argument("offset")` request-query reads. Group 1 is the name.
+	pyTornadoArgRe = regexp.MustCompile(`\.\s*get_(?:query_)?argument\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
 	// djangoPaginatorRe matches `Paginator(<qs>, <n>)` — the canonical Django
 	// core paginator constructor.
 	djangoPaginatorRe = regexp.MustCompile(`\bPaginator\s*\(`)
@@ -49,6 +69,18 @@ var (
 	// jsQueryDestructureRe matches `const { a, b } = req.query`. Group 1 is the
 	// brace contents.
 	jsQueryDestructureRe = regexp.MustCompile(`\{\s*([^}]*?)\s*\}\s*=\s*(?:req|request|ctx)\.query\b`)
+
+	// jsHonoQueryRe matches Hono's request-query reads:
+	//   c.req.query("limit") / c.req.query('offset')
+	// Group 1 is the param name. A bare `c.req.query()` (all params, no literal)
+	// has no name and does not match — honest-partial.
+	jsHonoQueryRe = regexp.MustCompile(`\.\s*req\s*\.\s*query\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
+	// jsAdonisInputRe matches AdonisJS's request reads:
+	//   request.input("limit") / request.qs().limit / request.qs()["offset"]
+	// Group 1 is the input() literal, group 2 the qs() attribute name, group 3
+	// the qs() bracket literal (exactly one non-empty per match).
+	jsAdonisInputRe = regexp.MustCompile(`\.\s*(?:input\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']|qs\s*\(\s*\)\s*(?:\.\s*([A-Za-z_][A-Za-z0-9_]*)|\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']))`)
 
 	// sequelizeOrPrismaTakeRe / sequelizeOrPrismaSkipRe match Prisma `take:` /
 	// `skip:` keys (also used by some query builders).

--- a/internal/engine/http_endpoint_pagination_test.go
+++ b/internal/engine/http_endpoint_pagination_test.go
@@ -879,3 +879,246 @@ def items():
 		t.Fatalf("paginated=%q want absent (lone limit is ambiguous)", got)
 	}
 }
+
+// ===========================================================================
+// Wave3 endpoint_pagination_posture — concrete request-idiom reader extension
+// (epic #3872). Each framework reads query params from the request object via
+// a framework-specific idiom the reader previously did not recognise; the
+// reader extension surfaces limit/offset/page/cursor so applyEndpointPagination
+// stamps the EXACT posture. Every positive asserts paginated=true +
+// pagination_style + pagination_params explicitly (never len>0); every
+// framework has a paired negative proving non-vacuousness.
+// ===========================================================================
+
+// --- JS/TS: Hono c.req.query("...") reads (jsPaginationVerdict) ------------
+
+func TestPagination_Hono_ReqQueryLimitOffset(t *testing.T) {
+	src := `
+import { Hono } from 'hono'
+const app = new Hono()
+app.get('/items', (c) => {
+  const limit = c.req.query('limit')
+  const offset = c.req.query('offset')
+  return c.json([])
+})
+`
+	eps := deprecProps(t, "typescript", "src/hono.ts", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+func TestPagination_Hono_LoneLimitNotPaginated(t *testing.T) {
+	src := `
+import { Hono } from 'hono'
+const app = new Hono()
+app.get('/items', (c) => {
+  const limit = c.req.query('limit')
+  return c.json([])
+})
+`
+	eps := deprecProps(t, "typescript", "src/hono.ts", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want absent (lone limit is ambiguous)", got)
+	}
+}
+
+// --- JS/TS: AdonisJS request.input(...) / request.qs() reads ---------------
+
+func TestPagination_Adonis_InputLimitOffset(t *testing.T) {
+	src := `
+import Route from '@ioc:Adonis/Core/Route'
+Route.get('/items', async ({ request }) => {
+  const limit = request.input('limit')
+  const offset = request.input('offset')
+  return []
+})
+`
+	eps := deprecProps(t, "typescript", "start/routes.ts", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+func TestPagination_Adonis_QsCursor(t *testing.T) {
+	// request.qs().cursor — a cursor token is unambiguous on its own.
+	src := `
+import Route from '@ioc:Adonis/Core/Route'
+Route.get('/feed', async ({ request }) => {
+  const cursor = request.qs().cursor
+  return []
+})
+`
+	eps := deprecProps(t, "typescript", "start/routes.ts", src)
+	e := mustEndpoint(t, eps, "GET /feed")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "cursor" {
+		t.Fatalf("pagination_style=%q want cursor", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "cursor" {
+		t.Fatalf("pagination_params=%q want cursor", got)
+	}
+}
+
+func TestPagination_Adonis_NoParamNotPaginated(t *testing.T) {
+	src := `
+import Route from '@ioc:Adonis/Core/Route'
+Route.get('/health', async ({ request }) => {
+  return 'ok'
+})
+`
+	eps := deprecProps(t, "typescript", "start/routes.ts", src)
+	e := mustEndpoint(t, eps, "GET /health")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want absent (no pagination param)", got)
+	}
+}
+
+// --- Python: Bottle request.query.<name> reads (pythonRequestQueryParams) --
+
+func TestPagination_Bottle_QueryAttrLimitOffset(t *testing.T) {
+	src := `
+from bottle import route, request
+
+@route("/items")
+def items():
+    limit = request.query.limit
+    offset = request.query.offset
+    return []
+`
+	eps := deprecProps(t, "python", "app/b.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+func TestPagination_Bottle_LoneLimitNotPaginated(t *testing.T) {
+	src := `
+from bottle import route, request
+
+@route("/items")
+def items():
+    limit = request.query.get("limit")
+    return []
+`
+	eps := deprecProps(t, "python", "app/b.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want absent (lone limit is ambiguous)", got)
+	}
+}
+
+// --- Python: Falcon req.get_param("...") reads ------------------------------
+
+func TestPagination_Falcon_GetParamLimitOffset(t *testing.T) {
+	src := `
+import falcon
+
+class ItemsResource:
+    def on_get(self, req, resp):
+        limit = req.get_param("limit")
+        offset = req.get_param("offset")
+        resp.media = []
+
+app = falcon.App()
+app.add_route("/items", ItemsResource())
+`
+	eps := deprecProps(t, "python", "app/f.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+func TestPagination_Falcon_NoParamNotPaginated(t *testing.T) {
+	src := `
+import falcon
+
+class HealthResource:
+    def on_get(self, req, resp):
+        resp.media = {"status": "ok"}
+
+app = falcon.App()
+app.add_route("/health", HealthResource())
+`
+	eps := deprecProps(t, "python", "app/f.py", src)
+	e := mustEndpoint(t, eps, "GET /health")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want absent (no pagination param)", got)
+	}
+}
+
+// --- Python: Tornado self.get_query_argument("...") reads ------------------
+
+func TestPagination_Tornado_GetQueryArgLimitOffset(t *testing.T) {
+	src := `
+import tornado.web
+
+class ItemsHandler(tornado.web.RequestHandler):
+    def get(self):
+        limit = self.get_query_argument("limit")
+        offset = self.get_query_argument("offset")
+        self.write([])
+
+app = tornado.web.Application([(r"/items", ItemsHandler)])
+`
+	eps := deprecProps(t, "python", "app/t.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+func TestPagination_Tornado_LoneLimitNotPaginated(t *testing.T) {
+	src := `
+import tornado.web
+
+class ItemsHandler(tornado.web.RequestHandler):
+    def get(self):
+        limit = self.get_argument("limit")
+        self.write([])
+
+app = tornado.web.Application([(r"/items", ItemsHandler)])
+`
+	eps := deprecProps(t, "python", "app/t.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want absent (lone limit is ambiguous)", got)
+	}
+}


### PR DESCRIPTION
Closes #4216 (epic #3872 / #3628).

## What

Extends the endpoint pagination param-reader so five frameworks' `endpoint_pagination_posture` actually fires. `applyEndpointPagination` stamps posture only when the reader recognises a framework's query-param read idiom; these five synthesize endpoints but read params via idioms the reader didn't recognise, so they were HONEST-MISSING.

### Idioms ADDED

| framework | idiom | reader regex | reader fn |
|---|---|---|---|
| jsts hono | `c.req.query("limit")` | `jsHonoQueryRe` | `jsQueryParams` |
| jsts adonisjs | `request.input("limit")` / `request.qs().cursor` | `jsAdonisInputRe` | `jsQueryParams` |
| python bottle | `request.query.limit` / `.get("limit")` / `["limit"]` | `pyBottleQueryRe` | `pythonRequestQueryParams` |
| python falcon | `req.get_param("limit")` / `get_param_as_int` | `pyFalconGetParamRe` | `pythonRequestQueryParams` |
| python tornado | `self.get_query_argument("limit")` / `get_argument` | `pyTornadoArgRe` | `pythonRequestQueryParams` |

All reuse the existing honest-partial `classifyParamShape`: `limit+offset` → offset, a cursor token → cursor, a **lone limit stays unstamped**. No existing koa/fastify/hapi/restify/feathers/nestjs/flask/etc reader changed.

### HONESTLY DEFERRED

- **aiohttp** (stays missing): handler is a separate out-of-line coroutine (`app.router.add_get("/items", list_items)`); the endpoint anchors at the `add_get` line and the 1000-char `handlerBodyWindow` does not reach the handler body, so `request.query.get(...)` is not window-reachable. Crediting needs a Python separate-handler body locator (cf. Go `findGoHandlerBody`) — out of scope. Documented in the registry note.

## Tests (exact posture asserted, never len>0)

Positives: `TestPagination_Hono_ReqQueryLimitOffset`, `TestPagination_Adonis_InputLimitOffset`, `TestPagination_Adonis_QsCursor`, `TestPagination_Bottle_QueryAttrLimitOffset`, `TestPagination_Falcon_GetParamLimitOffset`, `TestPagination_Tornado_GetQueryArgLimitOffset` — each asserts paginated=true + style + params=limit,offset (Adonis cursor variant asserts style=cursor, params=cursor).

Negatives (non-vacuousness): `TestPagination_Hono_LoneLimitNotPaginated`, `TestPagination_Adonis_NoParamNotPaginated`, `TestPagination_Bottle_LoneLimitNotPaginated`, `TestPagination_Falcon_NoParamNotPaginated`, `TestPagination_Tornado_LoneLimitNotPaginated`.

Self-audit: stashing the reader extension makes all six positives FAIL; restored. Full `go test ./internal/engine/` passes (no regressions); `gofmt -l` + `go vet` clean; covtool `fmt --check` canonical; `validate` ok.

## Registry: before → after

`capabilities.Routing.endpoint_pagination_posture`:
- hono / adonisjs / bottle / falcon / tornado: **missing → partial** (per-framework note)
- aiohttp: **missing → missing** (note updated to document the honest defer)

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)