### PR TITLE
ui+backend: Error-flow (THROWS/CATCHES) view (#4267)

### DIFF
--- a/internal/dashboard/handlers_errorflow.go
+++ b/internal/dashboard/handlers_errorflow.go
@@ -1,0 +1,419 @@
+package dashboard
+
+// handlers_errorflow.go — group-level Error-flow surface (#4267, epic #4249).
+//
+// Route:
+//
+//	GET /api/errorflow/{group}  — exception types modelled in the group, each
+//	                              listing the functions/endpoints that THROW it
+//	                              and the handlers that CATCH it, with file refs
+//	                              and an honest uncaught flag.
+//
+// What the graph genuinely models (verified against the shared exception-flow
+// emitter internal/extractor/exception_flow.go and the per-language extractors
+// internal/extractors/{python,golang,rust,elixir,...}/exception_flow.go, plus
+// the per-endpoint reader internal/mcp/endpoint_posture.go::resolveErrorFlow):
+//
+//   - One SCOPE.ExceptionType / subtype="exception_type" node per distinct
+//     (normalized, unqualified) type name, carried on a SYNTHETIC constant
+//     SourceFile ("<exception>") so identical type names converge — across
+//     files AND languages — to a SINGLE node. Its Name is "exception:<Type>"
+//     (e.g. "exception:ValidationError"); we strip that prefix for display.
+//
+//   - THROWS and CATCHES are the two error-flow edge kinds
+//     (types.RelationshipKindThrows / RelationshipKindCatches). The direction
+//     is uniform across every emitter: the EDGE ORIGINATES AT THE CALLABLE and
+//     points at the exception-type node —
+//       THROWS  : raising function/method/endpoint → SCOPE.ExceptionType
+//       CATCHES : handling function/method         → SCOPE.ExceptionType
+//     Edge Properties carry `exception_type` (the bare type name) and, when the
+//     detector recorded it, `pattern` (throw_new / raise / instanceof / …).
+//
+//   - Precision-first / honest-partial: only TYPED throws/catches are recorded.
+//     Bare `except:` / untyped `catch(e){}` / anonymous inline errors emit NO
+//     edge. So CATCHES edges are GENUINELY SPARSE in many repos.
+//
+// The per-endpoint Paths posture (#4263) already shows a single endpoint's
+// throws/catches. This route is the GROUP-LEVEL ROLLUP, inverted around the
+// exception type: for each exception, who can raise it and who handles it, so
+// you can spot the type that is thrown in five places and caught nowhere in the
+// indexed graph.
+//
+// HONESTY on "uncaught": a CATCHES edge is only emitted for a TYPED catch the
+// indexer could see. An exception with THROWS but no CATCHES edge anywhere in
+// the group therefore means "no typed catcher found in the indexed graph" —
+// which may be a genuinely uncaught throw OR a throw caught by an untyped /
+// out-of-scope / cross-repo handler the indexer did not model. We label that
+// state honestly as `uncaught` with `uncaught_reason` = "no_catcher_in_graph"
+// and NEVER assert it as fact in prose; the client renders it as a cautious
+// warning, not a hard error. Exceptions with ≥1 CATCHES edge are `caught`.
+// Exception nodes that are only ever CAUGHT (no THROWS in graph) are surfaced
+// too but never flagged uncaught. A repo with no exception modelling yields an
+// empty `exceptions` list and a clean empty state on the client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
+	"github.com/cajasmota/archigraph/internal/graph/fbreader"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes — mirror webui-v2/src/data/types.ts (Error-flow surface)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ErrorFlowSite is one callable that throws or catches an exception type (the
+// FromID side of a THROWS / CATCHES edge), resolved to an entity where possible.
+type ErrorFlowSite struct {
+	// EntityID is the repo-qualified entity ID when the callable resolves to a
+	// collected entity, else the raw edge FromID.
+	EntityID string `json:"entity_id"`
+	// Name is the callable's display name (entity name, else the raw key tail).
+	Name string `json:"name"`
+	// Kind is the callable entity Kind when resolved (SCOPE.Function /
+	// SCOPE.Method / SCOPE.Endpoint / …), else empty.
+	Kind       string `json:"kind,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+	SourceFile string `json:"source_file,omitempty"`
+	StartLine  int    `json:"start_line,omitempty"`
+	// Pattern is the detector label the edge recorded (throw_new / raise /
+	// instanceof / errors_is / …) when present.
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// ErrorFlowException is one exception type with everything that throws and
+// catches it across the group.
+type ErrorFlowException struct {
+	// Type is the bare exception type name (no "exception:" prefix), e.g.
+	// "ValidationError".
+	Type string `json:"type"`
+	// Throwers are the callables that can raise this type (THROWS edges).
+	Throwers []ErrorFlowSite `json:"throwers"`
+	// Catchers are the handlers that catch this type (CATCHES edges).
+	Catchers []ErrorFlowSite `json:"catchers"`
+	// Uncaught is true when this type is thrown at least once but has NO
+	// CATCHES edge anywhere in the indexed group. See UncaughtReason —
+	// honestly this means "no typed catcher in graph", not a proven leak.
+	Uncaught bool `json:"uncaught"`
+	// UncaughtReason qualifies an uncaught flag so the client never over-claims:
+	// "no_catcher_in_graph" — thrown but no typed CATCHES edge was indexed
+	// (may be genuinely uncaught OR caught by an untyped / out-of-scope handler).
+	UncaughtReason string `json:"uncaught_reason,omitempty"`
+	// ThrowCount / CatchCount are the resolved edge counts.
+	ThrowCount int `json:"throw_count"`
+	CatchCount int `json:"catch_count"`
+}
+
+// ErrorFlowReport is the wire shape for GET /api/errorflow/{group}.
+type ErrorFlowReport struct {
+	Group string `json:"group"`
+
+	// Totals.
+	TotalExceptions int `json:"total_exceptions"` // exception types with ≥1 throw or catch
+	TotalUncaught   int `json:"total_uncaught"`   // thrown-but-no-catcher-in-graph
+	TotalThrows     int `json:"total_throws"`     // THROWS edges resolved
+	TotalCatches    int `json:"total_catches"`    // CATCHES edges resolved
+
+	// Exceptions — uncaught first (most throwers first within), then caught.
+	Exceptions []ErrorFlowException `json:"exceptions"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure fold — testable without a live server
+// ─────────────────────────────────────────────────────────────────────────────
+
+// efEntMeta is the resolved-entity metadata the fold uses to turn a raw THROWS /
+// CATCHES endpoint ID into a named, file-referenced thrower/catcher, and to turn
+// an exception-type node ID into its bare type name.
+type efEntMeta struct {
+	name, kind, sourceFile, repoSlug string
+	startLine                        int
+}
+
+// efEdge is one THROWS or CATCHES edge: callable (FromID) → exception-type node
+// (ToID) plus the edge's properties (exception_type / pattern).
+type efEdge struct {
+	fromID, toID string
+	catch        bool
+	props        map[string]string
+}
+
+// efAccum accumulates the fold across repos before assembly.
+type efAccum struct {
+	// entByID resolves any entity ID → its metadata (callables AND exception
+	// nodes; exception nodes carry the synthetic "<exception>" SourceFile).
+	entByID map[string]efEntMeta
+	// excByKey keyed by bare type name; throwers/catchers de-duped per type.
+	excByKey   map[string]*efExcAccum
+	excOrder   []string // insertion order, for deterministic assembly
+	totalThrow int
+	totalCatch int
+}
+
+type efExcAccum struct {
+	exc         *ErrorFlowException
+	seenThrower map[string]struct{}
+	seenCatcher map[string]struct{}
+	throwers    []ErrorFlowSite
+	catchers    []ErrorFlowSite
+}
+
+func newEFAccum() *efAccum {
+	return &efAccum{
+		entByID:  map[string]efEntMeta{},
+		excByKey: map[string]*efExcAccum{},
+	}
+}
+
+// exceptionTypeKey resolves a THROWS/CATCHES edge target to the bare exception
+// type name. Prefers the resolved exception node's Name (stripped of the
+// "exception:" prefix); falls back to the edge's `exception_type` property, then
+// the raw target tail (also prefix-stripped). Never invents a name.
+func (a *efAccum) exceptionTypeKey(toID string, props map[string]string) string {
+	if meta, ok := a.entByID[toID]; ok && meta.name != "" {
+		return strings.TrimPrefix(meta.name, "exception:")
+	}
+	if t := strings.TrimSpace(props["exception_type"]); t != "" {
+		return t
+	}
+	return strings.TrimPrefix(idTail(toID), "exception:")
+}
+
+// siteFor builds an ErrorFlowSite for a callable edge endpoint, resolving entity
+// metadata where possible and falling back to the raw key tail otherwise.
+func (a *efAccum) siteFor(fromID string, props map[string]string) ErrorFlowSite {
+	site := ErrorFlowSite{
+		EntityID: fromID,
+		Name:     idTail(fromID),
+		Pattern:  strings.TrimSpace(props["pattern"]),
+	}
+	if meta, ok := a.entByID[fromID]; ok {
+		if meta.name != "" {
+			site.Name = meta.name
+		}
+		site.EntityID = meta.repoSlug + "/" + fromID
+		site.Kind = meta.kind
+		site.Repo = meta.repoSlug
+		site.SourceFile = meta.sourceFile
+		site.StartLine = meta.startLine
+	}
+	return site
+}
+
+// addEdge folds one THROWS / CATCHES edge into the accumulator.
+func (a *efAccum) addEdge(e efEdge) {
+	typeName := a.exceptionTypeKey(e.toID, e.props)
+	if typeName == "" {
+		return
+	}
+
+	acc := a.excByKey[typeName]
+	if acc == nil {
+		acc = &efExcAccum{
+			exc:         &ErrorFlowException{Type: typeName, Throwers: []ErrorFlowSite{}, Catchers: []ErrorFlowSite{}},
+			seenThrower: map[string]struct{}{},
+			seenCatcher: map[string]struct{}{},
+		}
+		a.excByKey[typeName] = acc
+		a.excOrder = append(a.excOrder, typeName)
+	}
+
+	if e.catch {
+		if _, dup := acc.seenCatcher[e.fromID]; dup {
+			return
+		}
+		acc.seenCatcher[e.fromID] = struct{}{}
+		acc.catchers = append(acc.catchers, a.siteFor(e.fromID, e.props))
+		a.totalCatch++
+		return
+	}
+	if _, dup := acc.seenThrower[e.fromID]; dup {
+		return
+	}
+	acc.seenThrower[e.fromID] = struct{}{}
+	acc.throwers = append(acc.throwers, a.siteFor(e.fromID, e.props))
+	a.totalThrow++
+}
+
+// assemble produces the final report: exceptions with the highest-signal
+// (uncaught, then widest thrower fan-out) first, totals, and stable ordering.
+func (a *efAccum) assemble(group string) ErrorFlowReport {
+	report := ErrorFlowReport{
+		Group:        group,
+		TotalThrows:  a.totalThrow,
+		TotalCatches: a.totalCatch,
+		Exceptions:   []ErrorFlowException{},
+	}
+
+	for _, typeName := range a.excOrder {
+		acc := a.excByKey[typeName]
+		sortSites(acc.throwers)
+		sortSites(acc.catchers)
+		acc.exc.Throwers = acc.throwers
+		acc.exc.Catchers = acc.catchers
+		acc.exc.ThrowCount = len(acc.throwers)
+		acc.exc.CatchCount = len(acc.catchers)
+
+		// Honest uncaught: thrown at least once, but no typed catcher anywhere
+		// in the indexed graph. NOT asserted as a proven leak.
+		if acc.exc.ThrowCount > 0 && acc.exc.CatchCount == 0 {
+			acc.exc.Uncaught = true
+			acc.exc.UncaughtReason = "no_catcher_in_graph"
+			report.TotalUncaught++
+		}
+
+		report.TotalExceptions++
+		report.Exceptions = append(report.Exceptions, *acc.exc)
+	}
+
+	sort.SliceStable(report.Exceptions, func(i, j int) bool {
+		ei, ej := report.Exceptions[i], report.Exceptions[j]
+		// Uncaught (thrown-but-unhandled) first — the actionable signal.
+		if ei.Uncaught != ej.Uncaught {
+			return ei.Uncaught
+		}
+		// Then widest thrower fan-out.
+		if ei.ThrowCount != ej.ThrowCount {
+			return ei.ThrowCount > ej.ThrowCount
+		}
+		if ei.CatchCount != ej.CatchCount {
+			return ei.CatchCount > ej.CatchCount
+		}
+		return ei.Type < ej.Type
+	})
+
+	return report
+}
+
+// sortSites orders thrower/catcher sites deterministically: named first, then by
+// name, repo, file/line, entity id.
+func sortSites(sites []ErrorFlowSite) {
+	sort.SliceStable(sites, func(i, j int) bool {
+		if sites[i].Name != sites[j].Name {
+			return sites[i].Name < sites[j].Name
+		}
+		if sites[i].Repo != sites[j].Repo {
+			return sites[i].Repo < sites[j].Repo
+		}
+		if sites[i].SourceFile != sites[j].SourceFile {
+			return sites[i].SourceFile < sites[j].SourceFile
+		}
+		if sites[i].StartLine != sites[j].StartLine {
+			return sites[i].StartLine < sites[j].StartLine
+		}
+		return sites[i].EntityID < sites[j].EntityID
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler: GET /api/errorflow/{group}
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleErrorFlow(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	acc := newEFAccum()
+
+	cachedGrp, _ := s.graphs.GetGroupCached(groupName)
+
+	throws := string(types.RelationshipKindThrows)
+	catches := string(types.RelationshipKindCatches)
+
+	for _, rp := range repoPaths {
+		var doc *graph.Document
+		var rdr *fbreader.Reader
+		if cachedGrp != nil {
+			if dr, ok := cachedGrp.Repos[rp.Slug]; ok && dr != nil {
+				doc = dr.Doc
+				rdr = dr.Reader
+			}
+		}
+		if doc == nil && rdr == nil {
+			stateDir := daemon.StateDirForRepo(rp.Path)
+			var loadErr error
+			doc, loadErr = graph.LoadGraphFromDir(stateDir)
+			if loadErr != nil {
+				continue
+			}
+		}
+
+		iterEntities := func(visit func(id, name, kind, sourceFile string, startLine int)) {
+			if rdr != nil {
+				rdr.IterateEntities(func(e *fb.Entity) bool {
+					visit(string(e.Id()), string(e.Name()), string(e.Kind()), string(e.SourceFile()), int(e.SourceLine()))
+					return true
+				})
+				return
+			}
+			for i := range doc.Entities {
+				ent := &doc.Entities[i]
+				visit(ent.ID, ent.Name, ent.Kind, ent.SourceFile, ent.StartLine)
+			}
+		}
+
+		iterRelationships := func(visit func(fromID, toID, kind string, props map[string]string)) {
+			if rdr != nil {
+				rdr.IterateRelationships(func(rel *fb.Relationship) bool {
+					props := make(map[string]string, rel.PropertiesLength())
+					var pe fb.PropertyEntry
+					for i := 0; i < rel.PropertiesLength(); i++ {
+						if rel.Properties(&pe, i) {
+							props[string(pe.Key())] = string(pe.Value())
+						}
+					}
+					visit(string(rel.FromId()), string(rel.ToId()), string(rel.Kind()), props)
+					return true
+				})
+				return
+			}
+			for i := range doc.Relationships {
+				rl := &doc.Relationships[i]
+				visit(rl.FromID, rl.ToID, rl.Kind, rl.Properties)
+			}
+		}
+
+		// Pass 1: index every entity so THROWS/CATCHES callable endpoints and
+		// the exception-type target nodes resolve to a real name / Kind / ref.
+		iterEntities(func(id, name, kind, sourceFile string, startLine int) {
+			acc.entByID[id] = efEntMeta{name: name, kind: kind, sourceFile: sourceFile, repoSlug: rp.Slug, startLine: startLine}
+		})
+
+		// Pass 2: fold THROWS / CATCHES edges → per-exception thrower/catcher map.
+		iterRelationships(func(fromID, toID, kind string, props map[string]string) {
+			switch kind {
+			case throws:
+				acc.addEdge(efEdge{fromID: fromID, toID: toID, catch: false, props: props})
+			case catches:
+				acc.addEdge(efEdge{fromID: fromID, toID: toID, catch: true, props: props})
+			}
+		})
+	}
+
+	report := acc.assemble(groupName)
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(report)
+}

--- a/internal/dashboard/handlers_errorflow_test.go
+++ b/internal/dashboard/handlers_errorflow_test.go
@@ -1,0 +1,132 @@
+package dashboard
+
+import "testing"
+
+// efProps builds a THROWS/CATCHES edge property map.
+func efProps(exceptionType, pattern string) map[string]string {
+	m := map[string]string{}
+	if exceptionType != "" {
+		m["exception_type"] = exceptionType
+	}
+	if pattern != "" {
+		m["pattern"] = pattern
+	}
+	return m
+}
+
+// TestErrorFlowFoldRollupAndUncaught verifies the core fold: per-exception
+// thrower/catcher rollup, per-site de-duplication, the honest uncaught flag
+// (thrown-but-no-catcher-in-graph), totals, and uncaught-first ordering.
+func TestErrorFlowFoldRollupAndUncaught(t *testing.T) {
+	a := newEFAccum()
+
+	// Exception nodes (synthetic "<exception>" SourceFile) + callables.
+	a.entByID["exc:ValidationError"] = efEntMeta{name: "exception:ValidationError", kind: "SCOPE.ExceptionType", sourceFile: "<exception>", repoSlug: "api"}
+	a.entByID["exc:NotFound"] = efEntMeta{name: "exception:NotFound", kind: "SCOPE.ExceptionType", sourceFile: "<exception>", repoSlug: "api"}
+	a.entByID["createUser"] = efEntMeta{name: "createUser", kind: "SCOPE.Function", sourceFile: "users.py", repoSlug: "api", startLine: 10}
+	a.entByID["updateUser"] = efEntMeta{name: "updateUser", kind: "SCOPE.Function", sourceFile: "users.py", repoSlug: "api", startLine: 30}
+	a.entByID["handler"] = efEntMeta{name: "handler", kind: "SCOPE.Function", sourceFile: "views.py", repoSlug: "api", startLine: 5}
+
+	// ValidationError: thrown by two functions, caught by one → CAUGHT.
+	a.addEdge(efEdge{fromID: "createUser", toID: "exc:ValidationError", catch: false, props: efProps("ValidationError", "raise")})
+	a.addEdge(efEdge{fromID: "updateUser", toID: "exc:ValidationError", catch: false, props: efProps("ValidationError", "raise")})
+	a.addEdge(efEdge{fromID: "createUser", toID: "exc:ValidationError", catch: false, props: efProps("ValidationError", "raise")}) // dup thrower
+	a.addEdge(efEdge{fromID: "handler", toID: "exc:ValidationError", catch: true, props: efProps("ValidationError", "except")})
+
+	// NotFound: thrown once, never caught → UNCAUGHT (no_catcher_in_graph).
+	a.addEdge(efEdge{fromID: "createUser", toID: "exc:NotFound", catch: false, props: efProps("NotFound", "raise")})
+
+	rep := a.assemble("g")
+
+	if rep.TotalThrows != 3 { // dup thrower not counted (2 ValidationError + 1 NotFound)
+		t.Fatalf("TotalThrows = %d, want 3", rep.TotalThrows)
+	}
+	if rep.TotalCatches != 1 {
+		t.Fatalf("TotalCatches = %d, want 1", rep.TotalCatches)
+	}
+	if rep.TotalExceptions != 2 {
+		t.Fatalf("TotalExceptions = %d, want 2", rep.TotalExceptions)
+	}
+	if rep.TotalUncaught != 1 {
+		t.Fatalf("TotalUncaught = %d, want 1", rep.TotalUncaught)
+	}
+
+	// Uncaught (NotFound) must sort first — the actionable signal.
+	first := rep.Exceptions[0]
+	if first.Type != "NotFound" || !first.Uncaught || first.UncaughtReason != "no_catcher_in_graph" {
+		t.Fatalf("expected NotFound uncaught first, got %+v", first)
+	}
+	if first.ThrowCount != 1 || first.CatchCount != 0 {
+		t.Fatalf("NotFound counts wrong: %+v", first)
+	}
+
+	// ValidationError caught, two throwers de-duped, resolved + sorted by name.
+	ve := rep.Exceptions[1]
+	if ve.Type != "ValidationError" || ve.Uncaught {
+		t.Fatalf("expected ValidationError caught, got %+v", ve)
+	}
+	if ve.ThrowCount != 2 || ve.CatchCount != 1 {
+		t.Fatalf("ValidationError counts wrong: %+v", ve)
+	}
+	if ve.Throwers[0].Name != "createUser" || ve.Throwers[1].Name != "updateUser" {
+		t.Fatalf("thrower order wrong: %+v", ve.Throwers)
+	}
+	// Resolved thrower carries repo-qualified ID + kind + ref + pattern.
+	if ve.Throwers[0].EntityID != "api/createUser" || ve.Throwers[0].Kind != "SCOPE.Function" ||
+		ve.Throwers[0].SourceFile != "users.py" || ve.Throwers[0].Pattern != "raise" {
+		t.Fatalf("thrower resolution wrong: %+v", ve.Throwers[0])
+	}
+	if ve.Catchers[0].Name != "handler" || ve.Catchers[0].SourceFile != "views.py" {
+		t.Fatalf("catcher resolution wrong: %+v", ve.Catchers[0])
+	}
+}
+
+// TestErrorFlowTypeKeyResolution verifies exception-type key resolution falls
+// back honestly: entity Name (prefix-stripped) → edge property → raw tail.
+func TestErrorFlowTypeKeyResolution(t *testing.T) {
+	a := newEFAccum()
+
+	// Resolved node: name wins (prefix stripped).
+	a.entByID["n1"] = efEntMeta{name: "exception:IOException"}
+	if got := a.exceptionTypeKey("n1", efProps("ignored", "")); got != "IOException" {
+		t.Fatalf("resolved key = %q, want IOException", got)
+	}
+	// Unresolved node but edge property present → property.
+	if got := a.exceptionTypeKey("scope:exceptiontype:TimeoutError", efProps("TimeoutError", "")); got != "TimeoutError" {
+		t.Fatalf("prop key = %q, want TimeoutError", got)
+	}
+	// Unresolved, no property → raw tail (prefix-stripped), never invented.
+	if got := a.exceptionTypeKey("scope:exceptiontype:exception:Boom", nil); got != "Boom" {
+		t.Fatalf("tail key = %q, want Boom", got)
+	}
+}
+
+// TestErrorFlowCatchOnlyNotUncaught verifies an exception that is only ever
+// CAUGHT (no THROWS in graph) is surfaced but never flagged uncaught.
+func TestErrorFlowCatchOnlyNotUncaught(t *testing.T) {
+	a := newEFAccum()
+	a.addEdge(efEdge{fromID: "mw", toID: "exc:Panic", catch: true, props: efProps("Panic", "recover")})
+
+	rep := a.assemble("g")
+	if rep.TotalExceptions != 1 || rep.TotalUncaught != 0 {
+		t.Fatalf("catch-only: exceptions=%d uncaught=%d, want 1/0", rep.TotalExceptions, rep.TotalUncaught)
+	}
+	if rep.Exceptions[0].Uncaught {
+		t.Fatalf("catch-only exception must not be uncaught: %+v", rep.Exceptions[0])
+	}
+	if rep.Exceptions[0].CatchCount != 1 || rep.Exceptions[0].ThrowCount != 0 {
+		t.Fatalf("catch-only counts wrong: %+v", rep.Exceptions[0])
+	}
+}
+
+// TestErrorFlowEmpty verifies a clean empty report when no THROWS/CATCHES edges
+// were folded (repo with no exception modelling).
+func TestErrorFlowEmpty(t *testing.T) {
+	rep := newEFAccum().assemble("g")
+	if rep.TotalExceptions != 0 || rep.TotalThrows != 0 || rep.TotalCatches != 0 || rep.TotalUncaught != 0 {
+		t.Fatalf("empty report not clean: %+v", rep)
+	}
+	if rep.Exceptions == nil {
+		t.Fatalf("Exceptions must be non-nil empty slice for stable JSON")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -564,6 +564,11 @@ func (s *Server) routes() http.Handler {
 	// Angular/… DI).
 	mux.HandleFunc("GET /api/di/{group}", s.handleDI)
 
+	// #4267 (epic #4249): Error-flow surface — exception types rolled up across
+	// the group, each listing its THROWS (throwers) and CATCHES (catchers) with
+	// an honest uncaught flag (thrown-but-no-typed-catcher-in-graph).
+	mux.HandleFunc("GET /api/errorflow/{group}", s.handleErrorFlow)
+
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)
 	mux.HandleFunc("GET /api/groups/{group}/god-nodes", s.handleGroupGodNodes)

--- a/webui-v2/src/components/chrome/screens.ts
+++ b/webui-v2/src/components/chrome/screens.ts
@@ -23,6 +23,7 @@ import {
   Server,
   Waypoints,
   Syringe,
+  Flame,
   Wrench,
   Inbox,
   Settings,
@@ -49,6 +50,7 @@ export const SCREENS: ScreenDef[] = [
   { to: "security", label: "Security", Icon: ShieldCheck, shortcut: "S" },
   { to: "taint", label: "Taint", Icon: Waypoints, shortcut: "X" },
   { to: "di", label: "Dependency Injection", Icon: Syringe, shortcut: "J" },
+  { to: "errorflow", label: "Error flow", Icon: Flame, shortcut: "E" },
   { to: "quality", label: "Quality", Icon: GaugeCircle, shortcut: "Q" },
   { to: "operations", label: "Operations", Icon: Wrench, shortcut: "O" },
 ];

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2274,3 +2274,51 @@ export interface DIReport {
   frameworks: string[];
   groups: DIFrameworkGroup[];
 }
+
+// ---------------------------------------------------------------------------
+// Error-flow surface (#4267, epic #4249). GET /api/errorflow/{group} →
+// handlers_errorflow.go, which rolls up SCOPE.ExceptionType nodes across the
+// group: each exception type lists the callables that THROW it (throwers) and
+// the handlers that CATCH it (catchers), with an honest uncaught flag.
+// ---------------------------------------------------------------------------
+
+/** One callable that throws or catches an exception type (THROWS/CATCHES FromID). */
+export interface ErrorFlowSite {
+  entity_id: string;
+  name: string;
+  /** Callable entity Kind when resolved (SCOPE.Function / SCOPE.Method / …). */
+  kind?: string;
+  repo?: string;
+  source_file?: string;
+  start_line?: number;
+  /** Detector label the edge recorded (throw_new / raise / instanceof / …). */
+  pattern?: string;
+}
+
+/** One exception type with everything that throws and catches it in the group. */
+export interface ErrorFlowException {
+  /** Bare exception type name, no "exception:" prefix (e.g. "ValidationError"). */
+  type: string;
+  throwers: ErrorFlowSite[];
+  catchers: ErrorFlowSite[];
+  /**
+   * True when thrown ≥1× but no CATCHES edge anywhere in the indexed group.
+   * Honestly this means "no typed catcher in graph" (see uncaught_reason) — it
+   * may be a genuine leak OR caught by an untyped / out-of-scope handler.
+   */
+  uncaught: boolean;
+  /** Qualifies `uncaught`: "no_catcher_in_graph" (the only value emitted today). */
+  uncaught_reason?: string;
+  throw_count: number;
+  catch_count: number;
+}
+
+/** GET /api/errorflow/{group} — exception types rolled up with throw/catch sites. */
+export interface ErrorFlowReport {
+  group: string;
+  total_exceptions: number;
+  total_uncaught: number;
+  total_throws: number;
+  total_catches: number;
+  exceptions: ErrorFlowException[];
+}

--- a/webui-v2/src/hooks/use-errorflow.ts
+++ b/webui-v2/src/hooks/use-errorflow.ts
@@ -1,0 +1,29 @@
+/* ============================================================
+   hooks/use-errorflow.ts — Error-flow data hook (#4267).
+
+   Wraps api.getErrorFlow in TanStack Query. Backed by the route
+   GET /api/errorflow/{group} (handlers_errorflow.go → handleErrorFlow),
+   which rolls up SCOPE.ExceptionType nodes across the group: each
+   exception type lists the callables that THROW it (throwers) and
+   the handlers that CATCH it (catchers), with file refs and an
+   honest uncaught flag (thrown-but-no-typed-catcher-in-graph).
+
+   Pure static graph read. Honest-empty when the group has no
+   THROWS/CATCHES edges (no exception modelling indexed).
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export const errorFlowQueryKey = (groupId: string) =>
+  ["errorflow", groupId] as const;
+
+/** Error-flow report for the group. */
+export function useErrorFlow(groupId: string) {
+  return useQuery({
+    queryKey: errorFlowQueryKey(groupId),
+    queryFn: () => api.getErrorFlow(groupId),
+    enabled: !!groupId,
+    staleTime: 30_000,
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -71,6 +71,7 @@ import type {
   IaCReport,
   DataflowReport,
   DIReport,
+  ErrorFlowReport,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -839,6 +840,18 @@ export const api = {
   getDI: (groupId: string) =>
     request<DIReport>(
       `/di/${encodeURIComponent(groupId)}`,
+    ),
+
+  // --- Error-flow (#4267) ---
+  // Raw JSON (no v2 envelope) → `request`. Handler: handlers_errorflow.go
+  // handleErrorFlow, which rolls up SCOPE.ExceptionType nodes across the group
+  // with their THROWS (throwers) and CATCHES (catchers) and an honest uncaught
+  // flag (thrown-but-no-typed-catcher-in-graph).
+
+  /** GET /api/errorflow/{group} — exception types → throwers + catchers, uncaught flag. */
+  getErrorFlow: (groupId: string) =>
+    request<ErrorFlowReport>(
+      `/errorflow/${encodeURIComponent(groupId)}`,
     ),
 };
 

--- a/webui-v2/src/routes/errorflow.tsx
+++ b/webui-v2/src/routes/errorflow.tsx
@@ -1,0 +1,470 @@
+/* ============================================================
+   Error-flow view (#4267, epic #4249).
+
+   Route: /g/:groupId/errorflow
+
+   The graph models error flow via two edge kinds that both
+   originate at a CALLABLE and point at a synthetic, file-agnostic
+   SCOPE.ExceptionType node (Name "exception:<Type>"):
+
+     THROWS  : raising function/method/endpoint → exception type
+     CATCHES : handling function/method         → exception type
+
+   Identical type names converge — across files AND languages — to
+   ONE exception node, so a NotFound raised in services.py and
+   caught in views.py share a node. The per-endpoint Paths posture
+   (#4263) already shows a single endpoint's throws/catches; THIS
+   screen is the GROUP-LEVEL ROLLUP, inverted around the exception
+   type: for each exception, who can raise it and who handles it —
+   so you can spot a type thrown in five places and caught nowhere.
+
+   Data: GET /api/errorflow/{group} (handlers_errorflow.go →
+   handleErrorFlow), raw-JSON ErrorFlowReport.
+
+   HONESTY on "uncaught": only TYPED throws/catches are recorded
+   (bare `except:` / untyped `catch(e){}` emit no edge), so CATCHES
+   edges are genuinely sparse. An exception thrown but with no
+   CATCHES edge anywhere in the indexed graph is flagged `uncaught`
+   with reason "no_catcher_in_graph" — which may be a genuine leak
+   OR a throw caught by an untyped / out-of-scope / cross-repo
+   handler the indexer did not model. We render that as a cautious
+   warning ("no catcher in graph"), NEVER as a proven-leak claim.
+   A repo with no exception modelling shows a clean empty state.
+   ============================================================ */
+
+import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Flame,
+  ShieldAlert,
+  ShieldCheck,
+  ArrowUpFromLine,
+  ArrowDownToLine,
+  ChevronRight,
+  ListFilter,
+  AlertTriangle,
+  Bug,
+} from "lucide-react";
+
+import { Badge, Card, CardBody, Pill } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RefLine } from "@/components/RefLine";
+import { RepoChip } from "@/lib/repo-color";
+import { cn } from "@/lib/utils";
+import { useErrorFlow } from "@/hooks/use-errorflow";
+import type {
+  ErrorFlowException,
+  ErrorFlowReport,
+  ErrorFlowSite,
+} from "@/data/types";
+
+type Tone = "neutral" | "accent" | "success" | "warning" | "danger" | "info";
+
+// ---------------------------------------------------------------------------
+// § Styling helpers
+// ---------------------------------------------------------------------------
+
+/** A short, readable label for a graph entity Kind (SCOPE.Function → Function). */
+function kindLabel(kind?: string): string {
+  if (!kind) return "";
+  return kind.includes(".") ? kind.split(".").pop()! : kind;
+}
+
+/** Entity-Kind → tone so endpoints vs functions vs methods read distinctly. */
+function kindTone(kind?: string): Tone {
+  switch (kindLabel(kind).toLowerCase()) {
+    case "endpoint":
+    case "controller":
+    case "resolver":
+      return "info";
+    case "function":
+    case "method":
+      return "accent";
+    default:
+      return "neutral";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// § Shared shells
+// ---------------------------------------------------------------------------
+
+function SkeletonRows({ n = 6 }: { n?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: n }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 h-16 px-4 rounded-lg border border-border"
+        >
+          <Skeleton w="w-1/4" />
+          <Skeleton w="w-6" h="h-2" />
+          <Skeleton w="w-1/3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <Bug size={32} className="text-text-4" />
+      <p className="text-md font-medium text-text">{title}</p>
+      <p className="text-sm text-text-3 max-w-md">{hint}</p>
+    </div>
+  );
+}
+
+function ErrorState() {
+  return (
+    <div className="flex flex-col items-center py-16 text-center gap-3">
+      <AlertTriangle size={32} className="text-danger" />
+      <p className="text-md font-medium text-text">Could not load error-flow map</p>
+      <p className="text-sm text-text-3 max-w-sm">
+        The daemon returned an error. Confirm the group is indexed and the daemon
+        is reachable, then retry.
+      </p>
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: Tone;
+}) {
+  return (
+    <Card className={cn("flex-1 min-w-[120px]")}>
+      <CardBody className="py-3">
+        <p
+          className={cn(
+            "text-2xl font-semibold tabular-nums",
+            tone === "danger" && value > 0 ? "text-danger" : "text-text",
+          )}
+        >
+          {value}
+        </p>
+        <p className="text-xs text-text-4 mt-0.5">{label}</p>
+      </CardBody>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Callable label + ref (thrower / catcher site)
+// ---------------------------------------------------------------------------
+
+function SiteName({ site }: { site: ErrorFlowSite }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <span
+        className="font-mono text-sm text-text truncate"
+        title={site.entity_id}
+      >
+        {site.name}
+      </span>
+      {site.kind && (
+        <Badge tone={kindTone(site.kind)} className="shrink-0">
+          {kindLabel(site.kind)}
+        </Badge>
+      )}
+    </span>
+  );
+}
+
+function SiteRow({
+  site,
+  groupId,
+  direction,
+}: {
+  site: ErrorFlowSite;
+  groupId: string;
+  direction: "throw" | "catch";
+}) {
+  const Icon = direction === "throw" ? ArrowUpFromLine : ArrowDownToLine;
+  const iconClass = direction === "throw" ? "text-danger" : "text-success";
+  return (
+    <div className="flex flex-col gap-0.5 pl-6 py-1">
+      <div className="flex items-center gap-2 min-w-0 flex-wrap">
+        <Icon size={12} className={cn("shrink-0", iconClass)} />
+        <SiteName site={site} />
+        {site.pattern && (
+          <span
+            className="font-mono text-[10px] text-text-4 shrink-0"
+            title={`detector pattern: ${site.pattern}`}
+          >
+            {site.pattern}
+          </span>
+        )}
+        {site.repo && (
+          <RepoChip slug={site.repo} groupId={groupId} maxLength={14} />
+        )}
+      </div>
+      {site.repo && site.source_file && (
+        <RefLine
+          repo={site.repo}
+          file={site.source_file}
+          line={site.start_line ?? 0}
+          name={site.name}
+          className="text-[11px]"
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One collapsible site list (throwers or catchers)
+// ---------------------------------------------------------------------------
+
+const COLLAPSE_AT = 5;
+
+function SiteList({
+  label,
+  sites,
+  groupId,
+  direction,
+}: {
+  label: string;
+  sites: ErrorFlowSite[];
+  groupId: string;
+  direction: "throw" | "catch";
+}) {
+  const [open, setOpen] = useState(false);
+  const many = sites.length > COLLAPSE_AT;
+  const shown = many && !open ? sites.slice(0, COLLAPSE_AT) : sites;
+
+  return (
+    <div className="space-y-0.5">
+      <p className="text-[11px] uppercase tracking-wide text-text-4 pl-1">
+        {label} ({sites.length})
+      </p>
+      <div className="border-l border-border/60 ml-1">
+        {shown.map((s) => (
+          <SiteRow
+            key={`${direction}:${s.entity_id}`}
+            site={s}
+            groupId={groupId}
+            direction={direction}
+          />
+        ))}
+      </div>
+      {many && (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="inline-flex items-center gap-1 text-[11px] text-text-3 hover:text-text pl-6"
+        >
+          <ChevronRight
+            size={12}
+            className={cn("transition-transform", open && "rotate-90")}
+          />
+          {open
+            ? "Show fewer"
+            : `Show ${sites.length - COLLAPSE_AT} more`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § One exception card (type + its throwers + catchers)
+// ---------------------------------------------------------------------------
+
+function ExceptionCard({
+  exc,
+  groupId,
+}: {
+  exc: ErrorFlowException;
+  groupId: string;
+}) {
+  return (
+    <Card
+      className={cn(
+        exc.uncaught && "border-warning/60",
+      )}
+    >
+      <CardBody className="py-2.5 space-y-2">
+        {/* Exception header */}
+        <div className="flex items-center gap-2 min-w-0 flex-wrap">
+          <Flame size={14} className="text-danger shrink-0" />
+          <span
+            className="font-mono text-sm font-medium text-text truncate"
+            title={exc.type}
+          >
+            {exc.type}
+          </span>
+          {exc.uncaught ? (
+            <Badge
+              tone="warning"
+              className="shrink-0 inline-flex items-center gap-1"
+              title="Thrown but no typed catcher was found in the indexed graph. This may be a genuine uncaught throw OR caught by an untyped / out-of-scope handler the indexer did not model."
+            >
+              <ShieldAlert size={11} />
+              no catcher in graph
+            </Badge>
+          ) : (
+            exc.catch_count > 0 && (
+              <Badge
+                tone="success"
+                className="shrink-0 inline-flex items-center gap-1"
+                title={`Caught by ${exc.catch_count} handler(s) in the graph.`}
+              >
+                <ShieldCheck size={11} />
+                caught
+              </Badge>
+            )
+          )}
+          <span className="ml-auto text-[11px] text-text-4 tabular-nums shrink-0">
+            {exc.throw_count} throw{exc.throw_count === 1 ? "" : "s"} ·{" "}
+            {exc.catch_count} catch{exc.catch_count === 1 ? "" : "es"}
+          </span>
+        </div>
+
+        {exc.throwers.length > 0 && (
+          <SiteList
+            label="Thrown by"
+            sites={exc.throwers}
+            groupId={groupId}
+            direction="throw"
+          />
+        )}
+        {exc.catchers.length > 0 && (
+          <SiteList
+            label="Caught by"
+            sites={exc.catchers}
+            groupId={groupId}
+            direction="catch"
+          />
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// § Screen body
+// ---------------------------------------------------------------------------
+
+type FilterMode = "all" | "uncaught" | "caught";
+
+function ErrorFlowBody({
+  data,
+  groupId,
+}: {
+  data: ErrorFlowReport;
+  groupId: string;
+}) {
+  const [filter, setFilter] = useState<FilterMode>("all");
+
+  const filtered = useMemo(() => {
+    switch (filter) {
+      case "uncaught":
+        return data.exceptions.filter((e) => e.uncaught);
+      case "caught":
+        return data.exceptions.filter((e) => !e.uncaught);
+      default:
+        return data.exceptions;
+    }
+  }, [data.exceptions, filter]);
+
+  const caughtCount = data.total_exceptions - data.total_uncaught;
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
+      {/* Summary */}
+      <div className="flex flex-wrap gap-3">
+        <SummaryStat label="Exception types" value={data.total_exceptions} />
+        <SummaryStat
+          label="No catcher in graph"
+          value={data.total_uncaught}
+          tone="danger"
+        />
+        <SummaryStat label="Throws" value={data.total_throws} />
+        <SummaryStat label="Catches" value={data.total_catches} />
+      </div>
+
+      {/* Filter */}
+      {data.total_uncaught > 0 && caughtCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <ListFilter size={13} className="text-text-4" />
+          <Pill active={filter === "all"} onClick={() => setFilter("all")}>
+            All ({data.total_exceptions})
+          </Pill>
+          <Pill
+            active={filter === "uncaught"}
+            onClick={() => setFilter("uncaught")}
+          >
+            No catcher ({data.total_uncaught})
+          </Pill>
+          <Pill active={filter === "caught"} onClick={() => setFilter("caught")}>
+            Caught ({caughtCount})
+          </Pill>
+        </div>
+      )}
+
+      {/* Exceptions */}
+      <div className="space-y-2">
+        {filtered.map((exc) => (
+          <ExceptionCard key={exc.type} exc={exc} groupId={groupId} />
+        ))}
+      </div>
+
+      <p className="text-[10px] text-text-4">
+        Each card is a genuine SCOPE.ExceptionType node: identical type names
+        converge — across files and languages — to one node, so its throwers
+        (THROWS) and catchers (CATCHES) form the error contract. Only TYPED
+        throws/catches are recorded — bare <code>except:</code> / untyped{" "}
+        <code>catch(e)</code> emit no edge. A “no catcher in graph” badge means
+        no typed catcher was indexed: it may be genuinely uncaught OR caught by
+        an untyped / out-of-scope / cross-repo handler — it is a cautious
+        warning, not a proven leak.
+      </p>
+    </div>
+  );
+}
+
+export default function ErrorFlowScreen() {
+  const { groupId = "" } = useParams<{ groupId: string }>();
+  const { data, isLoading, isError } = useErrorFlow(groupId);
+
+  const hasAny = (data?.total_exceptions ?? 0) > 0;
+
+  return (
+    <div className="flex flex-col h-full bg-bg">
+      {isLoading ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <SkeletonRows />
+        </div>
+      ) : isError ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <ErrorState />
+        </div>
+      ) : !hasAny ? (
+        <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4">
+          <EmptyState
+            title="No error-flow modelling found"
+            hint="No THROWS / CATCHES edges were extracted for this group. The error-flow map appears once an indexed repo has TYPED throws/catches — only typed raises (raise NotFound / throw new ValidationError) and typed catches are recorded; bare `except:` and untyped `catch(e)` emit no edge by design."
+          />
+        </div>
+      ) : (
+        <>
+          <div className="border-b border-border shrink-0 px-4 py-2.5 flex items-center gap-2">
+            <Flame size={15} className="text-text-3" />
+            <h2 className="text-sm font-medium text-text">Error flow</h2>
+            <span className="text-[11px] text-text-4">
+              exception types → who throws &amp; who catches them
+            </span>
+          </div>
+          <ErrorFlowBody data={data!} groupId={groupId} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/webui-v2/src/routes/router.tsx
+++ b/webui-v2/src/routes/router.tsx
@@ -26,6 +26,7 @@ import DocsScreen from "./docs";
 import SecurityScreen from "./security";
 import DataflowScreen from "./dataflow";
 import DIScreen from "./di";
+import ErrorFlowScreen from "./errorflow";
 import QualityScreen from "./quality";
 import SettingsScreen from "./settings";
 import PendingScreen from "./pending";
@@ -63,6 +64,7 @@ export const router = createBrowserRouter([
           { path: "security", element: <SecurityScreen />, handle: { surfaceLabel: "Security" } },
           { path: "taint", element: <DataflowScreen />, handle: { surfaceLabel: "Taint" } },
           { path: "di", element: <DIScreen />, handle: { surfaceLabel: "Dependency Injection" } },
+          { path: "errorflow", element: <ErrorFlowScreen />, handle: { surfaceLabel: "Error flow" } },
           { path: "quality", element: <QualityScreen />, handle: { surfaceLabel: "Quality" } },
           { path: "settings", element: <SettingsScreen />, handle: { surfaceLabel: "Group settings" } },
           { path: "pending", element: <PendingScreen />, handle: { surfaceLabel: "Pending" } },


### PR DESCRIPTION
Group-level **Error-flow** view (epic #4249): a rollup of `SCOPE.ExceptionType` nodes — for each exception type, which callables **THROW** it and which handlers **CATCH** it, surfacing throws with no catcher in the indexed graph. The per-endpoint Paths posture (#4263) already shows a single endpoint's throws/catches; this is the group-wide rollup, inverted around the exception type.

## How error-flow is modelled
- `internal/extractor/exception_flow.go`: one synthetic, file-agnostic `SCOPE.ExceptionType` node per distinct (normalized, unqualified) type name (Name `exception:<Type>`), so identical names converge — across files AND languages — to ONE node.
- Edge direction is uniform across every language emitter: the edge **originates at the callable** and points at the exception node — `THROWS`: raising fn/method/endpoint → ExceptionType; `CATCHES`: handler → ExceptionType. Props carry `exception_type` and (when detected) `pattern`.
- Precision-first: only TYPED throws/catches emit edges (bare `except:` / untyped `catch(e)` emit none), so CATCHES edges are genuinely sparse.

## Backend
- `GET /api/errorflow/{group}` → `internal/dashboard/handlers_errorflow.go::handleErrorFlow`. Walks the cached group graph (mmap reader) with per-repo fallback, resolves THROWS/CATCHES edges to named + file-referenced thrower/catcher sites, dedups per site, rolls up per exception type with totals and uncaught-first ordering. Registered in `server.go`; raw-JSON envelope. Pure-fold unit tests in `handlers_errorflow_test.go`.

## Honest uncaught labelling
An exception thrown ≥1× with **no** typed CATCHES edge anywhere in the graph is flagged `uncaught=true` with `uncaught_reason="no_catcher_in_graph"`. This is rendered as a cautious **"no catcher in graph"** warning — it may be a genuine uncaught throw OR caught by an untyped / out-of-scope / cross-repo handler the indexer did not model. It is never asserted as a proven leak. Catch-only exceptions (no THROWS) are surfaced but never flagged.

## Frontend
- `/g/:groupId/errorflow` (`routes/errorflow.tsx`): exception types → throwers + catchers, "no catcher in graph" warning badge, all/uncaught/caught filter, collapsible site lists, loading/empty/error states. Reuses Badge/Card/Pill/Skeleton + RefLine/RepoChip. Wired via `screens.ts` (Flame icon, shortcut E), `router.tsx`, `api.getErrorFlow`, `use-errorflow` hook, and `ErrorFlow*` types.

## Gates
- `go build ./...` ✓ · `go test ./internal/dashboard/... ./internal/mcp/...` ✓ · gofmt/vet clean ✓
- `npm run lint` (tsc --noEmit) clean ✓ · `npm run build` (vite) ✓ built in 6.57s

**DEPLOY-DEFERRED.**

Closes #4267

🤖 Generated with [Claude Code](https://claude.com/claude-code)