### PR TITLE
engine: link $lookup DataAccess nodes to their JOINS_COLLECTION edges (#4244)

### DIFF
--- a/internal/engine/orm_queries_csharp_mongo_agg.go
+++ b/internal/engine/orm_queries_csharp_mongo_agg.go
@@ -146,6 +146,10 @@ func scanCSharpMongoAggregation(
 			return // dynamic from — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+		// #4244 — node-anchored twin so the join is reachable from the
+		// $lookup DataAccess node. entityName MUST match the emitStage Name.
+		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,
@@ -167,7 +171,7 @@ func scanCSharpMongoAggregation(
 			props["caller"] = caller
 		}
 		emitStage(types.EntityRecord{
-			Name:               fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx),
+			Name:               entityName,
 			Kind:               mongoAggStageEntityKind,
 			Subtype:            "$lookup",
 			SourceFile:         path,

--- a/internal/engine/orm_queries_csharp_mongo_agg_test.go
+++ b/internal/engine/orm_queries_csharp_mongo_agg_test.go
@@ -15,7 +15,15 @@ func runMongoAggCSharp(t *testing.T, src string) ([]types.EntityRecord, []types.
 	var rels []types.RelationshipRecord
 	scanCSharpMongoAggregation(src, funcs, "Services/BookService.cs", "csharp",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/engine/orm_queries_go_mongo_agg.go
+++ b/internal/engine/orm_queries_go_mongo_agg.go
@@ -146,6 +146,10 @@ func scanGoMongoAggregation(
 				props["caller"] = caller
 			}
 
+			// Stage entity Name — computed up front so the node-anchored
+			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
+			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+
 			switch op {
 			case "$lookup":
 				lk := mongoAggGoParseLookup(st)
@@ -161,6 +165,8 @@ func scanGoMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+					// #4244 — node-anchored twin.
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
 				}
 			case "$graphLookup":
 				lk := mongoAggGoParseLookup(st)
@@ -170,6 +176,8 @@ func scanGoMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+					// #4244 — node-anchored twin (graphLookup stage node).
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
 				}
 			case "$group":
 				if id, accs := mongoAggGoParseGroup(st); id != "" || accs != "" {
@@ -186,7 +194,6 @@ func scanGoMongoAggregation(
 				}
 			}
 
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
 			emitStage(types.EntityRecord{
 				Name:       name,
 				Kind:       mongoAggStageEntityKind,

--- a/internal/engine/orm_queries_go_mongo_agg_test.go
+++ b/internal/engine/orm_queries_go_mongo_agg_test.go
@@ -16,7 +16,15 @@ func runGoMongoAgg(t *testing.T, src string) ([]types.EntityRecord, []types.Rela
 	var rels []types.RelationshipRecord
 	scanGoMongoAggregation(src, funcs, "svc/agg.go", "go",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/engine/orm_queries_java_mongo_agg.go
+++ b/internal/engine/orm_queries_java_mongo_agg.go
@@ -157,6 +157,10 @@ func scanJavaSpringMongoAggregation(
 			return // dynamic from or unresolved collection — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+		// #4244 — node-anchored twin so the join is reachable from the
+		// $lookup DataAccess node. entityName MUST match the emitStage Name.
+		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,
@@ -178,7 +182,7 @@ func scanJavaSpringMongoAggregation(
 			props["caller"] = caller
 		}
 		emitStage(types.EntityRecord{
-			Name:               fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx),
+			Name:               entityName,
 			Kind:               mongoAggStageEntityKind,
 			Subtype:            "$lookup",
 			SourceFile:         path,

--- a/internal/engine/orm_queries_java_mongo_agg_test.go
+++ b/internal/engine/orm_queries_java_mongo_agg_test.go
@@ -15,7 +15,15 @@ func runMongoAggJava(t *testing.T, src string) ([]types.EntityRecord, []types.Re
 	var rels []types.RelationshipRecord
 	scanJavaSpringMongoAggregation(src, funcs, "svc/BookService.java", "java",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/engine/orm_queries_jsts_mongo_agg.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg.go
@@ -66,6 +66,7 @@ package engine
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -252,6 +253,10 @@ func mongoAggEmitStages(
 			props["caller"] = caller
 		}
 
+		// Stage entity Name — computed up front so the node-anchored
+		// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
+		name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+
 		switch op {
 		case "$lookup":
 			lk := mongoAggParseLookup(st)
@@ -267,6 +272,9 @@ func mongoAggEmitStages(
 					props["as"] = lk.as
 				}
 				emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+				// #4244 — node-anchored twin so the join is reachable from
+				// the $lookup DataAccess node.
+				emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
 			}
 		case "$graphLookup":
 			lk := mongoAggParseLookup(st)
@@ -276,6 +284,8 @@ func mongoAggEmitStages(
 					props["as"] = lk.as
 				}
 				emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+				// #4244 — node-anchored twin (graphLookup stage node).
+				emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
 			}
 		case "$group":
 			id, accs := mongoAggParseGroup(st)
@@ -291,7 +301,6 @@ func mongoAggEmitStages(
 			}
 		}
 
-		name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
 		emitStage(types.EntityRecord{
 			Name:       name,
 			Kind:       mongoAggStageEntityKind,
@@ -554,6 +563,56 @@ func mongoAggJoinEdge(fromColl string, lk mongoAggLookup, stageName string) type
 	}
 	return types.RelationshipRecord{
 		FromID:     fmt.Sprintf("Class:%s", capitalisedSingular(fromColl)),
+		ToID:       fmt.Sprintf("Class:%s", capitalisedSingular(lk.from)),
+		Kind:       mongoAggJoinEdgeKind,
+		Properties: props,
+	}
+}
+
+// mongoAggStageJoinEdge builds the NODE-ANCHORED twin of mongoAggJoinEdge: a
+// JOINS_COLLECTION edge whose FromID is the `$lookup` / `$graphLookup`
+// SCOPE.DataAccess STAGE entity itself (referenced by a Format-A structural-ref
+// stub keyed on the stage's source file + Name), and whose ToID is the same
+// `from`-collection Class the collection-anchored edge points at.
+//
+// WHY THIS EXISTS (#4244): the collection-anchored edge mongoAggJoinEdge emits
+// connects the aggregating Class → the looked-up Class. The per-stage
+// SCOPE.DataAccess node a consumer naturally `find`s ("inspections.aggregate#2
+// $lookup") was previously connected to NOTHING — fully isolated in both
+// directions — so the join target was not traversable from the node. This edge
+// makes `node → JOINS_COLLECTION → Class:<from>` a single direct hop. It does
+// NOT replace the collection-anchored edge (both fire); it adds the missing
+// node-side link so neighbors(stageNode) is non-empty.
+//
+// The FromID stub format is the resolver's Format A —
+//
+//	scope:<kind>:<subtype>:<lang>:<file_path>:<entity_name>
+//
+// — which the resolver rewrites to the stage entity's graph ID via its
+// byLocation[file][name] index (kind/subtype segments are advisory; the
+// file+name pair is the actual key, and the `#<idx>` suffix in the stage Name
+// keeps it unique per call site). Caller MUST pass the EXACT stage Name it
+// emitted for the entity, the stage's source-file path, and language.
+func mongoAggStageJoinEdge(stageName, stageFile, lang string, lk mongoAggLookup, stageOp string) types.RelationshipRecord {
+	props := map[string]string{
+		"pattern_type": mongoAggPatternType,
+		"stage":        stageOp,
+		// Flag the node-anchored twin so a reader (and any future de-dup
+		// pass) can tell it apart from the collection-anchored edge.
+		"anchor": "stage_node",
+	}
+	if lk.localField != "" {
+		props["local_field"] = lk.localField
+	}
+	if lk.foreignField != "" {
+		props["foreign_field"] = lk.foreignField
+	}
+	if lk.as != "" {
+		props["as"] = lk.as
+	}
+	return types.RelationshipRecord{
+		FromID: fmt.Sprintf("scope:dataaccess:%s:%s:%s:%s",
+			stageOp, strings.ToLower(lang), filepath.ToSlash(stageFile), stageName),
 		ToID:       fmt.Sprintf("Class:%s", capitalisedSingular(lk.from)),
 		Kind:       mongoAggJoinEdgeKind,
 		Properties: props,

--- a/internal/engine/orm_queries_jsts_mongo_agg_test.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg_test.go
@@ -16,7 +16,15 @@ func runMongoAgg(t *testing.T, src string) ([]types.EntityRecord, []types.Relati
 	var rels []types.RelationshipRecord
 	scanJSMongoAggregation(src, funcs, "svc/agg.js", "javascript",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/engine/orm_queries_mongo_agg_lookup_link_test.go
+++ b/internal/engine/orm_queries_mongo_agg_lookup_link_test.go
@@ -1,0 +1,141 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4244 — the `$lookup` SCOPE.DataAccess stage node was fully isolated: the
+// JOINS_COLLECTION edge connected the aggregating Class to the looked-up Class,
+// but NOTHING connected the per-stage node a consumer naturally `find`s
+// ("inspections.aggregate#N $lookup"). This test indexes a Python pymongo
+// aggregation carrying `$lookup: { from: "inspections_history", ... }` inside a
+// service method and asserts that, after reference resolution, a
+// JOINS_COLLECTION edge originates FROM the `$lookup` stage entity's graph ID —
+// i.e. the join target is reachable from the node `find` returns.
+//
+// NON-VACUOUS PROOF: the same body first asserts the PRE-FIX invariant — that
+// the ONLY JOINS_COLLECTION edge whose FromID resolves to the stage node is the
+// one mongoAggStageJoinEdge adds. We assert the Class-anchored edge (FromID
+// "Class:Inspection") STILL fires (no regression), AND that a SEPARATE
+// node-anchored edge exists whose FromID is the stage-node structural-ref stub.
+// Deleting the mongoAggStageJoinEdge calls makes the node-anchored assertions
+// fail (the stage node has zero outgoing edges — the original bug).
+func TestMongoAggPy_LookupNode_IsTraversableToJoin_4244(t *testing.T) {
+	src := `
+from pymongo import MongoClient
+
+class InspectionService:
+    def with_history(self, db):
+        pipeline = [
+            {"$lookup": {
+                "from": "inspections_history",
+                "localField": "_id",
+                "foreignField": "inspection_id",
+                "as": "history",
+            }},
+            {"$match": {"status": "open"}},
+        ]
+        return db.inspections.aggregate(pipeline)
+`
+	// Drive the scanner directly so we collect the UNFILTERED edge set,
+	// including the node-anchored twin (runMongoAggPy strips it).
+	funcs := indexEnclosingFunctions("python", src)
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	scanPythonMongoAggregation(src, funcs, "svc/agg.py", "python", nil,
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+
+	// Locate the $lookup stage entity the consumer would `find`.
+	lookupEnt := pyFindStage(ents, "$lookup")
+	if lookupEnt == nil {
+		t.Fatalf("expected a $lookup SCOPE.DataAccess stage entity; ents=%+v", ents)
+	}
+	if lookupEnt.Kind != string(types.EntityKindDataAccess) {
+		t.Fatalf("stage kind = %q, want SCOPE.DataAccess", lookupEnt.Kind)
+	}
+
+	// REGRESSION GUARD: the collection-anchored edge must still fire.
+	classEdge := pyFindJoinTo(rels, capitalisedSingular("inspections_history"))
+	if classEdge == nil {
+		t.Fatalf("expected a JOINS_COLLECTION edge to inspections_history; rels=%+v", rels)
+	}
+	if classEdge.FromID != "Class:"+capitalisedSingular("inspections") {
+		// The collection-anchored edge originates from the aggregating Class.
+		// (There are now two edges to the same target; ensure at least one is
+		// the Class-anchored form.)
+		var sawClassAnchored bool
+		for i := range rels {
+			r := &rels[i]
+			if r.Kind == string(types.RelationshipKindJoinsCollection) &&
+				r.ToID == "Class:"+capitalisedSingular("inspections_history") &&
+				r.FromID == "Class:"+capitalisedSingular("inspections") {
+				sawClassAnchored = true
+			}
+		}
+		if !sawClassAnchored {
+			t.Fatalf("collection-anchored JOINS_COLLECTION edge (Class:Inspection -> Class:Inspections_history) missing; rels=%+v", rels)
+		}
+	}
+
+	// THE FIX: find the node-anchored JOINS_COLLECTION edge whose FromID is the
+	// stage-node structural-ref stub (Format A: scope:dataaccess:...:<name>).
+	var nodeEdge *types.RelationshipRecord
+	for i := range rels {
+		r := &rels[i]
+		if r.Kind != string(types.RelationshipKindJoinsCollection) {
+			continue
+		}
+		if r.ToID != "Class:"+capitalisedSingular("inspections_history") {
+			continue
+		}
+		if strings.HasPrefix(r.FromID, "scope:dataaccess:") {
+			nodeEdge = r
+			break
+		}
+	}
+	if nodeEdge == nil {
+		t.Fatalf("PRE-FIX BUG: no node-anchored JOINS_COLLECTION edge from the $lookup stage node; the node is isolated. rels=%+v", rels)
+	}
+	// The stub must name THIS stage entity by file+name so the resolver binds
+	// it to the stage node and not something else.
+	if !strings.HasSuffix(nodeEdge.FromID, ":"+lookupEnt.Name) {
+		t.Fatalf("node-anchored FromID %q does not reference stage entity name %q", nodeEdge.FromID, lookupEnt.Name)
+	}
+
+	// END-TO-END PROOF: run the real reference resolver over the emitted
+	// entities + edges. After resolution the node-anchored edge's FromID MUST
+	// equal the $lookup stage entity's deterministic graph ID — i.e. the join
+	// is genuinely traversable FROM the node `find` returns, not a dangling
+	// stub. The stage entity carries the file+name the stub keys on.
+	//
+	// The real pipeline assigns each entity its deterministic graph ID before
+	// resolution; replicate that here (BuildIndex skips ID-less records).
+	for i := range ents {
+		ents[i].ID = ents[i].ComputeID()
+	}
+	idx := resolve.BuildIndex(ents)
+	resolve.References(rels, idx)
+
+	wantID := lookupEnt.ComputeID()
+	var resolvedNodeEdge *types.RelationshipRecord
+	for i := range rels {
+		r := &rels[i]
+		if r.Kind == string(types.RelationshipKindJoinsCollection) && r.FromID == wantID {
+			resolvedNodeEdge = r
+			break
+		}
+	}
+	if resolvedNodeEdge == nil {
+		t.Fatalf("after resolution no JOINS_COLLECTION edge originates from the $lookup stage node ID %q (node still isolated); rels=%+v", wantID, rels)
+	}
+	// And it points at the looked-up collection.
+	if resolvedNodeEdge.ToID == "" {
+		t.Fatalf("resolved node-anchored edge has empty ToID")
+	}
+}

--- a/internal/engine/orm_queries_php_mongo_agg.go
+++ b/internal/engine/orm_queries_php_mongo_agg.go
@@ -217,6 +217,10 @@ func scanPHPMongoAggregation(
 			return // dynamic from or unresolved collection — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, stageName))
+		// #4244 — node-anchored twin so the join is reachable from the
+		// $lookup DataAccess node. entityName MUST match the emitStage Name.
+		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, stageName))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,
@@ -238,7 +242,7 @@ func scanPHPMongoAggregation(
 			props["caller"] = caller
 		}
 		emitStage(types.EntityRecord{
-			Name:               fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx),
+			Name:               entityName,
 			Kind:               mongoAggStageEntityKind,
 			Subtype:            "$lookup",
 			SourceFile:         path,

--- a/internal/engine/orm_queries_php_mongo_agg_test.go
+++ b/internal/engine/orm_queries_php_mongo_agg_test.go
@@ -15,7 +15,15 @@ func runMongoAggPHP(t *testing.T, src string) ([]types.EntityRecord, []types.Rel
 	var rels []types.RelationshipRecord
 	scanPHPMongoAggregation(src, funcs, "src/BookService.php", "php",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -248,6 +248,11 @@ func scanPythonMongoAggregation(
 				props["caller"] = caller
 			}
 
+			// Stage entity Name — computed up front so the node-anchored
+			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity by
+			// its exact file+name in a Format-A structural-ref stub.
+			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+
 			switch op {
 			case "$lookup":
 				lk := mongoAggParseLookup(st)
@@ -263,6 +268,10 @@ func scanPythonMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+					// #4244 — also link the join FROM the $lookup DataAccess
+					// node so it is traversable (node → JOINS_COLLECTION →
+					// Class:<from>). Only when `from` is statically present.
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
 				}
 				// Correlated sub-pipeline join: a `$lookup` may carry a
 				// `pipeline: [ ... ]` whose own `$lookup` stages are NESTED joins
@@ -274,6 +283,9 @@ func scanPythonMongoAggregation(
 				// it). Bounded recursion over the static stage text — honest.
 				for _, nlk := range mongoAggCollectNestedLookups(st) {
 					emitJoin(mongoAggJoinEdge(coll, nlk, "lookup"))
+					// #4244 — node-anchored twin for each nested `from`, so the
+					// correlated joins are also reachable from the $lookup node.
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, nlk, "lookup"))
 				}
 			case "$graphLookup":
 				lk := mongoAggParseLookup(st)
@@ -283,6 +295,8 @@ func scanPythonMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+					// #4244 — node-anchored twin (graphLookup stage node).
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
 				}
 			case "$group":
 				id, accs := mongoAggParseGroup(st)
@@ -298,7 +312,6 @@ func scanPythonMongoAggregation(
 				}
 			}
 
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
 			emitStage(types.EntityRecord{
 				Name:       name,
 				Kind:       mongoAggStageEntityKind,

--- a/internal/engine/orm_queries_python_mongo_agg_builderjoin_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_builderjoin_test.go
@@ -107,7 +107,15 @@ def get_inspection_devices(params):
 	var rels []types.RelationshipRecord
 	scanPythonMongoAggregation(serviceSrc, funcs, servicePath, "python", resolver,
 		func(e types.EntityRecord) {},
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return rels
 }

--- a/internal/engine/orm_queries_python_mongo_agg_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_test.go
@@ -31,7 +31,19 @@ func runMongoAggPyXFile(
 	}
 	scanPythonMongoAggregation(src, funcs, "svc/agg.py", "python", resolver,
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — the scan now emits a NODE-ANCHORED JOINS_COLLECTION twin
+			// (FromID = the $lookup stage node, marked anchor=stage_node)
+			// alongside the historical collection-anchored edge. The existing
+			// assertions in this file count/inspect the collection-anchored
+			// edges only; strip the twin here so they remain meaningful. The
+			// twin itself is asserted by TestMongoAggPy_LookupNode_*_4244,
+			// which collects the unfiltered edge set directly.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }
@@ -1203,7 +1215,14 @@ def run(db):
 	var rels []types.RelationshipRecord
 	scanPythonMongoAggregation(serviceSrc, funcs, servicePath, "python", resolver,
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count assertion sees the collection-anchored edge set.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	if len(rels) != 1 {
 		t.Fatalf("expected 1 on-disk cross-file join edge, got %d: %+v", len(rels), rels)

--- a/internal/engine/orm_queries_ruby_mongoid_agg.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg.go
@@ -176,6 +176,10 @@ func scanRubyMongoidAggCalls(
 				props["caller"] = caller
 			}
 
+			// Stage entity Name — computed up front so the node-anchored
+			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
+			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+
 			switch op {
 			case "$lookup":
 				lk := mongoidParseLookup(st)
@@ -191,6 +195,8 @@ func scanRubyMongoidAggCalls(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+					// #4244 — node-anchored twin.
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
 				}
 			case "$graphLookup":
 				lk := mongoidParseLookup(st)
@@ -200,10 +206,11 @@ func scanRubyMongoidAggCalls(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+					// #4244 — node-anchored twin (graphLookup stage node).
+					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
 				}
 			}
 
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
 			emitStage(types.EntityRecord{
 				Name:       name,
 				Kind:       mongoAggStageEntityKind,

--- a/internal/engine/orm_queries_ruby_mongoid_agg_test.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg_test.go
@@ -15,7 +15,15 @@ func runMongoidAgg(t *testing.T, src string) ([]types.EntityRecord, []types.Rela
 	var rels []types.RelationshipRecord
 	scanRubyMongoidAggregation(src, funcs, "app/models/book.rb", "ruby",
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {
+			// #4244 — drop the node-anchored JOINS_COLLECTION twin so the
+			// count/identity assertions below see the collection-anchored
+			// edge set they were written against.
+			if r.Properties["anchor"] == "stage_node" {
+				return
+			}
+			rels = append(rels, r)
+		},
 	)
 	return ents, rels
 }

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1758,24 +1758,32 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// Format B: tail contains stubMemberDelim → (scope_name, member_name).
 	if hash := strings.IndexByte(tail, stubMemberDelim); hash >= 0 {
 		scopeName, memberName := tail[:hash], tail[hash+1:]
-		if scopeName == "" || memberName == "" {
-			return "", statusUnmatched, true
-		}
-		fileBucket := idx.byMember[filePath]
-		if fileBucket == nil {
-			return "", statusUnmatched, true
-		}
-		scopeBucket := fileBucket[scopeName]
-		if scopeBucket == nil {
-			return "", statusUnmatched, true
-		}
-		if id, ok := scopeBucket[memberName]; ok {
-			if id == "" {
-				return "", statusAmbiguous, true
+		// #4244 — an entity Name may legitimately CONTAIN '#' as a literal
+		// character rather than a scope/member separator. The Mongo
+		// aggregation pass names each pipeline-stage SCOPE.DataAccess node
+		// "<coll>.aggregate#<idx> <op>" (e.g. "inspections.aggregate#0
+		// $lookup"); a structural-ref to that node carries the '#' in its
+		// tail. Such a stub is Format A (the whole tail is the entity Name),
+		// not Format B. Only treat it as Format B when both halves are
+		// non-empty AND the byMember index actually has a matching member —
+		// otherwise fall through to the Format-A byLocation lookup below,
+		// which keys on the FULL tail (the real entity Name, '#' included).
+		// This is strictly additive: every previously-resolving Format-B stub
+		// still hits the byMember branch and returns first.
+		if scopeName != "" && memberName != "" {
+			if fileBucket := idx.byMember[filePath]; fileBucket != nil {
+				if scopeBucket := fileBucket[scopeName]; scopeBucket != nil {
+					if id, ok := scopeBucket[memberName]; ok {
+						if id == "" {
+							return "", statusAmbiguous, true
+						}
+						return id, statusRewritten, true
+					}
+				}
 			}
-			return id, statusRewritten, true
 		}
-		return "", statusUnmatched, true
+		// byMember miss (or empty half) — fall through to Format A so a
+		// '#'-bearing entity Name resolves via byLocation[file][fullTail].
 	}
 
 	// Format A: tail is the entity name. Try the kind-aware location


### PR DESCRIPTION
## Problem (#4244, epic #3648)

The Mongo aggregation pass emits, per `$lookup` / `$graphLookup` stage, a `SCOPE.DataAccess` node (e.g. `inspections.aggregate#2 $lookup`) **and** a `JOINS_COLLECTION` edge. But the edge connected the aggregating Class → looked-up Class; **nothing** connected the per-stage DataAccess node a consumer naturally `find`s. Verified live on deploy-10 / upvate-core@develop: 57 `JOINS_COLLECTION` edges exist, yet `neighbors($lookup node, both)` is empty in **both** directions — the node is fully isolated, so the join target isn't traversable from it.

## Root cause

`mongoAggJoinEdge` builds `Class:<AggColl> -> Class:<FromColl>`. The stage DataAccess entity (`<coll>.aggregate#<idx> <op>`) is never referenced by any edge endpoint, so it has zero edges.

## Fix

Option (a) — alongside the existing collection-anchored edge, emit a **node-anchored JOINS_COLLECTION twin** (`mongoAggStageJoinEdge`) whose `FromID` is a Format-A structural-ref stub keyed on the stage entity's source-file + Name. The resolver rewrites it to the stage node's graph ID, making `$lookup-node -> JOINS_COLLECTION -> Class:<from>` a single direct hop. Chosen because it mirrors how the existing edge already targets the `from`-collection Class, and keeps the Class-side edge **unchanged** (no regression). Only fires when `$lookup.from` is statically present. Applied to all six emitters: python, jsts, go, ruby, php, java, csharp.

Resolver change (`internal/resolve/refs.go`): an entity Name may legitimately contain `#` (the stage scheme uses `...aggregate#<idx>...`). The scope-stub resolver treated `#` as the Format-B scope/member delimiter and returned unmatched; it now falls through to the Format-A `byLocation` lookup (full tail) when the `byMember` probe misses. **Strictly additive** — every previously-resolving Format-B stub still returns first; `internal/resolve` tests stay green.

## Test (value-asserting, full-resolution)

`orm_queries_mongo_agg_lookup_link_test.go` indexes a pymongo aggregation with `$lookup:{from:"inspections_history"}` inside a service method, runs the **real reference resolver**, and asserts a `JOINS_COLLECTION` edge originates **FROM** the `$lookup` stage node's deterministic graph ID. Proven **non-vacuous**: disabling the node-anchored emit makes the test fail with the node isolated (only the Class-anchored edge remains). The existing mongo-agg harnesses filter the node-anchored twin so their count assertions stay meaningful — and those assertions confirm the **Class-side edges still fire**.

## Gates

- `go build ./...` clean
- `go test ./internal/engine/ ./internal/resolve/` fully passes
- `gofmt -l` + `go vet` clean on touched files/packages

DEPLOY-DEFERRED.

Closes #4244

🤖 Generated with [Claude Code](https://claude.com/claude-code)