### PR TITLE
ui+backend: Paths endpoint-posture + effective-contract sections (#4254)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -724,6 +724,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths", s.handleV2PathsList)
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/orphans", s.handleV2PathsOrphans)
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}", s.handleV2PathDetail)
+	// #4254 — lazy posture + effective-contract sections for the detail pane.
+	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}/posture", s.handleV2PathPosture)
 	// #1935 Phase 1 — ShapeTree subtree resolution (lazy class-field walk).
 	mux.HandleFunc("GET /api/v2/groups/{id}/shape", s.handleV2Shape)
 	// Module-level GDS analysis (#1384, epic #1380) — SCC + PageRank +

--- a/internal/dashboard/v2_paths_posture.go
+++ b/internal/dashboard/v2_paths_posture.go
@@ -1,0 +1,284 @@
+// v2_paths_posture.go — Paths detail-pane "Posture" + "Effective contract"
+// surface for WebUI v2 (#4254, epic #4249).
+//
+// Route:
+//
+//	GET /api/v2/groups/:id/paths/:hash/posture → v2PathPostureResponse
+//
+// This is the LAZY sibling of the main path-detail route: the Paths detail pane
+// fetches it only when a path is opened, so the (large) paths-list and the
+// path-detail payloads stay lean. It surfaces two graph-derived facets the flat
+// auth_policy never exposed:
+//
+//   - posture: per endpoint entity — deprecation/api_version, rate-limit,
+//     THROWS/error-flow exception list, feature-gates, and (gRPC/tRPC-aware)
+//     auth — assembled by the SAME code archigraph_endpoint_posture runs
+//     (internal/mcp.EndpointPostureForEntity → buildPosturePayload).
+//   - effective_contract: per-verb status codes, serializer, permissions, and an
+//     MRO-inherited flag for handlers resolved through a mixin EXTENDS chain —
+//     resolved by the SAME code archigraph_effective_contract runs
+//     (internal/mcp.EffectiveContractForTarget → computeEffectiveContract).
+//
+// HONESTY: posture facets are frequently empty (a route with no throws / no rate
+// limit / no deprecation); those endpoints are still returned but with empty
+// facets so the UI can render "none" rather than fabricating. effective_contract
+// is null for non-ViewSet endpoints (NestJS/Go/GraphQL routes that carry no DRF
+// router-expansion or pack-known base) — the contract result simply has no
+// groups and the UI shows the empty state.
+
+package dashboard
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror webui-v2/src/data/types.ts
+// ---------------------------------------------------------------------------
+
+// v2PathPostureResponse is the payload for
+// GET /api/v2/groups/:id/paths/:hash/posture. Both sections are honest-empty:
+// Endpoints may all carry empty facets, and Contract may have zero groups.
+type v2PathPostureResponse struct {
+	PathHash string `json:"path_hash"`
+	Path     string `json:"path"`
+	// Endpoints is one posture row per matched endpoint entity (a path can have
+	// several verbs / repos). Rows with no posture facet are kept (HasPosture
+	// false) so the pane can show "none" rather than dropping the verb.
+	Endpoints []mcp.PosturePayload `json:"endpoints"`
+	// Contract is the resolved per-verb effective contract grouped by owning
+	// ViewSet, or null when no DRF/pack-known ViewSet backs this path. Note
+	// carries the honest-partial explanation when no groups resolved.
+	Contract *mcp.EffectiveContractResult `json:"contract"`
+}
+
+// handleV2PathPosture — GET /api/v2/groups/:id/paths/:hash/posture
+//
+// Lazily serves the Posture + Effective-contract sections for the Paths detail
+// pane, reusing the MCP endpoint_posture + effective_contract computation
+// server-side (no re-derivation — same code path the MCP tools run, so the two
+// surfaces never drift).
+func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	pathHash := r.PathValue("hash")
+	if id == "" || pathHash == "" {
+		writeV2Err(w, http.StatusBadRequest, "params_required", "group id and path hash required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(id)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "group_not_found", err.Error())
+		return
+	}
+
+	// Build the in-memory document set the MCP helpers wrap, keyed by repo slug
+	// (the SAME slug both packages use for prefixed entity ids).
+	docs := make(map[string]*graph.Document)
+	for _, repo := range sortedRepos(grp) {
+		docs[repo.Slug] = repo.Doc
+	}
+
+	// Per-repo handler-resolution index, built lazily and reused across the
+	// matched endpoint definitions of the same repo (#1646 pattern).
+	repoIdx := map[string]*repoEntityIndex{}
+
+	var pathStr string
+	var postures []mcp.PosturePayload
+	// contractTargets collects the distinct ViewSet/handler class names this
+	// path resolves to, so we issue one effective_contract resolution per owning
+	// ViewSet (deduplicated). Lower-cased leaf is the resolution key.
+	contractTargets := []string{}
+	seenTarget := map[string]bool{}
+
+	for _, repo := range sortedRepos(grp) {
+		if repo.Doc == nil {
+			continue
+		}
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+			kind := dashStripScopePrefix(e.Kind)
+			isHTTP := types.IsHTTPEndpointKind(kind) ||
+				strings.EqualFold(kind, httpEndpointKind) ||
+				e.Kind == "Endpoint" || e.Kind == "Route"
+			if !isHTTP {
+				continue
+			}
+			if e.Kind == "http_endpoint_call" ||
+				e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+				continue
+			}
+			path := e.Properties["path"]
+			if path == "" {
+				path = e.Name
+			}
+			if hashStr(path) != pathHash {
+				continue
+			}
+			if pathStr == "" {
+				pathStr = path
+			}
+
+			// --- Posture: assemble from the endpoint entity itself AND its
+			// resolved handler. The posture facets (THROWS/CATCHES/GATED_BY edges,
+			// rate-limit / deprecation / auth props) may live on either the
+			// synthetic definition OR the real handler method, so we surface both
+			// and keep whichever carries posture. We always emit at least the
+			// endpoint row (HasPosture may be false → UI shows "none").
+			if p, ok := mcp.EndpointPostureForEntity(grp.Name, docs, repo.Slug, e.ID); ok {
+				postures = append(postures, p)
+			}
+
+			idx := repoIdx[repo.Slug]
+			if idx == nil {
+				idx = buildRepoEntityIndex(repo)
+				repoIdx[repo.Slug] = idx
+			}
+			for _, h := range idx.resolveHandlers(e) {
+				if h.ID == e.ID {
+					continue
+				}
+				// A resolved handler that carries posture of its own (the real
+				// viewset method's THROWS/rate-limit/etc.) — surface it too.
+				if hp, ok := mcp.EndpointPostureForEntity(grp.Name, docs, repo.Slug, h.ID); ok && hp.HasPosture {
+					postures = append(postures, hp)
+				}
+				// Effective-contract target: the owning class of the resolved
+				// handler ("RoleViewSet.create" → "RoleViewSet").
+				if cls := owningClassOfHandler(h); cls != "" {
+					key := strings.ToLower(cls)
+					if !seenTarget[key] {
+						seenTarget[key] = true
+						contractTargets = append(contractTargets, cls)
+					}
+				}
+			}
+			// Also consider the endpoint's own drf_view_method attribution (the
+			// router-expanded route records "ViewSet.method" directly), so a path
+			// whose handler did not re-resolve still yields a contract target.
+			if dvm := e.Properties["drf_view_method"]; dvm != "" {
+				if cls := classFromDotted(dvm); cls != "" {
+					key := strings.ToLower(cls)
+					if !seenTarget[key] {
+						seenTarget[key] = true
+						contractTargets = append(contractTargets, cls)
+					}
+				}
+			}
+		}
+	}
+
+	if pathStr == "" {
+		writeV2Err(w, http.StatusNotFound, "path_not_found", "path not found: "+pathHash)
+		return
+	}
+
+	// Deterministic, deduplicated posture rows (a verb's endpoint + handler can
+	// produce two rows for the same entity id across repeated path entities).
+	postures = dedupePostures(postures)
+	sort.Slice(postures, func(i, j int) bool {
+		if postures[i].Path != postures[j].Path {
+			return postures[i].Path < postures[j].Path
+		}
+		if postures[i].Method != postures[j].Method {
+			return postures[i].Method < postures[j].Method
+		}
+		return postures[i].EntityID < postures[j].EntityID
+	})
+	if postures == nil {
+		postures = []mcp.PosturePayload{}
+	}
+
+	// --- Effective contract: resolve each distinct owning ViewSet and merge the
+	// groups. Reuses the MRO/baseknowledge-pack-aware computation the MCP tool
+	// runs. Null when no ViewSet backs this path (non-DRF endpoints).
+	var contract *mcp.EffectiveContractResult
+	sort.Strings(contractTargets)
+	for _, target := range contractTargets {
+		res := mcp.EffectiveContractForTarget(grp.Name, docs, target)
+		if len(res.Groups) == 0 {
+			continue
+		}
+		if contract == nil {
+			merged := res
+			merged.Target = pathStr
+			contract = &merged
+			continue
+		}
+		contract.Groups = append(contract.Groups, res.Groups...)
+	}
+
+	writeV2JSON(w, http.StatusOK, v2OK(v2PathPostureResponse{
+		PathHash:  pathHash,
+		Path:      pathStr,
+		Endpoints: postures,
+		Contract:  contract,
+	}))
+}
+
+// owningClassOfHandler returns the class/ViewSet leaf that owns a resolved
+// handler entity, for use as an effective_contract resolution target. Prefers
+// the handler's qualified name ("app.views.RoleViewSet.create" → "RoleViewSet"),
+// then its plain name, then any drf_view_method attribution. Empty when no class
+// can be derived (a free-function handler).
+func owningClassOfHandler(h *graph.Entity) string {
+	if h == nil {
+		return ""
+	}
+	if cls := classFromDotted(h.QualifiedName); cls != "" {
+		return cls
+	}
+	if cls := classFromDotted(h.Name); cls != "" {
+		return cls
+	}
+	if h.Properties != nil {
+		if cls := classFromDotted(h.Properties["drf_view_method"]); cls != "" {
+			return cls
+		}
+	}
+	return ""
+}
+
+// classFromDotted returns the class leaf from a dotted "Owner.method" (or
+// "pkg.Owner.method") string: the second-to-last dotted segment. Returns "" when
+// the input has no dot (a bare name with no method, which carries no class
+// attribution on its own).
+func classFromDotted(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Strip any "<repo>::" scope prefix first.
+	if sc := strings.LastIndex(s, "::"); sc >= 0 {
+		s = s[sc+2:]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-2]
+}
+
+// dedupePostures removes duplicate posture rows by entity id (the same handler
+// can be reached through several path entities / verbs). First occurrence wins.
+func dedupePostures(in []mcp.PosturePayload) []mcp.PosturePayload {
+	if len(in) == 0 {
+		return in
+	}
+	seen := map[string]bool{}
+	out := in[:0:0]
+	for _, p := range in {
+		if seen[p.EntityID] {
+			continue
+		}
+		seen[p.EntityID] = true
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/dashboard/v2_paths_posture_test.go
+++ b/internal/dashboard/v2_paths_posture_test.go
@@ -1,0 +1,227 @@
+package dashboard
+
+// v2_paths_posture_test.go — unit tests for the lazy Paths posture +
+// effective-contract sibling route (#4254). Verifies the dashboard reuses the
+// MCP endpoint_posture / effective_contract computation and surfaces it under
+// the v2 envelope, with honest-empty handling.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// postureResponseEnvelope decodes the v2OK envelope around v2PathPostureResponse.
+type postureResponseEnvelope struct {
+	OK   bool                  `json:"ok"`
+	Data v2PathPostureResponse `json:"data"`
+}
+
+func fetchPosture(t *testing.T, srv *Server, group, hash string) v2PathPostureResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/groups/"+group+"/paths/"+hash+"/posture", nil)
+	req.SetPathValue("id", group)
+	req.SetPathValue("hash", hash)
+	rw := httptest.NewRecorder()
+	srv.handleV2PathPosture(rw, req)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", rw.Code, rw.Body.String())
+	}
+	var env postureResponseEnvelope
+	if err := json.NewDecoder(rw.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v — body: %s", err, rw.Body.String())
+	}
+	if !env.OK {
+		t.Fatalf("envelope ok=false: %s", rw.Body.String())
+	}
+	return env.Data
+}
+
+func injectPostureGroup(t *testing.T, name string, doc *graph.Document) *Server {
+	t.Helper()
+	cache := NewGraphCache(60 * time.Second)
+	srv := &Server{graphs: cache}
+	grp := &DashGroup{Name: name, Repos: map[string]*DashRepo{doc.Repo: {Slug: doc.Repo, Doc: doc}}}
+	cache.mu.Lock()
+	cache.entries[name] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	cache.mu.Unlock()
+	return srv
+}
+
+// TestPathPosture_SurfacesFacets — an endpoint carrying THROWS / rate_limit /
+// deprecation / feature-gate / auth props is surfaced with its posture, AND the
+// router-expanded route's effective contract resolves per verb.
+func TestPathPosture_SurfacesFacets(t *testing.T) {
+	const path = "/api/v1/roles/{pk}"
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			// The DRF router-expanded POST route — carries the stamped per-verb
+			// effective contract AND posture props.
+			{
+				ID:   "ep:roles:post",
+				Name: "RoleViewSet.create",
+				Kind: "http_endpoint_definition",
+				Properties: map[string]string{
+					"path":                     path,
+					"verb":                     "POST",
+					"pattern_type":             "drf_router_expanded",
+					"drf_view_method":          "RoleViewSet.create",
+					"effective_kind":           "inherited",
+					"effective_source_class":   "CreateModelMixin",
+					"effective_status":         "201",
+					"effective_error_statuses": "400",
+					"serializer_class":         "RoleSerializer",
+					"middleware_names":         "IsAuthenticated",
+					"auth_required":            "true",
+					// posture props
+					"rate_limited": "true",
+					"rate_limit":   "100/min",
+					"deprecated":   "true",
+					"api_version":  "v1",
+					"auth_method":  "session",
+				},
+				SourceFile: "roles/views.py",
+				StartLine:  12,
+			},
+			// The exception type the route throws (THROWS target).
+			{
+				ID:   "exc:ValidationError",
+				Name: "exception:ValidationError",
+				Kind: "SCOPE.ExceptionType",
+			},
+			// A feature flag the route is gated by (GATED_BY target).
+			{
+				ID:   "feature:roles_v2",
+				Name: "feature:roles_v2",
+				Kind: "SCOPE.FeatureFlag",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "t1", FromID: "ep:roles:post", ToID: "exc:ValidationError", Kind: "THROWS"},
+			{ID: "g1", FromID: "ep:roles:post", ToID: "feature:roles_v2", Kind: "GATED_BY"},
+		},
+	}
+
+	srv := injectPostureGroup(t, "g1", doc)
+	resp := fetchPosture(t, srv, "g1", hashStr(path))
+
+	if resp.Path != path {
+		t.Errorf("Path = %q, want %q", resp.Path, path)
+	}
+
+	// --- Posture assertions ---
+	if len(resp.Endpoints) == 0 {
+		t.Fatalf("expected at least one posture endpoint")
+	}
+	var found *mcp.PosturePayload
+	for i := range resp.Endpoints {
+		if resp.Endpoints[i].EntityID == "svc::ep:roles:post" {
+			found = &resp.Endpoints[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("posture endpoint svc::ep:roles:post not found in %+v", resp.Endpoints)
+	}
+	if !found.HasPosture {
+		t.Errorf("expected HasPosture=true")
+	}
+	if found.ErrorFlow == nil || len(found.ErrorFlow.Throws) != 1 || found.ErrorFlow.Throws[0] != "ValidationError" {
+		t.Errorf("error_flow throws = %+v, want [ValidationError]", found.ErrorFlow)
+	}
+	if found.RateLimit["rate_limit"] != "100/min" {
+		t.Errorf("rate_limit = %+v, want 100/min", found.RateLimit)
+	}
+	if found.Deprecation["api_version"] != "v1" {
+		t.Errorf("deprecation api_version = %+v, want v1", found.Deprecation)
+	}
+	if len(found.FeatureGate) != 1 || found.FeatureGate[0] != "roles_v2" {
+		t.Errorf("feature_gates = %+v, want [roles_v2]", found.FeatureGate)
+	}
+	if found.Auth["auth_method"] != "session" {
+		t.Errorf("auth = %+v, want auth_method=session", found.Auth)
+	}
+
+	// --- Effective contract assertions (reused MRO/pack-aware projection) ---
+	if resp.Contract == nil {
+		t.Fatalf("expected non-nil effective contract for a DRF ViewSet path")
+	}
+	if len(resp.Contract.Groups) == 0 {
+		t.Fatalf("expected at least one contract group, note=%q", resp.Contract.Note)
+	}
+	var post *mcp.EffectiveContract
+	for gi := range resp.Contract.Groups {
+		for hi := range resp.Contract.Groups[gi].Handlers {
+			h := &resp.Contract.Groups[gi].Handlers[hi]
+			if h.Verb == "POST" {
+				post = h
+			}
+		}
+	}
+	if post == nil {
+		t.Fatalf("POST contract not found in %+v", resp.Contract.Groups)
+	}
+	if post.DefaultStatus != 201 {
+		t.Errorf("POST default_status = %d, want 201", post.DefaultStatus)
+	}
+	if len(post.ErrorStatuses) != 1 || post.ErrorStatuses[0] != 400 {
+		t.Errorf("POST error_statuses = %+v, want [400]", post.ErrorStatuses)
+	}
+	if post.Serializer != "RoleSerializer" {
+		t.Errorf("POST serializer = %q, want RoleSerializer", post.Serializer)
+	}
+	if post.Kind != "inherited" {
+		t.Errorf("POST kind = %q, want inherited (MRO-inherited handler)", post.Kind)
+	}
+}
+
+// TestPathPosture_HonestEmpty — a plain endpoint with no posture facets and no
+// DRF ViewSet still returns 200 with an honest-empty posture row and a null
+// contract (non-ViewSet endpoint).
+func TestPathPosture_HonestEmpty(t *testing.T) {
+	const path = "/health"
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID:         "ep:health",
+				Name:       "healthCheck",
+				Kind:       "http_endpoint",
+				Properties: map[string]string{"path": path, "verb": "GET"},
+				SourceFile: "main.go",
+				StartLine:  3,
+			},
+		},
+	}
+	srv := injectPostureGroup(t, "g2", doc)
+	resp := fetchPosture(t, srv, "g2", hashStr(path))
+
+	if len(resp.Endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint row, got %d", len(resp.Endpoints))
+	}
+	if resp.Endpoints[0].HasPosture {
+		t.Errorf("expected HasPosture=false for a bare endpoint")
+	}
+	if resp.Contract != nil {
+		t.Errorf("expected nil contract for non-ViewSet endpoint, got %+v", resp.Contract)
+	}
+}
+
+// TestPathPosture_NotFound — an unknown hash returns 404.
+func TestPathPosture_NotFound(t *testing.T) {
+	doc := &graph.Document{Repo: "svc"}
+	srv := injectPostureGroup(t, "g3", doc)
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/groups/g3/paths/deadbeef/posture", nil)
+	req.SetPathValue("id", "g3")
+	req.SetPathValue("hash", "deadbeef")
+	rw := httptest.NewRecorder()
+	srv.handleV2PathPosture(rw, req)
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d — %s", rw.Code, rw.Body.String())
+	}
+}

