### PR TITLE
mcp: neighbors surfaces all edge kinds both directions + labels kind (#4242)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -201,6 +201,16 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		SourceFile string `json:"file,omitempty"`
 		StartLine  int    `json:"line,omitempty"`
 		HopCount   int    `json:"hop_count"`
+		// EdgeKind is the on-graph relationship kind of the inbound edge via
+		// which this caller was discovered (CALLS, INJECTED_INTO, THROWS,
+		// CATCHES, REFERENCES, IMPORTS, …). #4242: pre-fix, find_callers only
+		// walked inboundRefKinds (CALLS/REFERENCES/IMPORTS/TESTS/…), silently
+		// dropping every non-CALLS semantic predecessor (INJECTED_INTO, THROWS,
+		// CATCHES, JOINS_COLLECTION, …) that the callees/out side already
+		// surfaces — so the rewrite oracle falsely concluded those edges were
+		// unmodeled. The walk now includes all semantic kinds AND labels the
+		// kind per neighbor so a consumer can tell INJECTED_INTO from CALLS.
+		EdgeKind string `json:"edge_kind,omitempty"`
 		// ViaInherits marks a caller reached by a reverse-INHERITS hop (#3834):
 		// an inheriting subclass stub that exposes this (base) member's
 		// behaviour, not a direct CALLS-site of it.
@@ -248,7 +258,13 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			next := []string{}
 			for _, n := range frontier {
 				for _, e := range adj.in[n] {
-					if !inboundRefKinds[e.kind] {
+					// #4242: accept every semantic predecessor edge, not just the
+					// inboundRefKinds allow-list. The out/callees side already
+					// surfaces all kinds; mirroring it here is what makes the
+					// reverse direction symmetric. Pure-structural edges
+					// (CONTAINS — every entity is contained by its module) carry
+					// no caller signal and stay excluded (see #1915).
+					if !isInboundNeighborKind(e.kind) {
 						continue
 					}
 					if _, seen := visited[e.target]; seen {
@@ -312,6 +328,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 					EntityID: prefixedID(r.Repo, id),
 					Name:     name,
 					HopCount: d,
+					EdgeKind: dk, // #4242: label the discovering edge kind.
 					isTest:   isTestFileMCP(id),
 				})
 				continue
@@ -347,6 +364,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 				SourceFile: e.SourceFile,
 				StartLine:  e.StartLine,
 				HopCount:   d,
+				EdgeKind:   dk, // #4242: label the discovering edge kind.
 				isTest:     isTestFileMCP(e.SourceFile),
 			}
 			if isInheritsEdge {
@@ -525,6 +543,11 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		SourceFile string `json:"file,omitempty"`
 		StartLine  int    `json:"line,omitempty"`
 		HopCount   int    `json:"hop_count"`
+		// EdgeKind is the on-graph relationship kind of the outbound edge via
+		// which this callee was discovered (CALLS, INJECTED_INTO, THROWS, …).
+		// #4242: symmetric with the callers side so a consumer can tell an
+		// INJECTED_INTO callee from a CALLS one.
+		EdgeKind string `json:"edge_kind,omitempty"`
 		// ViaInherits marks a callee reached by hopping through an inherited
 		// member's INHERITS edge (#3834) — i.e. the node is a defining base/
 		// mixin member, not a direct CALLS target of the queried entity.
@@ -559,6 +582,10 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		visited := map[string]int{target: 0}
 		mroExternal := map[string]*graph.Entity{}
 		mroVia := map[string]bool{}
+		// discoveredVia[id] = on-graph edge kind via which `id` was first reached
+		// on the outbound BFS — used to label each callee with its edge_kind so
+		// the out side is symmetric with the callers side (#4242).
+		discoveredVia := map[string]string{}
 		frontier := []string{target}
 		for d := 0; d < depth; d++ {
 			next := []string{}
@@ -568,6 +595,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 						continue
 					}
 					visited[e.target] = d + 1
+					discoveredVia[e.target] = e.kind
 					next = append(next, e.target)
 				}
 				for _, me := range mroOutboundEdges(r, n) {
@@ -576,6 +604,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 					}
 					visited[me.Target] = d + 1
 					mroVia[me.Target] = true
+					discoveredVia[me.Target] = inheritsEdgeKind // #4242
 					if me.External && me.Contract != nil {
 						mroExternal[me.Target] = me.Contract
 					}
@@ -610,6 +639,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 				SourceFile: e.SourceFile,
 				StartLine:  e.StartLine,
 				HopCount:   d,
+				EdgeKind:   discoveredVia[id], // #4242: label the discovering edge kind.
 				isTest:     isTestFileMCP(e.SourceFile),
 			}
 			if mroVia[id] {
@@ -1506,6 +1536,49 @@ var inboundRefKinds = map[string]bool{
 	"STEP_IN_PROCESS": true,
 	"PRODUCES":        true,
 	"CONSUMES":        true,
+}
+
+// inboundNeighborStructuralKinds are edge kinds that carry NO predecessor /
+// caller signal and must stay excluded from find_callers regardless of the
+// broadened semantic-edge acceptance (#4242). CONTAINS is the canonical case:
+// every entity is contained by its module/file, so a CONTAINS predecessor is
+// the structural parent, not a caller (preserves #1915 / the
+// TestFindCallers_ExcludesContainsEdges contract). DECLARES/DEFINES are the
+// same structural-ownership shape.
+var inboundNeighborStructuralKinds = map[string]bool{
+	"CONTAINS": true,
+	"DECLARES": true,
+	"DEFINES":  true,
+}
+
+// isInboundNeighborKind reports whether an inbound edge of the given kind
+// represents a real predecessor (caller / in-neighbor) of an entity for the
+// archigraph_neighbors(direction=in) / find_callers walk.
+//
+// #4242: the pre-fix walk used the inboundRefKinds allow-list only, which
+// covered CALLS/REFERENCES/IMPORTS/TESTS/… but DROPPED every non-CALLS semantic
+// predecessor — INJECTED_INTO, THROWS, CATCHES, JOINS_COLLECTION, DEPENDS_ON,
+// EXTENDS, INHERITS, … — even though the forward (callees/out) side already
+// surfaced all of them. That asymmetry made the rewrite oracle conclude those
+// edges were "unmodeled" when they exist on the graph. We now accept any edge
+// kind that is a known reference kind OR a projected semantic kind OR a
+// type/dependency relation, excluding only the pure-structural ownership edges
+// (CONTAINS/DECLARES/DEFINES). Mirrors the all-kinds out side.
+func isInboundNeighborKind(kind string) bool {
+	if inboundNeighborStructuralKinds[strings.ToUpper(kind)] {
+		return false
+	}
+	if inboundRefKinds[kind] {
+		return true
+	}
+	if isSemanticEdgeKind(kind) {
+		return true
+	}
+	switch strings.ToUpper(kind) {
+	case "EXTENDS", "INHERITS", "DEPENDS_ON", "IMPLEMENTS":
+		return true
+	}
+	return false
 }
 
 // deadMarkerRe matches conventional dead-code / deprecation name markers. A

--- a/internal/mcp/neighbors_all_edge_kinds_4242_test.go
+++ b/internal/mcp/neighbors_all_edge_kinds_4242_test.go
@@ -1,0 +1,214 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// neighbors4242Doc builds the fixture that reproduces the live deploy-10 bug
+// (#4242): non-CALLS edges were surfaced on the forward (callees/out) side but
+// silently dropped from the reverse (callers/in) side, and no edge was labelled
+// with its kind.
+//
+// Topology:
+//
+//	DevicesService    --INJECTED_INTO--> DevicesReadController   (NestJS DI)
+//	DeviceHandler     --THROWS-->        DeviceNotFoundException (error flow)
+//	OrderService      --CALLS-->         PaymentGateway          (control: CALLS)
+func neighbors4242Doc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "svc", Name: "DevicesService", Kind: "SCOPE.Component", SourceFile: "devices.service.ts", StartLine: 10},
+			{ID: "ctrl", Name: "DevicesReadController", Kind: "SCOPE.Component", SourceFile: "devices.read.controller.ts", StartLine: 5},
+			{ID: "handler", Name: "DeviceHandler", Kind: "SCOPE.Operation", SourceFile: "device.handler.ts", StartLine: 20},
+			{ID: "exc", Name: "DeviceNotFoundException", Kind: "SCOPE.Schema", SourceFile: "errors.ts", StartLine: 1},
+			{ID: "order", Name: "OrderService", Kind: "SCOPE.Operation", SourceFile: "order.service.ts", StartLine: 3},
+			{ID: "gateway", Name: "PaymentGateway", Kind: "SCOPE.Operation", SourceFile: "payment.ts", StartLine: 7},
+		},
+		[]graph.Relationship{
+			{FromID: "svc", ToID: "ctrl", Kind: "INJECTED_INTO"},
+			{FromID: "handler", ToID: "exc", Kind: "THROWS"},
+			{FromID: "order", ToID: "gateway", Kind: "CALLS"},
+		},
+	)
+}
+
+// findNeighbor returns the neighbor entry whose name matches, or nil.
+func findNeighbor(list []any, name string) map[string]any {
+	for _, item := range list {
+		if m, ok := item.(map[string]any); ok && m["name"] == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// TestNeighbors4242_InboundSurfacesInjectedInto is the headline non-vacuous
+// assertion: neighbors(Controller, direction=in) must return the Service that
+// was INJECTED_INTO it, labelled edge_kind=INJECTED_INTO. On the pre-fix code
+// the inbound walk was restricted to inboundRefKinds (CALLS/REFERENCES/…),
+// which excludes INJECTED_INTO, so callers came back empty — this test FAILS
+// on pre-fix code, proving it reproduces the live bug.
+func TestNeighbors4242_InboundSurfacesInjectedInto(t *testing.T) {
+	srv := newTestServer(t, neighbors4242Doc())
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ctrl",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	svc := findNeighbor(callers, "DevicesService")
+	if svc == nil {
+		t.Fatalf("INJECTED_INTO predecessor DevicesService missing from callers (the #4242 bug): %v", callers)
+	}
+	if svc["edge_kind"] != "INJECTED_INTO" {
+		t.Errorf("expected edge_kind=INJECTED_INTO, got %v", svc["edge_kind"])
+	}
+}
+
+// TestNeighbors4242_InboundSurfacesThrows asserts the THROWS error-flow edge is
+// reachable from the exception type via direction=in, labelled edge_kind=THROWS.
+// Also fails on pre-fix code (THROWS is not in inboundRefKinds).
+func TestNeighbors4242_InboundSurfacesThrows(t *testing.T) {
+	srv := newTestServer(t, neighbors4242Doc())
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "exc",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	h := findNeighbor(callers, "DeviceHandler")
+	if h == nil {
+		t.Fatalf("THROWS predecessor DeviceHandler missing from callers (the #4242 bug): %v", callers)
+	}
+	if h["edge_kind"] != "THROWS" {
+		t.Errorf("expected edge_kind=THROWS, got %v", h["edge_kind"])
+	}
+}
+
+// TestNeighbors4242_OutboundStillWorks proves the forward side is symmetric and
+// also labels the edge kind. neighbors(Service, direction=out) returns the
+// Controller it is INJECTED_INTO; neighbors(Handler, direction=out) returns the
+// exception it THROWS — each labelled with edge_kind.
+func TestNeighbors4242_OutboundStillWorks(t *testing.T) {
+	srv := newTestServer(t, neighbors4242Doc())
+
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "svc",
+		"depth":     float64(1),
+	})
+	callees, ok := out["callees"].([]any)
+	if !ok {
+		t.Fatalf("expected callees array, got %T", out["callees"])
+	}
+	ctrl := findNeighbor(callees, "DevicesReadController")
+	if ctrl == nil {
+		t.Fatalf("INJECTED_INTO callee DevicesReadController missing: %v", callees)
+	}
+	if ctrl["edge_kind"] != "INJECTED_INTO" {
+		t.Errorf("expected callee edge_kind=INJECTED_INTO, got %v", ctrl["edge_kind"])
+	}
+
+	out2 := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "handler",
+		"depth":     float64(1),
+	})
+	callees2, _ := out2["callees"].([]any)
+	exc := findNeighbor(callees2, "DeviceNotFoundException")
+	if exc == nil {
+		t.Fatalf("THROWS callee DeviceNotFoundException missing: %v", callees2)
+	}
+	if exc["edge_kind"] != "THROWS" {
+		t.Errorf("expected callee edge_kind=THROWS, got %v", exc["edge_kind"])
+	}
+}
+
+// TestNeighbors4242_CallsUnaffected asserts the existing CALLS behaviour is a
+// strict superset: a CALLS predecessor/successor still resolves on both sides
+// and is now labelled edge_kind=CALLS (additive, no field removed).
+func TestNeighbors4242_CallsUnaffected(t *testing.T) {
+	srv := newTestServer(t, neighbors4242Doc())
+
+	in := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "gateway",
+		"depth":     float64(1),
+	})
+	callers, _ := in["callers"].([]any)
+	order := findNeighbor(callers, "OrderService")
+	if order == nil {
+		t.Fatalf("CALLS caller OrderService regressed (missing): %v", callers)
+	}
+	if order["edge_kind"] != "CALLS" {
+		t.Errorf("expected edge_kind=CALLS, got %v", order["edge_kind"])
+	}
+
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "order",
+		"depth":     float64(1),
+	})
+	callees, _ := out["callees"].([]any)
+	gw := findNeighbor(callees, "PaymentGateway")
+	if gw == nil {
+		t.Fatalf("CALLS callee PaymentGateway regressed (missing): %v", callees)
+	}
+	if gw["edge_kind"] != "CALLS" {
+		t.Errorf("expected callee edge_kind=CALLS, got %v", gw["edge_kind"])
+	}
+}
+
+// TestNeighbors4242_BothMergesDirections asserts the unified neighbors(both)
+// tool merges the now-symmetric in/out sets: querying the Controller returns
+// the INJECTED_INTO Service under callers (the in side) — the exact shape the
+// rewrite oracle consumes.
+func TestNeighbors4242_BothMergesDirections(t *testing.T) {
+	srv := newTestServer(t, neighbors4242Doc())
+
+	out := callFlowTool(t, srv.handleNeighbors, map[string]any{
+		"entity_id": "ctrl",
+		"direction": "both",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array in both-merge, got %T (%v)", out["callers"], out)
+	}
+	if findNeighbor(callers, "DevicesService") == nil {
+		t.Fatalf("direction=both dropped the INJECTED_INTO caller DevicesService: %v", out)
+	}
+}
+
+// TestNeighbors4242_ContainsStillExcluded guards the #1915 contract: the
+// broadened acceptance must NOT let a structural CONTAINS parent leak back in
+// as a caller.
+func TestNeighbors4242_ContainsStillExcluded(t *testing.T) {
+	doc := minDoc(
+		[]graph.Entity{
+			{ID: "file", Name: "mod.ts", Kind: "SCOPE.Component", SourceFile: "mod.ts"},
+			{ID: "fn", Name: "doThing", Kind: "SCOPE.Operation", SourceFile: "mod.ts", StartLine: 4},
+			{ID: "real", Name: "RealCaller", Kind: "SCOPE.Operation", SourceFile: "caller.ts", StartLine: 2},
+		},
+		[]graph.Relationship{
+			{FromID: "file", ToID: "fn", Kind: "CONTAINS"},
+			{FromID: "real", ToID: "fn", Kind: "CALLS"},
+		},
+	)
+	srv := newTestServer(t, doc)
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "fn",
+		"depth":     float64(1),
+	})
+	callers, _ := out["callers"].([]any)
+	if findNeighbor(callers, "mod.ts") != nil {
+		t.Errorf("CONTAINS parent mod.ts leaked into callers: %v", callers)
+	}
+	if findNeighbor(callers, "RealCaller") == nil {
+		t.Errorf("real CALLS caller missing: %v", callers)
+	}
+}


