### PR TITLE
feat(mcp): graph-orientation analysis — key entities, cross-cutting edges, orientation questions (#4290)

### DIFF
--- a/internal/graph/orientation.go
+++ b/internal/graph/orientation.go
@@ -1,0 +1,492 @@
+package graph
+
+// orientation.go — graph-orientation analysis (issue #4290).
+//
+// This file synthesises a "where do I start reading this codebase?" view from
+// attributes the Pass-4 algorithm pass (see algorithms.go) already wrote onto
+// the on-disk graph: per-entity betweenness Centrality, PageRank, CommunityID,
+// and per-edge Confidence. Nothing here re-runs an expensive centrality pass —
+// betweenness is read straight off Entity.Centrality, so the analysis is O(V+E)
+// and safe to run inline on an MCP request.
+//
+// Three parts:
+//   1. KeyEntities    — structural hubs/bridges ranked by a blend of degree
+//                       centrality (cheap, computed here) and the precomputed
+//                       approximate betweenness centrality.
+//   2. CrossCutEdges  — edges that bridge communities, cross a file-type/layer
+//                       boundary, or wire a peripheral node to a hub. Each
+//                       carries a human-readable reason and a composite score.
+//   3. Questions      — templated orientation questions mined from ambiguous
+//                       (low-confidence) edges, high-betweenness bridge nodes,
+//                       and isolated nodes.
+//
+// All outputs are deterministic: every ranking has an ID-based tiebreak so the
+// surface is reproducible across runs (matching the #481 determinism contract).
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// AmbiguousConfidenceThreshold is the effective-confidence ceiling below which
+// an edge is treated as "ambiguous" for question mining. Fallback speculation
+// (0.4) and anything more pessimistic falls below it; regex/AST-grade edges
+// (>=0.7) do not. Edges with a zero/unset confidence read as 1.0 (direct AST)
+// and are never ambiguous (see types.EffectiveConfidence).
+const AmbiguousConfidenceThreshold = 0.5
+
+// KeyEntity is a structural hub/bridge in the graph.
+type KeyEntity struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Kind        string  `json:"kind"`
+	SourceFile  string  `json:"source_file,omitempty"`
+	CommunityID int     `json:"community_id"`
+	Degree      int     `json:"degree"`      // in+out degree (cheap centrality)
+	Betweenness float64 `json:"betweenness"` // precomputed approx. betweenness
+	PageRank    float64 `json:"pagerank"`    // precomputed pagerank
+	Score       float64 `json:"score"`       // composite ranking score
+	Reason      string  `json:"reason"`      // why this entity is a key entity
+}
+
+// CrossCutEdge is an edge that crosses a structural boundary.
+type CrossCutEdge struct {
+	FromID        string   `json:"from_id"`
+	ToID          string   `json:"to_id"`
+	FromName      string   `json:"from_name"`
+	ToName        string   `json:"to_name"`
+	Kind          string   `json:"kind"`
+	Score         float64  `json:"score"`
+	Reasons       []string `json:"reasons"`
+	FromCommunity int      `json:"from_community"`
+	ToCommunity   int      `json:"to_community"`
+}
+
+// OrientQuestion is a templated orientation question with provenance.
+type OrientQuestion struct {
+	Question string   `json:"question"`
+	Source   string   `json:"source"` // ambiguous_edge | bridge_node | isolated_node
+	Entities []string `json:"entities,omitempty"`
+}
+
+// OrientationResult bundles the three analysis parts.
+type OrientationResult struct {
+	KeyEntities   []KeyEntity      `json:"key_entities"`
+	CrossCutEdges []CrossCutEdge   `json:"cross_cutting_edges"`
+	Questions     []OrientQuestion `json:"orientation_questions"`
+}
+
+// OrientationOptions bounds the analysis output.
+type OrientationOptions struct {
+	TopEntities  int // max KeyEntities returned (default 15)
+	TopEdges     int // max CrossCutEdges returned (default 15)
+	MaxQuestions int // max OrientQuestions returned (default 12)
+}
+
+// DefaultOrientationOptions returns the production caps.
+func DefaultOrientationOptions() OrientationOptions {
+	return OrientationOptions{TopEntities: 15, TopEdges: 15, MaxQuestions: 12}
+}
+
+func (o OrientationOptions) normalized() OrientationOptions {
+	if o.TopEntities <= 0 {
+		o.TopEntities = 15
+	}
+	if o.TopEdges <= 0 {
+		o.TopEdges = 15
+	}
+	if o.MaxQuestions <= 0 {
+		o.MaxQuestions = 12
+	}
+	return o
+}
+
+// communityOf reads an entity's community id, defaulting to -1 ("ungrouped")
+// when the Pass-4 attribute is absent.
+func communityOf(e Entity) int {
+	if e.CommunityID != nil {
+		return *e.CommunityID
+	}
+	return -1
+}
+
+func centralityOf(e Entity) float64 {
+	if e.Centrality != nil {
+		return *e.Centrality
+	}
+	return 0
+}
+
+func pageRankOf(e Entity) float64 {
+	if e.PageRank != nil {
+		return *e.PageRank
+	}
+	return 0
+}
+
+// effectiveEdgeConfidence mirrors types.EffectiveConfidence without importing
+// the types package (graph is a lower-level package): a zero/unset confidence
+// reads as 1.0 (direct AST), and values are clamped to [0,1].
+func effectiveEdgeConfidence(c float64) float64 {
+	if c == 0 {
+		return 1.0
+	}
+	if c < 0 {
+		return 0
+	}
+	if c > 1 {
+		return 1
+	}
+	return c
+}
+
+// layerOf derives a coarse architectural layer from an entity's source path and
+// language. The mapping is intentionally heuristic and cheap; it exists so the
+// cross-cutting scorer can reward edges that span layers (e.g. an HTTP handler
+// reaching into a data-access function). Returns "" when no layer is inferable.
+func layerOf(e Entity) string {
+	p := strings.ToLower(e.SourceFile)
+	switch {
+	case containsAny(p, "test", "spec", "__tests__", "_test."):
+		return "test"
+	case containsAny(p, "migration", "schema", "models/", "model/", "entity/", "entities/", "repository", "repositories", "dao", "/db/", "database"):
+		return "data"
+	case containsAny(p, "controller", "handler", "route", "router", "endpoint", "/api/", "resolver", "rest"):
+		return "api"
+	case containsAny(p, "service", "usecase", "use_case", "domain", "business"):
+		return "service"
+	case containsAny(p, "/ui/", "component", "view", "page", "/web/", "frontend", "client/"):
+		return "ui"
+	case containsAny(p, "config", "settings", "/infra", "deploy", "terraform", "k8s", "helm"):
+		return "infra"
+	}
+	return ""
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// fileExt returns the lowercased extension (incl dot) of an entity's source
+// file, or "" if none. Used for file-type-boundary detection.
+func fileExt(e Entity) string {
+	p := e.SourceFile
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		p = p[i+1:]
+	}
+	if i := strings.LastIndexByte(p, '.'); i >= 0 {
+		return strings.ToLower(p[i:])
+	}
+	return ""
+}
+
+// AnalyzeOrientation computes the three-part orientation view over a single
+// graph document's entities and relationships. It reads the precomputed Pass-4
+// attributes (Centrality/PageRank/CommunityID) and computes only cheap O(V+E)
+// quantities (degree, boundary checks) inline.
+func AnalyzeOrientation(entities []Entity, rels []Relationship, opts OrientationOptions) OrientationResult {
+	opts = opts.normalized()
+
+	byID := make(map[string]Entity, len(entities))
+	for _, e := range entities {
+		byID[e.ID] = e
+	}
+
+	// Degree centrality: count in+out edges per entity (endpoints present in the
+	// entity set only, matching BuildGraph's edge-filtering contract).
+	inDeg := make(map[string]int, len(entities))
+	outDeg := make(map[string]int, len(entities))
+	for _, r := range rels {
+		if r.FromID == "" || r.ToID == "" || r.FromID == r.ToID {
+			continue
+		}
+		if _, ok := byID[r.FromID]; !ok {
+			continue
+		}
+		if _, ok := byID[r.ToID]; !ok {
+			continue
+		}
+		outDeg[r.FromID]++
+		inDeg[r.ToID]++
+	}
+	degree := func(id string) int { return inDeg[id] + outDeg[id] }
+
+	// ---- Part 1: key entities -------------------------------------------------
+	// Normalise degree and betweenness to [0,1] across the corpus so the blend is
+	// scale-free, then rank by 0.6*betweenness + 0.4*degree (betweenness is the
+	// better bridge signal; degree is the better hub signal — both matter).
+	maxDeg, maxBetw := 0, 0.0
+	for _, e := range entities {
+		if d := degree(e.ID); d > maxDeg {
+			maxDeg = d
+		}
+		if b := centralityOf(e); b > maxBetw {
+			maxBetw = b
+		}
+	}
+	keys := make([]KeyEntity, 0, len(entities))
+	for _, e := range entities {
+		d := degree(e.ID)
+		if d == 0 {
+			continue // isolated nodes are surfaced via questions, not as hubs
+		}
+		betw := centralityOf(e)
+		normDeg, normBetw := 0.0, 0.0
+		if maxDeg > 0 {
+			normDeg = float64(d) / float64(maxDeg)
+		}
+		if maxBetw > 0 {
+			normBetw = betw / maxBetw
+		}
+		score := 0.6*normBetw + 0.4*normDeg
+		keys = append(keys, KeyEntity{
+			ID:          e.ID,
+			Name:        e.Name,
+			Kind:        e.Kind,
+			SourceFile:  e.SourceFile,
+			CommunityID: communityOf(e),
+			Degree:      d,
+			Betweenness: betw,
+			PageRank:    pageRankOf(e),
+			Score:       score,
+			Reason:      keyEntityReason(normBetw, normDeg, e),
+		})
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		if keys[i].Score != keys[j].Score {
+			return keys[i].Score > keys[j].Score
+		}
+		return keys[i].ID < keys[j].ID
+	})
+	if len(keys) > opts.TopEntities {
+		keys = keys[:opts.TopEntities]
+	}
+
+	// ---- Part 2: cross-cutting edges -----------------------------------------
+	// Score = sum of boundary signals:
+	//   +2.0 bridges two distinct (grouped) communities
+	//   +1.0 crosses an architectural layer boundary
+	//   +0.5 crosses a file-type (extension) boundary
+	//   +1.0 wires a peripheral node (degree<=2) to a hub (top-tier degree)
+	hubCut := maxDeg / 5 // "hub" = top-20%-degree-ish; cheap proxy
+	if hubCut < 3 {
+		hubCut = 3
+	}
+	cuts := make([]CrossCutEdge, 0)
+	for _, r := range rels {
+		if r.FromID == "" || r.ToID == "" || r.FromID == r.ToID {
+			continue
+		}
+		from, okf := byID[r.FromID]
+		to, okt := byID[r.ToID]
+		if !okf || !okt {
+			continue
+		}
+		var reasons []string
+		score := 0.0
+		cf, ct := communityOf(from), communityOf(to)
+		if cf != ct && cf >= 0 && ct >= 0 {
+			score += 2.0
+			reasons = append(reasons, "bridges_communities")
+		}
+		if lf, lt := layerOf(from), layerOf(to); lf != "" && lt != "" && lf != lt {
+			score += 1.0
+			reasons = append(reasons, fmt.Sprintf("crosses_layer:%s->%s", lf, lt))
+		}
+		if ef, et := fileExt(from), fileExt(to); ef != "" && et != "" && ef != et {
+			score += 0.5
+			reasons = append(reasons, "crosses_file_type")
+		}
+		df, dt := degree(r.FromID), degree(r.ToID)
+		if (df <= 2 && dt >= hubCut) || (dt <= 2 && df >= hubCut) {
+			score += 1.0
+			reasons = append(reasons, "peripheral_to_hub")
+		}
+		if score == 0 {
+			continue
+		}
+		cuts = append(cuts, CrossCutEdge{
+			FromID:        r.FromID,
+			ToID:          r.ToID,
+			FromName:      from.Name,
+			ToName:        to.Name,
+			Kind:          r.Kind,
+			Score:         score,
+			Reasons:       reasons,
+			FromCommunity: cf,
+			ToCommunity:   ct,
+		})
+	}
+	sort.SliceStable(cuts, func(i, j int) bool {
+		if cuts[i].Score != cuts[j].Score {
+			return cuts[i].Score > cuts[j].Score
+		}
+		if cuts[i].FromID != cuts[j].FromID {
+			return cuts[i].FromID < cuts[j].FromID
+		}
+		return cuts[i].ToID < cuts[j].ToID
+	})
+	if len(cuts) > opts.TopEdges {
+		cuts = cuts[:opts.TopEdges]
+	}
+
+	// ---- Part 3: orientation questions ---------------------------------------
+	questions := mineQuestions(entities, rels, byID, degree, keys, opts.MaxQuestions)
+
+	return OrientationResult{
+		KeyEntities:   keys,
+		CrossCutEdges: cuts,
+		Questions:     questions,
+	}
+}
+
+func keyEntityReason(normBetw, normDeg float64, e Entity) string {
+	switch {
+	case e.IsArticulationPt:
+		return "articulation_point — removing it disconnects part of the graph"
+	case e.IsGodNode:
+		return "god_node — top-percentile betweenness and/or pagerank"
+	case normBetw >= 0.5 && normDeg >= 0.5:
+		return "high_betweenness_and_degree — central hub bridging the graph"
+	case normBetw >= 0.5:
+		return "high_betweenness — a bridge on many shortest paths"
+	default:
+		return "high_degree — a well-connected hub"
+	}
+}
+
+// mineQuestions builds a deterministic, deduplicated list of templated
+// orientation questions from three sources: ambiguous (low-confidence) edges,
+// high-betweenness bridge nodes (the top key entities), and isolated nodes.
+func mineQuestions(entities []Entity, rels []Relationship, byID map[string]Entity, degree func(string) int, keys []KeyEntity, max int) []OrientQuestion {
+	out := make([]OrientQuestion, 0, max)
+	seen := make(map[string]bool)
+	add := func(q OrientQuestion) {
+		if seen[q.Question] {
+			return
+		}
+		seen[q.Question] = true
+		out = append(out, q)
+	}
+
+	// (a) Ambiguous edges — sorted by ascending confidence (most ambiguous
+	// first), tiebroken by endpoint IDs for determinism.
+	type ambEdge struct {
+		from, to string
+		kind     string
+		conf     float64
+	}
+	var amb []ambEdge
+	for _, r := range rels {
+		if r.FromID == "" || r.ToID == "" {
+			continue
+		}
+		conf := effectiveEdgeConfidence(r.Confidence)
+		if conf >= AmbiguousConfidenceThreshold {
+			continue
+		}
+		if _, ok := byID[r.FromID]; !ok {
+			continue
+		}
+		if _, ok := byID[r.ToID]; !ok {
+			continue
+		}
+		amb = append(amb, ambEdge{r.FromID, r.ToID, r.Kind, conf})
+	}
+	sort.SliceStable(amb, func(i, j int) bool {
+		if amb[i].conf != amb[j].conf {
+			return amb[i].conf < amb[j].conf
+		}
+		if amb[i].from != amb[j].from {
+			return amb[i].from < amb[j].from
+		}
+		return amb[i].to < amb[j].to
+	})
+
+	// (b) Bridge nodes — the highest-betweenness key entities.
+	type bridge struct {
+		id, name string
+		betw     float64
+	}
+	var bridges []bridge
+	for _, k := range keys {
+		if k.Betweenness > 0 {
+			bridges = append(bridges, bridge{k.ID, k.Name, k.Betweenness})
+		}
+	}
+	// keys are already betweenness-weighted & sorted; keep that order.
+
+	// (c) Isolated nodes — degree 0, sorted by ID.
+	var isolated []Entity
+	for _, e := range entities {
+		if degree(e.ID) == 0 {
+			isolated = append(isolated, e)
+		}
+	}
+	sort.SliceStable(isolated, func(i, j int) bool { return isolated[i].ID < isolated[j].ID })
+
+	// Interleave the three sources round-robin so a single dominant source can't
+	// crowd the others out of a small budget. Order of preference per round:
+	// bridge, ambiguous, isolated.
+	bi, ai, ii := 0, 0, 0
+	for len(out) < max && (bi < len(bridges) || ai < len(amb) || ii < len(isolated)) {
+		if bi < len(bridges) && len(out) < max {
+			b := bridges[bi]
+			bi++
+			name := b.name
+			if name == "" {
+				name = b.id
+			}
+			add(OrientQuestion{
+				Question: fmt.Sprintf("%q sits on many shortest paths (a bridge). What does it coordinate, and what breaks if it changes?", name),
+				Source:   "bridge_node",
+				Entities: []string{b.id},
+			})
+		}
+		if ai < len(amb) && len(out) < max {
+			e := amb[ai]
+			ai++
+			fn := nameOr(byID, e.from)
+			tn := nameOr(byID, e.to)
+			add(OrientQuestion{
+				Question: fmt.Sprintf("Is the %s edge %q -> %q real? It was inferred with low confidence (%.2f) and may be a dynamic/ambiguous binding.", strings.ToLower(orDash(e.kind)), fn, tn, e.conf),
+				Source:   "ambiguous_edge",
+				Entities: []string{e.from, e.to},
+			})
+		}
+		if ii < len(isolated) && len(out) < max {
+			e := isolated[ii]
+			ii++
+			name := e.Name
+			if name == "" {
+				name = e.ID
+			}
+			add(OrientQuestion{
+				Question: fmt.Sprintf("%q has no recorded relationships. Is it dead code, an entry point, or wired up dynamically?", name),
+				Source:   "isolated_node",
+				Entities: []string{e.ID},
+			})
+		}
+	}
+	return out
+}
+
+func nameOr(byID map[string]Entity, id string) string {
+	if e, ok := byID[id]; ok && e.Name != "" {
+		return e.Name
+	}
+	return id
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "(unknown)"
+	}
+	return s
+}