--- a/internal/mcp/dashboard_api.go
+++ b/internal/mcp/dashboard_api.go
@@ -1,0 +1,87 @@
+package mcp
+
+// dashboard_api.go — exported, request-envelope-free entry points that let the
+// dashboard backend reuse the EXACT posture + effective-contract computation the
+// archigraph_endpoint_posture and archigraph_effective_contract MCP tools run
+// (#4254, epic #4249).
+//
+// Both surfaces (the MCP tool and the dashboard Paths detail pane) MUST agree
+// byte-for-byte on what an endpoint's posture / a ViewSet's per-verb contract
+// is. The only way to guarantee that is for both to call the same code. The MCP
+// handlers operate on the internal *LoadedRepo / *LoadedGroup model, which the
+// dashboard does not hold — but a LoadedRepo needs nothing more than a repo slug
+// and a *graph.Document (every derived index builds lazily on first use). So
+// these helpers wrap the dashboard's already-loaded graph.Documents into a
+// throwaway LoadedGroup and delegate to buildPosturePayload /
+// computeEffectiveContract.
+//
+// The returned types (PosturePayload, EffectiveContractResult, ...) are exported
+// aliases of the internal wire structs, so the dashboard serialises the IDENTICAL
+// JSON shape the MCP tools emit — no re-derivation, no drift.
+
+import "github.com/cajasmota/archigraph/internal/graph"
+
+// PosturePayload is the exported per-endpoint posture shape (error_flow / THROWS,
+// rate_limit, deprecation, feature_gates, auth). Identical to what
+// archigraph_endpoint_posture returns per entity.
+type PosturePayload = posturePayload
+
+// ErrorFlow is the exported THROWS/CATCHES facet.
+type ErrorFlow = errorFlow
+
+// EffectiveContractResult is the exported top-level effective-contract envelope.
+type EffectiveContractResult = effectiveContractResult
+
+// EffectiveContractGroup is the exported per-ViewSet group.
+type EffectiveContractGroup = effectiveContractGroup
+
+// EffectiveContract is the exported per-verb contract.
+type EffectiveContract = effectiveContract
+
+// loadedGroupFromDocs builds a throwaway LoadedGroup over the supplied in-memory
+// graph.Documents (keyed by repo slug). Each LoadedRepo carries only Repo + Doc;
+// every derived index (adjacency, byID, EXTENDS walk) is built lazily by the
+// existing getters the moment the computation touches it. Documents that are nil
+// are skipped.
+func loadedGroupFromDocs(group string, docs map[string]*graph.Document) *LoadedGroup {
+	lg := &LoadedGroup{Name: group, Repos: make(map[string]*LoadedRepo, len(docs))}
+	for slug, doc := range docs {
+		if doc == nil {
+			continue
+		}
+		lg.Repos[slug] = &LoadedRepo{Repo: slug, Doc: doc}
+	}
+	return lg
+}
+
+// EndpointPostureForEntity computes the full posture (error_flow, rate_limit,
+// deprecation, feature_gates, auth) for a single endpoint entity in repo `slug`
+// of the supplied in-memory document set, reusing buildPosturePayload — the same
+// assembly archigraph_endpoint_posture runs. Returns (payload, true) when the
+// entity is found, (zero, false) otherwise. The HasPosture field reports whether
+// any facet is non-empty (the honest-empty signal the dashboard renders as
+// "none").
+func EndpointPostureForEntity(group string, docs map[string]*graph.Document, slug, entityID string) (PosturePayload, bool) {
+	lg := loadedGroupFromDocs(group, docs)
+	r, ok := lg.Repos[slug]
+	if !ok || r.Doc == nil {
+		return PosturePayload{}, false
+	}
+	byID := r.getByID()
+	e, ok := byID[entityID]
+	if !ok || e == nil {
+		return PosturePayload{}, false
+	}
+	return buildPosturePayload(r, e), true
+}
+
+// EffectiveContractForTarget resolves `target` (a ViewSet/controller entity_id,
+// prefixed id, or bare class name) to its grouped per-verb effective contract
+// across the supplied document set, reusing computeEffectiveContract — the same
+// MRO/baseknowledge-pack-aware resolution archigraph_effective_contract runs.
+// When nothing resolves the result's Groups is empty and Note explains why
+// (honest-partial — never a fabricated contract).
+func EffectiveContractForTarget(group string, docs map[string]*graph.Document, target string) EffectiveContractResult {
+	lg := loadedGroupFromDocs(group, docs)
+	return computeEffectiveContract(lg, target)
+}

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -161,6 +161,16 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 		return errRes, nil
 	}
 
