### PR TITLE
mcp: orientation map in handshake instructions

### DIFF
--- a/cmd/mcp-audit/main.go
+++ b/cmd/mcp-audit/main.go
@@ -228,7 +228,11 @@ func buildReport(tools []mcpapi.Tool, ceiling, baseline int) AuditReport {
 // initEnvelopeBytes is the approximate byte count of the MCP initialize
 // envelope (server name, version string, instructions, JSON-RPC framing).
 // Derived from empirical measurement; update when instructions change.
-const initEnvelopeBytes = 512
+//
+// Breakdown: ~339 bytes of fixed framing (server name/version + JSON-RPC) plus
+// the mcpInstructions orientation map (~1180 bytes; internal/mcp/server.go).
+// When mcpInstructions changes, recompute as framing + len(mcpInstructions).
+const initEnvelopeBytes = 1519
 
 // printHuman writes a human-readable table to stdout.
 func printHuman(r AuditReport) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -50,9 +50,34 @@ func resolveReloadDebounce() time.Duration {
 	return defaultReloadDebounceMS * time.Millisecond
 }
 
-// mcpInstructions is the handshake text returned to MCP clients on initialize.
-// It tells agents to call archigraph_whoami first and act on suggested_action.
-const mcpInstructions = `archigraph code-graph MCP. Call archigraph_whoami on connect (cwd= set to caller dir); act on suggested_action. Set ARCHIGRAPH_WHOAMI_NUDGE=quiet to suppress doc-state (CI).`
+// mcpInstructions is the handshake text returned to MCP clients on initialize
+// (pushed to the model at the MCP `initialize` step — no tool call required).
+//
+// It is a deliberately compact ORIENTATION MAP, not a manual: it tells agents
+// to call archigraph_whoami first, states the cross-cutting CONVENTIONS that
+// every tool shares (id forms, token budgeting, repo/ref scoping, deprecated
+// tools), and groups the real tools by INTENT so an agent can pick one without
+// a discovery round-trip. Per-tool param detail intentionally stays in each
+// tool's inputSchema — duplicating it here would blow the handshake budget.
+//
+// This string is BUDGET-SENSITIVE: it ships in the initialize envelope counted
+// by cmd/mcp-audit against mcp.TokenCeiling. Every tool named below MUST be a
+// real registration (see registerTools); audit fails the build if the handshake
+// exceeds the ceiling. When you edit this text, re-run `go run ./cmd/mcp-audit`
+// and update initEnvelopeBytes in cmd/mcp-audit/main.go to match the new length.
+const mcpInstructions = `archigraph: a code knowledge-graph over your indexed repos (entities + typed edges). Call archigraph_whoami first - it resolves group/repo/ref from your cwd; act on its suggested_action.
+
+CONVENTIONS
+- entity_id/source/target accept an id, qualified_name, OR a bare label.
+- Output is token-budgeted; pass verbose / token_budget / max_results for more.
+- Defaults to cwd repo at HEAD; widen with cross_repo=true or group/ref. Each tool's inputSchema documents its params. Deprecated: expand, find_callers, find_callees - use neighbors.
+
+PICK A TOOL BY INTENT
+- Find code: find (semantic "where is X?"); search_entities (substring); get_source (by id|qname|label); inspect (entity + calls/called_by).
+- Navigate: neighbors (in|out|both); trace / find_paths (path between nodes); subgraph (N-hop); impact_radius (blast-radius); traces (process flows).
+- HTTP: endpoints; effective_contract (per-verb); endpoint_posture (auth/rate_limit); cross_links, payload_drift (cross-repo).
+- Effects/security: effects (db/http/fs/mutation); data_flows; security_findings (taint); auth_coverage; secrets.
+- Structure: dead_code; import_cycles / quality_cycles; clusters; module_analysis; stats.`
 
 // sentinelToolName is the single tool returned when the caller's cwd is not
 // covered by any registered archigraph group (#1769).

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3362,3 +3362,83 @@ func TestMCP_WhoamiP50Under50ms(t *testing.T) {
 	}
 	t.Logf("whoami p50=%dms (limit %dms), archigraph_mcp_metrics p50=%dms", p50, p50LimitMS, metricsP50)
 }
