### PR TITLE
ui: Dependency-Injection (INJECTED_INTO) view (#4266)

### DIFF
--- a/internal/dashboard/handlers_di.go
+++ b/internal/dashboard/handlers_di.go
@@ -1,0 +1,406 @@
+package dashboard
+
+// handlers_di.go — Dependency-Injection surface (#4266, epic #4249).
+//
+// Route:
+//
+//	GET /api/di/{group}  — DI providers grouped by framework, each provider
+//	                       listing the consumers it is INJECTED_INTO, with file
+//	                       refs and the DI framework.
+//
+// What the graph genuinely models (verified against the INJECTED_INTO emitters:
+// internal/extractors/javascript/angular.go, internal/custom/javascript/
+// nestjs_di.go, internal/custom/java/di_graph.go, internal/custom/python/
+// di_graph.go, internal/custom/golang/di_graph.go, internal/custom/php/
+// di_graph.go, internal/custom/csharp/dotnet_di.go, and the engine framework
+// rules under internal/engine/rules/*/frameworks/*.yaml):
+//
+//   - INJECTED_INTO is the ONE DI edge kind (types.RelationshipKindInjectedInto).
+//     The convention is uniform across every emitter: provider INJECTED_INTO
+//     consumer — i.e. FromID is the provider/service/token that gets injected,
+//     ToID is the consumer (controller / other service / handler) that declares
+//     it as a constructor or field dependency.
+//
+//   - Edge Properties carry, by convention, `provider`, `consumer` and
+//     `framework` (nestjs / angular / spring / micronaut / quarkus / guice /
+//     fastapi / dependency-injector / asp_net_mvc / …), and sometimes `via`
+//     (constructor / field / param) and `qualifier` (Spring @Qualifier / DI
+//     token). We surface the framework, via and qualifier when present.
+//
+// The force-graph already renders INJECTED_INTO edges (PR #4252/#4260), but a
+// force-graph is a poor surface for "which providers inject into which
+// consumers": you cannot scan a provider's full consumer fan-out, nor group by
+// framework. This dedicated route walks the graph for INJECTED_INTO edges and
+// returns a provider→consumers map grouped by framework — a clean, scannable DI
+// map. Mirrors handlers_iac.go / handlers_graphql.go exactly: prefer the cached
+// group graph, fall back to a direct per-repo load; iterate entities AND
+// relationships via the mmap reader when available; raw-JSON envelope.
+//
+// HONESTY: only genuine INJECTED_INTO edges are surfaced. Endpoints that resolve
+// to a collected entity get its real name + file ref; unresolved endpoints fall
+// back to the edge's `provider`/`consumer` property or the raw key tail — never
+// an invented name. A repo with no DI yields an empty `groups` and a clean empty
+// state on the client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
+	"github.com/cajasmota/archigraph/internal/graph/fbreader"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes — mirror webui-v2/src/data/types.ts (DI surface)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// DIConsumer is one consumer a provider is injected into (the ToID side of an
+// INJECTED_INTO edge), resolved to an entity where possible.
+type DIConsumer struct {
+	// EntityID is the repo-qualified entity ID when the consumer resolves to a
+	// collected entity, else the raw edge ToID.
+	EntityID string `json:"entity_id"`
+	// Name is the consumer's display name (entity name, or the edge `consumer`
+	// property, or the raw key tail).
+	Name string `json:"name"`
+	// Kind is the consumer entity Kind when resolved (e.g. SCOPE.Controller,
+	// SCOPE.Service, SCOPE.Class), else empty.
+	Kind       string `json:"kind,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+	SourceFile string `json:"source_file,omitempty"`
+	StartLine  int    `json:"start_line,omitempty"`
+	// Via is the injection mechanism when the edge records it (constructor /
+	// field / param).
+	Via string `json:"via,omitempty"`
+	// Qualifier is the DI qualifier / token disambiguator when present.
+	Qualifier string `json:"qualifier,omitempty"`
+}
+
+// DIProvider is one injectable provider (the FromID side of INJECTED_INTO edges)
+// together with every consumer it injects into.
+type DIProvider struct {
+	// EntityID is the repo-qualified entity ID when the provider resolves to a
+	// collected entity, else the raw edge FromID.
+	EntityID string `json:"entity_id"`
+	// Name is the provider's display name.
+	Name string `json:"name"`
+	// Kind is the provider entity Kind when resolved, else empty.
+	Kind       string `json:"kind,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+	SourceFile string `json:"source_file,omitempty"`
+	StartLine  int    `json:"start_line,omitempty"`
+	// Framework is the DI framework this provider's injections belong to.
+	Framework string `json:"framework,omitempty"`
+	// Consumers are the consumers this provider is INJECTED_INTO (≥1).
+	Consumers []DIConsumer `json:"consumers"`
+}
+
+// DIFrameworkGroup is the providers observed under one DI framework.
+type DIFrameworkGroup struct {
+	Framework string       `json:"framework"`
+	Count     int          `json:"count"`
+	Providers []DIProvider `json:"providers"`
+}
+
+// DIReport is the wire shape for GET /api/di/{group}.
+type DIReport struct {
+	Group string `json:"group"`
+
+	// Totals.
+	TotalProviders  int `json:"total_providers"`
+	TotalConsumers  int `json:"total_consumers"`
+	TotalInjections int `json:"total_injections"`
+
+	// Frameworks observed, sorted.
+	Frameworks []string `json:"frameworks"`
+
+	// Groups — providers grouped by framework, frameworks by provider count desc.
+	Groups []DIFrameworkGroup `json:"groups"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure fold — testable without a live server
+// ─────────────────────────────────────────────────────────────────────────────
+
+// diEntMeta is the resolved-entity metadata the fold uses to turn a raw
+// INJECTED_INTO endpoint ID into a named, file-referenced provider/consumer.
+type diEntMeta struct {
+	name, kind, sourceFile, repoSlug string
+	startLine                        int
+}
+
+// diEdge is one INJECTED_INTO edge: provider (FromID) → consumer (ToID) plus the
+// edge's properties (provider/consumer/framework/via/qualifier).
+type diEdge struct {
+	fromID, toID string
+	props        map[string]string
+}
+
+// diAccum accumulates the fold across repos before assembly.
+type diAccum struct {
+	// entByID resolves an endpoint ID → its entity metadata.
+	entByID map[string]diEntMeta
+	// providers keyed by framework+providerID; consumers de-duped per provider.
+	provByKey       map[string]*diProvAccum
+	provOrder       []string // insertion order, for deterministic assembly
+	frameworks      map[string]bool
+	totalInjections int
+}
+
+type diProvAccum struct {
+	prov      *DIProvider
+	seenCons  map[string]struct{}
+	consumers []DIConsumer
+}
+
+func newDIAccum() *diAccum {
+	return &diAccum{
+		entByID:    map[string]diEntMeta{},
+		provByKey:  map[string]*diProvAccum{},
+		frameworks: map[string]bool{},
+	}
+}
+
+// addEdge folds one INJECTED_INTO edge into the accumulator. filterFramework, if
+// non-empty (already lower-cased), restricts to edges of that framework.
+func (a *diAccum) addEdge(e diEdge, filterFramework string) {
+	framework := strings.TrimSpace(e.props["framework"])
+	if filterFramework != "" && strings.ToLower(framework) != filterFramework {
+		return
+	}
+
+	provMeta, provResolved := a.entByID[e.fromID]
+	consMeta, consResolved := a.entByID[e.toID]
+
+	providerName := e.props["provider"]
+	if provResolved && provMeta.name != "" {
+		providerName = provMeta.name
+	}
+	if providerName == "" {
+		providerName = idTail(e.fromID)
+	}
+	consumerName := e.props["consumer"]
+	if consResolved && consMeta.name != "" {
+		consumerName = consMeta.name
+	}
+	if consumerName == "" {
+		consumerName = idTail(e.toID)
+	}
+
+	key := framework + "\x00" + e.fromID
+	acc := a.provByKey[key]
+	if acc == nil {
+		prov := &DIProvider{
+			EntityID:  e.fromID,
+			Name:      providerName,
+			Framework: framework,
+			Consumers: []DIConsumer{},
+		}
+		if provResolved {
+			prov.EntityID = provMeta.repoSlug + "/" + e.fromID
+			prov.Kind = provMeta.kind
+			prov.Repo = provMeta.repoSlug
+			prov.SourceFile = provMeta.sourceFile
+			prov.StartLine = provMeta.startLine
+		}
+		acc = &diProvAccum{prov: prov, seenCons: map[string]struct{}{}}
+		a.provByKey[key] = acc
+		a.provOrder = append(a.provOrder, key)
+	}
+
+	// De-duplicate consumers per provider (multiple edges can land the same
+	// provider→consumer pair across passes/repos).
+	if _, dup := acc.seenCons[e.toID]; dup {
+		return
+	}
+	acc.seenCons[e.toID] = struct{}{}
+
+	cons := DIConsumer{
+		EntityID:  e.toID,
+		Name:      consumerName,
+		Via:       strings.TrimSpace(e.props["via"]),
+		Qualifier: strings.TrimSpace(e.props["qualifier"]),
+	}
+	if consResolved {
+		cons.EntityID = consMeta.repoSlug + "/" + e.toID
+		cons.Kind = consMeta.kind
+		cons.Repo = consMeta.repoSlug
+		cons.SourceFile = consMeta.sourceFile
+		cons.StartLine = consMeta.startLine
+	}
+	acc.consumers = append(acc.consumers, cons)
+
+	if framework != "" {
+		a.frameworks[framework] = true
+	}
+	a.totalInjections++
+}
+
+// assemble produces the final report: providers grouped by framework (DI hubs
+// first), totals, and the sorted framework list.
+func (a *diAccum) assemble(group string) DIReport {
+	report := DIReport{Group: group, TotalInjections: a.totalInjections}
+
+	byFramework := map[string]*DIFrameworkGroup{}
+	distinctConsumers := map[string]struct{}{}
+	for _, key := range a.provOrder {
+		acc := a.provByKey[key]
+		sort.SliceStable(acc.consumers, func(i, j int) bool {
+			if acc.consumers[i].Name != acc.consumers[j].Name {
+				return acc.consumers[i].Name < acc.consumers[j].Name
+			}
+			return acc.consumers[i].EntityID < acc.consumers[j].EntityID
+		})
+		acc.prov.Consumers = acc.consumers
+		for _, c := range acc.consumers {
+			distinctConsumers[c.EntityID] = struct{}{}
+		}
+		report.TotalProviders++
+
+		fw := acc.prov.Framework
+		g := byFramework[fw]
+		if g == nil {
+			g = &DIFrameworkGroup{Framework: fw}
+			byFramework[fw] = g
+		}
+		g.Providers = append(g.Providers, *acc.prov)
+	}
+	report.TotalConsumers = len(distinctConsumers)
+
+	for _, g := range byFramework {
+		g.Count = len(g.Providers)
+		sort.SliceStable(g.Providers, func(i, j int) bool {
+			// Providers with more consumers first (the DI hubs), then by name.
+			if len(g.Providers[i].Consumers) != len(g.Providers[j].Consumers) {
+				return len(g.Providers[i].Consumers) > len(g.Providers[j].Consumers)
+			}
+			return g.Providers[i].Name < g.Providers[j].Name
+		})
+		report.Groups = append(report.Groups, *g)
+	}
+	sort.SliceStable(report.Groups, func(i, j int) bool {
+		if report.Groups[i].Count != report.Groups[j].Count {
+			return report.Groups[i].Count > report.Groups[j].Count
+		}
+		return report.Groups[i].Framework < report.Groups[j].Framework
+	})
+
+	for f := range a.frameworks {
+		report.Frameworks = append(report.Frameworks, f)
+	}
+	sort.Strings(report.Frameworks)
+
+	return report
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler: GET /api/di/{group}
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleDI(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	q := r.URL.Query()
+	filterFramework := strings.ToLower(strings.TrimSpace(q.Get("framework")))
+
+	acc := newDIAccum()
+
+	cachedGrp, _ := s.graphs.GetGroupCached(groupName)
+
+	for _, rp := range repoPaths {
+		var doc *graph.Document
+		var rdr *fbreader.Reader
+		if cachedGrp != nil {
+			if dr, ok := cachedGrp.Repos[rp.Slug]; ok && dr != nil {
+				doc = dr.Doc
+				rdr = dr.Reader
+			}
+		}
+		if doc == nil && rdr == nil {
+			stateDir := daemon.StateDirForRepo(rp.Path)
+			var loadErr error
+			doc, loadErr = graph.LoadGraphFromDir(stateDir)
+			if loadErr != nil {
+				continue
+			}
+		}
+
+		iterEntities := func(visit func(id, name, kind, sourceFile string, startLine int)) {
+			if rdr != nil {
+				rdr.IterateEntities(func(e *fb.Entity) bool {
+					visit(string(e.Id()), string(e.Name()), string(e.Kind()), string(e.SourceFile()), int(e.SourceLine()))
+					return true
+				})
+				return
+			}
+			for i := range doc.Entities {
+				ent := &doc.Entities[i]
+				visit(ent.ID, ent.Name, ent.Kind, ent.SourceFile, ent.StartLine)
+			}
+		}
+
+		iterRelationships := func(visit func(fromID, toID, kind string, props map[string]string)) {
+			if rdr != nil {
+				rdr.IterateRelationships(func(rel *fb.Relationship) bool {
+					props := make(map[string]string, rel.PropertiesLength())
+					var pe fb.PropertyEntry
+					for i := 0; i < rel.PropertiesLength(); i++ {
+						if rel.Properties(&pe, i) {
+							props[string(pe.Key())] = string(pe.Value())
+						}
+					}
+					visit(string(rel.FromId()), string(rel.ToId()), string(rel.Kind()), props)
+					return true
+				})
+				return
+			}
+			for i := range doc.Relationships {
+				rl := &doc.Relationships[i]
+				visit(rl.FromID, rl.ToID, rl.Kind, rl.Properties)
+			}
+		}
+
+		// Pass 1: index every entity so INJECTED_INTO endpoints resolve to a
+		// real name / Kind / file ref.
+		iterEntities(func(id, name, kind, sourceFile string, startLine int) {
+			acc.entByID[id] = diEntMeta{name: name, kind: kind, sourceFile: sourceFile, repoSlug: rp.Slug, startLine: startLine}
+		})
+
+		injectedInto := string(types.RelationshipKindInjectedInto)
+
+		// Pass 2: fold INJECTED_INTO edges → provider→consumers map.
+		iterRelationships(func(fromID, toID, kind string, props map[string]string) {
+			if kind != injectedInto {
+				return
+			}
+			acc.addEdge(diEdge{fromID: fromID, toID: toID, props: props}, filterFramework)
+		})
+	}
+
+	report := acc.assemble(groupName)
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(report)
+}

--- a/internal/dashboard/handlers_di_test.go
+++ b/internal/dashboard/handlers_di_test.go
@@ -1,0 +1,145 @@
+package dashboard
+
+import "testing"
+
+// p builds an INJECTED_INTO edge property map.
+func diProps(framework, provider, consumer, via, qualifier string) map[string]string {
+	m := map[string]string{}
+	if framework != "" {
+		m["framework"] = framework
+	}
+	if provider != "" {
+		m["provider"] = provider
+	}
+	if consumer != "" {
+		m["consumer"] = consumer
+	}
+	if via != "" {
+		m["via"] = via
+	}
+	if qualifier != "" {
+		m["qualifier"] = qualifier
+	}
+	return m
+}
+
+// TestDIFoldGroupsAndDedups verifies the core fold: provider→consumers grouping,
+// per-provider consumer de-duplication, framework grouping with DI-hubs-first
+// ordering, and the resolved totals.
+func TestDIFoldGroupsAndDedups(t *testing.T) {
+	a := newDIAccum()
+	// One nestjs provider injected into two controllers (a DI hub) + a repeat
+	// edge for the same pair (must de-dup).
+	a.entByID["UsersService"] = diEntMeta{name: "UsersService", kind: "SCOPE.Service", sourceFile: "users.service.ts", repoSlug: "api", startLine: 4}
+	a.entByID["UsersController"] = diEntMeta{name: "UsersController", kind: "SCOPE.Controller", sourceFile: "users.controller.ts", repoSlug: "api", startLine: 9}
+	a.entByID["AdminController"] = diEntMeta{name: "AdminController", kind: "SCOPE.Controller", sourceFile: "admin.controller.ts", repoSlug: "api", startLine: 3}
+
+	a.addEdge(diEdge{fromID: "UsersService", toID: "UsersController", props: diProps("nestjs", "UsersService", "UsersController", "constructor", "")}, "")
+	a.addEdge(diEdge{fromID: "UsersService", toID: "AdminController", props: diProps("nestjs", "UsersService", "AdminController", "constructor", "")}, "")
+	a.addEdge(diEdge{fromID: "UsersService", toID: "UsersController", props: diProps("nestjs", "UsersService", "UsersController", "constructor", "")}, "") // dup
+	// A second, smaller nestjs provider.
+	a.addEdge(diEdge{fromID: "MailService", toID: "UsersController", props: diProps("nestjs", "MailService", "UsersController", "", "")}, "")
+	// A spring provider — distinct framework group.
+	a.addEdge(diEdge{fromID: "Repo", toID: "OrderService", props: diProps("spring", "Repo", "OrderService", "field", "primaryRepo")}, "")
+
+	rep := a.assemble("g")
+
+	if rep.TotalInjections != 4 { // dup not counted
+		t.Fatalf("TotalInjections = %d, want 4", rep.TotalInjections)
+	}
+	if rep.TotalProviders != 3 {
+		t.Fatalf("TotalProviders = %d, want 3", rep.TotalProviders)
+	}
+	// Distinct consumers: UsersController, AdminController, OrderService.
+	if rep.TotalConsumers != 3 {
+		t.Fatalf("TotalConsumers = %d, want 3", rep.TotalConsumers)
+	}
+
+	// nestjs (2 providers) must sort before spring (1) — more providers first.
+	if len(rep.Groups) != 2 || rep.Groups[0].Framework != "nestjs" || rep.Groups[1].Framework != "spring" {
+		t.Fatalf("group order/frameworks unexpected: %+v", rep.Groups)
+	}
+	if rep.Groups[0].Count != 2 {
+		t.Fatalf("nestjs Count = %d, want 2", rep.Groups[0].Count)
+	}
+
+	// Within nestjs, the DI hub (UsersService, 2 consumers) is first.
+	hub := rep.Groups[0].Providers[0]
+	if hub.Name != "UsersService" || len(hub.Consumers) != 2 {
+		t.Fatalf("nestjs hub = %s with %d consumers, want UsersService/2", hub.Name, len(hub.Consumers))
+	}
+	// Resolved provider carries repo-qualified ID + kind + ref.
+	if hub.EntityID != "api/UsersService" || hub.Kind != "SCOPE.Service" || hub.SourceFile != "users.service.ts" {
+		t.Fatalf("hub resolution wrong: %+v", hub)
+	}
+	// Consumers sorted by name: AdminController before UsersController.
+	if hub.Consumers[0].Name != "AdminController" || hub.Consumers[1].Name != "UsersController" {
+		t.Fatalf("consumer order wrong: %+v", hub.Consumers)
+	}
+	if hub.Consumers[0].Via != "constructor" || hub.Consumers[0].Kind != "SCOPE.Controller" {
+		t.Fatalf("consumer facet wrong: %+v", hub.Consumers[0])
+	}
+
+	// Frameworks list sorted.
+	if len(rep.Frameworks) != 2 || rep.Frameworks[0] != "nestjs" || rep.Frameworks[1] != "spring" {
+		t.Fatalf("Frameworks = %v, want [nestjs spring]", rep.Frameworks)
+	}
+
+	// Spring consumer carries the qualifier.
+	spring := rep.Groups[1].Providers[0]
+	if spring.Consumers[0].Qualifier != "primaryRepo" {
+		t.Fatalf("spring qualifier = %q, want primaryRepo", spring.Consumers[0].Qualifier)
+	}
+}
+
+// TestDIFoldUnresolvedFallback verifies that an endpoint with no indexed entity
+// falls back to the edge property name, then the raw key tail — never invented.
+func TestDIFoldUnresolvedFallback(t *testing.T) {
+	a := newDIAccum()
+	// No entByID entries. provider prop present, consumer prop absent.
+	a.addEdge(diEdge{
+		fromID: "api::SCOPE.Token:DATA_SOURCE",
+		toID:   "api::SCOPE.Class:OrderService",
+		props:  diProps("guice", "DataSource", "", "", ""),
+	}, "")
+	rep := a.assemble("g")
+	if rep.TotalProviders != 1 {
+		t.Fatalf("TotalProviders = %d, want 1", rep.TotalProviders)
+	}
+	prov := rep.Groups[0].Providers[0]
+	if prov.Name != "DataSource" { // from provider prop
+		t.Fatalf("provider name = %q, want DataSource (from prop)", prov.Name)
+	}
+	if prov.EntityID != "api::SCOPE.Token:DATA_SOURCE" { // unresolved ⇒ raw id, not repo-qualified
+		t.Fatalf("unresolved provider EntityID = %q, want raw id", prov.EntityID)
+	}
+	if prov.Repo != "" || prov.SourceFile != "" {
+		t.Fatalf("unresolved provider must have no repo/ref: %+v", prov)
+	}
+	// consumer prop absent ⇒ raw key tail.
+	if prov.Consumers[0].Name != "OrderService" {
+		t.Fatalf("consumer name = %q, want OrderService (key tail)", prov.Consumers[0].Name)
+	}
+}
+
+// TestDIFoldFrameworkFilter verifies the framework query filter restricts edges.
+func TestDIFoldFrameworkFilter(t *testing.T) {
+	a := newDIAccum()
+	a.addEdge(diEdge{fromID: "A", toID: "B", props: diProps("nestjs", "A", "B", "", "")}, "spring")
+	a.addEdge(diEdge{fromID: "C", toID: "D", props: diProps("spring", "C", "D", "", "")}, "spring")
+	rep := a.assemble("g")
+	if rep.TotalProviders != 1 || rep.Groups[0].Framework != "spring" {
+		t.Fatalf("framework filter failed: %+v", rep.Groups)
+	}
+}
+
+// TestDIFoldEmpty verifies a clean empty report when no DI edges exist.
+func TestDIFoldEmpty(t *testing.T) {
+	rep := newDIAccum().assemble("g")
+	if rep.TotalProviders != 0 || rep.TotalConsumers != 0 || rep.TotalInjections != 0 {
+		t.Fatalf("empty totals nonzero: %+v", rep)
+	}
+	if len(rep.Groups) != 0 || len(rep.Frameworks) != 0 {
+		t.Fatalf("empty report has groups/frameworks: %+v", rep)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -559,6 +559,11 @@ func (s *Server) routes() http.Handler {
 	// flows (DATA_FLOWS_TO) + ranked security findings (source→sink paths).
 	mux.HandleFunc("GET /api/dataflow/{group}", s.handleDataflow)
 
+	// #4266 (epic #4249): Dependency-Injection surface — providers grouped by
+	// framework, each listing the consumers it is INJECTED_INTO (NestJS/Spring/
+	// Angular/… DI).
+	mux.HandleFunc("GET /api/di/{group}", s.handleDI)
+
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)
 	mux.HandleFunc("GET /api/groups/{group}/god-nodes", s.handleGroupGodNodes)

--- a/webui-v2/src/components/chrome/screens.ts
+++ b/webui-v2/src/components/chrome/screens.ts
@@ -22,6 +22,7 @@ import {
   Boxes,
   Server,
   Waypoints,
+  Syringe,
   Wrench,
   Inbox,
   Settings,
@@ -47,6 +48,7 @@ export const SCREENS: ScreenDef[] = [
   { to: "docs", label: "Docs", Icon: FileText, shortcut: "D" },
   { to: "security", label: "Security", Icon: ShieldCheck, shortcut: "S" },
   { to: "taint", label: "Taint", Icon: Waypoints, shortcut: "X" },
+  { to: "di", label: "Dependency Injection", Icon: Syringe, shortcut: "J" },
   { to: "quality", label: "Quality", Icon: GaugeCircle, shortcut: "Q" },
   { to: "operations", label: "Operations", Icon: Wrench, shortcut: "O" },
 ];

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2221,3 +2221,56 @@ export interface DataflowReport {
   taint_method?: string;
   flow_method?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Dependency-Injection surface (#4266, epic #4249)
+//
+// Wire shape for GET /api/di/{group} (handlers_di.go → handleDI). RAW JSON
+// (not the v2 envelope). Mirrors the Go structs in internal/dashboard/
+// handlers_di.go, which walks the graph for INJECTED_INTO edges (provider
+// INJECTED_INTO consumer) and groups providers by DI framework.
+// ---------------------------------------------------------------------------
+
+/** One consumer a provider is INJECTED_INTO (the ToID side of the edge). */
+export interface DIConsumer {
+  entity_id: string;
+  name: string;
+  /** Consumer entity Kind when resolved (SCOPE.Controller / SCOPE.Service / …). */
+  kind?: string;
+  repo?: string;
+  source_file?: string;
+  start_line?: number;
+  /** Injection mechanism when recorded (constructor / field / param). */
+  via?: string;
+  /** DI qualifier / token disambiguator when present. */
+  qualifier?: string;
+}
+
+/** One injectable provider with every consumer it injects into. */
+export interface DIProvider {
+  entity_id: string;
+  name: string;
+  kind?: string;
+  repo?: string;
+  source_file?: string;
+  start_line?: number;
+  framework?: string;
+  consumers: DIConsumer[];
+}
+
+/** Providers observed under one DI framework. */
+export interface DIFrameworkGroup {
+  framework: string;
+  count: number;
+  providers: DIProvider[];
+}
+
+/** GET /api/di/{group} — DI providers grouped by framework. */
+export interface DIReport {
+  group: string;
+  total_providers: number;
+  total_consumers: number;
+  total_injections: number;
+  frameworks: string[];
+  groups: DIFrameworkGroup[];
+}

--- a/webui-v2/src/hooks/use-di.ts
+++ b/webui-v2/src/hooks/use-di.ts
@@ -1,0 +1,28 @@
+/* ============================================================
+   hooks/use-di.ts — Dependency-Injection data hook (#4266).
+
+   Wraps api.getDI in TanStack Query. Backed by the route
+   GET /api/di/{group} (handlers_di.go → handleDI), which walks
+   the graph for INJECTED_INTO edges (provider INJECTED_INTO
+   consumer) and returns a raw-JSON DIReport: providers grouped
+   by DI framework (nestjs / spring / angular / …), each listing
+   the consumers it injects into, with file refs.
+
+   Pure static graph read. Honest-empty when the group has no
+   INJECTED_INTO edges (no DI frameworks indexed).
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export const diQueryKey = (groupId: string) => ["di", groupId] as const;
+
+/** Dependency-Injection report for the group. */
+export function useDI(groupId: string) {
+  return useQuery({
+    queryKey: diQueryKey(groupId),
+    queryFn: () => api.getDI(groupId),
+    enabled: !!groupId,
+    staleTime: 30_000,
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -70,6 +70,7 @@ import type {
   GraphQLReport,
   IaCReport,
   DataflowReport,
+  DIReport,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -827,6 +828,17 @@ export const api = {
   getDataflow: (groupId: string) =>
     request<DataflowReport>(
       `/dataflow/${encodeURIComponent(groupId)}`,
+    ),
+
+  // --- Dependency-Injection (#4266) ---
+  // Raw JSON (no v2 envelope) → `request`. Handler: handlers_di.go handleDI,
+  // which returns a DIReport (providers grouped by framework, each listing the
+  // consumers it is INJECTED_INTO).
+
+  /** GET /api/di/{group} — DI providers → consumers, grouped by framework. */
+  getDI: (groupId: string) =>
+    request<DIReport>(
+      `/di/${encodeURIComponent(groupId)}`,
     ),
 };
 

--- a/webui-v2/src/routes/di.tsx
+++ b/webui-v2/src/routes/di.tsx
@@ -1,0 +1,422 @@
+/* ============================================================
+   Dependency-Injection view (#4266, epic #4249).
+
+   Route: /g/:groupId/di
+
+   The graph models DI via the INJECTED_INTO edge (provider
+   INJECTED_INTO consumer), emitted by every framework's DI pass
+   (NestJS / Angular / Spring / Micronaut / Quarkus / Guice /
+   FastAPI / dependency-injector / ASP.NET / …). The force-graph
+   renders those edges but is a poor surface for "which providers
+   inject into which consumers": you cannot scan a provider's full
+   consumer fan-out, nor group by framework.
+
+   This screen surfaces that as a scannable DI map: providers
+   grouped by DI framework, each provider listing every consumer it
+   is injected into (the DI hubs — providers with the widest
+   fan-out — sort first), with a Kind badge, the injection
+   mechanism (constructor / field), a qualifier when present, and a
+   RefLine source ref.
+
+   Data: GET /api/di/{group} (handlers_di.go → handleDI), raw-JSON
+   DIReport.
+
+   Layout mirrors IaC / Data-flow: full-height column, a summary
+   stat row, a framework filter, and a grouped provider → consumers
+   list. Reuses Card / Badge / Pill / Skeleton + RefLine + RepoChip.
+
+   HONESTY: only genuine INJECTED_INTO edges render. Endpoints that
+   resolve to an entity get a real name + ref; unresolved ones show
+   the edge's provider/consumer label or the raw key tail — never an
+   invented name. A repo with no DI shows a clean empty state.
+   ============================================================ */
+
+import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Syringe,
+  Boxes,
+  ArrowRight,
+  ChevronRight,
+  ListFilter,
+  AlertTriangle,
+  Package,
+} from "lucide-react";
+
+import { Badge, Card, CardBody, Pill } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RefLine } from "@/components/RefLine";
+import { RepoChip } from "@/lib/repo-color";
+import { cn } from "@/lib/utils";
+import { useDI } from "@/hooks/use-di";
+import type { DIConsumer, DIProvider, DIReport } from "@/data/types";
+
+type Tone = "neutral" | "accent" | "success" | "warning" | "danger" | "info";
+
+// ---------------------------------------------------------------------------
+// § Styling helpers
+// ---------------------------------------------------------------------------
+
+/** A short, readable label for a graph entity Kind (SCOPE.Controller → Controller). */
+function kindLabel(kind?: string): string {
+  if (!kind) return "";
+  const tail = kind.includes(".") ? kind.split(".").pop()! : kind;
+  return tail;
+}
+
+/** Entity-Kind → tone, so controllers vs services vs plain classes read distinctly. */
+function kindTone(kind?: string): Tone {
+  switch (kindLabel(kind).toLowerCase()) {
+    case "controller":
+    case "resolver":
+    case "gateway":
+      return "info";
+    case "service":
+    case "provider":
+      return "accent";
+    case "repository":
+    case "datasource":
+      return "success";
+    default:
+      return "neutral";
+  }
+}
+
+/** DI framework → tone for the framework heading pill. */
+function frameworkTone(fw: string): Tone {
+  switch ((fw || "").toLowerCase()) {
+    case "nestjs":
+    case "angular":
+      return "danger";
+    case "spring":
+    case "micronaut":
+    case "quarkus":
+    case "guice":
+      return "success";
+    case "fastapi":
+    case "dependency-injector":
+      return "info";
+    default:
+      return "neutral";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// § Shared shells
+// ---------------------------------------------------------------------------
+
+function SkeletonRows({ n = 6 }: { n?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: n }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 h-16 px-4 rounded-lg border border-border"
+        >
+          <Skeleton w="w-1/4" />
+          <Skeleton w="w-6" h="h-2" />
+          <Skeleton w="w-1/3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <Syringe size={32} className="text-text-4" />
+      <p className="text-md font-medium text-text">{title}</p>
+      <p className="text-sm text-text-3 max-w-md">{hint}</p>
+    </div>
+  );
+}
+
+function ErrorState() {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <AlertTriangle size={32} className="text-danger" />
+      <p className="text-md font-medium text-text">Could not load dependency-injection map</p>
+      <p className="text-sm text-text-3 max-w-sm">
+        The daemon returned an error. Confirm the group is indexed and the daemon
+        is reachable, then retry.
+      </p>
+    </div>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <Card className={cn("flex-1 min-w-[120px]")}>
+      <CardBody className="py-3">
+        <p className="text-2xl font-semibold tabular-nums text-text">{value}</p>
+        <p className="text-xs text-text-4 mt-0.5">{label}</p>
+      </CardBody>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Endpoint label (provider / consumer)
+// ---------------------------------------------------------------------------
+
+function EntityName({
+  name,
+  kind,
+  entityId,
+}: {
+  name: string;
+  kind?: string;
+  entityId: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span className="font-mono text-sm text-text truncate" title={entityId}>
+        {name}
+      </span>
+      {kind && (
+        <Badge tone={kindTone(kind)} className="shrink-0">
+          {kindLabel(kind)}
+        </Badge>
+      )}
+    </span>
+  );
+}
+
+function EntityRefLine({
+  repo,
+  sourceFile,
+  startLine,
+  name,
+}: {
+  repo?: string;
+  sourceFile?: string;
+  startLine?: number;
+  name: string;
+}) {
+  if (!repo || !sourceFile) return null;
+  return (
+    <RefLine
+      repo={repo}
+      file={sourceFile}
+      line={startLine ?? 0}
+      name={name}
+      className="text-[11px]"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One consumer row (provider INJECTED_INTO consumer)
+// ---------------------------------------------------------------------------
+
+function ConsumerRow({ consumer, groupId }: { consumer: DIConsumer; groupId: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 pl-6 py-1">
+      <div className="flex items-center gap-2 min-w-0 flex-wrap">
+        <ArrowRight size={12} className="text-text-4 shrink-0" />
+        <EntityName name={consumer.name} kind={consumer.kind} entityId={consumer.entity_id} />
+        {consumer.via && (
+          <span
+            className="font-mono text-[10px] text-text-4 shrink-0"
+            title={`injected via ${consumer.via}`}
+          >
+            {consumer.via}
+          </span>
+        )}
+        {consumer.qualifier && (
+          <span
+            className="font-mono text-[10px] text-text-3 shrink-0"
+            title={`DI qualifier / token: ${consumer.qualifier}`}
+          >
+            @{consumer.qualifier}
+          </span>
+        )}
+        {consumer.repo && (
+          <RepoChip slug={consumer.repo} groupId={groupId} maxLength={14} />
+        )}
+      </div>
+      <EntityRefLine
+        repo={consumer.repo}
+        sourceFile={consumer.source_file}
+        startLine={consumer.start_line}
+        name={consumer.name}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One provider card (provider + the consumers it injects into)
+// ---------------------------------------------------------------------------
+
+const COLLAPSE_AT = 5; // collapse consumer lists longer than this
+
+function ProviderCard({ provider, groupId }: { provider: DIProvider; groupId: string }) {
+  const [open, setOpen] = useState(false);
+  const many = provider.consumers.length > COLLAPSE_AT;
+  const shown = many && !open ? provider.consumers.slice(0, COLLAPSE_AT) : provider.consumers;
+
+  return (
+    <Card>
+      <CardBody className="py-2.5 space-y-1">
+        {/* Provider header */}
+        <div className="flex items-center gap-2 min-w-0 flex-wrap">
+          <Syringe size={13} className="text-accent shrink-0" />
+          <EntityName name={provider.name} kind={provider.kind} entityId={provider.entity_id} />
+          {provider.repo && (
+            <RepoChip slug={provider.repo} groupId={groupId} maxLength={14} />
+          )}
+          <span
+            className="ml-auto text-[11px] text-text-4 tabular-nums shrink-0"
+            title={`injected into ${provider.consumers.length} consumer(s)`}
+          >
+            {provider.consumers.length} consumer{provider.consumers.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <EntityRefLine
+          repo={provider.repo}
+          sourceFile={provider.source_file}
+          startLine={provider.start_line}
+          name={provider.name}
+        />
+
+        {/* Consumers */}
+        <div className="border-l border-border/60 ml-1">
+          {shown.map((c) => (
+            <ConsumerRow key={c.entity_id} consumer={c} groupId={groupId} />
+          ))}
+        </div>
+        {many && (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1 text-[11px] text-text-3 hover:text-text pl-6"
+          >
+            <ChevronRight size={12} className={cn("transition-transform", open && "rotate-90")} />
+            {open
+              ? "Show fewer"
+              : `Show ${provider.consumers.length - COLLAPSE_AT} more consumer${
+                  provider.consumers.length - COLLAPSE_AT === 1 ? "" : "s"
+                }`}
+          </button>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Screen
+// ---------------------------------------------------------------------------
+
+function DIBody({ data, groupId }: { data: DIReport; groupId: string }) {
+  const [framework, setFramework] = useState<string>("all");
+
+  const filteredGroups = useMemo(
+    () =>
+      framework === "all"
+        ? data.groups
+        : data.groups.filter((g) => g.framework === framework),
+    [data.groups, framework],
+  );
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
+      {/* Summary */}
+      <div className="flex flex-wrap gap-3">
+        <SummaryStat label="Providers" value={data.total_providers} />
+        <SummaryStat label="Consumers" value={data.total_consumers} />
+        <SummaryStat label="Injections" value={data.total_injections} />
+        <SummaryStat label="Frameworks" value={data.frameworks.length} />
+      </div>
+
+      {/* Framework filter */}
+      {data.groups.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <ListFilter size={13} className="text-text-4" />
+          <Pill active={framework === "all"} onClick={() => setFramework("all")}>
+            All ({data.total_providers})
+          </Pill>
+          {data.groups.map((g) => (
+            <Pill
+              key={g.framework || "—"}
+              active={framework === g.framework}
+              onClick={() => setFramework(g.framework)}
+            >
+              {g.framework || "unknown"} ({g.count})
+            </Pill>
+          ))}
+        </div>
+      )}
+
+      {/* Provider → consumers, grouped by framework */}
+      <div className="space-y-5">
+        {filteredGroups.map((g) => (
+          <section key={g.framework || "—"} className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Package size={14} className="text-text-4" />
+              <Badge tone={frameworkTone(g.framework)} className="uppercase">
+                {g.framework || "unknown"}
+              </Badge>
+              <span className="text-[11px] text-text-4 tabular-nums">
+                {g.count} provider{g.count === 1 ? "" : "s"}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {g.providers.map((p) => (
+                <ProviderCard key={`${g.framework}:${p.entity_id}`} provider={p} groupId={groupId} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <p className="text-[10px] text-text-4">
+        Each row is a genuine INJECTED_INTO edge: the provider (service / token)
+        is injected into the consumer (controller / service / handler) that
+        declares it as a constructor or field dependency. Providers with the
+        widest consumer fan-out — the DI hubs — sort first.
+      </p>
+    </div>
+  );
+}
+
+export default function DIScreen() {
+  const { groupId = "" } = useParams<{ groupId: string }>();
+  const { data, isLoading, isError } = useDI(groupId);
+
+  const hasAny = (data?.total_injections ?? 0) > 0;
+
+  return (
+    <div className="flex flex-col h-full bg-bg">
+      {isLoading ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <SkeletonRows />
+        </div>
+      ) : isError ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <ErrorState />
+        </div>
+      ) : !hasAny ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <EmptyState
+            title="No dependency-injection wiring found"
+            hint="No INJECTED_INTO edges were extracted for this group. The DI map appears once an indexed repo uses a DI framework (NestJS / Angular / Spring / Micronaut / Quarkus / Guice / FastAPI / dependency-injector / ASP.NET) — the framework's DI pass then records each provider → consumer injection."
+          />
+        </div>
+      ) : (
+        <>
+          <div className="border-b border-border shrink-0 px-4 py-2.5 flex items-center gap-2">
+            <Boxes size={15} className="text-text-3" />
+            <h2 className="text-sm font-medium text-text">Dependency Injection</h2>
+            <span className="text-[11px] text-text-4">
+              providers → the consumers they inject into
+            </span>
+          </div>
+          <DIBody data={data!} groupId={groupId} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/webui-v2/src/routes/router.tsx
+++ b/webui-v2/src/routes/router.tsx
@@ -25,6 +25,7 @@ import IaCScreen from "./iac";
 import DocsScreen from "./docs";
 import SecurityScreen from "./security";
 import DataflowScreen from "./dataflow";
+import DIScreen from "./di";
 import QualityScreen from "./quality";
 import SettingsScreen from "./settings";
 import PendingScreen from "./pending";
@@ -61,6 +62,7 @@ export const router = createBrowserRouter([
           { path: "docs/*", element: <DocsScreen />, handle: { surfaceLabel: "Docs" } },
           { path: "security", element: <SecurityScreen />, handle: { surfaceLabel: "Security" } },
           { path: "taint", element: <DataflowScreen />, handle: { surfaceLabel: "Taint" } },
+          { path: "di", element: <DIScreen />, handle: { surfaceLabel: "Dependency Injection" } },
           { path: "quality", element: <QualityScreen />, handle: { surfaceLabel: "Quality" } },
           { path: "settings", element: <SettingsScreen />, handle: { surfaceLabel: "Group settings" } },
           { path: "pending", element: <PendingScreen />, handle: { surfaceLabel: "Pending" } },


### PR DESCRIPTION
Closes #4266 (epic #4249). **DEPLOY-DEFERRED.**

## What

A dedicated **Dependency-Injection** surface: which providers inject into which consumers (NestJS / Angular / Spring / Micronaut / Quarkus / Guice / FastAPI / dependency-injector / ASP.NET DI), via the `INJECTED_INTO` edge — convention `provider INJECTED_INTO consumer` (FromID=provider, ToID=consumer), uniform across every emitter.

## Backend or graph payload?

**New backend route** `GET /api/di/{group}` (`handlers_di.go` → `handleDI`). The force-graph already renders `INJECTED_INTO` edges (#4252/#4260), but it cannot show a provider's full consumer fan-out, nor group by framework — a focused, scannable list is the clearer DI map. The handler walks the graphstate for `INJECTED_INTO` edges and returns providers grouped by DI framework, each with the consumers it injects into (resolved names / Kinds / file refs). Mirrors `handlers_iac.go` / `handlers_graphql.go` exactly (cached group graph → per-repo fallback, mmap reader, raw-JSON envelope). The edge-fold is a pure, unit-tested helper.

## Frontend

A **Dependency Injection** screen at `/g/:groupId/di`: provider → consumers as a framework-grouped, expandable list (DI hubs — widest fan-out — first), with Kind badges, injection mechanism (constructor/field), DI qualifier, and `RefLine` source refs. Reuses Badge/Card/Pill/Skeleton + RefLine/RepoChip; loading/empty/error states. Registered in `router.tsx` + `screens.ts` (rail shortcut `J`).

## Honesty

Only genuine `INJECTED_INTO` edges render. Unresolved endpoints fall back to the edge `provider`/`consumer` property, then the raw key tail — never an invented name. Repos with no DI get a clean empty state.

## Gates

- Backend: `go build ./...` ✓, `go vet ./internal/dashboard/` ✓, `gofmt` clean ✓, `go test ./internal/dashboard/` ✓ (incl. new `TestDIFold*`)
- Frontend: `npm ci` ✓, `npm run lint` (tsc --noEmit) ✓ clean, `npm run build` (vite) ✓ `built in 7.39s`

## Honest gaps

- The DI **framework** comes from the edge's `framework` property; edges without it group under "unknown".
- `via` (constructor/field) and `qualifier` surface only when the emitter records them — not every framework pass populates them.
- `dist/` is gitignored; source only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)