+	out := computeEffectiveContract(lg, target)
+	return jsonResult(out), nil
+}
+
+// computeEffectiveContract resolves the target ViewSet within lg, gathers its
+// router-expanded routes (or class-fallback synthesis), and returns the grouped
+// per-verb effective-contract result. Factored out of handleEffectiveContract so
+// the dashboard backend can reuse the EXACT same MRO/pack-aware computation
+// (#4254) without going through the MCP request envelope.
+func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractResult {
 	wantVS, _ := resolveEffectiveContractTarget(lg, target)
 
 	// Gather, per (repo, ViewSet), the projected per-verb contracts of every
@@ -264,7 +274,7 @@ func (s *Server) handleEffectiveContract(_ context.Context, req mcpapi.CallToolR
 			"(pass its entity_id or exact class name, not a method or module), that " +
 			"it is a DRF ViewSet, and that its base class is one the pack knows."
 	}
-	return jsonResult(out), nil
+	return out
 }
 
 // backfillEffectiveContractFromMRO fills the per-verb contract fields a

--- a/webui-v2/src/components/Paths/EndpointDetail/PostureSection.tsx
+++ b/webui-v2/src/components/Paths/EndpointDetail/PostureSection.tsx
@@ -1,0 +1,316 @@
+/**
+ * PostureSection.tsx — "Posture" + "Effective contract" detail-pane sections
+ * for the Paths screen (#4254, epic #4249).
+ *
+ * Lazy-fetches GET /api/v2/groups/:id/paths/:hash/posture (TanStack Query keyed
+ * by group + path hash) when a path is opened. Surfaces two graph-derived facets
+ * the flat auth_policy never exposed:
+ *
+ *   Posture            — per endpoint: deprecation / api_version + rate-limit
+ *                        badges, a Throws/error-flow list, feature-gate pills,
+ *                        and resolved auth props.
+ *   Effective contract — per-verb table: default + error status codes,
+ *                        serializer, permissions, and an `inherited` tag for
+ *                        MRO-resolved (mixin) handlers.
+ *
+ * HONESTY: both sections are honest-empty. Posture rows with no facet render
+ * "No posture signals"; a null contract (non-ViewSet endpoint) renders the
+ * empty-state note rather than a fabricated table.
+ */
+
+import { ShieldAlert, FileSignature } from "lucide-react";
+import { Badge, Skeleton } from "@/components/ui";
+import { SectionHeader } from "@/components/SectionHeader";
+import { usePathPosture } from "@/hooks/use-paths";
+import type {
+  PosturePayload,
+  EffectiveContract,
+  EffectiveContractResult,
+} from "@/data/types";
+
+interface PostureSectionProps {
+  groupId: string;
+  pathHash: string;
+  postureOpen: boolean;
+  contractOpen: boolean;
+  onTogglePosture: () => void;
+  onToggleContract: () => void;
+}
+
+/* ----------------------------------------------------------------
+   Small presentational helpers
+   ---------------------------------------------------------------- */
+
+/** A labelled key→value pill row (rate-limit / deprecation / auth props). */
+function PropBadges({ props, tone }: { props?: Record<string, string>; tone: "warning" | "info" | "neutral" }) {
+  const entries = Object.entries(props ?? {});
+  if (entries.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([k, v]) => (
+        <Badge key={k} tone={tone}>
+          <span className="opacity-70">{k}</span>
+          <span className="font-mono">{v}</span>
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+/** One endpoint's posture facets, or an honest-empty note. */
+function PostureRow({ p }: { p: PosturePayload }) {
+  const throws = p.error_flow?.throws ?? [];
+  const catches = p.error_flow?.catches ?? [];
+  const gates = p.feature_gates ?? [];
+
+  return (
+    <div className="px-4 py-2.5 border-b border-border-soft last:border-b-0">
+      <div className="flex items-center gap-2 mb-1.5">
+        {p.method && (
+          <span className="text-[10px] font-mono font-semibold text-text-3 uppercase">{p.method}</span>
+        )}
+        <span className="text-xs text-text-2 font-mono truncate">{p.name ?? p.path ?? p.entity_id}</span>
+        <span className="text-[10px] text-text-4">{p.repo}</span>
+      </div>
+
+      {!p.has_posture ? (
+        <p className="text-[11px] text-text-4 italic">No posture signals on this endpoint.</p>
+      ) : (
+        <div className="space-y-1.5 pl-1">
+          {/* Deprecation / versioning */}
+          {p.deprecation && Object.keys(p.deprecation).length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] text-text-4 font-medium w-20 shrink-0">Deprecation</span>
+              <PropBadges props={p.deprecation} tone="warning" />
+            </div>
+          )}
+
+          {/* Rate limit */}
+          {p.rate_limit && Object.keys(p.rate_limit).length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] text-text-4 font-medium w-20 shrink-0">Rate limit</span>
+              <PropBadges props={p.rate_limit} tone="info" />
+            </div>
+          )}
+
+          {/* Throws / error flow */}
+          {(throws.length > 0 || catches.length > 0) && (
+            <div className="flex items-start gap-2 flex-wrap">
+              <span className="text-[10px] text-text-4 font-medium w-20 shrink-0 pt-0.5">Error flow</span>
+              <div className="flex flex-wrap gap-1">
+                {throws.map((t) => (
+                  <Badge key={`t-${t}`} tone="danger">
+                    <span className="opacity-70">throws</span>
+                    <span className="font-mono">{t}</span>
+                  </Badge>
+                ))}
+                {catches.map((c) => (
+                  <Badge key={`c-${c}`} tone="neutral">
+                    <span className="opacity-70">catches</span>
+                    <span className="font-mono">{c}</span>
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Feature gates */}
+          {gates.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] text-text-4 font-medium w-20 shrink-0">Feature gates</span>
+              <div className="flex flex-wrap gap-1">
+                {gates.map((g) => (
+                  <Badge key={g} tone="accent">
+                    <span className="font-mono">{g}</span>
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Auth (gRPC/tRPC interceptor + HTTP guard props) */}
+          {p.auth && Object.keys(p.auth).length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10px] text-text-4 font-medium w-20 shrink-0">Auth</span>
+              <PropBadges props={p.auth} tone="neutral" />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Per-verb effective-contract table row. */
+function ContractRow({ c }: { c: EffectiveContract }) {
+  const errs = c.error_statuses ?? [];
+  const perms = c.permissions ?? [];
+  return (
+    <tr className="border-b border-border-soft last:border-b-0 align-top">
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-mono font-semibold text-text-2 uppercase">{c.verb}</span>
+          {c.kind === "inherited" && (
+            <Badge tone="info" title={c.source_class ? `inherited from ${c.source_class}` : "MRO-inherited handler"}>
+              inherited
+            </Badge>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex flex-wrap gap-1">
+          {c.default_status ? (
+            <Badge tone="success">{c.default_status}</Badge>
+          ) : (
+            <span className="text-[11px] text-text-4">—</span>
+          )}
+          {errs.map((s) => (
+            <Badge key={s} tone="danger">{s}</Badge>
+          ))}
+        </div>
+      </td>
+      <td className="px-3 py-2 text-[11px] font-mono text-text-2">
+        {c.serializer || <span className="text-text-4">—</span>}
+      </td>
+      <td className="px-3 py-2">
+        {perms.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {perms.map((p) => (
+              <Badge key={p} tone="neutral">
+                <span className="font-mono">{p}</span>
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <span className="text-[11px] text-text-4">{c.auth_required ? "auth required" : "—"}</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function ContractTable({ contract }: { contract: EffectiveContractResult }) {
+  const groups = contract.groups ?? [];
+  if (groups.length === 0) {
+    return (
+      <p className="px-4 py-3 text-[11px] text-text-4 italic">
+        {contract.note ??
+          "No effective contract — this endpoint is not backed by a DRF ViewSet (or a framework base the knowledge pack recognises)."}
+      </p>
+    );
+  }
+  return (
+    <div className="py-1">
+      {groups.map((g, gi) => (
+        <div key={`${g.repo}-${g.class}-${gi}`}>
+          <div className="flex items-center gap-2 px-4 py-1.5">
+            <span className="text-xs font-medium text-text-2 font-mono">{g.class}</span>
+            {g.framework && <span className="text-[10px] text-text-4">{g.framework}</span>}
+          </div>
+          <table className="w-full text-left">
+            <thead>
+              <tr className="text-[10px] text-text-4 uppercase tracking-wide">
+                <th className="px-3 py-1 font-medium">Verb</th>
+                <th className="px-3 py-1 font-medium">Status</th>
+                <th className="px-3 py-1 font-medium">Serializer</th>
+                <th className="px-3 py-1 font-medium">Permissions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {g.handlers.map((c, ci) => (
+                <ContractRow key={`${c.verb}-${c.path}-${ci}`} c={c} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------
+   PostureSection — both sections + lazy query
+   ---------------------------------------------------------------- */
+export function PostureSection({
+  groupId,
+  pathHash,
+  postureOpen,
+  contractOpen,
+  onTogglePosture,
+  onToggleContract,
+}: PostureSectionProps) {
+  // Lazy-fetch only when at least one of the two sections is open.
+  const enabledHash = postureOpen || contractOpen ? pathHash : null;
+  const { data, isLoading, isError, error } = usePathPosture(groupId, enabledHash);
+
+  const endpoints = data?.endpoints ?? [];
+  const postureCount = endpoints.filter((e) => e.has_posture).length;
+  const contract = data?.contract ?? null;
+  const contractCount = (contract?.groups ?? []).reduce((n, g) => n + g.handlers.length, 0);
+
+  return (
+    <>
+      {/* Posture */}
+      <div>
+        <SectionHeader
+          icon={<ShieldAlert size={14} />}
+          title="Posture"
+          count={data ? postureCount : undefined}
+          infoText="Operational posture resolved from the graph — deprecation / API version, rate limits, thrown exceptions (error flow), and feature-flag gates. Shown only when the endpoint carries the signal."
+          open={postureOpen}
+          onToggle={onTogglePosture}
+        />
+        {postureOpen && (
+          <div>
+            {isLoading ? (
+              <div className="px-4 py-3 space-y-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            ) : isError ? (
+              <p className="px-4 py-3 text-[11px] text-danger">
+                Failed to load posture{error instanceof Error ? `: ${error.message}` : ""}.
+              </p>
+            ) : endpoints.length === 0 ? (
+              <p className="px-4 py-3 text-[11px] text-text-4 italic">No endpoints resolved for this path.</p>
+            ) : (
+              endpoints.map((p) => <PostureRow key={p.entity_id} p={p} />)
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Effective contract */}
+      <div>
+        <SectionHeader
+          icon={<FileSignature size={14} />}
+          title="Effective contract"
+          count={data && contract ? contractCount : undefined}
+          infoText="Per-verb effective contract resolved through the MRO/inheritance chain — success + error status codes, serializer, and permission classes. Inherited (mixin) handlers are tagged. Null for non-ViewSet endpoints."
+          open={contractOpen}
+          onToggle={onToggleContract}
+        />
+        {contractOpen && (
+          <div>
+            {isLoading ? (
+              <div className="px-4 py-3 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            ) : isError ? (
+              <p className="px-4 py-3 text-[11px] text-danger">
+                Failed to load effective contract{error instanceof Error ? `: ${error.message}` : ""}.
+              </p>
+            ) : !contract ? (
+              <p className="px-4 py-3 text-[11px] text-text-4 italic">
+                No effective contract — this endpoint is not backed by a DRF ViewSet.
+              </p>
+            ) : (
+              <ContractTable contract={contract} />
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -995,6 +995,88 @@ export interface PathDetail {
   tests: PathEntity[];
 }
 
+/* ------------------------------------------------------------------
+   Endpoint posture + effective contract (#4254, epic #4249)
+
+   Returned by GET /api/v2/groups/:id/paths/:hash/posture — the lazy
+   sibling route the detail pane fetches when a path is opened. Mirrors
+   the Go internal/mcp.PosturePayload / EffectiveContractResult shapes
+   the archigraph_endpoint_posture / archigraph_effective_contract tools
+   emit (same code path, no drift). All facets are honest-empty: a row
+   may carry no posture at all (has_posture=false), and `contract` is
+   null for non-ViewSet endpoints.
+   ------------------------------------------------------------------ */
+
+/** THROWS / CATCHES exception-flow facet of an endpoint's posture. */
+export interface PostureErrorFlow {
+  throws?: string[];
+  catches?: string[];
+}
+
+/** Per-endpoint posture row (one per matched endpoint entity). */
+export interface PosturePayload {
+  entity_id: string;
+  name?: string;
+  kind?: string;
+  repo: string;
+  source_file?: string;
+  start_line?: number;
+  method?: string;
+  path?: string;
+  error_flow?: PostureErrorFlow;
+  /** rate_limited / rate_limit / rate_limit_scope / rate_limit_source props. */
+  rate_limit?: Record<string, string>;
+  /** deprecated / deprecated_since / api_version / ... props. */
+  deprecation?: Record<string, string>;
+  /** Feature-flag keys this endpoint is gated by (GATED_BY edges). */
+  feature_gates?: string[];
+  /** Resolved auth/interceptor props (HTTP guard + gRPC/tRPC). */
+  auth?: Record<string, string>;
+  /** True when at least one facet above is non-empty. */
+  has_posture: boolean;
+}
+
+/** One verb's effective contract within a ViewSet group. */
+export interface EffectiveContract {
+  verb: string;
+  path?: string;
+  handler?: string;
+  /** "explicit" | "inherited" | "action" — "inherited" marks an MRO handler. */
+  kind?: string;
+  source_class?: string;
+  default_status?: number;
+  error_statuses?: number[];
+  serializer?: string;
+  pagination?: boolean;
+  permissions?: string[];
+  behaviour?: string;
+  auth_required?: boolean;
+}
+
+/** One owning ViewSet's grouped per-verb contracts. */
+export interface EffectiveContractGroup {
+  class: string;
+  framework?: string;
+  repo?: string;
+  handlers: EffectiveContract[];
+}
+
+/** Grouped effective-contract result; note explains an empty groups list. */
+export interface EffectiveContractResult {
+  target: string;
+  groups: EffectiveContractGroup[] | null;
+  note?: string;
+}
+
+/** Payload for GET /api/v2/groups/:id/paths/:hash/posture. */
+export interface PathPostureResponse {
+  path_hash: string;
+  path: string;
+  endpoints: PosturePayload[];
+  /** null when no DRF/pack-known ViewSet backs this path. */
+  contract: EffectiveContractResult | null;
+}
+
 /** One orphan caller row. */
 export interface OrphanCaller {
   id: string;

--- a/webui-v2/src/hooks/use-paths.ts
+++ b/webui-v2/src/hooks/use-paths.ts
@@ -42,6 +42,22 @@ export function usePathDetail(groupId: string, pathHash: string | null) {
   });
 }
 
+export const pathPostureQueryKey = (groupId: string, hash: string) =>
+  ["paths", groupId, "posture", hash] as const;
+
+/**
+ * Lazy posture + effective-contract sections for the open path (#4254).
+ * Fetched only once a path is selected so the main detail payload stays lean.
+ */
+export function usePathPosture(groupId: string, pathHash: string | null) {
+  return useQuery({
+    queryKey: pathPostureQueryKey(groupId, pathHash ?? ""),
+    queryFn: () => api.getPathPosture(groupId, pathHash!),
+    enabled: !!groupId && !!pathHash,
+    staleTime: 60_000,
+  });
+}
+
 /** Orphan callers list — fetched when the Orphans tab is active. */
 export function useOrphans(groupId: string, enabled: boolean) {
   return useQuery({

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -32,6 +32,7 @@ import type {
   EventFlowDetailResponse,
   PathsListResponse,
   PathDetail,
+  PathPostureResponse,
   OrphansResponse,
   ShapeResponse,
   SystemStatus,
@@ -495,6 +496,18 @@ export const api = {
   /** GET /api/v2/groups/:id/paths/orphans — orphan caller list. */
   listOrphans: (groupId: string) =>
     requestV2<OrphansResponse>(`/groups/${encodeURIComponent(groupId)}/paths/orphans`),
+
+  /**
+   * GET /api/v2/groups/:id/paths/:hash/posture — lazy posture +
+   * effective-contract sections for the detail pane (#4254). Reuses the
+   * archigraph_endpoint_posture / archigraph_effective_contract computation
+   * server-side. Fetched only when a path is opened so the main paths payload
+   * stays lean.
+   */
+  getPathPosture: (groupId: string, pathHash: string) =>
+    requestV2<PathPostureResponse>(
+      `/groups/${encodeURIComponent(groupId)}/paths/${encodeURIComponent(pathHash)}/posture`,
+    ),
 
   /**
    * GET /api/v2/groups/:id/shape — lazy ShapeTree subtree resolver

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -30,6 +30,7 @@ import { RefLine } from "@/components/RefLine";
 import { SectionHeader } from "@/components/SectionHeader";
 import { ShapeTree, type ShapeTreeRow } from "@/components/ShapeTree";
 import { AuthSection } from "@/components/Paths/EndpointDetail/AuthSection";
+import { PostureSection } from "@/components/Paths/EndpointDetail/PostureSection";
 import { AuthSeverityBadge } from "@/components/Paths/AuthSeverityBadge";
 import {
   usePaths, usePathDetail, useOrphans, useAuthCoverageIndex,
@@ -718,6 +719,8 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     description: true,
     auth: true,
+    posture: false,
+    contract: false,
     parameters: true,
     response: true,
     defined: true,
@@ -863,6 +866,20 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
               Uses auth_policy when present (Java, #1942 Phase 1); falls back
               to legacy auth/auth_scheme flags. */}
         <AuthSection detail={detail} />
+
+        {/* 1c. Posture + Effective contract (#4254) — lazy-fetched sibling
+              route. Posture surfaces deprecation / rate-limit / error-flow /
+              feature-gates; Effective contract surfaces the per-verb status
+              codes / serializer / permissions with an MRO-inherited tag. Both
+              honest-empty (collapsed by default). */}
+        <PostureSection
+          groupId={groupId}
+          pathHash={detail.path_hash}
+          postureOpen={openSections.posture}
+          contractOpen={openSections.contract}
+          onTogglePosture={() => toggleSection("posture")}
+          onToggleContract={() => toggleSection("contract")}
+        />
 
         {/* 2. Parameters — ShapeTree subtree (#1935 Phase 1).
             Each parameter row is its own top-level entry; body params


### PR DESCRIPTION
Closes #4254 (epic #4249).

Surfaces, in the existing Paths detail pane, the **endpoint posture** (deprecation / api_version, rate-limit, THROWS error-flow, feature-gates, auth) AND the per-verb **effective contract** (status codes, serializer, permissions, MRO-inherited handler tag) — facets that until now only the MCP tools exposed. The Paths screen previously showed only the flat `auth_policy`.

## Reuse (no re-derivation)
The dashboard backend calls the **exact** computation the MCP tools run:
- `archigraph_endpoint_posture` → `internal/mcp/endpoint_posture.go:buildPosturePayload`
- `archigraph_effective_contract` (#4243/#4246) → `internal/mcp/effective_contract_tool.go` (MRO/baseknowledge-pack-aware)

New exported, request-envelope-free entry points in `internal/mcp/dashboard_api.go` (`EndpointPostureForEntity`, `EffectiveContractForTarget`) wrap the dashboard's already-loaded `graph.Document`s into a throwaway `LoadedGroup` (every derived index builds lazily) and delegate to the existing helpers. To enable this, the group-iteration core of `handleEffectiveContract` was factored into `computeEffectiveContract`, called by both the MCP handler and the dashboard — one code path, no drift.

## Route (lazy sibling — keeps the main paths payload lean)
`GET /api/v2/groups/:id/paths/:hash/posture` → `{ endpoints: PosturePayload[], contract: EffectiveContractResult | null }`, registered in `server.go`, matching the raw-JSON v2 envelope of the `/api/security/*` siblings.

## Frontend
Two collapsed-by-default detail-pane sections (`Posture`, `Effective contract`) in `webui-v2/src/components/Paths/EndpointDetail/PostureSection.tsx`, slotted after `AuthSection`. Lazy-fetched via TanStack Query keyed by group+hash (only when a section is open), reusing `Badge`/`SectionHeader`/`Skeleton` with consistent loading / empty / error states.

## Honesty
- Posture rows with no signal render "No posture signals" (never fabricated).
- `contract` is null for non-ViewSet endpoints (NestJS/Go/GraphQL) → empty-state note, not a fake table.

## Gates
- Backend: `go build ./...` clean, `go vet` clean, `gofmt` clean; `go test ./internal/dashboard/... ./internal/mcp/...` pass (incl. 3 new posture tests).
- Frontend: `npm ci` ok, `npm run lint` (tsc --noEmit) clean, `npm run build` (vite) succeeds.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)