### PR TITLE
fix(mcp): kind_filter accepts short-form kind (DataAccess matches SCOPE.DataAccess) (#4287)

### DIFF
--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -198,14 +198,28 @@ func expandKindAlias(kind string) []string {
 // matchesKindFilter reports whether entity e matches kindFilter, respecting
 // alias expansion. An empty kindFilter always returns true (no filtering).
 //
+// Kinds are namespaced with a leading "SCOPE." segment per ADR-0003 (e.g.
+// "SCOPE.DataAccess"). #4287: a filter may be supplied either fully-qualified
+// ("SCOPE.DataAccess") or as the short leaf form ("DataAccess"). To support the
+// natural short form, both the entity kind and the filter are compared with the
+// "SCOPE." namespace prefix stripped, in addition to the literal comparison.
+// This keeps fully-qualified filters working while letting the leaf match.
+//
 // Use this instead of strings.EqualFold(e.Kind, kindFilter) everywhere a kind
 // filter is applied to graph entities.
 func matchesKindFilter(e *graph.Entity, kindFilter string) bool {
 	if kindFilter == "" {
 		return true
 	}
+	entityLeaf := stripScopePrefix(e.Kind)
 	for _, k := range expandKindAlias(kindFilter) {
+		// Literal / fully-qualified comparison (e.g. "SCOPE.DataAccess").
 		if strings.EqualFold(e.Kind, k) {
+			return true
+		}
+		// Leaf comparison: a short-form filter ("DataAccess") matches a
+		// namespaced entity kind ("SCOPE.DataAccess"), and vice versa.
+		if strings.EqualFold(entityLeaf, stripScopePrefix(k)) {
 			return true
 		}
 	}

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -228,6 +228,31 @@ func TestMatchesKindFilter_NonHTTPKindNotAffected(t *testing.T) {
 	}
 }
 
+// #4287: a short-form (unprefixed leaf) kind_filter must match a namespaced
+// SCOPE.* entity kind, while the fully-qualified form keeps working.
+func TestMatchesKindFilter_ShortFormMatchesScopeNamespaced(t *testing.T) {
+	e := &graph.Entity{Kind: "SCOPE.DataAccess"}
+	if !matchesKindFilter(e, "DataAccess") {
+		t.Error("short-form filter DataAccess should match SCOPE.DataAccess entity (#4287)")
+	}
+	if !matchesKindFilter(e, "SCOPE.DataAccess") {
+		t.Error("fully-qualified filter SCOPE.DataAccess should still match SCOPE.DataAccess entity")
+	}
+	// Leaf match is symmetric: a SCOPE.-prefixed filter should match an
+	// unprefixed entity kind too.
+	bare := &graph.Entity{Kind: "DataAccess"}
+	if !matchesKindFilter(bare, "SCOPE.DataAccess") {
+		t.Error("SCOPE.DataAccess filter should match unprefixed DataAccess entity")
+	}
+	// Unrelated leaf must not collide.
+	if matchesKindFilter(e, "Function") {
+		t.Error("SCOPE.DataAccess entity should not match Function filter")
+	}
+	if matchesKindFilter(e, "SCOPE.Function") {
+		t.Error("SCOPE.DataAccess entity should not match SCOPE.Function filter")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // #2314: classifyEndpointKind tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4287

## Problem
`search_entities(..., kind_filter="DataAccess")` returned 0 results because the actual entity kind is namespaced as `SCOPE.DataAccess` (ADR-0003). `matchesKindFilter` only did a literal `EqualFold(e.Kind, filter)`, so the natural short-form filter never matched the `SCOPE.`-prefixed kind.

## Matching rule
In `matchesKindFilter` (`internal/mcp/endpoint_tools.go`), for each alias-expanded filter value, compare in two ways:
1. Literal / fully-qualified: `EqualFold(e.Kind, k)` — unchanged, keeps `kind_filter="SCOPE.DataAccess"` working.
2. Leaf: `EqualFold(stripScopePrefix(e.Kind), stripScopePrefix(k))` — strips the known `SCOPE.` namespace segment from both sides so `kind_filter="DataAccess"` matches `SCOPE.DataAccess` (and vice versa).

Only the single known `SCOPE.` namespace prefix is stripped (via the existing `stripScopePrefix` helper), so unrelated leaves don't collide. Matching remains case-insensitive, matching the existing convention.

## Tests
Added `TestMatchesKindFilter_ShortFormMatchesScopeNamespaced` asserting:
- `DataAccess` matches `SCOPE.DataAccess`
- `SCOPE.DataAccess` (fully-qualified) still matches
- `SCOPE.DataAccess` filter matches an unprefixed `DataAccess` entity (symmetry)
- `Function` / `SCOPE.Function` do NOT match a `SCOPE.DataAccess` entity (no collision)

## Gates
- `go test ./internal/mcp/ -run 'Search|Kind|search' -count=1` — pass
- `go build ./...` — clean
- `go vet ./internal/mcp/` + `gofmt -l` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)