### PR TITLE
mcp: harden get_source entity resolution to cut error rate (#4272)

### DIFF
--- a/internal/mcp/get_source_resolution_4272_test.go
+++ b/internal/mcp/get_source_resolution_4272_test.go
@@ -1,0 +1,177 @@
+package mcp
+
+// get_source_resolution_4272_test.go — regression coverage for #4272.
+//
+// THE BUG (root cause of the ~8% archigraph_get_source error rate, the busiest
+// MCP tool): handleGetNodeSource resolved a "<repo>::<localid>" prefixed
+// entity_id ONLY via r.LabelIndex.ByID[localid]. When the prefixed arg pointed
+// at an entity that resolves by qualified_name or label (not by its raw id) — or
+// when the "<repo>::" prefix was present but the subsequent fallback ran
+// LookupAll on the STILL-PREFIXED string — resolution fell through to
+// "node not found", even though the entity was in the index all along. This
+// mirrors the #4243 effective_contract prefix gap.
+//
+// These tests assert handleGetNodeSource resolves an entity by:
+//
+//	(a) bare local id
+//	(b) "<repo>::"-prefixed id
+//	(c) qualified_name (bare AND "<repo>::"-prefixed — the prefixed-by-qname form
+//	    is the case that ERRORED pre-fix)
+//	(d) label
+//
+// and (e) returns a HELPFUL not-found for a genuinely-missing arg: the error
+// names the attempted forms and offers a did-you-mean nearest match, so the
+// caller can self-correct instead of re-erroring.
+//
+// Non-vacuous proof: cases (c-prefixed) and (e) FAIL on the pre-fix handler —
+// (c-prefixed) returned "node not found", and (e) returned a bare
+// "node not found: <arg>" with no attempted-forms / suggestion.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// writeSrcFile writes content to a real file under dir and returns its absolute
+// path. get_source reads e.SourceFile directly when it is absolute (the test
+// LoadedRepo has no Path), so entities point at these temp files.
+func writeSrcFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+	return p
+}
+
+// getSourceResolutionDoc builds a single-repo graph whose one real entity has a
+// distinct id, qualified_name, and label, each pointing at a real source file so
+// the read path succeeds for whichever form resolves.
+func getSourceResolutionDoc(t *testing.T) *graph.Document {
+	t.Helper()
+	dir := t.TempDir()
+	src := writeSrcFile(t, dir, "service.py", strings.Join([]string{
+		"class OrderService:",
+		"    def place_order(self, cart):",
+		"        # MARKER_PLACE_ORDER_BODY",
+		"        return self.repo.save(cart)",
+		"",
+	}, "\n"))
+	return &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID:            "ent_place_order_42",
+				Name:          "place_order",
+				QualifiedName: "core.services.order_service.OrderService.place_order",
+				Kind:          "SCOPE.Operation", Subtype: "method",
+				SourceFile: src, StartLine: 2, EndLine: 4, Language: "python",
+			},
+			// A second, similarly-named entity so the did-you-mean suggestion has a
+			// near neighbour to surface for a typo'd arg.
+			{
+				ID:            "ent_place_order_sync_9",
+				Name:          "place_order_sync",
+				QualifiedName: "core.services.order_service.OrderService.place_order_sync",
+				Kind:          "SCOPE.Operation", Subtype: "method",
+				SourceFile: src, StartLine: 2, EndLine: 4, Language: "python",
+			},
+		},
+	}
+}
+
+func getSourceOK(t *testing.T, srv *Server, arg string) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": arg}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source(%q) error: %v", arg, err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source(%q) tool error: %s", arg, extractResultText(t, res))
+	}
+	return extractResultText(t, res)
+}
+
+func TestGetSource_ResolvesByBareLocalID_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	text := getSourceOK(t, srv, "ent_place_order_42")
+	if !strings.Contains(text, "MARKER_PLACE_ORDER_BODY") {
+		t.Errorf("(a) bare id: body not returned, got:\n%s", text)
+	}
+}
+
+func TestGetSource_ResolvesByPrefixedID_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	text := getSourceOK(t, srv, "upvate-core::ent_place_order_42")
+	if !strings.Contains(text, "MARKER_PLACE_ORDER_BODY") {
+		t.Errorf("(b) prefixed id: body not returned, got:\n%s", text)
+	}
+}
+
+func TestGetSource_ResolvesByQualifiedName_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	qn := "core.services.order_service.OrderService.place_order"
+	text := getSourceOK(t, srv, qn)
+	if !strings.Contains(text, "MARKER_PLACE_ORDER_BODY") {
+		t.Errorf("(c) qualified_name: body not returned, got:\n%s", text)
+	}
+}
+
+// TestGetSource_ResolvesByPrefixedQualifiedName_4272 is the load-bearing
+// regression: a "<repo>::<qualified_name>" arg. Pre-fix this fell through to
+// "node not found" because the prefixed branch only consulted ByID[local] and
+// the cross-repo fallback ran LookupAll on the still-prefixed string.
+func TestGetSource_ResolvesByPrefixedQualifiedName_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	arg := "upvate-core::core.services.order_service.OrderService.place_order"
+	text := getSourceOK(t, srv, arg)
+	if !strings.Contains(text, "MARKER_PLACE_ORDER_BODY") {
+		t.Errorf("(c-prefixed) prefixed qualified_name: body not returned, got:\n%s", text)
+	}
+}
+
+func TestGetSource_ResolvesByLabel_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	text := getSourceOK(t, srv, "place_order")
+	if !strings.Contains(text, "MARKER_PLACE_ORDER_BODY") {
+		t.Errorf("(d) label: body not returned, got:\n%s", text)
+	}
+}
+
+// TestGetSource_HelpfulNotFound_4272 asserts the clearer-error change: a
+// genuinely-missing arg yields an error that (1) names the attempted resolution
+// forms and (2) offers a did-you-mean nearest match — so the caller can
+// self-correct. Pre-fix the error was a bare "node not found: <arg>".
+func TestGetSource_HelpfulNotFound_4272(t *testing.T) {
+	srv := newTestServer(t, getSourceResolutionDoc(t))
+	req := mcpapi.CallToolRequest{}
+	// Typo of a real label: close enough that did-you-mean should surface it.
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "place_ordr"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error for missing arg, got success:\n%s", extractResultText(t, res))
+	}
+	msg := extractResultText(t, res)
+	if !strings.Contains(msg, "place_ordr") {
+		t.Errorf("not-found error should echo the arg, got: %s", msg)
+	}
+	// (1) attempted forms named.
+	if !strings.Contains(strings.ToLower(msg), "tried") {
+		t.Errorf("not-found error should list attempted forms (id/qualified_name/label), got: %s", msg)
+	}
+	// (2) did-you-mean nearest match — the close label should be suggested.
+	if !strings.Contains(strings.ToLower(msg), "did you mean") || !strings.Contains(msg, "place_order") {
+		t.Errorf("not-found error should offer a did-you-mean nearest match (place_order), got: %s", msg)
+	}
+}

