### PR TITLE
engine: remove dead custom_extractors YAML mechanism (#3636 P1)

### DIFF
--- a/docs/adrs/0021-engine-custom-extractors-rescue-remove-extend.md
+++ b/docs/adrs/0021-engine-custom-extractors-rescue-remove-extend.md
@@ -1,15 +1,13 @@
-# ADR: Engine — rescue / remove / extend the YAML-rules `custom_extractor` mechanism
+# ADR-0021: Engine — rescue / remove / extend the YAML-rules `custom_extractor` mechanism
 
-- **Status:** Proposed
-- **Date:** 2026-06-02
+- **Status:** Accepted
+- **Date:** 2026-06-02 (accepted 2026-06-03)
 - **Deciders:** archigraph maintainers
 - **Related:** ADR-0001 (Go-native single binary), ADR-0018 (agent-learned patterns), issue #3585/#3586 (dead Java pattern-extractor layer cited as coverage)
-- **Scope:** read-only architecture evaluation; this ADR adds documentation only. No code changed.
-
-> Note on location: the repo's existing ADRs live in `docs/adrs/` with numbered
-> prefixes (`0001-…`, `0018-…`). This file was placed at the explicitly-requested
-> path `docs/adr/ENGINE-rescue-vs-remove.md` for review; on acceptance it should be
-> renumbered and moved into `docs/adrs/` to match convention.
+- **Scope:** architecture evaluation. The REMOVE half (#3636 P1) is implemented: the dead
+  `custom_extractors:` YAML blocks and the `CustomExtractor` struct were deleted, a
+  cite-validity guard added, and useful description prose migrated into the corresponding
+  Go extractor doc-comments. EXTEND (P2–P4) is deferred.
 
 ---
 

--- a/internal/custom/golang/gin.go
+++ b/internal/custom/golang/gin.go
@@ -18,6 +18,14 @@ func init() {
 	extractor.Register("custom_go_gin", &ginExtractor{})
 }
 
+// ginExtractor extracts Gin HTTP-framework structure from Go source.
+//
+// It recognises routes (r.GET/POST/PUT/DELETE/PATCH and friends), route groups
+// (r.Group) with full path resolution, middleware chains (r.Use), request
+// binding (c.ShouldBindJSON/BindJSON), engine creation (gin.Default/gin.New),
+// custom validators (RegisterValidation), NoRoute/NoMethod error handlers, and
+// static file serving (r.Static/r.StaticFS). It emits OWNS, DEPENDS_ON, and
+// CALLS relationships among the resulting entities.
 type ginExtractor struct{}
 
 func (e *ginExtractor) Language() string { return "custom_go_gin" }

--- a/internal/engine/loader_test.go
+++ b/internal/engine/loader_test.go
@@ -1,6 +1,10 @@
 package engine
 
 import (
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -96,6 +100,50 @@ func TestLoadAllRules_EmbedFS(t *testing.T) {
 		if len(data) == 0 {
 			t.Errorf("embedded file %q is empty", p)
 		}
+	}
+}
+
+// TestRules_NoCustomExtractors is a cite-validity guard. The `custom_extractors:`
+// YAML mechanism was a dead, never-read pointer to legacy Python module paths
+// (see docs/adr/ENGINE-rescue-vs-remove.md, #3636). It was removed wholesale —
+// the FrameworkRule struct no longer carries the field, and every block was
+// deleted from the rule corpus. The Go extractors those blocks pointed at run
+// via the internal/custom registry, not via this YAML.
+//
+// This test FAILS if any rule YAML reintroduces a `custom_extractors` key or
+// comment, so the dead mechanism cannot silently return.
+func TestRules_NoCustomExtractors(t *testing.T) {
+	var offenders []string
+
+	err := fs.WalkDir(rulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		data, readErr := rulesFS.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if strings.Contains(line, "custom_extractors") {
+				offenders = append(offenders, path+":"+strconv.Itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded rules: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("the dead `custom_extractors` YAML mechanism was reintroduced in %d location(s); "+
+			"remove it and document the corresponding Go extractor instead (see #3636):\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
 	}
 }
 

--- a/internal/engine/rules/clojure/frameworks/alia.yaml
+++ b/internal/engine/rules/clojure/frameworks/alia.yaml
@@ -18,11 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: (alia/cluster ...)
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), (alia/execute ...)
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), (alia/prepare ...)
-      (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/clojure/frameworks/amazonica_dynamodb.yaml
+++ b/internal/engine/rules/clojure/frameworks/amazonica_dynamodb.yaml
@@ -14,12 +14,3 @@ framework:
     Amazonica provides a Clojure wrapper around the AWS Java SDK.
     cognitect-labs/aws-api is the alternative pure-Clojure approach.
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: amazonica/far DynamoDB calls (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/clojure/frameworks/carmine.yaml
+++ b/internal/engine/rules/clojure/frameworks/carmine.yaml
@@ -1,7 +1,6 @@
 # Clojure Carmine Redis extraction rules.
 #
 # Top-level `frameworks:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 frameworks:
   name: Carmine (taoensso/carmine)
@@ -24,12 +23,3 @@ frameworks:
     Carmine is the primary Clojure Redis client. The wcar macro (with-car-connection)
     is the idiomatic way to send commands. Commands are namespaced under the car/ alias.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: wcar/*conn*/car/wcar/taoensso.carmine connections
-      (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), pub/sub
-      (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op), Lua
-      (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/clojure/frameworks/elastisch.yaml
+++ b/internal/engine/rules/clojure/frameworks/elastisch.yaml
@@ -14,10 +14,3 @@ frameworks:
   notes: |
     elastisch (clojurewerkz/elastisch) is the primary Clojure Elasticsearch client.
     Uses (esr/connect "http://...") pattern.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract esr/connect / es/connect connection calls, search queries,
-      aggregations, and ILM patterns for Clojure.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/clojure/orms/mongodb_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/mongodb_clojure.yaml
@@ -14,14 +14,3 @@ orms_database:
       - mc/connect
       - mc/aggregate
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/clojure/orms/mysql_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/mysql_clojure.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/clojure/orms/neo4j.yaml
+++ b/internal/engine/rules/clojure/orms/neo4j.yaml
@@ -24,10 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Neocons
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/clojure/orms/next_jdbc_postgresql.yaml
+++ b/internal/engine/rules/clojure/orms/next_jdbc_postgresql.yaml
@@ -23,12 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: next.jdbc/clojure.java.jdbc
-      datasource connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER),
-      LISTEN/NOTIFY (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY),
-      COPY (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/clojure/orms/sqlite_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/sqlite_clojure.yaml
@@ -25,12 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: next.jdbc/clojure.java.jdbc connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/cpp/frameworks/qt6.yaml
+++ b/internal/engine/rules/cpp/frameworks/qt6.yaml
@@ -54,7 +54,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cpp.qt_extractor"
-    function: "extract"
-    description: "Extract Qt signal/slot graph (connect() old and new syntax), QObject subclass hierarchy, .ui XML widget tree, and Q_PROPERTY metadata. Emits DEPENDS_ON (signal/slot wiring) and OWNS (widget hierarchy) relationships."

--- a/internal/engine/rules/cpp/orms/mysql_cpp.yaml
+++ b/internal/engine/rules/cpp/orms/mysql_cpp.yaml
@@ -21,13 +21,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml
+++ b/internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml
@@ -31,12 +31,3 @@ orm_db:
 
     '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: sqlite3_open/sqlite3_open_v2 calls
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/cpp/orms/sqlitecpp.yaml
+++ b/internal/engine/rules/cpp/orms/sqlitecpp.yaml
@@ -25,12 +25,3 @@ orm_db:
 
     '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: SQLite::Database construction
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/csharp/frameworks/asp_net_core.yaml
+++ b/internal/engine/rules/csharp/frameworks/asp_net_core.yaml
@@ -139,35 +139,3 @@ relationship_rules:
     source_group: 2
     target_group: 1
 
-custom_extractors:
-  - module: archigraph.engine.rules.languages.csharp.aspnet_core_extractor
-    function: extract
-    description: >
-      Extracts ASP.NET Core controller-based attribute routes ([HttpGet]/[HttpPost]/etc.)
-      and Minimal API routes (app.MapGet/MapPost/etc.) as SCOPE.Operation/endpoint,
-      DI registrations (AddScoped/AddTransient/AddSingleton) as SCOPE.Pattern with
-      INFERRED_FROM_ASPNET_DI provenance, middleware pipeline registrations as
-      SCOPE.Pattern with INFERRED_FROM_ASPNET_MIDDLEWARE provenance, SignalR Hub
-      subclasses and MapHub calls as SCOPE.Operation/endpoint, gRPC MapGrpcService
-      mappings as SCOPE.Service, health check endpoints as SCOPE.Operation/endpoint,
-      background services (IHostedService/BackgroundService) as SCOPE.Service, and
-      Entity Framework DbContext/DbSet entities as SCOPE.Schema.
-  - module: archigraph.engine.rules.languages.csharp.aspnet_request_response_extractor
-    function: extract
-    description: >
-      Extract ACCEPTS_INPUT and RETURNS relationships from ASP.NET Core controller
-      action methods. Detects [FromBody] parameter annotations and method return
-      types (including ActionResult<T> and Task<ActionResult<T>> async unwrapping).
-      Emits DTO and response entities as SCOPE.Schema(kind=dto/response).
-  - module: archigraph.engine.rules.languages._engine.config_prefix_extractor
-    function: extract
-    description: >
-      Extract PathBase / applicationUrl from launchSettings.json and Program.cs
-      as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated
-      on well-known config file basenames.
-  - module: archigraph.engine.rules.languages._engine.config_consumer_extractor
-    function: extract
-    description: >
-      Extract Configuration["Key"] and Configuration.GetValue<T>("Key") reads
-      as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read)
-      edges from consuming entities.

--- a/internal/engine/rules/csharp/frameworks/blazor_server.yaml
+++ b/internal/engine/rules/csharp/frameworks/blazor_server.yaml
@@ -29,12 +29,3 @@ frameworks:
       distinguishes Blazor Server from Blazor WebAssembly.
 
       '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.csharp.blazor_extractor
-    function: extract
-    description: >
-      Extracts Blazor @page route directives as SCOPE.Operation/endpoint,
-      @inject DI declarations as SCOPE.Component with DEPENDS_ON relationships,
-      @code block methods as SCOPE.Operation/function, PascalCase component tags
-      as SCOPE.UIComponent/component with OWNS relationships, [Parameter] and
-      [CascadingParameter] properties, and @layout/@inherits directives.

--- a/internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml
+++ b/internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml
@@ -25,12 +25,3 @@ frameworks:
       Client/Server/Shared subproject structure.
 
       '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.csharp.blazor_extractor
-    function: extract
-    description: >
-      Extracts Blazor @page route directives as SCOPE.Operation/endpoint,
-      @inject DI declarations as SCOPE.Component with DEPENDS_ON relationships,
-      @code block methods as SCOPE.Operation/function, PascalCase component tags
-      as SCOPE.UIComponent/component with OWNS relationships, [Parameter] and
-      [CascadingParameter] properties, and @layout/@inherits directives.

--- a/internal/engine/rules/csharp/frameworks/entity_framework_core.yaml
+++ b/internal/engine/rules/csharp/frameworks/entity_framework_core.yaml
@@ -33,20 +33,4 @@ frameworks:
 
       '
 
-custom_extractors:
-  - module: archigraph.engine.rules.languages.csharp.ef_core_extractor
-    function: extract
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract
-    description: >
-      Extracts EF Core DbContext subclasses as SCOPE.Service (INFERRED_FROM_EF_CONTEXT),
-      DbSet<T> properties as SCOPE.Schema (INFERRED_FROM_EF_ENTITY) with OWNS edges from
-      context, HasOne/HasMany/WithOne/WithMany Fluent API calls as SCOPE.Schema
-      (INFERRED_FROM_EF_RELATIONSHIP) with DEPENDS_ON to target entity, LINQ
-      .Where()/.Select()/.Include()/.ThenInclude() chains as SCOPE.Operation/query
-      (INFERRED_FROM_EF_QUERY), Migration Up()/Down() methods as SCOPE.Schema
-      (INFERRED_FROM_EF_MIGRATION) with OWNS from migration class, modelBuilder.Entity<T>()
-      configuration blocks with .HasIndex()/.HasKey() metadata, and database provider
-      registrations (UseSqlServer/UseNpgsql/UseSqlite/etc.) as SCOPE.Service/provider
-      (INFERRED_FROM_EF_PROVIDER).
 

--- a/internal/engine/rules/csharp/orms/cassandra_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/cassandra_csharp.yaml
@@ -18,11 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Cluster.Builder()
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), .Execute()
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/csharp/orms/dynamodb_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/dynamodb_csharp.yaml
@@ -19,15 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: AmazonDynamoDBClient/DynamoDBContext
-      connections (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), table
-      definitions (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), GSI/LSI indexes
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_INDEX), query/scan operations
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/csharp/orms/mongodb_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/mongodb_csharp.yaml
@@ -16,14 +16,3 @@ orms_database:
       - BsonDocument
       - FilterDefinition<
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/csharp/orms/mysql_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/mysql_csharp.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/csharp/orms/neo4j.yaml
+++ b/internal/engine/rules/csharp/orms/neo4j.yaml
@@ -24,10 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER) with node labels and relationship types.

--- a/internal/engine/rules/csharp/orms/nest_elasticsearch.yaml
+++ b/internal/engine/rules/csharp/orms/nest_elasticsearch.yaml
@@ -15,10 +15,3 @@ orms_database:
   notes: |
     NEST is the high-level .NET Elasticsearch client. Elasticsearch.Net is the
     low-level client. Both are detected by the extractor.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract ElasticClient / ElasticsearchClient connections, search queries,
-      aggregations, ILM policies, and index creation for C#.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/csharp/orms/npgsql.yaml
+++ b/internal/engine/rules/csharp/orms/npgsql.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: NpgsqlConnection/NpgsqlDataSource
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY),
-      BeginBinaryImport/Export COPY operations
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/csharp/orms/redis_stackexchange.yaml
+++ b/internal/engine/rules/csharp/orms/redis_stackexchange.yaml
@@ -1,7 +1,6 @@
 # C# StackExchange.Redis extraction rules.
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms:
   name: StackExchange.Redis
@@ -24,13 +23,3 @@ orms:
     StackExchange.Redis is the de-facto .NET Redis client, used widely in ASP.NET
     Core applications. The IDatabase interface is the primary operations interface.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: ConnectionMultiplexer.Connect/ConnectAsync/
-      IDatabase/IConnectionMultiplexer connections (SCOPE.Service), cache ops
-      .get/.set/.hget/.hset/.expire (SCOPE.Operation/cache_op), pub/sub
-      .publish/.subscribe (SCOPE.Operation/pubsub), streams
-      (SCOPE.Operation/stream_op), Lua .eval/.evalsha (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/csharp/orms/sqlite_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/sqlite_csharp.yaml
@@ -23,12 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: Microsoft.Data.Sqlite connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/dart/frameworks/dynamodb_dart.yaml
+++ b/internal/engine/rules/dart/frameworks/dynamodb_dart.yaml
@@ -11,12 +11,3 @@ framework:
   notes: >
     aws_dynamodb_api on pub.dev is the Dart/Flutter client for DynamoDB.
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: DynamoDB() connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/dart/frameworks/elastic_client_dart.yaml
+++ b/internal/engine/rules/dart/frameworks/elastic_client_dart.yaml
@@ -11,10 +11,3 @@ frameworks:
     - client.search(
   notes: |
     elastic_client is the primary Dart Elasticsearch client (pub.dev).
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract ElasticClient connections, search queries, aggregations,
-      and ILM patterns for Dart.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/dart/frameworks/flutter_desktop.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_desktop.yaml
@@ -24,7 +24,3 @@ frameworks:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/flutter_desktop_macos_windows_linux.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_desktop_macos_windows_linux.yaml
@@ -35,7 +35,3 @@ mobile:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/flutter_mobile_cross_platform.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_mobile_cross_platform.yaml
@@ -28,7 +28,3 @@ frameworks:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/flutter_mobile_ios_android.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_mobile_ios_android.yaml
@@ -43,7 +43,3 @@ mobile:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/flutter_web.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_web.yaml
@@ -24,7 +24,3 @@ frameworks:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/flutter_web_web_target.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_web_web_target.yaml
@@ -26,7 +26,3 @@ mobile:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dart.flutter_extractor"
-    function: "extract"
-    description: "Extract Flutter widgets, BLoC/Cubit/ChangeNotifier state management, Navigator routes, and GoRouter routes"

--- a/internal/engine/rules/dart/frameworks/redis_dart.yaml
+++ b/internal/engine/rules/dart/frameworks/redis_dart.yaml
@@ -1,7 +1,6 @@
 # Dart Redis client extraction rules.
 #
 # Top-level `frameworks:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 frameworks:
   name: redis_dart / resp_client
@@ -23,12 +22,3 @@ frameworks:
     redis_dart and resp_client are the primary Dart Redis packages. Both provide
     similar APIs. RedisConnection() is the primary connection signal.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: RedisConnection/RedisClient connections
-      (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), pub/sub
-      (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op), Lua
-      (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/dart/orms/drift_formerly_moor.yaml
+++ b/internal/engine/rules/dart/orms/drift_formerly_moor.yaml
@@ -28,11 +28,3 @@ orm_database:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: drift LazyDatabase/NativeDatabase connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS).

--- a/internal/engine/rules/dart/orms/mongo_dart.yaml
+++ b/internal/engine/rules/dart/orms/mongo_dart.yaml
@@ -13,14 +13,3 @@ orms_database:
       - db.collection(
       - collection.aggregateToStream(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/dart/orms/mysql_dart.yaml
+++ b/internal/engine/rules/dart/orms/mysql_dart.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/dart/orms/neo4j.yaml
+++ b/internal/engine/rules/dart/orms/neo4j.yaml
@@ -22,10 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Neo4Dart
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/dart/orms/postgres_dart.yaml
+++ b/internal/engine/rules/dart/orms/postgres_dart.yaml
@@ -19,12 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: PostgreSQLConnection/Connection
-      instantiation (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER),
-      LISTEN/NOTIFY (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY),
-      COPY (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/dart/orms/sqflite.yaml
+++ b/internal/engine/rules/dart/orms/sqflite.yaml
@@ -23,12 +23,3 @@ orm_database:
 
       '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: sqflite/drift openDatabase connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml
+++ b/internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml
@@ -18,12 +18,3 @@ frameworks:
     Elixir apps that do not need PostgreSQL. exqlite provides the raw SQLite3
     NIF bindings. Configured via config :myapp, MyApp.Repo, adapter: Ecto.Adapters.SQLite3.
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: Ecto.Adapters.SQLite3/exqlite connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/elixir/frameworks/ecto_standalone.yaml
+++ b/internal/engine/rules/elixir/frameworks/ecto_standalone.yaml
@@ -40,18 +40,3 @@ frameworks:
     it is the primary DB layer.
 
     '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.elixir.ecto_extractor
-    function: extract
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract
-    description: >
-      Extracts Ecto schema "table_name" declarations, has_one/has_many/belongs_to/many_to_many
-      associations, changeset/2 function definitions (cast/validate_required), Repo.get/all/
-      insert/update/delete calls, from q in Schema Ecto.Query expressions, Ecto.Multi.new()
-      transaction chains with step operations, use Ecto.Repo module declarations, and
-      Migration create table/alter table/create index blocks.
-      Emits SCOPE.Schema, SCOPE.Operation/function, SCOPE.Operation/query,
-      SCOPE.Pattern, SCOPE.Service.
-      Relationships: DEPENDS_ON (ecto_association), OWNS (schema->changesets, repo->queries,
-      multi->steps).

--- a/internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml
+++ b/internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml
@@ -17,10 +17,3 @@ frameworks:
   notes: |
     Two major Elixir Elasticsearch libraries: elasticsearch-elixir (danielberkompas)
     and tirexs (way2ex). Both provide connection and query primitives.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract Elasticsearch.start_link / Tirexs connections, search calls,
-      aggregations, and ILM patterns for Elixir.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml
+++ b/internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml
@@ -14,13 +14,3 @@ framework:
     ExAws.Dynamo (ex_aws_dynamo) is the standard Elixir DynamoDB client,
     part of the ExAws ecosystem.
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: ExAws.Dynamo connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml
+++ b/internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml
@@ -14,14 +14,3 @@ frameworks:
       - Mongo.insert_one(
       - Mongo.aggregate(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/elixir/frameworks/myxql.yaml
+++ b/internal/engine/rules/elixir/frameworks/myxql.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/elixir/frameworks/phoenix.yaml
+++ b/internal/engine/rules/elixir/frameworks/phoenix.yaml
@@ -46,16 +46,3 @@ frameworks:
     Phoenix apps.
 
     '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.elixir.phoenix_extractor
-    function: extract
-    description: >
-      Extracts Phoenix router HTTP routes (get/post/put/patch/delete/options),
-      resources CRUD expansion (8 routes), live routes, pipeline declarations,
-      LiveView/LiveComponent module declarations with mount/handle_event/handle_info
-      callbacks, Phoenix Controller action functions, and HEEx template component
-      calls (<.component> and <Module.function>).
-      Emits SCOPE.Operation/endpoint, SCOPE.Pattern, SCOPE.UIComponent/component,
-      SCOPE.Operation/function.
-      Relationships: CALLS (routes_to), OWNS (module->callbacks/actions),
-      DEPENDS_ON (scope->pipeline, template->component).

--- a/internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml
+++ b/internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml
@@ -34,14 +34,3 @@ frameworks:
     marker. LiveComponent modules use use Phoenix.LiveComponent.
 
     '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.elixir.phoenix_extractor
-    function: extract
-    description: >
-      Extracts Phoenix LiveView/LiveComponent module declarations with
-      mount/handle_event/handle_info callbacks, Phoenix router live routes,
-      and HEEx template component calls (<.component> and <Module.function>).
-      Emits SCOPE.UIComponent/component, SCOPE.Operation/function,
-      SCOPE.Operation/endpoint.
-      Relationships: OWNS (module->callbacks), CALLS (routes_to),
-      DEPENDS_ON (template->component).

--- a/internal/engine/rules/elixir/frameworks/postgrex.yaml
+++ b/internal/engine/rules/elixir/frameworks/postgrex.yaml
@@ -19,12 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: Postgrex.start_link/Repo.start_link
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/elixir/frameworks/redix.yaml
+++ b/internal/engine/rules/elixir/frameworks/redix.yaml
@@ -1,7 +1,6 @@
 # Elixir Redix extraction rules.
 #
 # Top-level `frameworks:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 frameworks:
   name: Redix
@@ -24,11 +23,3 @@ frameworks:
     Redix is the most popular Elixir Redis client. It uses GenServer processes as
     connection holders. Redix.start_link is the primary connection signal.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: Redix.start_link connections (SCOPE.Service),
-      cache ops (SCOPE.Operation/cache_op), pub/sub (SCOPE.Operation/pubsub),
-      streams (SCOPE.Operation/stream_op), Lua eval (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/elixir/frameworks/xandra.yaml
+++ b/internal/engine/rules/elixir/frameworks/xandra.yaml
@@ -18,11 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Xandra.start_link
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), Xandra.execute
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/elixir/orms/neo4j.yaml
+++ b/internal/engine/rules/elixir/orms/neo4j.yaml
@@ -24,10 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Bolt.Sips
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/go/frameworks/echo.yaml
+++ b/internal/engine/rules/go/frameworks/echo.yaml
@@ -52,10 +52,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.go.echo_extractor"
-    function: "extract"
-    description: "Extract Echo routes (e.GET/POST/PUT/DELETE/PATCH/etc.), route groups (e.Group) with full path resolution, middleware chains (e.Use), request binding (c.Bind/BindJSON/BindQuery), engine creation (echo.New), WebSocket endpoints (echo.IsWebSocket / upgrader.Upgrade), custom validators (e.Validator assignment and echo.Validator interface implementations), and static file serving (e.Static/e.File). Emits OWNS and CALLS relationships."
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract viper.Get/GetString/GetBool/GetInt etc. reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities."

--- a/internal/engine/rules/go/frameworks/fiber.yaml
+++ b/internal/engine/rules/go/frameworks/fiber.yaml
@@ -52,25 +52,5 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
 # These run after YAML-driven extraction and contribute additional entities +
 # relationships to the pipeline result.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.go.fiber_extractor
-    function: extract
-    description: >-
-      Fiber-specific extractor: HTTP route registrations (app.Get/Post/Put/Delete/Patch,
-      Title-case methods) → SCOPE.Operation/endpoint (INFERRED_FROM_FIBER_ROUTE);
-      app.Group("/prefix") with nested group path resolution → SCOPE.Component
-      (INFERRED_FROM_FIBER_GROUP) + OWNS edges to child routes; app.Use(middleware)
-      pipeline registrations → SCOPE.Pattern (INFERRED_FROM_FIBER_MIDDLEWARE) + CALLS
-      edges from engine/group; c.BodyParser/c.QueryParser/c.ParamsParser/c.ReqHeaderParser
-      binding sites → SCOPE.Schema (INFERRED_FROM_FIBER_BINDING); fiber.New() engine
-      instantiation → SCOPE.Service (INFERRED_FROM_FIBER_ENGINE); app.Static() mounts
-      → SCOPE.Pattern metadata (INFERRED_FROM_FIBER_STATIC); WebSocket upgrades via
-      websocket.New() → SCOPE.Operation/endpoint (INFERRED_FROM_FIBER_WEBSOCKET).
-  - module: archigraph.engine.rules.languages._engine.config_consumer_extractor
-    function: extract
-    description: >-
-      Extract viper.Get/GetString/GetBool/GetInt etc. reads as SCOPE.Pattern/config_key
-      entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities.

--- a/internal/engine/rules/go/frameworks/gin.yaml
+++ b/internal/engine/rules/go/frameworks/gin.yaml
@@ -52,10 +52,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.go.gin_extractor"
-    function: "extract"
-    description: "Extract Gin routes (r.GET/POST/PUT/DELETE/PATCH), route groups (r.Group) with full path resolution, middleware chains (r.Use), request binding (c.ShouldBindJSON/BindJSON), engine creation (gin.Default/gin.New), custom validators (RegisterValidation), NoRoute/NoMethod error handlers, and static file serving (r.Static/r.StaticFS). Emits OWNS, DEPENDS_ON, CALLS relationships."
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract viper.Get/GetString/GetBool/GetInt etc. reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities."

--- a/internal/engine/rules/go/frameworks/gorm.yaml
+++ b/internal/engine/rules/go/frameworks/gorm.yaml
@@ -37,7 +37,3 @@ source_patterns:
 
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.go.gorm_extractor"
-    function: "extract"
-    description: "Extract GORM models (gorm.Model embedded structs and gorm-tagged structs -> SCOPE.Schema), associations (HasOne/HasMany/BelongsTo/Many2Many struct tags and slice/pointer fields -> DEPENDS_ON), lifecycle hooks (BeforeCreate/AfterCreate/etc. -> SCOPE.Operation/function), scope functions (func(db *gorm.DB) *gorm.DB -> SCOPE.Operation/function), migrations (AutoMigrate/Migrator -> SCOPE.Pattern), DB operations (db.Create/Find/First/Where/Preload/etc. -> SCOPE.Operation/function), custom table names (TableName() method -> schema metadata), and DB connections (gorm.Open() -> SCOPE.Service)."

--- a/internal/engine/rules/go/orms/cassandra_go.yaml
+++ b/internal/engine/rules/go/orms/cassandra_go.yaml
@@ -16,11 +16,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: gocql.NewCluster
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), .Query()/.Execute()
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), .Prepare()
-      (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/go/orms/dynamodb_go.yaml
+++ b/internal/engine/rules/go/orms/dynamodb_go.yaml
@@ -18,14 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: dynamodb.NewFromConfig connections
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), TableName struct fields
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), .query()/.scan() operations
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX via
-      dax.New (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/go/orms/elasticsearch_go.yaml
+++ b/internal/engine/rules/go/orms/elasticsearch_go.yaml
@@ -16,10 +16,3 @@ orms_database:
   notes: |
     Two major Go Elasticsearch clients: official go-elasticsearch and olivere/elastic.
     Both are handled by the extractor.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract client connections (NewDefaultClient/NewClient), Search() calls,
-      aggregations (NewTermsAggregation etc.), ILM policies, and index creation.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/go/orms/go_redis.yaml
+++ b/internal/engine/rules/go/orms/go_redis.yaml
@@ -19,13 +19,3 @@ database_libraries:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: client connections (SCOPE.Service), cache
-      operations get/set/hget/hset/expire (SCOPE.Operation/cache_op), pub/sub
-      publish/subscribe (SCOPE.Operation/pubsub), streams XADD/XREAD/XREADGROUP/XACK
-      (SCOPE.Operation/stream_op), Lua eval/evalsha (SCOPE.Operation/lua_script),
-      rate-limiting limiter.Allow/gcra (SCOPE.Pattern/rate_limit).

--- a/internal/engine/rules/go/orms/golang_migrate.yaml
+++ b/internal/engine/rules/go/orms/golang_migrate.yaml
@@ -22,6 +22,3 @@ orms_database:
     SQL syntax required.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/go/orms/mongo_driver.yaml
+++ b/internal/engine/rules/go/orms/mongo_driver.yaml
@@ -23,14 +23,3 @@ database_libraries:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/go/orms/mysql_go.yaml
+++ b/internal/engine/rules/go/orms/mysql_go.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/go/orms/neo4j.yaml
+++ b/internal/engine/rules/go/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER) with node labels and relationship types.

--- a/internal/engine/rules/go/orms/pgx.yaml
+++ b/internal/engine/rules/go/orms/pgx.yaml
@@ -25,13 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: pgx.Connect/pgxpool.New connections
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), pgxpool setup
-      (SCOPE.Pattern, INFERRED_FROM_POSTGRES_POOL), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), CopyFrom/CopyTo
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/go/orms/sqlite_go.yaml
+++ b/internal/engine/rules/go/orms/sqlite_go.yaml
@@ -26,12 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: go-sqlite3/modernc connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/haskell/orms/cassandra_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/cassandra_haskell.yaml
@@ -16,10 +16,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: runCas / CAS.connect
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), runCas execute
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL).

--- a/internal/engine/rules/haskell/orms/dynamodb_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/dynamodb_haskell.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: runDynamoDB/newEnv connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/haskell/orms/mysql_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/mysql_haskell.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/haskell/orms/neo4j.yaml
+++ b/internal/engine/rules/haskell/orms/neo4j.yaml
@@ -26,10 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via hasbolt
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/haskell/orms/postgresql_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/postgresql_haskell.yaml
@@ -24,12 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: connect/connectPostgreSQL/acquire
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER),
-      LISTEN/NOTIFY (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY),
-      COPY (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/haskell/orms/sqlite_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/sqlite_haskell.yaml
@@ -25,12 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: direct-sqlite/persistent-sqlite connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/java/frameworks/android_jetpack_compose.yaml
+++ b/internal/engine/rules/java/frameworks/android_jetpack_compose.yaml
@@ -29,7 +29,3 @@ frameworks:
     projects.
 
     '
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.android_extractor"
-    function: "extract"
-    description: "Extract Android Manifest components (activity/service/receiver/provider), Intent-based navigation, Fragment transactions, and ViewModel/LiveData dependencies. Emits DEPENDS_ON and OWNS relationships."

--- a/internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml
+++ b/internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml
@@ -41,7 +41,3 @@ frameworks:
     Jetpack project.
 
     '
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.android_extractor"
-    function: "extract"
-    description: "Extract Android Manifest components (activity/service/receiver/provider), Intent-based navigation, Fragment transactions, and ViewModel/LiveData dependencies. Emits DEPENDS_ON and OWNS relationships."

--- a/internal/engine/rules/java/frameworks/android_sdk.yaml
+++ b/internal/engine/rules/java/frameworks/android_sdk.yaml
@@ -38,7 +38,3 @@ frameworks:
     local.properties with sdk.dir distinguishes Android from server-side Java.
 
     '
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.android_extractor"
-    function: "extract"
-    description: "Extract Android Manifest components (activity/service/receiver/provider), Intent-based navigation, Fragment transactions, and ViewModel/LiveData dependencies. Emits DEPENDS_ON and OWNS relationships."

--- a/internal/engine/rules/java/frameworks/hibernate.yaml
+++ b/internal/engine/rules/java/frameworks/hibernate.yaml
@@ -38,18 +38,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.hibernate_extractor"
-    function: "extract"
-    description: >
-      Extract Hibernate/JPA deep patterns: @Entity classes (SCOPE.Schema),
-      @OneToMany/@ManyToOne/@OneToOne/@ManyToMany associations (DEPENDS_ON),
-      @NamedQuery HQL strings (SCOPE.Operation/function, INFERRED_FROM_HIBERNATE_HQL),
-      CriteriaBuilder/CriteriaQuery usage (SCOPE.Operation/function,
-      INFERRED_FROM_HIBERNATE_CRITERIA), @EntityListeners (SCOPE.Pattern,
-      INFERRED_FROM_HIBERNATE_LISTENER), @Cacheable/@Cache L2 caching metadata,
-      @NamedEntityGraph (SCOPE.Pattern, INFERRED_FROM_HIBERNATE_ENTITY_GRAPH),
-      @Converter / AttributeConverter (SCOPE.Component,
-      INFERRED_FROM_HIBERNATE_CONVERTER), EntityManagerFactory / EntityManager
-      (SCOPE.Service, INFERRED_FROM_HIBERNATE_EM). Emits OWNS and DEPENDS_ON
-      relationships.

--- a/internal/engine/rules/java/frameworks/jakarta_ee.yaml
+++ b/internal/engine/rules/java/frameworks/jakarta_ee.yaml
@@ -41,10 +41,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.jakarta_ee_extractor"
-    function: "extract"
-    description: "Extract Jakarta EE Servlets (@WebServlet, @WebFilter), JPA entities (@Entity, @ManyToOne etc.), EJB beans (@Stateless, @Stateful, @Singleton, @MessageDriven), WebSocket endpoints (@ServerEndpoint), Bean Validation (ConstraintValidator), Interceptors (@Interceptor, @AroundInvoke), and resource injection (@Resource, @PersistenceContext). Emits DEPENDS_ON, OWNS relationships."
-  - module: "archigraph.engine.rules.languages.java.jakarta_ee_advanced_extractor"
-    function: "extract"
-    description: "Extract Jakarta EE advanced APIs: CDI producers/observers/decorators, Security auth mechanisms and identity stores, Batch batchlets and chunk steps, Concurrency managed executors, Lifecycle PostConstruct/PreDestroy, JAX-WS SOAP services, JAXB XML models, JSON-B serializers, JSP custom tags. Emits DEPENDS_ON and OWNS relationships."

--- a/internal/engine/rules/java/frameworks/junit5.yaml
+++ b/internal/engine/rules/java/frameworks/junit5.yaml
@@ -36,16 +36,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.junit5_extractor"
-    function: "extract"
-    description: >
-      Extract JUnit 5 (Jupiter) patterns: @Test/@ParameterizedTest/@RepeatedTest
-      methods (SCOPE.Operation/function, INFERRED_FROM_JUNIT5_TEST) with assertion
-      metadata, parameterized source type, repeat count, @DisplayName, @Disabled,
-      @Tag; @Nested classes (SCOPE.Component, INFERRED_FROM_JUNIT5_NESTED);
-      @BeforeAll/@BeforeEach/@AfterAll/@AfterEach lifecycle methods
-      (SCOPE.Operation/function, INFERRED_FROM_JUNIT5_LIFECYCLE);
-      @ExtendWith extension classes (SCOPE.Pattern, INFERRED_FROM_JUNIT5_EXTENSION).
-      Emits OWNS (class→test, class→lifecycle) and DEPENDS_ON
-      (kind=junit5_extension) relationships.

--- a/internal/engine/rules/java/frameworks/langchain4j.yaml
+++ b/internal/engine/rules/java/frameworks/langchain4j.yaml
@@ -38,7 +38,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.langchain4j_extractor"
-    function: "extract"
-    description: "Extract LangChain4J AI service interfaces (@AiService), tool methods (@Tool), prompt patterns (@SystemMessage/@UserMessage), ChatLanguageModel fields, RAG components (EmbeddingStore/ContentRetriever), ChatMemory, and DI wiring. Emits OWNS and DEPENDS_ON relationships."

--- a/internal/engine/rules/java/frameworks/micronaut.yaml
+++ b/internal/engine/rules/java/frameworks/micronaut.yaml
@@ -128,10 +128,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.micronaut_extractor"
-    function: "extract"
-    description: "Extract Micronaut @Controller endpoints (class+method path resolution), @Singleton/@Prototype beans, @Scheduled tasks, @Retryable/@CircuitBreaker AOP patterns, @Client HTTP client interfaces, and @Replaces bean overrides. Emits DEPENDS_ON relationships for DI injection and client/override references."
-  - module: "archigraph.engine.rules.languages._engine.config_prefix_extractor"
-    function: "extract"
-    description: "Extract micronaut.server.context-path (YAML) as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."

--- a/internal/engine/rules/java/frameworks/microprofile.yaml
+++ b/internal/engine/rules/java/frameworks/microprofile.yaml
@@ -10,7 +10,6 @@
 # quarkus, micronaut, open_liberty, payara, helidon.
 # Detection happens via the host framework's detection rules — MicroProfile
 # does not have its own standalone detection.  The YAML below provides the
-# custom_extractors entry consumed by the CustomExtractorRegistry.
 
 frameworks:
   name: Eclipse MicroProfile
@@ -58,10 +57,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.microprofile_extractor"
-    function: "extract"
-    description: "Extract MicroProfile fault tolerance (@Retry, @CircuitBreaker, @Fallback), health checks (@Liveness, @Readiness), REST clients (@RegisterRestClient, @RestClient @Inject), config (@ConfigProperty), metrics (@Counted, @Timed, @Gauge), reactive messaging (@Incoming, @Outgoing), and JWT auth (@RolesAllowed). Emits DEPENDS_ON relationships for fallback methods, REST client injection, and reactive messaging channel linking."
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract @ConfigProperty(name='key') annotations as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges. Enables blast-radius analysis for MicroProfile config changes."

--- a/internal/engine/rules/java/frameworks/quarkus.yaml
+++ b/internal/engine/rules/java/frameworks/quarkus.yaml
@@ -138,10 +138,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.quarkus_extractor"
-    function: "extract"
-    description: "Extract Quarkus JAX-RS endpoints (class+method @Path resolution), Panache ORM/MongoDB entities and repositories, CDI @Inject dependency graph, REST Data Panache auto CRUD, and @MongoEntity metadata. Emits DEPENDS_ON relationships."
-  - module: "archigraph.engine.rules.languages._engine.config_prefix_extractor"
-    function: "extract"
-    description: "Extract quarkus.http.root-path (properties) and quarkus.http.root-path (YAML) as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."

--- a/internal/engine/rules/java/frameworks/spring_boot.yaml
+++ b/internal/engine/rules/java/frameworks/spring_boot.yaml
@@ -38,19 +38,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.spring_boot_extractor"
-    function: "extract"
-    description: "Extract Spring Boot DI graph (@Autowired, constructor injection), request mappings (@RequestMapping, @GetMapping etc.), and @Configuration beans. Emits DEPENDS_ON and OWNS relationships."
-  - module: "archigraph.engine.rules.languages.java.spring_ecosystem_extractor"
-    function: "extract"
-    description: "Extract Spring Ecosystem advanced patterns: Security (FilterChain, @PreAuthorize, @Secured), Batch (Job/Step/Reader/Writer chains), AMQP (@RabbitListener, queue beans), AI (ChatClient, @Description tools, VectorStore), Vault (@VaultPropertySource), Data (Mongo/Redis repos, @Document, @Query), Cloud (@FeignClient, @CircuitBreaker, @StreamListener), Integration (@ServiceActivator, IntegrationFlow), WebFlux (RouterFunction, HandlerFunction, WebClient), Kafka (@KafkaListener, @KafkaHandler)."
-  - module: "archigraph.engine.rules.languages.java.spring_request_response_extractor"
-    function: "extract"
-    description: "Extract ACCEPTS_INPUT and RETURNS relationships from Spring controller methods. Detects @RequestBody parameter annotations and method return types (including ResponseEntity<T> unwrapping). Emits DTO entities as SCOPE.Schema(kind=dto)."
-  - module: "archigraph.engine.rules.languages._engine.config_prefix_extractor"
-    function: "extract"
-    description: "Extract server.servlet.context-path (properties) and server.servlet.context-path / spring.application.name (YAML) as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract @Value(\"${key}\") annotations as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming classes/methods to config key entities. Enables blast-radius analysis for Spring config changes."

--- a/internal/engine/rules/java/frameworks/spring_mvc.yaml
+++ b/internal/engine/rules/java/frameworks/spring_mvc.yaml
@@ -108,10 +108,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.spring_ecosystem_extractor"
-    function: "extract"
-    description: "Extract Spring Ecosystem advanced patterns: Security, Batch, AMQP, AI, Vault, Data, Cloud, Integration, WebFlux, Kafka."
-  - module: "archigraph.engine.rules.languages.java.spring_request_response_extractor"
-    function: "extract"
-    description: "Extract ACCEPTS_INPUT and RETURNS relationships from Spring controller methods. Detects @RequestBody parameter annotations and method return types (including ResponseEntity<T> unwrapping). Emits DTO entities as SCOPE.Schema(kind=dto)."

--- a/internal/engine/rules/java/frameworks/spring_webflux.yaml
+++ b/internal/engine/rules/java/frameworks/spring_webflux.yaml
@@ -27,10 +27,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.java.spring_ecosystem_extractor"
-    function: "extract"
-    description: "Extract Spring Ecosystem advanced patterns: Security, Batch, AMQP, AI, Vault, Data, Cloud, Integration, WebFlux, Kafka."
-  - module: "archigraph.engine.rules.languages.java.spring_request_response_extractor"
-    function: "extract"
-    description: "Extract ACCEPTS_INPUT and RETURNS relationships from Spring controller methods. Detects @RequestBody parameter annotations and method return types (including ResponseEntity<T> unwrapping). Emits DTO entities as SCOPE.Schema(kind=dto)."

--- a/internal/engine/rules/java/orms/dynamodb_java.yaml
+++ b/internal/engine/rules/java/orms/dynamodb_java.yaml
@@ -28,16 +28,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: client connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions @DynamoDBTable
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), GSI/LSI indexes
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_INDEX), query/scan operations
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE), Enhanced Client
-      @DynamoDbBean (SCOPE.Schema, INFERRED_FROM_DYNAMODB_ENHANCED).