--- a/internal/graph/orientation_test.go
+++ b/internal/graph/orientation_test.go
@@ -1,0 +1,227 @@
+package graph
+
+import (
+	"strings"
+	"testing"
+)
+
+// intp / fp are small helpers for the *int / *float64 Pass-4 attribute fields.
+func intp(v int) *int       { return &v }
+func fp(v float64) *float64 { return &v }
+
+// buildOrientFixture constructs a tiny two-community graph with a known bridge,
+// a peripheral->hub edge, a cross-layer edge, an ambiguous edge, and an isolated
+// node — so every analysis branch is exercised by one fixture.
+//
+// Communities:
+//
+//	community 0: api_handler (hub), helper_a
+//	community 1: data_repo (hub), helper_b
+//
+// bridge: api_handler -> data_repo crosses communities AND layers (api->data).
+// peripheral: leaf -> api_handler (leaf has degree 1, api_handler is a hub).
+// ambiguous: api_handler -> dynamic_target (confidence 0.4).
+// isolated: orphan (no edges).
+func buildOrientFixture() ([]Entity, []Relationship) {
+	entities := []Entity{
+		{ID: "api_handler", Name: "ApiHandler", Kind: "function", SourceFile: "src/api/handler.go",
+			CommunityID: intp(0), Centrality: fp(0.90), PageRank: fp(0.30)},
+		{ID: "data_repo", Name: "DataRepo", Kind: "function", SourceFile: "src/db/repository.go",
+			CommunityID: intp(1), Centrality: fp(0.40), PageRank: fp(0.20)},
+		{ID: "helper_a", Name: "HelperA", Kind: "function", SourceFile: "src/api/util.go",
+			CommunityID: intp(0), Centrality: fp(0.05), PageRank: fp(0.05)},
+		{ID: "helper_b", Name: "HelperB", Kind: "function", SourceFile: "src/db/util.go",
+			CommunityID: intp(1), Centrality: fp(0.05), PageRank: fp(0.05)},
+		{ID: "leaf", Name: "Leaf", Kind: "function", SourceFile: "src/api/leaf.go",
+			CommunityID: intp(0), Centrality: fp(0.0), PageRank: fp(0.01)},
+		{ID: "dynamic_target", Name: "DynamicTarget", Kind: "function", SourceFile: "src/api/dyn.go",
+			CommunityID: intp(0), Centrality: fp(0.0), PageRank: fp(0.01)},
+		{ID: "orphan", Name: "Orphan", Kind: "function", SourceFile: "src/misc/orphan.go",
+			CommunityID: intp(-1), Centrality: fp(0.0), PageRank: fp(0.0)},
+	}
+	rels := []Relationship{
+		// api_handler is the central hub: edges to helper_a, data_repo, helper_b, dyn.
+		{FromID: "api_handler", ToID: "helper_a", Kind: "CALLS"},
+		{FromID: "api_handler", ToID: "helper_b", Kind: "CALLS"},
+		{FromID: "api_handler", ToID: "data_repo", Kind: "CALLS"}, // cross-community + cross-layer bridge
+		{FromID: "data_repo", ToID: "helper_b", Kind: "CALLS"},
+		{FromID: "leaf", ToID: "api_handler", Kind: "CALLS"}, // peripheral -> hub
+		// ambiguous low-confidence edge.
+		{FromID: "api_handler", ToID: "dynamic_target", Kind: "CALLS", Confidence: 0.4},
+	}
+	return entities, rels
+}
+
+func TestAnalyzeOrientation_KeyEntityRanking(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	res := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+
+	if len(res.KeyEntities) == 0 {
+		t.Fatal("expected key entities, got none")
+	}
+	// api_handler has the highest degree AND highest betweenness — must rank #1.
+	if res.KeyEntities[0].ID != "api_handler" {
+		t.Errorf("expected api_handler as top key entity, got %q (full: %+v)",
+			res.KeyEntities[0].ID, res.KeyEntities)
+	}
+	// Scores must be monotonically non-increasing (sorted).
+	for i := 1; i < len(res.KeyEntities); i++ {
+		if res.KeyEntities[i].Score > res.KeyEntities[i-1].Score {
+			t.Errorf("key entities not sorted by score at %d: %v > %v",
+				i, res.KeyEntities[i].Score, res.KeyEntities[i-1].Score)
+		}
+	}
+	// Isolated node must NOT appear as a key entity (degree 0).
+	for _, k := range res.KeyEntities {
+		if k.ID == "orphan" {
+			t.Error("isolated node 'orphan' must not be ranked as a key entity")
+		}
+		if k.Degree <= 0 {
+			t.Errorf("key entity %q has non-positive degree %d", k.ID, k.Degree)
+		}
+	}
+}
+
+func TestAnalyzeOrientation_CrossCommunityEdgeScoresHigh(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	res := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+
+	if len(res.CrossCutEdges) == 0 {
+		t.Fatal("expected cross-cutting edges, got none")
+	}
+	// The api_handler->data_repo edge bridges communities (0->1) AND layers
+	// (api->data); it must be the highest-scoring cross-cutting edge.
+	top := res.CrossCutEdges[0]
+	if top.FromID != "api_handler" || top.ToID != "data_repo" {
+		t.Errorf("expected api_handler->data_repo as top cross-cut edge, got %s->%s",
+			top.FromID, top.ToID)
+	}
+	if !hasReason(top.Reasons, "bridges_communities") {
+		t.Errorf("top edge missing bridges_communities reason: %v", top.Reasons)
+	}
+	var foundLayer bool
+	for _, r := range top.Reasons {
+		if strings.HasPrefix(r, "crosses_layer:") {
+			foundLayer = true
+		}
+	}
+	if !foundLayer {
+		t.Errorf("top edge missing crosses_layer reason: %v", top.Reasons)
+	}
+	// Intra-community helper edges (api_handler->helper_a) must not appear with a
+	// bridges_communities reason.
+	for _, e := range res.CrossCutEdges {
+		if e.FromID == "api_handler" && e.ToID == "helper_a" && hasReason(e.Reasons, "bridges_communities") {
+			t.Error("intra-community edge wrongly flagged as bridging communities")
+		}
+	}
+}
+
+func TestAnalyzeOrientation_PeripheralToHub(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	res := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+	var found bool
+	for _, e := range res.CrossCutEdges {
+		if e.FromID == "leaf" && e.ToID == "api_handler" {
+			found = true
+			if !hasReason(e.Reasons, "peripheral_to_hub") {
+				t.Errorf("leaf->api_handler missing peripheral_to_hub reason: %v", e.Reasons)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected leaf->api_handler peripheral-to-hub edge in cross-cut output")
+	}
+}
+
+func TestAnalyzeOrientation_QuestionsGenerated(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	res := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+
+	if len(res.Questions) == 0 {
+		t.Fatal("expected orientation questions, got none")
+	}
+	sources := map[string]bool{}
+	var ambiguousMentionsDyn, isolatedMentionsOrphan bool
+	for _, q := range res.Questions {
+		sources[q.Source] = true
+		if q.Source == "ambiguous_edge" && containsAll(q.Entities, "dynamic_target") {
+			ambiguousMentionsDyn = true
+		}
+		if q.Source == "isolated_node" && containsAll(q.Entities, "orphan") {
+			isolatedMentionsOrphan = true
+		}
+		if strings.TrimSpace(q.Question) == "" {
+			t.Error("generated an empty question")
+		}
+	}
+	for _, want := range []string{"bridge_node", "ambiguous_edge", "isolated_node"} {
+		if !sources[want] {
+			t.Errorf("expected at least one question from source %q; got sources %v", want, sources)
+		}
+	}
+	if !ambiguousMentionsDyn {
+		t.Error("expected an ambiguous-edge question referencing dynamic_target")
+	}
+	if !isolatedMentionsOrphan {
+		t.Error("expected an isolated-node question referencing orphan")
+	}
+}
+
+func TestAnalyzeOrientation_Caps(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	res := AnalyzeOrientation(entities, rels, OrientationOptions{
+		TopEntities: 2, TopEdges: 1, MaxQuestions: 2,
+	})
+	if len(res.KeyEntities) > 2 {
+		t.Errorf("TopEntities cap not honored: got %d", len(res.KeyEntities))
+	}
+	if len(res.CrossCutEdges) > 1 {
+		t.Errorf("TopEdges cap not honored: got %d", len(res.CrossCutEdges))
+	}
+	if len(res.Questions) > 2 {
+		t.Errorf("MaxQuestions cap not honored: got %d", len(res.Questions))
+	}
+}
+
+func TestAnalyzeOrientation_Deterministic(t *testing.T) {
+	entities, rels := buildOrientFixture()
+	a := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+	b := AnalyzeOrientation(entities, rels, DefaultOrientationOptions())
+	if len(a.KeyEntities) != len(b.KeyEntities) {
+		t.Fatal("non-deterministic key-entity count")
+	}
+	for i := range a.KeyEntities {
+		if a.KeyEntities[i].ID != b.KeyEntities[i].ID {
+			t.Errorf("non-deterministic key-entity order at %d: %s vs %s",
+				i, a.KeyEntities[i].ID, b.KeyEntities[i].ID)
+		}
+	}
+	for i := range a.Questions {
+		if a.Questions[i].Question != b.Questions[i].Question {
+			t.Errorf("non-deterministic question order at %d", i)
+		}
+	}
+}
+
+func hasReason(rs []string, want string) bool {
+	for _, r := range rs {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(have []string, want ...string) bool {
+	set := map[string]bool{}
+	for _, h := range have {
+		set[h] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcp/orient_4290_test.go
+++ b/internal/mcp/orient_4290_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func ip(v int) *int           { return &v }
+func f64p(v float64) *float64 { return &v }
+
+// Test_handleOrient_4290 verifies the archigraph_orient MCP handler returns the
+// three orientation parts (key entities, cross-cutting edges, questions) for a
+// loaded repo, reading the Pass-4 attributes off the in-memory doc.
+func Test_handleOrient_4290(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "demo",
+		Entities: []graph.Entity{
+			{ID: "api", Name: "Api", Kind: "function", SourceFile: "src/api/h.go",
+				CommunityID: ip(0), Centrality: f64p(0.9), PageRank: f64p(0.3)},
+			{ID: "repo", Name: "Repo", Kind: "function", SourceFile: "src/db/r.go",
+				CommunityID: ip(1), Centrality: f64p(0.4), PageRank: f64p(0.2)},
+			{ID: "h", Name: "Helper", Kind: "function", SourceFile: "src/api/u.go",
+				CommunityID: ip(0), Centrality: f64p(0.05), PageRank: f64p(0.05)},
+			{ID: "orphan", Name: "Orphan", Kind: "function", SourceFile: "src/x/o.go",
+				CommunityID: ip(-1)},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "api", ToID: "h", Kind: "CALLS"},
+			{FromID: "api", ToID: "repo", Kind: "CALLS"},                  // cross-community bridge
+			{FromID: "api", ToID: "repo", Kind: "CALLS", Confidence: 0.4}, // ambiguous dup-kind ok via diff conf
+		},
+	}
+	srv := newTestServer(t, doc)
+	text := callEndpointToolText(t, srv.handleOrient, map[string]any{"group": "test"})
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, text)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 repo block, got %d: %s", len(got), text)
+	}
+	block := got[0]
+	if block["repo"] != "demo" {
+		t.Errorf("wrong repo: %v", block["repo"])
+	}
+	ke, _ := block["key_entities"].([]any)
+	if len(ke) == 0 {
+		t.Fatal("expected key_entities")
+	}
+	if first := ke[0].(map[string]any); first["id"] != "api" {
+		t.Errorf("expected 'api' as top key entity, got %v", first["id"])
+	}
+	cc, _ := block["cross_cutting_edges"].([]any)
+	if len(cc) == 0 {
+		t.Error("expected cross_cutting_edges")
+	}
+	qs, _ := block["orientation_questions"].([]any)
+	if len(qs) == 0 {
+		t.Error("expected orientation_questions")
+	}
+}
+
+// Test_handleOrient_4290_Caps verifies the cap args narrow the output.
+func Test_handleOrient_4290_Caps(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "demo",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "A", SourceFile: "p/a.go", CommunityID: ip(0), Centrality: f64p(0.9)},
+			{ID: "b", Name: "B", SourceFile: "p/b.go", CommunityID: ip(1), Centrality: f64p(0.5)},
+			{ID: "c", Name: "C", SourceFile: "p/c.go", CommunityID: ip(0), Centrality: f64p(0.1)},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "a", ToID: "b", Kind: "CALLS"},
+			{FromID: "a", ToID: "c", Kind: "CALLS"},
+			{FromID: "b", ToID: "c", Kind: "CALLS"},
+		},
+	}
+	srv := newTestServer(t, doc)
+	text := callEndpointToolText(t, srv.handleOrient, map[string]any{
+		"group":        "test",
+		"top_entities": 1,
+	})
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, text)
+	}
+	ke, _ := got[0]["key_entities"].([]any)
+	if len(ke) != 1 {
+		t.Errorf("top_entities=1 should cap to 1 key entity, got %d", len(ke))
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -546,6 +546,24 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("ref"), // PH1c: optional git ref
 	), s.wrap("archigraph_clusters", s.handleListCommunities))
 
