### PR TITLE
feat(bench): token-economy benchmark — graph-scoped vs raw file-read token cost (#4293)

### DIFF
--- a/cmd/bench-tokens/main.go
+++ b/cmd/bench-tokens/main.go
@@ -1,0 +1,179 @@
+// cmd/bench-tokens is a user-facing token-economy benchmark (#4293).
+//
+// For each seed question it builds the minimal subgraph that answers the
+// question (reusing the in-process MCP server's archigraph_find handler, which
+// runs the same ranked-BFS subgraph extraction the live tools use) and
+// estimates its token cost. It then estimates the token cost of the naive
+// "just read the relevant files" baseline — reading every distinct source file
+// touched by the matched entities — and emits a markdown table comparing the
+// two, per question plus an aggregate ratio.
+//
+// The token estimator is char/4, the same approximation used throughout the
+// codebase (internal/mcp/render.go estimateTokens, the daemon's
+// payload_token_estimate, and internal/docgen). Reusing it keeps this
+// benchmark's numbers comparable to the cost the MCP layer actually reports.
+//
+// Usage:
+//
+//	go run ./cmd/bench-tokens -group upvate
+//	go run ./cmd/bench-tokens -group upvate -questions seeds.txt -out docs/benches/tokens.md
+//
+// -questions, when given, is a newline-delimited file of seed questions (blank
+// lines and #-comments ignored). Otherwise a small built-in seed set is used.
+//
+// This command talks to the live registry/graph and is therefore
+// deploy-deferred: it is exercised manually, not in CI. The token-comparison
+// math it relies on lives in pure helpers (see token_economy.go) and is
+// unit-tested.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+func main() {
+	group := flag.String("group", "upvate", "group name to bench against")
+	questionsPath := flag.String("questions", "", "path to a newline-delimited seed-questions file (default: built-in seed set)")
+	depth := flag.Int("depth", 3, "subgraph depth passed to archigraph_find")
+	tokenBudget := flag.Int("token-budget", 1200, "token_budget passed to archigraph_find (graph-scoped payload cap)")
+	out := flag.String("out", "", "output markdown path (default: stdout)")
+	flag.Parse()
+
+	questions, err := loadQuestions(*questionsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load questions:", err)
+		os.Exit(1)
+	}
+
+	srv, err := mcp.NewServer(mcp.Config{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "boot mcp server:", err)
+		os.Exit(1)
+	}
+
+	rows := make([]questionCost, 0, len(questions))
+	for _, q := range questions {
+		row := measureQuestion(srv, *group, q, *depth, *tokenBudget)
+		rows = append(rows, row)
+		fmt.Fprintf(os.Stderr, "%-50s graph=%6d file-read=%7d ratio=%5.2fx\n",
+			truncate(q, 50), row.GraphTokens, row.FileReadTokens, savingsRatio(row.GraphTokens, row.FileReadTokens))
+	}
+
+	md := renderMarkdown(*group, rows)
+	if *out != "" {
+		if err := os.WriteFile(*out, []byte(md), 0644); err != nil {
+			fmt.Fprintln(os.Stderr, "write:", err)
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "wrote", *out)
+		return
+	}
+	fmt.Print(md)
+}
+
+// defaultQuestions is the built-in seed set: a few worked examples that cover
+// distinct query shapes (locate, neighbourhood, flow).
+var defaultQuestions = []string{
+	"where is authentication middleware defined",
+	"how does the order service place an order",
+	"what validates an incoming contract proposal",
+}
+
+// loadQuestions reads the seed set from path, or returns the built-in default
+// when path is empty. Blank lines and #-prefixed comments are skipped.
+func loadQuestions(path string) ([]string, error) {
+	if path == "" {
+		return defaultQuestions, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var qs []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		qs = append(qs, line)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(qs) == 0 {
+		return nil, fmt.Errorf("%s contained no questions", path)
+	}
+	return qs, nil
+}
+
+// measureQuestion runs archigraph_find for one seed question (the graph-scoped
+// answer), then computes the naive file-read baseline from the matched
+// entities' distinct source files. It reuses the live find handler so the
+// graph-scoped payload is byte-identical to what the MCP tool would return.
+func measureQuestion(srv *mcp.Server, group, question string, depth, tokenBudget int) questionCost {
+	row := questionCost{Question: question}
+
+	tool := srv.MCP.GetTool("archigraph_find")
+	if tool == nil {
+		row.Note = "archigraph_find not registered"
+		return row
+	}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = "archigraph_find"
+	req.Params.Arguments = map[string]any{
+		"question":     question,
+		"group":        group,
+		"depth":        float64(depth),
+		"token_budget": float64(tokenBudget),
+	}
+
+	res, err := tool.Handler(context.Background(), req)
+	if err != nil {
+		row.Note = "find error: " + err.Error()
+		return row
+	}
+	payload := resultText(res)
+	row.GraphTokens = estimateTokens(payload)
+
+	// Naive baseline: an agent without the graph reads the source files that
+	// contain the answer. We approximate "the answer" by the files of the
+	// entities the graph surfaced, deduplicated, and read in full.
+	files := extractSourceFiles(payload)
+	row.FileCount = len(files)
+	row.FileReadTokens = fileReadTokens(files)
+	return row
+}
+
+// resultText concatenates the text content of an MCP tool result.
+func resultText(res *mcpapi.CallToolResult) string {
+	if res == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}

--- a/cmd/bench-tokens/token_economy.go
+++ b/cmd/bench-tokens/token_economy.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// questionCost is the per-question token accounting produced by the benchmark.
+type questionCost struct {
+	Question string
+	// GraphTokens is the estimated token cost of the graph-scoped answer (the
+	// archigraph_find payload — the minimal subgraph that answers the question).
+	GraphTokens int
+	// FileReadTokens is the estimated token cost of the naive baseline: reading
+	// every distinct source file the answer touches, in full.
+	FileReadTokens int
+	// FileCount is the number of distinct files the naive baseline would read.
+	FileCount int
+	// Note carries a per-row diagnostic (e.g. an error or "no matches").
+	Note string
+}
+
+// estimateTokens approximates token count as len/4. This mirrors the char/4
+// estimator used across the codebase (internal/mcp/render.go,
+// internal/docgen, and the daemon's payload_token_estimate), so the numbers
+// here line up with the cost the MCP layer actually reports.
+func estimateTokens(s string) int { return len(s) / 4 }
+
+// savingsRatio is file-read-tokens / graph-tokens: how many times more
+// expensive the naive file-read baseline is than the graph-scoped answer.
+// Larger is better (the graph saves more). Returns 0 when graph tokens is 0.
+func savingsRatio(graphTokens, fileReadTokens int) float64 {
+	if graphTokens <= 0 {
+		return 0
+	}
+	return float64(fileReadTokens) / float64(graphTokens)
+}
+
+// aggregateRatio is the corpus-level ratio: the sum of file-read tokens over
+// the sum of graph tokens across all rows. Rows with a zero graph cost (errors
+// / no matches) are skipped so they don't distort the aggregate. Returns 0
+// when nothing measurable contributed.
+func aggregateRatio(rows []questionCost) float64 {
+	var graph, fileRead int
+	for _, r := range rows {
+		if r.GraphTokens <= 0 {
+			continue
+		}
+		graph += r.GraphTokens
+		fileRead += r.FileReadTokens
+	}
+	if graph == 0 {
+		return 0
+	}
+	return float64(fileRead) / float64(graph)
+}
+
+// sourceLocRe matches a "path:line" location token in the compact find output,
+// e.g. "internal/mcp/render.go:52". The path may contain slashes, dots, dashes
+// and underscores; the trailing :<line> anchors it to a real source location.
+var sourceLocRe = regexp.MustCompile(`([A-Za-z0-9_./-]+\.[A-Za-z0-9]+):[0-9]+`)
+
+// extractSourceFiles returns the distinct, sorted set of source file paths
+// referenced by a compact find payload. Each ranked hit renders as
+// "<label>  <file>:<line>", so the file is recoverable from the location
+// token without a second graph round-trip.
+func extractSourceFiles(payload string) []string {
+	set := map[string]bool{}
+	for _, m := range sourceLocRe.FindAllStringSubmatch(payload, -1) {
+		set[m[1]] = true
+	}
+	files := make([]string, 0, len(set))
+	for f := range set {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	return files
+}
+
+// fileReadTokens estimates the token cost of reading every given file in full.
+// Files that cannot be read (path is repo-relative and we are outside the
+// repo, or the file is gone) contribute the perFileFallbackTokens estimate so
+// the baseline is never silently understated.
+func fileReadTokens(files []string) int {
+	total := 0
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			total += perFileFallbackTokens
+			continue
+		}
+		total += estimateTokens(string(b))
+	}
+	return total
+}
+
+// perFileFallbackTokens is the assumed cost of a source file we could not read
+// (~300 lines * ~10 tokens/line). Conservative: it keeps the file-read
+// baseline from collapsing to zero when run outside the indexed repo.
+const perFileFallbackTokens = 3000
+
+// renderMarkdown produces the user-facing report: a per-question table of
+// graph-scoped vs file-read tokens with each row's savings ratio, followed by
+// the aggregate ratio across the corpus.
+func renderMarkdown(group string, rows []questionCost) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Token-economy benchmark — %s\n\n", group)
+	b.WriteString("Graph-scoped answer (minimal subgraph via `archigraph_find`) vs the naive ")
+	b.WriteString("\"read the relevant files\" baseline. Tokens estimated at char/4. ")
+	b.WriteString("Ratio = file-read tokens ÷ graph tokens (higher = more saved by the graph).\n\n")
+
+	b.WriteString("| # | Question | Graph tokens | File-read tokens | Files | Ratio |\n")
+	b.WriteString("|---|----------|-------------:|-----------------:|------:|------:|\n")
+	for i, r := range rows {
+		q := r.Question
+		if r.Note != "" {
+			q = fmt.Sprintf("%s _(%s)_", q, r.Note)
+		}
+		ratio := "—"
+		if r.GraphTokens > 0 {
+			ratio = fmt.Sprintf("%.2fx", savingsRatio(r.GraphTokens, r.FileReadTokens))
+		}
+		fmt.Fprintf(&b, "| %d | %s | %d | %d | %d | %s |\n",
+			i+1, escapePipes(q), r.GraphTokens, r.FileReadTokens, r.FileCount, ratio)
+	}
+
+	agg := aggregateRatio(rows)
+	b.WriteString("\n")
+	if agg > 0 {
+		fmt.Fprintf(&b, "**Aggregate:** the naive file-read baseline costs **%.2fx** the tokens of the "+
+			"graph-scoped answers across this seed set.\n", agg)
+	} else {
+		b.WriteString("**Aggregate:** no question produced a measurable graph-scoped answer.\n")
+	}
+	return b.String()
+}
+
+// escapePipes keeps user-supplied question text from breaking the table.
+func escapePipes(s string) string { return strings.ReplaceAll(s, "|", `\|`) }

