### PR TITLE
engine: redis query_attribution (java spring-data-redis + elixir redix) (#4271 redis)

### DIFF
--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -248,7 +248,8 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 		scanInfra()
 	case "elixir":
 		// Driver-topology: Xandra CQL, ExAws DynamoDB TableName, Elasticsearch
-		// index, MongoDB collection (2nd-arg literal), and Bolt.Sips Cypher
+		// index, MongoDB collection (2nd-arg literal), Redix Redis key-value
+		// (keyspace-prefix attribution), and Bolt.Sips Cypher
 		// node-label attribution (#4271). The native Bolt.Sips schema/relationship
 		// extractor (internal/custom/elixir/neo4j.go) is unchanged; this pass adds
 		// the cross-language QUERIES topology edge.

--- a/internal/engine/orm_queries_drivers_other.go
+++ b/internal/engine/orm_queries_drivers_other.go
@@ -31,6 +31,9 @@
 //     Ruby   : client.search(index: 'products')
 //   - Cassandra (CQL FROM/INTO/UPDATE table — reuses extractSQLTable)
 //     any lang: session.execute("SELECT ... FROM events")
+//   - Redis (KEY-VALUE — attribute to the KEYSPACE prefix, not a table) (#4271)
+//     Java   : redisTemplate.opsForValue().get("user:42") / @RedisHash("people")
+//     Elixir : Redix.command(conn, ["HGET", "user:1", "name"])
 //
 // Resource names are singularised + capitalised via capitalisedSingular so
 // the edge target matches the same Class:<Model> shape the resolver keys on.
@@ -545,6 +548,62 @@ func mentionsJavaCassandra(src string) bool {
 	return strings.Contains(src, "com.datastax") || strings.Contains(src, "CqlSession")
 }
 
+// mentionsJavaRedis gates the Spring Data Redis key-value pass: the file must
+// reference the Spring Data Redis API (RedisTemplate / StringRedisTemplate /
+// the opsFor* accessors / the @RedisHash entity annotation / the package).
+func mentionsJavaRedis(src string) bool {
+	return strings.Contains(src, "org.springframework.data.redis") ||
+		strings.Contains(src, "RedisTemplate") ||
+		strings.Contains(src, "StringRedisTemplate") ||
+		strings.Contains(src, "@RedisHash") ||
+		strings.Contains(src, "opsForValue") ||
+		strings.Contains(src, "opsForHash") ||
+		strings.Contains(src, "opsForList") ||
+		strings.Contains(src, "opsForSet") ||
+		strings.Contains(src, "opsForZSet")
+}
+
+// javaRedisOpsKeyRe matches the Spring Data Redis RedisTemplate accessor calls
+// where the KEY is the first quoted string-literal argument:
+//
+//	redisTemplate.opsForValue().get("user:42")
+//	redisTemplate.opsForValue().set("user:42", value)
+//	redisTemplate.opsForHash().get("user:1", "name")     // key = "user:1"
+//	redisTemplate.opsForHash().put("session:abc", f, v)
+//	redisTemplate.opsForList().leftPush("queue:jobs", v)
+//	redisTemplate.delete("user:42")
+//
+// Group 1 = the accessor / command method (get/set/put/leftPush/delete/...),
+// group 2 = the key literal. The accessor method name is mapped to a Redis
+// command verb by javaRedisMethodToCommand before redisCommandOp runs.
+var javaRedisOpsKeyRe = regexp.MustCompile(
+	`\.(get|set|increment|decrement|getAndSet|getAndDelete|put|putIfAbsent|entries|delete|leftPush|rightPush|leftPop|rightPop|add|members|score|size|hasKey|expire|append)\s*\(\s*"((?:[^"\\]|\\.)*)"`,
+)
+
+// javaRedisHashAnnoRe matches the Spring Data Redis `@RedisHash("people")`
+// aggregate-root annotation. The quoted literal is the Redis keyspace the
+// entity maps to (its key prefix). Group 1 = keyspace literal.
+var javaRedisHashAnnoRe = regexp.MustCompile(
+	`@RedisHash\s*\(\s*(?:(?:value|timeToLive)\s*=\s*)?"([A-Za-z_][\w$.:-]*)"`,
+)
+
+// javaRedisMethodToCommand maps a Spring Data Redis ops-accessor METHOD name to
+// a Redis COMMAND verb so redisCommandOp can canonicalise the operation.
+func javaRedisMethodToCommand(method string) string {
+	switch method {
+	case "get", "getAndSet", "entries", "members", "score", "size", "hasKey":
+		return "GET"
+	case "set", "put", "putIfAbsent", "add", "leftPush", "rightPush", "append":
+		return "SET"
+	case "increment", "decrement", "expire":
+		return "INCR"
+	case "delete", "getAndDelete", "leftPop", "rightPop":
+		return "DEL"
+	default:
+		return ""
+	}
+}
+
 func scanJavaDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 	if mentionsJavaMongo(src) {
 		for _, m := range javaGetCollectionRe.FindAllStringSubmatchIndex(src, -1) {
@@ -579,6 +638,53 @@ func scanJavaDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 	scanJavaSpringDataCassandra(src, funcs, emit)
 	scanJavaSpringDataElastic(src, funcs, emit)
 	scanJavaSpringDataMongo(src, funcs, emit)
+	scanJavaSpringDataRedis(src, funcs, emit)
+}
+
+// scanJavaSpringDataRedis attributes Spring Data Redis key-value access sites to
+// the KEYSPACE they touch (Redis has no table/collection — see the keyspace
+// rule on emitRedisTargets):
+//
+//   - `redisTemplate.opsForValue().get("user:42")` / `.set(...)` / `opsForHash()
+//     .get("user:1", field)` / `redisTemplate.delete("user:42")` → Class:User
+//     (op from the command: get→find, set→create, delete→delete).
+//   - `@RedisHash("people")` aggregate-root entity → Class:People (the entity's
+//     keyspace prefix), attributed to the entity class.
+//
+// Dynamic keys — a bare variable, concatenation, or an interpolated literal —
+// are honest-skipped (only quoted static literals are captured AND
+// redisKeyspaceFromLiteral rejects interpolation markers). The op-accessor
+// method name is mapped to a Redis command verb so the operation is accurate.
+func scanJavaSpringDataRedis(src string, funcs []funcSpan, emit emitORMQueryFn) {
+	if !mentionsJavaRedis(src) {
+		return
+	}
+	// RedisTemplate opsFor* / delete key-literal access sites.
+	for _, m := range javaRedisOpsKeyRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		method := src[m[2]:m[3]]
+		key := src[m[4]:m[5]]
+		keyspace := redisKeyspaceFromLiteral(key)
+		if keyspace == "" {
+			continue // dynamic / non-identifier prefix → honest-skip.
+		}
+		caller := enclosingFuncAt(funcs, m[0])
+		emit(caller, keyspace, redisCommandOp(javaRedisMethodToCommand(method)), "", "redis", false)
+	}
+	// @RedisHash("people") aggregate-root entity → its keyspace.
+	for _, m := range javaRedisHashAnnoRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		keyspace := redisKeyspaceFromLiteral(src[m[2]:m[3]])
+		if keyspace == "" {
+			continue
+		}
+		caller := resolveJavaSpringTypeCaller(src, funcs, m[0], m[1])
+		emit(caller, keyspace, "find", "", "redis", false)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1002,6 +1108,30 @@ func mentionsElixirBolt(src string) bool {
 	return strings.Contains(src, "Bolt.Sips") || strings.Contains(src, "Boltx")
 }
 
+// mentionsElixirRedix gates the Redix key-value data-access pass. "redix" does
+// NOT contain "redis", so the substring is checked explicitly (#1489 lesson).
+func mentionsElixirRedix(src string) bool {
+	return strings.Contains(src, "Redix")
+}
+
+// elixirRedixCmdKeyRe matches a Redix data-access command list where the COMMAND
+// verb is the first list element and the KEY is the second:
+//
+//	Redix.command(conn, ["HGET", "user:1", "name"])
+//	Redix.command!(conn, ["GET", "session:abc"])
+//	Redix.command(conn, ["SET", "flag", "1"])
+//	Redix.noreply_command(conn, ["DEL", "user:42"])
+//
+// Group 1 = command verb, group 2 = key literal. PUBLISH/SUBSCRIBE commands are
+// pub/sub (handled by synthesizeElixirRedisPubSub), NOT data-access, so they are
+// excluded from the command alternation. Interpolated keys (`"user:#{id}"`) are
+// captured as a literal but rejected by redisKeyspaceFromLiteral's marker check,
+// and a bare-variable key (`[command, key]`) is not a quoted literal → both are
+// honest-skipped.
+var elixirRedixCmdKeyRe = regexp.MustCompile(
+	`Redix\.[a-z_]*command[a-z_!]*\s*\(\s*[^,\[]+,\s*\[\s*"((?i:GET|MGET|SET|SETEX|SETNX|MSET|GETSET|APPEND|INCR|INCRBY|DECR|DECRBY|HGET|HSET|HMGET|HMSET|HGETALL|HDEL|HINCRBY|HKEYS|HVALS|LPUSH|RPUSH|LPOP|RPOP|LRANGE|LLEN|LREM|SADD|SREM|SMEMBERS|SCARD|SISMEMBER|SPOP|ZADD|ZREM|ZRANGE|ZSCORE|EXPIRE|EXPIREAT|PERSIST|TTL|TYPE|EXISTS|DEL|UNLINK|GETDEL|RENAME))"\s*,\s*"((?:[^"\\]|\\.)*)"`,
+)
+
 func scanElixirDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 	// Cassandra (Xandra): CQL FROM/INTO/UPDATE table.
 	if mentionsElixirXandra(src) {
@@ -1064,6 +1194,13 @@ func scanElixirDrivers(src string, funcs []funcSpan, emit emitORMQueryFn) {
 			emit(caller, lm[1], op, "", "neo4j", false)
 		}
 	}
+	// Redis key-value (Redix): `Redix.command(conn, ["HGET", "user:1", ...])`
+	// data-access command → Class:<keyspace> (keyspace = key prefix before ':').
+	// PUBLISH/SUBSCRIBE are pub/sub (synthesizeElixirRedisPubSub), excluded here.
+	// Interpolated / variable keys are honest-skipped. orm=redis.
+	if mentionsElixirRedix(src) {
+		emitRedisTargets(src, funcs, emit, elixirRedixCmdKeyRe)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1081,6 +1218,127 @@ func emitDynamoTargets(src string, funcs []funcSpan, emit emitORMQueryFn) {
 		}
 		caller := enclosingFuncAt(funcs, m[0])
 		emit(caller, capitalisedSingular(src[m[2]:m[3]]), "find", "", "dynamodb", false)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redis key-value data-access attribution (KEYSPACE-PREFIX model) — #4271
+// ---------------------------------------------------------------------------
+//
+// Redis is a KEY-VALUE store: there is no table / collection / index, so the
+// QUERIES edge cannot attribute to one. Instead we attribute to the KEYSPACE
+// the command touches, derived from the command's KEY literal (the first
+// argument of HGET/HSET/GET/SET/HGETALL/LPUSH/SADD/ZADD/EXPIRE/DEL/...):
+//
+//	redisTemplate.opsForValue().get("user:42")  → key "user:42" → keyspace "user"
+//	Redix.command(conn, ["HGET", "session:abc"]) → key "session:abc" → "session"
+//	GET "flag"                                    → key "flag"     → keyspace "flag"
+//
+// Keyspace rule: take the substring BEFORE the first ':' if the key contains
+// one (the conventional Redis keyspace prefix, e.g. `user:42` → `user`); else
+// use the whole literal (`flag` → `flag`). The result is run through
+// capitalisedSingular so the edge target is the SAME `Class:<Model>` shape the
+// resolver keys on (`user` → Class:User, `people` → Class:People). The orm tag
+// is "redis".
+//
+// Conservative by construction (precision over recall): ONLY clear STATIC
+// string-literal keys are attributed. Fully-dynamic keys — string
+// interpolation (`#{var}` Elixir, `${var}`/template literals), concatenation
+// (`"user:" + id`), or a bare variable — are honest-skipped because the
+// matchers capture only quoted literals AND redisKeyspaceFromLiteral rejects a
+// literal that still contains an interpolation marker. There is no
+// FROM/INTO/UPDATE verb to parse, so the operation is mapped from the Redis
+// COMMAND verb (GET/HGET/... → find, SET/HSET/LPUSH/... → create/update,
+// DEL → delete) where the command is recoverable; opsFor* accessors that do
+// not name a command default to "find".
+
+// redisDynamicKeyMarkers are interpolation / concatenation markers that, when
+// present inside a captured "literal", mean the key is NOT fully static — we
+// honest-skip it rather than attribute a bogus keyspace.
+var redisDynamicKeyMarkers = []string{"#{", "${", "<%", "%>", "{{"}
+
+// redisKeyspaceFromLiteral derives the keyspace Class name from a Redis key
+// literal: the prefix before the first ':' if present, else the whole literal.
+// Returns "" for an empty key, a key that still contains an interpolation
+// marker (dynamic → honest-skip), or a key whose prefix is empty / non-alnum.
+func redisKeyspaceFromLiteral(key string) string {
+	if key == "" {
+		return ""
+	}
+	for _, mark := range redisDynamicKeyMarkers {
+		if strings.Contains(key, mark) {
+			return "" // dynamic / interpolated → honest-skip.
+		}
+	}
+	prefix := key
+	if i := strings.IndexByte(key, ':'); i >= 0 {
+		prefix = key[:i]
+	}
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return ""
+	}
+	// Belt-and-suspenders: the prefix must look like an identifier-ish keyspace
+	// (letters/digits/_/-/.) so an odd literal does not produce a junk target.
+	for _, r := range prefix {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '_', r == '-', r == '.':
+		default:
+			return ""
+		}
+	}
+	return capitalisedSingular(prefix)
+}
+
+// redisCommandOp maps a Redis data-access COMMAND verb to the canonical
+// operation. Read commands → find; mutating set/push/add commands → create;
+// in-place field/counter updates → update; deletes/expiry → delete. An
+// unrecognised / absent command defaults to "find" (the conservative read
+// assumption for an opsFor* accessor without a named command).
+func redisCommandOp(cmd string) string {
+	switch strings.ToUpper(cmd) {
+	case "GET", "MGET", "HGET", "HGETALL", "HMGET", "LRANGE", "SMEMBERS",
+		"ZRANGE", "ZRANGEBYSCORE", "EXISTS", "TYPE", "TTL", "GETRANGE",
+		"SCARD", "LLEN", "HKEYS", "HVALS", "SISMEMBER", "ZSCORE":
+		return "find"
+	case "SET", "SETEX", "SETNX", "MSET", "HSET", "HMSET", "HSETNX",
+		"LPUSH", "RPUSH", "SADD", "ZADD", "APPEND", "GETSET":
+		return "create"
+	case "INCR", "INCRBY", "DECR", "DECRBY", "HINCRBY", "EXPIRE", "EXPIREAT",
+		"PEXPIRE", "PERSIST", "RENAME":
+		return "update"
+	case "DEL", "UNLINK", "HDEL", "LREM", "SREM", "ZREM", "LPOP", "RPOP",
+		"SPOP", "GETDEL":
+		return "delete"
+	default:
+		return "find"
+	}
+}
+
+// emitRedisTargets is the shared, language-agnostic Redis key-value emitter.
+// For every (command, key-literal) pair matched by `cmdKeyRe` (which MUST set
+// submatch group 1 = command verb — may be empty — and group 2 = the quoted
+// key literal), it derives the keyspace Class via redisKeyspaceFromLiteral and
+// emits a `caller -> Class:<keyspace>` QUERIES edge with orm="redis" and the
+// command-derived operation. Dynamic keys (no quoted literal captured, or a
+// literal that still carries an interpolation marker) yield no edge.
+func emitRedisTargets(src string, funcs []funcSpan, emit emitORMQueryFn, cmdKeyRe *regexp.Regexp) {
+	for _, m := range cmdKeyRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		cmd := ""
+		if m[2] >= 0 && m[3] >= 0 {
+			cmd = src[m[2]:m[3]]
+		}
+		key := src[m[4]:m[5]]
+		keyspace := redisKeyspaceFromLiteral(key)
+		if keyspace == "" {
+			continue // empty / dynamic / non-identifier prefix → honest-skip.
+		}
+		caller := enclosingFuncAt(funcs, m[0])
+		emit(caller, keyspace, redisCommandOp(cmd), "", "redis", false)
 	}
 }
 