--- a/internal/engine/rules/java/orms/mysql_java.yaml
+++ b/internal/engine/rules/java/orms/mysql_java.yaml
@@ -26,13 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/java/orms/neo4j.yaml
+++ b/internal/engine/rules/java/orms/neo4j.yaml
@@ -38,14 +38,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER) with node labels and relationship types,
-      Spring Data Neo4j @Node/@Relationship (SCOPE.Schema,
-      INFERRED_FROM_NEO4J_SDN), Neo4j OGM @NodeEntity/@RelationshipEntity
-      (SCOPE.Schema, INFERRED_FROM_NEO4J_OGM). Emits DEPENDS_ON relationships
-      for SDN and OGM mappings.

--- a/internal/engine/rules/java/orms/postgresql_java.yaml
+++ b/internal/engine/rules/java/orms/postgresql_java.yaml
@@ -26,13 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: JDBC/HikariCP/PGSimpleDataSource
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), HikariCP
-      pool setup (SCOPE.Pattern, INFERRED_FROM_POSTGRES_POOL), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/java/orms/spring_data_cassandra.yaml
+++ b/internal/engine/rules/java/orms/spring_data_cassandra.yaml
@@ -29,15 +29,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), CQL execution
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), table definitions
-      (SCOPE.Schema/table, INFERRED_FROM_CASSANDRA_TABLE), materialized
-      views (SCOPE.Schema/view, INFERRED_FROM_CASSANDRA_VIEW), UDTs
-      (SCOPE.Schema/udt, INFERRED_FROM_CASSANDRA_UDT), Spring Data repos/
-      templates (SCOPE.Schema, INFERRED_FROM_CASSANDRA_SPRING), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/java/orms/spring_data_elasticsearch.yaml
+++ b/internal/engine/rules/java/orms/spring_data_elasticsearch.yaml
@@ -16,11 +16,3 @@ orms_database:
   notes: |
     Spring Data Elasticsearch provides @Document for index mapping and
     ElasticsearchRepository for CRUD + search operations.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract index mappings (@Document), ElasticsearchRepository interfaces,
