### PR TITLE
coverage: credit already-shipped cross-lang query_attribution cells (#4271 Tier-1)

### DIFF
--- a/internal/engine/orm_queries_datastore_infra_test.go
+++ b/internal/engine/orm_queries_datastore_infra_test.go
@@ -64,6 +64,25 @@ public class GraphRepo {
 	}
 }
 
+func TestInfra_Neo4jCSharpSessionRun(t *testing.T) {
+	// C# Neo4j.Driver: `session.Run("MATCH (n:Label) ...")`. The
+	// language-agnostic cypher emitter (run for csharp via scanInfra in
+	// applyORMQueries) attributes the first node label to a QUERIES edge.
+	src := `using Neo4j.Driver;
+public class GraphRepo {
+    private ISession session;
+    public void Load() {
+        session.Run("MATCH (a:Account)-[:OWNS]->(d:Device) RETURN d");
+    }
+}
+`
+	edges := detectORM(t, "csharp", "GraphRepo.cs", src)
+	e := assertEdgeExists(t, edges, "Function:Load", "Class:Account", "find")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
 func TestInfra_Neo4jNoDriverNoEmit(t *testing.T) {
 	// A `session.run(...)` with NO neo4j/bolt import must NOT fire — the
 	// import gate keeps the broad `.run(` surface from over-firing.


### PR DESCRIPTION
## What

Credits **7 cross-language `query_attribution` registry cells** whose native Go
query-topology extractors **already shipped in #3645** but whose registry cells
were left stale-`missing` (with a "no native query-topology extractor" note that
is no longer true). This closes a Tier-1 verify-and-credit slice of epic #4271.

**No production code change** — only fixture/value-asserting tests + registry
credit. `internal/engine/orm_queries.go` and
`internal/engine/orm_queries_drivers_other.go` are untouched.

## Cells credited (before → after)

| Cell | before | after | Driving test (value-asserting) | QUERIES edge asserted |
|---|---|---|---|---|
| `lang.csharp.driver.dynamodb` | missing | **full** | `TestDriver_CSharpDynamoTableName` | `Function:Get → Class:Product` op=find orm=dynamodb |
| `lang.csharp.driver.cassandra` | missing | **full** | `TestDriver_CSharpCassandraCQL` | `Function:List → Class:Event` op=find orm=cassandra |
| `lang.csharp.driver.elastic` | missing | **full** | `TestDriver_CSharpElasticIndex` | `Function:Run → Class:Log` op=find orm=elastic |
| `lang.csharp.driver.mongodb` | missing | **full** | `TestDriver_CSharpMongoGetCollection` | `Function:GetUser → Class:User` op=find orm=mongodb |
| `lang.python.driver.neo4j` | missing | **partial** | `TestInfra_Neo4jPythonBoltSessionRun` | `Function:list_people → Class:Person` op=find orm=neo4j |
| `lang.csharp.driver.neo4j` | missing | **partial** | `TestInfra_Neo4jCSharpSessionRun` *(new)* | `Function:Load → Class:Account` op=find orm=neo4j |
| `lang.java.orm.neo4j` | missing | **partial** | `TestInfra_Neo4jJavaGraphDatabase` | `Function:load → Class:User` op=find orm=neo4j |

The 4 C# driver cells and 2 of the 3 neo4j cells were already covered by
shipped value-asserting tests (verify-first); only `lang.csharp.driver.neo4j`
needed a new test (`TestInfra_Neo4jCSharpSessionRun`), added here.

Status rationale:
- **C# driver cells → `full`**: static literal capture of collection/table/index
  (and CQL FROM parse) with dynamic names honest-skipped — mirrors the `full`
  sibling `lang.java.driver.mongodb` and the `lang.jsts.driver.*` cells.
- **neo4j cells → `partial`**: the shared Cypher emitter attributes only the
  FIRST node label of a MATCH pattern + a coarse CRUD verb, and honest-skips
  dynamic/parameterised labels — mirrors the `partial` sibling
  `lang.go.driver.neo4j`.

## Gates
- `covtool fmt --check`: canonical
- `covtool validate`: ok (658 records; only pre-existing map-coverage warnings,
  identical to the `full`/`partial` sibling cells)
- `go test ./internal/engine/` (the driver + infra value tests): pass
- `gofmt -l` + `go vet ./internal/engine/`: clean

## Deploy
**DEPLOY-DEFERRED** — registry credit + tests only; no extractor/daemon change,
so no reindex required to land. Refs #4271.
