### PR TITLE
engine: emit $lookup JOINS_COLLECTION with FromID = the DataAccess node id (#4244)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -3088,6 +3088,60 @@ func (i *Indexer) buildPatternContainsRels(records []types.EntityRecord) []types
 	return out
 }
 
+// buildMongoAggStageJoinRels emits the NODE-ANCHORED JOINS_COLLECTION twin for
+// every Mongo-aggregation `$lookup` / `$graphLookup` stage entity, with a
+// FIRST-CLASS FromID equal to the stage entity's own (already-stamped) graph id
+// — `r.ID`. This is the #4244 fix: the per-stage SCOPE.DataAccess node a
+// consumer `find`s ("inspections.aggregate@L38#9 $lookup") must be traversable
+// to its join target via `node → JOINS_COLLECTION → Class:<from>`. The two
+// previous fixes emitted this twin at EXTRACT time with a structural-ref STUB
+// FromID and relied on the resolver to rewrite it to the node id; that rewrite
+// did NOT land on the node's actual id in production (twin FromID stayed a
+// synthetic value ≠ graph.EntityID(<the node>)), so neighbors(<node>) was empty
+// live — twice. Emitting here, AFTER stampEntityIDs, lets us use the node's real
+// id directly (no stub, no resolver round-trip) — exactly like
+// buildPatternContainsRels emits file→Pattern CONTAINS edges.
+//
+// Targets: the stage entity's `from` property (the top-level lookup target) plus
+// any extra targets recorded under join_targets (the Python correlated
+// sub-pipeline nested froms). Both endpoints are deterministic — FromID is a
+// resolved hex id (resolver leaves it untouched via isHexID), ToID is the
+// canonical Class:<from> node the collection-anchored edge already points at.
+// Runs after stampEntityIDs so r.ID is populated. Returns nil when no
+// aggregation stage entities are present (zero-cost on graphs without Mongo).
+func (i *Indexer) buildMongoAggStageJoinRels(records []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for k := range records {
+		r := &records[k]
+		if r.ID == "" || r.Properties == nil {
+			continue
+		}
+		if r.Kind != string(types.EntityKindDataAccess) {
+			continue
+		}
+		if r.Properties["pattern_type"] != engine.MongoAggPatternType {
+			continue
+		}
+		// Only $lookup / $graphLookup stages carry a join target; other
+		// stages ($group, $facet, …) have no `from` and no join_targets.
+		var targets []string
+		if from := r.Properties["from"]; from != "" {
+			targets = append(targets, from)
+		}
+		if extra := r.Properties[engine.MongoAggStageJoinTargetsKey]; extra != "" {
+			for _, t := range strings.Split(extra, ",") {
+				if t != "" {
+					targets = append(targets, t)
+				}
+			}
+		}
+		for _, t := range targets {
+			out = append(out, engine.MongoAggStageNodeJoinRel(r.ID, t))
+		}
+	}
+	return out
+}
+
 // foldShadowStats reports the result of foldClassHierarchyShadows for the
 // stderr log line.
 type foldShadowStats struct {
@@ -3811,6 +3865,18 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 			len(patternContainsRels))
 	}
 
+	// #4244 — node-anchored $lookup/$graphLookup JOINS_COLLECTION twins. Emitted
+	// here, AFTER stampEntityIDs, so each twin's FromID is the stage entity's
+	// REAL graph id (r.ID) rather than a structural-ref stub. Appended alongside
+	// patternContainsRels below (post-disposition, both endpoints are resolved
+	// hex ids so they bypass the resolver/classifier).
+	mongoAggStageJoinRels := i.buildMongoAggStageJoinRels(merged)
+	if len(mongoAggStageJoinRels) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"mongo-agg-stage-joins: emitted %d node-anchored JOINS_COLLECTION twins ($lookup node → Class:<from>)\n",
+			len(mongoAggStageJoinRels))
+	}
+
 	// Resolver pass — rewrite stub-form FromID/ToID values across:
 	//   - embedded EntityRecord.Relationships (Pass 1 + Pass 2.5 + Pass 3)
 	//   - standalone Pass 2.5 RelationshipRecords (engine output)
