### PR TITLE
python-separate-handler-body-locator

### DIFF
--- a/internal/engine/http_endpoint_pagination.go
+++ b/internal/engine/http_endpoint_pagination.go
@@ -133,6 +133,15 @@ func resolveEndpointPagination(lang, content string, e *types.EntityRecord) (pag
 		if v, ok := pythonPaginationVerdict(region, body); ok {
 			return v, true
 		}
+		// Out-of-line registration (aiohttp `app.router.add_get("/x", handler)`,
+		// starlette `Route("/x", handler)`): the StartLine-anchored body window
+		// above is the REGISTRATION line, not the separately-defined handler, so
+		// it never reaches the `async def handler` body. Locate the handler body
+		// by its source_handler reference and scan its real body for request
+		// query-param reads (mirrors goPaginationVerdict). Refs #3872.
+		if v, ok := pythonSourceHandlerPaginationVerdict(content, e); ok {
+			return v, true
+		}
 	case "java":
 		// For Spring the route annotation (@GetMapping) is the anchor and the
 		// `Pageable` param / `Page<…>` return live on the handler SIGNATURE line
@@ -473,6 +482,96 @@ func pythonRequestQueryParams(body string) map[string]bool {
 		addPaginationParam(present, m[1])
 	}
 	return present
+}
+
+// pythonSourceHandlerName extracts the bare handler function name from an
+// endpoint's `source_handler` property. The synthesizers stamp it as
+// `<refKind>:<name>` (e.g. `Controller:list_items` for aiohttp,
+// `SCOPE.Operation:list_users` for starlette); the cross-file resolver may
+// later rebind it to a dotted `Mod.handler` — we keep only the final segment,
+// which is the name the `def <handler>` locator anchors on.
+func pythonSourceHandlerName(e *types.EntityRecord) string {
+	h := e.Properties["source_handler"]
+	if i := strings.IndexByte(h, ':'); i >= 0 {
+		h = h[i+1:]
+	}
+	if i := strings.LastIndexByte(h, '.'); i >= 0 {
+		h = h[i+1:]
+	}
+	return strings.TrimSpace(h)
+}
+
+// pythonSourceHandlerPaginationVerdict resolves param-based pagination by
+// locating the handler body via the endpoint's source_handler reference and
+// running the same request-query sniffer used for in-line ASGI/WSGI handlers.
+// This reaches OUT-OF-LINE registrations (aiohttp / starlette) whose StartLine
+// is the registration line, so the StartLine-anchored body window never covers
+// the separately-defined handler. Mirrors goPaginationVerdict. Refs #3872.
+func pythonSourceHandlerPaginationVerdict(content string, e *types.EntityRecord) (paginationVerdict, bool) {
+	handler := pythonSourceHandlerName(e)
+	if handler == "" {
+		return paginationVerdict{}, false
+	}
+	body := findPyHandlerBody(content, handler)
+	if body == "" {
+		return paginationVerdict{}, false
+	}
+	// Django Paginator / fastapi-pagination shapes can also appear in an
+	// out-of-line handler body — reuse the full body classifier so they are
+	// not missed, then fall through to the request-query sniffer.
+	if djangoPaginatorRe.MatchString(body) {
+		return paginationVerdict{paginated: true, style: "page", params: []string{"page"}, source: "Django Paginator"}, true
+	}
+	if fastapiPaginateRe.MatchString(body) {
+		return paginationVerdict{paginated: true, style: "page", params: []string{"page", "size"}, source: "fastapi-pagination paginate()"}, true
+	}
+	present := pythonRequestQueryParams(body)
+	return classifyParamShape(present, "request.query")
+}
+
+// findPyHandlerBody returns the indented body of a Python function located by
+// name, mirroring findGoHandlerBody for the brace-free language. It anchors on
+// `def <handler>(` / `async def <handler>(`, then captures every subsequent
+// line that is either blank or indented deeper than the `def` keyword, stopping
+// at the first line dedented to (or below) the def's own indentation. This
+// bounds the scan to exactly the function's own block, so a sibling function or
+// a later same-name read cannot leak pagination params into the verdict.
+func findPyHandlerBody(content, handler string) string {
+	if handler == "" {
+		return ""
+	}
+	re := regexp.MustCompile(`(?m)^([ \t]*)(?:async\s+)?def\s+` + regexp.QuoteMeta(handler) + `\s*\(`)
+	loc := re.FindStringSubmatchIndex(content)
+	if loc == nil {
+		return ""
+	}
+	defIndentWidth := pyIndentWidth(content[loc[2]:loc[3]])
+
+	// Start at the line AFTER the (possibly multi-line) signature. Advance to
+	// the end of the line that closes the signature `)` then `:`; a simple
+	// next-line start is sufficient because the sniffer tolerates the signature
+	// line itself being excluded (FastAPI typed params are handled elsewhere).
+	rest := content[loc[1]:]
+	nl := strings.IndexByte(rest, '\n')
+	if nl < 0 {
+		return ""
+	}
+	bodyStart := loc[1] + nl + 1
+	lines := strings.Split(content[bodyStart:], "\n")
+	var b strings.Builder
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			b.WriteString(ln)
+			b.WriteByte('\n')
+			continue
+		}
+		if pyIndentWidth(ln) <= defIndentWidth {
+			break // dedent to def level or below ends the function block
+		}
+		b.WriteString(ln)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // addPaginationParam lower-cases a candidate param name and records it iff it