--- a/internal/engine/orm_queries_drivers_other_test.go
+++ b/internal/engine/orm_queries_drivers_other_test.go
@@ -1034,3 +1034,217 @@ end
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Redis — Java Spring Data Redis (key-value) + Elixir Redix (#4271)
+// ---------------------------------------------------------------------------
+//
+// Redis is a key-value store: the QUERIES edge attributes to the KEYSPACE the
+// command touches (the key prefix before the first ':', else the whole key),
+// run through capitalisedSingular → Class:<Keyspace>. orm="redis", op derived
+// from the Redis command verb. Dynamic / interpolated keys are honest-skipped.
+
+func TestDriver_JavaRedisOpsForValueGet(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisTemplate;
+public class UserCache {
+    private RedisTemplate<String, Object> redisTemplate;
+    public Object load(String id) {
+        return redisTemplate.opsForValue().get("user:42");
+    }
+}
+`
+	edges := detectORM(t, "java", "UserCache.java", src)
+	e := assertEdgeExists(t, edges, "Function:load", "Class:User", "find")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_JavaRedisOpsForValueSet(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisTemplate;
+public class SessionStore {
+    private RedisTemplate<String, Object> redisTemplate;
+    public void save(String tok) {
+        redisTemplate.opsForValue().set("session:abc", tok);
+    }
+}
+`
+	edges := detectORM(t, "java", "SessionStore.java", src)
+	e := assertEdgeExists(t, edges, "Function:save", "Class:Session", "create")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_JavaRedisOpsForHashGet(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisTemplate;
+public class ProfileCache {
+    private RedisTemplate<String, Object> redisTemplate;
+    public Object field(String id) {
+        return redisTemplate.opsForHash().get("user:1", "name");
+    }
+}
+`
+	edges := detectORM(t, "java", "ProfileCache.java", src)
+	e := assertEdgeExists(t, edges, "Function:field", "Class:User", "find")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_JavaRedisTemplateDelete(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisTemplate;
+public class CacheEvictor {
+    private RedisTemplate<String, Object> redisTemplate;
+    public void evict(String id) {
+        redisTemplate.delete("user:42");
+    }
+}
+`
+	edges := detectORM(t, "java", "CacheEvictor.java", src)
+	e := assertEdgeExists(t, edges, "Function:evict", "Class:User", "delete")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_JavaRedisHashEntity(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisHash;
+@RedisHash("people")
+public class Person {
+    @Id private String id;
+}
+`
+	edges := detectORM(t, "java", "Person.java", src)
+	e := assertEdgeExists(t, edges, "Function:Person", "Class:People", "find")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+// Non-vacuous negative: a dynamic key (a variable, not a quoted literal) is
+// honest-skipped — no redis QUERIES edge.
+func TestDriver_JavaRedisDynamicKeySkipped(t *testing.T) {
+	src := `import org.springframework.data.redis.core.RedisTemplate;
+public class UserCache {
+    private RedisTemplate<String, Object> redisTemplate;
+    public Object load(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+}
+`
+	edges := detectORM(t, "java", "UserCache.java", src)
+	for _, e := range edges {
+		if e.ORM == "redis" {
+			t.Errorf("expected no redis edge for dynamic key, got %+v", e)
+		}
+	}
+}
+
+func TestDriver_ElixirRedixHGet(t *testing.T) {
+	src := `defmodule UserCache do
+  def load(conn, id) do
+    Redix.command(conn, ["HGET", "user:1", "name"])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/user_cache.ex", src)
+	e := assertEdgeExists(t, edges, "Function:load", "Class:User", "find")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_ElixirRedixSet(t *testing.T) {
+	src := `defmodule SessionStore do
+  def save(conn, tok) do
+    Redix.command!(conn, ["SET", "session:abc", tok])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/session_store.ex", src)
+	e := assertEdgeExists(t, edges, "Function:save", "Class:Session", "create")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_ElixirRedixDel(t *testing.T) {
+	src := `defmodule CacheEvictor do
+  def evict(conn, id) do
+    Redix.noreply_command(conn, ["DEL", "user:42"])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/cache_evictor.ex", src)
+	e := assertEdgeExists(t, edges, "Function:evict", "Class:User", "delete")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+func TestDriver_ElixirRedixBareKey(t *testing.T) {
+	src := `defmodule FlagStore do
+  def get_flag(conn) do
+    Redix.command(conn, ["GET", "flag"])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/flag_store.ex", src)
+	e := assertEdgeExists(t, edges, "Function:get_flag", "Class:Flag", "find")
+	if e.ORM != "redis" {
+		t.Errorf("expected orm=redis, got %q", e.ORM)
+	}
+}
+
+// Non-vacuous negative: an interpolated key (`"user:#{id}"`) is captured as a
+// literal but rejected by redisKeyspaceFromLiteral's interpolation-marker
+// check — honest-skipped (no redis edge).
+func TestDriver_ElixirRedixInterpolatedKeySkipped(t *testing.T) {
+	src := `defmodule UserCache do
+  def load(conn, id) do
+    Redix.command(conn, ["HGET", "user:#{id}", "name"])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/user_cache.ex", src)
+	for _, e := range edges {
+		if e.ORM == "redis" {
+			t.Errorf("expected no redis edge for interpolated key, got %+v", e)
+		}
+	}
+}
+
+// Non-vacuous negative: a bare-variable key (not a quoted literal) yields no
+// redis edge.
+func TestDriver_ElixirRedixVariableKeySkipped(t *testing.T) {
+	src := `defmodule UserCache do
+  def load(conn, key) do
+    Redix.command(conn, ["GET", key])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/user_cache.ex", src)
+	for _, e := range edges {
+		if e.ORM == "redis" {
+			t.Errorf("expected no redis edge for variable key, got %+v", e)
+		}
+	}
+}
+
+// Guard: a Redix PUBLISH is pub/sub, NOT a data-access command — it must NOT
+// produce a redis QUERIES edge (the channel is handled by the pub/sub pass).
+func TestDriver_ElixirRedixPublishNotAttributed(t *testing.T) {
+	src := `defmodule Notifier do
+  def push(conn, msg) do
+    Redix.command(conn, ["PUBLISH", "events:user", msg])
+  end
+end
+`
+	edges := detectORM(t, "elixir", "lib/notifier.ex", src)
+	for _, e := range edges {
+		if e.ORM == "redis" {
+			t.Errorf("expected no redis QUERIES edge for PUBLISH, got %+v", e)
+		}
+	}
+}


### PR DESCRIPTION
Closes the **REDIS** Tier-4 slice of #4271 — the LAST serial-chain slice. **GREENFIELD**: no Redis query-attribution emitter existed before (only `redis_pubsub_edges.go`, which models pub/sub *channels*, not data access — left untouched).

## Design — keyspace-prefix attribution
Redis is a **key-value** store: no table / collection / index. The QUERIES edge attributes to the **keyspace** the command touches, derived from the command's **key literal**:

- keyspace = substring **before the first `:`** if present (`user:42` → `user`), else the whole key (`flag` → `flag`)
- run through `capitalisedSingular` → `Class:<Keyspace>` (the same target shape the resolver keys on: `user` → `Class:User`, `people` → `Class:People`)
- `orm="redis"`; operation derived from the Redis command verb (GET/HGET → find, SET/HSET/LPUSH → create, INCR/EXPIRE → update, DEL → delete)

Conservative (precision over recall): only clear **static quoted** keys. Interpolated (`#{}`/`${}`), concatenated, or bare-variable keys are **honest-skipped** (matchers capture only quoted literals AND `redisKeyspaceFromLiteral` rejects interpolation markers).

Shared `emitRedisTargets(src, funcs, emit, cmdKeyRe)` + `redisKeyspaceFromLiteral` + `redisCommandOp`.

## Drivers gated
- **Java spring-data-redis** (`scanJavaSpringDataRedis`): `redisTemplate.opsForValue().get("user:42")`, `opsForHash().get("user:1", field)`, `redisTemplate.delete(...)`, and `@RedisHash("people")` aggregate root → keyspace. query_attribution **missing → full**.
- **Elixir redix** (`emitRedisTargets` + `elixirRedixCmdKeyRe`): `Redix.command(conn, ["HGET", "user:1", ...])` — CMD = 1st list elem, key = 2nd. PUBLISH/SUBSCRIBE excluded (pub/sub). query_attribution **missing → full**.

## model_extraction — honest-missing
`@RedisHash` is recognised but emitted **only** as a QUERIES keyspace edge, not as a schema/model entity, so java spring-data-redis `model_extraction` is left **missing** with a note (same follow-up shape as the java elastic model_extraction gap).

## Tests — 13 value-asserting (exact From/To/op/orm)
Java: OpsForValueGet (load→Class:User find), OpsForValueSet (save→Class:Session create), OpsForHashGet (field→Class:User find), TemplateDelete (evict→Class:User delete), HashEntity (Person→Class:People). Elixir: HGet (load→Class:User find), Set (save→Class:Session create), Del (evict→Class:User delete), BareKey (→Class:Flag). Non-vacuous negatives: JavaRedisDynamicKeySkipped, ElixirRedixInterpolatedKeySkipped, ElixirRedixVariableKeySkipped, ElixirRedixPublishNotAttributed.

## Gates
`covtool fmt --check` canonical ✓ · `validate` ok ✓ · `go test ./internal/engine/` ✓ (no pub/sub or sibling scan*Drivers regression) · `gofmt -l` clean ✓ · `go vet` clean ✓.

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)