--- a/internal/mcp/get_source_resolve.go
+++ b/internal/mcp/get_source_resolve.go
@@ -1,0 +1,308 @@
+package mcp
+
+// get_source_resolve.go — entity resolution for archigraph_get_source (#4272).
+//
+// get_source is the busiest MCP tool; its ~8% live error rate was dominated by
+// resolution failures on WELL-FORMED args, not by genuinely-missing entities.
+// The legacy inline resolver in handleGetNodeSource:
+//
+//   - handled a "<repo>::<localid>" prefix only via r.LabelIndex.ByID[localid];
+//     a prefixed arg that resolved by qualified_name or label (not by raw id)
+//     fell through, and the cross-repo fallback then ran LookupAll on the
+//     STILL-PREFIXED string — so it matched nothing and returned a bare
+//     "node not found" (the same prefix gap fixed for effective_contract in
+//     #4243); and
+//   - on a true miss returned only "node not found: <arg>" with no hint, so the
+//     caller could not self-correct and often re-errored.
+//
+// resolveSourceEntity hardens this: it tries id → qualified_name → label →
+// qualified-name suffix across the group for BOTH the raw arg and its
+// prefix-stripped local form, and on a genuine miss returns a clearer error
+// (attempted forms + nearest did-you-mean) WITHOUT masking real not-founds.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// sourceResolution is the outcome of resolveSourceEntity. Exactly one of
+// {entity, ambiguous, notFound} is populated.
+type sourceResolution struct {
+	entity *graph.Entity
+	repo   *LoadedRepo
+
+	// ambiguous holds >1 distinct matches for a label that resolved in multiple
+	// places; the handler renders the clarifier list.
+	ambiguous []sourceCandidate
+
+	// notFound carries a clearer error message (attempted forms + did-you-mean)
+	// for a genuine miss.
+	notFound string
+}
+
+type sourceCandidate struct {
+	ent  *graph.Entity
+	repo *LoadedRepo
+}
+
+// resolveSourceEntity resolves nodeID to a single entity across lg, accepting an
+// id, a qualified_name, or a label — each optionally carrying a "<repo>::"
+// prefix. Resolution order, evaluated for both the raw arg and its
+// prefix-stripped local form:
+//
+//  1. exact entity id (prefixed branch first: if the "<repo>::" prefix names a
+//     loaded repo, prefer that repo's id/qname/label match);
+//  2. exact qualified_name / label across all repos (LookupAll);
+//  3. qualified_name SUFFIX match (a dotted arg matching the tail of an
+//     entity's qualified_name) — lets a caller pass a partially-qualified name.
+//
+// A label that resolves to >1 distinct entity yields an ambiguous result. A true
+// miss yields notFound with attempted forms and a did-you-mean nearest match.
+func resolveSourceEntity(lg *LoadedGroup, nodeID string) sourceResolution {
+	rp, local := splitPrefixed(nodeID)
+
+	// Candidate lookup keys, most-specific first: the prefix-stripped local form
+	// (the form the LabelIndex is keyed by, per ADR-0009) then the raw arg.
+	// De-duplicated; order preserved.
+	keys := make([]string, 0, 2)
+	seen := map[string]bool{}
+	for _, k := range []string{local, nodeID} {
+		if k != "" && !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+
+	// Phase 1 — if the prefix names a loaded repo, prefer a match within it for
+	// any candidate key (id, then qname/label via LookupAll). This keeps a
+	// fully-prefixed arg pinned to its own repo even when another repo carries a
+	// same-named entity.
+	if rp != "" {
+		if r, ok := lg.Repos[rp]; ok && r.Doc != nil && r.LabelIndex != nil {
+			if e := r.LabelIndex.ByID[local]; e != nil {
+				return sourceResolution{entity: e, repo: r}
+			}
+			for _, key := range keys {
+				if hits := r.LabelIndex.LookupAll(key); len(hits) == 1 {
+					return sourceResolution{entity: hits[0], repo: r}
+				} else if len(hits) > 1 {
+					return ambiguousFrom(hits, r)
+				}
+			}
+		}
+	}
+
+	// Phase 2 — exact id/qname/label across the whole group, for every key.
+	var cands []sourceCandidate
+	for _, r := range lg.Repos {
+		if r.Doc == nil || r.LabelIndex == nil {
+			continue
+		}
+		for _, key := range keys {
+			for _, hit := range r.LabelIndex.LookupAll(key) {
+				cands = appendUniqueCandidate(cands, sourceCandidate{ent: hit, repo: r})
+			}
+		}
+	}
+	if len(cands) == 1 {
+		return sourceResolution{entity: cands[0].ent, repo: cands[0].repo}
+	}
+	if len(cands) > 1 {
+		return sourceResolution{ambiguous: cands}
+	}
+
+	// Phase 3 — qualified_name suffix match. A dotted arg (with or without the
+	// "<repo>::" prefix) that is a trailing segment of exactly one entity's
+	// qualified_name resolves to it; >1 is ambiguous.
+	if sc := suffixMatch(lg, keys); len(sc) == 1 {
+		return sourceResolution{entity: sc[0].ent, repo: sc[0].repo}
+	} else if len(sc) > 1 {
+		return sourceResolution{ambiguous: sc}
+	}
+
+	// Genuine miss — build a clearer error so the caller can self-correct.
+	return sourceResolution{notFound: notFoundMessage(lg, nodeID, keys)}
+}
+
+func ambiguousFrom(hits []*graph.Entity, r *LoadedRepo) sourceResolution {
+	cands := make([]sourceCandidate, 0, len(hits))
+	for _, h := range hits {
+		cands = append(cands, sourceCandidate{ent: h, repo: r})
+	}
+	if len(cands) == 1 {
+		return sourceResolution{entity: cands[0].ent, repo: cands[0].repo}
+	}
+	return sourceResolution{ambiguous: cands}
+}
+
+func appendUniqueCandidate(cands []sourceCandidate, c sourceCandidate) []sourceCandidate {
+	for _, x := range cands {
+		if x.ent == c.ent {
+			return cands
+		}
+	}
+	return append(cands, c)
+}
+
+// suffixMatch finds entities whose qualified_name ends with ".<key>" (or equals
+// key) for any candidate key. Only dotted keys are considered to avoid matching
+// every short label.
+func suffixMatch(lg *LoadedGroup, keys []string) []sourceCandidate {
+	var out []sourceCandidate
+	for _, key := range keys {
+		if !strings.Contains(key, ".") {
+			continue
+		}
+		needle := strings.ToLower(key)
+		for _, r := range lg.Repos {
+			if r.Doc == nil {
+				continue
+			}
+			for i := range r.Doc.Entities {
+				e := &r.Doc.Entities[i]
+				qn := strings.ToLower(e.QualifiedName)
+				if qn == "" {
+					continue
+				}
+				if qn == needle || strings.HasSuffix(qn, "."+needle) {
+					out = appendUniqueCandidate(out, sourceCandidate{ent: e, repo: r})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// notFoundMessage builds the clearer not-found error: it names the attempted
+// resolution forms and, when a near match exists, offers a did-you-mean.
+func notFoundMessage(lg *LoadedGroup, nodeID string, keys []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "node not found: %s", nodeID)
+	fmt.Fprintf(&b, " (tried id, qualified_name, label, and qualified-name suffix for: %s)",
+		strings.Join(keys, ", "))
+	if sug := didYouMean(lg, keys); sug != "" {
+		fmt.Fprintf(&b, "; did you mean %q?", sug)
+	}
+	return b.String()
+}
+
+// didYouMean returns the single closest entity label/qualified_name to any
+// candidate key by normalised Levenshtein distance, or "" when nothing is close
+// enough (threshold: edit distance ≤ 1/3 of the longer string).
+func didYouMean(lg *LoadedGroup, keys []string) string {
+	type scored struct {
+		name string
+		dist int
+		max  int
+	}
+	var best *scored
+	consider := func(target, candidate string) {
+		if candidate == "" {
+			return
+		}
+		d := levenshteinDist(strings.ToLower(target), strings.ToLower(candidate))
+		m := len(target)
+		if len(candidate) > m {
+			m = len(candidate)
+		}
+		if m == 0 || d*3 > m { // require >2/3 similarity
+			return
+		}
+		if best == nil || d < best.dist {
+			best = &scored{name: candidate, dist: d, max: m}
+		}
+	}
+	for _, key := range keys {
+		leaf := key
+		if i := strings.LastIndex(key, "."); i >= 0 {
+			leaf = key[i+1:]
+		}
+		for _, r := range lg.Repos {
+			if r.Doc == nil {
+				continue
+			}
+			for i := range r.Doc.Entities {
+				e := &r.Doc.Entities[i]
+				consider(key, e.QualifiedName)
+				consider(leaf, e.Name)
+			}
+		}
+	}
+	if best == nil {
+		return ""
+	}
+	return best.name
+}
+
+// levenshteinDist is the standard edit distance between two strings. Local to
+// the mcp package to avoid a cross-package dependency for one small helper.
+func levenshteinDist(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	cur := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(rb)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}
+
+// ambiguousMatches renders an ambiguous candidate list into the stable clarifier
+// payload get_source returns so the caller can pick one id.
+func ambiguousMatches(cands []sourceCandidate, query string) map[string]any {
+	out := make([]map[string]any, 0, len(cands))
+	for _, c := range cands {
+		out = append(out, map[string]any{
+			"id":             prefixedID(c.repo.Repo, c.ent.ID),
+			"qualified_name": c.ent.QualifiedName,
+			"label":          c.ent.Name,
+			"repo":           c.repo.Repo,
+			"source_file":    c.ent.SourceFile,
+			"start_line":     c.ent.StartLine,
+			"kind":           stripScopePrefix(c.ent.Kind),
+		})
+	}
+	// Deterministic ordering for stable output / tests.
+	sort.Slice(out, func(i, j int) bool {
+		return fmt.Sprint(out[i]["id"]) < fmt.Sprint(out[j]["id"])
+	})
+	return map[string]any{
+		"ambiguous": true,
+		"query":     query,
+		"count":     len(out),
+		"matches":   out,
+		"note":      "multiple entities match this label; call again with one of the ids above.",
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2184,59 +2184,23 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	if errRes != nil {
 		return errRes, nil
 	}
-	var e *graph.Entity
-	var lr *LoadedRepo
-	if rp, lid := splitPrefixed(nodeID); rp != "" {
-		if r, ok := lg.Repos[rp]; ok && r.Doc != nil {
-			e = r.LabelIndex.ByID[lid]
-			lr = r
-		}
+	// #4272 / #1650 — hardened entity resolution. resolveSourceEntity accepts an
+	// id, qualified_name, or label, each optionally "<repo>::"-prefixed, and
+	// tries id → qname → label → qname-suffix across the group for both the raw
+	// arg and its prefix-stripped local form (the prefix gap that erroneously
+	// returned "node not found" — the same class fixed for effective_contract in
+	// #4243). A label matching >1 distinct entity yields a clarifier list; a
+	// genuine miss yields a clearer error (attempted forms + did-you-mean) so the
+	// caller can self-correct rather than re-erroring.
+	resn := resolveSourceEntity(lg, nodeID)
+	if resn.notFound != "" {
+		return mcpapi.NewToolResultError(resn.notFound), nil
 	}
-	// #1650: accept qualified_name or label. Gather all matches across repos;
-	// if more than one resolves we return a clarifier list of {id,
-	// qualified_name, file:line, repo} so the caller can disambiguate without
-	// a follow-up inspect round-trip.
-	if e == nil {
-		type cand struct {
-			ent  *graph.Entity
-			repo *LoadedRepo
-		}
-		var cands []cand
-		for _, r := range lg.Repos {
-			if r.Doc == nil {
-				continue
-			}
-			for _, hit := range r.LabelIndex.LookupAll(nodeID) {
-				cands = append(cands, cand{ent: hit, repo: r})
-			}
-		}
-		if len(cands) == 0 {
-			return mcpapi.NewToolResultError("node not found: " + nodeID), nil
-		}
-		if len(cands) > 1 {
-			out := make([]map[string]any, 0, len(cands))
-			for _, c := range cands {
-				out = append(out, map[string]any{
-					"id":             prefixedID(c.repo.Repo, c.ent.ID),
-					"qualified_name": c.ent.QualifiedName,
-					"label":          c.ent.Name,
-					"repo":           c.repo.Repo,
-					"source_file":    c.ent.SourceFile,
-					"start_line":     c.ent.StartLine,
-					"kind":           stripScopePrefix(c.ent.Kind),
-				})
-			}
-			return jsonResult(map[string]any{
-				"ambiguous": true,
-				"query":     nodeID,
-				"count":     len(out),
-				"matches":   out,
-				"note":      "multiple entities match this label; call again with one of the ids above.",
-			}), nil
-		}
-		e = cands[0].ent
-		lr = cands[0].repo
+	if len(resn.ambiguous) > 0 {
+		return jsonResult(ambiguousMatches(resn.ambiguous, nodeID)), nil
 	}
+	e := resn.entity
+	lr := resn.repo
 
 	// #3833 — MRO-aware resolution. When the entity is an INHERITED member (a
 	// bodyless DRF synthetic, or a method resolved via EXTENDS to a base that


### PR DESCRIPTION
## Summary

`archigraph_get_source` is the busiest MCP tool (live: 345 calls / 28 errors ≈ 8%). Root-cause analysis found the error rate is dominated by resolution failures on **well-formed** args, not genuinely-missing entities.

### Dominant error class

The legacy inline resolver in `handleGetNodeSource` (`internal/mcp/tools.go`) handled the `<repo>::<localid>` prefix **only** via `r.LabelIndex.ByID[local]`. The error path:

- A `<repo>::`-prefixed arg that resolves by `qualified_name` or `label` (not by raw id) failed the `ByID` lookup, then the `if e == nil` cross-repo fallback ran `LookupAll(nodeID)` on the **still-prefixed** string — which matches nothing in the local-id-keyed index — returning a bare `node not found: <arg>`.

This is the same `<repo>::` prefix gap fixed for `archigraph_effective_contract` in #4243.

### Hardening

New `resolveSourceEntity` (`internal/mcp/get_source_resolve.go`) tries **id → qualified_name → label → qualified-name suffix** across the group for **both** the raw arg and its prefix-stripped local form. Ambiguous labels still return the existing clarifier list.

### Clearer not-found

On a genuine miss the error now names the attempted resolution forms and offers a **did-you-mean** nearest match (local Levenshtein), so the caller can self-correct instead of re-erroring — cutting the *effective* error rate even where the entity truly doesn't exist. Real not-founds are NOT masked as success.

### Tests

`get_source_resolution_4272_test.go` drives `handleGetNodeSource` and asserts resolution by (a) bare id, (b) prefixed id, (c) qualified_name incl. prefixed, (d) label, and (e) a helpful not-found with attempted-forms + suggestion. **Non-vacuous**: `(c-prefixed)` and `(e)` fail on the pre-fix handler (verified: `(c-prefixed)` returned `node not found`, `(e)` lacked attempted-forms/did-you-mean).

### Gates

`go build ./...`, `go test ./internal/mcp/...` (full suite), `gofmt -l`, `go vet ./internal/mcp/...` all clean.

Closes #4272 (epic #3648). **DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)