### PR TITLE
test: isolate daemon integration tests to per-test sockets/roots (#4022)

### DIFF
--- a/internal/daemon/boot_watcher_async_test.go
+++ b/internal/daemon/boot_watcher_async_test.go
@@ -26,8 +26,7 @@ import (
 // deadline; with the old synchronous code Dial would never succeed until the
 // stall cleared.
 func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
-	root := shortTempRoot(t)
-	t.Setenv(daemon.EnvRoot, root)
+	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("layout: %v", err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -56,14 +56,34 @@ func shortTempRoot(t *testing.T) string {
 	return d
 }
 
+// isolateDaemonEnv points this test's in-process daemon at a per-test temp
+// root (its own socket, pid file and log dir) and disables the Layer-1
+// self-defense check (#4022).
+//
+// Without the self-defense override these tests are NOT hermetic: `go test`
+// compiles and runs the test binary under /tmp, so SelfDefenseCheck treats the
+// in-test daemon as an ephemeral /tmp daemon and refuses to start it whenever a
+// real canonical daemon is running on the machine — surfacing as the
+// "daemon never became ready" timeouts this change fixes. The in-test daemon
+// uses an isolated root + socket and never touches the canonical socket, so
+// skipping the anti-displacement check is correct here.
+//
+// It returns the temp root so callers can build a Layout from it.
+func isolateDaemonEnv(t *testing.T) string {
+	t.Helper()
+	root := shortTempRoot(t)
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv(daemon.EnvDisableSelfDefense, "1")
+	return root
+}
+
 // runDaemonForTest starts daemon.Run in a goroutine and returns the
 // layout (for dialing) plus a stop function. The returned context is
 // the one the daemon listens on — cancel it to force shutdown if Stop
 // over RPC is what's being exercised.
 func runDaemonForTest(t *testing.T, idx daemon.IndexFunc, rb daemon.RebuildFunc) daemon.Layout {
 	t.Helper()
-	root := shortTempRoot(t)
-	t.Setenv(daemon.EnvRoot, root)
+	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("layout: %v", err)

--- a/internal/daemon/mcp_rpc_integration_test.go
+++ b/internal/daemon/mcp_rpc_integration_test.go
@@ -109,8 +109,7 @@ func cancelOnCleanup(t *testing.T) (ctx context.Context, cancel context.CancelFu
 // socket path. The daemon stops when the test ends.
 func runDaemonWithMCP(t *testing.T) string {
 	t.Helper()
-	root := shortTempRoot(t)
-	t.Setenv(daemon.EnvRoot, root)
+	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("layout: %v", err)
@@ -218,8 +217,7 @@ func TestMCPToolCall_Integration_StatsReturnsContent(t *testing.T) {
 func TestMCPToolCall_Integration_NilCallTool_ReturnsErrorBlock(t *testing.T) {
 	// Start a daemon where MCPCallTool is nil — the service should return
 	// a structured error block (IsError=true) rather than a protocol error.
-	root := shortTempRoot(t)
-	t.Setenv(daemon.EnvRoot, root)
+	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("layout: %v", err)

--- a/internal/daemon/phaseb_test.go
+++ b/internal/daemon/phaseb_test.go
@@ -19,8 +19,7 @@ import (
 // is created in a tempdir and registered via ReposToWatch.
 func runDaemonWithPhaseBForTest(t *testing.T, repos []string, schedIdx daemon.Config) (daemon.Layout, func()) {
 	t.Helper()
-	root := shortTempRoot(t)
-	t.Setenv(daemon.EnvRoot, root)
+	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("layout: %v", err)

--- a/internal/daemon/selfdefense.go
+++ b/internal/daemon/selfdefense.go
@@ -30,6 +30,24 @@ import (
 	"github.com/cajasmota/archigraph/internal/process"
 )
 
+// EnvDisableSelfDefense, when set to a truthy value ("1", "true"), disables the
+// Layer-1 startup conflict check in SelfDefenseCheck. It exists solely so the
+// daemon integration tests can boot a fully-isolated daemon (its own
+// ARCHIGRAPH_DAEMON_ROOT + per-test socket) on a machine where a real canonical
+// daemon is already running.
+//
+// Without this seam, every in-test daemon whose test binary lives under /tmp
+// (which is where `go test` compiles and runs its binary) is refused startup by
+// SelfDefenseCheck the moment any canonical daemon is alive — producing the
+// "daemon never became ready" timeouts tracked in #4022. The in-test daemons
+// never touch the canonical socket (they use isolated roots/sockets), so the
+// anti-displacement protection the check provides is not needed for them.
+//
+// This is NEVER set in production: cmd/archigraph does not set it, and the
+// canonical daemon installed via launchd/systemd runs from a non-/tmp path so
+// the check is a no-op for it regardless.
+const EnvDisableSelfDefense = "ARCHIGRAPH_DISABLE_SELFDEFENSE"
+
 // canonicalBasenames is the set of binary base-names that identify a genuine
 // archigraph daemon process. A process whose executable base-name is NOT in
 // this set is never treated as canonical, even if the full path contains the
@@ -54,6 +72,13 @@ func isTmpPath(path string) bool {
 func SelfDefenseCheck(logger *slog.Logger) error {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "selfdefense")
+	}
+
+	// Test isolation seam (#4022): allow a fully-isolated in-test daemon to boot
+	// even when a real canonical daemon is running. See EnvDisableSelfDefense.
+	if v := os.Getenv(EnvDisableSelfDefense); v == "1" || strings.EqualFold(v, "true") {
+		logger.Warn("selfdefense: Layer-1 conflict check disabled via " + EnvDisableSelfDefense)
+		return nil
 	}
 
 	self, err := os.Executable()


### PR DESCRIPTION
## Problem

The daemon integration tests (`internal/daemon`) boot an in-process daemon and dial it. They fail with `daemon never became ready` (10s timeouts) whenever a real canonical daemon is running on the machine, or when run in a sandbox — they are not hermetic with respect to a live daemon.

## Root cause

The tests already set `ARCHIGRAPH_DAEMON_ROOT` to a per-test temp root (own socket/pid/logs). But `go test` compiles and runs the test binary under `/tmp`, so `daemon.Run`'s Layer-1 `SelfDefenseCheck` (`internal/daemon/selfdefense.go`) treats every in-test daemon as an ephemeral `/tmp` daemon and **refuses to start it** while any canonical (non-`/tmp`) daemon is alive (e.g. `~/go/bin/archigraph daemon`). The listener never binds, so the dial-based readiness probe in `waitDaemonReady` / `runDaemonForTest` (`internal/daemon/daemon_test.go`) times out. The per-test socket isolation was already correct — the daemon just exited before ever creating its socket.

## Fix

Added a narrow, opt-in test seam: `ARCHIGRAPH_DISABLE_SELFDEFENSE` (`daemon.EnvDisableSelfDefense`). When set truthy, `SelfDefenseCheck` skips the Layer-1 conflict check. The daemon-booting test helpers set it (alongside `ARCHIGRAPH_DAEMON_ROOT`) through a new shared `isolateDaemonEnv(t)` helper, applied via `t.Setenv` (per-test, auto-reverted). In-test daemons use isolated roots + sockets and never touch the canonical socket, so the anti-displacement protection is not needed for them.

The seam is never set in production — `cmd/archigraph` does not set it, and the canonical daemon runs from a non-`/tmp` path where the check is already a no-op. The Layer-1 protection itself is unchanged: the self-defense e2e test (`TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary`) spawns a real `archigraph daemon` subprocess that does **not** inherit the override and still correctly refuses to start (verified: "Layer 1 PASS: /tmp binary correctly refused").

## Tests now green (previously timed out)

Verified in a sandbox (`HOME`/`XDG`/`ARCHIGRAPH_DAEMON_ROOT` isolated) **with a live canonical daemon running**:

- `TestBoot_WatcherSubscriptionDoesNotBlockBind`
- `TestDaemon_PingStatus`
- `TestDaemon_RebuildStatusObservability`
- `TestPhaseB_StatusRPCReflectsWatcher`
- plus the MCP-RPC integration and progress daemon tests

Gates: `go build ./...`, `gofmt -l internal/daemon/`, `go vet ./internal/daemon/...` all clean. No assertions weakened.

DEPLOY-DEFERRED.

Closes #4022

🤖 Generated with [Claude Code](https://claude.com/claude-code)