### PR DESCRIPTION
Closes #4242 (epic #3648). **DEPLOY-DEFERRED.**

## The bug (verified live on deploy-10)
`archigraph_neighbors(direction=in)` / `find_callers` walked only the `inboundRefKinds` allow-list (CALLS/REFERENCES/IMPORTS/TESTS/ROUTES_TO/…). Every **non-CALLS semantic predecessor** — INJECTED_INTO, THROWS, CATCHES, JOINS_COLLECTION, DEPENDS_ON, EXTENDS, … — was silently dropped on the reverse side, even though the forward (callees/out) side already surfaced all of them (no allow-list there).

Result: `neighbors(DevicesReadController, direction=in)` returned `callers:[]` while `neighbors(DevicesService, direction=out)` returned its INJECTED_INTO controllers — the **same edges**, asymmetric. The rewrite oracle therefore concluded NestJS controller-DI and THROWS were "unmodeled" when 215 INJECTED_INTO + 336 THROWS + 124 CATCHES edges exist on the live graph.

## Fix
1. **Adjacency walk** — replaced the inbound allow-list filter with `isInboundNeighborKind()`: accepts any reference OR projected-semantic (`isSemanticEdgeKind`, which covers INJECTED_INTO/THROWS/CATCHES/JOINS_COLLECTION/DEPENDS_ON_*/…) OR type/dependency edge (EXTENDS/INHERITS/DEPENDS_ON/IMPLEMENTS), excluding only pure-structural ownership edges (CONTAINS/DECLARES/DEFINES). This mirrors the all-kinds out side and preserves the #1915 "CONTAINS is not a caller" contract.
2. **Kind label** — added an additive `edge_kind` field to each caller/callee entry (the on-graph relationship kind of the discovering edge). Both directions now track and emit it, so a consumer can tell INJECTED_INTO from CALLS. **No existing field removed** — the callers/callees JSON shape stays backward-compatible.

## Schema change (backward-compatible)
`{id, name, kind?, repo?, file?, line?, hop_count, via_inherits?}` → adds `edge_kind` (`omitempty`). Token-budget-friendly (only emitted when known).

## Test — `internal/mcp/neighbors_all_edge_kinds_4242_test.go`
Fixture: `Service --INJECTED_INTO--> Controller`, `Handler --THROWS--> ExceptionType`, `OrderService --CALLS--> PaymentGateway` (control).
- `neighbors(Controller, in)` → Service with `edge_kind=INJECTED_INTO`
- `neighbors(ExceptionType, in)` → Handler with `edge_kind=THROWS`
- out side symmetric + labelled; CALLS unaffected both directions; `direction=both` merges; CONTAINS still excluded.

**Non-vacuous proof:** reverting the in-side filter to `inboundRefKinds[e.kind]` makes the three inbound tests FAIL with `callers:[]` — the exact live symptom — then pass with the fix restored.

## Gates
`go build ./...` ✓ · `go test ./internal/mcp/...` ✓ (full suite) · `gofmt -l` clean · `go vet ./internal/mcp/...` clean · no new imports / no import cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)