+	// #4290 — graph-orientation analysis. Reads Pass-4 attributes already on the
+	// graph (betweenness Centrality, PageRank, CommunityID) plus cheap inline
+	// degree/boundary computation to answer "where do I start reading this
+	// codebase?". Returns, per repo: key entities (structural hubs/bridges ranked
+	// by a betweenness+degree blend), cross-cutting edges (bridge communities /
+	// cross layer / cross file-type / peripheral->hub, with reasons), and
+	// templated orientation questions mined from ambiguous edges, bridge nodes,
+	// and isolated nodes. Caps overridable via top_entities/top_edges/max_questions.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_orient",
+		mcpapi.WithDescription("Orientation analysis: key entities, cross-cutting edges, orientation questions."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithNumber("top_entities", mcpapi.DefaultNumber(15)),
+		mcpapi.WithNumber("top_edges", mcpapi.DefaultNumber(15)),
+		mcpapi.WithNumber("max_questions", mcpapi.DefaultNumber(12)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_orient", s.handleOrient))
+
 	// #2764 — Phase 1A effect classification. Returns the union of
 	// db/http/fs/mutation effects for the named entity, plus per-effect
 	// confidence (0..1) and sink primitive tags. Pure functions report

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -529,6 +529,8 @@ func TestToolNameSurface(t *testing.T) {
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
 		"archigraph_clusters", "archigraph_stats",
+		// #4290 graph-orientation analysis
+		"archigraph_orient",
 		// bundled (2 retained; cross_links re-wired)
 		"archigraph_enrichments", "archigraph_repairs",
 		// unchanged — trace included here as it was not renamed
@@ -691,8 +693,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_effective_contract (#3836 per-verb ViewSet effective contract).
 	// +1 archigraph_endpoint_posture (deploy-9 caps surfacing: error_flow/
 	// rate_limit/deprecation/feature_flag/grpc-auth posture).
-	if got := len(allRegisteredTools); got != 57 {
-		t.Errorf("expected 57 registered tools, got %d — update this count if tools are added/removed (added archigraph_endpoint_posture deploy-9 caps surfacing)", got)
+	// +1 archigraph_orient (#4290 graph-orientation analysis).
+	if got := len(allRegisteredTools); got != 58 {
+		t.Errorf("expected 58 registered tools, got %d — update this count if tools are added/removed (added archigraph_orient #4290 orientation analysis)", got)
 	}
 }
 
@@ -3145,6 +3148,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_trace":                {"group": "g", "source": "r1::a1", "target": "r1::a4"},
 		"archigraph_traces":               {"group": "g", "action": "list"},
 		"archigraph_clusters":             {"group": "g"},
+		"archigraph_orient":               {"group": "g"}, // #4290 orientation analysis
 		"archigraph_stats":                {"group": "g"},
 		"archigraph_enrichments":          {"group": "g", "action": "list"},
 		"archigraph_repairs":              {"group": "g", "action": "list"},
@@ -3252,8 +3256,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 57 {
-		t.Errorf("expected 57 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_endpoint_posture deploy-9 caps surfacing)", len(tools))
+	if len(tools) != 58 {
+		t.Errorf("expected 58 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_orient #4290 orientation analysis)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2073,6 +2073,49 @@ func (s *Server) handleListCommunities(ctx context.Context, req mcpapi.CallToolR
 }
 
 // ---------------------------------------------------------------------------
+// orient (#4290) — graph-orientation analysis
+// ---------------------------------------------------------------------------
+
+// handleOrient surfaces a "where do I start reading this codebase?" view built
+// from Pass-4 attributes already on the graph (betweenness Centrality,
+// PageRank, CommunityID) plus cheap inline degree/boundary computation. Three
+// parts: key entities (structural hubs/bridges), cross-cutting edges (boundary
+// crossers), and templated orientation questions. See
+// internal/graph/orientation.go for the analysis.
+//
+// Per-repo: each repo in scope gets its own analysis block (communities and
+// centrality are repo-local). Optional caps: top_entities, top_edges,
+// max_questions (all default to the production values in
+// graph.DefaultOrientationOptions).
+func (s *Server) handleOrient(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	def := graph.DefaultOrientationOptions()
+	opts := graph.OrientationOptions{
+		TopEntities:  argInt(req, "top_entities", def.TopEntities),
+		TopEdges:     argInt(req, "top_edges", def.TopEdges),
+		MaxQuestions: argInt(req, "max_questions", def.MaxQuestions),
+	}
+	out := []map[string]any{}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		res := graph.AnalyzeOrientation(r.Doc.Entities, r.Doc.Relationships, opts)
+		out = append(out, map[string]any{
+			"repo":                  r.Repo,
+			"key_entities":          res.KeyEntities,
+			"cross_cutting_edges":   res.CrossCutEdges,
+			"orientation_questions": res.Questions,
+		})
+	}
+	return jsonResult(out), nil
+}
+
+// ---------------------------------------------------------------------------
 // save_finding
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4290

## What's built
A new MCP tool **`archigraph_orient`** answering "where do I start reading this codebase?" — a graph-orientation view in three parts, synthesised from Pass-4 attributes **already on the graph** (per-entity betweenness `Centrality`, `PageRank`, `CommunityID`; per-edge `Confidence`) plus cheap inline O(V+E) degree/boundary computation. **No expensive centrality re-run** — betweenness is read straight off `Entity.Centrality`, so the tool is safe to run inline on an MCP request.

1. **Key entities** — structural hubs/bridges ranked by `0.6*norm(betweenness) + 0.4*norm(degree)` (betweenness is the better bridge signal, degree the better hub signal; both normalised to [0,1] so the blend is scale-free). Each carries a reason: articulation_point / god_node / high_betweenness(_and_degree) / high_degree. Isolated nodes are excluded here (surfaced via questions instead).
2. **Cross-cutting edges** — scored by boundary signals, each with a reason: bridges-communities (+2, using the existing Louvain community assignments), crosses-layer (+1, coarse path heuristic api/data/service/ui/infra/test), crosses-file-type (+0.5), peripheral→hub (+1).
3. **Orientation questions** — templated (not LLM), mined round-robin from ambiguous (effective-confidence < 0.5) edges, high-betweenness bridge nodes, and isolated nodes — so a single source can't crowd a small budget.

Caps overridable via `top_entities` / `top_edges` / `max_questions`. All rankings have ID tiebreaks → deterministic (#481 contract).

## Reused from existing clustering / algorithms
- Per-entity **community assignments** (`CommunityID`) from the Louvain pass — the cross-community "surprise" signal (same source as `ComputeSurpriseEdges`).
- Precomputed **betweenness `Centrality`** and **`PageRank`** from `ComputeCentrality` (algorithms.go).
- `IsGodNode` / `IsArticulationPt` flags for richer key-entity reasons.
- Conventions: per-repo loop + caps + arg helpers mirror `archigraph_clusters` (`handleListCommunities`); registration mirrors the surrounding tools in `server.go`.

## Centrality approach / bounds
Degree centrality is computed inline (O(E)). Approximate betweenness is **not recomputed** — it is consumed from the graph, where the algorithm pass already computes it (exact weighted Brandes/Floyd-Warshall under 3000 nodes, unweighted Brandes above). So this PR adds no new heavy compute path and ships an honest, accurate betweenness signal.

## Files
- `internal/graph/orientation.go` — `AnalyzeOrientation` + types (unit-tested, no MCP deps).
- `internal/graph/orientation_test.go` — ranking, cross-community/peripheral scoring, question generation, caps, determinism.
- `internal/mcp/tools.go` — `handleOrient`.
- `internal/mcp/server.go` — tool registration.
- `internal/mcp/orient_4290_test.go` + `server_test.go` count updates.

## Gates
`go build ./...` clean · `go vet` clean · `gofmt -l` clean · `go test ./internal/graph ./internal/mcp` pass (incl. tool-count audits).

DEPLOY-DEFERRED — registered + tested, not wired into any live daemon by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)