### PR TITLE
iac-stamp-resource-properties

### DIFF
--- a/internal/engine/iac_cloudformation_edges.go
+++ b/internal/engine/iac_cloudformation_edges.go
@@ -515,6 +515,15 @@ func applyCloudFormationEdges(args DetectorPassArgs) DetectorPassResult {
 		if strings.HasPrefix(r.typ, "AWS::Serverless::") {
 			props["iac_tool"] = "sam"
 		}
+		// Epic #4194 — stamp curated scalar config properties (InstanceType,
+		// Runtime, MemorySize, Timeout, DBInstanceClass, ...) from the resource
+		// body. Intrinsic-function values (Ref/GetAtt/Sub/...) are skipped (they
+		// remain reference edges mined below).
+		for k, v := range cfnExtractScalarProperties(r.body) {
+			if _, exists := props[k]; !exists {
+				props[k] = v
+			}
+		}
 		emitEntity(eid, kind, "cfn_resource", r.logicalID, r.line, props)
 		knownIDs[r.logicalID] = eid
 	}

--- a/internal/engine/iac_cloudformation_properties.go
+++ b/internal/engine/iac_cloudformation_properties.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// iac_cloudformation_properties.go — epic #4194 (iac_resource_property_extraction).
+//
+// Stamp a CURATED, bounded allow-list of high-signal SCALAR resource
+// configuration properties from a CloudFormation/SAM resource's Properties body
+// onto the resource entity's Properties map. This ADDS scalar config alongside
+// the existing Ref/GetAtt/Sub/DependsOn edge mining — it does NOT replace it.
+//
+// CloudFormation templates are YAML or JSON and are parsed here with the same
+// regex/string approach the rest of this file uses (no full YAML parser). To
+// stay robust and bounded we ONLY stamp a key when:
+//   - the key is in cfnCuratedScalarKeys (the allow-list), AND
+//   - its value on the same line is a *literal scalar*: a quoted/bare string,
+//     an integer/float, or a boolean.
+//
+// We deliberately SKIP and never stamp:
+//   - intrinsic-function values (!Ref, !GetAtt, !Sub, !ImportValue, !FindInMap,
+//     and their { "Fn::..." : ... } / { "Ref": ... } long forms) — those are
+//     reference edges, mined elsewhere,
+//   - block/object/list values (a key whose value continues on following
+//     indented lines, or starts with { or [).
+//
+// Typical stamped count is small (2–5 props on a real resource: e.g. a Lambda
+// gets Runtime + MemorySize + Timeout; an EC2 instance gets InstanceType),
+// keeping per-resource property fan-out bounded.
+
+// cfnCuratedScalarKeys is the allow-list of high-signal CloudFormation property
+// keys we stamp. CloudFormation uses PascalCase property names. Chosen to mirror
+// the cross-tool curated set (compute sizing, runtime/engine/version, scaling,
+// networking, storage) while staying bounded.
+var cfnCuratedScalarKeys = map[string]struct{}{
+	// compute sizing / SKU
+	"InstanceType":    {},
+	"DBInstanceClass": {},
+	"CacheNodeType":   {},
+	"Size":            {},
+	"Tier":            {},
+	// memory / timeout (Lambda / SAM)
+	"MemorySize": {},
+	"Timeout":    {},
+	// runtime / engine / version
+	"Runtime":       {},
+	"Engine":        {},
+	"EngineVersion": {},
+	// scaling / count / replicas
+	"DesiredCapacity": {},
+	"MinSize":         {},
+	"MaxSize":         {},
+	"DesiredCount":    {},
+	"MinCapacity":     {},
+	"MaxCapacity":     {},
+	// networking
+	"Port":     {},
+	"Protocol": {},
+	// storage
+	"AllocatedStorage": {},
+	"StorageType":      {},
+}
+
+// cfnScalarLineRe matches a `Key: value` (YAML) or `"Key": value,` (JSON) line
+// capturing the key (group 1) and the raw value text (group 2). The value runs
+// to end-of-line; we validate/strip it in cfnLiteralScalarValue.
+var cfnScalarLineRe = regexp.MustCompile(`(?m)^[ \t]*["']?([A-Za-z0-9]+)["']?[ \t]*:[ \t]*(.+?)[ \t]*,?[ \t]*$`)
+
+// cfnIntrinsicPrefixes lists value prefixes that indicate an intrinsic function
+// (a reference), not a literal scalar. Such values are never stamped.
+var cfnIntrinsicPrefixes = []string{
+	"!Ref", "!GetAtt", "!Sub", "!ImportValue", "!FindInMap", "!Join",
+	"!Select", "!Split", "!Base64", "!Cidr", "!GetAZs", "!If", "!Equals",
+	"Fn::", "\"Fn::", "'Fn::",
+}
+
+// cfnExtractScalarProperties scans a CloudFormation resource body and returns a
+// map of curated scalar property key→value. Returns nil when none match (callers
+// should not create an empty map).
+func cfnExtractScalarProperties(body string) map[string]string {
+	if body == "" {
+		return nil
+	}
+	var props map[string]string
+	for _, m := range cfnScalarLineRe.FindAllStringSubmatch(body, -1) {
+		key := m[1]
+		if _, ok := cfnCuratedScalarKeys[key]; !ok {
+			continue
+		}
+		val, ok := cfnLiteralScalarValue(m[2])
+		if !ok {
+			continue
+		}
+		if props == nil {
+			props = map[string]string{}
+		}
+		// First occurrence wins (a resource declares each property once; SAM
+		// Globals merge is out of scope for this bounded stamping).
+		if _, exists := props[key]; !exists {
+			props[key] = val
+		}
+	}
+	return props
+}
+
+// cfnLiteralScalarValue validates that raw is a literal scalar (string, number,
+// or bool) and returns its cleaned value. Returns ("", false) for intrinsic
+// functions, references (a long-form { "Ref": ... } reduces to "{" here), and
+// block/collection openers.
+func cfnLiteralScalarValue(raw string) (string, bool) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return "", false // key with no inline value → nested block/object
+	}
+	// Reject intrinsic-function / reference values.
+	for _, p := range cfnIntrinsicPrefixes {
+		if strings.HasPrefix(v, p) {
+			return "", false
+		}
+	}
+	// Reject collection / object openers and JSON ref objects.
+	if v[0] == '{' || v[0] == '[' {
+		return "", false
+	}
+	// Strip a trailing inline comment (YAML).
+	if i := strings.Index(v, " #"); i >= 0 {
+		v = strings.TrimSpace(v[:i])
+	}
+	// Strip surrounding quotes (single or double).
+	if len(v) >= 2 && (v[0] == '"' || v[0] == '\'') && v[len(v)-1] == v[0] {
+		inner := v[1 : len(v)-1]
+		// A quoted value containing ${...} is a Sub-style template — reference.
+		if strings.Contains(inner, "${") {
+			return "", false
+		}
+		if inner == "" {
+			return "", false
+		}
+		return inner, true
+	}
+	// Bare value: must not contain interpolation or whitespace-separated tokens
+	// that imply a structure. Allow numbers, booleans, and simple bare strings.
+	if strings.Contains(v, "${") {
+		return "", false
+	}
+	// A bare value with internal spaces is unusual for these curated keys and
+	// risks capturing fragments — keep it bounded to single-token values.
+	if strings.ContainsAny(v, " \t") {
+		return "", false
+	}
+	return v, true
+}

