### PR TITLE
mcp: effective_contract resolves via existing EXTENDS edges (#4243)

### DIFF
--- a/internal/mcp/effective_contract_extends_4243_test.go
+++ b/internal/mcp/effective_contract_extends_4243_test.go
@@ -1,0 +1,168 @@
+package mcp
+
+// effective_contract_extends_4243_test.go — regression coverage for #4243.
+//
+// THE BUG (verified live on upvate-core): archigraph_effective_contract is
+// normally called with an entity_id. When that entity_id resolved to a DRF
+// ViewSet that the Python extractor emits as Kind="View" with an EMPTY subtype
+// (so isClassEntity is false for it), resolveEffectiveContractTarget matched
+// neither the router-route branch nor the class-entity branch and fell through
+// to the raw-leaf fallback. For a hex / "<repo>::<id>" entity_id that leaf is
+// the id itself (no dot to split), so wantVS never matched any route's ViewSet
+// name and the tool returned groups:null with a misleading "reindex may help"
+// note — even though the router-expanded routes (and the ViewSet's EXTENDS edge
+// to ModelViewSet) were present in the index all along.
+//
+// These tests reproduce that null result on the pre-fix resolver and assert the
+// post-fix tool returns the per-verb contract for ALL THREE target forms a
+// caller might pass: the bare class name, the LOCAL entity id, and the
+// "<repo>::<localid>" prefixed entity id.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// drfViewKindViewSetDoc mirrors the live upvate-core shape: a JurisdictionViewSet
+// emitted as Kind="View", Subtype="" (NOT a SCOPE.Component/class), an EXTENDS
+// edge to viewsets.ModelViewSet (base_name carries the dotted attribute form the
+// external synthesiser rewrites the ToID away from), and a couple of
+// router-expanded routes attributed to it via drf_view_method.
+func drfViewKindViewSetDoc() *graph.Document {
+	route := func(id string, props map[string]string) graph.Entity {
+		p := map[string]string{"pattern_type": "drf_router_expanded", "framework": "django"}
+		for k, v := range props {
+			p[k] = v
+		}
+		return graph.Entity{ID: id, Name: id, Kind: "http_endpoint", Language: "python", Properties: p}
+	}
+	return &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			// The ViewSet — Kind="View", empty subtype, exactly as the Python
+			// extractor emits it on upvate-core. isClassEntity is FALSE for it.
+			{ID: "vs1", Name: "JurisdictionViewSet",
+				QualifiedName: "core.views.jurisdiction_viewset.JurisdictionViewSet",
+				Kind:          "View", Subtype: "", SourceFile: "core/views/jurisdiction_viewset.py",
+				StartLine: 22, EndLine: 22, Language: "python"},
+			// The pack-recognised base, rewritten to an ext: placeholder named
+			// after the import module root — the live "ext:viewsets" shape.
+			{ID: "ext:viewsets", Name: "viewsets", QualifiedName: "viewsets",
+				Kind: "SCOPE.External", Language: "python"},
+			// INHERITED create — the #278 contract, stamped by the engine.
+			route("http:create", map[string]string{
+				"verb": "POST", "path": "/api/v1/jurisdictions",
+				"drf_view_method":          "JurisdictionViewSet.create",
+				"effective_kind":           "inherited",
+				"effective_source_class":   "CreateModelMixin",
+				"effective_status":         "201",
+				"effective_error_statuses": "400",
+			}),
+			// INHERITED list.
+			route("http:list", map[string]string{
+				"verb": "GET", "path": "/api/v1/jurisdictions",
+				"drf_view_method":        "JurisdictionViewSet.list",
+				"effective_kind":         "inherited",
+				"effective_source_class": "ListModelMixin",
+				"effective_status":       "200",
+			}),
+		},
+		Relationships: []graph.Relationship{
+			// The ViewSet EXTENDS edge — base_name is the dotted "viewsets.ModelViewSet"
+			// the hierarchy extractor records (its leaf, ModelViewSet, is what the
+			// baseknowledge pack matches), while ToID points at the ext: placeholder.
+			{FromID: "vs1", ToID: "ext:viewsets", Kind: "EXTENDS",
+				Properties: map[string]string{"language": "python", "base_name": "viewsets.ModelViewSet"}},
+		},
+	}
+}
+
+// TestEffectiveContract_4243_ResolvesByEntityIDForms asserts the tool returns the
+// per-verb contract for a Kind="View" DRF ViewSet whether the caller passes the
+// bare class name, the local entity id, or the "<repo>::<id>" prefixed id.
+//
+// NON-VACUOUS: on the pre-fix resolver the two id forms returned groups:null
+// (see TestEffectiveContract_4243_PreFixResolverReturnedNull below, which
+// asserts the OLD raw-leaf behaviour that this fix removes).
+func TestEffectiveContract_4243_ResolvesByEntityIDForms(t *testing.T) {
+	srv := newTestServer(t, drfViewKindViewSetDoc())
+
+	for _, target := range []string{
+		"JurisdictionViewSet", // bare class name (already worked pre-fix)
+		"vs1",                 // LOCAL entity id (returned null pre-fix)
+		"upvate-core::vs1",    // prefixed entity id (returned null pre-fix)
+	} {
+		t.Run(target, func(t *testing.T) {
+			out := callEffectiveContract(t, srv, target)
+			if len(out.Groups) != 1 {
+				t.Fatalf("target %q: expected 1 group, got %d (note=%q)", target, len(out.Groups), out.Note)
+			}
+			g := out.Groups[0]
+			if g.Class != "JurisdictionViewSet" {
+				t.Errorf("target %q: group class = %q; want JurisdictionViewSet", target, g.Class)
+			}
+			if len(g.Handlers) != 2 {
+				t.Fatalf("target %q: expected 2 per-verb handlers, got %d: %+v", target, len(g.Handlers), g.Handlers)
+			}
+			create := handlerByVerbPath(t, g, "POST", "/api/v1/jurisdictions")
+			if create.Kind != "inherited" || create.SourceClass != "CreateModelMixin" || create.DefaultStatus != 201 {
+				t.Errorf("target %q: create contract = {kind:%q source:%q status:%d}; want {inherited CreateModelMixin 201}",
+					target, create.Kind, create.SourceClass, create.DefaultStatus)
+			}
+			if len(create.ErrorStatuses) != 1 || create.ErrorStatuses[0] != 400 {
+				t.Errorf("target %q: create error_statuses = %v; want [400]", target, create.ErrorStatuses)
+			}
+			list := handlerByVerbPath(t, g, "GET", "/api/v1/jurisdictions")
+			if list.Kind != "inherited" || list.DefaultStatus != 200 {
+				t.Errorf("target %q: list contract = {kind:%q status:%d}; want {inherited 200}", target, list.Kind, list.DefaultStatus)
+			}
+		})
+	}
+}
+
+// TestEffectiveContract_4243_PreFixResolverReturnedNull proves the bug was real
+// and the fix is non-vacuous: it reconstructs the OLD resolution semantics
+// (router-route OR class-entity branch only, then raw-leaf fallback) and shows
+// that a Kind="View" ViewSet's local id resolved to a wantVS that matches NO
+// route — the live groups:null. The current resolver (asserted above) fixes it.
+func TestEffectiveContract_4243_PreFixResolverReturnedNull(t *testing.T) {
+	doc := drfViewKindViewSetDoc()
+	srv := newTestServer(t, doc)
+	lg := srv.State.groups["test"]
+	r := lg.Repos["upvate-core"]
+
+	// OLD resolveEffectiveContractTarget: only the router-route and class-entity
+	// branches returned; everything else fell to the raw leaf. A Kind="View"
+	// ViewSet matched neither branch.
+	oldResolve := func(arg string) string {
+		for _, e := range r.LabelIndex.LookupAll(arg) {
+			if isRouterExpandedRoute(e) {
+				if vs := viewSetNameForRoute(e); vs != "" {
+					return strings.ToLower(vs)
+				}
+			}
+			if isClassEntity(e) {
+				return strings.ToLower(leafAfterDot(e.Name))
+			}
+		}
+		return strings.ToLower(leafAfterDot(arg)) // raw-leaf fallback
+	}
+
+	wantVS := oldResolve("vs1")
+	if wantVS == "jurisdictionviewset" {
+		t.Fatalf("pre-fix resolver should NOT have resolved the View-kind ViewSet id to its name; got %q", wantVS)
+	}
+	// And that broken wantVS matches none of the routes — the null result.
+	matched := 0
+	for i := range r.Doc.Entities {
+		e := &r.Doc.Entities[i]
+		if isRouterExpandedRoute(e) && strings.ToLower(viewSetNameForRoute(e)) == wantVS {
+			matched++
+		}
+	}
+	if matched != 0 {
+		t.Fatalf("pre-fix wantVS %q unexpectedly matched %d routes; the bug requires 0", wantVS, matched)
+	}
+}

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -92,29 +92,55 @@ func viewSetNameForRoute(e *graph.Entity) string {
 //
 //  1. The arg matches a router-expanded route entity → derive its ViewSet.
 //  2. The arg matches a class/component entity → use its leaf name.
-//  3. The arg matches no entity → treat the raw string's leaf as the ViewSet
+//  3. The arg matches ANY other entity (e.g. a DRF ViewSet the Python
+//     extractor emits as Kind="View" with an empty subtype, so isClassEntity is
+//     false for it) → use that entity's leaf name. A resolved entity_id is an
+//     explicit user target, so its own name is the ViewSet to group by — this
+//     is the #4243 fix: previously a ViewSet entity_id fell through to case 4
+//     and grouped by the raw (often hex / repo-prefixed) id, matching nothing.
+//  4. The arg matches no entity → treat the raw string's leaf as the ViewSet
 //     name (lets callers pass a bare class name that isn't itself indexed as a
 //     standalone entity, e.g. when only the routes carry it).
 //
+// The arg is matched both as given and with any "<repo>::" prefix stripped, so
+// a fully-prefixed entity_id (the form archigraph_effective_contract is
+// normally called with) resolves to its local entity — the LabelIndex is keyed
+// by LOCAL id (#4243).
+//
 // Returns the lower-cased ViewSet leaf to match routes against, plus the
-// resolved entity (may be nil for case 3).
+// resolved entity (may be nil for case 4).
 func resolveEffectiveContractTarget(lg *LoadedGroup, arg string) (string, *graph.Entity) {
+	// Candidate lookup keys: the raw arg, plus its local id if it carries a
+	// "<repo>::" prefix (LabelIndex.ByID is keyed by local id, not prefixed).
+	keys := []string{arg}
+	if _, local := splitPrefixed(arg); local != arg {
+		keys = append(keys, local)
+	}
 	for _, r := range reposToConsider(lg, nil) {
 		if r.LabelIndex == nil {
 			continue
 		}
-		for _, e := range r.LabelIndex.LookupAll(arg) {
-			if isRouterExpandedRoute(e) {
-				if vs := viewSetNameForRoute(e); vs != "" {
-					return strings.ToLower(vs), e
+		for _, key := range keys {
+			for _, e := range r.LabelIndex.LookupAll(key) {
+				if isRouterExpandedRoute(e) {
+					if vs := viewSetNameForRoute(e); vs != "" {
+						return strings.ToLower(vs), e
+					}
 				}
-			}
-			if isClassEntity(e) {
-				return strings.ToLower(leafAfterDot(e.Name)), e
+				if isClassEntity(e) {
+					return strings.ToLower(leafAfterDot(e.Name)), e
+				}
+				// Case 3: any other resolved entity (the Kind="View" DRF ViewSet
+				// case) — group by its own leaf name. An entity_id the caller
+				// passed IS the ViewSet; its name is the grouping key. Router
+				// entities are handled above, so this never hijacks a route.
+				if e.Name != "" {
+					return strings.ToLower(leafAfterDot(e.Name)), e
+				}
 			}
 		}
 	}
-	// Case 3: no entity matched — fall back to the raw leaf.
+	// Case 4: no entity matched — fall back to the raw leaf.
 	return strings.ToLower(leafAfterDot(arg)), nil
 }
 
@@ -230,11 +256,13 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 	}
 
 	if len(out.Groups) == 0 {
-		out.Note = "no effective contract resolvable for this ViewSet: neither " +
-			"router-expanded routes nor a ViewSet class entity with EXTENDS edges to " +
-			"a known framework base (e.g. ModelViewSet) were found in the index. " +
-			"Confirm the target is a DRF ViewSet and that its class is indexed; if the " +
-			"index predates the DRF expansion pass (#3964) a reindex may help."
+		out.Note = "no effective contract resolvable for \"" + target + "\": no " +
+			"router-expanded routes are attributed to this ViewSet, and its class " +
+			"entity carries no EXTENDS edge to a framework base the baseknowledge " +
+			"pack recognises (ModelViewSet / GenericViewSet / ReadOnlyModelViewSet / " +
+			"APIView / ViewSet). Verify the target resolves to the ViewSet itself " +
+			"(pass its entity_id or exact class name, not a method or module), that " +
+			"it is a DRF ViewSet, and that its base class is one the pack knows."
 	}
 	return jsonResult(out), nil
 }


### PR DESCRIPTION
Closes #4243 (epic #3648).

## Symptom
`archigraph_effective_contract` returned `groups: null` for DRF ViewSets (JurisdictionViewSet, UserProfileViewSet, jurisdictions http-endpoints) on a fresh full reindex of upvate-core, with a misleading note suggesting "a reindex may help" — despite 415 EXTENDS edges being present in the graph.

## Root cause
The tool is normally invoked with an `entity_id`. The Python extractor emits a DRF ViewSet as `Kind="View"` with an **empty subtype**, so `isClassEntity` is false for it. `resolveEffectiveContractTarget` matched neither the router-route branch nor the class-entity branch and fell through to the raw-leaf fallback. For a hex / `<repo>::<id>` entity_id that leaf is the id itself (no `.` to split on), so `wantVS` never matched any route's ViewSet name → empty groups → the misleading note.

The EXTENDS data was never the problem: the edge carries `base_name="viewsets.ModelViewSet"`, whose leaf `ModelViewSet` resolves cleanly through the baseknowledge pack (6 members). The 415 edges are real and traversable. The **target resolver** simply discarded the resolved `View` entity.

Verified against the live upvate-core@develop graph: passing the bare name `JurisdictionViewSet` already worked (13 handlers); passing the entity_id (`upvate-core::ad724058a62119a1` or local `ad724058a62119a1`) returned `groups:0` + the misleading note.

## Fix
- `resolveEffectiveContractTarget` now strips a `<repo>::` prefix before lookup (`LabelIndex.ByID` is keyed by the **local** id), and when a resolved entity is neither a router-route nor a class entity, groups by that entity's own leaf name — a resolved `entity_id` IS the ViewSet.
- Replaced the misleading "reindex may help" note with an accurate diagnostic for the genuine no-resolve case (names the recognised bases; tells the caller to target the ViewSet itself, not a method/module).

## Test (non-vacuous)
`effective_contract_extends_4243_test.go` reproduces the live shape (`Kind="View"` ViewSet + `EXTENDS->viewsets.ModelViewSet` + router-expanded routes) and asserts the per-verb contract resolves for all three target forms (bare name, local id, prefixed id), checking `kind`/`source_class`/`default_status`/`error_statuses`. A companion test pins the pre-fix raw-leaf behaviour. Reverting the source fix makes the two id-form subtests FAIL with exactly the live `groups:null` + old note, while the bare-name subtest still passes — matching the live observation.

## Gates
- `go build ./...` ✅
- `go test ./internal/mcp/...` ✅ (full package)
- `gofmt -l` clean ✅
- `go vet ./internal/mcp/` clean ✅

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)