### PR TITLE
engine: resolve $lookup node-anchored JOINS_COLLECTION to the actual DataAccess node id (#4244)

### DIFF
--- a/internal/engine/orm_queries_csharp_mongo_agg.go
+++ b/internal/engine/orm_queries_csharp_mongo_agg.go
@@ -58,7 +58,6 @@
 package engine
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -148,7 +147,9 @@ func scanCSharpMongoAggregation(
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
 		// #4244 — node-anchored twin so the join is reachable from the
 		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		// The `@L<line>` segment keeps the per-call-site stage node unique
+		// (see mongoAggStageName).
+		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
 		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{

--- a/internal/engine/orm_queries_go_mongo_agg.go
+++ b/internal/engine/orm_queries_go_mongo_agg.go
@@ -53,7 +53,6 @@
 package engine
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -148,7 +147,7 @@ func scanGoMongoAggregation(
 
 			// Stage entity Name — computed up front so the node-anchored
 			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+			name := mongoAggStageName(coll, callLine, idx, op)
 
 			switch op {
 			case "$lookup":

--- a/internal/engine/orm_queries_java_mongo_agg.go
+++ b/internal/engine/orm_queries_java_mongo_agg.go
@@ -54,7 +54,6 @@
 package engine
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -159,7 +158,9 @@ func scanJavaSpringMongoAggregation(
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
 		// #4244 — node-anchored twin so the join is reachable from the
 		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		// The `@L<line>` segment keeps the per-call-site stage node unique
+		// (see mongoAggStageName).
+		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
 		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{

--- a/internal/engine/orm_queries_jsts_mongo_agg.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg.go
@@ -81,6 +81,28 @@ const mongoAggPatternType = "mongo_aggregation"
 // lives in Subtype.
 var mongoAggStageEntityKind = string(types.EntityKindDataAccess)
 
+// mongoAggStageName builds the canonical Name for a single pipeline-stage
+// SCOPE.DataAccess entity, shared by every per-language Mongo-aggregation
+// emitter so the naming scheme stays identical across languages.
+//
+// Format: `<coll>.aggregate@L<callLine>#<stageIdx> <op>`
+//
+// The `@L<callLine>` segment is load-bearing (#4244 re-fix): the graph entity
+// ID is graph.EntityID(repo, kind, Name, file), which ignores StartLine and
+// the looked-up `from` collection. Without the call-line segment, two
+// `coll.aggregate(...)` calls on the SAME collection in the SAME file each
+// restart stage indexing at #0, so stage #N of one call and stage #N of the
+// other produce the IDENTICAL Name → IDENTICAL graph ID. That collapses two
+// DISTINCT `$lookup` stages (with different `from`) into ONE node, and the
+// node-anchored JOINS_COLLECTION twins from both stages pile onto it —
+// producing the cross-stage mis-link / "isolated-looking" node observed live
+// on upvate-core building/service.py (four `inspections_cln.aggregate(...)`
+// calls). The call line disambiguates the per-call-site stage so each node
+// owns exactly its own join.
+func mongoAggStageName(coll string, callLine, stageIdx int, op string) string {
+	return fmt.Sprintf("%s.aggregate@L%d#%d %s", coll, callLine, stageIdx, op)
+}
+
 // mongoAggJoinEdgeKind is the cross-collection join edge emitted for
 // $lookup / $graphLookup.
 var mongoAggJoinEdgeKind = string(types.RelationshipKindJoinsCollection)
@@ -255,7 +277,9 @@ func mongoAggEmitStages(
 
 		// Stage entity Name — computed up front so the node-anchored
 		// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
-		name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+		// The `@L<callLine>` segment keeps the per-call-site stage node unique
+		// (see mongoAggStageName).
+		name := mongoAggStageName(coll, callLine, idx, op)
 
 		switch op {
 		case "$lookup":

--- a/internal/engine/orm_queries_mongo_agg_multi_lookup_link_test.go
+++ b/internal/engine/orm_queries_mongo_agg_multi_lookup_link_test.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4244 RE-FIX — the original #4247 fixture used a SINGLE `$lookup`, so it
+// never exercised the production failure observed live on upvate-core
+// (building/service.py): a file with SEVERAL `coll.aggregate(...)` calls on the
+// SAME collection. Each call independently restarts pipeline-stage indexing at
+// #0, and the graph entity ID is graph.EntityID(repo, kind, Name, file) — which
+// IGNORES StartLine AND the looked-up `from`. With the old Name scheme
+// (`<coll>.aggregate#<idx> <op>`), stage #N of call A and stage #N of call B
+// produced the IDENTICAL Name → IDENTICAL graph ID, COLLAPSING two distinct
+// `$lookup` stages (different `from`) into ONE node. That node then carried the
+// node-anchored JOINS_COLLECTION twins of BOTH stages, so neighbors(node)
+// returned a CROSS-STAGE mix — and the `find`-able stage node was effectively
+// unusable. The single-lookup fixture could never catch this.
+//
+// This test reproduces the REAL shape: two aggregations on `db.inspections`,
+// each with a `$lookup` at the SAME stage index but a DISTINCT `from`. It
+// stamps IDs exactly like production (graph.EntityID) and runs the REAL
+// resolver, then asserts:
+//
+//   - the two `$lookup` stages occupy DISTINCT graph nodes (no collapse), and
+//   - each `$lookup` node has a JOINS_COLLECTION edge to ITS OWN `from`
+//     collection and to NO OTHER collection (no cross-stage mis-link).
+//
+// NON-VACUOUS PROOF: under the pre-fix Name scheme the two stages share an ID,
+// so the distinctness assertion fails AND each surviving node carries BOTH
+// joins — the assertions below fail on origin/main and pass only after the
+// `@L<callLine>` Name segment is added (mongoAggStageName).
+func TestMongoAggPy_MultiLookupSameCollection_NoCollapse_4244(t *testing.T) {
+	src := `
+from pymongo import MongoClient
+
+class InspectionService:
+    def report_a(self, db):
+        pipeline = [{"$match": {"x": 1}}, {"$lookup": {"from": "buildings", "as": "b"}}]
+        return db.inspections.aggregate(pipeline)
+
+    def report_b(self, db):
+        pipeline = [{"$match": {"y": 2}}, {"$lookup": {"from": "contracts", "as": "c"}}]
+        return db.inspections.aggregate(pipeline)
+`
+	const path = "core/services/inspection/service.py"
+	const repoTag = "upvate-core"
+
+	funcs := indexEnclosingFunctions("python", src)
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	scanPythonMongoAggregation(src, funcs, path, "python", nil,
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+
+	// Stamp IDs exactly as production does (cmd/archigraph stampEntityIDs).
+	for i := range ents {
+		if ents[i].Name == "" {
+			continue
+		}
+		ents[i].ID = graph.EntityID(repoTag, ents[i].Kind, ents[i].Name, ents[i].SourceFile)
+	}
+
+	// Collect the two $lookup stage nodes by their `from` (via the looked-up
+	// collection recorded on the node-anchored twin before resolution).
+	type lookupNode struct {
+		id   string
+		from string // the Class the node SHOULD (and only should) join
+	}
+	var lookups []lookupNode
+	for i := range ents {
+		e := &ents[i]
+		if e.Subtype != "$lookup" {
+			continue
+		}
+		// Find the node-anchored twin whose stub names THIS entity, to learn
+		// its intended `from` target.
+		var to string
+		for j := range rels {
+			r := &rels[j]
+			if r.Properties["anchor"] != "stage_node" {
+				continue
+			}
+			// The stub FromID ends with ":<entity Name>".
+			if len(r.FromID) >= len(e.Name) && r.FromID[len(r.FromID)-len(e.Name):] == e.Name {
+				to = r.ToID
+			}
+		}
+		lookups = append(lookups, lookupNode{id: e.ID, from: to})
+	}
+	if len(lookups) != 2 {
+		t.Fatalf("expected 2 $lookup stage entities, got %d (ents=%+v)", len(lookups), ents)
+	}
+
+	// (1) NO COLLAPSE: the two stages must have DISTINCT graph IDs. Pre-fix
+	// they share an ID because Name (= aggregate#1 $lookup for both) + file +
+	// kind are identical.
+	if lookups[0].id == lookups[1].id {
+		t.Fatalf("COLLAPSE: the two $lookup stages share graph ID %s — distinct stages merged into one node (pre-fix #4244 bug)", lookups[0].id)
+	}
+	if lookups[0].from == lookups[1].from || lookups[0].from == "" || lookups[1].from == "" {
+		t.Fatalf("test setup: expected two distinct non-empty `from` targets, got %q and %q", lookups[0].from, lookups[1].from)
+	}
+
+	// Run the REAL resolver over the emitted edges.
+	idx := resolve.BuildIndex(ents)
+	resolve.References(rels, idx)
+
+	// (2) NO CROSS-STAGE MIS-LINK: each $lookup node's outgoing
+	// node-anchored JOINS_COLLECTION edges must point ONLY at its own `from`.
+	for _, ln := range lookups {
+		var targets []string
+		for j := range rels {
+			r := &rels[j]
+			if r.Kind != string(types.RelationshipKindJoinsCollection) {
+				continue
+			}
+			if r.Properties["anchor"] != "stage_node" {
+				continue
+			}
+			if r.FromID == ln.id {
+				targets = append(targets, r.ToID)
+			}
+		}
+		if len(targets) == 0 {
+			t.Fatalf("ISOLATED: $lookup node %s has no outgoing node-anchored JOINS_COLLECTION (expected -> %s)", ln.id, ln.from)
+		}
+		for _, tgt := range targets {
+			if tgt != ln.from {
+				t.Fatalf("CROSS-STAGE MIS-LINK: $lookup node %s joins %s but should join ONLY %s", ln.id, tgt, ln.from)
+			}
+		}
+	}
+}

--- a/internal/engine/orm_queries_php_mongo_agg.go
+++ b/internal/engine/orm_queries_php_mongo_agg.go
@@ -219,7 +219,11 @@ func scanPHPMongoAggregation(
 		emitJoin(mongoAggJoinEdge(coll, lk, stageName))
 		// #4244 — node-anchored twin so the join is reachable from the
 		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		entityName := fmt.Sprintf("%s.aggregate#%d $lookup", coll, stageIdx)
+		// The `@L<line>` segment keeps the per-call-site stage node unique so
+		// two `$lookup`s at the same per-file stage index in different
+		// aggregations never collapse onto one graph node (see
+		// mongoAggStageName).
+		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
 		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, stageName))
 
 		props := map[string]string{

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -54,7 +54,6 @@
 package engine
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -251,7 +250,22 @@ func scanPythonMongoAggregation(
 			// Stage entity Name — computed up front so the node-anchored
 			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity by
 			// its exact file+name in a Format-A structural-ref stub.
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+			//
+			// #4244 re-fix: the Name MUST embed the call-site line. The graph
+			// entity ID is graph.EntityID(repo, kind, NAME, file) — it ignores
+			// StartLine and the looked-up `from`. A file with several
+			// `coll.aggregate(...)` calls on the SAME collection (the upvate
+			// building/service.py shape — four `inspections_cln.aggregate(...)`
+			// calls) independently restarts stage indexing at #0, so stage #2 of
+			// call A and stage #2 of call B previously produced the IDENTICAL
+			// Name (`inspections.aggregate#2 $lookup`) and therefore the IDENTICAL
+			// graph ID — collapsing two DISTINCT `$lookup` stages (different
+			// `from`) into ONE node. That node then carried BOTH stages'
+			// JOINS_COLLECTION twins, so neighbors() returned a cross-stage
+			// mix (and the `find`-able node looked wrong / unresolvable). The
+			// `@L<line>` segment makes the per-call-site stage Name — and thus
+			// the node ID and the twin's FromID stub — unique.
+			name := mongoAggStageName(coll, callLine, idx, op)
 
 			switch op {
 			case "$lookup":

--- a/internal/engine/orm_queries_ruby_mongoid_agg.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg.go
@@ -178,7 +178,7 @@ func scanRubyMongoidAggCalls(
 
 			// Stage entity Name — computed up front so the node-anchored
 			// JOINS_COLLECTION twin (#4244) can reference THIS stage entity.
-			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+			name := mongoAggStageName(coll, callLine, idx, op)
 
 			switch op {
 			case "$lookup":


### PR DESCRIPTION
## Re-fix of #4244 (forward fix on top of merged #4247)

#4247 added a node-anchored `JOINS_COLLECTION` twin so the `$lookup` `SCOPE.DataAccess` stage node would be traversable to its join target. Its single-`$lookup` fixture passed, but live on deploy-11 (upvate-core, `building/service.py`) `neighbors(<$lookup node>)` still came back wrong/empty.

### Real root cause — ID collision, not a resolver miss
`graph.EntityID(repo, kind, Name, file)` **ignores `StartLine` and the looked-up `from`.** `building/service.py` makes four `inspections_cln.aggregate(...)` calls on the **same** collection; each pipeline independently restarts stage indexing at `#0`. So stage `#2` of one call and stage `#2` of another had the **identical Name** `inspections.aggregate#2 $lookup` → **identical graph ID**. Two distinct `$lookup` stages (different `from`) **collapsed into one node**, which then carried **both** stages' node-anchored twins — a cross-stage mis-link (one node joining several unrelated collections). The twin stub *did* resolve; it resolved to a collapsed, polluted node. The single-lookup fixture never exercised this.

### Fix
Embed the call-site line in the per-stage Name via a shared `mongoAggStageName` helper:

```
<coll>.aggregate@L<callLine>#<idx> <op>
```

This makes the stage Name (and thus the node ID and the twin's FromID stub) unique per call site, so distinct `$lookup` stages no longer collapse and each node owns exactly its own join. Applied to all six emitters (python, jsts, go, ruby, php, java, csharp). The Class-anchored edge (`mongoAggJoinEdge`, keyed on `Class:<coll>`/`Class:<from>`, no stage Name) is untouched — no regression to its counts/identity.

### Evidence on real upvate data
Driving the real `building/service.py` + `queries.py` through the production ORM pass + cross-file resolver + `graph.EntityID` stamping + real resolver:
- Before: **15 cross-stage mis-linked** `$lookup` nodes; several names mapping to multiple distinct stages.
- After: **0 spurious links.** The 2 remaining multi-target nodes are genuine correlated/nested `$lookup` joins (the behavior #4247 intends).

### Test (non-vacuous)
`TestMongoAggPy_MultiLookupSameCollection_NoCollapse_4244` reproduces the real shape — two aggregations on the same collection, `$lookup` at the same stage index, distinct `from` — stamps IDs with `graph.EntityID` like production, runs the real resolver, and asserts the two stages are **distinct** nodes each joining **only** its own `from`.
- Pre-fix Name scheme: fails with `COLLAPSE: the two $lookup stages share graph ID ...`.
- Post-fix: passes.

### Gates
- `go build ./...` ✅
- `go test ./internal/engine/ ./internal/resolve/` ✅ (full)
- `gofmt -l` ✅ clean · `go vet` ✅ clean
- Existing #4247 single-lookup test still passes.

DEPLOY-DEFERRED.

Closes #4244

🤖 Generated with [Claude Code](https://claude.com/claude-code)