### PR TITLE
fix(mcp): find honors explicit group when cwd is outside the group (#4286)

### DIFF
--- a/internal/mcp/find_explicit_group_4286_test.go
+++ b/internal/mcp/find_explicit_group_4286_test.go
@@ -1,0 +1,119 @@
+// find_explicit_group_4286_test.go — tests for #4286: archigraph_find honors an
+// explicit `group=` even when the caller's cwd is inside a repo of a DIFFERENT
+// group. Before the fix, find pinned the cwd-resolved repo slug as a repo_filter
+// regardless of which group it belonged to; since that slug does not exist in
+// the explicitly-requested group's loaded repo set, reposToConsider returned
+// zero repos and find emitted "# no repos loaded for this group" — while the
+// other group-scoped tools (search_entities, etc.) served the same group fine.
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// newTestServerTwoGroups builds a Server whose registry+state contain two
+// distinct groups, each with one repo backed by a real on-disk path (t.TempDir)
+// so cwd resolution can match group A's repo path. Returns the server and the
+// on-disk path of group A's repo (to be used as cwd).
+func newTestServerTwoGroups(t *testing.T, groupA, repoA string, docA *graph.Document, groupB, repoB string, docB *graph.Document) (*Server, string) {
+	t.Helper()
+
+	pathA := t.TempDir()
+	pathB := t.TempDir()
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		groupA: {Repos: map[string]RegistryRepo{repoA: {Path: pathA}}},
+		groupB: {Repos: map[string]RegistryRepo{repoB: {Path: pathB}}},
+	}}
+
+	st := NewState(reg)
+	st.mu.Lock()
+	lgA := &LoadedGroup{Name: groupA, Repos: map[string]*LoadedRepo{
+		repoA: {Repo: repoA, Doc: docA, LabelIndex: BuildLabelIndex(docA), BM25: BuildBM25(docA)},
+	}}
+	lgB := &LoadedGroup{Name: groupB, Repos: map[string]*LoadedRepo{
+		repoB: {Repo: repoB, Doc: docB, LabelIndex: BuildLabelIndex(docB), BM25: BuildBM25(docB)},
+	}}
+	st.groups[groupA] = lgA
+	st.groups[groupB] = lgB
+	st.mu.Unlock()
+
+	return &Server{State: st, Tel: NewTelemetry(0)}, pathA
+}
+
+// TestFind_ExplicitGroupFromOutsideCwd reproduces #4286: cwd is inside group A's
+// repo, but the request passes group=B (and leaves cross_repo unset). find must
+// resolve group B and search its repos rather than bailing with "no repos
+// loaded for this group".
+func TestFind_ExplicitGroupFromOutsideCwd(t *testing.T) {
+	docA := &graph.Document{
+		Repo: "repoA",
+		Entities: []graph.Entity{
+			{ID: "fn_a", Name: "alphaWidgetBuilder", Kind: "SCOPE.Function", SourceFile: "a/alpha.go", StartLine: 3},
+		},
+	}
+	docB := &graph.Document{
+		Repo: "repoB",
+		Entities: []graph.Entity{
+			{ID: "fn_b", Name: "betaWidgetBuilder", Kind: "SCOPE.Function", SourceFile: "b/beta.go", StartLine: 9},
+		},
+	}
+
+	srv, cwdInA := newTestServerTwoGroups(t, "groupA", "repoA", docA, "groupB", "repoB", docB)
+
+	// cwd is inside groupA's repo, but we explicitly ask for groupB. cross_repo
+	// is intentionally left unset — that is the broken path.
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":     "groupB",
+		"query":     "widget builder beta",
+		"cwd":       cwdInA,
+		"full":      true,
+		"min_score": 0.0,
+	})
+
+	if strings.Contains(res, "no repos loaded") {
+		t.Fatalf("#4286 regression: explicit group=groupB from a cwd inside groupA returned 'no repos loaded'; got:\n%s", res)
+	}
+	if !strings.Contains(res, "betaWidgetBuilder") {
+		t.Errorf("expected groupB entity betaWidgetBuilder in results; got:\n%s", res)
+	}
+	// groupA's entity must NOT appear — we searched groupB only.
+	if strings.Contains(res, "alphaWidgetBuilder") {
+		t.Errorf("group isolation broken: groupA entity leaked into groupB find; got:\n%s", res)
+	}
+}
+
+// TestFind_ExplicitGroupMatchingCwdStillScopesToRepo guards the preserved
+// behavior: when the explicit group MATCHES the cwd's group, find still pins to
+// the cwd-resolved repo (the #2643 default), not all repos.
+func TestFind_ExplicitGroupMatchingCwdStillScopesToRepo(t *testing.T) {
+	docA := &graph.Document{
+		Repo: "repoA",
+		Entities: []graph.Entity{
+			{ID: "fn_a", Name: "alphaWidgetBuilder", Kind: "SCOPE.Function", SourceFile: "a/alpha.go", StartLine: 3},
+		},
+	}
+	docB := &graph.Document{
+		Repo: "repoB",
+		Entities: []graph.Entity{
+			{ID: "fn_b", Name: "betaWidgetBuilder", Kind: "SCOPE.Function", SourceFile: "b/beta.go", StartLine: 9},
+		},
+	}
+
+	srv, cwdInA := newTestServerTwoGroups(t, "groupA", "repoA", docA, "groupB", "repoB", docB)
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":     "groupA",
+		"query":     "widget builder alpha",
+		"cwd":       cwdInA,
+		"full":      true,
+		"min_score": 0.0,
+	})
+
+	if !strings.Contains(res, "alphaWidgetBuilder") {
+		t.Errorf("expected groupA entity alphaWidgetBuilder; got:\n%s", res)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -568,7 +568,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	}
 	var err error
 	_ = err // retained for symmetry with other handlers
