### PR TITLE
fix(mcp): neighbors surfaces semantic edges (JOINS_COLLECTION etc.) consistent with inspect (#4288)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -317,7 +317,13 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 				// both id and name so the signal reaches the agent. Without
 				// this, find_callers returns N-1 callers for any model whose
 				// admin.py / __init__.py source isn't an indexed entity.
-				if !isFileRefEdge {
+				//
+				// #4288: extend the same synthetic-fallback to projected semantic
+				// predecessors whose far side is unresolved (symmetric with the
+				// callees-side JOINS_COLLECTION fix). inspect's semantic_edges emits
+				// these regardless of resolution; neighbors must not silently drop
+				// them.
+				if !isFileRefEdge && !isSemanticEdgeKind(dk) {
 					continue
 				}
 				name := id
@@ -631,6 +637,33 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 				e = mroExternal[id]
 			}
 			if e == nil {
+				// #4288: a semantic out-edge (JOINS_COLLECTION, GRAPH_RELATES,
+				// DEPENDS_ON_SERVICE, …) may point at a far-side id that has no
+				// backing indexed entity — the real upvate-core case is a
+				// DataAccess node JOINS_COLLECTION-ing a class id (Class:Inspection)
+				// that was never stamped as an Entity. inspect's semantic_edges
+				// section emits that edge regardless of target resolution; neighbors
+				// previously DROPPED it here, producing the inspect-vs-neighbors gap.
+				// Emit a synthetic callee using the id as both id and name so the
+				// semantic neighbour surfaces with its edge_kind, exactly like the
+				// callers-side file-ref synthetic fallback (#2015). Pure-structural
+				// or CALLS targets that fail to resolve are NOT fabricated — only
+				// the projected semantic kinds, to avoid leaking dangling refs.
+				dk := discoveredVia[id]
+				if !isSemanticEdgeKind(dk) {
+					continue
+				}
+				name := id
+				if i := strings.LastIndexByte(name, '/'); i >= 0 {
+					name = name[i+1:]
+				}
+				callees = append(callees, callee{
+					EntityID: prefixedID(r.Repo, id),
+					Name:     name,
+					HopCount: d,
+					EdgeKind: dk,
+					isTest:   isTestFileMCP(id),
+				})
 				continue
 			}
 			c := callee{

--- a/internal/mcp/neighbors_semantic_unresolved_4288_test.go
+++ b/internal/mcp/neighbors_semantic_unresolved_4288_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+// neighbors_semantic_unresolved_4288_test.go — #4288: archigraph_neighbors must
+// surface semantic edges (JOINS_COLLECTION etc.) that inspect's semantic_edges
+// section already shows, INCLUDING when the far-side target is not a backing
+// indexed entity (the real upvate-core case: a DataAccess node JOINS_COLLECTION
+// upvate-core::Class:Inspection where Class:Inspection has no Entity record).
+//
+// Pre-fix neighbors(out)/find_callees silently dropped any out-edge whose
+// ToID did not resolve in byID — so the JOINS_COLLECTION neighbour vanished
+// while inspect still listed it. This mirrors the asymmetry #4242 fixed for the
+// inbound side, but the bug here is the unresolved-target drop on the out side.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeJoinsCollectionUnresolvedDoc models the upvate case: a DataAccess node
+// with an outbound JOINS_COLLECTION edge to a class id that is NOT an indexed
+// entity (no Entity record for "Class:Inspection").
+func makeJoinsCollectionUnresolvedDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "api",
+		Entities: []graph.Entity{
+			{ID: "da", Name: "InspectionDataAccess", Kind: "SCOPE.DataAccess", SourceFile: "da.ts", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			// far side "Class:Inspection" has no Entity record (unresolved).
+			{ID: "j1", FromID: "da", ToID: "Class:Inspection", Kind: "JOINS_COLLECTION", Properties: map[string]string{"line": "9"}},
+		},
+	}
+}
+
+// TestNeighbors_4288_SurfacesUnresolvedJoinsCollection asserts neighbors(both)
+// surfaces the JOINS_COLLECTION edge with edge_kind=JOINS_COLLECTION even though
+// the target is not a backing indexed entity.
+func TestNeighbors_4288_SurfacesUnresolvedJoinsCollection(t *testing.T) {
+	srv := newTestServer(t, makeJoinsCollectionUnresolvedDoc())
+	out := callNeighbors3834(t, srv, "da", "out")
+	raw, _ := out["callees"].([]any)
+	var got map[string]any
+	for _, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["edge_kind"] == "JOINS_COLLECTION" {
+			got = m
+		}
+	}
+	if got == nil {
+		t.Fatalf("neighbors(out) did not surface JOINS_COLLECTION edge; callees=%v", raw)
+	}
+	if got["id"] != "api::Class:Inspection" {
+		t.Errorf("JOINS_COLLECTION neighbour id = %v, want api::Class:Inspection", got["id"])
+	}
+}
+
+// TestNeighbors_4288_ResolvedSemanticTargetStillSurfaces guards the common case
+// where the semantic-edge target IS an indexed entity — it must continue to
+// surface with its semantic edge_kind.
+func TestNeighbors_4288_ResolvedSemanticTargetStillSurfaces(t *testing.T) {
+	srv := newTestServer(t, makeSemanticEdgeDoc())
+	out := callNeighbors3834(t, srv, "model", "out")
+	raw, _ := out["callees"].([]any)
+	var got map[string]any
+	for _, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["id"] == "api::orders" {
+			got = m
+		}
+	}
+	if got == nil {
+		t.Fatalf("neighbors(out) did not surface JOINS_COLLECTION neighbour orders; callees=%v", raw)
+	}
+	if got["edge_kind"] != "JOINS_COLLECTION" {
+		t.Errorf("edge_kind = %v, want JOINS_COLLECTION", got["edge_kind"])
+	}
+}