-      search queries (QueryBuilders), aggregations (AggregationBuilders), ILM policies,
-      and client connections (RestHighLevelClient / ElasticsearchClient).
-      Emits SCOPE.Schema, SCOPE.Service, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/java/orms/spring_data_mongodb.yaml
+++ b/internal/engine/rules/java/orms/spring_data_mongodb.yaml
@@ -20,14 +20,3 @@ orms_database:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/java/orms/spring_data_redis.yaml
+++ b/internal/engine/rules/java/orms/spring_data_redis.yaml
@@ -18,12 +18,3 @@ orms_database:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: JedisPool/LettuceConnectionFactory/RedisClient.create
-      connections (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), Spring Data
-      Redis patterns @Cacheable/@CachePut/@CacheEvict/RedisTemplate/ReactiveRedisTemplate/
-      @RedisHash (SCOPE.Pattern/INFERRED_FROM_REDIS_SPRING).

--- a/internal/engine/rules/java/orms/sqlite_java.yaml
+++ b/internal/engine/rules/java/orms/sqlite_java.yaml
@@ -21,12 +21,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: sqlite-jdbc JDBC connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/javascript_typescript/frameworks/angular.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/angular.yaml
@@ -32,7 +32,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.angular_extractor"
-    function: "extract"
-    description: "Extract Angular NgModule DI graph, components, directives, services, pipes, and router routes"

