### PR TITLE
feat(export): static graph export to GraphML and Cypher (#4291)

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/export"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// newExportCmd returns the `archigraph export` subcommand (issue #4291).
+//
+// It loads a group's indexed graph (the same load path used by feedback,
+// doctor and links: per-repo StateDir → graph.LoadGraphFromDir) and writes a
+// static interchange file. Two formats are supported in this PR:
+//
+//	archigraph export graphml [--group g --ref r --out file.graphml]
+//	archigraph export cypher  [--group g --ref r --out file.cypher]
+//
+// The self-contained HTML/SVG export described in #4291 is a deferred
+// follow-up.
+func newExportCmd() *cobra.Command {
+	var group string
+	var refFlag string
+	var outPath string
+
+	cmd := &cobra.Command{
+		Use:   "export <graphml|cypher>",
+		Short: "Export the group graph to a static file (GraphML or Cypher)",
+		Long: `export serializes a group's indexed code graph to a static file for
+offline analysis or visualization.
+
+Formats:
+  graphml   GraphML 1.0 XML (<graphml>/<graph>/<node>/<edge>) — opens in
+            Gephi, yEd, Cytoscape, etc.
+  cypher    Neo4j Cypher CREATE statements — load into a Neo4j database.
+
+The graph is loaded from the indexed store for the resolved group and ref;
+run 'archigraph index' first if no graph exists.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format := args[0]
+			switch format {
+			case "graphml", "cypher":
+			default:
+				return fmt.Errorf("export: unknown format %q (want: graphml | cypher)", format)
+			}
+
+			// Resolve ref the same way as the other read-only commands.
+			resolvedRef, _, err := resolveRef(refFlag, false /* @all not meaningful here */)
+			if err != nil {
+				return err
+			}
+
+			doc, err := loadGroupGraphForExport(cmd, group, resolvedRef)
+			if err != nil {
+				return err
+			}
+
+			// Resolve destination writer.
+			out := cmd.OutOrStdout()
+			var w *os.File
+			if outPath != "" && outPath != "-" {
+				w, err = os.Create(outPath)
+				if err != nil {
+					return fmt.Errorf("export: create %s: %w", outPath, err)
+				}
+				defer w.Close()
+			}
+
+			var werr error
+			switch format {
+			case "graphml":
+				if w != nil {
+					werr = export.WriteGraphML(w, doc)
+				} else {
+					werr = export.WriteGraphML(out, doc)
+				}
+			case "cypher":
+				if w != nil {
+					werr = export.WriteCypher(w, doc)
+				} else {
+					werr = export.WriteCypher(out, doc)
+				}
+			}
+			if werr != nil {
+				return fmt.Errorf("export: write %s: %w", format, werr)
+			}
+
+			if outPath != "" && outPath != "-" {
+				fmt.Fprintf(out, "✓ exported %d entities, %d relationships to %s (%s)\n",
+					len(doc.Entities), len(doc.Relationships), outPath, format)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&group, "group", "", "group to export (default: infer from current directory)")
+	cmd.Flags().StringVar(&refFlag, "ref", "", refFlagUsage)
+	cmd.Flags().StringVar(&outPath, "out", "", "output file (default: stdout; '-' is stdout)")
+	return cmd
+}
+
+// loadGroupGraphForExport resolves the group, loads every repo's indexed graph
+// for the given ref and merges them into a single graph.Document. It reuses the
+// canonical load path (StateDir → graph.LoadGraphFromDir); repos with no graph
+// on disk are skipped with a warning rather than failing the whole export.
+//
+// ref == "" means the current HEAD ref (StateDirForRepo); a named ref uses
+// StateDirForRepoRef.
+func loadGroupGraphForExport(cmd *cobra.Command, group, ref string) (*graph.Document, error) {
+	w := cmd.OutOrStderr()
+
+	if group == "" {
+		resolved, err := inferGroupFromCWD()
+		if err != nil {
+			return nil, fmt.Errorf("export: could not infer group from current directory: %w\nUse --group <name> to specify a group explicitly", err)
+		}
+		group = resolved
+	}
+
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		return nil, fmt.Errorf("export: group %q not found: %w", group, err)
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("export: load group config: %w", err)
+	}
+
+	merged := &graph.Document{Repo: group}
+	loadedRepos := 0
+	for _, repo := range cfg.Repos {
+		if repo.Path == "" {
+			continue
+		}
+		var stateDir string
+		if ref == "" {
+			stateDir = daemon.StateDirForRepo(repo.Path)
+		} else {
+			stateDir = daemon.StateDirForRepoRef(repo.Path, ref)
+		}
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			fmt.Fprintf(w, "warning: skipping repo %s (graph not found: %v)\n", repo.Slug, err)
+			continue
+		}
+		merged.Entities = append(merged.Entities, doc.Entities...)
+		merged.Relationships = append(merged.Relationships, doc.Relationships...)
+		loadedRepos++
+	}
+
+	if loadedRepos == 0 {
+		return nil, fmt.Errorf("export: no indexed graphs found for group %q — run `archigraph index` first", group)
+	}
+
+	merged.Stats = graph.Stats{
+		Entities:      len(merged.Entities),
+		Relationships: len(merged.Relationships),
+	}
+	return merged, nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -65,6 +65,7 @@ func newRoot() *cobra.Command {
 		newDocgenCmd(),
 		newRegisterCmd(),
 		newGroupCmd(),
+		newExportCmd(),
 		newRemoveCmd(),
 		newDeleteCmd(),
 		newBranchesCmd(),
@@ -175,6 +176,10 @@ MCP:
 Dashboard:
   dashboard                       Open dashboard in browser (auto-starts daemon if needed)
   dashboard serve [--port N]      Run standalone dashboard HTTP server (dev/advanced)
+
+Export:
+  export graphml [--group --ref --out file]   Export the group graph to GraphML (XML)
+  export cypher  [--group --ref --out file]   Export the group graph to Neo4j Cypher
 
 Quality:
   quality <fixture-dir>                       Measure extraction recall vs a golden fixture

--- a/internal/graph/export/cypher.go
+++ b/internal/graph/export/cypher.go
@@ -1,0 +1,132 @@
+package export
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// WriteCypher streams doc as a Neo4j Cypher script to w. Each entity becomes a
+// node created with a label derived from its Kind and an `id` property carrying
+// the stable graph id; each relationship becomes a MATCH...CREATE pair keyed on
+// those ids:
+//
+//	CREATE (n:Function {id: '...', name: '...', kind: '...', file: '...', line: 12});
+//	...
+//	MATCH (a {id: '...'}), (b {id: '...'}) CREATE (a)-[:CALLS]->(b);
+//
+// Node creation is emitted first so every MATCH that follows can resolve its
+// endpoints. String values are single-quote-escaped; labels and relationship
+// types are sanitized to valid Cypher identifiers (Neo4j does not accept
+// arbitrary characters in unescaped labels/types). The writer is buffered and
+// flushed before returning.
+func WriteCypher(w io.Writer, doc *graph.Document) error {
+	bw := bufio.NewWriter(w)
+
+	if _, err := io.WriteString(bw,
+		"// archigraph static graph export (Cypher)\n"); err != nil {
+		return err
+	}
+
+	// Nodes.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		label := cypherLabel(e.Kind)
+		if _, err := fmt.Fprintf(bw,
+			"CREATE (n:%s {id: '%s', name: '%s', kind: '%s', file: '%s', line: %d});\n",
+			label,
+			cypherEscape(e.ID),
+			cypherEscape(e.Name),
+			cypherEscape(e.Kind),
+			cypherEscape(e.SourceFile),
+			e.StartLine,
+		); err != nil {
+			return err
+		}
+	}
+
+	// Relationships.
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		relType := cypherRelType(r.Kind)
+		if _, err := fmt.Fprintf(bw,
+			"MATCH (a {id: '%s'}), (b {id: '%s'}) CREATE (a)-[:%s]->(b);\n",
+			cypherEscape(r.FromID),
+			cypherEscape(r.ToID),
+			relType,
+		); err != nil {
+			return err
+		}
+	}
+
+	return bw.Flush()
+}
+
+// cypherEscape escapes a string for use inside single-quoted Cypher string
+// literals. Backslashes are doubled and single quotes are backslash-escaped;
+// control characters that would break a single-line statement are escaped to
+// their Cypher escape sequences.
+func cypherEscape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\'':
+			b.WriteString(`\'`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// cypherLabel turns an entity Kind into a valid Cypher node label. Labels must
+// start with a letter and contain only letters, digits and underscores;
+// anything else is sanitized. Empty/invalid kinds fall back to "Entity".
+func cypherLabel(kind string) string {
+	return sanitizeIdent(kind, "Entity")
+}
+
+// cypherRelType turns a relationship Kind into a valid Cypher relationship
+// type. Conventionally upper-cased. Empty/invalid kinds fall back to "RELATED".
+func cypherRelType(kind string) string {
+	return sanitizeIdent(strings.ToUpper(kind), "RELATED")
+}
+
+// sanitizeIdent maps an arbitrary string to a valid Cypher identifier
+// (letters, digits, underscores; must not start with a digit). Invalid
+// characters become underscores. If the result is empty it returns fallback.
+func sanitizeIdent(s, fallback string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, r := range s {
+		switch {
+		case unicode.IsLetter(r):
+			b.WriteRune(r)
+		case unicode.IsDigit(r):
+			if i == 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "" || out == strings.Repeat("_", len(out)) {
+		return fallback
+	}
+	return out
+}

--- a/internal/graph/export/cypher_test.go
+++ b/internal/graph/export/cypher_test.go
@@ -1,0 +1,94 @@
+package export
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteCypher_Statements(t *testing.T) {
+	var sb strings.Builder
+	if err := WriteCypher(&sb, sampleDoc()); err != nil {
+		t.Fatalf("WriteCypher: %v", err)
+	}
+	out := sb.String()
+	lines := nonCommentLines(out)
+
+	// 2 CREATE nodes + 1 MATCH/CREATE edge = 3 statement lines.
+	if len(lines) != 3 {
+		t.Fatalf("want 3 statements, got %d:\n%s", len(lines), out)
+	}
+
+	// Node 1: label from Kind "Class", id property, escaped single quote in file.
+	if !strings.HasPrefix(lines[0], "CREATE (n:Class {id: 'n1'") {
+		t.Errorf("node1 statement = %q", lines[0])
+	}
+	if !strings.Contains(lines[0], `file: 'src/order\'s.go'`) {
+		t.Errorf("node1 missing escaped single quote in file: %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "line: 12") {
+		t.Errorf("node1 missing line: %q", lines[0])
+	}
+
+	// Node 2: Kind "method-impl" -> label sanitized to a valid identifier.
+	if !strings.HasPrefix(lines[1], "CREATE (n:method_impl {id: 'n2'") {
+		t.Errorf("node2 label not sanitized: %q", lines[1])
+	}
+
+	// Edge: MATCH on ids, CREATE typed rel upper-cased.
+	wantEdge := "MATCH (a {id: 'n2'}), (b {id: 'n1'}) CREATE (a)-[:CALLS]->(b);"
+	if lines[2] != wantEdge {
+		t.Errorf("edge statement = %q, want %q", lines[2], wantEdge)
+	}
+
+	// Every statement must terminate with a semicolon.
+	for i, l := range lines {
+		if !strings.HasSuffix(l, ";") {
+			t.Errorf("statement %d not semicolon-terminated: %q", i, l)
+		}
+	}
+}
+
+func TestCypherEscape(t *testing.T) {
+	cases := map[string]string{
+		"plain":     "plain",
+		"it's":      `it\'s`,
+		`a\b`:       `a\\b`,
+		"line1\nl2": `line1\nl2`,
+		"tab\there": `tab\there`,
+		"cr\rhere":  `cr\rhere`,
+	}
+	for in, want := range cases {
+		if got := cypherEscape(in); got != want {
+			t.Errorf("cypherEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeIdent(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Class", "Class"},
+		{"method-impl", "method_impl"},
+		{"calls.async", "calls_async"},
+		{"", "Entity"},
+		{"123", "_123"},
+		{"---", "Entity"}, // all-underscore -> fallback
+	}
+	for _, c := range cases {
+		if got := sanitizeIdent(c.in, "Entity"); got != c.want {
+			t.Errorf("sanitizeIdent(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// nonCommentLines returns non-empty, non-comment statement lines.
+func nonCommentLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" || strings.HasPrefix(l, "//") {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}

--- a/internal/graph/export/graphml.go
+++ b/internal/graph/export/graphml.go
@@ -1,0 +1,169 @@
+// Package export provides pure, streaming serializers that turn an in-memory
+// graph.Document into static interchange formats for offline analysis and
+// visualization. The serializers hold no global state and never read the
+// network or filesystem — callers own the io.Writer.
+//
+// Scope (issue #4291): GraphML (XML, GraphML 1.0 namespace) and Cypher
+// (Neo4j CREATE statements). The self-contained HTML/SVG export is a
+// deferred follow-up.
+package export
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// graphmlKeys declares the <key> elements (the GraphML attribute schema) once
+// at the top of the document. Node and edge attributes are referenced by these
+// ids from each <data> element.
+var graphmlNodeKeys = []struct{ id, name, typ string }{
+	{"name", "name", "string"},
+	{"kind", "kind", "string"},
+	{"file", "file", "string"},
+	{"line", "line", "int"},
+}
+
+var graphmlEdgeKeys = []struct{ id, name, typ string }{
+	{"ekind", "kind", "string"},
+}
+
+// WriteGraphML streams doc as a GraphML 1.0 document to w. The output is a
+// standard <graphml>/<graph>/<node>/<edge> tree: each entity becomes a <node>
+// carrying name/kind/file/line data, and each relationship becomes a directed
+// <edge> carrying its kind. Edges whose endpoints are not present as nodes are
+// still emitted (GraphML readers tolerate dangling references); callers that
+// need a closed graph should filter beforehand.
+//
+// All attribute values are XML-escaped. The writer is buffered internally and
+// flushed before returning so no giant string is materialized.
+func WriteGraphML(w io.Writer, doc *graph.Document) error {
+	bw := bufio.NewWriter(w)
+
+	if _, err := io.WriteString(bw, xmlHeader); err != nil {
+		return err
+	}
+
+	// Attribute key declarations.
+	for _, k := range graphmlNodeKeys {
+		if _, err := fmt.Fprintf(bw,
+			"  <key id=%q for=\"node\" attr.name=%q attr.type=%q/>\n",
+			k.id, k.name, k.typ); err != nil {
+			return err
+		}
+	}
+	for _, k := range graphmlEdgeKeys {
+		if _, err := fmt.Fprintf(bw,
+			"  <key id=%q for=\"edge\" attr.name=%q attr.type=%q/>\n",
+			k.id, k.name, k.typ); err != nil {
+			return err
+		}
+	}
+
+	if _, err := io.WriteString(bw, "  <graph id=\"G\" edgedefault=\"directed\">\n"); err != nil {
+		return err
+	}
+
+	// Nodes.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if _, err := fmt.Fprintf(bw, "    <node id=%q>\n", xmlEscape(e.ID)); err != nil {
+			return err
+		}
+		if err := graphmlData(bw, "name", e.Name); err != nil {
+			return err
+		}
+		if err := graphmlData(bw, "kind", e.Kind); err != nil {
+			return err
+		}
+		if err := graphmlData(bw, "file", e.SourceFile); err != nil {
+			return err
+		}
+		if err := graphmlData(bw, "line", fmt.Sprintf("%d", e.StartLine)); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(bw, "    </node>\n"); err != nil {
+			return err
+		}
+	}
+
+	// Edges.
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		id := r.ID
+		if id == "" {
+			id = fmt.Sprintf("e%d", i)
+		}
+		if _, err := fmt.Fprintf(bw,
+			"    <edge id=%q source=%q target=%q>\n",
+			xmlEscape(id), xmlEscape(r.FromID), xmlEscape(r.ToID)); err != nil {
+			return err
+		}
+		if err := graphmlEdgeData(bw, "ekind", r.Kind); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(bw, "    </edge>\n"); err != nil {
+			return err
+		}
+	}
+
+	if _, err := io.WriteString(bw, "  </graph>\n</graphml>\n"); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+const xmlHeader = `<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+`
+
+// graphmlData writes a node <data key=...>value</data> line.
+func graphmlData(w io.Writer, key, value string) error {
+	_, err := fmt.Fprintf(w, "      <data key=%q>%s</data>\n", key, xmlEscape(value))
+	return err
+}
+
+// graphmlEdgeData writes an edge <data key=...>value</data> line.
+func graphmlEdgeData(w io.Writer, key, value string) error {
+	_, err := fmt.Fprintf(w, "      <data key=%q>%s</data>\n", key, xmlEscape(value))
+	return err
+}
+
+// xmlEscape escapes the five XML predefined entities. It is deliberately
+// minimal and allocation-light: it scans for any character that needs
+// escaping and only builds a new string when one is found.
+func xmlEscape(s string) string {
+	needs := false
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '&', '<', '>', '"', '\'':
+			needs = true
+		}
+		if needs {
+			break
+		}
+	}
+	if !needs {
+		return s
+	}
+	buf := make([]byte, 0, len(s)+16)
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; c {
+		case '&':
+			buf = append(buf, "&amp;"...)
+		case '<':
+			buf = append(buf, "&lt;"...)
+		case '>':
+			buf = append(buf, "&gt;"...)
+		case '"':
+			buf = append(buf, "&quot;"...)
+		case '\'':
+			buf = append(buf, "&apos;"...)
+		default:
+			buf = append(buf, c)
+		}
+	}
+	return string(buf)
+}

--- a/internal/graph/export/graphml_test.go
+++ b/internal/graph/export/graphml_test.go
@@ -1,0 +1,156 @@
+package export
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// sampleDoc builds a tiny in-memory graph that exercises special characters
+// requiring escaping in both formats.
+func sampleDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:         "n1",
+				Name:       `Order<Service> & "Co"`,
+				Kind:       "Class",
+				SourceFile: "src/order's.go",
+				StartLine:  12,
+			},
+			{
+				ID:         "n2",
+				Name:       "placeOrder",
+				Kind:       "method-impl", // non-identifier char -> sanitized for Cypher
+				SourceFile: "src/order.go",
+				StartLine:  20,
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "n2", ToID: "n1", Kind: "calls"},
+		},
+	}
+}
+
+func TestWriteGraphML_ValidXMLStructure(t *testing.T) {
+	var sb strings.Builder
+	if err := WriteGraphML(&sb, sampleDoc()); err != nil {
+		t.Fatalf("WriteGraphML: %v", err)
+	}
+	out := sb.String()
+
+	// Must be well-formed XML and parse into the GraphML shape.
+	type data struct {
+		Key   string `xml:"key,attr"`
+		Value string `xml:",chardata"`
+	}
+	type node struct {
+		ID   string `xml:"id,attr"`
+		Data []data `xml:"data"`
+	}
+	type edge struct {
+		ID     string `xml:"id,attr"`
+		Source string `xml:"source,attr"`
+		Target string `xml:"target,attr"`
+		Data   []data `xml:"data"`
+	}
+	type gml struct {
+		XMLName xml.Name `xml:"graphml"`
+		Nodes   []node   `xml:"graph>node"`
+		Edges   []edge   `xml:"graph>edge"`
+	}
+	var parsed gml
+	if err := xml.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not well-formed GraphML: %v\n%s", err, out)
+	}
+
+	if len(parsed.Nodes) != 2 {
+		t.Fatalf("want 2 nodes, got %d", len(parsed.Nodes))
+	}
+	if len(parsed.Edges) != 1 {
+		t.Fatalf("want 1 edge, got %d", len(parsed.Edges))
+	}
+
+	// Verify the first node's escaped attributes round-tripped to their
+	// original literal values after XML decoding.
+	n1 := parsed.Nodes[0]
+	if n1.ID != "n1" {
+		t.Errorf("node id = %q, want n1", n1.ID)
+	}
+	got := map[string]string{}
+	for _, d := range n1.Data {
+		got[d.Key] = d.Value
+	}
+	if got["name"] != `Order<Service> & "Co"` {
+		t.Errorf("name data = %q, want literal with < & \"", got["name"])
+	}
+	if got["file"] != "src/order's.go" {
+		t.Errorf("file data = %q", got["file"])
+	}
+	if got["line"] != "12" {
+		t.Errorf("line data = %q, want 12", got["line"])
+	}
+
+	// Edge endpoints + kind.
+	e := parsed.Edges[0]
+	if e.Source != "n2" || e.Target != "n1" {
+		t.Errorf("edge endpoints = %s->%s, want n2->n1", e.Source, e.Target)
+	}
+	if len(e.Data) != 1 || e.Data[0].Value != "calls" {
+		t.Errorf("edge data = %+v, want kind=calls", e.Data)
+	}
+
+	// Raw escaping must be present in the serialized form (not just after decode).
+	if !strings.Contains(out, "&lt;Service&gt;") {
+		t.Errorf("raw output missing escaped < >:\n%s", out)
+	}
+	if !strings.Contains(out, "&amp;") {
+		t.Errorf("raw output missing escaped &")
+	}
+	if !strings.Contains(out, "&apos;") {
+		t.Errorf("raw output missing escaped apostrophe")
+	}
+}
+
+func TestWriteGraphML_HeaderAndKeys(t *testing.T) {
+	var sb strings.Builder
+	if err := WriteGraphML(&sb, &graph.Document{}); err != nil {
+		t.Fatalf("WriteGraphML empty: %v", err)
+	}
+	out := sb.String()
+	if !strings.HasPrefix(out, `<?xml version="1.0"`) {
+		t.Errorf("missing XML declaration")
+	}
+	if !strings.Contains(out, `xmlns="http://graphml.graphdrawing.org/xmlns"`) {
+		t.Errorf("missing GraphML namespace")
+	}
+	for _, want := range []string{
+		`<key id="name" for="node"`,
+		`<key id="kind" for="node"`,
+		`<key id="file" for="node"`,
+		`<key id="line" for="node"`,
+		`<key id="ekind" for="edge"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing key declaration %q", want)
+		}
+	}
+}
+
+func TestXMLEscape(t *testing.T) {
+	cases := map[string]string{
+		"plain": "plain",
+		"a<b>c": "a&lt;b&gt;c",
+		"a&b":   "a&amp;b",
+		`"q"`:   "&quot;q&quot;",
+		"it's":  "it&apos;s",
+		"":      "",
+	}
+	for in, want := range cases {
+		if got := xmlEscape(in); got != want {
+			t.Errorf("xmlEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #4291.

## What's done
Adds an `archigraph export graphml|cypher [--group --ref --out <file>]` subcommand and a pure, streaming serializer package `internal/graph/export`.

- **GraphML** (`internal/graph/export/graphml.go`): standard GraphML 1.0 XML — `<graphml>`/`<graph>`/`<node>`/`<edge>` with `<key>` declarations. Node attrs: `name`, `kind`, `file`, `line`; edge attr: `kind`. All values XML-escaped (`& < > " '`).
- **Cypher** (`internal/graph/export/cypher.go`): `CREATE (n:Kind {id, name, kind, file, line})` per entity, then `MATCH (a {id}), (b {id}) CREATE (a)-[:KIND]->(b)` per relationship. Single-quote string escaping (`\' \\ \n \r \t`); labels/rel-types sanitized to valid Cypher identifiers (e.g. `method-impl` → `method_impl`, rel types upper-cased).
- Both serializers stream through a `bufio.Writer` — no giant in-memory strings.
- The command reuses the existing group-load path used by `feedback`/`doctor`/`links`: group → repos → `StateDirForRepo`/`StateDirForRepoRef` → `graph.LoadGraphFromDir`, merging per-repo documents. Supports `--ref`, `--group` (inferred from CWD if omitted), and `--out` (stdout by default).
- Registered in the root command and the advanced help text.

## Tests
Focused serializer tests (`graphml_test.go`, `cypher_test.go`): small in-memory graph with special chars; GraphML output is parsed back with `encoding/xml` to assert structure + escaping round-trip; Cypher output asserts exact statements, semicolon termination, escaping, and identifier sanitization. `go build ./...`, the touched packages' `go test`, `go vet`, and `gofmt -l` are all clean.

## Deferred
The self-contained **HTML/SVG** export portion of #4291 is intentionally left for a follow-up PR. Not closing #4291.

## Deploy
Deploy-deferred — no daemon/index/MCP changes required to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)