--- a/internal/engine/iac_cloudformation_properties_test.go
+++ b/internal/engine/iac_cloudformation_properties_test.go
@@ -1,0 +1,145 @@
+package engine
+
+import "testing"
+
+// TestCFN_StampScalarProps_YAML asserts the EXACT curated scalar config
+// properties are stamped on YAML resources, and that intrinsic-function /
+// nested values are NOT stamped.
+func TestCFN_StampScalarProps_YAML(t *testing.T) {
+	src := `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ProcessorFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.12
+      MemorySize: 512
+      Timeout: 30
+      Role: !GetAtt FnRole.Arn
+      Environment:
+        Variables:
+          BUCKET: !Ref DataBucket
+  Db:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: postgres
+      DBInstanceClass: db.t3.micro
+      AllocatedStorage: 20
+      MasterUsername: !Ref DbUser
+`
+	ents, _ := cfnRun("yaml", "infra/template.yaml", src)
+
+	fn := cfnFindEntityByLogical(ents, "ProcessorFn")
+	if fn == nil {
+		t.Fatalf("missing ProcessorFn entity")
+	}
+	for k, want := range map[string]string{
+		"Runtime":    "python3.12",
+		"MemorySize": "512",
+		"Timeout":    "30",
+	} {
+		if got := fn.Properties[k]; got != want {
+			t.Errorf("ProcessorFn.%s = %q, want %q", k, got, want)
+		}
+	}
+	// Role is a !GetAtt intrinsic — must NOT be stamped (it stays an edge). Note
+	// "Role" is not in the allow-list anyway, but assert no leakage of intrinsics.
+	if v, ok := fn.Properties["Role"]; ok {
+		t.Errorf("Role intrinsic must not be stamped; got %q", v)
+	}
+
+	db := cfnFindEntityByLogical(ents, "Db")
+	if db == nil {
+		t.Fatalf("missing Db entity")
+	}
+	for k, want := range map[string]string{
+		"Engine":           "postgres",
+		"DBInstanceClass":  "db.t3.micro",
+		"AllocatedStorage": "20",
+	} {
+		if got := db.Properties[k]; got != want {
+			t.Errorf("Db.%s = %q, want %q", k, got, want)
+		}
+	}
+	// MasterUsername is !Ref → reference, and not in the allow-list either.
+	if v, ok := db.Properties["MasterUsername"]; ok {
+		t.Errorf("MasterUsername intrinsic must not be stamped; got %q", v)
+	}
+}
+
+// TestCFN_StampScalarProps_JSON asserts curated scalars from a JSON template and
+// that a long-form { "Fn::GetAtt": [...] } value is not stamped.
+func TestCFN_StampScalarProps_JSON(t *testing.T) {
+	src := `{
+  "Resources": {
+    "WebInstance": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t3.micro",
+        "SubnetId": { "Ref": "Subnet" }
+      }
+    }
+  }
+}`
+	ents, _ := cfnRun("json", "infra/template.json", src)
+	inst := cfnFindEntityByLogical(ents, "WebInstance")
+	if inst == nil {
+		t.Fatalf("missing WebInstance entity")
+	}
+	if got := inst.Properties["InstanceType"]; got != "t3.micro" {
+		t.Errorf("WebInstance.InstanceType = %q, want %q", got, "t3.micro")
+	}
+	// SubnetId is a { "Ref": ... } object → not a scalar, not in allow-list.
+	if v, ok := inst.Properties["SubnetId"]; ok {
+		t.Errorf("SubnetId ref object must not be stamped; got %q", v)
+	}
+}
+
+// TestCFN_StampScalarProps_SubTemplateNotStamped is the boundary case: a curated
+// key whose value is a !Sub / ${...} template must NOT be stamped as a scalar.
+func TestCFN_StampScalarProps_SubTemplateNotStamped(t *testing.T) {
+	src := `Resources:
+  Svc:
+    Type: AWS::ECS::Service
+    Properties:
+      DesiredCount: 3
+      Engine: !Sub "${EnginePrefix}-postgres"
+`
+	ents, _ := cfnRun("yaml", "infra/template.yaml", src)
+	svc := cfnFindEntityByLogical(ents, "Svc")
+	if svc == nil {
+		t.Fatalf("missing Svc entity")
+	}
+	if got := svc.Properties["DesiredCount"]; got != "3" {
+		t.Errorf("Svc.DesiredCount = %q, want %q", got, "3")
+	}
+	if v, ok := svc.Properties["Engine"]; ok {
+		t.Errorf("!Sub-valued Engine must not be stamped; got %q", v)
+	}
+}
+
+// Unit-level guard on the scalar value parser.
+func TestCFN_LiteralScalarValue(t *testing.T) {
+	cases := []struct {
+		raw     string
+		wantVal string
+		wantOK  bool
+	}{
+		{`t3.micro`, "t3.micro", true},
+		{`"t3.micro"`, "t3.micro", true},
+		{`512`, "512", true},
+		{`true`, "true", true},
+		{`!Ref Foo`, "", false},
+		{`!GetAtt Foo.Arn`, "", false},
+		{`{ "Ref": "Foo" }`, "", false},
+		{`!Sub "${X}-y"`, "", false},
+		{`"${X}-y"`, "", false},
+		{`[1, 2]`, "", false},
+		{``, "", false},
+	}
+	for _, c := range cases {
+		got, ok := cfnLiteralScalarValue(c.raw)
+		if ok != c.wantOK || got != c.wantVal {
+			t.Errorf("cfnLiteralScalarValue(%q) = (%q,%v), want (%q,%v)", c.raw, got, ok, c.wantVal, c.wantOK)
+		}
+	}
+}

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -246,6 +246,13 @@ func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, 
 		}
 		// Issue #3527 — dynamic "x" {} nested blocks as child entities.
 		out = append(out, extractDynamicBlocks(body, src, path, lang, selfRef)...)