--- a/internal/engine/http_endpoint_pagination_pybody_3872_test.go
+++ b/internal/engine/http_endpoint_pagination_pybody_3872_test.go
@@ -1,0 +1,177 @@
+// Python separate-handler body locator (#3872).
+//
+// Out-of-line route registration (aiohttp `app.router.add_get("/x", handler)`,
+// starlette `Route("/x", handler)`) anchors the endpoint StartLine at the
+// REGISTRATION line, so the StartLine-anchored handler-body window never reaches
+// the separately-defined handler. These tests drive the full synthesis +
+// pagination pass and assert the EXACT pagination posture now stamps when the
+// body is located via the endpoint's source_handler reference.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// aiohttp `app.router.add_get(path, handler)` with the handler defined
+// out-of-line above the registration: limit+offset → offset style.
+func TestPagination_AiohttpOutOfLineOffset(t *testing.T) {
+	src := `
+from aiohttp import web
+
+async def list_items(request):
+    limit = request.query.get("limit")
+    offset = request.query.get("offset")
+    return web.json_response([])
+
+app = web.Application()
+app.router.add_get("/items", list_items)
+`
+	eps := deprecProps(t, "python", "app/routes.py", src)
+	e := mustEndpoint(t, eps, "GET /items")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+	if got := e.Properties["pagination_source"]; got != "request.query" {
+		t.Fatalf("pagination_source=%q want request.query", got)
+	}
+}
+
+// aiohttp `app.router.add_route("GET", path, handler)` generic form with a
+// cursor token in the out-of-line handler → cursor style.
+func TestPagination_AiohttpAddRouteCursor(t *testing.T) {
+	src := `
+from aiohttp import web
+
+async def feed(request):
+    cursor = request.query.get("cursor")
+    return web.json_response([])
+
+app = web.Application()
+app.router.add_route("GET", "/feed", feed)
+`
+	eps := deprecProps(t, "python", "app/routes.py", src)
+	e := mustEndpoint(t, eps, "GET /feed")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "cursor" {
+		t.Fatalf("pagination_style=%q want cursor", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "cursor" {
+		t.Fatalf("pagination_params=%q want cursor", got)
+	}
+}
+
+// starlette `Route(path, handler, methods=[...])` with the handler defined
+// out-of-line, reading from request.query_params → offset style. (Starlette
+// already anchors at the def line, but the source_handler fallback must also
+// resolve it correctly and must not regress the posture.)
+func TestPagination_StarletteOutOfLineOffset(t *testing.T) {
+	src := `
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+async def list_users(request):
+    limit = request.query_params.get("limit")
+    offset = request.query_params.get("offset")
+    return JSONResponse([])
+
+routes = [
+    Route("/users", list_users, methods=["GET"]),
+]
+app = Starlette(routes=routes)
+`
+	eps := deprecProps(t, "python", "app/main.py", src)
+	e := mustEndpoint(t, eps, "GET /users")
+	if e.Properties["paginated"] != "true" {
+		t.Fatalf("paginated=%q want true (props: %v)", e.Properties["paginated"], e.Properties)
+	}
+	if e.Properties["pagination_style"] != "offset" {
+		t.Fatalf("pagination_style=%q want offset", e.Properties["pagination_style"])
+	}
+	if got := e.Properties["pagination_params"]; got != "limit,offset" {
+		t.Fatalf("pagination_params=%q want limit,offset", got)
+	}
+}
+
+// Negative / honest-partial: an out-of-line aiohttp handler that reads NO
+// pagination param yields no posture. Guards against the locator leaking a
+// false positive (e.g. by scanning a sibling function's body).
+func TestPagination_AiohttpOutOfLineNoPosture(t *testing.T) {
+	src := `
+from aiohttp import web
+
+async def get_item(request):
+    item_id = request.match_info.get("id")
+    return web.json_response({})
+
+# A sibling function that DOES paginate — must NOT leak into get_item's verdict.
+async def other(request):
+    limit = request.query.get("limit")
+    offset = request.query.get("offset")
+    return web.json_response([])
+
+app = web.Application()
+app.router.add_get("/items/{id}", get_item)
+`
+	eps := deprecProps(t, "python", "app/routes.py", src)
+	e := mustEndpoint(t, eps, "GET /items/{id}")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want unset (sibling pagination leaked? props: %v)", got, e.Properties)
+	}
+	if got := e.Properties["pagination_style"]; got != "" {
+		t.Fatalf("pagination_style=%q want unset", got)
+	}
+}
+
+// Boundary: a lone `limit` (no offset/page/cursor companion) is ambiguous and
+// must NOT stamp, even when reached via the out-of-line locator.
+func TestPagination_AiohttpOutOfLineLoneLimitAmbiguous(t *testing.T) {
+	src := `
+from aiohttp import web
+
+async def search(request):
+    limit = request.query.get("limit")
+    return web.json_response([])
+
+app = web.Application()
+app.router.add_get("/search", search)
+`
+	eps := deprecProps(t, "python", "app/routes.py", src)
+	e := mustEndpoint(t, eps, "GET /search")
+	if got := e.Properties["paginated"]; got != "" {
+		t.Fatalf("paginated=%q want unset (lone limit is ambiguous; props: %v)", got, e.Properties)
+	}
+}
+
+// Unit: findPyHandlerBody captures only the named function's own indented block,
+// stopping at the dedent — a following sibling def must be excluded.
+func TestFindPyHandlerBody_BlockBounded(t *testing.T) {
+	src := `async def list_items(request):
+    limit = request.query.get("limit")
+    offset = request.query.get("offset")
+    return []
+
+async def other(request):
+    cursor = request.query.get("cursor")
+    return []
+`
+	body := findPyHandlerBody(src, "list_items")
+	if body == "" {
+		t.Fatal("findPyHandlerBody returned empty")
+	}
+	if !strings.Contains(body, `request.query.get("limit")`) || !strings.Contains(body, `request.query.get("offset")`) {
+		t.Fatalf("body missing list_items reads: %q", body)
+	}
+	if strings.Contains(body, "cursor") {
+		t.Fatalf("body leaked the sibling `other` block: %q", body)
+	}
+}


### PR DESCRIPTION
Closes #4223

## What
Adds a Python separate-handler body locator so body-window-based pagination caps reach OUT-OF-LINE handlers (aiohttp / starlette), mirroring the existing Go design.

### Problem
`resolveEndpointPagination` derives the handler body from a `handlerBodyWindow` anchored at the endpoint's `StartLine`. For Python out-of-line registration — aiohttp `app.router.add_get("/items", list_items)` / `add_route` / `@routes.get` — `StartLine` is the REGISTRATION line, so the window never reaches the separately-defined `async def list_items` body and the `request.query.get("limit")` pagination idiom is missed.

This is already solved for Go: `goPaginationVerdict` follows `Properties["source_handler"]` → `findGoHandlerBody`. aiohttp (`Controller:<name>`) and starlette (`SCOPE.Operation:<name>`) already stamp `source_handler`; the Python side just had no consumer.

### Build (mirrors the Go design)
- **`findPyHandlerBody(content, handler)`** — indentation-based Python body locator (brace-free analogue of `findGoHandlerBody`): anchors on `def`/`async def <name>(`, captures the indented block, stops at the first dedent to/below the def indent so a sibling function cannot leak params.
- **`pythonSourceHandlerPaginationVerdict`** — resolves the handler body via `source_handler` and runs the existing `pythonRequestQueryParams` sniffer (plus Django Paginator / fastapi-pagination shapes), wired as a fallback in the `python` branch of `resolveEndpointPagination`.

### Cells flipped
- aiohttp `endpoint_pagination_posture`: **missing → partial**.
- starlette: already `full` (it anchors at the def line via `findPyDefLine`) — **confirmed non-regressed** by test.

### Honest-missing (documented in registry note)
Dynamically-named reads (`request.query.get(var)`) and params named only in middleware remain unreached. `request_sink_dataflow` is NOT wired in this PR (no aiohttp cell exists for it; out of scope).

## Tests (all value-asserting)
- `TestPagination_AiohttpOutOfLineOffset` — asserts paginated=true, style=offset, params=limit,offset, source=request.query.
- `TestPagination_AiohttpAddRouteCursor` — `add_route("GET",…)` form → style=cursor, params=cursor.
- `TestPagination_StarletteOutOfLineOffset` — starlette `Route(path, handler, methods=[…])` → style=offset, params=limit,offset (regression guard).
- `TestPagination_AiohttpOutOfLineNoPosture` — sibling function paginates; target handler does not → NO posture (anti-leak).
- `TestPagination_AiohttpOutOfLineLoneLimitAmbiguous` — lone `limit` → unstamped (honest-partial boundary).
- `TestFindPyHandlerBody_BlockBounded` — locator captures only the named block, excludes the following sibling def.

Non-vacuousness proven: neutering the verdict drops the aiohttp posture; restored → passes.

## Gates
- `covtool fmt --check`: canonical. `covtool validate`: ok.
- `go test ./internal/engine/`: full package PASS, zero regressions.
- `gofmt -l` + `go vet`: clean.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)