--- a/internal/engine/rules/javascript_typescript/frameworks/express.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/express.yaml
@@ -117,13 +117,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.express_extractor"
-    function: "extract"
-    description: "Extract Express.js route handlers, Router composition, middleware chains, error handling, static, config, Passport strategies, Socket.io, and param middleware"
-  - module: "archigraph.engine.rules.languages._engine.config_prefix_extractor"
-    function: "extract"
-    description: "Extract app.use() mount path prefix from app.js as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract process.env.KEY and process.env['KEY'] reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities."

--- a/internal/engine/rules/javascript_typescript/frameworks/fastify.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/fastify.yaml
@@ -51,7 +51,3 @@ source_patterns:
 
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.fastify_extractor"
-    function: "extract"
-    description: "Extract Fastify route handlers with schema validation, plugin registration, decorators, lifecycle hooks, prefix routing, and reply patterns"

--- a/internal/engine/rules/javascript_typescript/frameworks/jest.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/jest.yaml
@@ -39,7 +39,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.jest_extractor"
-    function: "extract"
-    description: "Extract Jest/Vitest describe suites, test cases, mocks, spies, snapshots, lifecycle hooks"

--- a/internal/engine/rules/javascript_typescript/frameworks/langchain.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/langchain.yaml
@@ -81,14 +81,3 @@ source_patterns:
 
 relationship_rules: []
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.langchain_ts_extractor
-    function: extract
-    description: >-
-      LangChain TS/JS extractor: LCEL .pipe() chains, RunnableSequence.from(),
-      agents (createReactAgent + AgentExecutor), DynamicTool/DynamicStructuredTool
-      and tool() factory, RAG pipelines (createRetrievalChain, RetrievalQAChain),
-      prompts (ChatPromptTemplate, PromptTemplate), memory (BufferMemory,
-      ConversationSummaryMemory). Emits DEPENDS_ON (pipe stages), OWNS
-      (agent->tools), CALLS (chain invocations).

--- a/internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml
@@ -34,10 +34,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.nestjs_extractor"
-    function: "extract"
-    description: "Extract NestJS Module DI graph, controllers, route handlers, guards, interceptors, and services"
-  - module: "archigraph.engine.rules.languages._engine.config_consumer_extractor"
-    function: "extract"
-    description: "Extract process.env.KEY and process.env['KEY'] reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities."

--- a/internal/engine/rules/javascript_typescript/frameworks/next_js.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/next_js.yaml
@@ -22,10 +22,3 @@ frameworks:
   - server actions
   - route segments
   notes: Detect App Router via presence of app/layout.tsx or app/page.tsx
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.nextjs_extractor
-    function: extract
-    description: "Next.js App Router, Pages Router, API routes, and server action extraction"
-  - module: archigraph.engine.rules.languages._engine.config_consumer_extractor
-    function: extract
-    description: "Extract process.env.KEY and process.env['KEY'] reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read) edges from consuming entities."

--- a/internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml
@@ -21,6 +21,3 @@ frameworks:
   - useRoute
   - definePageMeta
   notes: nuxt.config.ts is definitive; also check pages/ + composables/ dirs
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.nuxt_extractor
-    function: extract

--- a/internal/engine/rules/javascript_typescript/frameworks/react.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/react.yaml
@@ -36,7 +36,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.react_extractor"
-    function: "extract"
-    description: "Extract React components, hooks, context relationships, OWNS and DEPENDS_ON edges"

--- a/internal/engine/rules/javascript_typescript/frameworks/remix.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/remix.yaml
@@ -22,8 +22,4 @@ frameworks:
   - useLoaderData
   - useActionData
   - Form
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.remix_extractor
-    function: extract
-    description: "Remix file-based routes, loader/action, nested layouts, and boundary detection"
   notes: remix.config.js or @remix-run/react dep is definitive

--- a/internal/engine/rules/javascript_typescript/frameworks/svelte.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/svelte.yaml
@@ -18,6 +18,3 @@ frameworks:
   - '$:'
   - on:click
   notes: .svelte extension is definitive
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.svelte_extractor
-    function: extract

--- a/internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml
@@ -18,6 +18,3 @@ frameworks:
   - +layout.svelte
   - +server.ts
   notes: src/routes/ directory with + file prefixes is definitive
-  custom_extractors:
-    - module: archigraph.engine.rules.languages.javascript_typescript.svelte_extractor
-      function: extract

--- a/internal/engine/rules/javascript_typescript/frameworks/trpc.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/trpc.yaml
@@ -77,7 +77,3 @@ source_patterns:
 
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.trpc_extractor"
-    function: "extract"
-    description: "Extract tRPC routers, query/mutation procedures, middleware chains, input schemas, caller factories, and mergeRouters composition"

--- a/internal/engine/rules/javascript_typescript/frameworks/vue.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/vue.yaml
@@ -30,7 +30,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.vue_extractor"
-    function: "extract"
-    description: "Extract Vue SFC components, composables, Pinia stores, Nuxt routes, and OWNS/DEPENDS_ON relationships"