-	_, lg, errRes := s.resolveAndGroup(req)
+	resolvedGroup, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -605,15 +605,28 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	// Priority order:
 	//   1. repo_filter set explicitly → use it (existing behaviour).
 	//   2. cross_repo=true           → search all repos (new opt-in).
-	//   3. neither, cwd resolves     → filter to the cwd-resolved repo.
-	//   4. neither, cwd unresolved   → search all repos (graceful fallback).
+	//   3. neither, cwd resolves to THIS group → filter to the cwd-resolved repo.
+	//   4. neither, cwd unresolved / other group → search all repos in the
+	//      resolved group (graceful fallback).
+	//
+	// #4286: the cwd-repo default must only apply when the cwd actually resolves
+	// to the group we're serving. resolveAndGroup honors an explicit `group=`
+	// param, so the served group can differ from the cwd's group (e.g. caller is
+	// inside repo of group A but passes group=B). In that case ResolveCWD returns
+	// a RepoSlug from group A that does NOT exist in group B's loaded repo set,
+	// so reposToConsider yields zero repos → "no repos loaded for this group".
+	// The other group-scoped tools (search_entities, neighbors, stats, …) never
+	// pin to a cwd repo, so they serve an explicit group correctly. We align find
+	// with them: skip the cwd-repo default unless the cwd's group matches the
+	// served group.
 	if len(repoFilter) == 0 && !crossRepo {
 		cwd := s.inferCWD(req)
 		cwdRes := ResolveCWD(s.State, cwd)
-		if cwdRes.RepoSlug != "" {
+		if cwdRes.RepoSlug != "" && cwdRes.Group == resolvedGroup {
 			repoFilter = []string{cwdRes.RepoSlug}
 		}
-		// If cwd doesn't resolve, repoFilter stays nil → reposToConsider returns all.
+		// If cwd doesn't resolve, or resolves to a different group, repoFilter
+		// stays nil → reposToConsider returns all repos in the served group.
 	}
 
 	repos := reposToConsider(lg, repoFilter)


### PR DESCRIPTION
Closes #4286

## Root cause
`handleQueryGraph` (the `archigraph_find` / BM25 tool) applies a #2643 cwd-default: when no `repo_filter` and `cross_repo` are set, it pins the cwd-resolved `RepoSlug` as a `repo_filter`. `ResolveCWD` resolves purely from cwd and has no awareness of an explicit `group=` param.

When a caller passes `group=B` from a cwd inside a repo of group A, the pinned slug belongs to group A and does **not** exist in group B's loaded repo set. `reposToConsider` then returns zero repos and `find` emits `# no repos loaded for this group`. Passing `cross_repo=true` skipped the block entirely, which is why that path returned results.

The other group-scoped tools (`search_entities`, `neighbors`, `stats`, `inspect`, `effective_contract`, `endpoints`) never pin to a cwd repo — they call `reposToConsider(lg, repo_filter)` directly — so they serve an explicit group correctly. `find` was the divergent path.

## Fix
Only apply the cwd-repo default when the cwd's resolved group **matches** the served group (`resolvedGroup`, now captured from `resolveAndGroup`). When the explicit group differs from the cwd's group (or cwd is unresolved), `repo_filter` stays nil and `reposToConsider` returns all repos in the served group — aligning `find` with `search_entities`. Behavior when cwd resolves to the served group is unchanged (still scopes to the cwd repo, #2643 preserved). No need to pass `cross_repo=true` to make an explicit group work.

## Tests
`find_explicit_group_4286_test.go`:
- `TestFind_ExplicitGroupFromOutsideCwd` — cwd inside group A + `group=B`, `cross_repo` unset: asserts no "no repos loaded" sentinel and group B's entity returns (verified to fail against pre-fix code with the exact sentinel).
- `TestFind_ExplicitGroupMatchingCwdStillScopesToRepo` — guards preserved cwd-scoping when explicit group matches cwd group.

Gates: `go build ./...` clean, `go vet ./internal/mcp/` clean, `gofmt -l` clean on touched files, `go test ./internal/mcp/ -run 'Find|find'` passes.

DEPLOY-DEFERRED: ships next daemon deploy window; live daemon not restarted/reindexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)