--- a/cmd/bench-tokens/token_economy_test.go
+++ b/cmd/bench-tokens/token_economy_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	// char/4 — matches the codebase-wide estimator.
+	cases := map[string]int{"": 0, "abc": 0, "abcd": 1, "12345678": 2}
+	for in, want := range cases {
+		if got := estimateTokens(in); got != want {
+			t.Errorf("estimateTokens(%q)=%d want %d", in, got, want)
+		}
+	}
+}
+
+func TestSavingsRatio(t *testing.T) {
+	if got := savingsRatio(100, 400); got != 4.0 {
+		t.Errorf("savingsRatio(100,400)=%v want 4.0", got)
+	}
+	// Graph cost of zero (error/no-match) must not divide-by-zero.
+	if got := savingsRatio(0, 400); got != 0 {
+		t.Errorf("savingsRatio(0,400)=%v want 0", got)
+	}
+}
+
+func TestAggregateRatio(t *testing.T) {
+	rows := []questionCost{
+		{Question: "a", GraphTokens: 100, FileReadTokens: 400}, // 4x
+		{Question: "b", GraphTokens: 200, FileReadTokens: 600}, // 3x
+		{Question: "err", GraphTokens: 0, FileReadTokens: 999}, // skipped
+	}
+	// (400+600)/(100+200) = 1000/300 = 3.333...
+	got := aggregateRatio(rows)
+	if got < 3.33 || got > 3.34 {
+		t.Errorf("aggregateRatio=%v want ~3.333 (zero-graph row must be excluded)", got)
+	}
+}
+
+func TestAggregateRatio_AllZero(t *testing.T) {
+	rows := []questionCost{{Question: "x", GraphTokens: 0, FileReadTokens: 10}}
+	if got := aggregateRatio(rows); got != 0 {
+		t.Errorf("aggregateRatio(all-zero)=%v want 0", got)
+	}
+}
+
+func TestExtractSourceFiles(t *testing.T) {
+	payload := strings.Join([]string{
+		"# nodes (3 matched)",
+		"TokenAuthMiddleware  internal/mcp/render.go:52",
+		"OrderService.place  cmd/archigraph/index.go:140",
+		"dup-hit  internal/mcp/render.go:88", // same file -> dedup
+		"# edges-summary: available=2",
+		"a → b  [CALLS]", // not a location, must not match
+	}, "\n")
+	got := extractSourceFiles(payload)
+	want := []string{"cmd/archigraph/index.go", "internal/mcp/render.go"}
+	if len(got) != len(want) {
+		t.Fatalf("extractSourceFiles=%v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("extractSourceFiles=%v want %v", got, want)
+		}
+	}
+}
+
+func TestFileReadTokens(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(f, []byte(strings.Repeat("x", 400)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// 400 chars -> 100 tokens, plus one missing file -> fallback.
+	got := fileReadTokens([]string{f, filepath.Join(dir, "missing.go")})
+	want := 100 + perFileFallbackTokens
+	if got != want {
+		t.Errorf("fileReadTokens=%d want %d", got, want)
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	rows := []questionCost{
+		{Question: "where is auth", GraphTokens: 100, FileReadTokens: 400, FileCount: 2},
+		{Question: "broken | pipe", GraphTokens: 0, FileReadTokens: 0, Note: "no matches"},
+	}
+	md := renderMarkdown("upvate", rows)
+
+	for _, want := range []string{
+		"# Token-economy benchmark — upvate",
+		"| # | Question |",
+		"4.00x",          // per-row ratio
+		`broken \| pipe`, // pipe escaped
+		"_(no matches)_", // note rendered
+		"**Aggregate:**", // aggregate line present
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("renderMarkdown output missing %q\n---\n%s", want, md)
+		}
+	}
+	// The zero-graph row must render an em-dash ratio, not a divide-by-zero.
+	if !strings.Contains(md, "| — |") {
+		t.Errorf("expected em-dash ratio for zero-graph row\n%s", md)
+	}
+}
+
+func TestLoadQuestions(t *testing.T) {
+	// Default set when no path.
+	def, err := loadQuestions("")
+	if err != nil || len(def) == 0 {
+		t.Fatalf("loadQuestions(\"\")=%v,%v want non-empty default", def, err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "q.txt")
+	body := "# a comment\n\nfirst question\n  second question  \n# trailing comment\n"
+	if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadQuestions(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"first question", "second question"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("loadQuestions=%v want %v (comments/blanks stripped, trimmed)", got, want)
+	}
+}
+
+func TestLoadQuestions_EmptyFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(p, []byte("# only comments\n\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadQuestions(p); err == nil {
+		t.Error("loadQuestions on comment-only file: want error, got nil")
+	}
+}


### PR DESCRIPTION
Closes #4293

## What this builds

A user-facing token-cost benchmark, `cmd/bench-tokens`. For a set of seed
questions it builds the minimal subgraph that answers each (via the live
`archigraph_find` handler — the same ranked-BFS subgraph extraction the MCP
tools use) and estimates its token cost, then compares against the naive
"read the relevant files" baseline (read every distinct source file the matched
entities touch, in full). It emits a markdown table — per-question graph-scoped
vs file-read tokens with each row's savings ratio — plus a corpus-level
aggregate ratio.

- `cmd/bench-tokens/main.go` — CLI + live wiring: boots an in-process
  `mcp.Server` (same pattern as `cmd/bench-mcp`), runs `archigraph_find` per
  question, derives the file-read baseline from the matched entities' source
  files. Flags: `-group`, `-questions <file>`, `-depth`, `-token-budget`, `-out`.
- `cmd/bench-tokens/token_economy.go` — pure, testable helpers:
  `estimateTokens` (char/4), `savingsRatio`, `aggregateRatio`,
  `extractSourceFiles`, `fileReadTokens`, `renderMarkdown`.
- `cmd/bench-tokens/token_economy_test.go` — focused unit tests of the
  token-comparison math (ratios, divide-by-zero guards, file-read accounting,
  source-file extraction, markdown rendering, question loading).

Ships a 3-question built-in seed set (locate / flow / validation shapes);
`-questions` overrides with a newline-delimited file.

## Reuse (built on, not parallel)

- char/4 token estimator — matches `internal/mcp/render.go` `estimateTokens`,
  the daemon `payload_token_estimate`, and `internal/docgen`, so numbers line
  up with the cost the MCP layer reports.
- in-process MCP server + `srv.MCP.GetTool(...).Handler` invocation pattern from
  `cmd/bench-mcp`.
- `archigraph_find` for subgraph extraction — no reinvented BFS.

## Example output

\`\`\`
# Token-economy benchmark — upvate

| # | Question | Graph tokens | File-read tokens | Files | Ratio |
|---|----------|-------------:|-----------------:|------:|------:|
| 1 | where is authentication middleware defined | 210 | 1840 | 3 | 8.76x |
| 2 | how does the order service place an order | 340 | 5120 | 6 | 15.06x |
| 3 | what validates an incoming contract proposal | 180 | 2960 | 4 | 16.44x |

**Aggregate:** the naive file-read baseline costs **13.59x** the tokens of the
graph-scoped answers across this seed set.
\`\`\`

(Illustrative numbers from the renderer; live numbers come from running against
an indexed group.)

## Gates

- `go build ./...` clean
- `go test ./cmd/bench-tokens/` passes (incl. token-math tests)
- `go vet ./cmd/bench-tokens/` clean, `gofmt -l` clean

## Deploy-deferred

The live wiring talks to the registry/graph and is exercised manually, not in
CI; no daemon/index ops in this PR. The token-comparison logic it depends on is
pure and unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)