### PR DESCRIPTION
Closes #4288

## Root cause
`inspect().semantic_edges` emits every projected semantic edge (JOINS_COLLECTION, GRAPH_RELATES, DEPENDS_ON_SERVICE, THROWS/CATCHES, DATA_FLOWS_TO, …) regardless of whether the far-side target resolves to a backing indexed entity. `neighbors` (find_callees / find_callers) walked all adjacency edges but **dropped any edge whose far-side id did not resolve in `byID`**. The real upvate-core case: DataAccess node `upvate-core::37a62b82500fcaa4` has an outbound `JOINS_COLLECTION` to `upvate-core::Class:Inspection`, but `Class:Inspection` was never stamped as an Entity — so inspect listed the edge while `neighbors(both)` returned empty. (Resolved-target semantic edges already surfaced with `edge_kind` via #4242; the gap was purely the unresolved-target drop.)

## neighbors fix
For an edge whose far-side id does not resolve to an indexed entity, emit a synthetic neighbour (id used as both `id` and `name`) **when the discovering edge is a projected semantic kind** (`isSemanticEdgeKind`), labeled with its `edge_kind` — symmetric on both directions and mirroring the existing callers-side file-ref synthetic fallback (#2015). Non-semantic / unresolved CALLS targets are still not fabricated, so no dangling-ref leak. Resolved-target semantic edges are unchanged (still surface with `edge_kind` per #4242).

## data_flows — deferred (follow-up #4299)
`handleDataFlows` reads the dedicated request-input→sink **taint sidecar** (#3867), not the live graph's JOINS_COLLECTION edges. `data_flows(sink_kind=db)` returning 0 despite a JOINS_COLLECTION edge is therefore a separate sidecar-producer concern (indexer side, needs an index run to validate). Scoped out of this MCP read-tool fix and filed as **#4299**.

## Tests
- New `neighbors_semantic_unresolved_4288_test.go`: asserts `neighbors(out)` on a node with an **unresolved-target** JOINS_COLLECTION surfaces it with `edge_kind=JOINS_COLLECTION`; plus a guard that resolved-target semantic edges keep surfacing.
- Gates: `go test ./internal/mcp/ -run 'Neighbor|Semantic|Inspect|DataFlow' -count=1` passes; `go build ./...`, `go vet`, `gofmt -l` clean on touched files.

DEPLOY-DEFERRED (no live daemon ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)