### PR TITLE
iac-stamp-cdk-pulumi-properties

### DIFF
--- a/internal/engine/cdk_edges.go
+++ b/internal/engine/cdk_edges.go
@@ -294,6 +294,37 @@ func applyCDKEdges(args DetectorPassArgs) DetectorPassResult {
 		})
 	}
 
+	// stampScalarProps stamps curated literal scalar config props (epic #4194)
+	// from a construct's props body onto its already-emitted InfraResource
+	// entity, by LogicalId. It mutates the local `entities` slice in place.
+	// No-op when the construct has no entity yet or no curated scalar props.
+	stampScalarProps := func(logicalID, propsBody string) {
+		if logicalID == "" || propsBody == "" {
+			return
+		}
+		scalars := iacCodeExtractScalarProperties(propsBody)
+		if len(scalars) == 0 {
+			return
+		}
+		for i := range entities {
+			if entities[i].Kind != cdkResourceKind || entities[i].Name != logicalID ||
+				entities[i].SourceFile != path {
+				continue
+			}
+			if entities[i].Properties == nil {
+				entities[i].Properties = map[string]string{}
+			}
+			for k, v := range scalars {
+				// Never clobber the structural props emitResource set; only add
+				// curated config keys (which never collide with those).
+				if _, exists := entities[i].Properties[k]; !exists {
+					entities[i].Properties[k] = v
+				}
+			}
+			return
+		}
+	}
+
 	// emitDependsOn records `fromLogical --DEPENDS_ON--> toLogical`, the same
 	// edge kind the hcl extractor emits for Terraform `depends_on`.
 	emitDependsOn := func(fromLogical, toLogical, reason, detail string) {
@@ -324,7 +355,7 @@ func applyCDKEdges(args DetectorPassArgs) DetectorPassResult {
 	}
 
 	if cdkIsPython(lang) {
-		applyCDKEdgesPython(src, path, lang, emitResource, emitDependsOn, varToLogical, logicalIDs)
+		applyCDKEdgesPython(src, path, lang, emitResource, emitDependsOn, stampScalarProps, varToLogical, logicalIDs)
 		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
@@ -397,6 +428,8 @@ func applyCDKEdges(args DetectorPassArgs) DetectorPassResult {
 		if !logicalIDs[enclosingLogical] || propsBody == "" {
 			continue
 		}
+		// epic #4194: stamp curated literal scalar config props onto the entity.
+		stampScalarProps(enclosingLogical, propsBody)
 		for _, rm := range cdkPropsRefRe.FindAllStringSubmatch(propsBody, -1) {
 			ref := rm[1]
 			if ref == "" {
@@ -427,6 +460,7 @@ func applyCDKEdgesPython(
 	src, path, lang string,
 	emitResource func(logicalID, constructType string, offset int),
 	emitDependsOn func(fromLogical, toLogical, reason, detail string),
+	stampScalarProps func(logicalID, propsBody string),
 	varToLogical map[string]string,
 	logicalIDs map[string]bool,
 ) {
@@ -486,6 +520,8 @@ func applyCDKEdgesPython(
 		if !logicalIDs[enclosingLogical] || argsBody == "" {
 			continue
 		}
+		// epic #4194: stamp curated literal scalar config props onto the entity.
+		stampScalarProps(enclosingLogical, argsBody)
 		for _, rm := range cdkPyKwargRefRe.FindAllStringSubmatch(argsBody, -1) {
 			ref := rm[1]
 			passedLogical, ok := varToLogical[ref]

--- a/internal/engine/cdk_properties_test.go
+++ b/internal/engine/cdk_properties_test.go
@@ -1,0 +1,167 @@
+// Value-asserting tests for CDK curated scalar property stamping (epic #4194,
+// iac_resource_property_extraction). These assert the EXACT stamped key=value
+// pairs on the InfraResource entity, the negatives (enum/ref/call-valued props
+// are NOT stamped as scalars), and a regression guard that the existing
+// props_ref DEPENDS_ON edge mining still fires unchanged.
+package engine
+
+import (
+	"testing"
+)
+
+// TestCDK_ScalarProps_TS asserts curated literal scalar props on a TS
+// lambda.Function are stamped with exact values, while enum/call-valued props
+// (runtime: lambda.Runtime.X, timeout: Duration.seconds(30)) are NOT stamped as
+// scalars (they remain reference-bearing and out of scope here).
+func TestCDK_ScalarProps_TS(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+export class FnStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const handler = new lambda.Function(this, 'Handler', {
+      memorySize: 512,
+      timeout: Duration.seconds(30),
+      runtime: lambda.Runtime.NODEJS_20_X,
+      description: 'a handler',
+    });
+  }
+}
+`
+	ents, _ := runCDKDetect(t, "typescript", "lib/fn-stack.ts", src)
+	r := cdkResourceByName(ents, "Handler")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'Handler', got %+v", ents)
+	}
+	// memorySize=512 — a clean numeric literal, IS stamped.
+	if got := r.props["memorySize"]; got != "512" {
+		t.Errorf("Handler memorySize = %q, want 512", got)
+	}
+	// timeout=Duration.seconds(30) — a call expression, NOT a clean scalar.
+	if got, ok := r.props["timeout"]; ok {
+		t.Errorf("Handler timeout stamped as scalar = %q, want NOT stamped (call expr)", got)
+	}
+	// runtime=lambda.Runtime.NODEJS_20_X — an enum member ref, NOT stamped.
+	if got, ok := r.props["runtime"]; ok {
+		t.Errorf("Handler runtime stamped as scalar = %q, want NOT stamped (enum ref)", got)
+	}
+	// description — not in the curated allow-list, never stamped.
+	if _, ok := r.props["description"]; ok {
+		t.Errorf("Handler description stamped, want NOT stamped (not curated)")
+	}
+}
+
+// TestCDK_ScalarProps_TS_StringAndBool asserts quoted-string and bool curated
+// scalars are stamped with exact values.
+func TestCDK_ScalarProps_TS_StringAndBool(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+export class DbStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const db = new rds.DatabaseInstance(this, 'Db', {
+      engine: 'postgres',
+      engineVersion: '15.3',
+      allocatedStorage: 100,
+      port: 5432,
+    });
+  }
+}
+`
+	ents, _ := runCDKDetect(t, "typescript", "lib/db-stack.ts", src)
+	r := cdkResourceByName(ents, "Db")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'Db', got %+v", ents)
+	}
+	checks := map[string]string{
+		"engine":           "postgres",
+		"engineVersion":    "15.3",
+		"allocatedStorage": "100",
+		"port":             "5432",
+	}
+	for k, want := range checks {
+		if got := r.props[k]; got != want {
+			t.Errorf("Db %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestCDK_ScalarProps_Python asserts Python snake_case curated kwargs are
+// stamped with exact values, while enum/call-valued kwargs are NOT.
+func TestCDK_ScalarProps_Python(t *testing.T) {
+	src := `from aws_cdk import aws_lambda as _lambda, Duration
+from constructs import Construct
+
+class FnStack(Stack):
+    def __init__(self, scope: Construct, id: str) -> None:
+        super().__init__(scope, id)
+        handler = _lambda.Function(self, "Handler",
+            memory_size=512,
+            engine="aurora",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+        )
+`
+	ents, _ := runCDKDetect(t, "python", "stacks/fn_stack.py", src)
+	r := cdkResourceByName(ents, "Handler")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'Handler', got %+v", ents)
+	}
+	if got := r.props["memory_size"]; got != "512" {
+		t.Errorf("Handler memory_size = %q, want 512", got)
+	}
+	if got := r.props["engine"]; got != "aurora" {
+		t.Errorf("Handler engine = %q, want aurora", got)
+	}
+	if got, ok := r.props["runtime"]; ok {
+		t.Errorf("Handler runtime stamped = %q, want NOT stamped (enum ref)", got)
+	}
+}
+
+// TestCDK_ScalarProps_NoRegressionPropsRefEdge guards that stamping scalar
+// props does NOT regress the existing props_ref DEPENDS_ON edge mining: a
+// construct variable passed into another construct's props still produces the
+// enclosing→passed DEPENDS_ON edge.
+func TestCDK_ScalarProps_NoRegressionPropsRefEdge(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+export class AppStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const dataBucket = new s3.Bucket(this, 'DataBucket', { versioned: true });
+    const handler = new lambda.Function(this, 'Handler', {
+      memorySize: 256,
+      bucket: dataBucket,
+    });
+  }
+}
+`
+	ents, rels := runCDKDetect(t, "typescript", "lib/app-stack.ts", src)
+
+	// Scalar stamping still happened.
+	h := cdkResourceByName(ents, "Handler")
+	if h == nil || h.props["memorySize"] != "256" {
+		t.Fatalf("expected Handler memorySize=256, got %+v", h)
+	}
+
+	// props_ref edge Handler→DataBucket still fires.
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var found *relResult
+	for i := range deps {
+		if deps[i].from == "SCOPE.InfraResource:Handler" &&
+			deps[i].to == "SCOPE.InfraResource:DataBucket" &&
+			deps[i].props["reason"] == "props_ref" {
+			found = &deps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected props_ref DEPENDS_ON Handler→DataBucket, got %+v", deps)
+	}
+	if found.props["props_ref"] != "dataBucket" {
+		t.Errorf("props_ref detail = %q, want dataBucket", found.props["props_ref"])
+	}
+}

--- a/internal/engine/iac_code_properties.go
+++ b/internal/engine/iac_code_properties.go
@@ -1,0 +1,185 @@
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// iac_code_properties.go — epic #4194 (iac_resource_property_extraction).
+//
+// Stamp a CURATED, bounded allow-list of high-signal SCALAR resource
+// configuration properties from the props/args body of a CODE-FIRST IaC
+// resource (AWS CDK constructs, Pulumi resources — TypeScript & Python) onto
+// the resource entity's Properties map. This ADDS scalar config alongside the
+// existing reference-edge mining (props_ref / output_ref / depends_on) — it
+// does NOT replace it.
+//
+// Code-first IaC declares resource config as object-literal properties (TS:
+// `{ memorySize: 512, runtime: ... }`) or keyword arguments (Python:
+// `memory_size=512, runtime=...`). We parse these with the same regex/string
+// approach the surrounding edge miners use (no full TS/Py AST). To stay robust
+// and bounded we ONLY stamp a key when:
+//   - the key (lower-cased, after stripping a leading `_`) is in
+//     iacCodeCuratedScalarKeys (the allow-list), AND
+//   - its value is a *literal scalar*: a quoted string, an integer/float, or a
+//     boolean.
+//
+// We deliberately SKIP and never stamp:
+//   - construct/enum/Output references (`lambda.Runtime.NODEJS_20_X`,
+//     `Duration.seconds(30)`, `bucket.arn`, `role.arn`) — those are reference
+//     edges, mined elsewhere,
+//   - object / array / template-interpolation values.
+//
+// Both TS camelCase (`memorySize`, `instanceType`) and Python snake_case
+// (`memory_size`, `instance_type`) spellings are accepted; the stamped key is
+// preserved tool-native (as written in source) so a consumer sees exactly what
+// the author wrote. Typical stamped count is small (2–5 props on a real
+// resource), keeping per-resource property fan-out bounded.
+
+// iacCodeCuratedScalarKeys is the allow-list of high-signal scalar config keys
+// we stamp, normalized to lower-case with underscores removed so a single set
+// matches both `memorySize`/`memory_size` and `instanceType`/`instance_type`.
+// It mirrors the cross-tool curated set established for Terraform/CFN (#4230):
+// compute sizing/SKU, memory/timeout, runtime/engine/version, scaling,
+// networking, storage.
+var iacCodeCuratedScalarKeys = map[string]struct{}{
+	// compute sizing / SKU
+	"instancetype":  {},
+	"machinetype":   {},
+	"size":          {},
+	"sku":           {},
+	"tier":          {},
+	"instanceclass": {},
+	"nodetype":      {},
+	"vmsize":        {},
+	// memory / timeout
+	"memorysize": {},
+	"memory":     {},
+	"timeout":    {},
+	// runtime / engine / version
+	"runtime":       {},
+	"engine":        {},
+	"engineversion": {},
+	"version":       {},
+	// scaling / count / replicas
+	"count":           {},
+	"desiredcapacity": {},
+	"desiredcount":    {},
+	"minsize":         {},
+	"maxsize":         {},
+	"mincapacity":     {},
+	"maxcapacity":     {},
+	"replicas":        {},
+	// networking
+	"port":     {},
+	"protocol": {},
+	// storage
+	"allocatedstorage": {},
+	"storagetype":      {},
+}
+
+// iacCodeKeyMatches reports whether a source-written key (e.g. "memorySize" or
+// "memory_size") is in the curated allow-list, after case/underscore folding.
+func iacCodeKeyMatches(rawKey string) bool {
+	norm := strings.ToLower(strings.ReplaceAll(rawKey, "_", ""))
+	_, ok := iacCodeCuratedScalarKeys[norm]
+	return ok
+}
+
+// iacCodePropAssignRe matches a single `key: value` (TS object property) or
+// `key=value` (Python kwarg) assignment, capturing the key (group 1) and the
+// raw value up to the next comma / closing brace / newline (group 2). The value
+// is validated/cleaned in iacCodeLiteralScalarValue. Keys allow a leading `_`
+// (Python `_lambda`-style aliasing never applies to kwarg keys, but harmless).
+var iacCodePropAssignRe = regexp.MustCompile(
+	`(?m)(?:^|[\s,{(])([A-Za-z_][\w]*)\s*[:=]\s*([^,}\n\r]+)`,
+)
+
+// iacCodeExtractScalarProperties scans a CDK/Pulumi props or args body and
+// returns a map of curated scalar key→value. Returns nil when none match (the
+// caller should not create an empty map). The first occurrence of each key
+// wins. Keys are preserved exactly as written in source (tool-native casing).
+func iacCodeExtractScalarProperties(body string) map[string]string {
+	if body == "" {
+		return nil
+	}
+	var props map[string]string
+	for _, m := range iacCodePropAssignRe.FindAllStringSubmatch(body, -1) {
+		key := m[1]
+		if !iacCodeKeyMatches(key) {
+			continue
+		}
+		val, ok := iacCodeLiteralScalarValue(m[2])
+		if !ok {
+			continue
+		}
+		if props == nil {
+			props = map[string]string{}
+		}
+		if _, exists := props[key]; !exists {
+			props[key] = val
+		}
+	}
+	return props
+}
+
+// iacCodeLiteralScalarValue validates that raw is a literal scalar (quoted
+// string, number, or bool) and returns its cleaned value. Returns ("", false)
+// for references (enum/construct/Output accessors like `lambda.Runtime.X`,
+// `Duration.seconds(30)`, `bucket.arn`), object/array openers, and
+// template/interpolated strings.
+func iacCodeLiteralScalarValue(raw string) (string, bool) {
+	v := strings.TrimSpace(raw)
+	// Trim a trailing semicolon that can leak in on the last TS property.
+	v = strings.TrimRight(v, ";")
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", false
+	}
+	// Object / array openers are collections — never scalars.
+	if v[0] == '{' || v[0] == '[' {
+		return "", false
+	}
+	// Quoted string (single, double, or backtick).
+	if c := v[0]; c == '"' || c == '\'' || c == '`' {
+		// Find the matching closing quote of the same kind.
+		end := strings.IndexByte(v[1:], c)
+		if end < 0 {
+			return "", false
+		}
+		inner := v[1 : 1+end]
+		// A template string containing ${...} interpolation is a reference.
+		if c == '`' && strings.Contains(inner, "${") {
+			return "", false
+		}
+		if inner == "" {
+			return "", false
+		}
+		return inner, true
+	}
+	// Bare value. A reference shows up as an identifier with a `.` (member
+	// access: `lambda.Runtime.NODEJS_20_X`, `Duration.seconds`, `bucket.arn`) or
+	// a `(` (function call: `Duration.seconds(30)`). Reject those — they are
+	// edges, not scalars.
+	if strings.ContainsAny(v, ".(") {
+		return "", false
+	}
+	// Booleans (TS true/false, Python True/False) → normalize to lower-case.
+	switch v {
+	case "true", "True":
+		return "true", true
+	case "false", "False":
+		return "false", true
+	}
+	// Numbers: a clean integer or float literal (optionally signed). Allows
+	// underscores in TS/Py numeric separators (512_000).
+	if iacCodeNumberRe.MatchString(v) {
+		return strings.ReplaceAll(v, "_", ""), true
+	}
+	// Anything else (bare identifier, expression fragment) is not a clean scalar.
+	return "", false
+}
+
+// iacCodeNumberRe matches a clean integer or float numeric literal, optionally
+// signed, optionally with `_` digit separators (TS 2021 / Python).
+var iacCodeNumberRe = regexp.MustCompile(`^[+-]?[0-9][0-9_]*(?:\.[0-9_]+)?$`)

--- a/internal/engine/pulumi_edges.go
+++ b/internal/engine/pulumi_edges.go
@@ -254,6 +254,35 @@ func applyPulumiEdges(args DetectorPassArgs) DetectorPassResult {
 		})
 	}
 
+	// stampScalarProps stamps curated literal scalar config props (epic #4194)
+	// from a resource's args body onto its already-emitted InfraResource entity,
+	// by logical name. It mutates the local `entities` slice in place. No-op when
+	// the resource has no entity yet or no curated scalar props.
+	stampScalarProps := func(logicalName, argsBody string) {
+		if logicalName == "" || argsBody == "" {
+			return
+		}
+		scalars := iacCodeExtractScalarProperties(argsBody)
+		if len(scalars) == 0 {
+			return
+		}
+		for i := range entities {
+			if entities[i].Kind != pulumiResourceKind || entities[i].Name != logicalName ||
+				entities[i].SourceFile != path {
+				continue
+			}
+			if entities[i].Properties == nil {
+				entities[i].Properties = map[string]string{}
+			}
+			for k, v := range scalars {
+				if _, exists := entities[i].Properties[k]; !exists {
+					entities[i].Properties[k] = v
+				}
+			}
+			return
+		}
+	}
+
 	emitDependsOn := func(fromName, toName, reason, detail string) {
 		if fromName == "" || toName == "" || fromName == toName {
 			return
@@ -313,7 +342,7 @@ func applyPulumiEdges(args DetectorPassArgs) DetectorPassResult {
 	}
 
 	if pulumiIsPython(lang) {
-		applyPulumiEdgesPython(src, emitResource, emitDependsOn, emitCrossStack, varToName, resourceNames)
+		applyPulumiEdgesPython(src, emitResource, emitDependsOn, emitCrossStack, stampScalarProps, varToName, resourceNames)
 		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
@@ -378,6 +407,8 @@ func applyPulumiEdges(args DetectorPassArgs) DetectorPassResult {
 		if !resourceNames[consumerName] || argsBody == "" {
 			continue
 		}
+		// epic #4194: stamp curated literal scalar config props onto the entity.
+		stampScalarProps(consumerName, argsBody)
 		applyPulumiArgEdges(consumerName, argsBody, varToName, emitDependsOn)
 	}
 
@@ -421,6 +452,7 @@ func applyPulumiEdgesPython(
 	emitResource func(logicalName, resourceType, scopeOverride string, offset int),
 	emitDependsOn func(fromName, toName, reason, detail string),
 	emitCrossStack func(ref string, offset int),
+	stampScalarProps func(logicalName, argsBody string),
 	varToName map[string]string,
 	resourceNames map[string]bool,
 ) {
@@ -477,6 +509,8 @@ func applyPulumiEdgesPython(
 		if !resourceNames[consumerName] || argsBody == "" {
 			continue
 		}
+		// epic #4194: stamp curated literal scalar config props onto the entity.
+		stampScalarProps(consumerName, argsBody)
 		applyPulumiArgEdges(consumerName, argsBody, varToName, emitDependsOn)
 	}
 }

--- a/internal/engine/pulumi_properties_test.go
+++ b/internal/engine/pulumi_properties_test.go
@@ -1,0 +1,141 @@
+// Value-asserting tests for Pulumi curated scalar property stamping (epic
+// #4194, iac_resource_property_extraction). They assert the EXACT stamped
+// key=value pairs on the InfraResource entity, the negatives (Output/ref-valued
+// args are NOT stamped as scalars), and a regression guard that the existing
+// output_ref DEPENDS_ON edge mining still fires unchanged.
+package engine
+
+import (
+	"testing"
+)
+
+// TestPulumi_ScalarProps_TS asserts curated literal scalar args on a TS Pulumi
+// resource are stamped with exact values, while Output-valued args
+// (role: role.arn) are NOT stamped as scalars.
+func TestPulumi_ScalarProps_TS(t *testing.T) {
+	src := `import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const web = new aws.ec2.Instance("web", {
+    instanceType: "t3.micro",
+    ami: ami.id,
+    count: 3,
+});
+`
+	ents, _ := runPulumiDetect(t, "typescript", "index.ts", src)
+	r := pulumiResourceByName(ents, "web")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'web', got %+v", ents)
+	}
+	// instanceType="t3.micro" — quoted-string scalar, IS stamped.
+	if got := r.props["instanceType"]; got != "t3.micro" {
+		t.Errorf("web instanceType = %q, want t3.micro", got)
+	}
+	// count=3 — numeric scalar, IS stamped.
+	if got := r.props["count"]; got != "3" {
+		t.Errorf("web count = %q, want 3", got)
+	}
+	// ami=ami.id — an Output/member-access reference, NOT stamped (and ami isn't
+	// curated anyway, doubly excluded).
+	if _, ok := r.props["ami"]; ok {
+		t.Errorf("web ami stamped, want NOT stamped (output ref / not curated)")
+	}
+}
+
+// TestPulumi_ScalarProps_TS_OutputValuedCuratedKeyNotStamped asserts that a
+// CURATED key whose value is an Output reference is NOT stamped as a scalar.
+func TestPulumi_ScalarProps_TS_OutputValuedCuratedKeyNotStamped(t *testing.T) {
+	src := `import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const cache = new aws.elasticache.Cluster("cache", {
+    nodeType: sizing.nodeType,
+    port: 6379,
+});
+`
+	ents, _ := runPulumiDetect(t, "typescript", "index.ts", src)
+	r := pulumiResourceByName(ents, "cache")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'cache', got %+v", ents)
+	}
+	// nodeType=sizing.nodeType — member-access ref, curated key but NOT stamped.
+	if got, ok := r.props["nodeType"]; ok {
+		t.Errorf("cache nodeType stamped = %q, want NOT stamped (output ref)", got)
+	}
+	// port=6379 — numeric scalar, IS stamped.
+	if got := r.props["port"]; got != "6379" {
+		t.Errorf("cache port = %q, want 6379", got)
+	}
+}
+
+// TestPulumi_ScalarProps_Python asserts Python snake_case curated kwargs are
+// stamped with exact values, while Output-valued kwargs are NOT.
+func TestPulumi_ScalarProps_Python(t *testing.T) {
+	src := `import pulumi
+import pulumi_aws as aws
+
+web = aws.ec2.Instance("web",
+    instance_type="t3.large",
+    ami=ami.id,
+    desired_capacity=2,
+)
+`
+	ents, _ := runPulumiDetect(t, "python", "__main__.py", src)
+	r := pulumiResourceByName(ents, "web")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'web', got %+v", ents)
+	}
+	if got := r.props["instance_type"]; got != "t3.large" {
+		t.Errorf("web instance_type = %q, want t3.large", got)
+	}
+	if got := r.props["desired_capacity"]; got != "2" {
+		t.Errorf("web desired_capacity = %q, want 2", got)
+	}
+	if _, ok := r.props["ami"]; ok {
+		t.Errorf("web ami stamped, want NOT stamped (output ref / not curated)")
+	}
+}
+
+// TestPulumi_ScalarProps_NoRegressionOutputRefEdge guards that scalar stamping
+// does NOT regress the existing output_ref DEPENDS_ON edge mining.
+func TestPulumi_ScalarProps_NoRegressionOutputRefEdge(t *testing.T) {
+	src := `import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const data = new aws.s3.Bucket("data", { versioned: true });
+
+const fn = new aws.lambda.Function("fn", {
+    runtime: "nodejs20.x",
+    memorySize: 1024,
+    environment: { variables: { BUCKET: data.arn } },
+});
+`
+	ents, rels := runPulumiDetect(t, "typescript", "index.ts", src)
+
+	// Scalar stamping still happened on fn.
+	fn := pulumiResourceByName(ents, "fn")
+	if fn == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'fn', got %+v", ents)
+	}
+	if got := fn.props["runtime"]; got != "nodejs20.x" {
+		t.Errorf("fn runtime = %q, want nodejs20.x", got)
+	}
+	if got := fn.props["memorySize"]; got != "1024" {
+		t.Errorf("fn memorySize = %q, want 1024", got)
+	}
+
+	// output_ref edge fn→data still fires.
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var found *relResult
+	for i := range deps {
+		if deps[i].from == "SCOPE.InfraResource:fn" &&
+			deps[i].to == "SCOPE.InfraResource:data" &&
+			deps[i].props["reason"] == "output_ref" {
+			found = &deps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected output_ref DEPENDS_ON fn→data, got %+v", deps)
+	}
+}


### PR DESCRIPTION
Closes #4232 (epic #4194, iac_resource_property_extraction).

## Summary

Extend the **AWS CDK** and **Pulumi** code-first IaC extractors to STAMP a curated, bounded allow-list of literal SCALAR resource-configuration properties onto resource entities. Both previously mined the props/args body only for reference edges (`props_ref` / `output_ref`) and discarded scalar values.

Mirrors the just-merged Terraform/OpenTofu/CloudFormation precedent (#4230): same conceptual curated set, tool-native casing, stamping ONLY literal scalars (string/number/bool), SKIPPING references/enums/Output/collections (those stay edges).

## Changes

- **`internal/engine/iac_code_properties.go`** (new): shared `iacCodeExtractScalarProperties` + curated allow-list, folding camelCase + snake_case so `memorySize`/`memory_size` both match. Stamps only quoted strings, numbers, `true`/`false`; rejects member-access/call refs (`lambda.Runtime.X`, `Duration.seconds(30)`, `bucket.arn`) and object/array values.
- **`internal/engine/cdk_edges.go`**: Pass 5 props/kwargs body → `stampScalarProps` closure merges curated key=value onto the construct's `SCOPE.InfraResource` by LogicalId (TS + Python). Existing `props_ref` edge mining untouched.
- **`internal/engine/pulumi_edges.go`**: Pass 5 args body → `stampScalarProps` by logical name, right before `applyPulumiArgEdges` runs the existing `output_ref`/`depends_on` edge mining (so both happen) (TS + Python).
- **registry**: `iac_resource_property_extraction` `not_applicable` → `partial` for `infra.iac.cdk` and `infra.iac.pulumi`, per-tool-accurate notes.

## Curated keys (per tool, case/underscore-folded)

compute sizing/SKU (instanceType/machineType/size/sku/tier/instanceClass/nodeType/vmSize), memory/timeout (memorySize/memory/timeout), runtime/engine/version (runtime/engine/engineVersion/version), scaling (count/desiredCapacity/desiredCount/minSize/maxSize/minCapacity/maxCapacity/replicas), networking (port/protocol), storage (allocatedStorage/storageType).

## Tests (value-asserting, exact key=value)

CDK: `TestCDK_ScalarProps_TS`, `TestCDK_ScalarProps_TS_StringAndBool`, `TestCDK_ScalarProps_Python`, `TestCDK_ScalarProps_NoRegressionPropsRefEdge`.
Pulumi: `TestPulumi_ScalarProps_TS`, `TestPulumi_ScalarProps_TS_OutputValuedCuratedKeyNotStamped`, `TestPulumi_ScalarProps_Python`, `TestPulumi_ScalarProps_NoRegressionOutputRefEdge`.

Negatives assert enum/Output/call-valued curated keys are NOT stamped as scalars; regression tests assert the existing `props_ref`/`output_ref` DEPENDS_ON edges still fire.

## Gates

- `go test ./internal/engine/ ./tools/coverage/...` — PASS, zero regressions.
- `gofmt -l` clean, `go vet` clean.
- covtool `fmt --check` canonical, `validate` ok.

## Honesty caveats

- **Both tools = PARTIAL, not full**: single-file regex over the TS + Python lanes only; CDK-Java/Go/C# and Pulumi-Go/C#/Java property stamping deferred (same scope bound as resource_extraction).
- CDK enum-wrapped / `Duration.seconds()` values are intentionally NOT unwrapped (correctness over coverage) — only cleanly-literal values are stamped.
- The CDK-Python args regex (`cdkPyConstructPropsRe`) is bounded at the first `)`, so a call-valued kwarg (`Duration.seconds(30)`) truncates the scanned body — a pre-existing edge-miner limitation that scalar stamping inherits. Curated scalars after such a kwarg may be missed; this is honest PARTIAL behavior.

DEPLOY-DEFERRED: live-daemon reindex is a separate coordinated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)