+		// Epic #4194 — stamp curated scalar config attributes (instance_type,
+		// runtime, memory_size, timeout, count, ...) onto the resource entity's
+		// Properties. Reference-valued attributes are skipped here (they remain
+		// CALLS/DEPENDS_ON edges mined above).
+		ep := &EntityProps{Properties: out[0].Properties}
+		stampResourceScalarProperties(ep, body, src)
+		out[0].Properties = ep.Properties
 	}
 
 	return out, true

--- a/internal/extractors/hcl/resource_properties.go
+++ b/internal/extractors/hcl/resource_properties.go
@@ -1,0 +1,185 @@
+package hcl
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// resource_properties.go — epic #4194 (iac_resource_property_extraction).
+//
+// Stamp a CURATED, bounded allow-list of high-signal SCALAR configuration
+// attributes from a Terraform/OpenTofu `resource` block body onto the resource
+// entity's Properties map, as plain key→value strings. This ADDS scalar config
+// alongside the existing reference-edge mining (DEPENDS_ON / CALLS / iteration
+// meta) — it does NOT replace it.
+//
+// Bounded scope (avoid graph bloat): we only stamp attributes whose key is in
+// curatedResourceScalarKeys AND whose value is a *literal scalar*
+// (string_lit / numeric_lit / bool_lit). We deliberately SKIP:
+//   - nested blocks (already handled as dynamic child entities / meta-blocks),
+//   - collection values (objects, tuples/lists),
+//   - interpolations / traversal references (var.*, data.*, resource refs) —
+//     those are reference edges, not scalar config, and are mined elsewhere.
+//
+// Typical stamped count is small: 2–6 props on a real resource (e.g. an
+// aws_instance gets instance_type + count; a lambda gets runtime + memory_size
+// + timeout). The allow-list is intentionally curated rather than "every
+// attribute" to keep per-resource property fan-out bounded.
+
+// curatedResourceScalarKeys is the allow-list of high-signal scalar resource
+// attribute keys we stamp. Chosen to be cross-provider useful (compute sizing,
+// runtime, scaling, networking, engine/version) while staying bounded. Keys
+// not in this set are left to the reference-edge miner and are not stamped as
+// scalar config.
+var curatedResourceScalarKeys = map[string]struct{}{
+	// compute sizing / SKU
+	"instance_type":  {},
+	"machine_type":   {},
+	"size":           {},
+	"sku":            {},
+	"tier":           {},
+	"instance_class": {},
+	"node_type":      {},
+	"vm_size":        {},
+	// memory / timeout (serverless + containers)
+	"memory_size": {},
+	"memory":      {},
+	"timeout":     {},
+	// runtime / engine / version
+	"runtime":        {},
+	"engine":         {},
+	"engine_version": {},
+	"version":        {},
+	// scaling / count / replicas
+	"count":            {},
+	"desired_capacity": {},
+	"min_size":         {},
+	"max_size":         {},
+	"replicas":         {},
+	// networking
+	"port":     {},
+	"protocol": {},
+	// storage
+	"allocated_storage": {},
+	"storage_type":      {},
+}
+
+// stampResourceScalarProperties scans a resource block body for the curated
+// scalar attributes and stamps them onto rec.Properties. No-op when the body
+// has no matching scalar attributes (Properties stays nil to avoid empty maps).
+func stampResourceScalarProperties(rec *EntityProps, body *sitter.Node, src []byte) {
+	if body == nil || rec == nil {
+		return
+	}
+	count := int(body.ChildCount())
+	for i := 0; i < count; i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		keyNode := firstChildByType(attr, "identifier")
+		if keyNode == nil {
+			continue
+		}
+		key := nodeText(keyNode, src)
+		if _, ok := curatedResourceScalarKeys[key]; !ok {
+			continue
+		}
+		val, ok := scalarLiteralValue(attr, src)
+		if !ok {
+			// Value is a reference / collection / interpolation — skip it.
+			// Reference values remain edges (mined by extractCalls), they are
+			// intentionally NOT stamped as scalar config.
+			continue
+		}
+		if rec.Properties == nil {
+			rec.Properties = map[string]string{}
+		}
+		rec.Properties[key] = val
+	}
+}
+
+// EntityProps is the minimal interface into the property map we need. It mirrors
+// the relevant fields of types.EntityRecord so this helper can be unit-tested
+// without constructing a full record, and so the call site stays a one-liner.
+type EntityProps struct {
+	Properties map[string]string
+}
+
+// scalarLiteralValue returns the literal scalar value of an attribute's
+// expression and true, IFF the attribute value is exactly a single literal
+// (string_lit / numeric_lit / bool_lit). For string values the surrounding
+// quotes are stripped (the template_literal text is returned). For any
+// non-literal value (references, interpolated templates, collections, function
+// calls) it returns ("", false).
+func scalarLiteralValue(attr *sitter.Node, src []byte) (string, bool) {
+	expr := firstChildByType(attr, "expression")
+	if expr == nil {
+		return "", false
+	}
+	// A pure scalar is: expression → literal_value → {string_lit|numeric_lit|bool_lit}.
+	// References produce variable_expr/get_attr children directly under
+	// expression (no literal_value); collections produce collection_value;
+	// interpolated strings produce a template with interpolation children.
+	lit := firstChildByType(expr, "literal_value")
+	if lit == nil {
+		return "", false
+	}
+	// literal_value must have exactly one typed scalar child.
+	for i := 0; i < int(lit.ChildCount()); i++ {
+		c := lit.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "string_lit":
+			return scalarStringLit(c, src)
+		case "numeric_lit":
+			return strings.TrimSpace(nodeText(c, src)), true
+		case "bool_lit":
+			return strings.TrimSpace(nodeText(c, src)), true
+		}
+	}
+	return "", false
+}
+
+// scalarStringLit returns the inner text of a string_lit, but ONLY when it is a
+// plain literal (a single template_literal with no interpolation/template
+// expressions). A string containing ${...} interpolation is a reference-bearing
+// template and is NOT a scalar — those are mined as CALLS edges, so we return
+// ("", false) for them.
+func scalarStringLit(n *sitter.Node, src []byte) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	var literal string
+	sawLiteral := false
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "quoted_template_start", "quoted_template_end":
+			// quote delimiters — ignore
+		case "template_literal":
+			if sawLiteral {
+				// more than one literal segment → interpolated; not scalar
+				return "", false
+			}
+			literal = nodeText(c, src)
+			sawLiteral = true
+		default:
+			// template_interpolation, template_expr, etc. → not a plain scalar
+			return "", false
+		}
+	}
+	// Empty string literal ("") is a valid scalar value.
+	if !sawLiteral {
+		// could be the empty string "" (no template_literal child)
+		// confirm it really is just the two quote delimiters
+		return "", true
+	}
+	return literal, true
+}