--- a/internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml
@@ -18,11 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Client instantiation
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), CQL execution
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml
@@ -22,14 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: DynamoDBClient/DynamoDB.DocumentClient
-      connections (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), TableName
-      params (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), .query()/.scan()
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml
@@ -13,10 +13,3 @@ orms_database:
     - client.indices.create(
   notes: |
     Official JavaScript/TypeScript Elasticsearch client from Elastic.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract Client connections, client.search() calls, aggregations, ILM policies,
-      and index creation calls for JavaScript and TypeScript.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/javascript_typescript/orms/knex.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/knex.yaml
@@ -18,6 +18,3 @@ orms_and_database:
   - .where(
   - .select(
   notes: Query builder (not full ORM); often used with Objection.js on top
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml
@@ -16,14 +16,3 @@ orms_and_database:
       - collection.aggregate(
       - collection.watch(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/javascript_typescript/orms/mongoose.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mongoose.yaml
@@ -15,8 +15,3 @@ orms_and_database:
   - mongoose.model(
   - Schema.Types.
   notes: MongoDB ODM; no config file — detect via dep + mongoose.connect() call
-custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.mongoose_extractor
-    callable: extract
-    frameworks:
-      - mongoose

--- a/internal/engine/rules/javascript_typescript/orms/mysql_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mysql_js.yaml
@@ -26,13 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/javascript_typescript/orms/neo4j.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/neo4j.yaml
@@ -26,11 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER) with node labels and relationship types.
-      Supports template literal .run(`) forms.

--- a/internal/engine/rules/javascript_typescript/orms/objection.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/objection.yaml
@@ -19,8 +19,3 @@ orms_and_database:
   notes: Active-record style ORM built on top of Knex; models subclass Model and
     declare tableName/jsonSchema/relationMappings. Migrations reuse the Knex schema
     builder.
-  custom_extractors:
-  - module: archigraph.internal.custom.javascript.objection
-    callable: Extract
-    frameworks:
-    - objection

--- a/internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml
@@ -30,14 +30,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: pg Pool/Client connections and
-      postgres.js driver instantiation (SCOPE.Service,
-      INFERRED_FROM_POSTGRES_DRIVER), connection pool setup
-      (SCOPE.Pattern, INFERRED_FROM_POSTGRES_POOL), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/javascript_typescript/orms/prisma.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/prisma.yaml
@@ -22,6 +22,3 @@ orms_and_database:
   - 'model '
   notes: schema.prisma is definitive. victorhqc tree-sitter-prisma grammar for AST
     parsing.
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml
@@ -25,9 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.javascript_typescript.prisma_extractor"
-    function: "extract"
-    description: "Extract Prisma schema models, enums, relations, client queries, raw queries, middleware, and PrismaClient instantiation"
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/javascript_typescript/orms/redis_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/redis_js.yaml
@@ -1,7 +1,6 @@
 # JavaScript/TypeScript Redis client extraction rules.
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms:
   name: ioredis / node-redis
@@ -32,14 +31,3 @@ orms:
     ioredis and node-redis (createClient) are the dominant Redis clients for
     Node.js. Bull and BullMQ use Redis internally for job queuing.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: createClient/new Redis/IORedis/Cluster
-      connections (SCOPE.Service), cache ops .get/.set/.hget/.hset/.expire
-      (SCOPE.Operation/cache_op), pub/sub .publish/.subscribe with channel extraction
-      (SCOPE.Operation/pubsub), streams .xadd/.xread/.xreadgroup/.xack with stream
-      name (SCOPE.Operation/stream_op), Lua .eval/.evalsha (SCOPE.Operation/lua_script),
-      Bull/BullMQ new Queue("name") (SCOPE.Component/queue).

--- a/internal/engine/rules/javascript_typescript/orms/sequelize.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/sequelize.yaml
@@ -18,9 +18,3 @@ orms_and_database:
   - Model.init(
   - DataTypes.
   notes: Mature ORM; .sequelizerc file points to config location
-custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.sequelize_extractor
-    callable: extract
-    frameworks:
-      - sequelize
-      - sequelize-typescript

--- a/internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml
@@ -31,12 +31,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: better-sqlite3/sql.js/libsql connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/javascript_typescript/orms/typeorm.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/typeorm.yaml
@@ -24,9 +24,3 @@ orms_and_database:
   - DataSource
   - createConnection
   notes: data-source.ts is modern convention (TypeORM 0.3+); ormconfig.* is legacy
-custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.typeorm_extractor
-    callable: extract
-    frameworks:
-      - typeorm
-      - typeorm-legacy

--- a/internal/engine/rules/javascript_typescript/queues/bullmq.yaml
+++ b/internal/engine/rules/javascript_typescript/queues/bullmq.yaml
@@ -29,10 +29,3 @@ queues:
     BullMQ uses new Worker() for consumer registration.
     QueueScheduler is BullMQ-only (handles delayed/repeatable jobs).
 
-custom_extractors:
-  - module: archigraph.engine.rules.languages.javascript_typescript.bull_extractor
-    callable: extract
-    frameworks:
-      - bull
-      - bullmq
-      - bull-board

--- a/internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml
+++ b/internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml
@@ -35,7 +35,3 @@ frameworks:
     by absence of commonMain/ dirs.
 
     '
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.kotlin.compose_extractor"
-    function: "extract"
-    description: "Extract @Composable function tree, NavHost navigation graph routes, and ViewModel dependencies"

--- a/internal/engine/rules/kotlin/frameworks/ktor.yaml
+++ b/internal/engine/rules/kotlin/frameworks/ktor.yaml
@@ -92,10 +92,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.kotlin.ktor_extractor"
-    function: "extract"
-    description: "Extract Ktor routing DSL HTTP method routes (get/post/put/delete/patch), route() scope blocks, install(Plugin) plugin installs, authenticate() blocks, ContentNegotiation serialization formats, call.respond() invocations, and Application module extension functions. Emits OWNS and DEPENDS_ON relationships."
-  - module: "archigraph.engine.rules.languages._engine.config_prefix_extractor"
-    function: "extract"
-    description: "Extract ktor.deployment.rootPath from application.conf / application.yml as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."

--- a/internal/engine/rules/kotlin/frameworks/langchain4j.yaml
+++ b/internal/engine/rules/kotlin/frameworks/langchain4j.yaml
@@ -36,7 +36,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.kotlin.langchain4j_extractor"
-    function: "extract"
-    description: "Extract LangChain4J AI service interfaces (@AiService), tool methods (@Tool), prompt patterns, ChatLanguageModel fields, RAG components, ChatMemory, and DI wiring for Kotlin syntax. Emits OWNS and DEPENDS_ON relationships."

--- a/internal/engine/rules/kotlin/orms/cassandra_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/cassandra_kotlin.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: CqlSession.builder() / Cluster.builder()
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), CQL execution
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), table annotations
-      (SCOPE.Schema/table, INFERRED_FROM_CASSANDRA_TABLE), Spring Data repos
-      (SCOPE.Schema, INFERRED_FROM_CASSANDRA_SPRING), prepared statements
-      (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/kotlin/orms/dynamodb_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/dynamodb_kotlin.yaml
@@ -17,14 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: DynamoDbClient.builder() connections
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), table definitions and
-      @DynamoDbBean (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE /
-      INFERRED_FROM_DYNAMODB_ENHANCED), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), DAX (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX),
-      single-table design (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/kotlin/orms/elasticsearch_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/elasticsearch_kotlin.yaml
@@ -15,10 +15,3 @@ orms_database:
   notes: |
     Kotlin uses the Java high-level client via Kotlin extensions.
     Spring Data Elasticsearch is the most common integration.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract RestHighLevelClient / ElasticsearchClient connections, @Document classes,
-      ElasticsearchRepository interfaces, QueryBuilders, AggregationBuilders, ILM policies.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml
@@ -16,14 +16,3 @@ orms_database:
       - collection.aggregate(
       - client.startSession(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/kotlin/orms/mysql_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/mysql_kotlin.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/kotlin/orms/neo4j.yaml
+++ b/internal/engine/rules/kotlin/orms/neo4j.yaml
@@ -26,11 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER), Spring Data Neo4j @Node (SCOPE.Schema,
-      INFERRED_FROM_NEO4J_SDN).

--- a/internal/engine/rules/kotlin/orms/postgresql_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/postgresql_kotlin.yaml
@@ -22,12 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: Exposed Database.connect / R2DBC
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/kotlin/orms/redis_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/redis_kotlin.yaml
@@ -1,7 +1,6 @@
 # Kotlin Redis client extraction rules.
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms:
   name: Lettuce / Kreds (Kotlin Redis clients)
@@ -23,14 +22,3 @@ orms:
     Kotlin typically uses Lettuce (same JVM library as Java) or Kreds (native Kotlin
     coroutine-based client). Spring Data Redis integrates seamlessly with both.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: LettuceConnectionFactory/RedisClient.create/Kreds
-      connections (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), Spring Data
-      Redis @Cacheable/@CachePut/@CacheEvict/RedisTemplate/ReactiveRedisTemplate/
-      @RedisHash (SCOPE.Pattern/INFERRED_FROM_REDIS_SPRING), pub/sub
-      (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op), Lua
-      (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/kotlin/orms/sqlite_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/sqlite_kotlin.yaml
@@ -28,12 +28,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: SQLDelight drivers / Room.databaseBuilder
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/perl/orms/mysql_perl.yaml
+++ b/internal/engine/rules/perl/orms/mysql_perl.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/perl/orms/neo4j.yaml
+++ b/internal/engine/rules/perl/orms/neo4j.yaml
@@ -22,10 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via REST::Neo4p
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/perl/orms/postgresql_perl.yaml
+++ b/internal/engine/rules/perl/orms/postgresql_perl.yaml
@@ -18,12 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: DBI->connect("dbi:Pg:") connections
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/perl/orms/sqlite_perl.yaml
+++ b/internal/engine/rules/perl/orms/sqlite_perl.yaml
@@ -22,12 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: DBD::SQLite DBI connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/php/frameworks/laravel.yaml
+++ b/internal/engine/rules/php/frameworks/laravel.yaml
@@ -52,19 +52,3 @@ frameworks:
     alone is insufficient — always check artisan + app/Http/.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.php.laravel_extractor
-    function: extract
-    description: >
-      Extracts Laravel routes (HTTP verb routes and Route::resource expansions),
-      service container bindings (bind/singleton/scoped/instance),
-      Blade component class declarations, and Blade x-component tag usage.
-      Emits SCOPE.Operation/endpoint, SCOPE.Pattern, SCOPE.UIComponent/component.
-      Relationships: CALLS (routes_to), DEPENDS_ON (binding->concrete, template->component),
-      OWNS (provider->binding).
-  - module: archigraph.engine.rules.languages._engine.config_prefix_extractor
-    function: extract
-    description: >
-      Extract APP_URL prefix from RouteServiceProvider.php as
-      SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated
-      on well-known config file basenames.

--- a/internal/engine/rules/php/frameworks/symfony.yaml
+++ b/internal/engine/rules/php/frameworks/symfony.yaml
@@ -189,17 +189,3 @@ relationship_rules:
     source_group: 1
     target_group: 1
 
-custom_extractors:
-- module: archigraph.engine.rules.languages.php.symfony_extractor
-  function: extract
-  description: >
-    Extracts Symfony routes (#[Route] attributes and @Route annotations with full
-    path resolution including class-level prefixes), controller class declarations,
-    Doctrine ORM entities (#[ORM\Entity]/@ORM\Entity) with column annotations and
-    relationship mappings (OneToMany/ManyToOne/ManyToMany/OneToOne),
-    EventSubscriberInterface implementations with getSubscribedEvents() bindings,
-    and #[AsMessageHandler]/MessageHandlerInterface message handler classes.
-    Emits SCOPE.Operation/endpoint, SCOPE.Component, SCOPE.Schema, SCOPE.Pattern,
-    SCOPE.Service.
-    Relationships: CALLS (routes_to), OWNS (entity->column, subscriber->handler),
-    DEPENDS_ON (doctrine_relation, subscribes_to).

--- a/internal/engine/rules/php/orms/cassandra_php.yaml
+++ b/internal/engine/rules/php/orms/cassandra_php.yaml
@@ -17,11 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Cassandra\Cluster::builder()
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), .execute()
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/php/orms/dynamodb_php.yaml
+++ b/internal/engine/rules/php/orms/dynamodb_php.yaml
@@ -17,13 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: DynamoDbClient connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), DAX (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX),
-      single-table design (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/php/orms/elasticsearch_php.yaml
+++ b/internal/engine/rules/php/orms/elasticsearch_php.yaml
@@ -13,10 +13,3 @@ orms_database:
   notes: |
     Official PHP Elasticsearch client. v7 uses Elasticsearch\ClientBuilder,
     v8 uses Elastic\Elasticsearch\ClientBuilder.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract ClientBuilder connections, search() calls, aggregations,
-      ILM policies, and index creation for PHP.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/php/orms/eloquent_laravel_orm.yaml
+++ b/internal/engine/rules/php/orms/eloquent_laravel_orm.yaml
@@ -40,16 +40,3 @@ orms:
     Migration files in database/migrations/ contain Blueprint schema calls.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.php.eloquent_extractor
-    function: extract
-    description: >
-      Extracts Eloquent ORM-specific entities: Model class declarations, relationship
-      methods (hasOne/hasMany/belongsTo/belongsToMany/morphTo/morphMany),
-      query scope methods (scopeActive etc.), Observer lifecycle hooks
-      (creating/created/updating/updated/deleting/deleted), accessor/mutator methods
-      (getXAttribute/setXAttribute, Attribute::make), $casts/$fillable/$guarded metadata,
-      $table property, and DB::table() query scopes.
-      Emits SCOPE.Schema (model), SCOPE.Operation (scope/accessor/query), SCOPE.Pattern (observer).
-      Relationships: DEPENDS_ON (model->related, kind=eloquent_relationship),
-      OWNS (model->scope, model->accessor, model->query, observer->hook).

--- a/internal/engine/rules/php/orms/mongodb_php.yaml
+++ b/internal/engine/rules/php/orms/mongodb_php.yaml
@@ -16,14 +16,3 @@ orms_database:
       - ->aggregate(
       - ->watch(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/php/orms/mysql_php.yaml
+++ b/internal/engine/rules/php/orms/mysql_php.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/php/orms/neo4j.yaml
+++ b/internal/engine/rules/php/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Client::create
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/php/orms/postgresql_php.yaml
+++ b/internal/engine/rules/php/orms/postgresql_php.yaml
@@ -24,12 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: pg_connect/PDO::pgsql connections
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/php/orms/redis_php.yaml
+++ b/internal/engine/rules/php/orms/redis_php.yaml
@@ -1,7 +1,6 @@
 # PHP Redis client extraction rules.
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms:
   name: phpredis / Predis
@@ -25,13 +24,3 @@ orms:
     used in Laravel/Symfony applications. Detection signals overlap since both
     expose similar API surfaces.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: new Redis()/new Predis\Client() connections
-      (SCOPE.Service), cache ops ->get/->set/->hget/->hset/->expire
-      (SCOPE.Operation/cache_op), pub/sub ->publish/->subscribe
-      (SCOPE.Operation/pubsub), streams ->xadd/->xread (SCOPE.Operation/stream_op),
-      Lua ->eval/->evalsha (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/php/orms/sqlite_php.yaml
+++ b/internal/engine/rules/php/orms/sqlite_php.yaml
@@ -18,12 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: PDO::sqlite/SQLite3 connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/python/frameworks/celery.yaml
+++ b/internal/engine/rules/python/frameworks/celery.yaml
@@ -111,14 +111,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.celery_extractor
-    function: extract
-    description: >-
-      Celery-specific extractor: @shared_task/@app.task (SCOPE.Service/task) with
-      queue/bind/max_retries metadata; chain/group/chord canvas primitives
-      (SCOPE.Pattern/canvas) + DEPENDS_ON edges between tasks; beat_schedule entries
-      (SCOPE.Pattern/beat_entry) + DEPENDS_ON task; class-based Task lifecycle hooks
-      on_failure/on_success/on_retry/on_revoke (SCOPE.Operation/function) + OWNS from
-      task class; retry metadata captured from function body.

--- a/internal/engine/rules/python/frameworks/django.yaml
+++ b/internal/engine/rules/python/frameworks/django.yaml
@@ -154,28 +154,5 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
 # These run after YAML-driven extraction and contribute additional entities +
 # relationships to the pipeline result.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.django_extractor
-    function: extract
-    description: >-
-      Django-specific extractor: URL resolver patterns (path/re_path),
-      class-based view HTTP method handlers (OWNS edges), signal receivers
-      with sender model CALLS edges, admin.site.register and @admin.register
-      CALLS edges to registered models.
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract
-  - module: archigraph.engine.rules.languages._engine.config_prefix_extractor
-    function: extract
-    description: >-
-      Extract FORCE_SCRIPT_NAME / SCRIPT_NAME from Django settings.py as
-      SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated
-      on well-known config file basenames.
-  - module: archigraph.engine.rules.languages._engine.config_consumer_extractor
-    function: extract
-    description: >-
-      Extract os.getenv('KEY'), os.environ['KEY'], and os.environ.get('KEY')
-      reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read)
-      edges from consuming entities.

--- a/internal/engine/rules/python/frameworks/fastapi.yaml
+++ b/internal/engine/rules/python/frameworks/fastapi.yaml
@@ -115,36 +115,5 @@ relationship_rules:
     source_group: 1
     target_group: 1
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
 # These run after YAML-driven extraction and contribute additional entities +
 # relationships to the pipeline result.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.fastapi_extractor
-    function: extract
-    description: >-
-      FastAPI-specific extractor: HTTP route decorators (@app.get/post/put/delete/patch),
-      Depends() injection (CALLS edges to dependency functions), Pydantic BaseModel/
-      BaseSettings subclasses (SCOPE.Schema), APIRouter instantiation with prefix/tags
-      (SCOPE.Component), @app.websocket routes (SCOPE.Operation/endpoint),
-      @app.middleware decorators (SCOPE.Pattern), BackgroundTasks.add_task() call
-      sites (SCOPE.Operation/function + CALLS edges), and @app.on_event("startup"/
-      "shutdown") lifecycle hooks (SCOPE.Operation/function).
-  - module: archigraph.engine.rules.languages.python.fastapi_request_response_extractor
-    function: extract
-    description: >-
-      FastAPI request/response extractor: emits ACCEPTS_INPUT edges
-      from endpoint entities to Pydantic body parameter types, and RETURNS edges
-      from endpoint entities to response_model= decorator types and -> return
-      type annotations. Skips primitives and FastAPI framework response types.
-  - module: archigraph.engine.rules.languages._engine.config_prefix_extractor
-    function: extract
-    description: >-
-      Extract root_path / root_path_in_servers from FastAPI main.py as
-      SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated
-      on well-known config file basenames.
-  - module: archigraph.engine.rules.languages._engine.config_consumer_extractor
-    function: extract
-    description: >-
-      Extract os.getenv('KEY'), os.environ['KEY'], and os.environ.get('KEY')
-      reads as SCOPE.Pattern/config_key entities and emit DEPENDS_ON(kind=config_read)
-      edges from consuming entities.

--- a/internal/engine/rules/python/frameworks/flask.yaml
+++ b/internal/engine/rules/python/frameworks/flask.yaml
@@ -117,23 +117,5 @@ relationship_rules:
     source_group: 2
     target_group: 3
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
 # These run after YAML-driven extraction and contribute additional entities +
 # relationships to the pipeline result.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.flask_extractor
-    function: extract
-    description: >-
-      Flask-specific extractor: route decorators (@app.route, @app.get/post etc.),
-      Blueprint composition with url_prefix, before/after_request hooks,
-      @app.errorhandler, Flask-SQLAlchemy db.Model (SCOPE.Schema),
-      Flask-Login @login_required, Flask-WTF FlaskForm (SCOPE.Schema),
-      Flask-RESTful Resource + api.add_resource(), Flask-SocketIO @socketio.on,
-      app.config patterns, and @app.cli.command CLI commands.
-      Emits OWNS (blueprint→route, app→blueprint), DEPENDS_ON (endpoint→resource).
-  - module: archigraph.engine.rules.languages.python.flask_request_response_extractor
-    function: extract
-    description: >-
-      Flask request/response extractor: marshmallow schema.load() references
-      → ACCEPTS_INPUT, return type annotations → RETURNS.
-      Out of scope: Flask-RESTX/Flask-Smorest.

--- a/internal/engine/rules/python/frameworks/langchain.yaml
+++ b/internal/engine/rules/python/frameworks/langchain.yaml
@@ -52,14 +52,3 @@ source_patterns:
 
 relationship_rules: []
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.langchain_extractor
-    function: extract
-    description: >-
-      LangChain Python extractor: LCEL pipe chains, legacy chains, agents
-      (create_*_agent + AgentExecutor), @tool decorators and BaseTool classes,
-      RAG pipelines (RetrievalQA, create_stuff_documents_chain), prompts
-      (ChatPromptTemplate, PromptTemplate), memory (ConversationBufferMemory,
-      RunnableWithMessageHistory). Emits DEPENDS_ON (chain stages), OWNS
-      (agent->tools), CALLS (chain invocations).

--- a/internal/engine/rules/python/frameworks/pytest.yaml
+++ b/internal/engine/rules/python/frameworks/pytest.yaml
@@ -76,15 +76,3 @@ relationship_rules:
     source_group: 1
     target_group: 1
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.pytest_extractor
-    function: extract
-    description: >-
-      Pytest-specific extractor: def test_xxx / class TestXxx (SCOPE.Operation),
-      @pytest.fixture (SCOPE.Pattern), @pytest.mark.parametrize metadata,
-      conftest.py fixtures (SCOPE.Pattern), @pytest.mark.skip/xfail/slow metadata,
-      class TestXxx (SCOPE.Component) + OWNS test methods,
-      @pytest.mark.usefixtures DEPENDS_ON fixture,
-      monkeypatch/capsys/tmp_path DEPENDS_ON built-in fixture.
-      Emits OWNS (class→test), DEPENDS_ON (test/class→fixture).

--- a/internal/engine/rules/python/frameworks/sqlalchemy.yaml
+++ b/internal/engine/rules/python/frameworks/sqlalchemy.yaml
@@ -96,21 +96,3 @@ relationship_rules:
     source_group: 1
     target_group: 1
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.sqlalchemy_extractor
-    function: extract
-    description: >-
-      SQLAlchemy-specific extractor: declarative model classes (SCOPE.Schema,
-      INFERRED_FROM_SQLALCHEMY_MODEL), Column()/mapped_column() metadata,
-      relationship() → DEPENDS_ON (INFERRED_FROM_SQLALCHEMY_RELATIONSHIP),
-      ForeignKey() → DEPENDS_ON (INFERRED_FROM_SQLALCHEMY_FK),
-      session.query()/session.execute(select()) → SCOPE.Operation
-      (INFERRED_FROM_SQLALCHEMY_QUERY), create_engine() → SCOPE.Service
-      (INFERRED_FROM_SQLALCHEMY_ENGINE), @hybrid_property → SCOPE.Operation
-      (INFERRED_FROM_SQLALCHEMY_HYBRID), event.listen()/@event.listens_for()
-      → SCOPE.Pattern (INFERRED_FROM_SQLALCHEMY_EVENT), association Table()
-      → SCOPE.Schema (INFERRED_FROM_SQLALCHEMY_ASSOCIATION).
-      Supports both SQLAlchemy 1.x and 2.0 Mapped[]/mapped_column() style.
-      Emits OWNS (model→hybrid_property), DEPENDS_ON (model→related model,
-      model→FK table, event→target).

--- a/internal/engine/rules/python/orms/alembic.yaml
+++ b/internal/engine/rules/python/orms/alembic.yaml
@@ -14,6 +14,3 @@ orms_database:
     migration files contain upgrade() and downgrade() functions.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/python/orms/cassandra_py.yaml
+++ b/internal/engine/rules/python/orms/cassandra_py.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), CQL execution
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), table definitions
-      via cqlengine (SCOPE.Schema/table, INFERRED_FROM_CASSANDRA_TABLE),
-      prepared statements (SCOPE.Operation/prepared,
-      INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/python/orms/dynamodb_py.yaml
+++ b/internal/engine/rules/python/orms/dynamodb_py.yaml
@@ -20,15 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: boto3.resource/client connections
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), create_table definitions
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), IndexName patterns
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_INDEX), .query()/.scan() operations
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/python/orms/elasticsearch_py.yaml
+++ b/internal/engine/rules/python/orms/elasticsearch_py.yaml
@@ -16,10 +16,3 @@ orms_database:
   notes: |
     Official Python Elasticsearch client. elasticsearch-dsl provides a high-level
     ORM-like interface (Document, Search, Q). Both are detected here.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract Elasticsearch() client connections, elasticsearch-dsl Document classes,
-      Search() instances, Q() query builders, aggregations A(), ILM policies, and
-      index creation calls. Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/python/orms/mongoengine.yaml
+++ b/internal/engine/rules/python/orms/mongoengine.yaml
@@ -20,14 +20,3 @@ orms_database:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/python/orms/mysql_py.yaml
+++ b/internal/engine/rules/python/orms/mysql_py.yaml
@@ -25,13 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/python/orms/neo4j.yaml
+++ b/internal/engine/rules/python/orms/neo4j.yaml
@@ -29,12 +29,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER) with node labels and relationship types,
-      neomodel StructuredNode/StructuredRel (SCOPE.Schema,
-      INFERRED_FROM_NEO4J_NEOMODEL) with RelationshipTo DEPENDS_ON edges.

--- a/internal/engine/rules/python/orms/postgresql_py.yaml
+++ b/internal/engine/rules/python/orms/postgresql_py.yaml
@@ -31,14 +31,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: psycopg2/psycopg/asyncpg connections
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), connection pools
-      (SCOPE.Pattern, INFERRED_FROM_POSTGRES_POOL), LISTEN/NOTIFY channels
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY operations
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      with table/column extraction (SCOPE.Operation/query,
-      INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/python/orms/redis_py.yaml
+++ b/internal/engine/rules/python/orms/redis_py.yaml
@@ -1,7 +1,6 @@
 # Python Redis client extraction rules.
 #
 # Top-level `orms_database:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms_database:
   name: redis-py
@@ -30,15 +29,3 @@ orms_database:
     (merged into redis-py 4.2+). Upstash provides a REST-based Redis client for
     serverless environments.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: redis.Redis/StrictRedis/from_url/aioredis
-      connections (SCOPE.Service), cache ops get/set/hget/hset/expire/del
-      (SCOPE.Operation/cache_op), pub/sub publish/subscribe/psubscribe with channel
-      extraction (SCOPE.Operation/pubsub), streams xadd/xread/xreadgroup/xack with
-      stream name (SCOPE.Operation/stream_op), Lua eval/evalsha/SCRIPT LOAD
-      (SCOPE.Operation/lua_script), INCR+EXPIRE and sliding-window rate limiting
-      (SCOPE.Pattern/rate_limit).

--- a/internal/engine/rules/python/orms/sqlite_py.yaml
+++ b/internal/engine/rules/python/orms/sqlite_py.yaml
@@ -26,12 +26,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: sqlite3/aiosqlite connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/r/orms/mysql_r.yaml
+++ b/internal/engine/rules/r/orms/mysql_r.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/r/orms/neo4j.yaml
+++ b/internal/engine/rules/r/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via neo4r
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/r/orms/postgresql_r.yaml
+++ b/internal/engine/rules/r/orms/postgresql_r.yaml
@@ -23,13 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: dbConnect(RPostgres::Postgres() /
-      RPostgreSQL::PostgreSQL()) connections
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/r/orms/sqlite_r.yaml
+++ b/internal/engine/rules/r/orms/sqlite_r.yaml
@@ -24,12 +24,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: RSQLite dbConnect connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/ruby/frameworks/rspec.yaml
+++ b/internal/engine/rules/ruby/frameworks/rspec.yaml
@@ -13,7 +13,3 @@
 # Custom extractors
 # ---------------------------------------------------------------------------
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.ruby.rspec_extractor"
-    function: "extract"
-    description: "Extract RSpec describe/context groups, it/specify examples, let/let! helpers, before/after hooks, shared_examples/shared_context declarations, include_examples/it_behaves_like includes, and subject blocks — SCOPE.Component, SCOPE.Operation, SCOPE.Pattern, DEPENDS_ON relationships"

--- a/internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml
+++ b/internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml
@@ -48,15 +48,3 @@ frameworks:
 # Custom extractors
 # ---------------------------------------------------------------------------
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.ruby.rails_routes_extractor"
-    function: "extract"
-    description: "Deep config/routes.rb route_extraction: resolves the full route table from the Rails routing DSL — resources/resource (7/6 RESTful actions), nested resources (/photos/:photo_id/comments path composition), namespace + scope + scope module: prefixing, member/collection blocks, only:/except: filters, root, get/post/put/patch/delete to: 'c#a', match via:, mount engines, and concern/concerns: expansion. Each route carries the resolved full path, HTTP method, and controller#action handler with a CALLS structural-ref edge to the ActionController action."
-  - module: "archigraph.engine.rules.languages.ruby.rails_extractor"
-    function: "extract"
-    description: "Extract Rails routes (resources, member/collection), concerns, ActiveRecord callbacks and associations, controller filters — CALLS, OWNS, DEPENDS_ON relationships"
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract
-  - module: archigraph.engine.rules.languages._engine.config_prefix_extractor
-    function: extract
-    description: "Extract scope prefix from config/routes.rb as SCOPE.Pattern/config_prefix entities. Cross-framework extractor gated on well-known config file basenames."

--- a/internal/engine/rules/ruby/frameworks/sidekiq.yaml
+++ b/internal/engine/rules/ruby/frameworks/sidekiq.yaml
@@ -14,7 +14,3 @@
 # Custom extractors
 # ---------------------------------------------------------------------------
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.ruby.sidekiq_extractor"
-    function: "extract"
-    description: "Extract Sidekiq worker classes (include Sidekiq::Worker/Job), def perform, perform_async/in/at dispatch sites, sidekiq_options metadata, Sidekiq.configure_server/client blocks, Sidekiq::Middleware chain operations — SCOPE.Service, SCOPE.Operation, SCOPE.Pattern, OWNS and CALLS relationships"

--- a/internal/engine/rules/ruby/orms/cassandra_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/cassandra_ruby.yaml
@@ -17,11 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Cassandra.cluster
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), .execute()
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/ruby/orms/dynamodb_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/dynamodb_ruby.yaml
@@ -16,14 +16,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: Aws::DynamoDB::Client.new connections
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_CLIENT), table definitions
-      (SCOPE.Schema, INFERRED_FROM_DYNAMODB_TABLE), query/scan operations
-      (SCOPE.Operation/query, INFERRED_FROM_DYNAMODB_QUERY), streams
-      (SCOPE.Operation/stream_op, INFERRED_FROM_DYNAMODB_STREAM), DAX
-      (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX), single-table design
-      (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml
@@ -15,10 +15,3 @@ orms_database:
   notes: |
     Official Ruby Elasticsearch client. elasticsearch-model and elasticsearch-rails
     add ActiveRecord/ActiveModel integration.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract Elasticsearch::Client.new connections, .search() calls,
-      aggregations, ILM policies, and index creation for Ruby.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/ruby/orms/mongoid.yaml
+++ b/internal/engine/rules/ruby/orms/mongoid.yaml
@@ -23,14 +23,3 @@ orms:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/ruby/orms/mysql_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/mysql_ruby.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/ruby/orms/neo4j.yaml
+++ b/internal/engine/rules/ruby/orms/neo4j.yaml
@@ -27,12 +27,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections (SCOPE.Service,
-      INFERRED_FROM_NEO4J_DRIVER), Cypher query strings (SCOPE.Operation/query,
-      INFERRED_FROM_NEO4J_CYPHER), ActiveGraph include Neo4j::ActiveNode
-      (SCOPE.Schema, INFERRED_FROM_NEO4J_ACTIVEGRAPH) with has_many/has_one
-      DEPENDS_ON edges.

--- a/internal/engine/rules/ruby/orms/pg_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/pg_ruby.yaml
@@ -19,12 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: PG.connect/PG::Connection.new
-      (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/ruby/orms/redis_rb.yaml
+++ b/internal/engine/rules/ruby/orms/redis_rb.yaml
@@ -1,7 +1,6 @@
 # Ruby Redis client extraction rules.
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 orms:
   name: redis-rb
@@ -26,13 +25,3 @@ orms:
     redis-rb is the official Ruby Redis client. Sidekiq uses Redis as its queue
     backend. The Redis.current thread-safe accessor is common in Rails apps.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: Redis.new/Redis.current connections (SCOPE.Service),
-      cache ops .get/.set/.hget/.hset/.expire (SCOPE.Operation/cache_op), pub/sub
-      .publish/.subscribe/.psubscribe (SCOPE.Operation/pubsub), streams .xadd/.xread
-      (SCOPE.Operation/stream_op), Lua .eval/.evalsha (SCOPE.Operation/lua_script),
-      Sidekiq::Worker/Sidekiq::Job include patterns (SCOPE.Component/queue).

--- a/internal/engine/rules/ruby/orms/sqlite_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/sqlite_ruby.yaml
@@ -21,12 +21,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: sqlite3 gem connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/rust/frameworks/actix_web.yaml
+++ b/internal/engine/rules/rust/frameworks/actix_web.yaml
@@ -105,18 +105,6 @@ source_patterns:
     name_group: 1
     scope: file
 
-custom_extractors:
-  - module: archigraph.engine.rules.languages.rust.actix_web_extractor
-    function: extract
-    description: >
-      Extracts Actix-web macro-annotated route handlers (#[get], #[post], etc.) as
-      SCOPE.Operation/endpoint (INFERRED_FROM_ACTIX_ROUTE), web::scope groupings as
-      SCOPE.Component (INFERRED_FROM_ACTIX_SCOPE), .wrap(Middleware) registrations as
-      SCOPE.Pattern (INFERRED_FROM_ACTIX_MIDDLEWARE), web::Json/Path/Query/Form<T>
-      extractor types as SCOPE.Schema (INFERRED_FROM_ACTIX_EXTRACTOR), HttpServer::new()
-      as SCOPE.Service (INFERRED_FROM_ACTIX_SERVER), web::Data<T> app state as
-      SCOPE.Pattern (INFERRED_FROM_ACTIX_STATE), and WebSocket handler functions as
-      SCOPE.Operation/websocket (INFERRED_FROM_ACTIX_WEBSOCKET).
 
 relationship_rules:
   # Macro route connects path to the function immediately following it:

--- a/internal/engine/rules/rust/frameworks/axum.yaml
+++ b/internal/engine/rules/rust/frameworks/axum.yaml
@@ -122,7 +122,3 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.rust.axum_extractor"
-    function: "extract"
-    description: "Extract Axum Router routes (.route with get/post/put/delete/patch/head/options), nested routers (.nest), tower middleware layers (.layer, ServiceBuilder), State<T>/Extension<T> dependency injection patterns, Json<T>/Path<T>/Query<T>/Form<T> request extractors, axum::serve()/Server::bind() server entry points, and WebSocketUpgrade handlers. Emits OWNS (nest OWNS route), CALLS (server CALLS layer), DEPENDS_ON (handler DEPENDS_ON state) relationships."

--- a/internal/engine/rules/rust/frameworks/rocket.yaml
+++ b/internal/engine/rules/rust/frameworks/rocket.yaml
@@ -24,15 +24,3 @@ frameworks:
 
       '
 
-custom_extractors:
-  - module: archigraph.engine.rules.languages.rust.rocket_extractor
-    function: extract
-    description: >
-      Extracts Rocket macro-annotated route handlers (#[get], #[post], etc.) as
-      SCOPE.Operation/endpoint (INFERRED_FROM_ROCKET_ROUTE), #[catch(N)] error catchers
-      as SCOPE.Pattern (INFERRED_FROM_ROCKET_CATCHER), impl FromRequest guards as
-      SCOPE.Pattern (INFERRED_FROM_ROCKET_GUARD), impl Fairing types as SCOPE.Pattern
-      (INFERRED_FROM_ROCKET_FAIRING), Json<T>/Form<T>/Data<T>/MsgPack<T> data guards as
-      SCOPE.Schema (INFERRED_FROM_ROCKET_DATA_GUARD), rocket::build()/rocket::ignite()
-      as SCOPE.Service (INFERRED_FROM_ROCKET_LAUNCH), and State<T> managed state as
-      SCOPE.Pattern (INFERRED_FROM_ROCKET_STATE).

--- a/internal/engine/rules/rust/orms/cassandra_rust.yaml
+++ b/internal/engine/rules/rust/orms/cassandra_rust.yaml
@@ -18,11 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: SessionBuilder::new()
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), .query()
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), .prepare()
-      (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/rust/orms/dynamodb_rust.yaml
+++ b/internal/engine/rules/rust/orms/dynamodb_rust.yaml
@@ -17,13 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: Client::new connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), DAX (SCOPE.Service, INFERRED_FROM_DYNAMODB_DAX),
-      single-table design (SCOPE.Pattern, INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/rust/orms/elasticsearch_rs.yaml
+++ b/internal/engine/rules/rust/orms/elasticsearch_rs.yaml
@@ -11,10 +11,3 @@ orms_database:
     - EsClient::new(
   notes: |
     Official Rust Elasticsearch client from Elastic.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract Elasticsearch::new connections, .search() calls,
-      aggregations, ILM policies, and index creation for Rust.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/rust/orms/mongodb_mongodb.yaml
+++ b/internal/engine/rules/rust/orms/mongodb_mongodb.yaml
@@ -24,14 +24,3 @@ orms:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/rust/orms/mysql_rust.yaml
+++ b/internal/engine/rules/rust/orms/mysql_rust.yaml
@@ -22,13 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/rust/orms/neo4j.yaml
+++ b/internal/engine/rules/rust/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Graph::new
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/rust/orms/postgresql_rust.yaml
+++ b/internal/engine/rules/rust/orms/postgresql_rust.yaml
@@ -25,13 +25,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: tokio-postgres/deadpool-postgres/sqlx
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), deadpool/PgPool
-      pool setup (SCOPE.Pattern, INFERRED_FROM_POSTGRES_POOL), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/rust/orms/redis_redis_rs.yaml
+++ b/internal/engine/rules/rust/orms/redis_redis_rs.yaml
@@ -27,12 +27,3 @@ orms:
 
     '
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: redis::Client::open/Client::open connections
-      (SCOPE.Service), cache ops con.get/set/hget/hset/expire (SCOPE.Operation/cache_op),
-      pub/sub (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op),
-      Lua con.eval/con.evalsha (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/rust/orms/sqlite_rust.yaml
+++ b/internal/engine/rules/rust/orms/sqlite_rust.yaml
@@ -28,12 +28,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: rusqlite/sqlx connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml
+++ b/internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml
@@ -40,14 +40,3 @@ frameworks:
     continuation; treat as equivalent for detection purposes.
 
     '
-custom_extractors:
-  - module: archigraph.engine.rules.languages.scala.akka_extractor
-    function: extract
-    description: >
-      Extracts Akka/Pekko actor definitions (classic Actor, typed AbstractBehavior,
-      functional Behavior[T]), actor spawn hierarchy (context.spawn, context.actorOf)
-      with parent-child DEPENDS_ON edges, Akka HTTP route DSL with nested directive
-      resolution into full endpoint paths, and sealed trait/case class message protocols.
-      Emits SCOPE.Service (actors), SCOPE.Operation/endpoint (HTTP routes),
-      SCOPE.Pattern (message protocols).
-      Relationships: DEPENDS_ON (actor_spawn, message_protocol), EXTENDS (message variant).

--- a/internal/engine/rules/scala/frameworks/redis_scala.yaml
+++ b/internal/engine/rules/scala/frameworks/redis_scala.yaml
@@ -1,7 +1,6 @@
 # Scala Redis client extraction rules.
 #
 # Top-level `frameworks:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 frameworks:
   name: rediscala / redis4cats
@@ -24,12 +23,3 @@ frameworks:
     rediscala is an Akka-based async client. redis4cats (Typelevel) provides
     cats-effect integration for functional Scala Redis access.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: RedisClient/RedisCommands.make connections
-      (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), pub/sub
-      (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op), Lua
-      (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/scala/orms/cassandra_scala.yaml
+++ b/internal/engine/rules/scala/orms/cassandra_scala.yaml
@@ -20,12 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.cassandra.cassandra_extractor"
-    function: "extract"
-    description: >
-      Cross-language Cassandra extractor: Cluster.builder() / ReactiveCassandraSession
-      (SCOPE.Service, INFERRED_FROM_CASSANDRA_DRIVER), phantom Table objects
-      (SCOPE.Schema/table, INFERRED_FROM_CASSANDRA_TABLE), CQL execution
-      (SCOPE.Operation/cql, INFERRED_FROM_CASSANDRA_CQL), prepared statements
-      (SCOPE.Operation/prepared, INFERRED_FROM_CASSANDRA_PREPARED).

--- a/internal/engine/rules/scala/orms/elastic4s.yaml
+++ b/internal/engine/rules/scala/orms/elastic4s.yaml
@@ -14,10 +14,3 @@ orms_database:
   notes: |
     elastic4s is the most popular Scala Elasticsearch client (sksamuel/elastic4s).
     Provides type-safe DSL for Elasticsearch operations.
-  custom_extractors:
-  - module: "archigraph.engine.rules.languages.elasticsearch.elasticsearch_extractor"
-    function: "extract"
-    description: >
-      Extract ElasticClient connections, search queries, aggregations,
-      ILM policies, and index creation for Scala.
-      Emits SCOPE.Service, SCOPE.Schema, SCOPE.Operation, SCOPE.Pattern.

--- a/internal/engine/rules/scala/orms/mongodb_scala.yaml
+++ b/internal/engine/rules/scala/orms/mongodb_scala.yaml
@@ -15,14 +15,3 @@ orms_database:
       - ReactiveMongoApi
       - collection.aggregate(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/scala/orms/mysql_scala.yaml
+++ b/internal/engine/rules/scala/orms/mysql_scala.yaml
@@ -18,13 +18,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/scala/orms/neo4j.yaml
+++ b/internal/engine/rules/scala/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Driver[F]
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/scala/orms/postgresql_scala.yaml
+++ b/internal/engine/rules/scala/orms/postgresql_scala.yaml
@@ -23,12 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: doobie Transactor / Slick Database
-      connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER), LISTEN/NOTIFY
-      (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY), COPY
-      (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/scala/orms/scanamo.yaml
+++ b/internal/engine/rules/scala/orms/scanamo.yaml
@@ -19,13 +19,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: Scanamo(client) connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/scala/orms/sqlite_scala.yaml
+++ b/internal/engine/rules/scala/orms/sqlite_scala.yaml
@@ -22,12 +22,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: Slick/JDBC SQLite connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/sql/frameworks/dbmate.yaml
+++ b/internal/engine/rules/sql/frameworks/dbmate.yaml
@@ -15,6 +15,3 @@ frameworks_and_dialects:
     migration scripts. Detection is via these comment markers in .sql files.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/sql/frameworks/flyway.yaml
+++ b/internal/engine/rules/sql/frameworks/flyway.yaml
@@ -22,6 +22,3 @@ frameworks_and_dialects:
     convention and directory location.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/sql/frameworks/liquibase.yaml
+++ b/internal/engine/rules/sql/frameworks/liquibase.yaml
@@ -29,6 +29,3 @@ frameworks_and_dialects:
     root element. The --rollback comment in SQL format is a strong Liquibase SQL signal.
 
     '
-  custom_extractors:
-  - module: archigraph.engine.rules.languages.migration.migration_extractor
-    function: extract

--- a/internal/engine/rules/swift/frameworks/mongoswift.yaml
+++ b/internal/engine/rules/swift/frameworks/mongoswift.yaml
@@ -14,14 +14,3 @@ frameworks:
       - MongoDatabase(
       - collection.aggregate(
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.mongodb_extractor
-    function: extract
-    description: >-
-      MongoDB cross-language extractor: driver connections (SCOPE.Service),
-      aggregation pipelines (SCOPE.Operation/aggregation), change streams
-      (SCOPE.Operation/change_stream), transactions (SCOPE.Pattern),
-      index definitions (SCOPE.Schema/index), schema validation
-      (SCOPE.Schema/validation), GridFS (SCOPE.Operation/gridfs),
-      Atlas Search (SCOPE.Operation/atlas_search).

--- a/internal/engine/rules/swift/frameworks/redistack.yaml
+++ b/internal/engine/rules/swift/frameworks/redistack.yaml
@@ -1,7 +1,6 @@
 # Swift RediStack (Vapor redis-kit) extraction rules.
 #
 # Top-level `frameworks:` key is consumed by the modular_loader (detection).
-# custom_extractors entries are consumed by CustomExtractorRegistry.
 
 frameworks:
   name: RediStack (vapor/redis-kit)
@@ -23,12 +22,3 @@ frameworks:
     RediStack is the Swift NIO-based Redis client used in Vapor ecosystem.
     RedisConnection.make() is the primary connection factory.
 
-# custom_extractors: Python callables for patterns YAML rules cannot capture.
-custom_extractors:
-  - module: archigraph.engine.rules.languages.python.redis_extractor
-    function: extract
-    description: >-
-      Redis cross-language extractor: RedisConnection.make/RedisClient.make connections
-      (SCOPE.Service), cache ops (SCOPE.Operation/cache_op), pub/sub
-      (SCOPE.Operation/pubsub), streams (SCOPE.Operation/stream_op), Lua
-      (SCOPE.Operation/lua_script).

--- a/internal/engine/rules/swift/frameworks/swiftui.yaml
+++ b/internal/engine/rules/swift/frameworks/swiftui.yaml
@@ -30,7 +30,3 @@ frameworks:
     = app entry point.
 
     '
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.swift.swiftui_extractor"
-    function: "extract"
-    description: "Extract SwiftUI View structs, body hierarchy nesting, NavigationStack paths, and @State/@Binding property wrapper relationships"

--- a/internal/engine/rules/swift/frameworks/vapor.yaml
+++ b/internal/engine/rules/swift/frameworks/vapor.yaml
@@ -141,7 +141,3 @@ relationship_rules:
     source_group: 0
     target_group: 1
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.swift.vapor_extractor"
-    function: "extract"
-    description: "Extract Vapor routes (grouped path composition), Fluent @Model/@Field, Leaf template renders, and Middleware protocol conformances"

--- a/internal/engine/rules/swift/orms/dynamodb_swift.yaml
+++ b/internal/engine/rules/swift/orms/dynamodb_swift.yaml
@@ -17,13 +17,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.dynamodb.dynamodb_extractor"
-    function: "extract"
-    description: >
-      Cross-language DynamoDB extractor: DynamoDB(client:) connections (SCOPE.Service,
-      INFERRED_FROM_DYNAMODB_CLIENT), table definitions (SCOPE.Schema,
-      INFERRED_FROM_DYNAMODB_TABLE), query/scan operations (SCOPE.Operation/query,
-      INFERRED_FROM_DYNAMODB_QUERY), streams (SCOPE.Operation/stream_op,
-      INFERRED_FROM_DYNAMODB_STREAM), single-table design (SCOPE.Pattern,
-      INFERRED_FROM_DYNAMODB_SINGLE_TABLE).

--- a/internal/engine/rules/swift/orms/grdb.yaml
+++ b/internal/engine/rules/swift/orms/grdb.yaml
@@ -25,12 +25,3 @@ orms:
 
     '
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: GRDB DatabaseQueue/DatabasePool connections
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/rules/swift/orms/mysql_swift.yaml
+++ b/internal/engine/rules/swift/orms/mysql_swift.yaml
@@ -20,13 +20,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.mysql.mysql_extractor"
-    function: "extract"
-    description: >
-      Cross-language MySQL extractor: driver connections
-      (SCOPE.Service, INFERRED_FROM_MYSQL_DRIVER), stored procedure CALL
-      (SCOPE.Operation/procedure, INFERRED_FROM_MYSQL_PROCEDURE), prepared
-      statements (SCOPE.Operation/prepared, INFERRED_FROM_MYSQL_PREPARED),
-      embedded SQL table extraction
-      (SCOPE.Operation/query, INFERRED_FROM_MYSQL_QUERY).

--- a/internal/engine/rules/swift/orms/neo4j.yaml
+++ b/internal/engine/rules/swift/orms/neo4j.yaml
@@ -23,10 +23,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.neo4j.neo4j_extractor"
-    function: "extract"
-    description: >
-      Cross-language Neo4j extractor: driver connections via Theo
-      (SCOPE.Service, INFERRED_FROM_NEO4J_DRIVER), Cypher queries
-      (SCOPE.Operation/query, INFERRED_FROM_NEO4J_CYPHER).

--- a/internal/engine/rules/swift/orms/postgresnio.yaml
+++ b/internal/engine/rules/swift/orms/postgresnio.yaml
@@ -21,12 +21,3 @@ file_conventions: []
 source_patterns: []
 relationship_rules: []
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.postgresql.postgresql_extractor"
-    function: "extract"
-    description: >
-      Cross-language PostgreSQL extractor: PostgresConnection.connect /
-      PostgresClient connections (SCOPE.Service, INFERRED_FROM_POSTGRES_DRIVER),
-      LISTEN/NOTIFY (SCOPE.Operation/pubsub, INFERRED_FROM_POSTGRES_NOTIFY),
-      COPY (SCOPE.Operation/copy_op, INFERRED_FROM_POSTGRES_COPY), embedded SQL
-      (SCOPE.Operation/query, INFERRED_FROM_POSTGRES_QUERY).

--- a/internal/engine/rules/swift/orms/sqlite_swift.yaml
+++ b/internal/engine/rules/swift/orms/sqlite_swift.yaml
@@ -20,12 +20,3 @@ orms:
     import SQLite and Connection(...) construction. Commonly used in
     iOS/macOS apps that want SQL control without an ORM.
 
-custom_extractors:
-  - module: "archigraph.engine.rules.languages.sqlite.sqlite_extractor"
-    function: "extract"
-    description: >
-      Cross-language SQLite extractor: SQLite.swift Connection()
-      (SCOPE.Service, INFERRED_FROM_SQLITE_DRIVER), WAL mode
-      (SCOPE.Pattern, INFERRED_FROM_SQLITE_WAL), FTS virtual tables
-      (SCOPE.Schema/fts, INFERRED_FROM_SQLITE_FTS). In-memory databases
-      flagged with is_in_memory=true.

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -17,8 +17,6 @@ type FrameworkRule struct {
 	SourcePatterns []SourcePattern `yaml:"source_patterns"`
 	// RelationshipRules maps regex patterns to relationship edges.
 	RelationshipRules []RelationshipRule `yaml:"relationship_rules"`
-	// CustomExtractors references Go functions for complex extraction logic.
-	CustomExtractors []CustomExtractor `yaml:"custom_extractors"`
 }
 
 // FileConvention describes a file naming pattern for a framework.
@@ -72,15 +70,4 @@ type RelationshipRule struct {
 	SourceGroup int `yaml:"source_group"`
 	// TargetGroup is the regex capture group index for the target entity name.
 	TargetGroup int `yaml:"target_group"`
-}
-
-// CustomExtractor references a Go function for framework-specific extraction
-// that goes beyond what regex patterns can handle.
-type CustomExtractor struct {
-	// Module is a legacy module path retained for YAML compatibility, unused in Go.
-	Module string `yaml:"module"`
-	// Function is the function name within the module.
-	Function string `yaml:"function"`
-	// Description documents what the extractor does.
-	Description string `yaml:"description"`
 }


### PR DESCRIPTION
Implements the **REMOVE** half (#3636 P1) of the accepted ADR-0021 (`docs/adrs/0021-engine-custom-extractors-rescue-remove-extend.md`).

## What
The `custom_extractors:` YAML block was a 100%-dead mechanism: `FrameworkRule.CustomExtractors` was parsed by the loader but **read nowhere** (`grep -rn '\.CustomExtractors'` returned only the struct definition). The Go extractors those blocks named already run via the live `internal/custom` registry pipeline, so deleting them loses nothing at runtime.

## Changes
- **222 rule YAML files** — surgically removed the `custom_extractors:` block (key + its sequence items + directly-preceding `# custom_extractors:` comment headers). The rest of each file is byte-exact. Handles all three layouts: column-0 blocks, blocks nested under a non-FrameworkRule wrapper key (e.g. `orms_database:`), and sequence items at the same indent as the key.
- **`internal/engine/schema.go`** — removed the `CustomExtractors` field from `FrameworkRule` and the `CustomExtractor` struct type (13 lines).
- **Prose migration** — migrated the `gin.yaml` description into a doc-comment on `ginExtractor` (gin.go previously had no type/header doc). Other Go extractors (dynamodb, elasticsearch, …) already carry accurate file-level headers, and their YAML descriptions were aspirational/inaccurate (named SCOPE kinds the code does not emit), so that prose was intentionally **not** migrated.
- **Guard** — added `TestRules_NoCustomExtractors` (cite-validity guard) that walks the embedded rules FS and fails if any YAML reintroduces a `custom_extractors` key/comment.
- **ADR** — marked Accepted and renumbered `docs/adr/ENGINE-rescue-vs-remove.md` → `docs/adrs/0021-engine-custom-extractors-rescue-remove-extend.md` to match the `docs/adrs/NNNN-…` convention.

## Loader strictness
The loader uses plain `yaml.Unmarshal` (no `KnownFields(true)`) — **lenient**, so unknown fields are silently ignored. Removing the struct field alone would not break loading; the dead YAML data is removed too for hygiene and so the guard can enforce it.

## Verification
- `go build ./...` — clean
- `go test ./internal/engine/... ./internal/custom/... ./internal/extractors/` — **all pass** (forced `-count=1`)
- `gofmt -l` clean, `go vet ./internal/engine/...` clean
- **Rule-load count unchanged: 532 before and 532 after** (no file dropped from loading; all 222 still parse)

Did **not** touch `docs/coverage/registry.json` (owned by #3625). Did not touch the live `internal/extractors` `CustomExtractorRegistry` — that is a different, in-use mechanism.

EXTEND (#3636 P2–P4) deferred. **DEPLOY-DEFERRED.**

Closes #3636

🤖 Generated with [Claude Code](https://claude.com/claude-code)