### PR TITLE
install: imperative archigraph standing-directive in rules block

### DIFF
--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -44,7 +44,11 @@ import (
 // BlockVersion is the version embedded in the start marker. Bumping the
 // version causes doctor to flag any file whose block uses an older
 // version as OUTDATED so the next `archigraph install` rewrites it.
-const BlockVersion = 1
+//
+// v2 (#3648): added the imperative STANDING DIRECTIVE near the top of the
+// block so agents keep reaching for archigraph on structural questions for
+// the whole session instead of drifting back to grep after a few calls.
+const BlockVersion = 2
 
 // StartMarker / EndMarker bound the managed region inside every rules
 // file. Keep this stable across releases — bumping the marker syntax
@@ -211,6 +215,12 @@ func RenderBlock(groupName string) string {
 		"architecture knowledge graph available via MCP. When you (an AI coding "+
 		"agent) need to understand how this codebase fits together, prefer the "+
 		"archigraph MCP tools over `grep` + reading files.\n", groupName)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "### STANDING DIRECTIVE — query the graph, don't grep your way around it")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- **Default to archigraph for STRUCTURAL questions**: where is `X` defined, who calls/uses `Y`, how does a request flow end-to-end, what is the blast radius of a change, what are the modules. Reach for `archigraph_find` / `archigraph_inspect` / `archigraph_neighbors` / `archigraph_traces` / `archigraph_impact_radius` for these — **not** `grep` + reading files.")
+	fmt.Fprintln(&b, "- **This holds for the WHOLE session, not just your first few calls.** If you notice you have been grepping or opening files to answer a structural question, stop and query the graph instead — it is faster and more accurate, and it stays that way on call 50 as much as on call 1.")
+	fmt.Fprintln(&b, "- **`grep` is still right for**: raw string / substring / TODO / FIXME sweeps, and content that is not in the graph (comments, config values, log strings).")
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "### When to use archigraph instead of grep")
 	fmt.Fprintln(&b)

--- a/internal/install/rulesfiles/rulesfiles_test.go
+++ b/internal/install/rulesfiles/rulesfiles_test.go
@@ -41,6 +41,25 @@ func TestWriteAll_FreshRepo(t *testing.T) {
 		if !bytes.Contains(data, []byte("**demo**")) {
 			t.Errorf("%s: group name not embedded", target)
 		}
+		// The imperative STANDING DIRECTIVE (#3648) must be present in
+		// every target so agents keep using archigraph for the whole
+		// session instead of drifting back to grep. Assert the key phrases
+		// so this guard can't silently rot if the block is reworded.
+		if !bytes.Contains(data, []byte("STANDING DIRECTIVE")) {
+			t.Errorf("%s: standing directive heading missing", target)
+		}
+		if !bytes.Contains(data, []byte("STRUCTURAL questions")) {
+			t.Errorf("%s: directive does not mention STRUCTURAL questions", target)
+		}
+		if !bytes.Contains(data, []byte("not** `grep`")) {
+			t.Errorf("%s: directive does not push back against grep", target)
+		}
+		if !bytes.Contains(data, []byte("archigraph_find")) {
+			t.Errorf("%s: directive does not name archigraph_find", target)
+		}
+		if !bytes.Contains(data, []byte("WHOLE session")) {
+			t.Errorf("%s: directive does not assert whole-session scope", target)
+		}
 	}
 }
 
@@ -83,8 +102,13 @@ func TestWriteAll_ReplacesOlderVersionBlock(t *testing.T) {
 	if bytes.Contains(data, []byte("v=0")) {
 		t.Errorf("old version marker still present: %s", data)
 	}
-	if !bytes.Contains(data, []byte("v=1")) {
-		t.Errorf("new version marker missing: %s", data)
+	if !bytes.Contains(data, []byte(StartMarker)) {
+		t.Errorf("current version marker missing: %s", data)
+	}
+	// The replaced block must carry the new directive, not just a bumped
+	// version number.
+	if !bytes.Contains(data, []byte("STANDING DIRECTIVE")) {
+		t.Errorf("replaced block missing standing directive: %s", data)
 	}
 }
 


### PR DESCRIPTION
Closes #4237 (epic #3648).

**DEPLOY-DEFERRED** — block propagates to registered repos via `doctor` (OUTDATED) → next `archigraph install`; no live-daemon action in this PR.

## Why
The "how to use the MCP" block written into every per-repo agent-rule file was a **descriptive** table. It orients but doesn't push back, so agents use archigraph a couple of times then drift back to grep+read for structural questions ("agents use it a couple times then forget it exists").

## What
Added an imperative **STANDING DIRECTIVE** near the TOP of the block (seen first), keeping the existing orientation table below it.

### Before (descriptive table only)
```
## archigraph MCP

This repo is part of archigraph group **<g>**. ... prefer the archigraph
MCP tools over `grep` + reading files.

### When to use archigraph instead of grep
| Question shape | Prefer |
...
```

### After (directive + table)
```
## archigraph MCP

This repo is part of archigraph group **<g>**. ... prefer the archigraph
MCP tools over `grep` + reading files.

### STANDING DIRECTIVE — query the graph, don't grep your way around it

- **Default to archigraph for STRUCTURAL questions**: where is `X` defined,
  who calls/uses `Y`, how does a request flow end-to-end, what is the blast
  radius of a change, what are the modules. Reach for `archigraph_find` /
  `archigraph_inspect` / `archigraph_neighbors` / `archigraph_traces` /
  `archigraph_impact_radius` for these — **not** `grep` + reading files.
- **This holds for the WHOLE session, not just your first few calls.** If you
  notice you have been grepping or opening files to answer a structural
  question, stop and query the graph instead ...
- **`grep` is still right for**: raw string / substring / TODO / FIXME sweeps,
  and content that is not in the graph (comments, config values, log strings).

### When to use archigraph instead of grep
| Question shape | Prefer |
...   ← unchanged orientation table preserved
```

## BlockVersion bump
`BlockVersion` **1 → 2**. `doctor` now flags any file carrying the v=1 block as OUTDATED; the next `archigraph install` rewrites it. The any-version marker regex (`startMarkerAnyVersion` / `blockRegexAnyVersion`, `v=\d+`) is unchanged and still matches both old and new, so idempotent in-place replacement works across the bump (verified by `TestWriteAll_ReplacesOlderVersionBlock`).

## Which files get it
All 6 `Targets`, unchanged: `AGENTS.md`, `CLAUDE.md`, `.windsurfrules`, `.cursorrules`, `.codeium/instructions.md`, `.github/copilot-instructions.md`.

## Tests
- `TestWriteAll_FreshRepo`: now also asserts the directive's load-bearing phrases are present in **every** target — `STANDING DIRECTIVE`, `STRUCTURAL questions`, `not** \`grep\``, `archigraph_find`, `WHOLE session` — so the guard can't silently rot if the block is reworded.
- `TestWriteAll_ReplacesOlderVersionBlock`: replaced the `v=1`-pinned assertion with a `StartMarker`-presence check (version-agnostic) plus a directive-presence check (the replaced block must carry the directive, not just a bumped number).

`go build ./...`, `go vet ./internal/install/...`, `gofmt -l internal/install/rulesfiles/` clean; `go test ./internal/install/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)