--- a/internal/extractors/hcl/resource_properties_test.go
+++ b/internal/extractors/hcl/resource_properties_test.go
@@ -1,0 +1,148 @@
+package hcl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractResource runs the real HCL extractor and returns the resource entity
+// whose Name matches selfRef.
+func extractResource(t *testing.T, src, selfRef string) types.EntityRecord {
+	t.Helper()
+	e := &HCLExtractor{lang: "terraform"}
+	recs, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "main.tf",
+		Language: "terraform",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	for _, r := range recs {
+		if r.Name == selfRef && r.Subtype == "resource" {
+			return r
+		}
+	}
+	t.Fatalf("resource %q not found in %d records", selfRef, len(recs))
+	return types.EntityRecord{}
+}
+
+// TestStampScalarProps_AWSInstance asserts the EXACT curated scalar values are
+// stamped on an aws_instance: string instance_type and numeric count.
+func TestStampScalarProps_AWSInstance(t *testing.T) {
+	src := `resource "aws_instance" "web" {
+  instance_type = "t3.micro"
+  count         = 3
+  monitoring    = true
+}`
+	rec := extractResource(t, src, "aws_instance.web")
+	if got := rec.Properties["instance_type"]; got != "t3.micro" {
+		t.Errorf("instance_type = %q, want %q", got, "t3.micro")
+	}
+	if got := rec.Properties["count"]; got != "3" {
+		t.Errorf("count = %q, want %q", got, "3")
+	}
+	// "monitoring" is a bool literal but NOT in the curated allow-list — must
+	// not be stamped (bounded scope).
+	if _, ok := rec.Properties["monitoring"]; ok {
+		t.Errorf("monitoring should NOT be stamped (not in allow-list); got %q", rec.Properties["monitoring"])
+	}
+}
+
+// TestStampScalarProps_LambdaScalars asserts string + numeric curated props on
+// a lambda function resource.
+func TestStampScalarProps_LambdaScalars(t *testing.T) {
+	src := `resource "aws_lambda_function" "api" {
+  runtime     = "python3.12"
+  memory_size = 512
+  timeout     = 30
+}`
+	rec := extractResource(t, src, "aws_lambda_function.api")
+	for k, want := range map[string]string{
+		"runtime":     "python3.12",
+		"memory_size": "512",
+		"timeout":     "30",
+	} {
+		if got := rec.Properties[k]; got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestStampScalarProps_ReferenceNotStamped is the negative/boundary case: an
+// attribute whose value is a traversal REFERENCE (a curated key, but a
+// reference value) must NOT be stamped as a scalar — it stays an edge.
+func TestStampScalarProps_ReferenceNotStamped(t *testing.T) {
+	src := `resource "aws_db_instance" "db" {
+  engine            = "postgres"
+  instance_class    = aws_instance.web.type
+  allocated_storage = var.storage_gb
+}`
+	rec := extractResource(t, src, "aws_db_instance.db")
+	// Plain string scalar IS stamped.
+	if got := rec.Properties["engine"]; got != "postgres" {
+		t.Errorf("engine = %q, want %q", got, "postgres")
+	}
+	// Reference value (aws_instance.web.type) must NOT be stamped.
+	if v, ok := rec.Properties["instance_class"]; ok {
+		t.Errorf("instance_class is a reference and must not be stamped; got %q", v)
+	}
+	// var.* reference must NOT be stamped.
+	if v, ok := rec.Properties["allocated_storage"]; ok {
+		t.Errorf("allocated_storage is a var reference and must not be stamped; got %q", v)
+	}
+}
+
+// TestStampScalarProps_InterpolatedStringNotStamped: a curated key whose string
+// value contains ${...} interpolation is reference-bearing → not a scalar.
+func TestStampScalarProps_InterpolatedStringNotStamped(t *testing.T) {
+	src := `resource "aws_instance" "web" {
+  instance_type = "${var.size}.micro"
+}`
+	rec := extractResource(t, src, "aws_instance.web")
+	if v, ok := rec.Properties["instance_type"]; ok {
+		t.Errorf("interpolated instance_type must not be stamped; got %q", v)
+	}
+}
+
+// TestStampScalarProps_CollectionNotStamped: a curated key whose value is a
+// collection (object/list) is not a scalar → not stamped.
+func TestStampScalarProps_CollectionNotStamped(t *testing.T) {
+	// "size" is a curated key; here it is a list, not a scalar.
+	src := `resource "aws_autoscaling_group" "asg" {
+  min_size = 1
+  size     = [1, 2, 3]
+}`
+	rec := extractResource(t, src, "aws_autoscaling_group.asg")
+	if got := rec.Properties["min_size"]; got != "1" {
+		t.Errorf("min_size = %q, want %q", got, "1")
+	}
+	if v, ok := rec.Properties["size"]; ok {
+		t.Errorf("list-valued size must not be stamped; got %q", v)
+	}
+}
+
+// TestStampScalarProps_NoRegressionEdges confirms scalar stamping does NOT
+// suppress the existing reference-edge mining (DEPENDS_ON still emitted).
+func TestStampScalarProps_NoRegressionEdges(t *testing.T) {
+	src := `resource "aws_instance" "web" {
+  instance_type = "t3.micro"
+  depends_on    = [aws_iam_role.lambda_role]
+}`
+	rec := extractResource(t, src, "aws_instance.web")
+	if got := rec.Properties["instance_type"]; got != "t3.micro" {
+		t.Errorf("instance_type = %q, want t3.micro", got)
+	}
+	found := false
+	for _, rel := range rec.Relationships {
+		if rel.Kind == "DEPENDS_ON" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("DEPENDS_ON edge regressed: expected a depends_on edge alongside scalar stamping")
+	}
+}


### PR DESCRIPTION
Closes #4229 (epic #4194).

## What
IaC resource extractors previously mined resource bodies ONLY for cross-resource reference edges (DEPENDS_ON/CALLS/Ref/GetAtt/Sub) and DISCARDED scalar configuration settings, leaving `iac_resource_property_extraction` not_applicable for Terraform/OpenTofu/CloudFormation. This PR stamps a CURATED, bounded allow-list of high-signal scalar config props onto the resource entity Properties, ADDING scalar config alongside (not replacing) the existing reference-edge mining.

## Curated allow-list (rationale: cross-provider, high-signal, bounded to avoid graph bloat)
Compute sizing/SKU, memory/timeout, runtime/engine/version, scaling (count/replicas/min/max/desired), networking (port/protocol), storage. Typical 2-6 props per real resource.

- **Terraform/OpenTofu** (`hcl` tree-sitter, `resource_properties.go`): `stampResourceScalarProperties` stamps literal scalars (string_lit/numeric_lit/bool_lit) for curated keys; references (var.*/data.*/resource refs), `${...}` interpolations, and collections are SKIPPED (stay edges).
- **CloudFormation/SAM** (regex parser, YAML+JSON, `iac_cloudformation_properties.go`): `cfnExtractScalarProperties` stamps curated PascalCase scalar props; rejects intrinsic functions (`!Ref`/`!GetAtt`/`!Sub`/`Fn::*`/`{"Ref":...}`) and collection/Sub-template values.

**Deferred:** CDK + Pulumi (typed kwargs/args scalar literals) to a follow-up.

## Tests (value-asserting, exact key=value)
- HCL: `TestStampScalarProps_AWSInstance` (instance_type=t3.micro, count=3; monitoring NOT stamped — not in allow-list), `_LambdaScalars` (runtime=python3.12, memory_size=512, timeout=30), `_ReferenceNotStamped` (engine=postgres stamped; instance_class=ref / allocated_storage=var.* NOT stamped), `_InterpolatedStringNotStamped`, `_CollectionNotStamped` (min_size=1 stamped; list size NOT), `_NoRegressionEdges` (DEPENDS_ON still emitted).
- CFN: `TestCFN_StampScalarProps_YAML` (Runtime=python3.12/MemorySize=512/Timeout=30; Engine=postgres/DBInstanceClass=db.t3.micro/AllocatedStorage=20; intrinsics NOT stamped), `_JSON` (InstanceType=t3.micro; Ref-object NOT stamped), `_SubTemplateNotStamped` (DesiredCount=3 stamped; !Sub Engine NOT), `TestCFN_LiteralScalarValue` unit guard.

## Gates
gofmt clean, go vet clean, covtool fmt --check canonical, validate ok, full `hcl`+`engine` package tests pass (zero regressions). No .md committed.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)