+
+// TestMCPInstructionsOrientationMap guards the handshake orientation map
+// (mcpInstructions) so it can't silently rot back to a thin one-liner. The
+// instructions are pushed to the model at MCP initialize with no tool call, so
+// they are the agent's first and only zero-cost orientation surface. We assert
+// the load-bearing pieces: the whoami directive, the shared id-form convention,
+// the deprecated-tool steer, and at least one real tool name per INTENT group.
+//
+// Every tool named here MUST be a live registration; cmd/mcp-audit enforces the
+// token budget separately. If a tool below is renamed/removed, update both the
+// map in server.go and this test (and re-run mcp-audit).
+func TestMCPInstructionsOrientationMap(t *testing.T) {
+	t.Parallel()
+
+	// (1) whoami-first directive.
+	if !strings.Contains(mcpInstructions, "archigraph_whoami") {
+		t.Errorf("instructions must direct agents to call archigraph_whoami first")
+	}
+	if !strings.Contains(mcpInstructions, "suggested_action") {
+		t.Errorf("instructions must tell agents to act on suggested_action")
+	}
+
+	// (2) cross-cutting conventions: the id|qualified_name|label form and the
+	// deprecated-tool steer toward neighbors.
+	for _, want := range []string{"qualified_name", "bare label", "Deprecated", "neighbors"} {
+		if !strings.Contains(mcpInstructions, want) {
+			t.Errorf("instructions missing convention marker %q", want)
+		}
+	}
+
+	// (3) at least one real tool name per INTENT category, so the map covers
+	// the breadth of the toolset and can't decay to a single category.
+	perCategory := map[string]string{
+		"find code": "find",
+		"navigate":  "neighbors",
+		"http":      "endpoints",
+		"effects":   "effects",
+		"security":  "security_findings",
+		"structure": "module_analysis",
+	}
+	for category, tool := range perCategory {
+		if !strings.Contains(mcpInstructions, tool) {
+			t.Errorf("instructions missing %s tool %q", category, tool)
+		}
+	}
+
+	// Every tool token in the map must be a registered tool. Build the live
+	// tool-name set from a fully-constructed server (NewServer runs
+	// registerTools and wires the underlying MCP server; newTestServer does
+	// not, so srv.MCP would be nil here).
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+	if err := os.WriteFile(regPath, []byte(`{"groups":{}}`), 0o644); err != nil {
+		t.Fatalf("write temp registry: %v", err)
+	}
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	registered := map[string]bool{}
+	for name := range srv.MCP.ListTools() {
+		registered[name] = true
+	}
+	candidates := []string{
+		"find", "search_entities", "get_source", "inspect",
+		"neighbors", "trace", "find_paths", "subgraph", "impact_radius", "traces",
+		"endpoints", "effective_contract", "endpoint_posture", "cross_links", "payload_drift",
+		"effects", "data_flows", "security_findings", "auth_coverage", "secrets",
+		"dead_code", "import_cycles", "quality_cycles", "clusters", "module_analysis", "stats",
+		"expand", "find_callers", "find_callees",
+	}
+	for _, c := range candidates {
+		full := "archigraph_" + c
+		if !strings.Contains(mcpInstructions, c) {
+			continue // only validate names that actually appear in the map
+		}
+		if !registered[full] {
+			t.Errorf("instructions name %q (%s) is not a registered tool", c, full)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4235 — part of epic #3648 (MCP/indexer scaling + quality).

**DEPLOY-DEFERRED** (handshake text change; takes effect on next daemon rebuild + MCP reconnect).

## Before → after
The MCP handshake `instructions` field is pushed to the model at `initialize` (no tool call required), so it is an agent's first and only zero-cost orientation surface.

**Before** (1 line, whoami-only):
> archigraph code-graph MCP. Call archigraph_whoami on connect (cwd= set to caller dir); act on suggested_action. Set ARCHIGRAPH_WHOAMI_NUDGE=quiet to suppress doc-state (CI).

With 56 tools, that left agents blind to what tools exist or how to drive them (the reported pain point).

**After** — a compact orientation MAP (not a manual):
1. `archigraph_whoami` first, act on `suggested_action`.
2. **CONVENTIONS** — `entity_id`/`source`/`target` accept id|qualified_name|label; output is token-budgeted (`verbose`/`token_budget`/`max_results`); defaults to cwd repo at HEAD, widen with `cross_repo`/`group`/`ref`; each tool's `inputSchema` documents its params; deprecated = `expand`/`find_callers`/`find_callees` (use `neighbors`).
3. **PICK A TOOL BY INTENT** — real tools grouped by purpose: find code / navigate / http / effects+security / structure.

## Token budget (hard gate)
`cmd/mcp-audit` counts all 57 tool schemas + the initialize envelope (which includes `instructions`) against `mcp.TokenCeiling`.

| | tokens |
|---|---|
| before | 6244 |
| **after** | **6496** |
| ceiling | 6500 |

4 tokens of headroom. `TokenCeiling` is **unchanged** (raising it would fight token-cost epic #2828). `initEnvelopeBytes` in `cmd/mcp-audit/main.go` bumped 512 → 1519 (≈339 bytes fixed framing + 1180-byte instructions) so the audit reflects the new length.

## Follow-up (deliberately deferred)
Per-tool param-doc enrichment in the handshake is intentionally NOT included — it would blow the 6500 budget. It would need to be funded by trimming, e.g. dropping the 3 deprecated tools (`expand`/`find_callers`/`find_callees`) from the schema set. Tracked as future work under epic #3648.

## Verification
- `go build ./...` ✓
- `go test ./internal/mcp/ ./cmd/mcp-audit/` ✓ (incl. new `TestMCPInstructionsOrientationMap`)
- `go run ./cmd/mcp-audit` → PASS, 6496 ≤ 6500 ✓
- `gofmt -l` clean, `go vet ./internal/mcp/ ./cmd/mcp-audit/` clean ✓

`TestMCPInstructionsOrientationMap` asserts the whoami directive, the id|qualified_name|label convention, the deprecated-tool steer, and at least one real tool name per intent category — and cross-checks every named tool against the live registration set, so the map can't silently rot when tools are renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)