### PR TITLE
install: optional Claude Code grep-interceptor hook (nudge toward archigraph) (#4273)

### DIFF
--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -26,6 +26,7 @@ func newWizardCmd() *cobra.Command {
 		groupDocs      string
 		watchers       bool
 		gitHooks       bool
+		agentHooks     bool
 		runInstall     bool
 	)
 	cmd := &cobra.Command{
@@ -41,6 +42,7 @@ func newWizardCmd() *cobra.Command {
 				GroupDocs:      groupDocs,
 				Watchers:       watchers,
 				GitHooks:       gitHooks,
+				AgentHooks:     agentHooks,
 				RunInstall:     runInstall,
 			}
 			return runWizard(out, opts)
@@ -53,6 +55,7 @@ func newWizardCmd() *cobra.Command {
 	cmd.Flags().StringVar(&groupDocs, "group-docs", "", "optional path to shared group docs")
 	cmd.Flags().BoolVar(&watchers, "watchers", true, "enable watchers")
 	cmd.Flags().BoolVar(&gitHooks, "git-hooks", true, "enable git hooks")
+	cmd.Flags().BoolVar(&agentHooks, "agent-hooks", false, "opt-in: install the Claude Code PreToolUse grep-interceptor hook that nudges toward archigraph on structural greps (advisory-only, never blocks; Claude Code only)")
 	cmd.Flags().BoolVar(&runInstall, "install", true, "run install at the end")
 	return cmd
 }
@@ -63,6 +66,7 @@ type wizardOptions struct {
 	ParentDir, ReposCSV string
 	GroupDocs           string
 	Watchers, GitHooks  bool
+	AgentHooks          bool
 	RunInstall          bool
 }
 
@@ -70,6 +74,7 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 	cfg := &registry.GroupConfig{}
 	cfg.Features.Watchers = opts.Watchers
 	cfg.Features.GitHooks = opts.GitHooks
+	cfg.Features.AgentHooks = opts.AgentHooks
 	cfg.GroupDocs = opts.GroupDocs
 
 	// Step 1 — group name.

--- a/internal/install/agenthooks/claudecode.go
+++ b/internal/install/agenthooks/claudecode.go
@@ -1,0 +1,308 @@
+// Package agenthooks installs OPT-IN agent-host hooks that actively
+// reinforce the "query the graph, don't grep your way around it" standing
+// directive (#4238) at the moment a structural grep is about to run.
+//
+// Scope — CLAUDE CODE ONLY.
+//
+// Unlike the cross-host rules block written by internal/install/rulesfiles
+// (which every IDE coding agent reads as project context), this package
+// targets a mechanism that ONLY Claude Code exposes: a PreToolUse hook.
+// A PreToolUse hook is a JSON entry in `.claude/settings.json` with a
+// `matcher` (which tool it fires on) and a `command` (a shell command that
+// receives the tool call as JSON on stdin and may emit advisory output).
+// Other agent hosts (Cursor, Windsurf, Codex, Continue, Zed, …) have no
+// equivalent surface, so this installer is explicitly Claude-Code-only and
+// COMPLEMENTS — does not replace — the cross-host rules-block directive.
+//
+// Design constraints (all enforced here and in the embedded nudge script):
+//
+//   - ADVISORY ONLY, NEVER BLOCKING. The hook exits 0 and prints a one-line
+//     nudge to stderr. It never denies a tool call. A grep the agent wants
+//     to run still runs; we only suggest archigraph might be faster.
+//   - PRECISE heuristic, not "every grep". The nudge fires only on grep/rg
+//     invocations that look like STRUCTURAL queries (symbol hunts,
+//     definition lookups, who-calls patterns) — not TODO/string sweeps,
+//     which grep is genuinely the right tool for. A nudge that fires on
+//     every grep would train users to ignore it.
+//   - ONCE-PER-SESSION dedup. The script touches a per-session marker file
+//     the first time it fires and stays silent afterwards, so a session
+//     doesn't get spammed.
+//
+// Idempotency mirrors internal/install/rulesfiles: the managed PreToolUse
+// entry carries a stable marker id (Marker) so re-running install upserts
+// in place, an existing managed entry is replaced, and every other key in
+// `.claude/settings.json` — plus any unmanaged PreToolUse hooks the user
+// added — is preserved byte-compatibly (we round-trip through the JSON
+// document and only touch our own array element).
+package agenthooks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Marker is the stable identifier embedded in the managed PreToolUse hook
+// command so install/update/uninstall can find exactly our entry among any
+// other user-authored hooks. Bumping the trailing version causes an older
+// managed entry to be recognised and replaced in place.
+const Marker = "archigraph:grep-interceptor:v1"
+
+// MatcherTools is the Claude Code tool-matcher the hook fires on. Claude
+// Code's structural code search runs through the Bash tool (grep/rg), and
+// the harness also exposes dedicated Grep/Glob tools — matching all three
+// catches the structural-query surface. The matcher is a regex alternation
+// understood by Claude Code's PreToolUse matcher.
+const MatcherTools = "Bash|Grep|Glob"
+
+// SettingsRelPath is the project-relative path to the Claude Code project
+// settings file the hook lives in.
+var SettingsRelPath = filepath.Join(".claude", "settings.json")
+
+// NudgeScriptRelPath is the project-relative path the advisory nudge script
+// is written to. Keeping it on disk (rather than a giant inline command)
+// keeps the settings.json entry small and lets users read/audit it.
+var NudgeScriptRelPath = filepath.Join(".claude", "archigraph-grep-nudge.sh")
+
+// Install upserts the marker-identified PreToolUse nudge hook into the
+// project's .claude/settings.json (creating the file and the nudge script
+// if absent) and returns the absolute settings path that was touched.
+//
+// It is safe to call repeatedly: an existing managed entry is replaced in
+// place, all other settings and unmanaged hooks are preserved, and the
+// nudge script is rewritten to the current version.
+func Install(repoRoot string) (string, error) {
+	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
+	scriptPath := filepath.Join(repoRoot, NudgeScriptRelPath)
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return "", fmt.Errorf("agenthooks: mkdir: %w", err)
+	}
+	if err := writeNudgeScript(scriptPath); err != nil {
+		return "", err
+	}
+
+	doc, err := readSettings(settingsPath)
+	if err != nil {
+		return "", err
+	}
+	if err := upsertHook(doc, scriptPath); err != nil {
+		return "", err
+	}
+	if err := writeSettings(settingsPath, doc); err != nil {
+		return "", err
+	}
+	return settingsPath, nil
+}
+
+// Uninstall removes the marker-identified managed PreToolUse entry and
+// deletes the nudge script, leaving every other setting and any unmanaged
+// hooks untouched. It is idempotent: a missing file or missing entry is a
+// no-op.
+func Uninstall(repoRoot string) error {
+	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
+	scriptPath := filepath.Join(repoRoot, NudgeScriptRelPath)
+	_ = os.Remove(scriptPath)
+
+	doc, err := readSettings(settingsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !removeManagedHook(doc) {
+		return nil
+	}
+	return writeSettings(settingsPath, doc)
+}
+
+// IsInstalled reports whether the project's .claude/settings.json already
+// contains the marker-identified managed PreToolUse entry.
+func IsInstalled(repoRoot string) bool {
+	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
+	doc, err := readSettings(settingsPath)
+	if err != nil {
+		return false
+	}
+	_, idx := findManagedHook(doc)
+	return idx >= 0
+}
+
+// ── settings.json document surgery ───────────────────────────────────────
+
+// The Claude Code settings.json hook shape is:
+//
+//	{
+//	  "hooks": {
+//	    "PreToolUse": [
+//	      { "matcher": "Bash|Grep|Glob",
+//	        "hooks": [ { "type": "command", "command": "<marker> sh ..." } ] }
+//	    ]
+//	  }
+//	}
+//
+// We operate on map[string]any so that every key we do not understand is
+// preserved verbatim on the round-trip.
+
+// upsertHook inserts or replaces the managed PreToolUse matcher group.
+func upsertHook(doc map[string]any, scriptPath string) error {
+	entry := managedEntry(scriptPath)
+
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	pre, _ := hooks["PreToolUse"].([]any)
+
+	if _, idx := findManagedHookIn(pre); idx >= 0 {
+		pre[idx] = entry
+	} else {
+		pre = append(pre, entry)
+	}
+	hooks["PreToolUse"] = pre
+	doc["hooks"] = hooks
+	return nil
+}
+
+// removeManagedHook deletes the managed matcher group from PreToolUse.
+// Returns true if something was removed. Empty containers are pruned so an
+// uninstall leaves no dangling "hooks":{"PreToolUse":[]} cruft.
+func removeManagedHook(doc map[string]any) bool {
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		return false
+	}
+	pre, _ := hooks["PreToolUse"].([]any)
+	_, idx := findManagedHookIn(pre)
+	if idx < 0 {
+		return false
+	}
+	pre = append(pre[:idx], pre[idx+1:]...)
+	if len(pre) == 0 {
+		delete(hooks, "PreToolUse")
+	} else {
+		hooks["PreToolUse"] = pre
+	}
+	if len(hooks) == 0 {
+		delete(doc, "hooks")
+	}
+	return true
+}
+
+// findManagedHook locates the managed matcher group in the document.
+func findManagedHook(doc map[string]any) (map[string]any, int) {
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		return nil, -1
+	}
+	pre, _ := hooks["PreToolUse"].([]any)
+	return findManagedHookIn(pre)
+}
+
+// findManagedHookIn scans a PreToolUse array for the entry whose nested
+// command carries our Marker. Returns the entry and its index, or (nil,-1).
+func findManagedHookIn(pre []any) (map[string]any, int) {
+	for i, raw := range pre {
+		group, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, _ := group["hooks"].([]any)
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := hm["command"].(string); cmdHasMarker(cmd) {
+				return group, i
+			}
+		}
+	}
+	return nil, -1
+}
+
+// managedEntry builds the marker-tagged PreToolUse matcher group.
+func managedEntry(scriptPath string) map[string]any {
+	return map[string]any{
+		"matcher": MatcherTools,
+		"hooks": []any{
+			map[string]any{
+				"type": "command",
+				// The Marker is embedded as a leading shell comment so it is
+				// (a) inert at runtime and (b) reliably greppable for upsert.
+				"command": fmt.Sprintf("# %s\nsh %q", Marker, scriptPath),
+			},
+		},
+	}
+}
+
+func cmdHasMarker(cmd string) bool {
+	return len(cmd) > 0 && containsMarker(cmd)
+}
+
+// containsMarker is a tiny substring check kept separate so the marker
+// match is the single source of truth for managed-entry identification.
+func containsMarker(s string) bool {
+	for i := 0; i+len(Marker) <= len(s); i++ {
+		if s[i:i+len(Marker)] == Marker {
+			return true
+		}
+	}
+	return false
+}
+
+// ── JSON IO (preserve-everything-else round trip) ────────────────────────
+
+func readSettings(path string) (map[string]any, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	if len(b) == 0 {
+		return map[string]any{}, nil
+	}
+	doc := map[string]any{}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, fmt.Errorf("agenthooks: parse %s: %w", filepath.Base(path), err)
+	}
+	return doc, nil
+}
+
+func writeSettings(path string, doc map[string]any) error {
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// writeNudgeScript writes the advisory nudge script to disk (executable).
+func writeNudgeScript(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(NudgeScript), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/install/agenthooks/claudecode_test.go
+++ b/internal/install/agenthooks/claudecode_test.go
@@ -1,0 +1,285 @@
+package agenthooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// readDoc loads .claude/settings.json from a repo root as a generic doc.
+func readDoc(t *testing.T, repoRoot string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repoRoot, SettingsRelPath))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	doc := map[string]any{}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	return doc
+}
+
+// managedCount counts marker-identified managed PreToolUse entries.
+func managedCount(doc map[string]any) int {
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		return 0
+	}
+	pre, _ := hooks["PreToolUse"].([]any)
+	n := 0
+	for _, raw := range pre {
+		group, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, _ := group["hooks"].([]any)
+		for _, h := range inner {
+			hm, _ := h.(map[string]any)
+			if cmd, _ := hm["command"].(string); containsMarker(cmd) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// (a) fresh .claude/settings.json gets the marker-wrapped PreToolUse entry.
+func TestInstall_Fresh(t *testing.T) {
+	root := t.TempDir()
+	path, err := Install(root)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if path != filepath.Join(root, SettingsRelPath) {
+		t.Fatalf("unexpected settings path: %s", path)
+	}
+	if !IsInstalled(root) {
+		t.Fatal("IsInstalled = false after Install")
+	}
+	doc := readDoc(t, root)
+	if got := managedCount(doc); got != 1 {
+		t.Fatalf("managed entries = %d, want 1", got)
+	}
+	// Nudge script written and executable.
+	scriptPath := filepath.Join(root, NudgeScriptRelPath)
+	fi, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("nudge script not written: %v", err)
+	}
+	if fi.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("nudge script not executable: %v", fi.Mode())
+	}
+	// Matcher targets the structural tool surface.
+	hooks := doc["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	group := pre[0].(map[string]any)
+	if group["matcher"] != MatcherTools {
+		t.Fatalf("matcher = %v, want %v", group["matcher"], MatcherTools)
+	}
+}
+
+// (b) re-run is idempotent (no duplicate, surrounding JSON preserved).
+func TestInstall_Idempotent(t *testing.T) {
+	root := t.TempDir()
+
+	// Seed with unrelated settings + an unmanaged PreToolUse hook the user
+	// authored. Both must survive install untouched.
+	seed := map[string]any{
+		"model":       "claude-opus",
+		"customField": map[string]any{"nested": []any{"a", "b"}},
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Write",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "echo user-hook"},
+					},
+				},
+			},
+		},
+	}
+	seedBytes, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, SettingsRelPath), seedBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := Install(root); err != nil {
+			t.Fatalf("Install #%d: %v", i, err)
+		}
+	}
+
+	doc := readDoc(t, root)
+	if got := managedCount(doc); got != 1 {
+		t.Fatalf("managed entries after 3 installs = %d, want 1", got)
+	}
+	// Unrelated keys preserved.
+	if doc["model"] != "claude-opus" {
+		t.Fatalf("model key lost: %v", doc["model"])
+	}
+	cf, ok := doc["customField"].(map[string]any)
+	if !ok || cf["nested"] == nil {
+		t.Fatalf("customField lost: %v", doc["customField"])
+	}
+	// User's unmanaged Write hook preserved alongside ours.
+	hooks := doc["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	foundUser := false
+	for _, raw := range pre {
+		g := raw.(map[string]any)
+		if g["matcher"] == "Write" {
+			foundUser = true
+		}
+	}
+	if !foundUser {
+		t.Fatal("user's unmanaged Write hook was dropped")
+	}
+	if len(pre) != 2 {
+		t.Fatalf("PreToolUse len = %d, want 2 (user + managed)", len(pre))
+	}
+}
+
+// (c) an existing managed block is replaced in place (not appended).
+func TestInstall_ReplacesExistingManaged(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Install(root); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt/age the managed entry's command but keep the marker so it is
+	// still identifiable, then re-install: it must be replaced, not dupped.
+	doc := readDoc(t, root)
+	hooks := doc["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	group := pre[0].(map[string]any)
+	inner := group["hooks"].([]any)
+	hm := inner[0].(map[string]any)
+	hm["command"] = "# " + Marker + "\nsh /old/stale/path.sh"
+	b, _ := json.MarshalIndent(doc, "", "  ")
+	if err := os.WriteFile(filepath.Join(root, SettingsRelPath), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Install(root); err != nil {
+		t.Fatal(err)
+	}
+	doc2 := readDoc(t, root)
+	if got := managedCount(doc2); got != 1 {
+		t.Fatalf("managed entries after replace = %d, want 1", got)
+	}
+	// The stale path must be gone; current command points at the real script.
+	hooks2 := doc2["hooks"].(map[string]any)
+	pre2 := hooks2["PreToolUse"].([]any)
+	cmd := pre2[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"].(string)
+	if want := NudgeScriptRelPath; !containsSub(cmd, "archigraph-grep-nudge.sh") {
+		t.Fatalf("command not refreshed to current script (%s): %q", want, cmd)
+	}
+	if containsSub(cmd, "/old/stale/path.sh") {
+		t.Fatalf("stale command path survived replace: %q", cmd)
+	}
+}
+
+// Uninstall removes our entry + script, leaving user content intact.
+func TestUninstall(t *testing.T) {
+	root := t.TempDir()
+	// Seed an unrelated user setting.
+	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := []byte(`{"model":"x","hooks":{"PreToolUse":[{"matcher":"Write","hooks":[{"type":"command","command":"echo hi"}]}]}}`)
+	if err := os.WriteFile(filepath.Join(root, SettingsRelPath), seed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := Uninstall(root); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if IsInstalled(root) {
+		t.Fatal("still installed after Uninstall")
+	}
+	if _, err := os.Stat(filepath.Join(root, NudgeScriptRelPath)); !os.IsNotExist(err) {
+		t.Fatalf("nudge script not removed: %v", err)
+	}
+	doc := readDoc(t, root)
+	if doc["model"] != "x" {
+		t.Fatal("unrelated key lost on uninstall")
+	}
+	hooks := doc["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	if len(pre) != 1 || pre[0].(map[string]any)["matcher"] != "Write" {
+		t.Fatalf("user hook not preserved on uninstall: %v", pre)
+	}
+	// Idempotent second uninstall.
+	if err := Uninstall(root); err != nil {
+		t.Fatalf("second Uninstall: %v", err)
+	}
+}
+
+// (d) the heuristic classifies symbol-def greps structural and TODO/string
+// greps NOT.
+func TestClassifyStructural(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		// Structural: definition hunts.
+		{`grep -n 'def place_order' service.py`, true},
+		{`grep -rn "class OrderViewSet" .`, true},
+		{`grep -n "func validateOrder" *.go`, true},
+		{`rg "function handleSubmit" src/`, true},
+		{`grep -rn "interface PaymentGateway" .`, true},
+		// Structural: recursive symbol sweep (who-calls / usage).
+		{`grep -rn placeOrder .`, true},
+		{`rg OrderService`, true},
+		// NOT structural: TODO/FIXME/string sweeps.
+		{`grep -rn TODO .`, false},
+		{`grep -rn "FIXME: refactor" .`, false},
+		{`grep -n XXX file.go`, false},
+		// NOT structural: not a grep at all.
+		{`ls -la`, false},
+		{`cat service.py`, false},
+		{`go test ./...`, false},
+		// NOT structural: recursive grep for a non-symbol literal.
+		{`grep -rn "===" .`, false},
+	}
+	for _, c := range cases {
+		if got := classifyStructural(c.cmd); got != c.want {
+			t.Errorf("classifyStructural(%q) = %v, want %v", c.cmd, got, c.want)
+		}
+	}
+}
+
+// The embedded shell script must carry the marker and never use a blocking
+// exit code (advisory-only contract).
+func TestNudgeScript_AdvisoryContract(t *testing.T) {
+	if !containsSub(NudgeScript, Marker) {
+		t.Fatal("nudge script missing marker")
+	}
+	if !containsSub(NudgeScript, "exit 0") {
+		t.Fatal("nudge script must exit 0 (advisory only)")
+	}
+	// No deny/exit-2 blocking semantics.
+	if containsSub(NudgeScript, "exit 2") || containsSub(NudgeScript, `"deny"`) {
+		t.Fatal("nudge script must never block/deny")
+	}
+	// Once-per-session dedup marker logic present.
+	if !containsSub(NudgeScript, "marker") {
+		t.Fatal("nudge script missing once-per-session dedup")
+	}
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/agenthooks/nudge.go
+++ b/internal/install/agenthooks/nudge.go
@@ -1,0 +1,135 @@
+package agenthooks
+
+import (
+	"regexp"
+	"strings"
+)
+
+// NudgeScript is the POSIX-sh advisory hook body. It is written to
+// .claude/archigraph-grep-nudge.sh by Install and invoked by the managed
+// PreToolUse entry.
+//
+// Contract with Claude Code's PreToolUse mechanism:
+//
+//   - The tool call arrives as JSON on stdin. We read it, pull the command
+//     string out of it (best-effort, no jq dependency), and decide whether
+//     it looks like a STRUCTURAL grep.
+//   - We ALWAYS exit 0. This is advisory; we never deny a tool call. The
+//     nudge goes to stderr so it is visible without polluting any stdout the
+//     harness might parse.
+//   - We nudge at most ONCE PER SESSION: the first structural grep touches a
+//     per-session marker file under the session tmp dir; subsequent calls in
+//     the same session see the marker and stay silent, so we don't train the
+//     user to ignore a repeated nag.
+//
+// The structural heuristic intentionally mirrors classifyStructural below so
+// the Go table-test is an accurate proxy for the shell behaviour.
+const NudgeScript = `#!/bin/sh
+# archigraph grep-interceptor (` + Marker + `)
+# ADVISORY ONLY — nudges toward archigraph MCP on STRUCTURAL greps.
+# Never blocks: always exits 0. Claude Code ONLY (no other host has PreToolUse).
+
+# Read the PreToolUse payload (JSON) from stdin.
+payload="$(cat 2>/dev/null)"
+
+# Best-effort extraction of the command/pattern text without a jq dependency:
+# just scan the raw payload. The heuristic below is matched against it.
+cmd="$payload"
+
+# ---- structural-query heuristic (mirror of classifyStructural) ----
+# Only fire on grep/rg invocations. Bail on anything else.
+case "$cmd" in
+  *grep*|*\"rg\"*|*\ rg\ *|*ripgrep*) : ;;
+  *) exit 0 ;;
+esac
+
+# NOT structural: TODO/FIXME/string sweeps — grep is the right tool there.
+case "$cmd" in
+  *TODO*|*FIXME*|*XXX*|*HACK*) exit 0 ;;
+esac
+
+structural=0
+# Definition hunts: 'def X', 'class X', 'func X', 'function X', 'type X',
+# 'interface X', 'struct X' — language-agnostic symbol-definition patterns.
+case "$cmd" in
+  *def\ *|*class\ *|*func\ *|*function\ *|*interface\ *|*struct\ *|*type\ *) structural=1 ;;
+esac
+# Who-calls / usage hunts and recursive symbol sweeps: 'grep -r' / 'grep -rn'
+# for a bare identifier are almost always "where is X used / defined".
+case "$cmd" in
+  *grep\ -r*|*grep\ -rn*|*grep\ -nr*|*rg\ *) structural=1 ;;
+esac
+
+[ "$structural" = "1" ] || exit 0
+
+# ---- once-per-session dedup ----
+sess="${CLAUDE_SESSION_ID:-${TMPDIR:-/tmp}}"
+# Reduce the session id to a filesystem-safe token.
+token="$(printf '%s' "$sess" | tr -c 'A-Za-z0-9_.-' '_')"
+marker="${TMPDIR:-/tmp}/archigraph-grep-nudge.${token}"
+if [ -e "$marker" ]; then
+  exit 0
+fi
+: > "$marker" 2>/dev/null || true
+
+echo "archigraph: structural query — archigraph_find/inspect/neighbors is faster + more accurate than grep here (advisory; this grep still runs)." 1>&2
+exit 0
+`
+
+// ── Go mirror of the heuristic (for hermetic table-testing) ──────────────
+
+var (
+	reGrepTool   = regexp.MustCompile(`\b(grep|rg|ripgrep)\b`)
+	reNotStruct  = regexp.MustCompile(`\b(TODO|FIXME|XXX|HACK)\b`)
+	reDefHunt    = regexp.MustCompile(`\b(def|class|func|function|interface|struct|type)\s`)
+	reRecursive  = regexp.MustCompile(`grep\s+-[a-zA-Z]*r|grep\s+-[a-zA-Z]*\s|\brg\b`)
+	reSymbolLike = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]{2,}`)
+)
+
+// classifyStructural is the Go mirror of the shell heuristic in NudgeScript.
+// It returns true when a grep/rg command line looks like a STRUCTURAL query
+// (definition hunt, who-calls, or recursive symbol sweep) and false for
+// non-grep commands and TODO/string sweeps. It is the canonical, testable
+// statement of the heuristic; the shell version is kept behaviourally
+// equivalent.
+func classifyStructural(cmd string) bool {
+	if !reGrepTool.MatchString(cmd) {
+		return false
+	}
+	if reNotStruct.MatchString(cmd) {
+		return false
+	}
+	// Definition hunt — strongest structural signal.
+	if reDefHunt.MatchString(cmd) {
+		return true
+	}
+	// Recursive / ripgrep sweep for a symbol-like identifier is "where is X
+	// used/defined" — structural. Require a symbol-like token so a recursive
+	// grep for a punctuation/string literal doesn't trip it.
+	if reRecursive.MatchString(cmd) && reSymbolLike.MatchString(grepOperands(cmd)) {
+		return true
+	}
+	return false
+}
+
+// grepOperands returns the command's pattern/operand tokens: it drops
+// dash-flag tokens (e.g. "-rn") and the grep/rg tool words themselves, so
+// the symbol-like check inspects the SEARCH PATTERN rather than the literal
+// word "grep" or flag letters. Surrounding quotes are also trimmed so a
+// quoted pattern like "===" is judged on its real content.
+func grepOperands(cmd string) string {
+	toolWord := map[string]bool{"grep": true, "rg": true, "ripgrep": true, "egrep": true, "fgrep": true}
+	var b strings.Builder
+	for _, tok := range strings.Fields(cmd) {
+		if strings.HasPrefix(tok, "-") {
+			continue
+		}
+		if toolWord[tok] {
+			continue
+		}
+		tok = strings.Trim(tok, `"'`)
+		b.WriteString(tok)
+		b.WriteByte(' ')
+	}
+	return b.String()
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cajasmota/archigraph/internal/install/agenthooks"
 	"github.com/cajasmota/archigraph/internal/install/hooks"
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
 	"github.com/cajasmota/archigraph/internal/install/rulesfiles"
@@ -35,6 +36,12 @@ type Options struct {
 	// (AGENTS.md, CLAUDE.md, .windsurfrules, .cursorrules,
 	// .codeium/instructions.md, .github/copilot-instructions.md).
 	SkipRulesFiles bool
+	// InstallAgentHooks, when true, installs the OPT-IN Claude Code
+	// PreToolUse grep-interceptor hook (#4273) into each repo's
+	// .claude/settings.json. It is also gated by Config.Features.AgentHooks;
+	// either the explicit option OR the persisted feature flag enables it.
+	// CLAUDE CODE ONLY; advisory-only; never blocks.
+	InstallAgentHooks bool
 }
 
 // Result reports what an Apply call did so the CLI can print a summary.
@@ -54,6 +61,10 @@ type Result struct {
 	// RulesFilesStaleReplaced maps repo path → rules-file paths that
 	// were entirely predecessor content and got overwritten.
 	RulesFilesStaleReplaced map[string][]string
+	// AgentHooksInstalled lists repo paths that got the opt-in Claude Code
+	// PreToolUse grep-interceptor hook (#4273). Empty unless agent hooks
+	// were enabled.
+	AgentHooksInstalled []string
 }
 
 // Apply registers the group, writes its config, then installs hooks +
@@ -147,6 +158,14 @@ func Apply(opts Options) (*Result, error) {
 				res.RulesFiles[repo] = append([]string{}, rulesfiles.Targets...)
 			}
 		}
+		if opts.InstallAgentHooks || opts.Config.Features.AgentHooks {
+			if !opts.DryRun {
+				if _, err := agenthooks.Install(repo); err != nil {
+					return nil, fmt.Errorf("agent hooks for %s: %w", repo, err)
+				}
+			}
+			res.AgentHooksInstalled = append(res.AgentHooksInstalled, repo)
+		}
 		if !opts.SkipWatchers && opts.Config.Features.Watchers {
 			u := watchers.Unit{Group: opts.Group, Repo: repo, BinPath: opts.BinPath}
 			if !opts.DryRun {
@@ -226,6 +245,7 @@ func Uninstall(group string, purge bool) error {
 		loader := watchers.NewLoader()
 		for _, r := range cfg.Repos {
 			_ = hooks.Uninstall(r.Path)
+			_ = agenthooks.Uninstall(r.Path)
 			u := watchers.Unit{Group: group, Repo: r.Path, BinPath: bin}
 			// Deregister from the OS scheduler before removing the unit file so
 			// that the OS does not attempt to launch a missing binary.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -139,6 +139,16 @@ type GroupConfig struct {
 		// Example fleet JSON:
 		//   "features": { "track_worktrees": true }
 		TrackWorktrees bool `json:"track_worktrees,omitempty"`
+		// AgentHooks, when true, installs the OPT-IN Claude Code PreToolUse
+		// grep-interceptor hook into each repo's .claude/settings.json. The
+		// hook is advisory-only (never blocks) and nudges the agent toward
+		// archigraph MCP tools when it is about to run a STRUCTURAL grep.
+		//
+		// This is CLAUDE CODE ONLY reinforcement — no other agent host
+		// exposes a PreToolUse surface — and it COMPLEMENTS, not replaces,
+		// the cross-host rules block. Default false: it is opt-in to avoid
+		// nagging users who don't want it (#4273).
+		AgentHooks bool `json:"agent_hooks,omitempty"`
 	} `json:"features"`
 	// ExtraStdlibFilter is a user-extensible map from language tag to a list
 	// of bare-name symbols that should be suppressed as if they were stdlib


### PR DESCRIPTION
Closes #4273 (epic #3648).

**DEPLOY-DEFERRED** — installer module + unit tests only; no daemon rebuild/reindex/MCP changes. Safe to merge without a deploy.

## What

A new **opt-in** `internal/install/agenthooks` package installs a Claude Code **PreToolUse** hook that actively reinforces the "query the graph, don't grep your way around it" standing directive (#4238) — at the exact moment the agent is about to run a structural grep. This is the *active* counterpart to the *passive* cross-host rules block (`internal/install/rulesfiles`).

### settings.json upsert approach
- `claudecode.go` upserts a **marker-identified** (`archigraph:grep-interceptor:v1`) PreToolUse entry into the project `.claude/settings.json` (matcher `Bash|Grep|Glob`).
- It round-trips the JSON document as `map[string]any`, so **every other setting and any unmanaged user-authored hook is preserved**; re-install replaces our entry **in place** (no duplicates); uninstall removes our entry + the nudge script and prunes empty `hooks`/`PreToolUse` containers. Mirrors the idempotent marker discipline of `rulesfiles.go`.

### Heuristic + dedup + non-blocking design
- The nudge is a small shell script (`.claude/archigraph-grep-nudge.sh`) that reads the PreToolUse JSON payload on stdin.
- **Precise structural heuristic** (not every grep): fires only on `grep`/`rg` that look structural — definition hunts (`def`/`class`/`func`/`function`/`interface`/`struct`/`type X`) and recursive symbol sweeps (who-calls/usage). It explicitly **skips TODO/FIXME/XXX/HACK and non-symbol string sweeps**, which grep is the right tool for. The heuristic is mirrored in a testable Go function `classifyStructural`.
- **Advisory only, never blocking**: always `exit 0`, one-line nudge to stderr, never denies a tool call (the grep still runs).
- **Once-per-session dedup**: a session-keyed marker file under `$TMPDIR` is touched on first fire and silences subsequent calls, so it can't train users to ignore a repeated nag.

### Opt-in toggle
- `registry.GroupConfig.Features.AgentHooks` (persisted, default false) + `install.Options.InstallAgentHooks` + `archigraph wizard --agent-hooks` (default false). Either the flag or the persisted feature enables it. `install.Uninstall` reverses it per repo. Not installed for anyone by default — no nag risk.

### Test
`claudecode_test.go` (hermetic, no network/daemon): (a) fresh settings.json gets the marker-wrapped entry + executable script, (b) 3x re-run is idempotent and preserves unrelated keys *and* a user's unmanaged Write hook, (c) an aged-but-marked managed entry is replaced in place (stale path gone), uninstall round-trip, the structural-vs-string classifier table-test, and an advisory-contract assertion on the embedded script (carries marker, `exit 0`, no `exit 2`/deny).

## Honest scoping
This is **Claude-Code-ONLY** reinforcement — no other agent host (Cursor, Windsurf, Codex, Continue, Zed) exposes a PreToolUse surface. It **complements, does not replace** the cross-host rules-block directive. Documented in the package doc, the `Features.AgentHooks` doc comment, and the `--agent-hooks` help text.

## Gates
`go build ./...` ✓ · `go test ./internal/install/...` ✓ · `gofmt -l` clean ✓ · `go vet ./internal/install/...` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)