### PR TITLE
engine: elixir query_attribution foundation + drivers (cassandra/dynamo/elastic/mongo/neo4j) (#4271 elixir)

### DIFF
--- a/internal/engine/feature_flag_edges_test.go
+++ b/internal/engine/feature_flag_edges_test.go
@@ -1386,8 +1386,8 @@ end
 	if !ok {
 		t.Fatalf("expected GATED_BY for new_checkout, got %v", edges)
 	}
-	if g.From != "File:checkout.ex" {
-		t.Errorf("GATED_BY FromID = %q, want File:checkout.ex (no Elixir enclosing-func index)", g.From)
+	if g.From != "Function:run" {
+		t.Errorf("GATED_BY FromID = %q, want Function:run (Elixir def-head enclosing-func index, #4271)", g.From)
 	}
 	if g.To != "feature:new_checkout" {
 		t.Errorf("GATED_BY ToID = %q, want feature:new_checkout", g.To)

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -246,6 +246,14 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 	case "rust":
 		scanRustDrivers(src, funcs, emit)
 		scanInfra()
+	case "elixir":
+		// Driver-topology: Xandra CQL, ExAws DynamoDB TableName, Elasticsearch
+		// index, MongoDB collection (2nd-arg literal), and Bolt.Sips Cypher
+		// node-label attribution (#4271). The native Bolt.Sips schema/relationship
+		// extractor (internal/custom/elixir/neo4j.go) is unchanged; this pass adds
+		// the cross-language QUERIES topology edge.
+		scanElixirDrivers(src, funcs, emit)
+		scanInfra()
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}
@@ -257,7 +265,7 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 func ormQueriesSupportsLanguage(lang string) bool {
 	switch lang {
 	case "python", "javascript", "typescript", "go", "java", "ruby",
-		"csharp", "php", "rust":
+		"csharp", "php", "rust", "elixir":
 		return true
 	default:
 		return false
@@ -375,6 +383,14 @@ var (
 	rustOrmFuncRe = regexp.MustCompile(
 		`(?m)^\s*(?:pub\s+(?:\([^)]*\)\s*)?)?(?:async\s+|const\s+|unsafe\s+|extern\s+(?:"[^"]*"\s+)?)*fn\s+([A-Za-z_]\w*)`,
 	)
+
+	// Elixir: `def name(` / `defp name(` (public / private function head). The
+	// `?!` suffix some Elixir functions carry (e.g. `query!`) is NOT part of a
+	// `def` head; bang/question idioms appear on calls, not declarations, so the
+	// trailing-punctuation case is intentionally omitted.
+	elixirOrmFuncRe = regexp.MustCompile(
+		`(?m)^[ \t]*defp?\s+([A-Za-z_]\w*)`,
+	)
 )
 
 func indexEnclosingFunctions(lang, content string) []funcSpan {
@@ -396,6 +412,8 @@ func indexEnclosingFunctions(lang, content string) []funcSpan {
 		re = phpOrmFuncRe
 	case "rust":
 		re = rustOrmFuncRe
+	case "elixir":
+		re = elixirOrmFuncRe
 	default:
 		return nil
 	}

--- a/internal/engine/orm_queries_drivers_other.go
+++ b/internal/engine/orm_queries_drivers_other.go
@@ -917,6 +917,156 @@ func scanRubyDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 }
 
 // ---------------------------------------------------------------------------
+// Elixir (Xandra Cassandra / ExAws DynamoDB / Elasticsearch / mongodb / Bolt.Sips Neo4j)
+// ---------------------------------------------------------------------------
+//
+// Elixir is driver-based (no Ecto here — that is a separate ORM cell). Each
+// raw driver carries its target resource as a STATIC string literal in the
+// call: the CQL `FROM` table (Xandra), the DynamoDB table (ExAws first arg /
+// `"TableName" => "X"`), the ES index, the Mongo collection (2nd positional
+// arg), and the Cypher node label (Bolt.Sips). Interpolated literals (`#{var}`)
+// and pinned vars (`^var`) are honest-skipped because every matcher captures
+// only quoted literals.
+
+// elixirCqlRe matches a Xandra Cassandra execute call:
+//
+//	Xandra.execute(conn, "SELECT ... FROM t")
+//	Xandra.execute!(conn, "INSERT INTO t ...")
+//	Xandra.prepare(conn, "SELECT ... FROM t")
+//
+// The matcher ends at the opening paren; emitCQLTargets pulls the first string
+// literal (the conn arg is not a string, so the CQL is the first literal) and
+// parses the FROM/INTO/UPDATE table out of it.
+var elixirCqlRe = regexp.MustCompile(
+	`\bXandra\.(?:execute|execute!|prepare|prepare!|stream_pages!|run)\s*\(`,
+)
+
+// elixirMongoFindRe matches the elixir mongodb driver collection access, where
+// the collection is the SECOND positional argument (a quoted literal):
+//
+//	Mongo.find(conn, "users", %{})
+//	Mongo.find_one(topology, "orders", %{})
+//	Mongo.insert_one(conn, "products", %{...})
+//	Mongo.aggregate(conn, "events", pipeline)
+//
+// Captures the collection literal directly (group 1). The conn / topology arg
+// is consumed as a non-quote, non-paren run before the literal.
+var elixirMongoFindRe = regexp.MustCompile(
+	`\bMongo\.(?:find|find_one|insert_one|insert_many|update_one|update_many|delete_one|delete_many|count|count_documents|aggregate|replace_one)\s*\(\s*[^",()]*?,\s*"([A-Za-z_][\w$.-]*)"`,
+)
+
+// elixirDynamoFirstArgRe matches the ExAws.Dynamo helper form where the table
+// is the FIRST positional quoted literal:
+//
+//	ExAws.Dynamo.get_item("Products", %{...})
+//	ExAws.Dynamo.scan("Orders")
+//	ExAws.Dynamo.query("Events", ...)
+//	ExAws.Dynamo.put_item("Products", item)
+//
+// The `"TableName" => "X"` low-level map form is covered by the shared
+// emitDynamoTargets (dynamoTableNameKeyRe), so both idioms are attributed.
+var elixirDynamoFirstArgRe = regexp.MustCompile(
+	`\bExAws\.Dynamo\.(?:get_item|put_item|update_item|delete_item|query|scan|batch_get_item|batch_write_item)\s*\(\s*"([A-Za-z_][\w$.-]*)"`,
+)
+
+// elixirBoltCypherRe matches a Bolt.Sips / Boltx Cypher call and captures the
+// Cypher string literal (group 1):
+//
+//	Bolt.Sips.query!(conn, "MATCH (n:Label) ...")
+//	Bolt.Sips.query(conn, "CREATE (a:Person) ...")
+//	Boltx.query!(conn, "MATCH (u:User) ...")
+//
+// The conn arg is consumed as a non-quote run before the Cypher literal. This
+// mirrors reNeo4jExRun in internal/custom/elixir/neo4j.go (which emits the
+// SCOPE.Schema node/relationship entities); here we add the cross-language
+// QUERIES topology edge to the primary node label.
+var elixirBoltCypherRe = regexp.MustCompile(
+	`(?:Bolt\.Sips|Boltx)\.query!?\s*\(\s*[^"]*?"((?:[^"\\]|\\.)*)"`,
+)
+
+func mentionsElixirXandra(src string) bool {
+	return strings.Contains(src, "Xandra")
+}
+func mentionsElixirDynamo(src string) bool {
+	return strings.Contains(src, "ExAws.Dynamo") || strings.Contains(src, "ExAws.Dynamo.")
+}
+func mentionsElixirElastic(src string) bool {
+	return strings.Contains(src, "Elasticsearch") || strings.Contains(src, "Snap.") ||
+		strings.Contains(src, "elasticsearch")
+}
+func mentionsElixirMongo(src string) bool {
+	return strings.Contains(src, "Mongo.") || strings.Contains(src, "mongodb_driver") ||
+		strings.Contains(src, ":mongodb")
+}
+func mentionsElixirBolt(src string) bool {
+	return strings.Contains(src, "Bolt.Sips") || strings.Contains(src, "Boltx")
+}
+
+func scanElixirDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	// Cassandra (Xandra): CQL FROM/INTO/UPDATE table.
+	if mentionsElixirXandra(src) {
+		emitCQLTargets(src, funcs, emit, elixirCqlRe)
+	}
+	// DynamoDB (ExAws): first-arg table literal + `"TableName" => "X"` map form.
+	if mentionsElixirDynamo(src) {
+		for _, m := range elixirDynamoFirstArgRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			caller := enclosingFuncAt(funcs, m[0])
+			emit(caller, capitalisedSingular(src[m[2]:m[3]]), "find", "", "dynamodb", false)
+		}
+		emitDynamoTargets(src, funcs, emit)
+	}
+	// Elasticsearch: `index: "x"` / `"index" => "x"` / `.Index("x")` literal.
+	if mentionsElixirElastic(src) {
+		emitElasticTargets(src, funcs, emit)
+	}
+	// MongoDB: 2nd-arg collection literal → Class:<collection>.
+	if mentionsElixirMongo(src) {
+		for _, m := range elixirMongoFindRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			caller := enclosingFuncAt(funcs, m[0])
+			emit(caller, capitalisedSingular(src[m[2]:m[3]]), "find", "", "mongodb", false)
+		}
+	}
+	// Neo4j (Bolt.Sips / Boltx): the primary Cypher node label → Class:<label>.
+	// The native extractor (internal/custom/elixir/neo4j.go) emits the
+	// SCOPE.Schema node/relationship entities + GRAPH_RELATES edges; this adds the
+	// cross-language QUERIES topology edge so the elixir neo4j query_attribution
+	// cell reaches sibling parity with the other languages. Cypher whose label is
+	// dynamic / interpolated yields no edge (cypherLabelRe captures only static
+	// labels) — honest-partial.
+	if mentionsElixirBolt(src) {
+		for _, m := range elixirBoltCypherRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			cypher := src[m[2]:m[3]]
+			lm := cypherLabelRe.FindStringSubmatch(cypher)
+			if lm == nil {
+				continue
+			}
+			op := "find"
+			if vm := cypherVerbRe.FindStringSubmatch(cypher); vm != nil {
+				switch strings.ToLower(vm[1]) {
+				case "create", "merge":
+					op = "create"
+				case "set":
+					op = "update"
+				case "delete", "remove":
+					op = "delete"
+				}
+			}
+			caller := enclosingFuncAt(funcs, m[0])
+			emit(caller, lm[1], op, "", "neo4j", false)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Shared target emitters (language-agnostic — keyed on the literal value)
 // ---------------------------------------------------------------------------
 

--- a/internal/engine/orm_queries_drivers_other_test.go
+++ b/internal/engine/orm_queries_drivers_other_test.go
@@ -852,3 +852,185 @@ end
 		t.Errorf("expected orm=neo4j, got %q", e.ORM)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Elixir (Xandra Cassandra / ExAws DynamoDB / Elasticsearch / mongodb / Bolt.Sips Neo4j)
+// (#4271)
+// ---------------------------------------------------------------------------
+
+// Xandra: the CQL `FROM events` table is parsed out of the execute string and
+// attributed to the enclosing def. Asserts the exact Class:<table> target.
+func TestDriver_ElixirXandraCQL(t *testing.T) {
+	src := `defmodule Events do
+  def list(conn) do
+    Xandra.execute!(conn, "SELECT id, name FROM events WHERE day = ?")
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/events.ex", src)
+	e := assertEdgeExists(t, edges, "Function:list", "Class:Event", "find")
+	if e.ORM != "cassandra" {
+		t.Errorf("expected orm=cassandra, got %q", e.ORM)
+	}
+}
+
+// Xandra INSERT: verb canonicalises to create via the shared CQL extractor.
+func TestDriver_ElixirXandraInsert(t *testing.T) {
+	src := `defmodule Writer do
+  def add(conn) do
+    Xandra.execute(conn, "INSERT INTO orders (id) VALUES (?)")
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/writer.ex", src)
+	e := assertEdgeExists(t, edges, "Function:add", "Class:Order", "create")
+	if e.ORM != "cassandra" {
+		t.Errorf("expected orm=cassandra, got %q", e.ORM)
+	}
+}
+
+// ExAws DynamoDB helper form: the table is the first positional literal.
+func TestDriver_ElixirExAwsDynamoFirstArg(t *testing.T) {
+	src := `defmodule Store do
+  def get(id) do
+    ExAws.Dynamo.get_item("Products", %{"id" => id}) |> ExAws.request()
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/store.ex", src)
+	e := assertEdgeExists(t, edges, "Function:get", "Class:Product", "find")
+	if e.ORM != "dynamodb" {
+		t.Errorf("expected orm=dynamodb, got %q", e.ORM)
+	}
+}
+
+// ExAws DynamoDB low-level map form: `"TableName" => "X"` via the shared
+// emitDynamoTargets (dynamoTableNameKeyRe).
+func TestDriver_ElixirExAwsDynamoTableNameMap(t *testing.T) {
+	src := `defmodule LowLevel do
+  def scan() do
+    ExAws.Dynamo.scan(%{"TableName" => "Orders"}) |> ExAws.request()
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/low_level.ex", src)
+	e := assertEdgeExists(t, edges, "Function:scan", "Class:Order", "find")
+	if e.ORM != "dynamodb" {
+		t.Errorf("expected orm=dynamodb, got %q", e.ORM)
+	}
+}
+
+// Elasticsearch: `index: "products"` literal → Class:<index> via the shared
+// emitElasticTargets (esIndexKeyRe).
+func TestDriver_ElixirElasticIndex(t *testing.T) {
+	src := `defmodule Search do
+  alias Elasticsearch
+  def run(cluster) do
+    Elasticsearch.post(cluster, "/products/_search", %{index: "products"})
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/search.ex", src)
+	e := assertEdgeExists(t, edges, "Function:run", "Class:Product", "find")
+	if e.ORM != "elastic" {
+		t.Errorf("expected orm=elastic, got %q", e.ORM)
+	}
+}
+
+// MongoDB: the collection is the SECOND positional arg literal of Mongo.find.
+func TestDriver_ElixirMongoFind(t *testing.T) {
+	src := `defmodule Users do
+  def all(conn) do
+    Mongo.find(conn, "users", %{})
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/users.ex", src)
+	e := assertEdgeExists(t, edges, "Function:all", "Class:User", "find")
+	if e.ORM != "mongodb" {
+		t.Errorf("expected orm=mongodb, got %q", e.ORM)
+	}
+}
+
+// Bolt.Sips Neo4j: the primary Cypher node label → Class:<label>, op from the
+// leading clause (MATCH → find).
+func TestDriver_ElixirBoltSipsCypher(t *testing.T) {
+	src := `defmodule Graph do
+  def find_users(conn) do
+    Bolt.Sips.query!(conn, "MATCH (u:User) RETURN u")
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/graph.ex", src)
+	e := assertEdgeExists(t, edges, "Function:find_users", "Class:User", "find")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
+// Bolt.Sips CREATE: verb canonicalises to create.
+func TestDriver_ElixirBoltSipsCreate(t *testing.T) {
+	src := `defmodule Graph do
+  def add(conn) do
+    Bolt.Sips.query(conn, "CREATE (a:Person {name: $name}) RETURN a")
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/graph.ex", src)
+	e := assertEdgeExists(t, edges, "Function:add", "Class:Person", "create")
+	if e.ORM != "neo4j" {
+		t.Errorf("expected orm=neo4j, got %q", e.ORM)
+	}
+}
+
+// Non-vacuous negative: a dynamically-built CQL table name (interpolated) is
+// honest-skipped — extractSQLTable resolves no literal table, so no Cassandra
+// edge is emitted.
+func TestDriver_ElixirXandraDynamicTableSkipped(t *testing.T) {
+	src := `defmodule Dyn do
+  def list(conn, table) do
+    Xandra.execute!(conn, "SELECT * FROM " <> table)
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/dyn.ex", src)
+	for _, e := range edges {
+		if e.ORM == "cassandra" {
+			t.Errorf("expected no cassandra edge for dynamic table, got %+v", e)
+		}
+	}
+}
+
+// Non-vacuous negative: a dynamic DynamoDB table (a variable, not a literal) is
+// honest-skipped by both the first-arg matcher and emitDynamoTargets.
+func TestDriver_ElixirExAwsDynamoDynamicTableSkipped(t *testing.T) {
+	src := `defmodule Store do
+  def get(table, id) do
+    ExAws.Dynamo.get_item(table, %{"id" => id}) |> ExAws.request()
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/store.ex", src)
+	for _, e := range edges {
+		if e.ORM == "dynamodb" {
+			t.Errorf("expected no dynamodb edge for dynamic table, got %+v", e)
+		}
+	}
+}
+
+// Non-vacuous negative: an interpolated Cypher node label (#{var}) yields no
+// static label, so no neo4j QUERIES edge is emitted — honest-partial.
+func TestDriver_ElixirBoltSipsDynamicLabelSkipped(t *testing.T) {
+	src := `defmodule Graph do
+  def find_node(conn, label) do
+    Bolt.Sips.query!(conn, "MATCH (n) WHERE n.label = $label RETURN n")
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/graph.ex", src)
+	for _, e := range edges {
+		if e.ORM == "neo4j" {
+			t.Errorf("expected no neo4j edge for label-less MATCH, got %+v", e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the Tier-3 **ELIXIR query_attribution** slice of #4271. Elixir had no query-topology dispatch case; this is the foundation that unlocks all elixir QA cells, reusing the shared cross-language emitters.

### Foundation
- `orm_queries.go`: register `"elixir"` in `ormQueriesSupportsLanguage` + add the `case "elixir":` dispatch (`scanElixirDrivers` + `scanInfra`).
- New `elixirOrmFuncRe` (`def`/`defp` heads) wired into `indexEnclosingFunctions` so call sites attribute to their enclosing function (`Function:<name>`).

### Drivers (`scanElixirDrivers`) — all reuse the shared emitters, honest-skip dynamic/interpolated literals
| Driver | Idiom | Emitter |
|---|---|---|
| Cassandra (Xandra) | `Xandra.execute(conn, "SELECT ... FROM t")` | `elixirCqlRe` → `emitCQLTargets` |
| DynamoDB (ExAws) | `ExAws.Dynamo.get_item("Products", ..)` / `"TableName" => "X"` | `elixirDynamoFirstArgRe` + `emitDynamoTargets` |
| Elasticsearch | `index: "x"` / `.Index("x")` | `emitElasticTargets` |
| MongoDB | `Mongo.find(conn, "users", ..)` (2nd-arg literal) | `elixirMongoFindRe` |
| Neo4j (Bolt.Sips/Boltx) | `Bolt.Sips.query!(conn, "MATCH (u:User) ...")` | `elixirBoltCypherRe` + shared `cypherLabelRe`/`cypherVerbRe` |

The native Bolt.Sips schema / GRAPH_RELATES extractor (`internal/custom/elixir/neo4j.go`) is **unchanged**; the neo4j cell is deepened partial→full by the added QUERIES topology edge.

### Tests
8 value-asserting + 3 non-vacuous negatives, each asserting the exact QUERIES edge (`From=Function`, `To=Class:<target>`, op, orm). Dynamic-table / label-less-MATCH negatives prove no hallucination.

### Registry
Flips `lang.elixir.driver.{xandra,dynamodb,elastic,mongodb}` query_attribution `missing → full` and `lang.elixir.driver.neo4j` `partial → full`, with per-cell-accurate notes + test names.

### Side effect
The shared enclosing-function index also upgrades elixir feature-flag `GATED_BY` edges from `File:<path>` to `Function:<name>`; the stale `TestFeatureFlag_Elixir_FunWithFlags_atom_for_actor` assertion is updated to reflect the improved attribution.

Refs #4271. **DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)