### PR TITLE
fix(transport): bounded timeout on Windows named-pipe dial so CLI fails fast without a daemon (#4304)

### DIFF
--- a/internal/daemon/transport/transport_windows.go
+++ b/internal/daemon/transport/transport_windows.go
@@ -3,6 +3,7 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"os/user"
 	"strings"
@@ -10,6 +11,19 @@ import (
 
 	"github.com/Microsoft/go-winio"
 )
+
+// maxDialTimeout caps the wall-clock time a single named-pipe dial may take
+// before failing fast. The Unix path relies on net.DialTimeout(addr, timeout)
+// which is strictly bounded by the supplied timeout; this is the Windows
+// equivalent and exists so that a non-positive (zero/negative) timeout from a
+// caller can never degrade into go-winio's silent 2 s default — or, worse, an
+// unbounded ERROR_PIPE_BUSY retry loop — when no daemon is listening.
+//
+// All real callers pass an explicit positive timeout (2 s / 1 s / 200 ms — see
+// internal/daemon/client and internal/daemon/service); this constant only
+// guards the degenerate case so every CLI command fails fast when the daemon
+// is down, matching the Unix ENOENT-fast-fail behaviour. See issue #4304.
+const maxDialTimeout = 2 * time.Second
 
 // WindowsPipeName returns the canonical named-pipe path for the current user.
 // Form: \\.\pipe\archigraph-daemon-<username>
@@ -50,10 +64,26 @@ func listen(addr string) (net.Listener, error) {
 	return &statsListener{Listener: l}, nil
 }
 
-// dialTimeout dials a Windows named pipe at addr with the given timeout.
-// Returns a stats-tracked connection.
+// dialTimeout dials a Windows named pipe at addr, bounded by timeout.
+//
+// This mirrors the Unix path's net.DialTimeout("unix", addr, timeout): the dial
+// must fail fast (within timeout) when no daemon is listening rather than block.
+// We drive go-winio via an explicit context deadline we fully own — instead of
+// winio.DialPipe(addr, &timeout), whose nil/zero handling would silently fall
+// back to a 2 s default — so the bound is always honoured.
+//
+// A non-positive timeout is clamped to maxDialTimeout so a degenerate caller
+// can never produce an already-expired context that yields a confusing
+// "context deadline exceeded" before a single connect attempt, nor an
+// unbounded retry. See issue #4304.
 func dialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
-	c, err := winio.DialPipe(addr, &timeout)
+	if timeout <= 0 {
+		timeout = maxDialTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	c, err := winio.DialPipeContext(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/transport/transport_windows_test.go
+++ b/internal/daemon/transport/transport_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package transport_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/transport"
+)
+
+// TestDialTimeout_FailsFastWhenNoPipe is the regression test for issue #4304:
+// dialing a non-existent named pipe must return an error well within the
+// supplied timeout instead of hanging (which previously tripped the 15-minute
+// go test timeout on Windows CI via TestDelete_UnknownGroupReturnsClearError).
+func TestDialTimeout_FailsFastWhenNoPipe(t *testing.T) {
+	const addr = `\\.\pipe\archigraph-test-nonexistent-4304`
+	const timeout = time.Second
+
+	start := time.Now()
+	conn, err := transport.DialTimeout(addr, timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatalf("expected error dialing non-existent pipe %s", addr)
+	}
+	// Allow generous slack over the 1 s bound for slow CI, but it must be far
+	// below the 15-minute package timeout — a few seconds proves "fails fast".
+	if elapsed > 5*time.Second {
+		t.Fatalf("dial took %s; expected fast failure (~%s)", elapsed, timeout)
+	}
+}
+
+// TestDialTimeout_ClampsNonPositiveTimeout verifies a zero timeout does not
+// hang and does not silently inherit go-winio's 2 s default in an unbounded
+// way — it must still fail fast against a missing pipe.
+func TestDialTimeout_ClampsNonPositiveTimeout(t *testing.T) {
+	const addr = `\\.\pipe\archigraph-test-nonexistent-4304-zero`
+
+	start := time.Now()
+	conn, err := transport.DialTimeout(addr, 0)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatalf("expected error dialing non-existent pipe %s", addr)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("dial took %s; expected fast failure", elapsed)
+	}
+}


### PR DESCRIPTION
Closes #4304

## Root cause
On Windows CI, `internal/cli.TestDelete_UnknownGroupReturnsClearError` intermittently hung and tripped the 15-minute `go test` timeout (`panic: test timed out after 15m0s`), failing the whole `internal/cli` package on otherwise-unrelated PRs.

The CLI talks to the daemon over a Windows named pipe. `internal/daemon/transport/transport_windows.go`'s `dialTimeout` drove go-winio via `winio.DialPipe(addr, &timeout)`. That entry point's handling of a nil/zero timeout silently falls back to a 2 s default, and its `ERROR_PIPE_BUSY` retry loop (10 ms poll) is only bounded by the timeout it derives — so a degenerate/zero timeout, or a pipe stuck busy, could let the dial run far longer than intended instead of failing fast when no daemon is listening. The Unix path (`transport_unix.go`) uses `net.DialTimeout("unix", addr, timeout)`, which is strictly bounded — so Unix fails fast (ENOENT) while Windows could hang.

## Fix
`dialTimeout` (Windows) now:
- drives go-winio via an explicit context deadline we fully own — `winio.DialPipeContext(ctx, addr)` with `context.WithTimeout(..., timeout)` — instead of `DialPipe(addr, &timeout)`, so the bound is always honoured and never silently replaced by winio's internal default;
- clamps a non-positive timeout to a 2 s floor (`maxDialTimeout`) so a degenerate caller can't produce an unbounded retry or an already-expired context.

This makes the Windows dial fail fast (within the caller's timeout) when the daemon is down — identical observable behaviour to the Unix `net.DialTimeout` path. All real callers already pass an explicit positive timeout (2 s in `internal/daemon/client.DialPath`, 1 s / 200 ms in `internal/daemon/service`); the clamp only guards the degenerate case.

## Timeout value & Unix parity
`maxDialTimeout = 2 * time.Second`. This matches the CLI's own connect timeout: `internal/daemon/client.DialPath` dials with `transport.DialTimeout(socketPath, 2*time.Second)`, and `transport.DefaultDialTimeout` is also `2 * time.Second`. The floor only applies when a caller passes a non-positive timeout; every positive timeout is honoured exactly, so both platforms now behave identically.

## Fail-fast on unknown group
Already present and left intact: `runDeleteImpl` (internal/cli/delete.go) validates the group via `registry.Groups()` (pure file I/O, no dial) and returns `unknown group: <name>` **before** any `client.DialPath`/`client.Dial`. The core fix is the bounded dial so **all** CLI commands fail fast when no daemon exists; no behavioural change was needed in the delete path.

## Tests
- `go build ./...` clean (darwin); `GOOS=windows go build`/`go vet`/`go test -c` of the transport package clean.
- `go test ./internal/daemon/transport/ ./internal/cli/ -run 'Delete|Dial|Transport|Pipe' -count=1` passes on darwin (Unix dial-timeout path + all delete tests).
- `gofmt -l` / `go vet` clean on touched files.
- Added `transport_windows_test.go` (Windows-only) asserting a dial against a missing pipe returns an error well within the timeout (regression test for the hang) and that a zero timeout still fails fast.

The definitive verification is the Windows CI re-run, since the hang cannot be reproduced on darwin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)