### PR TITLE
ui+backend: Data-flow & Taint view (#4265)

### DIFF
--- a/internal/dashboard/handlers_dataflow.go
+++ b/internal/dashboard/handlers_dataflow.go
@@ -1,0 +1,530 @@
+package dashboard
+
+// handlers_dataflow.go — Data-flow & Taint surface (#4265, epic #4249).
+//
+// Route:
+//
+//	GET /api/dataflow/{group}  — request-input → sink taint flows + ranked
+//	                             security findings (source→sink paths).
+//
+// What the graph genuinely models (verified against the MCP tools this handler
+// mirrors server-side — internal/mcp/phase3_tools.go handleDataFlows and
+// internal/mcp/security_findings_tool.go handleSecurityFindings — and the passes
+// that produce the on-disk sidecars: internal/links/dataflow_pass.go and
+// internal/links/taint_flow.go):
+//
+//   - DATA_FLOWS_TO edges. The data-flow link pass walks request handlers and
+//     records every request-input → sink edge it can soundly follow (intra-
+//     function + bounded inter-procedural CALLS hops). Each edge carries the
+//     tainted request `field`, the `sink_kind`, the resolved `sink`, and the
+//     inter-procedural `hop_path`. The pass persists these to the data-flow
+//     sidecar (~/.archigraph/groups/<group>-links-data-flow.json). Precision-
+//     first: a flow the sniffer did not soundly follow is never fabricated.
+//
+//   - SecurityFinding records. The taint-flow pass (internal/links/taint_flow.go)
+//     BFS-walks from each taint SOURCE across CALLS to each reachable SINK whose
+//     category is active and unsanitised, emitting one ranked finding per
+//     (source, sink, category) with an aggregated confidence in [0,1] (per-hop
+//     decay × source/sink confidence). Persisted to the taint sidecar
+//     (~/.archigraph/groups/<group>-links-taint.json). The pass drops findings
+//     below TaintFindingFloor() (0.5); this handler surfaces every finding the
+//     pass kept (the UI ranks + lets the user threshold), so the count is honest.
+//
+// Both sidecar endpoints are "<repo>::<localId>" keys whose repo PREFIX written
+// by the link pass can diverge from dashboard repo slugs (underscore-vs-dash,
+// short-name-vs-full — see normalizeLinkEndpoints). Rather than depend on that
+// prefix, we index every entity-ID suffix → entity across all repos (the same
+// resolution normalizeLinkEndpoints uses) and resolve source/sink names, files,
+// and lines by suffix. Endpoints whose suffix is unknown or ambiguous keep their
+// raw key as the label — never fabricated.
+//
+// Follows handlers_iac.go / handlers_security.go: prefer the cached group graph,
+// fall back to a direct per-repo load; raw-JSON envelope. Sidecar paths mirror
+// the MCP tools exactly (sidecarPath / LinksFile + "-taint.json").
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
+	"github.com/cajasmota/archigraph/internal/graph/fbreader"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes — mirror webui-v2/src/data/types.ts (Data-flow / Taint surface)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// DataflowEndpoint is one end (source or sink) of a flow/finding, resolved to a
+// human-readable entity reference where possible.
+type DataflowEndpoint struct {
+	// EntityID is the resolved "<repo>/<id>" key when the endpoint resolved to a
+	// known entity, else the raw sidecar key.
+	EntityID string `json:"entity_id"`
+	Repo     string `json:"repo,omitempty"`
+	// Name is the entity name, or the raw key tail when unresolved.
+	Name       string `json:"name"`
+	Kind       string `json:"kind,omitempty"`
+	SourceFile string `json:"source_file,omitempty"`
+	Line       int    `json:"line,omitempty"`
+	// Primitive is the taint-rule label that fired (source_primitive /
+	// sink_primitive) — only set on findings.
+	Primitive string `json:"primitive,omitempty"`
+}
+
+// TaintFlow is one request-input → sink DATA_FLOWS_TO edge.
+type TaintFlow struct {
+	ID         string           `json:"id"`
+	Source     DataflowEndpoint `json:"source"`
+	Sink       DataflowEndpoint `json:"sink"`
+	Relation   string           `json:"relation,omitempty"`
+	Confidence float64          `json:"confidence"`
+	// Field is the tainted request field that flows to the sink.
+	Field string `json:"field,omitempty"`
+	// SinkKind classifies the sink (sql / command / fs / http / template / …).
+	SinkKind string `json:"sink_kind,omitempty"`
+	// HopPath is the inter-procedural chain from source to sink (raw string from
+	// the pass, "a -> b -> c" form when present).
+	HopPath  string `json:"hop_path,omitempty"`
+	HopCount int    `json:"hop_count,omitempty"`
+}
+
+// SecurityFindingView is one ranked taint source→sink finding.
+type SecurityFindingView struct {
+	Fingerprint string           `json:"fingerprint"`
+	Category    string           `json:"category"`
+	Confidence  float64          `json:"confidence"`
+	Source      DataflowEndpoint `json:"source"`
+	Sink        DataflowEndpoint `json:"sink"`
+	// Path is the ordered entity-ID chain from source to sink (inclusive). Each
+	// entry is resolved to a readable name where possible.
+	Path []DataflowPathStep `json:"path"`
+	// Hops is len(Path)-1 (number of call hops), clamped at 0.
+	Hops        int    `json:"hops"`
+	Explanation string `json:"explanation"`
+}
+
+// DataflowPathStep is one node on a finding's source→sink path.
+type DataflowPathStep struct {
+	EntityID string `json:"entity_id"`
+	Name     string `json:"name"`
+	Repo     string `json:"repo,omitempty"`
+}
+
+// DataflowReport is the wire shape for GET /api/dataflow/{group}.
+type DataflowReport struct {
+	Group string `json:"group"`
+
+	// Findings — ranked source→sink security findings (confidence desc).
+	Findings []SecurityFindingView `json:"findings"`
+	// Flows — request-input → sink DATA_FLOWS_TO edges.
+	Flows []TaintFlow `json:"flows"`
+
+	// Totals + roll-ups.
+	TotalFindings int `json:"total_findings"`
+	TotalFlows    int `json:"total_flows"`
+	// FindingsByCategory — vulnerability category → finding count.
+	FindingsByCategory map[string]int `json:"findings_by_category"`
+	// FlowsBySinkKind — sink_kind → flow count.
+	FlowsBySinkKind map[string]int `json:"flows_by_sink_kind"`
+	// ConfidenceFloor is the taint pass's drop threshold (provenance for the UI).
+	ConfidenceFloor float64 `json:"confidence_floor"`
+	// TaintMethod / FlowMethod identify the producing passes (provenance).
+	TaintMethod string `json:"taint_method,omitempty"`
+	FlowMethod  string `json:"flow_method,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sidecar shapes (read-side mirrors of the producer documents)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type dfLinkSidecar struct {
+	ID         string            `json:"id"`
+	Source     string            `json:"source"`
+	Target     string            `json:"target"`
+	Relation   string            `json:"relation"`
+	Confidence float64           `json:"confidence"`
+	Properties map[string]string `json:"properties,omitempty"`
+}
+
+type dfSidecarDoc struct {
+	Version int             `json:"version"`
+	Method  string          `json:"method"`
+	Links   []dfLinkSidecar `json:"links"`
+}
+
+// taintFindingSidecar mirrors the subset of links.SecurityFinding the dashboard
+// projects. Decoded structurally so the dashboard does not import internal/links
+// (and the substrate.TaintCategory enum) just to read a string category.
+type taintFindingSidecar struct {
+	Fingerprint     string   `json:"fingerprint"`
+	SourceID        string   `json:"source_id"`
+	SourcePrimitive string   `json:"source_primitive"`
+	SourceLine      int      `json:"source_line"`
+	SinkID          string   `json:"sink_id"`
+	SinkPrimitive   string   `json:"sink_primitive"`
+	SinkLine        int      `json:"sink_line"`
+	Category        string   `json:"category"`
+	Path            []string `json:"path"`
+	Confidence      float64  `json:"confidence"`
+	Repo            string   `json:"repo"`
+}
+
+type taintSidecarDoc struct {
+	Version  int                   `json:"version"`
+	Method   string                `json:"method"`
+	Findings []taintFindingSidecar `json:"findings"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sidecar path helpers (mirror internal/mcp)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// dataFlowSidecarPath mirrors mcp.sidecarPath(group, "data-flow").
+func dataFlowSidecarPath(group string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", "groups", group+"-links-data-flow.json")
+}
+
+// taintSidecarPath mirrors the MCP taint sidecar path: the group links file with
+// ".json" replaced by "-taint.json".
+func taintSidecarPath(group string) string {
+	return strings.TrimSuffix(defaultLinksFile(group), ".json") + "-taint.json"
+}
+
+// loadJSONSidecar reads + decodes a JSON sidecar; ok=false on any I/O or decode
+// error (missing file is the common, benign case).
+func loadJSONSidecar(path string, v any) bool {
+	if path == "" {
+		return false
+	}
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(buf, v) == nil
+}
+
+// dfEndpointTail returns the last ':' or '/'-delimited segment of an endpoint
+// key, used as a readable label when the entity does not resolve.
+func dfEndpointTail(key string) string {
+	// strip a "<repo>::" prefix first.
+	if _, local := dashSplitPrefixed(key); local != "" {
+		key = local
+	}
+	if i := strings.LastIndexAny(key, ":/"); i >= 0 && i+1 < len(key) {
+		return key[i+1:]
+	}
+	return key
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entity resolution: suffix → entity, across all repos
+// ─────────────────────────────────────────────────────────────────────────────
+
+// dfResolvedEntity is the minimal projection the report needs per entity.
+type dfResolvedEntity struct {
+	id         string
+	repo       string
+	name       string
+	kind       string
+	sourceFile string
+	line       int
+}
+
+// dfEntityIndex resolves a sidecar endpoint key to a dfResolvedEntity by entity-
+// ID suffix. Suffixes seen in more than one repo are recorded ambiguous and
+// never used (defensive — mirrors normalizeLinkEndpoints).
+type dfEntityIndex struct {
+	bySuffix  map[string]dfResolvedEntity
+	ambiguous map[string]bool
+}
+
+func (ix *dfEntityIndex) add(repo string, e dfResolvedEntity) {
+	if _, seen := ix.bySuffix[e.id]; seen {
+		ix.ambiguous[e.id] = true
+		return
+	}
+	e.repo = repo
+	ix.bySuffix[e.id] = e
+}
+
+// resolve returns the DataflowEndpoint for a sidecar key. Unknown/ambiguous keys
+// fall back to the raw tail label and keep the raw key as entity_id.
+func (ix *dfEntityIndex) resolve(key, primitive string, fallbackLine int) DataflowEndpoint {
+	_, local := dashSplitPrefixed(key)
+	if local == "" {
+		local = key
+	}
+	if !ix.ambiguous[local] {
+		if e, ok := ix.bySuffix[local]; ok {
+			line := e.line
+			if line == 0 && fallbackLine > 0 {
+				line = fallbackLine
+			}
+			return DataflowEndpoint{
+				EntityID:   e.repo + "/" + e.id,
+				Repo:       e.repo,
+				Name:       e.name,
+				Kind:       e.kind,
+				SourceFile: e.sourceFile,
+				Line:       line,
+				Primitive:  primitive,
+			}
+		}
+	}
+	return DataflowEndpoint{
+		EntityID:  key,
+		Name:      dfEndpointTail(key),
+		Line:      fallbackLine,
+		Primitive: primitive,
+	}
+}
+
+// resolveStep is the lighter resolver used for path nodes.
+func (ix *dfEntityIndex) resolveStep(key string) DataflowPathStep {
+	_, local := dashSplitPrefixed(key)
+	if local == "" {
+		local = key
+	}
+	if !ix.ambiguous[local] {
+		if e, ok := ix.bySuffix[local]; ok {
+			return DataflowPathStep{EntityID: e.repo + "/" + e.id, Name: e.name, Repo: e.repo}
+		}
+	}
+	return DataflowPathStep{EntityID: key, Name: dfEndpointTail(key)}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler: GET /api/dataflow/{group}
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleDataflow(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	q := r.URL.Query()
+	filterCategory := strings.ToLower(strings.TrimSpace(q.Get("category")))
+	filterSinkKind := strings.ToLower(strings.TrimSpace(q.Get("sink_kind")))
+
+	report := DataflowReport{
+		Group:              groupName,
+		Findings:           []SecurityFindingView{},
+		Flows:              []TaintFlow{},
+		FindingsByCategory: map[string]int{},
+		FlowsBySinkKind:    map[string]int{},
+	}
+
+	// Build the entity index from every repo's graph (suffix → entity).
+	ix := &dfEntityIndex{
+		bySuffix:  map[string]dfResolvedEntity{},
+		ambiguous: map[string]bool{},
+	}
+	cachedGrp, _ := s.graphs.GetGroupCached(groupName)
+	for _, rp := range repoPaths {
+		var doc *graph.Document
+		var rdr *fbreader.Reader
+		if cachedGrp != nil {
+			if dr, ok := cachedGrp.Repos[rp.Slug]; ok && dr != nil {
+				doc = dr.Doc
+				rdr = dr.Reader
+			}
+		}
+		if doc == nil && rdr == nil {
+			stateDir := daemon.StateDirForRepo(rp.Path)
+			var loadErr error
+			doc, loadErr = graph.LoadGraphFromDir(stateDir)
+			if loadErr != nil {
+				continue
+			}
+		}
+		if rdr != nil {
+			rdr.IterateEntities(func(e *fb.Entity) bool {
+				ix.add(rp.Slug, dfResolvedEntity{
+					id:         string(e.Id()),
+					name:       string(e.Name()),
+					kind:       string(e.Kind()),
+					sourceFile: string(e.SourceFile()),
+					line:       int(e.SourceLine()),
+				})
+				return true
+			})
+			continue
+		}
+		for i := range doc.Entities {
+			ent := &doc.Entities[i]
+			ix.add(rp.Slug, dfResolvedEntity{
+				id:         ent.ID,
+				name:       ent.Name,
+				kind:       ent.Kind,
+				sourceFile: ent.SourceFile,
+				line:       ent.StartLine,
+			})
+		}
+	}
+
+	// ── Findings (ranked taint source→sink) ──────────────────────────────────
+	var tdoc taintSidecarDoc
+	if loadJSONSidecar(taintSidecarPath(groupName), &tdoc) {
+		report.TaintMethod = tdoc.Method
+		for _, f := range tdoc.Findings {
+			cat := strings.ToLower(strings.TrimSpace(f.Category))
+			if filterCategory != "" && cat != filterCategory {
+				continue
+			}
+			src := ix.resolve(f.SourceID, f.SourcePrimitive, f.SourceLine)
+			sink := ix.resolve(f.SinkID, f.SinkPrimitive, f.SinkLine)
+			steps := make([]DataflowPathStep, 0, len(f.Path))
+			for _, p := range f.Path {
+				steps = append(steps, ix.resolveStep(p))
+			}
+			hops := len(f.Path) - 1
+			if hops < 0 {
+				hops = 0
+			}
+			report.Findings = append(report.Findings, SecurityFindingView{
+				Fingerprint: f.Fingerprint,
+				Category:    f.Category,
+				Confidence:  f.Confidence,
+				Source:      src,
+				Sink:        sink,
+				Path:        steps,
+				Hops:        hops,
+				Explanation: dfFindingExplanation(f, src, sink, hops),
+			})
+			report.FindingsByCategory[f.Category]++
+		}
+	}
+	// Rank findings by confidence desc, then category, then fingerprint (stable).
+	sort.SliceStable(report.Findings, func(i, j int) bool {
+		a, b := report.Findings[i], report.Findings[j]
+		if a.Confidence != b.Confidence {
+			return a.Confidence > b.Confidence
+		}
+		if a.Category != b.Category {
+			return a.Category < b.Category
+		}
+		return a.Fingerprint < b.Fingerprint
+	})
+	report.TotalFindings = len(report.Findings)
+
+	// ── Flows (request-input → sink DATA_FLOWS_TO edges) ─────────────────────
+	var fdoc dfSidecarDoc
+	if loadJSONSidecar(dataFlowSidecarPath(groupName), &fdoc) {
+		report.FlowMethod = fdoc.Method
+		for _, l := range fdoc.Links {
+			props := l.Properties
+			if props == nil {
+				props = map[string]string{}
+			}
+			sinkKind := strings.TrimSpace(props["sink_kind"])
+			if filterSinkKind != "" && strings.ToLower(sinkKind) != filterSinkKind {
+				continue
+			}
+			hopCount := 0
+			if v := strings.TrimSpace(props["hop_count"]); v != "" {
+				hopCount, _ = strconv.Atoi(v)
+			}
+			report.Flows = append(report.Flows, TaintFlow{
+				ID:         l.ID,
+				Source:     ix.resolve(l.Source, "", 0),
+				Sink:       ix.resolve(l.Target, "", 0),
+				Relation:   l.Relation,
+				Confidence: l.Confidence,
+				Field:      strings.TrimSpace(props["field"]),
+				SinkKind:   sinkKind,
+				HopPath:    strings.TrimSpace(props["hop_path"]),
+				HopCount:   hopCount,
+			})
+			if sinkKind != "" {
+				report.FlowsBySinkKind[sinkKind]++
+			}
+		}
+	}
+	// Stable flow order: by source name, then sink name, then id.
+	sort.SliceStable(report.Flows, func(i, j int) bool {
+		a, b := report.Flows[i], report.Flows[j]
+		if a.Source.Name != b.Source.Name {
+			return a.Source.Name < b.Source.Name
+		}
+		if a.Sink.Name != b.Sink.Name {
+			return a.Sink.Name < b.Sink.Name
+		}
+		return a.ID < b.ID
+	})
+	report.TotalFlows = len(report.Flows)
+
+	report.ConfidenceFloor = dataflowConfidenceFloor
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(report)
+}
+
+// dataflowConfidenceFloor mirrors links.TaintFindingFloor() — the taint pass
+// drops findings below this. Surfaced for UI provenance. Kept as a local const
+// (rather than importing internal/links) so the dashboard reader stays decoupled
+// from the producer's enum surface; the value is asserted in handlers_dataflow_test.go.
+const dataflowConfidenceFloor = 0.5
+
+// dfCategoryNarrative returns a short prose label for a finding category.
+// Mirrors mcp.categoryNarrative.
+func dfCategoryNarrative(cat string) string {
+	switch cat {
+	case "sql_injection":
+		return "SQL injection"
+	case "command_injection":
+		return "Command / dynamic-code injection"
+	case "path_traversal":
+		return "Path traversal"
+	case "xss":
+		return "Cross-site scripting"
+	case "redos":
+		return "Regular-expression DoS"
+	case "deserialization":
+		return "Unsafe deserialization"
+	case "ssrf":
+		return "Server-side request forgery"
+	}
+	return "Security finding"
+}
+
+// dfFindingExplanation builds a human-readable lead for a finding. Mirrors
+// mcp.buildFindingExplanation so the dashboard and MCP narrate identically.
+func dfFindingExplanation(f taintFindingSidecar, src, sink DataflowEndpoint, hops int) string {
+	cat := dfCategoryNarrative(f.Category)
+	if hops == 0 {
+		return fmt.Sprintf(
+			"%s: tainted input from %s (%s, line %d) reaches the sink %s (%s, line %d) inside the same function with no sanitizer in between. Confidence %.2f.",
+			cat, src.Name, f.SourcePrimitive, f.SourceLine, sink.Name, f.SinkPrimitive, f.SinkLine, f.Confidence,
+		)
+	}
+	return fmt.Sprintf(
+		"%s: tainted input from %s (%s, line %d) flows through %d call hop(s) to the sink %s (%s, line %d) without a sanitizer of category %s on the path. Confidence %.2f.",
+		cat, src.Name, f.SourcePrimitive, f.SourceLine, hops, sink.Name, f.SinkPrimitive, f.SinkLine, f.Category, f.Confidence,
+	)
+}

--- a/internal/dashboard/handlers_dataflow_test.go
+++ b/internal/dashboard/handlers_dataflow_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/links"
+)
+
+// TestDataflowConfidenceFloorMatchesProducer asserts the dashboard's surfaced
+// confidence floor stays in lock-step with the taint pass that produces the
+// sidecar. The dashboard keeps a local const (to avoid importing the producer's
+// enum surface in the request path) — this test is the coupling guard.
+func TestDataflowConfidenceFloorMatchesProducer(t *testing.T) {
+	if dataflowConfidenceFloor != links.TaintFindingFloor() {
+		t.Fatalf("dataflowConfidenceFloor = %v, want links.TaintFindingFloor() = %v",
+			dataflowConfidenceFloor, links.TaintFindingFloor())
+	}
+}
+
+func TestDfEndpointTail(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"upvate-core::SCOPE.Function:handleLogin", "handleLogin"},
+		{"repo::Kind:Name", "Name"},
+		{"sink:raw_sql_exec", "raw_sql_exec"},
+		{"bare", "bare"},
+		{"a/b/c", "c"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := dfEndpointTail(c.in); got != c.want {
+			t.Errorf("dfEndpointTail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDfEntityIndexResolve(t *testing.T) {
+	ix := &dfEntityIndex{
+		bySuffix:  map[string]dfResolvedEntity{},
+		ambiguous: map[string]bool{},
+	}
+	ix.add("api", dfResolvedEntity{id: "Func:login", name: "login", kind: "SCOPE.Function", sourceFile: "auth.go", line: 12})
+	// Duplicate suffix across repos ⇒ ambiguous, never resolved.
+	ix.add("api", dfResolvedEntity{id: "Func:dup", name: "a"})
+	ix.add("web", dfResolvedEntity{id: "Func:dup", name: "b"})
+
+	// Resolved endpoint: name/file/line come from the index; primitive passed through.
+	got := ix.resolve("api::Func:login", "req.body", 0)
+	if got.Name != "login" || got.Repo != "api" || got.SourceFile != "auth.go" || got.Line != 12 {
+		t.Fatalf("resolve(known) = %+v", got)
+	}
+	if got.EntityID != "api/Func:login" {
+		t.Fatalf("resolve(known).EntityID = %q, want api/Func:login", got.EntityID)
+	}
+	if got.Primitive != "req.body" {
+		t.Fatalf("resolve(known).Primitive = %q, want req.body", got.Primitive)
+	}
+
+	// fallbackLine used when the index has no line.
+	ix.add("api", dfResolvedEntity{id: "Func:noline", name: "noline"})
+	if got := ix.resolve("api::Func:noline", "", 99); got.Line != 99 {
+		t.Fatalf("resolve fallbackLine = %d, want 99", got.Line)
+	}
+
+	// Ambiguous suffix ⇒ falls back to raw tail label, raw key as entity_id.
+	amb := ix.resolve("api::Func:dup", "", 0)
+	if amb.Name != "dup" || amb.EntityID != "api::Func:dup" {
+		t.Fatalf("resolve(ambiguous) = %+v, want raw fallback", amb)
+	}
+
+	// Unknown suffix ⇒ raw fallback.
+	unk := ix.resolve("api::Func:missing", "", 0)
+	if unk.Name != "missing" || unk.EntityID != "api::Func:missing" {
+		t.Fatalf("resolve(unknown) = %+v, want raw fallback", unk)
+	}
+}
+
+func TestDfFindingExplanation(t *testing.T) {
+	src := DataflowEndpoint{Name: "handleSearch"}
+	sink := DataflowEndpoint{Name: "rawQuery"}
+
+	intra := dfFindingExplanation(taintFindingSidecar{
+		Category: "sql_injection", SourcePrimitive: "req.query", SourceLine: 4,
+		SinkPrimitive: "db.exec", SinkLine: 9, Confidence: 0.91,
+	}, src, sink, 0)
+	if intra == "" || !strings.Contains(intra, "SQL injection") || !strings.Contains(intra, "same function") {
+		t.Fatalf("intra explanation unexpected: %q", intra)
+	}
+
+	inter := dfFindingExplanation(taintFindingSidecar{
+		Category: "command_injection", SourcePrimitive: "req.body", SourceLine: 4,
+		SinkPrimitive: "exec", SinkLine: 40, Confidence: 0.72,
+	}, src, sink, 2)
+	if !strings.Contains(inter, "2 call hop(s)") {
+		t.Fatalf("inter explanation should mention hops: %q", inter)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -555,6 +555,10 @@ func (s *Server) routes() http.Handler {
 	// tool with typed config props + grant/event-source/dependency/topology edges.
 	mux.HandleFunc("GET /api/iac/{group}", s.handleIaC)
 
+	// #4265 (epic #4249): Data-flow & Taint surface — request-input → sink taint
+	// flows (DATA_FLOWS_TO) + ranked security findings (source→sink paths).
+	mux.HandleFunc("GET /api/dataflow/{group}", s.handleDataflow)
+
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)
 	mux.HandleFunc("GET /api/groups/{group}/god-nodes", s.handleGroupGodNodes)

--- a/webui-v2/src/components/chrome/screens.ts
+++ b/webui-v2/src/components/chrome/screens.ts
@@ -21,6 +21,7 @@ import {
   Link2,
   Boxes,
   Server,
+  Waypoints,
   Wrench,
   Inbox,
   Settings,
@@ -45,6 +46,7 @@ export const SCREENS: ScreenDef[] = [
   { to: "flows", label: "Flows", Icon: Workflow, shortcut: "F" },
   { to: "docs", label: "Docs", Icon: FileText, shortcut: "D" },
   { to: "security", label: "Security", Icon: ShieldCheck, shortcut: "S" },
+  { to: "taint", label: "Taint", Icon: Waypoints, shortcut: "X" },
   { to: "quality", label: "Quality", Icon: GaugeCircle, shortcut: "Q" },
   { to: "operations", label: "Operations", Icon: Wrench, shortcut: "O" },
 ];

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2130,3 +2130,94 @@ export interface IaCReport {
   counts_by_category: Record<string, number>;
   groups: IaCToolGroup[];
 }
+
+// ---------------------------------------------------------------------------
+// Data-flow & Taint surface (#4265, epic #4249)
+//
+// Wire shape for GET /api/dataflow/{group} (handlers_dataflow.go →
+// handleDataflow). RAW JSON (not the v2 envelope). Mirrors the Go structs in
+// internal/dashboard/handlers_dataflow.go, which reads two sidecars:
+//
+//   - the taint sidecar → ranked SecurityFinding records (source→sink paths,
+//     confidence, vulnerability category) produced by internal/links/taint_flow.go;
+//   - the data-flow sidecar → request-input → sink DATA_FLOWS_TO edges (the
+//     tainted field, sink_kind, inter-procedural hop_path) produced by
+//     internal/links/dataflow_pass.go.
+//
+// HONESTY: only genuinely-extracted flows/findings are surfaced. The taint pass
+// drops anything below confidence_floor and never fabricates a flow it could not
+// soundly follow; when both sidecars are absent the screen shows a clean empty
+// state. Source/sink names resolve to entity refs where the entity is known;
+// otherwise the raw endpoint tail is shown — never invented.
+// ---------------------------------------------------------------------------
+
+/** One end (source or sink) of a flow / finding, resolved to an entity ref. */
+export interface DataflowEndpoint {
+  /** "<repo>/<id>" when resolved, else the raw sidecar endpoint key. */
+  entity_id: string;
+  repo?: string;
+  /** Entity name, or the raw key tail when unresolved. */
+  name: string;
+  kind?: string;
+  source_file?: string;
+  line?: number;
+  /** Taint-rule label that fired (source_primitive / sink_primitive); findings only. */
+  primitive?: string;
+}
+
+/** One node on a finding's source→sink path. */
+export interface DataflowPathStep {
+  entity_id: string;
+  name: string;
+  repo?: string;
+}
+
+/** One ranked taint source→sink security finding. */
+export interface SecurityFindingView {
+  fingerprint: string;
+  /** sql_injection / command_injection / path_traversal / xss / ssrf / … */
+  category: string;
+  confidence: number;
+  source: DataflowEndpoint;
+  sink: DataflowEndpoint;
+  /** Ordered source→sink entity chain (inclusive). */
+  path: DataflowPathStep[];
+  /** len(path)-1 call hops, clamped at 0. */
+  hops: number;
+  explanation: string;
+}
+
+/** One request-input → sink DATA_FLOWS_TO edge. */
+export interface TaintFlow {
+  id: string;
+  source: DataflowEndpoint;
+  sink: DataflowEndpoint;
+  relation?: string;
+  confidence: number;
+  /** Tainted request field that flows to the sink. */
+  field?: string;
+  /** Sink classification (sql / command / fs / http / template / …). */
+  sink_kind?: string;
+  /** Inter-procedural chain ("a -> b -> c") when present. */
+  hop_path?: string;
+  hop_count?: number;
+}
+
+/** GET /api/dataflow/{group} — Data-flow & Taint report. */
+export interface DataflowReport {
+  group: string;
+  /** Ranked source→sink findings (confidence desc). */
+  findings: SecurityFindingView[];
+  /** Request-input → sink DATA_FLOWS_TO edges. */
+  flows: TaintFlow[];
+  total_findings: number;
+  total_flows: number;
+  /** Vulnerability category → finding count. */
+  findings_by_category: Record<string, number>;
+  /** sink_kind → flow count. */
+  flows_by_sink_kind: Record<string, number>;
+  /** Taint pass drop threshold (provenance). */
+  confidence_floor: number;
+  taint_method?: string;
+  flow_method?: string;
+}

--- a/webui-v2/src/hooks/use-dataflow.ts
+++ b/webui-v2/src/hooks/use-dataflow.ts
@@ -1,0 +1,33 @@
+/* ============================================================
+   hooks/use-dataflow.ts — Data-flow & Taint data hook (#4265).
+
+   Wraps api.getDataflow in TanStack Query. Backed by the route
+   GET /api/dataflow/{group} (handlers_dataflow.go → handleDataflow),
+   which returns a raw-JSON DataflowReport reading two sidecars:
+
+     - taint sidecar → ranked SecurityFinding records (source→sink
+       paths, confidence, vulnerability category), produced by
+       internal/links/taint_flow.go;
+     - data-flow sidecar → request-input → sink DATA_FLOWS_TO edges
+       (tainted field, sink_kind, inter-procedural hop_path),
+       produced by internal/links/dataflow_pass.go.
+
+   Pure static graph + sidecar read. Honest-empty when neither
+   sidecar exists for the group.
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export const dataflowQueryKey = (groupId: string) =>
+  ["dataflow", groupId] as const;
+
+/** Data-flow & taint report for the group. */
+export function useDataflow(groupId: string) {
+  return useQuery({
+    queryKey: dataflowQueryKey(groupId),
+    queryFn: () => api.getDataflow(groupId),
+    enabled: !!groupId,
+    staleTime: 30_000,
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -69,6 +69,7 @@ import type {
   GroupLinksReply,
   GraphQLReport,
   IaCReport,
+  DataflowReport,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -815,6 +816,17 @@ export const api = {
   getIaC: (groupId: string) =>
     request<IaCReport>(
       `/iac/${encodeURIComponent(groupId)}`,
+    ),
+
+  // --- Data-flow & Taint (#4265) ---
+  // Raw JSON (no v2 envelope) → `request`. Handler: handlers_dataflow.go
+  // handleDataflow, which returns a DataflowReport (ranked taint findings +
+  // request-input → sink DATA_FLOWS_TO edges).
+
+  /** GET /api/dataflow/{group} — taint flows + ranked source→sink findings. */
+  getDataflow: (groupId: string) =>
+    request<DataflowReport>(
+      `/dataflow/${encodeURIComponent(groupId)}`,
     ),
 };
 

--- a/webui-v2/src/routes/dataflow.tsx
+++ b/webui-v2/src/routes/dataflow.tsx
@@ -1,0 +1,585 @@
+/* ============================================================
+   Data-flow & Taint view (#4265, epic #4249).
+
+   Route: /g/:groupId/taint
+
+   The taint analysis (internal/links/taint_flow.go) and the data-flow
+   link pass (internal/links/dataflow_pass.go) had no dashboard surface.
+   This screen surfaces both:
+
+     - FINDINGS tab — ranked source→sink security findings: a tainted
+       request input reaches a dangerous sink (SQL exec / shell / fs /
+       template / SSRF / …) with no sanitizer on the path. Each finding
+       carries a vulnerability category, an aggregated confidence, the
+       resolved source + sink entity refs, and the inter-procedural path
+       (expandable). Ranked by confidence descending.
+
+     - FLOWS tab — the raw request-input → sink DATA_FLOWS_TO edges: the
+       tainted request `field`, the `sink_kind`, and the hop_path the
+       sniffer followed. A flow is a single observed data movement; a
+       finding is a flow the taint pass judged exploitable.
+
+   Data: GET /api/dataflow/{group} (handlers_dataflow.go → handleDataflow),
+   raw-JSON DataflowReport.
+
+   Layout mirrors Security / IaC: full-height column, a Tabs strip with
+   count pills, a summary stat row, a category / sink-kind filter, and a
+   ranked list with source→sink rows, sink-kind / category badges, a
+   confidence pill, an expandable hop-path, and a RefLine source ref.
+   Reuses Badge / Card / Pill / Tabs / Skeleton + RefLine + RepoChip.
+
+   HONESTY: only genuinely-extracted flows/findings render. The taint pass
+   drops anything below the confidence floor and never fabricates a flow it
+   could not soundly follow; when neither sidecar exists the screen shows a
+   clean empty state. Unresolved endpoints show their raw key tail — never
+   an invented name.
+   ============================================================ */
+
+import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  ShieldAlert,
+  Waypoints,
+  ArrowRight,
+  ChevronRight,
+  AlertTriangle,
+  Crosshair,
+  Target,
+  ListFilter,
+} from "lucide-react";
+
+import {
+  Badge,
+  Card,
+  CardBody,
+  Pill,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RefLine } from "@/components/RefLine";
+import { RepoChip } from "@/lib/repo-color";
+import { cn } from "@/lib/utils";
+import { useDataflow } from "@/hooks/use-dataflow";
+import type {
+  DataflowEndpoint,
+  DataflowReport,
+  SecurityFindingView,
+  TaintFlow,
+} from "@/data/types";
+
+type Tone = "neutral" | "accent" | "success" | "warning" | "danger" | "info";
+
+// ---------------------------------------------------------------------------
+// § Styling helpers
+// ---------------------------------------------------------------------------
+
+/** Vulnerability category → tone + readable label. */
+function categoryMeta(cat: string): { label: string; tone: Tone } {
+  switch ((cat || "").toLowerCase()) {
+    case "sql_injection":
+      return { label: "SQL injection", tone: "danger" };
+    case "command_injection":
+      return { label: "Command injection", tone: "danger" };
+    case "deserialization":
+      return { label: "Unsafe deserialization", tone: "danger" };
+    case "ssrf":
+      return { label: "SSRF", tone: "warning" };
+    case "path_traversal":
+      return { label: "Path traversal", tone: "warning" };
+    case "xss":
+      return { label: "XSS", tone: "warning" };
+    case "redos":
+      return { label: "ReDoS", tone: "info" };
+    default:
+      return { label: cat || "finding", tone: "neutral" };
+  }
+}
+
+/** sink_kind → tone. */
+function sinkKindTone(kind: string): Tone {
+  switch ((kind || "").toLowerCase()) {
+    case "sql":
+    case "command":
+    case "shell":
+    case "exec":
+      return "danger";
+    case "fs":
+    case "path":
+    case "template":
+      return "warning";
+    case "http":
+    case "url":
+      return "info";
+    default:
+      return "neutral";
+  }
+}
+
+/** Confidence → tone (high = danger because high-confidence taint is worse). */
+function confidenceTone(c: number): Tone {
+  if (c >= 0.85) return "danger";
+  if (c >= 0.7) return "warning";
+  return "info";
+}
+
+function ConfidencePill({ value }: { value: number }) {
+  return (
+    <Badge
+      tone={confidenceTone(value)}
+      className="tabular-nums shrink-0"
+      title={`Aggregated taint confidence ${value.toFixed(2)}`}
+    >
+      {Math.round(value * 100)}%
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Endpoint ref (source / sink)
+// ---------------------------------------------------------------------------
+
+function EndpointRef({
+  endpoint,
+  groupId,
+  icon,
+}: {
+  endpoint: DataflowEndpoint;
+  groupId: string;
+  icon: "source" | "sink";
+}) {
+  const Icon = icon === "source" ? Crosshair : Target;
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <Icon size={12} className="text-text-4 shrink-0" />
+      <span className="font-mono text-sm text-text truncate" title={endpoint.entity_id}>
+        {endpoint.name}
+      </span>
+      {endpoint.primitive && (
+        <span
+          className="font-mono text-[10px] text-text-4 shrink-0"
+          title={`taint primitive: ${endpoint.primitive}`}
+        >
+          {endpoint.primitive}
+        </span>
+      )}
+      {endpoint.repo && (
+        <RepoChip slug={endpoint.repo} groupId={groupId} maxLength={14} />
+      )}
+    </span>
+  );
+}
+
+function EndpointRefLine({ endpoint }: { endpoint: DataflowEndpoint }) {
+  if (!endpoint.source_file || !endpoint.repo) return null;
+  return (
+    <RefLine
+      repo={endpoint.repo}
+      file={endpoint.source_file}
+      line={endpoint.line ?? 0}
+      name={endpoint.name}
+      className="text-[11px]"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Shared shells
+// ---------------------------------------------------------------------------
+
+function SkeletonRows({ n = 6 }: { n?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: n }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 h-14 px-4 rounded-lg border border-border"
+        >
+          <Skeleton w="w-1/4" />
+          <Skeleton w="w-6" h="h-2" />
+          <Skeleton w="w-1/4" />
+          <Skeleton w="w-10" h="h-4" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <Waypoints size={32} className="text-text-4" />
+      <p className="text-md font-medium text-text">{title}</p>
+      <p className="text-sm text-text-3 max-w-md">{hint}</p>
+    </div>
+  );
+}
+
+function ErrorState() {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <AlertTriangle size={32} className="text-danger" />
+      <p className="text-md font-medium text-text">Could not load data-flow analysis</p>
+      <p className="text-sm text-text-3 max-w-sm">
+        The daemon returned an error. Confirm the group is indexed and the daemon
+        is reachable, then retry.
+      </p>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <Card className={cn("flex-1 min-w-[120px]")}>
+      <CardBody className="py-3">
+        <p className="text-2xl font-semibold tabular-nums text-text">{value}</p>
+        <p className="text-xs text-text-4 mt-0.5">{label}</p>
+      </CardBody>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One finding row (source → sink, ranked, expandable path)
+// ---------------------------------------------------------------------------
+
+function FindingRow({
+  finding,
+  groupId,
+}: {
+  finding: SecurityFindingView;
+  groupId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const { label, tone } = categoryMeta(finding.category);
+  const hasPath = finding.path.length > 2; // more than just [source, sink]
+
+  return (
+    <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-surface-2 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-wrap">
+        <Badge tone={tone} className="shrink-0">
+          {label}
+        </Badge>
+        <EndpointRef endpoint={finding.source} groupId={groupId} icon="source" />
+        <ArrowRight size={13} className="text-text-4 shrink-0" />
+        <EndpointRef endpoint={finding.sink} groupId={groupId} icon="sink" />
+        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+          {finding.hops > 0 && (
+            <span
+              className="text-[11px] text-text-4 tabular-nums"
+              title={`${finding.hops} call hop(s) from source to sink`}
+            >
+              {finding.hops} hop{finding.hops === 1 ? "" : "s"}
+            </span>
+          )}
+          <ConfidencePill value={finding.confidence} />
+        </div>
+      </div>
+
+      {finding.explanation && (
+        <p className="text-[12px] text-text-3 leading-snug">{finding.explanation}</p>
+      )}
+
+      {/* Source + sink refs */}
+      <div className="flex flex-col gap-0.5">
+        <EndpointRefLine endpoint={finding.source} />
+        <EndpointRefLine endpoint={finding.sink} />
+      </div>
+
+      {/* Expandable inter-procedural path */}
+      {hasPath && (
+        <div>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1 text-[11px] text-text-3 hover:text-text"
+          >
+            <ChevronRight
+              size={12}
+              className={cn("transition-transform", open && "rotate-90")}
+            />
+            {open ? "Hide" : "Show"} path ({finding.path.length} nodes)
+          </button>
+          {open && (
+            <div className="mt-1 flex flex-wrap items-center gap-1 pl-4">
+              {finding.path.map((step, i) => (
+                <span key={`${step.entity_id}:${i}`} className="inline-flex items-center gap-1">
+                  {i > 0 && <ArrowRight size={11} className="text-text-4" />}
+                  <span
+                    className="font-mono text-[11px] text-text-3"
+                    title={step.entity_id}
+                  >
+                    {step.name}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One flow row (request-input → sink edge)
+// ---------------------------------------------------------------------------
+
+function FlowRow({ flow, groupId }: { flow: TaintFlow; groupId: string }) {
+  return (
+    <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-surface-2 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-wrap">
+        {flow.sink_kind && (
+          <Badge tone={sinkKindTone(flow.sink_kind)} className="uppercase shrink-0">
+            {flow.sink_kind}
+          </Badge>
+        )}
+        <EndpointRef endpoint={flow.source} groupId={groupId} icon="source" />
+        {flow.field && (
+          <span
+            className="font-mono text-[11px] text-text-4 shrink-0"
+            title={`tainted request field: ${flow.field}`}
+          >
+            .{flow.field}
+          </span>
+        )}
+        <ArrowRight size={13} className="text-text-4 shrink-0" />
+        <EndpointRef endpoint={flow.sink} groupId={groupId} icon="sink" />
+        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+          {(flow.hop_count ?? 0) > 0 && (
+            <span className="text-[11px] text-text-4 tabular-nums">
+              {flow.hop_count} hop{flow.hop_count === 1 ? "" : "s"}
+            </span>
+          )}
+          {flow.confidence > 0 && <ConfidencePill value={flow.confidence} />}
+        </div>
+      </div>
+
+      {flow.hop_path && (
+        <p
+          className="font-mono text-[11px] text-text-4 truncate"
+          title={flow.hop_path}
+        >
+          {flow.hop_path}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-0.5">
+        <EndpointRefLine endpoint={flow.source} />
+        <EndpointRefLine endpoint={flow.sink} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Findings tab
+// ---------------------------------------------------------------------------
+
+function FindingsTab({
+  data,
+  groupId,
+}: {
+  data: DataflowReport;
+  groupId: string;
+}) {
+  const [category, setCategory] = useState<string>("all");
+
+  const categories = useMemo(
+    () =>
+      Object.entries(data.findings_by_category).sort(
+        (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+      ),
+    [data.findings_by_category],
+  );
+
+  const filtered = useMemo(
+    () =>
+      category === "all"
+        ? data.findings
+        : data.findings.filter((f) => f.category === category),
+    [data.findings, category],
+  );
+
+  if (data.total_findings === 0) {
+    return (
+      <EmptyState
+        title="No taint findings"
+        hint="The taint pass found no request-input → dangerous-sink path that crosses the confidence floor for this group. Findings appear once an indexed repo has a tainted source reaching an unsanitized sink."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {categories.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <ListFilter size={13} className="text-text-4" />
+          <Pill active={category === "all"} onClick={() => setCategory("all")}>
+            All ({data.total_findings})
+          </Pill>
+          {categories.map(([cat, n]) => (
+            <Pill key={cat} active={category === cat} onClick={() => setCategory(cat)}>
+              {categoryMeta(cat).label} ({n})
+            </Pill>
+          ))}
+        </div>
+      )}
+      <div className="space-y-2">
+        {filtered.map((f) => (
+          <FindingRow key={f.fingerprint} finding={f} groupId={groupId} />
+        ))}
+      </div>
+      <p className="text-[10px] text-text-4">
+        Ranked by aggregated taint confidence. The pass drops findings below the{" "}
+        {Math.round(data.confidence_floor * 100)}% floor — anything shown crossed it
+        and was not sanitized on the path.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Flows tab
+// ---------------------------------------------------------------------------
+
+function FlowsTab({ data, groupId }: { data: DataflowReport; groupId: string }) {
+  const [sinkKind, setSinkKind] = useState<string>("all");
+
+  const kinds = useMemo(
+    () =>
+      Object.entries(data.flows_by_sink_kind).sort(
+        (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+      ),
+    [data.flows_by_sink_kind],
+  );
+
+  const filtered = useMemo(
+    () =>
+      sinkKind === "all"
+        ? data.flows
+        : data.flows.filter((f) => f.sink_kind === sinkKind),
+    [data.flows, sinkKind],
+  );
+
+  if (data.total_flows === 0) {
+    return (
+      <EmptyState
+        title="No data flows resolved"
+        hint="No request-input → sink DATA_FLOWS_TO edges were recorded for this group. They appear once the data-flow link pass soundly follows a request field into a sink."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {kinds.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <ListFilter size={13} className="text-text-4" />
+          <Pill active={sinkKind === "all"} onClick={() => setSinkKind("all")}>
+            All ({data.total_flows})
+          </Pill>
+          {kinds.map(([k, n]) => (
+            <Pill key={k} active={sinkKind === k} onClick={() => setSinkKind(k)}>
+              {k} ({n})
+            </Pill>
+          ))}
+        </div>
+      )}
+      <div className="space-y-2">
+        {filtered.map((f) => (
+          <FlowRow key={f.id} flow={f} groupId={groupId} />
+        ))}
+      </div>
+      <p className="text-[10px] text-text-4">
+        Each row is one observed request-input → sink movement the sniffer followed
+        (intra-function + bounded inter-procedural hops). A flow becomes a finding
+        only when the taint pass judges it reaches a dangerous sink unsanitized.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Screen
+// ---------------------------------------------------------------------------
+
+export default function DataflowScreen() {
+  const { groupId = "" } = useParams<{ groupId: string }>();
+  const { data, isLoading, isError } = useDataflow(groupId);
+  const [tab, setTab] = useState<"findings" | "flows">("findings");
+
+  const hasAny =
+    (data?.total_findings ?? 0) > 0 || (data?.total_flows ?? 0) > 0;
+
+  return (
+    <div className="flex flex-col h-full bg-bg">
+      {isLoading ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <SkeletonRows />
+        </div>
+      ) : isError ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <ErrorState />
+        </div>
+      ) : !hasAny ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <EmptyState
+            title="No data-flow or taint analysis available"
+            hint="Neither taint findings nor request-input → sink flows were extracted for this group. They appear once an indexed repo has request handlers that reach data sinks (SQL / shell / fs / template / HTTP) — the taint and data-flow link passes then populate this view."
+          />
+        </div>
+      ) : (
+        <Tabs
+          value={tab}
+          onValueChange={(v) => setTab(v as typeof tab)}
+          className="flex flex-col flex-1 min-h-0"
+        >
+          <div className="border-b border-border shrink-0 px-4">
+            <TabsList className="border-0">
+              <TabsTrigger value="findings">
+                <ShieldAlert size={14} className="mr-1.5" />
+                Findings
+                {data!.total_findings > 0 && (
+                  <Pill className="ml-1.5">{data!.total_findings}</Pill>
+                )}
+              </TabsTrigger>
+              <TabsTrigger value="flows">
+                <Waypoints size={14} className="mr-1.5" />
+                Flows
+                {data!.total_flows > 0 && (
+                  <Pill className="ml-1.5">{data!.total_flows}</Pill>
+                )}
+              </TabsTrigger>
+            </TabsList>
+          </div>
+
+          <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
+            {/* Summary */}
+            <div className="flex flex-wrap gap-3">
+              <SummaryStat label="Findings" value={data!.total_findings} />
+              <SummaryStat label="Flows" value={data!.total_flows} />
+              <SummaryStat
+                label="Vuln categories"
+                value={Object.keys(data!.findings_by_category).length}
+              />
+              <SummaryStat
+                label="Sink kinds"
+                value={Object.keys(data!.flows_by_sink_kind).length}
+              />
+            </div>
+
+            <TabsContent value="findings">
+              <FindingsTab data={data!} groupId={groupId} />
+            </TabsContent>
+            <TabsContent value="flows">
+              <FlowsTab data={data!} groupId={groupId} />
+            </TabsContent>
+          </div>
+        </Tabs>
+      )}
+    </div>
+  );
+}

--- a/webui-v2/src/routes/router.tsx
+++ b/webui-v2/src/routes/router.tsx
@@ -24,6 +24,7 @@ import GraphQLScreen from "./graphql";
 import IaCScreen from "./iac";
 import DocsScreen from "./docs";
 import SecurityScreen from "./security";
+import DataflowScreen from "./dataflow";
 import QualityScreen from "./quality";
 import SettingsScreen from "./settings";
 import PendingScreen from "./pending";
@@ -59,6 +60,7 @@ export const router = createBrowserRouter([
           // Wildcard: the doc key (repoSlug/rel/path.md) may contain slashes.
           { path: "docs/*", element: <DocsScreen />, handle: { surfaceLabel: "Docs" } },
           { path: "security", element: <SecurityScreen />, handle: { surfaceLabel: "Security" } },
+          { path: "taint", element: <DataflowScreen />, handle: { surfaceLabel: "Taint" } },
           { path: "quality", element: <QualityScreen />, handle: { surfaceLabel: "Quality" } },
           { path: "settings", element: <SettingsScreen />, handle: { surfaceLabel: "Group settings" } },
           { path: "pending", element: <PendingScreen />, handle: { surfaceLabel: "Pending" } },


### PR DESCRIPTION
Closes #4265 (epic #4249). **DEPLOY-DEFERRED.**

Adds a Data-flow & Taint dashboard surface: request-input → sink taint flows plus ranked source→sink security findings.

## Backend
`GET /api/dataflow/{group}` (`internal/dashboard/handlers_dataflow.go` → `handleDataflow`), raw-JSON `DataflowReport`, registered in `server.go` next to `/api/security/*` and `/api/iac/{group}`. Server-side mirror of the two MCP tools:

- **Findings** — reads the taint sidecar (`<group>-links-taint.json`), the same `links.SecurityFinding` set `internal/mcp/security_findings_tool.go` projects: source→sink path, aggregated confidence, vulnerability category, explanation. Ranked confidence-desc.
- **Flows** — reads the data-flow sidecar (`<group>-links-data-flow.json`), the same DATA_FLOWS_TO edges `internal/mcp/phase3_tools.go` `handleDataFlows` projects: tainted `field`, `sink_kind`, `hop_path`.

Source/sink endpoints resolve to entity refs (name/file/line) via an entity-ID **suffix index** across all repos — sidesteps the link-pass repo-prefix divergence documented in `normalizeLinkEndpoints`. Unknown/ambiguous keys keep their raw tail; nothing is invented.

## Frontend
A **sibling "Taint" screen** (`routes/dataflow.tsx`), not a 4th Security tab — chosen because the data source is distinct (sidecars, not the graph detectors Security uses) and the view has two sub-surfaces of its own:

- **Findings** tab: ranked rows, category + confidence badges, hop count, expandable inter-procedural path, RefLine source & sink refs, category filter.
- **Flows** tab: `source.field → sink` rows, sink-kind badge, hop_path, sink-kind filter.

Reuses Badge/Card/Pill/Tabs/Skeleton + RefLine/RepoChip; full loading / empty / error states. Wired in `screens.ts` (shortcut X), `router.tsx`, `api.ts`, `data/types.ts`, `hooks/use-dataflow.ts`.

## Honesty
Only genuinely-extracted flows/findings render. The taint pass drops sub-floor findings and never fabricates a flow it could not soundly follow; when neither sidecar is present the screen shows a clean empty state.

## Gates
- Backend: `go build ./...` ✓ · `go test ./internal/dashboard/... ./internal/mcp/...` ✓ (both `ok`) · gofmt/vet clean
- Frontend: `npm run lint` (tsc --noEmit) ✓ · `npm run build` (vite) ✓ (`built in 14.98s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)