@@ -4113,6 +4179,26 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	// flow straight into the output without rewrite or classification.
 	for j := range patternContainsRels {
 		rel := &patternContainsRels[j]
+		relID := graph.RelationshipID(rel.FromID, rel.ToID, rel.Kind)
+		if seenRel[relID] {
+			continue
+		}
+		seenRel[relID] = true
+		relationships = append(relationships, graph.Relationship{
+			ID:         relID,
+			FromID:     rel.FromID,
+			ToID:       rel.ToID,
+			Kind:       rel.Kind,
+			Properties: rel.Properties,
+		})
+	}
+
+	// #4244 — node-anchored $lookup JOINS_COLLECTION twins (see
+	// buildMongoAggStageJoinRels above). Both endpoints are deterministic hex
+	// ids (FromID = the stage node's graph id), so they flow straight into the
+	// output without rewrite or classification — same as patternContainsRels.
+	for j := range mongoAggStageJoinRels {
+		rel := &mongoAggStageJoinRels[j]
 		relID := graph.RelationshipID(rel.FromID, rel.ToID, rel.Kind)
 		if seenRel[relID] {
 			continue

--- a/cmd/archigraph/index_mongoagg_4244_test.go
+++ b/cmd/archigraph/index_mongoagg_4244_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestMongoAggLookupNode_FromIDEqualsNodeID_4244 is the anti-false-pass test for
+// #4244. It indexes the REAL upvate-shaped fixture (mongo_helper_indirection_real
+// — multiple `inspections.aggregate(...)` calls on the SAME collection at
+// DIFFERENT call-site lines, each `$lookup` with a distinct `from`, mirroring
+// building/service.py L18/L28/L38/L57) through the FULL production indexer,
+// including graph.EntityID stamping and the post-stamp buildMongoAggStageJoinRels
+// pass.
+//
+// For EVERY `$lookup` / `$graphLookup` SCOPE.DataAccess stage entity it then:
+//
+//	a. recomputes the node id the SAME way production does —
+//	   graph.EntityID(repoTag, kind, name, file) — and asserts it equals the
+//	   stamped entity.ID;
+//	b. asserts there EXISTS a JOINS_COLLECTION edge whose **FromID == that exact
+//	   node id** AND whose ToID == the correct Class:<from> for THAT stage (not
+//	   another stage's from);
+//	c. drives the actual outgoing-adjacency lookup the live neighbors() query
+//	   uses (keyed on the node id) and asserts the edge surfaces.
+//
+// This is the assertion both prior fixes omitted: they asserted only that "a
+// JOINS_COLLECTION edge exists", never that "an edge whose FromID equals the
+// $lookup node's graph id exists". The stub-based emission could satisfy the
+// former while leaving the node isolated (FromID a synthetic stub) — which is
+// exactly what failed live, twice.
+func TestMongoAggLookupNode_FromIDEqualsNodeID_4244(t *testing.T) {
+	const repoTag = "mongoagg4244"
+	abs, err := filepath.Abs("testdata/mongo_helper_indirection_real")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	idx := newTestIndexer(t, repoTag, nil, "")
+	doc, err := idx.Run(context.Background(), abs)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Outgoing adjacency keyed on FromID — the SAME index the live
+	// neighbors()/findCallees query builds (see internal/mcp buildAdjacency:
+	// a.out[r.FromID] = append(..., r.ToID)). Building it from the emitted doc
+	// proves the edge is reachable FROM the node id.
+	type outEdge struct{ kind, to string }
+	outgoing := make(map[string][]outEdge)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		outgoing[r.FromID] = append(outgoing[r.FromID], outEdge{r.Kind, r.ToID})
+	}
+
+	var lookupStages int
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != string(types.EntityKindDataAccess) {
+			continue
+		}
+		if e.Subtype != "$lookup" && e.Subtype != "$graphLookup" {
+			continue
+		}
+		if e.Properties == nil || e.Properties["from"] == "" {
+			continue // a $lookup with a dynamic `from` emits no join — skip.
+		}
+		lookupStages++
+
+		// (a) Recompute the node id exactly as production does.
+		wantID := graph.EntityID(repoTag, e.Kind, e.Name, e.SourceFile)
+		if e.ID != wantID {
+			t.Fatalf("stage %q: stamped ID %q != graph.EntityID(repo,kind,name,file)=%q",
+				e.Name, e.ID, wantID)
+		}
+
+		// Collect every expected join target for THIS stage: the top-level
+		// `from` plus any recorded nested correlated froms.
+		wantTargets := map[string]bool{
+			"Class:" + engine.CapitalisedSingular(e.Properties["from"]): true,
+		}
+		if extra := e.Properties["join_targets"]; extra != "" {
+			for _, t := range splitCSV(extra) {
+				wantTargets["Class:"+engine.CapitalisedSingular(t)] = true
+			}
+		}
+
+		// (b) For each expected target, assert an edge FromID==node-id exists,
+		// AND its ToID is the correct Class for THIS stage.
+		gotTargets := map[string]bool{}
+		for _, oe := range outgoing[e.ID] {
+			if oe.kind == string(types.RelationshipKindJoinsCollection) {
+				gotTargets[oe.to] = true
+			}
+		}
+		for target := range wantTargets {
+			if !gotTargets[target] {
+				t.Fatalf("stage %q (id=%s): NO JOINS_COLLECTION edge with FromID==node-id to %q; "+
+					"node is isolated from its join target (the live bug). got outgoing=%v",
+					e.Name, e.ID, target, outgoing[e.ID])
+			}
+		}
+		// Cross-stage-mix guard: the node must NOT carry a join to a `from`
+		// that belongs to a different stage. Every JOINS_COLLECTION edge from
+		// this node must be one of THIS stage's targets.
+		for _, oe := range outgoing[e.ID] {
+			if oe.kind != string(types.RelationshipKindJoinsCollection) {
+				continue
+			}
+			if !wantTargets[oe.to] {
+				t.Fatalf("stage %q (id=%s): carries a CROSS-STAGE join to %q not among its own targets %v",
+					e.Name, e.ID, oe.to, keysOfBoolSet(wantTargets))
+			}
+		}
+	}
+
+	// The fixture mirrors building/service.py and has many `$lookup` stages
+	// across four separate aggregations; a regression that stops emitting stage
+	// entities (or froms) would zero this out.
+	if lookupStages < 10 {
+		t.Fatalf("expected >=10 $lookup stages with a static `from` on the upvate fixture, got %d", lookupStages)
+	}
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == ',' {
+			if cur != "" {
+				out = append(out, cur)
+			}
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+func keysOfBoolSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/archigraph/mongo_helper_indirection_test.go
+++ b/cmd/archigraph/mongo_helper_indirection_test.go
@@ -45,9 +45,17 @@ func TestMongoLookupHelperIndirection_MinimalShape(t *testing.T) {
 	type edge struct{ from, to string }
 	var joins []edge
 	for _, r := range doc.Relationships {
-		if r.Kind == "JOINS_COLLECTION" {
-			joins = append(joins, edge{from: r.FromID, to: r.ToID})
+		if r.Kind != "JOINS_COLLECTION" {
+			continue
 		}
+		// #4244 — skip the per-stage node-anchored twin (FromID = the $lookup
+		// node's hex id). This test asserts the collection-anchored edges
+		// (Class:Inspection -> Class:<from>); the node-anchored twins are
+		// covered by TestMongoAggLookupNode_FromIDEqualsNodeID_4244.
+		if r.Properties != nil && r.Properties["anchor"] == "stage_node" {
+			continue
+		}
+		joins = append(joins, edge{from: r.FromID, to: r.ToID})
 	}
 
 	if len(joins) == 0 {
@@ -100,6 +108,14 @@ func TestMongoLookupHelperIndirection_RealUpvateSource(t *testing.T) {
 	got := map[string]bool{}
 	for _, r := range doc.Relationships {
 		if r.Kind != "JOINS_COLLECTION" {
+			continue
+		}
+		// #4244 — the per-stage `$lookup` node also emits a NODE-ANCHORED twin
+		// JOINS_COLLECTION edge whose FromID is the stage node's graph id (a hex
+		// id), not Class:Inspection. This test asserts the COLLECTION-anchored
+		// edges (the helper-indirection resolution), so skip the node-anchored
+		// twins (Properties["anchor"]=="stage_node").
+		if r.Properties != nil && r.Properties["anchor"] == "stage_node" {
 			continue
 		}
 		if r.FromID != wantFrom {

--- a/internal/engine/orm_queries_csharp_mongo_agg.go
+++ b/internal/engine/orm_queries_csharp_mongo_agg.go
@@ -145,12 +145,11 @@ func scanCSharpMongoAggregation(
 			return // dynamic from — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-		// #4244 — node-anchored twin so the join is reachable from the
-		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		// The `@L<line>` segment keeps the per-call-site stage node unique
-		// (see mongoAggStageName).
+		// #4244 — node-anchored twin emitted post-stamp by
+		// buildMongoAggStageJoinRels from props["from"]. entityName MUST match
+		// the emitStage Name; the `@L<line>` segment keeps the per-call-site
+		// stage node unique (see mongoAggStageName).
 		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
-		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,

--- a/internal/engine/orm_queries_go_mongo_agg.go
+++ b/internal/engine/orm_queries_go_mongo_agg.go
@@ -164,8 +164,8 @@ func scanGoMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-					// #4244 — node-anchored twin.
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
+					// #4244 — node-anchored twin emitted post-stamp from
+					// props["from"] (buildMongoAggStageJoinRels).
 				}
 			case "$graphLookup":
 				lk := mongoAggGoParseLookup(st)
@@ -175,8 +175,8 @@ func scanGoMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
-					// #4244 — node-anchored twin (graphLookup stage node).
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
+					// #4244 — node-anchored twin emitted post-stamp from
+					// props["from"] (buildMongoAggStageJoinRels).
 				}
 			case "$group":
 				if id, accs := mongoAggGoParseGroup(st); id != "" || accs != "" {

--- a/internal/engine/orm_queries_java_mongo_agg.go
+++ b/internal/engine/orm_queries_java_mongo_agg.go
@@ -156,12 +156,12 @@ func scanJavaSpringMongoAggregation(
 			return // dynamic from or unresolved collection — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-		// #4244 — node-anchored twin so the join is reachable from the
-		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		// The `@L<line>` segment keeps the per-call-site stage node unique
+		// #4244 — the node-anchored twin (FromID = this stage's graph id →
+		// Class:<from>) is emitted post-stamp by buildMongoAggStageJoinRels
+		// from props["from"]. entityName MUST match the emitStage Name; the
+		// `@L<line>` segment keeps the per-call-site stage node unique
 		// (see mongoAggStageName).
 		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
-		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, "lookup"))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,

--- a/internal/engine/orm_queries_jsts_mongo_agg.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg.go
@@ -66,7 +66,6 @@ package engine
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -296,9 +295,11 @@ func mongoAggEmitStages(
 					props["as"] = lk.as
 				}
 				emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-				// #4244 — node-anchored twin so the join is reachable from
-				// the $lookup DataAccess node.
-				emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
+				// #4244 — the node-anchored twin (FromID = this stage's graph
+				// id → Class:<from>) is emitted by buildMongoAggStageJoinRels
+				// after stampEntityIDs. The top-level `from` recorded above is
+				// the twin target; nested/correlated targets are recorded via
+				// mongoAggAddStageJoinTarget.
 			}
 		case "$graphLookup":
 			lk := mongoAggParseLookup(st)
@@ -308,8 +309,7 @@ func mongoAggEmitStages(
 					props["as"] = lk.as
 				}
 				emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
-				// #4244 — node-anchored twin (graphLookup stage node).
-				emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
+				// #4244 — node-anchored twin emitted post-stamp (see above).
 			}
 		case "$group":
 			id, accs := mongoAggParseGroup(st)
@@ -593,53 +593,94 @@ func mongoAggJoinEdge(fromColl string, lk mongoAggLookup, stageName string) type
 	}
 }
 
-// mongoAggStageJoinEdge builds the NODE-ANCHORED twin of mongoAggJoinEdge: a
-// JOINS_COLLECTION edge whose FromID is the `$lookup` / `$graphLookup`
-// SCOPE.DataAccess STAGE entity itself (referenced by a Format-A structural-ref
-// stub keyed on the stage's source file + Name), and whose ToID is the same
-// `from`-collection Class the collection-anchored edge points at.
+// mongoAggStageJoinTargetsKey is the stage-entity Property under which the
+// node-anchored JOINS_COLLECTION twin targets are recorded (comma-separated
+// `from` collection names, in emission order, deduplicated). A later post-stamp
+// pass (buildMongoAggStageJoinRels in cmd/archigraph/index.go) reads this — plus
+// the single top-level `from` — to emit the node-anchored twin edges with a
+// FIRST-CLASS, already-resolved FromID equal to the stage entity's own graph id.
 //
-// WHY THIS EXISTS (#4244): the collection-anchored edge mongoAggJoinEdge emits
-// connects the aggregating Class → the looked-up Class. The per-stage
-// SCOPE.DataAccess node a consumer naturally `find`s ("inspections.aggregate#2
-// $lookup") was previously connected to NOTHING — fully isolated in both
-// directions — so the join target was not traversable from the node. This edge
-// makes `node → JOINS_COLLECTION → Class:<from>` a single direct hop. It does
-// NOT replace the collection-anchored edge (both fire); it adds the missing
-// node-side link so neighbors(stageNode) is non-empty.
-//
-// The FromID stub format is the resolver's Format A —
-//
-//	scope:<kind>:<subtype>:<lang>:<file_path>:<entity_name>
-//
-// — which the resolver rewrites to the stage entity's graph ID via its
-// byLocation[file][name] index (kind/subtype segments are advisory; the
-// file+name pair is the actual key, and the `#<idx>` suffix in the stage Name
-// keeps it unique per call site). Caller MUST pass the EXACT stage Name it
-// emitted for the entity, the stage's source-file path, and language.
-func mongoAggStageJoinEdge(stageName, stageFile, lang string, lk mongoAggLookup, stageOp string) types.RelationshipRecord {
-	props := map[string]string{
-		"pattern_type": mongoAggPatternType,
-		"stage":        stageOp,
-		// Flag the node-anchored twin so a reader (and any future de-dup
-		// pass) can tell it apart from the collection-anchored edge.
-		"anchor": "stage_node",
+// WHY A PROPERTY INSTEAD OF AN EDGE AT EXTRACT TIME (#4244, third fix):
+// the per-stage SCOPE.DataAccess node a consumer `find`s
+// ("inspections.aggregate@L38#9 $lookup") must be traversable to its join
+// target via `node → JOINS_COLLECTION → Class:<from>`. The graph entity id of
+// that node is graph.EntityID(repoTag, kind, Name, file), which is NOT known at
+// extract time (repoTag is only available during buildDocument, and the id is
+// stamped by stampEntityIDs). The two previous fixes emitted the twin edge with
+// a structural-ref STUB FromID (scope:dataaccess:...) and relied on the resolver
+// to rewrite it to the node id via byLocation[file][name]. That rewrite did NOT
+// land on the node's actual id in production — the twin's FromID stayed a
+// synthetic value ≠ graph.EntityID(<the node>), so neighbors(<node>) returned
+// empty live (twice). This fix abandons the stub+resolver path entirely: the
+// extract pass only RECORDS the join targets on the entity; the post-stamp pass
+// emits the edge with FromID = r.ID (the node's already-computed graph id), the
+// same way buildPatternContainsRels emits file→Pattern CONTAINS edges.
+const mongoAggStageJoinTargetsKey = "join_targets"
+
+// MongoAggStageJoinTargetsKey exports mongoAggStageJoinTargetsKey for the
+// post-stamp pass in cmd/archigraph/index.go (buildMongoAggStageJoinRels).
+const MongoAggStageJoinTargetsKey = mongoAggStageJoinTargetsKey
+
+// MongoAggPatternType exports mongoAggPatternType for the post-stamp pass; it
+// identifies the Mongo-aggregation stage entities whose node-anchored
+// JOINS_COLLECTION twins are emitted with FromID = the stage node's graph id.
+const MongoAggPatternType = mongoAggPatternType
+
+// MongoAggStageNodeJoinRel exports mongoAggStageNodeJoinRel for the post-stamp
+// pass. `nodeID` MUST be the stage entity's already-stamped graph id.
+func MongoAggStageNodeJoinRel(nodeID, fromColl string) types.RelationshipRecord {
+	return mongoAggStageNodeJoinRel(nodeID, fromColl)
+}
+
+// CapitalisedSingular exports capitalisedSingular so tests in other packages can
+// compute the canonical Class:<from> node name a JOINS_COLLECTION edge targets.
+func CapitalisedSingular(s string) string { return capitalisedSingular(s) }
+
+// mongoAggAddStageJoinTarget records `fromColl` as a node-anchored
+// JOINS_COLLECTION twin target on the stage entity's Properties map. Targets are
+// stored comma-separated under mongoAggStageJoinTargetsKey, in first-seen order,
+// deduplicated. The primary top-level lookup `from` is already stored under
+// `from` and is ALSO emitted by the post-stamp pass, so callers only need to
+// record EXTRA (nested/correlated) targets here — but recording the primary too
+// is harmless (the post-stamp pass deduplicates per-(FromID,ToID)). No-op when
+// fromColl is empty.
+func mongoAggAddStageJoinTarget(props map[string]string, fromColl string) {
+	if fromColl == "" || props == nil {
+		return
 	}
-	if lk.localField != "" {
-		props["local_field"] = lk.localField
+	existing := props[mongoAggStageJoinTargetsKey]
+	for _, t := range strings.Split(existing, ",") {
+		if t == fromColl {
+			return // already recorded
+		}
 	}
-	if lk.foreignField != "" {
-		props["foreign_field"] = lk.foreignField
+	if existing == "" {
+		props[mongoAggStageJoinTargetsKey] = fromColl
+		return
 	}
-	if lk.as != "" {
-		props["as"] = lk.as
-	}
+	props[mongoAggStageJoinTargetsKey] = existing + "," + fromColl
+}
+
+// mongoAggStageNodeJoinRel builds the NODE-ANCHORED twin JOINS_COLLECTION edge
+// with a FIRST-CLASS FromID: `nodeID` MUST be the stage entity's already-stamped
+// graph id (graph.EntityID(repoTag, kind, Name, file)). ToID is the looked-up
+// `from` collection Class — identical to the collection-anchored
+// mongoAggJoinEdge ToID. Both edges fire (collection-anchored + node-anchored);
+// this one makes neighbors(stageNode) non-empty. The FromID is a resolved hex id
+// so the resolver leaves it untouched (isHexID short-circuit) — there is no
+// stub and no byLocation round-trip. Used by buildMongoAggStageJoinRels.
+func mongoAggStageNodeJoinRel(nodeID, fromColl string) types.RelationshipRecord {
 	return types.RelationshipRecord{
-		FromID: fmt.Sprintf("scope:dataaccess:%s:%s:%s:%s",
-			stageOp, strings.ToLower(lang), filepath.ToSlash(stageFile), stageName),
-		ToID:       fmt.Sprintf("Class:%s", capitalisedSingular(lk.from)),
-		Kind:       mongoAggJoinEdgeKind,
-		Properties: props,
+		FromID: nodeID,
+		ToID:   fmt.Sprintf("Class:%s", capitalisedSingular(fromColl)),
+		Kind:   mongoAggJoinEdgeKind,
+		Properties: map[string]string{
+			"pattern_type": mongoAggPatternType,
+			"stage":        "$lookup",
+			// Flag the node-anchored twin so a reader (and any de-dup pass)
+			// can tell it apart from the collection-anchored edge.
+			"anchor": "stage_node",
+		},
 	}
 }
 

--- a/internal/engine/orm_queries_mongo_agg_lookup_link_test.go
+++ b/internal/engine/orm_queries_mongo_agg_lookup_link_test.go
@@ -1,30 +1,36 @@
 package engine
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// #4244 — the `$lookup` SCOPE.DataAccess stage node was fully isolated: the
-// JOINS_COLLECTION edge connected the aggregating Class to the looked-up Class,
-// but NOTHING connected the per-stage node a consumer naturally `find`s
-// ("inspections.aggregate#N $lookup"). This test indexes a Python pymongo
-// aggregation carrying `$lookup: { from: "inspections_history", ... }` inside a
-// service method and asserts that, after reference resolution, a
-// JOINS_COLLECTION edge originates FROM the `$lookup` stage entity's graph ID —
-// i.e. the join target is reachable from the node `find` returns.
+// #4244 (third fix) — the per-stage `$lookup` SCOPE.DataAccess node a consumer
+// `find`s ("inspections.aggregate@L38#9 $lookup") must be traversable to its
+// join target. The two PRIOR fixes emitted the node-anchored twin at EXTRACT
+// time with a structural-ref STUB FromID (scope:dataaccess:...) and relied on
+// the reference resolver to rewrite that stub to the node's graph id via
+// byLocation[file][name]. That rewrite did NOT land on the node's id in
+// production (the twin's FromID stayed a synthetic value ≠ the node id), so
+// neighbors(<node>) returned empty live — twice. BOTH prior tests asserted only
+// that "a JOINS_COLLECTION edge exists" and never that "an edge whose
+// FromID == graph.EntityID(<the $lookup node>) exists" — that gap was the false
+// pass.
 //
-// NON-VACUOUS PROOF: the same body first asserts the PRE-FIX invariant — that
-// the ONLY JOINS_COLLECTION edge whose FromID resolves to the stage node is the
-// one mongoAggStageJoinEdge adds. We assert the Class-anchored edge (FromID
-// "Class:Inspection") STILL fires (no regression), AND that a SEPARATE
-// node-anchored edge exists whose FromID is the stage-node structural-ref stub.
-// Deleting the mongoAggStageJoinEdge calls makes the node-anchored assertions
-// fail (the stage node has zero outgoing edges — the original bug).
-func TestMongoAggPy_LookupNode_IsTraversableToJoin_4244(t *testing.T) {
+// This fix abandons the stub+resolver entirely: the extract pass RECORDS join
+// targets on the stage entity (props["from"] for the primary lookup,
+// props["join_targets"] for the Python correlated nested froms) and a post-stamp
+// pass (buildMongoAggStageJoinRels in cmd/archigraph) emits the twin edge with
+// FromID = the stage node's already-stamped graph id. The two assertions below
+// are unit-level guards on the engine-side contract that pass relies on; the
+// FromID==node-id end-to-end assertion lives in
+// cmd/archigraph/index_mongoagg_4244_test.go.
+
+// TestMongoAggPy_StageRecordsJoinTargetsOnEntity asserts the extract pass NO
+// LONGER emits a stub-FromID node-anchored twin, and instead records the join
+// target(s) on the stage entity so the post-stamp pass can emit a real-id edge.
+func TestMongoAggPy_StageRecordsJoinTargetsOnEntity(t *testing.T) {
 	src := `
 from pymongo import MongoClient
 
@@ -41,8 +47,6 @@ class InspectionService:
         ]
         return db.inspections.aggregate(pipeline)
 `
-	// Drive the scanner directly so we collect the UNFILTERED edge set,
-	// including the node-anchored twin (runMongoAggPy strips it).
 	funcs := indexEnclosingFunctions("python", src)
 	var ents []types.EntityRecord
 	var rels []types.RelationshipRecord
@@ -51,7 +55,6 @@ class InspectionService:
 		func(r types.RelationshipRecord) { rels = append(rels, r) },
 	)
 
-	// Locate the $lookup stage entity the consumer would `find`.
 	lookupEnt := pyFindStage(ents, "$lookup")
 	if lookupEnt == nil {
 		t.Fatalf("expected a $lookup SCOPE.DataAccess stage entity; ents=%+v", ents)
@@ -59,83 +62,103 @@ class InspectionService:
 	if lookupEnt.Kind != string(types.EntityKindDataAccess) {
 		t.Fatalf("stage kind = %q, want SCOPE.DataAccess", lookupEnt.Kind)
 	}
+	// The stage entity carries the join target so the post-stamp pass can emit
+	// the node-anchored twin with a real FromID.
+	if lookupEnt.Properties["from"] != "inspections_history" {
+		t.Fatalf("stage entity props[from] = %q, want inspections_history",
+			lookupEnt.Properties["from"])
+	}
 
 	// REGRESSION GUARD: the collection-anchored edge must still fire.
 	classEdge := pyFindJoinTo(rels, capitalisedSingular("inspections_history"))
 	if classEdge == nil {
-		t.Fatalf("expected a JOINS_COLLECTION edge to inspections_history; rels=%+v", rels)
+		t.Fatalf("expected a collection-anchored JOINS_COLLECTION edge to inspections_history; rels=%+v", rels)
 	}
 	if classEdge.FromID != "Class:"+capitalisedSingular("inspections") {
-		// The collection-anchored edge originates from the aggregating Class.
-		// (There are now two edges to the same target; ensure at least one is
-		// the Class-anchored form.)
-		var sawClassAnchored bool
-		for i := range rels {
-			r := &rels[i]
-			if r.Kind == string(types.RelationshipKindJoinsCollection) &&
-				r.ToID == "Class:"+capitalisedSingular("inspections_history") &&
-				r.FromID == "Class:"+capitalisedSingular("inspections") {
-				sawClassAnchored = true
-			}
-		}
-		if !sawClassAnchored {
-			t.Fatalf("collection-anchored JOINS_COLLECTION edge (Class:Inspection -> Class:Inspections_history) missing; rels=%+v", rels)
-		}
+		t.Fatalf("collection-anchored FromID = %q, want Class:%s",
+			classEdge.FromID, capitalisedSingular("inspections"))
 	}
 
-	// THE FIX: find the node-anchored JOINS_COLLECTION edge whose FromID is the
-	// stage-node structural-ref stub (Format A: scope:dataaccess:...:<name>).
-	var nodeEdge *types.RelationshipRecord
+	// THE ANTI-FALSE-PASS GUARD: the extract pass must NOT emit any
+	// node-anchored twin at extract time — neither a `scope:` stub (the failed
+	// approach) NOR a hex id (the node id is unknown here). The twin is emitted
+	// exclusively by the post-stamp pass. Asserting zero stage-node edges here
+	// proves we abandoned the resolver-dependent emission.
 	for i := range rels {
 		r := &rels[i]
-		if r.Kind != string(types.RelationshipKindJoinsCollection) {
-			continue
-		}
-		if r.ToID != "Class:"+capitalisedSingular("inspections_history") {
-			continue
-		}
-		if strings.HasPrefix(r.FromID, "scope:dataaccess:") {
-			nodeEdge = r
-			break
+		if r.Properties != nil && r.Properties["anchor"] == "stage_node" {
+			t.Fatalf("extract pass emitted a node-anchored twin (FromID=%q) — it must be emitted post-stamp, not here", r.FromID)
 		}
 	}
-	if nodeEdge == nil {
-		t.Fatalf("PRE-FIX BUG: no node-anchored JOINS_COLLECTION edge from the $lookup stage node; the node is isolated. rels=%+v", rels)
-	}
-	// The stub must name THIS stage entity by file+name so the resolver binds
-	// it to the stage node and not something else.
-	if !strings.HasSuffix(nodeEdge.FromID, ":"+lookupEnt.Name) {
-		t.Fatalf("node-anchored FromID %q does not reference stage entity name %q", nodeEdge.FromID, lookupEnt.Name)
-	}
+}
 
-	// END-TO-END PROOF: run the real reference resolver over the emitted
-	// entities + edges. After resolution the node-anchored edge's FromID MUST
-	// equal the $lookup stage entity's deterministic graph ID — i.e. the join
-	// is genuinely traversable FROM the node `find` returns, not a dangling
-	// stub. The stage entity carries the file+name the stub keys on.
-	//
-	// The real pipeline assigns each entity its deterministic graph ID before
-	// resolution; replicate that here (BuildIndex skips ID-less records).
-	for i := range ents {
-		ents[i].ID = ents[i].ComputeID()
-	}
-	idx := resolve.BuildIndex(ents)
-	resolve.References(rels, idx)
+// TestMongoAggPy_NestedCorrelatedFromsRecordedAsJoinTargets asserts a correlated
+// `$lookup` carrying a nested sub-pipeline `$lookup` records BOTH the top-level
+// and the nested `from` so the post-stamp pass emits one node-anchored twin per
+// target (all anchored on the SAME stage node).
+func TestMongoAggPy_NestedCorrelatedFromsRecordedAsJoinTargets(t *testing.T) {
+	src := `
+from pymongo import MongoClient
 
-	wantID := lookupEnt.ComputeID()
-	var resolvedNodeEdge *types.RelationshipRecord
-	for i := range rels {
-		r := &rels[i]
-		if r.Kind == string(types.RelationshipKindJoinsCollection) && r.FromID == wantID {
-			resolvedNodeEdge = r
-			break
-		}
+def q(db):
+    pipeline = [
+        {"$lookup": {
+            "from": "m_contracts",
+            "as": "contract",
+            "pipeline": [
+                {"$lookup": {"from": "m_group_device_settings", "as": "gds"}},
+            ],
+        }},
+    ]
+    return db.inspections.aggregate(pipeline)
+`
+	funcs := indexEnclosingFunctions("python", src)
+	var ents []types.EntityRecord
+	scanPythonMongoAggregation(src, funcs, "svc/agg.py", "python", nil,
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) {},
+	)
+	lookupEnt := pyFindStage(ents, "$lookup")
+	if lookupEnt == nil {
+		t.Fatalf("expected a $lookup stage entity; ents=%+v", ents)
 	}
-	if resolvedNodeEdge == nil {
-		t.Fatalf("after resolution no JOINS_COLLECTION edge originates from the $lookup stage node ID %q (node still isolated); rels=%+v", wantID, rels)
+	if lookupEnt.Properties["from"] != "m_contracts" {
+		t.Fatalf("props[from] = %q, want m_contracts", lookupEnt.Properties["from"])
 	}
-	// And it points at the looked-up collection.
-	if resolvedNodeEdge.ToID == "" {
-		t.Fatalf("resolved node-anchored edge has empty ToID")
+	if got := lookupEnt.Properties[mongoAggStageJoinTargetsKey]; got != "m_group_device_settings" {
+		t.Fatalf("props[%s] = %q, want m_group_device_settings (nested correlated from)",
+			mongoAggStageJoinTargetsKey, got)
+	}
+}
+
+// TestMongoAggStageNodeJoinRel_FromIDIsTheNodeID asserts the edge builder uses a
+// first-class FromID equal to the node id passed in (no stub), and the canonical
+// Class:<from> ToID.
+func TestMongoAggStageNodeJoinRel_FromIDIsTheNodeID(t *testing.T) {
+	nodeID := "deadbeefdeadbeef" // stands in for graph.EntityID(...) output
+	rel := mongoAggStageNodeJoinRel(nodeID, "m_contracts")
+	if rel.FromID != nodeID {
+		t.Fatalf("FromID = %q, want the node id %q (first-class, not a stub)", rel.FromID, nodeID)
+	}
+	if rel.ToID != "Class:"+capitalisedSingular("m_contracts") {
+		t.Fatalf("ToID = %q, want Class:%s", rel.ToID, capitalisedSingular("m_contracts"))
+	}
+	if rel.Kind != string(types.RelationshipKindJoinsCollection) {
+		t.Fatalf("Kind = %q, want JOINS_COLLECTION", rel.Kind)
+	}
+	if rel.Properties["anchor"] != "stage_node" {
+		t.Fatalf("anchor prop = %q, want stage_node", rel.Properties["anchor"])
+	}
+}
+
+// TestMongoAggAddStageJoinTarget_DedupAndOrder guards the join-targets recorder.
+func TestMongoAggAddStageJoinTarget_DedupAndOrder(t *testing.T) {
+	props := map[string]string{}
+	mongoAggAddStageJoinTarget(props, "a")
+	mongoAggAddStageJoinTarget(props, "b")
+	mongoAggAddStageJoinTarget(props, "a") // dup — ignored
+	mongoAggAddStageJoinTarget(props, "")  // empty — ignored
+	if got := props[mongoAggStageJoinTargetsKey]; got != "a,b" {
+		t.Fatalf("join_targets = %q, want a,b", got)
 	}
 }

--- a/internal/engine/orm_queries_mongo_agg_multi_lookup_link_test.go
+++ b/internal/engine/orm_queries_mongo_agg_multi_lookup_link_test.go
@@ -4,36 +4,32 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/graph"
-	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// #4244 RE-FIX — the original #4247 fixture used a SINGLE `$lookup`, so it
-// never exercised the production failure observed live on upvate-core
-// (building/service.py): a file with SEVERAL `coll.aggregate(...)` calls on the
-// SAME collection. Each call independently restarts pipeline-stage indexing at
-// #0, and the graph entity ID is graph.EntityID(repo, kind, Name, file) — which
-// IGNORES StartLine AND the looked-up `from`. With the old Name scheme
-// (`<coll>.aggregate#<idx> <op>`), stage #N of call A and stage #N of call B
-// produced the IDENTICAL Name → IDENTICAL graph ID, COLLAPSING two distinct
-// `$lookup` stages (different `from`) into ONE node. That node then carried the
-// node-anchored JOINS_COLLECTION twins of BOTH stages, so neighbors(node)
-// returned a CROSS-STAGE mix — and the `find`-able stage node was effectively
-// unusable. The single-lookup fixture could never catch this.
+// #4244 RE-FIX — a file with SEVERAL `coll.aggregate(...)` calls on the SAME
+// collection. Each call independently restarts pipeline-stage indexing at #0,
+// and the graph entity ID is graph.EntityID(repo, kind, Name, file) — which
+// IGNORES StartLine AND the looked-up `from`. With a Name scheme that omitted
+// the call line, stage #N of call A and stage #N of call B produced the
+// IDENTICAL Name → IDENTICAL graph ID, COLLAPSING two distinct `$lookup` stages
+// (different `from`) into ONE node, which then carried BOTH stages' joins —
+// neighbors(node) returned a CROSS-STAGE mix.
 //
-// This test reproduces the REAL shape: two aggregations on `db.inspections`,
-// each with a `$lookup` at the SAME stage index but a DISTINCT `from`. It
-// stamps IDs exactly like production (graph.EntityID) and runs the REAL
-// resolver, then asserts:
+// This test reproduces the REAL shape (two aggregations on `db.inspections`,
+// each with a `$lookup` at the same stage index but a DISTINCT `from`), stamps
+// IDs exactly like production (graph.EntityID), then emits the node-anchored
+// twins the SAME way the post-stamp pass does (FromID = the stamped node id, via
+// MongoAggStageNodeJoinRel) and asserts:
 //
 //   - the two `$lookup` stages occupy DISTINCT graph nodes (no collapse), and
-//   - each `$lookup` node has a JOINS_COLLECTION edge to ITS OWN `from`
-//     collection and to NO OTHER collection (no cross-stage mis-link).
+//   - each `$lookup` node has a JOINS_COLLECTION edge whose FromID == that node's
+//     id to ITS OWN `from` collection and to NO OTHER (no cross-stage mis-link).
 //
-// NON-VACUOUS PROOF: under the pre-fix Name scheme the two stages share an ID,
-// so the distinctness assertion fails AND each surviving node carries BOTH
-// joins — the assertions below fail on origin/main and pass only after the
-// `@L<callLine>` Name segment is added (mongoAggStageName).
+// NON-VACUOUS: under a Name scheme without the `@L<callLine>` segment the two
+// stages share an ID, so the distinctness assertion fails AND the surviving
+// node carries BOTH joins. The FromID==node-id assertion (not merely
+// "an edge exists") is what makes this catch the live isolation bug.
 func TestMongoAggPy_MultiLookupSameCollection_NoCollapse_4244(t *testing.T) {
 	src := `
 from pymongo import MongoClient
@@ -52,10 +48,9 @@ class InspectionService:
 
 	funcs := indexEnclosingFunctions("python", src)
 	var ents []types.EntityRecord
-	var rels []types.RelationshipRecord
 	scanPythonMongoAggregation(src, funcs, path, "python", nil,
 		func(e types.EntityRecord) { ents = append(ents, e) },
-		func(r types.RelationshipRecord) { rels = append(rels, r) },
+		func(r types.RelationshipRecord) {},
 	)
 
 	// Stamp IDs exactly as production does (cmd/archigraph stampEntityIDs).
@@ -66,53 +61,40 @@ class InspectionService:
 		ents[i].ID = graph.EntityID(repoTag, ents[i].Kind, ents[i].Name, ents[i].SourceFile)
 	}
 
-	// Collect the two $lookup stage nodes by their `from` (via the looked-up
-	// collection recorded on the node-anchored twin before resolution).
+	// Emit the node-anchored twins exactly as buildMongoAggStageJoinRels does:
+	// FromID = the stamped stage node id, one edge per recorded `from`.
 	type lookupNode struct {
 		id   string
 		from string // the Class the node SHOULD (and only should) join
 	}
 	var lookups []lookupNode
+	var rels []types.RelationshipRecord
 	for i := range ents {
 		e := &ents[i]
 		if e.Subtype != "$lookup" {
 			continue
 		}
-		// Find the node-anchored twin whose stub names THIS entity, to learn
-		// its intended `from` target.
-		var to string
-		for j := range rels {
-			r := &rels[j]
-			if r.Properties["anchor"] != "stage_node" {
-				continue
-			}
-			// The stub FromID ends with ":<entity Name>".
-			if len(r.FromID) >= len(e.Name) && r.FromID[len(r.FromID)-len(e.Name):] == e.Name {
-				to = r.ToID
-			}
+		from := e.Properties["from"]
+		if from == "" {
+			t.Fatalf("stage %q has empty props[from]", e.Name)
 		}
-		lookups = append(lookups, lookupNode{id: e.ID, from: to})
+		lookups = append(lookups, lookupNode{id: e.ID, from: "Class:" + capitalisedSingular(from)})
+		rels = append(rels, MongoAggStageNodeJoinRel(e.ID, from))
 	}
 	if len(lookups) != 2 {
 		t.Fatalf("expected 2 $lookup stage entities, got %d (ents=%+v)", len(lookups), ents)
 	}
 
-	// (1) NO COLLAPSE: the two stages must have DISTINCT graph IDs. Pre-fix
-	// they share an ID because Name (= aggregate#1 $lookup for both) + file +
-	// kind are identical.
+	// (1) NO COLLAPSE: the two stages must have DISTINCT graph IDs.
 	if lookups[0].id == lookups[1].id {
 		t.Fatalf("COLLAPSE: the two $lookup stages share graph ID %s — distinct stages merged into one node (pre-fix #4244 bug)", lookups[0].id)
 	}
-	if lookups[0].from == lookups[1].from || lookups[0].from == "" || lookups[1].from == "" {
-		t.Fatalf("test setup: expected two distinct non-empty `from` targets, got %q and %q", lookups[0].from, lookups[1].from)
+	if lookups[0].from == lookups[1].from {
+		t.Fatalf("test setup: expected two distinct `from` targets, got %q and %q", lookups[0].from, lookups[1].from)
 	}
 
-	// Run the REAL resolver over the emitted edges.
-	idx := resolve.BuildIndex(ents)
-	resolve.References(rels, idx)
-
-	// (2) NO CROSS-STAGE MIS-LINK: each $lookup node's outgoing
-	// node-anchored JOINS_COLLECTION edges must point ONLY at its own `from`.
+	// (2) Each $lookup node's outgoing node-anchored JOINS_COLLECTION edge must
+	// have FromID == that node's graph id and point ONLY at its own `from`.
 	for _, ln := range lookups {
 		var targets []string
 		for j := range rels {
@@ -120,15 +102,13 @@ class InspectionService:
 			if r.Kind != string(types.RelationshipKindJoinsCollection) {
 				continue
 			}
-			if r.Properties["anchor"] != "stage_node" {
-				continue
+			if r.FromID != ln.id {
+				continue // FromID MUST be the node id — the whole point of #4244.
 			}
-			if r.FromID == ln.id {
-				targets = append(targets, r.ToID)
-			}
+			targets = append(targets, r.ToID)
 		}
 		if len(targets) == 0 {
-			t.Fatalf("ISOLATED: $lookup node %s has no outgoing node-anchored JOINS_COLLECTION (expected -> %s)", ln.id, ln.from)
+			t.Fatalf("ISOLATED: $lookup node %s has no outgoing JOINS_COLLECTION with FromID==node-id (expected -> %s)", ln.id, ln.from)
 		}
 		for _, tgt := range targets {
 			if tgt != ln.from {

--- a/internal/engine/orm_queries_php_mongo_agg.go
+++ b/internal/engine/orm_queries_php_mongo_agg.go
@@ -217,14 +217,13 @@ func scanPHPMongoAggregation(
 			return // dynamic from or unresolved collection — honest skip.
 		}
 		emitJoin(mongoAggJoinEdge(coll, lk, stageName))
-		// #4244 — node-anchored twin so the join is reachable from the
-		// $lookup DataAccess node. entityName MUST match the emitStage Name.
-		// The `@L<line>` segment keeps the per-call-site stage node unique so
-		// two `$lookup`s at the same per-file stage index in different
-		// aggregations never collapse onto one graph node (see
+		// #4244 — node-anchored twin emitted post-stamp by
+		// buildMongoAggStageJoinRels from props["from"]. entityName MUST match
+		// the emitStage Name; the `@L<line>` segment keeps the per-call-site
+		// stage node unique so two `$lookup`s at the same per-file stage index
+		// in different aggregations never collapse onto one graph node (see
 		// mongoAggStageName).
 		entityName := mongoAggStageName(coll, lineOfOffset(src, off), stageIdx, "$lookup")
-		emitJoin(mongoAggStageJoinEdge(entityName, path, lang, lk, stageName))
 
 		props := map[string]string{
 			"pattern_type": mongoAggPatternType,

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -282,10 +282,9 @@ func scanPythonMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-					// #4244 — also link the join FROM the $lookup DataAccess
-					// node so it is traversable (node → JOINS_COLLECTION →
-					// Class:<from>). Only when `from` is statically present.
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
+					// #4244 — the node-anchored twin (FromID = this stage's
+					// graph id) is emitted post-stamp by
+					// buildMongoAggStageJoinRels from props["from"].
 				}
 				// Correlated sub-pipeline join: a `$lookup` may carry a
 				// `pipeline: [ ... ]` whose own `$lookup` stages are NESTED joins
@@ -297,9 +296,12 @@ func scanPythonMongoAggregation(
 				// it). Bounded recursion over the static stage text — honest.
 				for _, nlk := range mongoAggCollectNestedLookups(st) {
 					emitJoin(mongoAggJoinEdge(coll, nlk, "lookup"))
-					// #4244 — node-anchored twin for each nested `from`, so the
-					// correlated joins are also reachable from the $lookup node.
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, nlk, "lookup"))
+					// #4244 — record each nested `from` as an extra
+					// node-anchored twin target so the correlated joins are
+					// also reachable from the $lookup node. The post-stamp pass
+					// (buildMongoAggStageJoinRels) emits one twin edge per
+					// recorded target with FromID = the stage node's graph id.
+					mongoAggAddStageJoinTarget(props, nlk.from)
 				}
 			case "$graphLookup":
 				lk := mongoAggParseLookup(st)
@@ -309,8 +311,8 @@ func scanPythonMongoAggregation(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
-					// #4244 — node-anchored twin (graphLookup stage node).
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
+					// #4244 — node-anchored twin emitted post-stamp from
+					// props["from"] (see buildMongoAggStageJoinRels).
 				}
 			case "$group":
 				id, accs := mongoAggParseGroup(st)

--- a/internal/engine/orm_queries_ruby_mongoid_agg.go
+++ b/internal/engine/orm_queries_ruby_mongoid_agg.go
@@ -195,8 +195,8 @@ func scanRubyMongoidAggCalls(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
-					// #4244 — node-anchored twin.
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "lookup"))
+					// #4244 — node-anchored twin emitted post-stamp from
+					// props["from"] (buildMongoAggStageJoinRels).
 				}
 			case "$graphLookup":
 				lk := mongoidParseLookup(st)
@@ -206,8 +206,8 @@ func scanRubyMongoidAggCalls(
 						props["as"] = lk.as
 					}
 					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
-					// #4244 — node-anchored twin (graphLookup stage node).
-					emitJoin(mongoAggStageJoinEdge(name, path, lang, lk, "graphLookup"))
+					// #4244 — node-anchored twin emitted post-stamp from
+					// props["from"] (buildMongoAggStageJoinRels).
 				}
 			}
 

--- a/internal/mcp/mongoagg_lookup_neighbors_4244_test.go
+++ b/internal/mcp/mongoagg_lookup_neighbors_4244_test.go
@@ -1,0 +1,63 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestMongoAggLookupNode_NeighborsSurfaceJoin_4244 drives the EXACT adjacency
+// path the live neighbors()/find-callees query uses (buildAdjacency(...).
+// Outgoing(nodeID)) and asserts the node-anchored JOINS_COLLECTION twin surfaces
+// FROM the `$lookup` DataAccess node id.
+//
+// This is the consumer-side half of the #4244 fix: the indexer now emits the
+// twin with FromID = graph.EntityID(repo, "SCOPE.DataAccess", name, file) (the
+// stage node's own graph id). buildAdjacency keys out-edges on FromID, so a
+// consumer that `find`s the `$lookup` node and asks for its neighbors must get
+// the join target. The two prior fixes left the twin's FromID a synthetic stub
+// that did NOT equal this id, so Outgoing(nodeID) was empty live — twice.
+func TestMongoAggLookupNode_NeighborsSurfaceJoin_4244(t *testing.T) {
+	const (
+		repo = "upvate-core"
+		file = "core/services/building/service.py"
+		// Mirror the live node name shape produced by mongoAggStageName:
+		// "<coll>.aggregate@L<line>#<idx> $lookup".
+		nodeName = "inspections.aggregate@L38#9 $lookup"
+		kind     = "SCOPE.DataAccess"
+	)
+	// The node id computed exactly as the indexer's stampEntityIDs does.
+	nodeID := graph.EntityID(repo, kind, nodeName, file)
+
+	doc := &graph.Document{
+		Repo: repo,
+		Entities: []graph.Entity{
+			{ID: nodeID, Kind: kind, Subtype: "$lookup", Name: nodeName, SourceFile: file},
+			{ID: "Class:M_contract", Kind: "Class", Name: "M_contract"},
+		},
+		Relationships: []graph.Relationship{
+			// Node-anchored twin: FromID == the $lookup node's graph id.
+			{
+				FromID:     nodeID,
+				ToID:       "Class:M_contract",
+				Kind:       "JOINS_COLLECTION",
+				Properties: map[string]string{"anchor": "stage_node"},
+			},
+		},
+	}
+
+	a := buildAdjacency(doc, repo)
+	out := a.Outgoing(nodeID)
+	if len(out) == 0 {
+		t.Fatalf("neighbors($lookup node %s) is EMPTY — the node is isolated from its join target (the live #4244 bug)", nodeID)
+	}
+	var found bool
+	for _, e := range out {
+		if e.kind == "JOINS_COLLECTION" && e.target == "Class:M_contract" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Outgoing(%s) = %+v; want a JOINS_COLLECTION edge -> Class:M_contract", nodeID, out)
+	}
+}


### PR DESCRIPTION
## Closes #4244

Third attempt — diagnosed from the live deploy-11 graph. The two prior fixes (#4247 stub, #4248 collision) both passed their fixtures and both failed live.

### The bug (origin/main)
The per-stage `$lookup`/`$graphLookup` `SCOPE.DataAccess` node a consumer `find`s (`inspections.aggregate@L38#9 $lookup`) was isolated live. Its node-anchored `JOINS_COLLECTION` twin was emitted at **extract time** with a structural-ref **stub** FromID:

```go
// internal/engine/orm_queries_jsts_mongo_agg.go (origin/main:638)
FromID: fmt.Sprintf("scope:dataaccess:%s:%s:%s:%s", stageOp, lang, file, stageName),
```

The resolver was supposed to rewrite that stub to the node's graph id via `byLocation[file][name]`. **Live, that rewrite did not land on the node's actual id** — the twin's FromID stayed `≠ graph.EntityID(<the node>)`, so `neighbors(<node>)` returned empty. Both prior tests asserted only that "a `JOINS_COLLECTION` edge exists", never that "an edge whose `FromID == graph.EntityID(<the $lookup node>)` exists" — that gap was the false pass.

### The fix
Abandon the stub + resolver path. The extract pass now only **records** the join target(s) on the stage entity (`props["from"]` for the primary lookup; `props["join_targets"]` for the Python correlated nested froms). A new post-stamp pass `buildMongoAggStageJoinRels`, run **after `stampEntityIDs`** in `buildDocument`, emits the twin with `FromID = r.ID` — the stage node's already-computed graph id — exactly like `buildPatternContainsRels`. FromID is a first-class resolved hex id (resolver leaves it untouched). The Class-anchored `JOINS_COLLECTION` edges (the original 57) are unchanged.

### Non-vacuous tests (assert `FromID == graph.EntityID` of the node)
- **cmd** (`index_mongoagg_4244_test.go`): full-indexer end-to-end on the real upvate fixture (`mongo_helper_indirection_real`, multiple aggregations on the same collection at L17/L27/L37/L56, each `$lookup` a distinct `from`). For every stage: recompute `graph.EntityID(repo,kind,name,file)`, assert `== entity.ID`, assert a `JOINS_COLLECTION` edge `FromID == that id → Class:<from>` for THAT stage (cross-stage-mix guard), then drive the FromID-keyed outgoing adjacency.
- **mcp** (`mongoagg_lookup_neighbors_4244_test.go`): drives the exact live query path `buildAdjacency(...).Outgoing(nodeID)` and asserts the join surfaces from the node id.
- **engine** (`orm_queries_mongo_agg_lookup_link_test.go`): asserts the extract pass emits **zero** node-anchored twins (the stub is gone) and records targets on the entity instead. Proven to **fail on origin/main** (which emits the `scope:dataaccess:...` stub at extract time) and pass only after the fix.

Gates: `go build ./...`, `go test ./internal/engine/ ./internal/resolve/ ./internal/mcp/ ./cmd/archigraph/`, `gofmt -l`, `go vet` — all clean. No regression to Class-anchored edges.

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)