### PR TITLE
feat(mcp): diff/PR-scoped impact analysis with cross-change merge-risk detection (#4292)

### DIFF
--- a/internal/graph/pr_impact.go
+++ b/internal/graph/pr_impact.go
@@ -1,0 +1,427 @@
+// Package graph — pr_impact.go computes diff/PR-scoped impact analysis and
+// cross-change merge-risk triage (issue #4292).
+//
+// This file is pure-Go and MCP-free, mirroring AnalyzeOrientation (#4290): the
+// thin MCP handler loads the per-ref graphs and supplies the changed-entity set
+// (reusing the same DiffDocs machinery that backs archigraph_diff_refs), then
+// calls into these functions. Keeping the analysis pure makes it unit-testable
+// on an in-memory graph with no daemon, no registry, and no git.
+//
+// Two analyses:
+//
+//  1. AnalyzePRImpact — single change. Given the HEAD graph (entities +
+//     relationships) and the set of entity IDs the diff touched, it resolves
+//     which communities those entities belong to (Entity.CommunityID from the
+//     Pass-4 algorithm pass) and walks the INBOUND dependency graph to find the
+//     downstream blast radius — every entity that transitively depends on a
+//     changed entity. This is the same inbound-BFS reachability used by
+//     archigraph_impact_radius, generalised to a *set* of seeds.
+//
+//  2. AnalyzeMergeRisk — multiple changes. Given each change's impacted-
+//     community set, it intersects them pairwise; any two changes whose
+//     impacted communities overlap are a merge-order / conflict risk. Pairs are
+//     ranked by shared-community count (descending), with the shared community
+//     ids listed.
+//
+// All outputs are deterministic with ID/index tiebreaks, per the #481 contract.
+package graph
+
+import "sort"
+
+// ---------------------------------------------------------------------------
+// Single-change impact
+// ---------------------------------------------------------------------------
+
+// ChangedEntity is a slim record of an entity the diff touched, annotated with
+// its community and a change-class (added | removed | modified).
+type ChangedEntity struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Kind        string `json:"kind"`
+	SourceFile  string `json:"source_file,omitempty"`
+	Change      string `json:"change"`       // added | removed | modified
+	CommunityID int    `json:"community_id"` // -1 when ungrouped/unknown
+}
+
+// ImpactedCommunity is a community touched by the change, with how many changed
+// entities and how many blast-radius entities fall inside it.
+type ImpactedCommunity struct {
+	CommunityID    int `json:"community_id"`
+	ChangedCount   int `json:"changed_count"`    // changed entities in this community
+	BlastRadiusHit int `json:"blast_radius_hit"` // downstream entities in this community
+}
+
+// BlastEntity is a downstream entity that transitively depends on a changed
+// entity, annotated with the BFS hop distance from the nearest changed seed.
+type BlastEntity struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Kind        string `json:"kind"`
+	SourceFile  string `json:"source_file,omitempty"`
+	CommunityID int    `json:"community_id"`
+	HopDistance int    `json:"hop_distance"`
+}
+
+// PRImpactResult is the structured output of AnalyzePRImpact.
+type PRImpactResult struct {
+	ChangedEntities     []ChangedEntity     `json:"changed_entities"`
+	ImpactedCommunities []ImpactedCommunity `json:"impacted_communities"`
+	BlastRadius         []BlastEntity       `json:"blast_radius"`
+
+	// Aggregate counts for quick triage.
+	ChangedCount     int  `json:"changed_count"`
+	CommunityCount   int  `json:"impacted_community_count"`
+	BlastRadiusCount int  `json:"blast_radius_count"`
+	Truncated        bool `json:"truncated,omitempty"`
+}
+
+// PRImpactOptions bounds the analysis.
+type PRImpactOptions struct {
+	Hops          int // downstream BFS depth (default 3, clamped [1,6])
+	MaxBlastNodes int // cap on blast_radius entries returned (default 500)
+}
+
+// DefaultPRImpactOptions returns the production caps.
+func DefaultPRImpactOptions() PRImpactOptions {
+	return PRImpactOptions{Hops: 3, MaxBlastNodes: 500}
+}
+
+func (o PRImpactOptions) normalized() PRImpactOptions {
+	if o.Hops <= 0 {
+		o.Hops = 3
+	}
+	if o.Hops > 6 {
+		o.Hops = 6
+	}
+	if o.MaxBlastNodes <= 0 {
+		o.MaxBlastNodes = 500
+	}
+	return o
+}
+
+// ChangeSet is the diff-derived input to AnalyzePRImpact: the entity IDs the
+// diff classified as added / removed / modified between base and head. The MCP
+// handler fills this from DiffDocs (the diff_refs engine), so this package does
+// not duplicate the git-diff logic.
+type ChangeSet struct {
+	Added    []DiffEntityEntry
+	Removed  []DiffEntityEntry
+	Modified []DiffEntityEntry
+}
+
+// ChangedIDs returns the union of changed entity IDs (added+removed+modified),
+// deduplicated and sorted for determinism. This is the seed set for both the
+// community resolution and the downstream BFS.
+func (c ChangeSet) ChangedIDs() []string {
+	seen := map[string]struct{}{}
+	for _, group := range [][]DiffEntityEntry{c.Added, c.Removed, c.Modified} {
+		for _, e := range group {
+			if e.ID != "" {
+				seen[e.ID] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// AnalyzePRImpact computes the single-change impact view: changed entities ->
+// impacted communities -> downstream blast radius.
+//
+// `entities`/`rels` are the HEAD graph (added & modified entities live here;
+// removed entities won't, which is fine — they have no downstream in HEAD).
+// `change` is the diff-derived change set. The function:
+//
+//  1. annotates each changed entity with its community,
+//  2. walks the INBOUND graph from the changed seeds (callers-of-callers,
+//     bounded by opts.Hops) to find every downstream dependent, and
+//  3. rolls up per-community changed/blast counts.
+func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, opts PRImpactOptions) PRImpactResult {
+	opts = opts.normalized()
+
+	byID := make(map[string]Entity, len(entities))
+	for i := range entities {
+		byID[entities[i].ID] = entities[i]
+	}
+
+	// Inbound adjacency: in[X] = entities that depend on X (callers). Restricted
+	// to edges whose both endpoints are present in the entity set, matching the
+	// edge-filtering contract used elsewhere.
+	in := make(map[string][]string, len(entities))
+	for _, r := range rels {
+		if r.FromID == "" || r.ToID == "" || r.FromID == r.ToID {
+			continue
+		}
+		if _, ok := byID[r.FromID]; !ok {
+			continue
+		}
+		if _, ok := byID[r.ToID]; !ok {
+			continue
+		}
+		// r.FromID depends on r.ToID, so FromID is a downstream dependent of ToID.
+		in[r.ToID] = append(in[r.ToID], r.FromID)
+	}
+
+	// ── Part 1: changed entities + their communities ─────────────────────────
+	classOf := map[string]string{}
+	for _, e := range change.Removed {
+		classOf[e.ID] = "removed"
+	}
+	for _, e := range change.Added {
+		classOf[e.ID] = "added"
+	}
+	for _, e := range change.Modified {
+		classOf[e.ID] = "modified"
+	}
+
+	changedIDs := change.ChangedIDs()
+	changed := make([]ChangedEntity, 0, len(changedIDs))
+	// communityChanged[community] = #changed entities in it.
+	communityChanged := map[int]int{}
+	seedSet := make(map[string]struct{}, len(changedIDs))
+	for _, id := range changedIDs {
+		seedSet[id] = struct{}{}
+		comm := -1
+		var name, kind, src string
+		if e, ok := byID[id]; ok {
+			comm = communityOf(e)
+			name, kind, src = e.Name, e.Kind, e.SourceFile
+		} else {
+			// Removed entity (gone from HEAD) — fall back to the diff record.
+			for _, group := range [][]DiffEntityEntry{change.Removed, change.Added, change.Modified} {
+				for _, de := range group {
+					if de.ID == id {
+						name, kind, src = de.Name, de.Kind, de.SourceFile
+					}
+				}
+			}
+		}
+		changed = append(changed, ChangedEntity{
+			ID:          id,
+			Name:        name,
+			Kind:        kind,
+			SourceFile:  src,
+			Change:      classOf[id],
+			CommunityID: comm,
+		})
+		communityChanged[comm]++
+	}
+
+	// ── Part 2: downstream blast radius (inbound BFS from all seeds) ──────────
+	// Multi-source BFS: distance is hops from the nearest changed seed.
+	dist := make(map[string]int, len(changedIDs))
+	frontier := make([]string, 0, len(changedIDs))
+	for id := range seedSet {
+		// Only seeds present in HEAD can have downstream dependents.
+		if _, ok := byID[id]; ok {
+			dist[id] = 0
+			frontier = append(frontier, id)
+		}
+	}
+	sort.Strings(frontier) // deterministic BFS expansion order
+	for d := 0; d < opts.Hops && len(frontier) > 0; d++ {
+		var next []string
+		for _, n := range frontier {
+			deps := in[n]
+			sort.Strings(deps)
+			for _, dep := range deps {
+				if _, seen := dist[dep]; seen {
+					continue
+				}
+				dist[dep] = d + 1
+				next = append(next, dep)
+			}
+		}
+		sort.Strings(next)
+		frontier = next
+	}
+
+	// Blast radius = reached entities that are not themselves changed seeds.
+	communityBlast := map[int]int{}
+	blast := make([]BlastEntity, 0, len(dist))
+	for id, d := range dist {
+		if _, isSeed := seedSet[id]; isSeed {
+			continue
+		}
+		e, ok := byID[id]
+		if !ok {
+			continue
+		}
+		comm := communityOf(e)
+		communityBlast[comm]++
+		blast = append(blast, BlastEntity{
+			ID:          id,
+			Name:        e.Name,
+			Kind:        e.Kind,
+			SourceFile:  e.SourceFile,
+			CommunityID: comm,
+			HopDistance: d,
+		})
+	}
+	// Deterministic order: nearest first, then ID.
+	sort.SliceStable(blast, func(i, j int) bool {
+		if blast[i].HopDistance != blast[j].HopDistance {
+			return blast[i].HopDistance < blast[j].HopDistance
+		}
+		return blast[i].ID < blast[j].ID
+	})
+	blastTotal := len(blast)
+	truncated := false
+	if len(blast) > opts.MaxBlastNodes {
+		blast = blast[:opts.MaxBlastNodes]
+		truncated = true
+	}
+
+	// ── Part 3: impacted communities roll-up ─────────────────────────────────
+	commIDs := map[int]struct{}{}
+	for c := range communityChanged {
+		commIDs[c] = struct{}{}
+	}
+	for c := range communityBlast {
+		commIDs[c] = struct{}{}
+	}
+	impacted := make([]ImpactedCommunity, 0, len(commIDs))
+	for c := range commIDs {
+		impacted = append(impacted, ImpactedCommunity{
+			CommunityID:    c,
+			ChangedCount:   communityChanged[c],
+			BlastRadiusHit: communityBlast[c],
+		})
+	}
+	// Rank by total touch (changed+blast) desc, then community id asc.
+	sort.SliceStable(impacted, func(i, j int) bool {
+		ti := impacted[i].ChangedCount + impacted[i].BlastRadiusHit
+		tj := impacted[j].ChangedCount + impacted[j].BlastRadiusHit
+		if ti != tj {
+			return ti > tj
+		}
+		return impacted[i].CommunityID < impacted[j].CommunityID
+	})
+
+	return PRImpactResult{
+		ChangedEntities:     changed,
+		ImpactedCommunities: impacted,
+		BlastRadius:         blast,
+		ChangedCount:        len(changed),
+		CommunityCount:      len(impacted),
+		BlastRadiusCount:    blastTotal,
+		Truncated:           truncated,
+	}
+}
+
+// ImpactedCommunityIDs returns the sorted set of (grouped) community ids a
+// PRImpactResult touches — used as the merge-risk overlap key. Ungrouped (-1)
+// is excluded: "everything not in a community" is not a meaningful conflict
+// signal, and including it would make every unrelated pair appear to overlap.
+func (r PRImpactResult) ImpactedCommunityIDs() []int {
+	out := make([]int, 0, len(r.ImpactedCommunities))
+	for _, c := range r.ImpactedCommunities {
+		if c.CommunityID < 0 {
+			continue
+		}
+		out = append(out, c.CommunityID)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Cross-change merge-risk
+// ---------------------------------------------------------------------------
+
+// ChangeImpact pairs a ref label with its impacted-community set. The MCP
+// handler builds one per input ref (running AnalyzePRImpact for each), then
+// hands the slice to AnalyzeMergeRisk.
+type ChangeImpact struct {
+	Ref         string // ref / branch / PR label
+	Communities []int  // impacted community ids (grouped only)
+}
+
+// MergeRiskPair is two refs whose impacted-community sets overlap.
+type MergeRiskPair struct {
+	RefA              string `json:"ref_a"`
+	RefB              string `json:"ref_b"`
+	SharedCount       int    `json:"shared_community_count"`
+	SharedCommunities []int  `json:"shared_communities"`
+}
+
+// MergeRiskResult is the ranked triage output of AnalyzeMergeRisk.
+type MergeRiskResult struct {
+	Pairs      []MergeRiskPair `json:"risk_pairs"`
+	RefCount   int             `json:"ref_count"`
+	RiskyPairs int             `json:"risky_pair_count"`
+}
+
+// AnalyzeMergeRisk intersects every change's impacted-community set pairwise and
+// returns the pairs that overlap, ranked by shared-community count descending.
+// Refs with disjoint community sets are safe to merge in any order and are
+// omitted from the result.
+//
+// Determinism: input refs are sorted by label; pairs are emitted with RefA<RefB
+// and ranked by (sharedCount desc, RefA asc, RefB asc).
+func AnalyzeMergeRisk(impacts []ChangeImpact) MergeRiskResult {
+	// Normalise: sort each community set + dedupe, and sort refs by label.
+	norm := make([]ChangeImpact, len(impacts))
+	copy(norm, impacts)
+	sort.SliceStable(norm, func(i, j int) bool { return norm[i].Ref < norm[j].Ref })
+	sets := make([]map[int]struct{}, len(norm))
+	for i, ci := range norm {
+		s := make(map[int]struct{}, len(ci.Communities))
+		for _, c := range ci.Communities {
+			if c >= 0 {
+				s[c] = struct{}{}
+			}
+		}
+		sets[i] = s
+	}
+
+	var pairs []MergeRiskPair
+	for i := 0; i < len(norm); i++ {
+		for j := i + 1; j < len(norm); j++ {
+			shared := intersectSets(sets[i], sets[j])
+			if len(shared) == 0 {
+				continue
+			}
+			sort.Ints(shared)
+			pairs = append(pairs, MergeRiskPair{
+				RefA:              norm[i].Ref,
+				RefB:              norm[j].Ref,
+				SharedCount:       len(shared),
+				SharedCommunities: shared,
+			})
+		}
+	}
+	sort.SliceStable(pairs, func(i, j int) bool {
+		if pairs[i].SharedCount != pairs[j].SharedCount {
+			return pairs[i].SharedCount > pairs[j].SharedCount
+		}
+		if pairs[i].RefA != pairs[j].RefA {
+			return pairs[i].RefA < pairs[j].RefA
+		}
+		return pairs[i].RefB < pairs[j].RefB
+	})
+
+	return MergeRiskResult{
+		Pairs:      pairs,
+		RefCount:   len(norm),
+		RiskyPairs: len(pairs),
+	}
+}
+
+func intersectSets(a, b map[int]struct{}) []int {
+	// Iterate the smaller set for efficiency.
+	if len(b) < len(a) {
+		a, b = b, a
+	}
+	var out []int
+	for k := range a {
+		if _, ok := b[k]; ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/internal/graph/pr_impact_test.go
+++ b/internal/graph/pr_impact_test.go
@@ -1,0 +1,170 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+func ci(v int) *int { return &v }
+
+// fixture: two communities.
+//
+//	community 0 (api): a -> b -> c   (c is the leaf "changed" thing)
+//	community 1 (db):  d -> e
+//
+// edges are FROM=caller TO=callee (caller depends on callee).
+func prImpactFixture() ([]Entity, []Relationship) {
+	ents := []Entity{
+		{ID: "a", Name: "A", Kind: "function", SourceFile: "api/a.go", CommunityID: ci(0)},
+		{ID: "b", Name: "B", Kind: "function", SourceFile: "api/b.go", CommunityID: ci(0)},
+		{ID: "c", Name: "C", Kind: "function", SourceFile: "api/c.go", CommunityID: ci(0)},
+		{ID: "d", Name: "D", Kind: "function", SourceFile: "db/d.go", CommunityID: ci(1)},
+		{ID: "e", Name: "E", Kind: "function", SourceFile: "db/e.go", CommunityID: ci(1)},
+	}
+	rels := []Relationship{
+		{FromID: "a", ToID: "b", Kind: "CALLS"}, // a depends on b
+		{FromID: "b", ToID: "c", Kind: "CALLS"}, // b depends on c
+		{FromID: "d", ToID: "e", Kind: "CALLS"}, // d depends on e
+	}
+	return ents, rels
+}
+
+// Changing leaf entity "c" should: mark c changed (community 0), and the blast
+// radius (inbound dependents) should reach b (hop 1) and a (hop 2), all in
+// community 0. community 1 is untouched.
+func TestAnalyzePRImpact_BlastRadiusAndCommunities(t *testing.T) {
+	ents, rels := prImpactFixture()
+	change := ChangeSet{
+		Modified: []DiffEntityEntry{{ID: "c", Name: "C", Kind: "function", SourceFile: "api/c.go"}},
+	}
+	res := AnalyzePRImpact(ents, rels, change, DefaultPRImpactOptions())
+
+	if res.ChangedCount != 1 || res.ChangedEntities[0].ID != "c" {
+		t.Fatalf("expected 1 changed entity c, got %+v", res.ChangedEntities)
+	}
+	if res.ChangedEntities[0].Change != "modified" {
+		t.Errorf("expected change=modified, got %q", res.ChangedEntities[0].Change)
+	}
+	if res.ChangedEntities[0].CommunityID != 0 {
+		t.Errorf("expected c in community 0, got %d", res.ChangedEntities[0].CommunityID)
+	}
+
+	// Blast radius: b (hop1), a (hop2). Sorted nearest-first.
+	if res.BlastRadiusCount != 2 {
+		t.Fatalf("expected blast radius 2 (a,b), got %d: %+v", res.BlastRadiusCount, res.BlastRadius)
+	}
+	if res.BlastRadius[0].ID != "b" || res.BlastRadius[0].HopDistance != 1 {
+		t.Errorf("expected b at hop1 first, got %+v", res.BlastRadius[0])
+	}
+	if res.BlastRadius[1].ID != "a" || res.BlastRadius[1].HopDistance != 2 {
+		t.Errorf("expected a at hop2 second, got %+v", res.BlastRadius[1])
+	}
+
+	// Only community 0 is impacted; db community 1 untouched.
+	if res.CommunityCount != 1 {
+		t.Fatalf("expected 1 impacted community, got %d: %+v", res.CommunityCount, res.ImpactedCommunities)
+	}
+	c0 := res.ImpactedCommunities[0]
+	if c0.CommunityID != 0 || c0.ChangedCount != 1 || c0.BlastRadiusHit != 2 {
+		t.Errorf("community 0 rollup wrong: %+v", c0)
+	}
+	if ids := res.ImpactedCommunityIDs(); !reflect.DeepEqual(ids, []int{0}) {
+		t.Errorf("ImpactedCommunityIDs = %v, want [0]", ids)
+	}
+}
+
+// Hops cap bounds the blast radius depth.
+func TestAnalyzePRImpact_HopsCap(t *testing.T) {
+	ents, rels := prImpactFixture()
+	change := ChangeSet{Modified: []DiffEntityEntry{{ID: "c"}}}
+	res := AnalyzePRImpact(ents, rels, change, PRImpactOptions{Hops: 1})
+	// hops=1 reaches only b, not a.
+	if res.BlastRadiusCount != 1 || res.BlastRadius[0].ID != "b" {
+		t.Fatalf("hops=1 should reach only b, got %+v", res.BlastRadius)
+	}
+}
+
+// A removed entity (gone from HEAD) is still reported as changed, using the diff
+// record for its metadata, and contributes no downstream (it has no HEAD edges).
+func TestAnalyzePRImpact_RemovedEntity(t *testing.T) {
+	ents, rels := prImpactFixture()
+	change := ChangeSet{
+		Removed: []DiffEntityEntry{{ID: "gone", Name: "Gone", Kind: "function", SourceFile: "api/gone.go"}},
+	}
+	res := AnalyzePRImpact(ents, rels, change, DefaultPRImpactOptions())
+	if res.ChangedCount != 1 || res.ChangedEntities[0].ID != "gone" {
+		t.Fatalf("expected changed=gone, got %+v", res.ChangedEntities)
+	}
+	if res.ChangedEntities[0].Change != "removed" || res.ChangedEntities[0].Name != "Gone" {
+		t.Errorf("removed entity metadata wrong: %+v", res.ChangedEntities[0])
+	}
+	if res.ChangedEntities[0].CommunityID != -1 {
+		t.Errorf("removed entity should be ungrouped (-1), got %d", res.ChangedEntities[0].CommunityID)
+	}
+	if res.BlastRadiusCount != 0 {
+		t.Errorf("removed-only change should have empty blast radius, got %d", res.BlastRadiusCount)
+	}
+}
+
+// Two changes touching the SAME community are a merge risk; a disjoint change is
+// not. The risky pair must be ranked first with the shared community listed.
+func TestAnalyzeMergeRisk_OverlapVsDisjoint(t *testing.T) {
+	impacts := []ChangeImpact{
+		{Ref: "pr-a", Communities: []int{0, 2}}, // api + shared
+		{Ref: "pr-b", Communities: []int{0, 3}}, // api + shared  -> overlaps pr-a on {0}
+		{Ref: "pr-c", Communities: []int{9}},    // disjoint from everyone
+	}
+	res := AnalyzeMergeRisk(impacts)
+	if res.RefCount != 3 {
+		t.Errorf("expected ref_count 3, got %d", res.RefCount)
+	}
+	if res.RiskyPairs != 1 {
+		t.Fatalf("expected exactly 1 risky pair, got %d: %+v", res.RiskyPairs, res.Pairs)
+	}
+	p := res.Pairs[0]
+	if p.RefA != "pr-a" || p.RefB != "pr-b" {
+		t.Errorf("expected pair (pr-a,pr-b), got (%s,%s)", p.RefA, p.RefB)
+	}
+	if p.SharedCount != 1 || !reflect.DeepEqual(p.SharedCommunities, []int{0}) {
+		t.Errorf("expected shared {0}, got count=%d comms=%v", p.SharedCount, p.SharedCommunities)
+	}
+}
+
+// Ranking: a pair sharing more communities ranks above one sharing fewer; ties
+// broken by ref labels for determinism.
+func TestAnalyzeMergeRisk_Ranking(t *testing.T) {
+	impacts := []ChangeImpact{
+		{Ref: "x", Communities: []int{1, 2, 3}},
+		{Ref: "y", Communities: []int{1, 2, 3}}, // shares 3 with x
+		{Ref: "z", Communities: []int{3}},       // shares 1 with x and y
+	}
+	res := AnalyzeMergeRisk(impacts)
+	if res.RiskyPairs != 3 {
+		t.Fatalf("expected 3 risky pairs, got %d: %+v", res.RiskyPairs, res.Pairs)
+	}
+	// Highest-overlap pair (x,y sharing 3) ranks first.
+	if res.Pairs[0].RefA != "x" || res.Pairs[0].RefB != "y" || res.Pairs[0].SharedCount != 3 {
+		t.Errorf("expected (x,y,3) first, got %+v", res.Pairs[0])
+	}
+	// Remaining two pairs each share exactly community 3; tie broken by ref.
+	for _, p := range res.Pairs[1:] {
+		if p.SharedCount != 1 || !reflect.DeepEqual(p.SharedCommunities, []int{3}) {
+			t.Errorf("expected the 1-overlap pairs to share {3}, got %+v", p)
+		}
+	}
+	if res.Pairs[1].RefA != "x" || res.Pairs[1].RefB != "z" {
+		t.Errorf("tiebreak: expected (x,z) before (y,z), got %+v", res.Pairs[1])
+	}
+}
+
+// Ungrouped (-1) communities never count as overlap.
+func TestAnalyzeMergeRisk_UngroupedIgnored(t *testing.T) {
+	impacts := []ChangeImpact{
+		{Ref: "a", Communities: []int{-1}},
+		{Ref: "b", Communities: []int{-1}},
+	}
+	res := AnalyzeMergeRisk(impacts)
+	if res.RiskyPairs != 0 {
+		t.Errorf("ungrouped-only changes should not be flagged as risks, got %+v", res.Pairs)
+	}
+}

--- a/internal/mcp/pr_impact_4292_test.go
+++ b/internal/mcp/pr_impact_4292_test.go
@@ -1,0 +1,63 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// callHandlerResult invokes a handler directly and returns the result (which may
+// be an error result). Unlike callEndpointToolText it does not require the tool
+// to be registered on srv.MCP, and it surfaces IsError.
+func callHandlerResult(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) *mcpapi.CallToolResult {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned go error: %v", err)
+	}
+	return res
+}
+
+// Test_handlePRImpact_ArgValidation covers the mode-selection / required-arg
+// error paths, which are pure handler logic validated before any disk access.
+func Test_handlePRImpact_ArgValidation(t *testing.T) {
+	srv := newTestServer(t, &graph.Document{Repo: "demo"})
+
+	cases := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "missing_repo",
+			args: map[string]any{"group": "test", "base": "main", "head": "x"},
+			want: "repo is required",
+		},
+		{
+			name: "single_missing_head",
+			args: map[string]any{"group": "test", "repo": "demo", "base": "main"},
+			want: "single mode requires both base= and head=",
+		},
+		{
+			name: "conflicts_too_few_refs",
+			args: map[string]any{"group": "test", "repo": "demo", "refs": []any{"only-one"}},
+			want: "at least 2 refs",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callHandlerResult(t, srv.handlePRImpact, tc.args)
+			if res == nil || !res.IsError {
+				t.Fatalf("expected an error result, got %v", res)
+			}
+			if got := resultText(res); !strings.Contains(got, tc.want) {
+				t.Errorf("expected error containing %q, got: %s", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/mcp/pr_impact_tools.go
+++ b/internal/mcp/pr_impact_tools.go
@@ -1,0 +1,194 @@
+// pr_impact_tools.go — MCP tool: archigraph_pr_impact (issue #4292).
+//
+// Diff/PR-scoped impact analysis with cross-change merge-risk detection. Two
+// modes, selected by the arguments supplied:
+//
+//	single mode    {base, head}  -> changed entities -> impacted communities ->
+//	                                downstream blast radius
+//	conflicts mode {refs:[...]}   -> each ref's impacted-community set, intersected
+//	                                pairwise -> ranked merge-order/conflict triage
+//
+// The core logic is pure and MCP-free (graph.AnalyzePRImpact / AnalyzeMergeRisk,
+// see internal/graph/pr_impact.go). This handler is the thin shell that loads
+// the per-ref graphs (the same StateDirForRepoRef path diff_refs uses) and feeds
+// the diff-derived change set in. The change set itself is computed by
+// graph.DiffDocs — the exact engine behind archigraph_diff_refs — so the git
+// diff logic is reused, not duplicated.
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// handlePRImpact implements archigraph_pr_impact.
+//
+// Arguments:
+//   - group (string, optional) — inferred from cwd / registry when omitted
+//   - repo  (string, required)
+//   - base, head (string) — single mode: diff base..head, then impact-analyse head
+//   - refs  (array of string) — conflicts mode: ≥2 refs, each diffed against `base`
+//     (or against the first ref when base omitted) to derive its change set, then
+//     pairwise community-overlap triage
+//   - hops  (number, optional) — downstream blast-radius depth (default 3, [1,6])
+func (s *Server) handlePRImpact(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName := argString(req, "group", "")
+	if groupName == "" {
+		cwd := s.inferCWD(req)
+		groupName, _ = groupFromRegistryWithCandidates(s.State, cwd)
+	}
+	if groupName == "" {
+		return mcpapi.NewToolResultError("group is required; pass group= or run from inside a registered repo"), nil
+	}
+	repoSlug := argString(req, "repo", "")
+	if repoSlug == "" {
+		return mcpapi.NewToolResultError("repo is required"), nil
+	}
+
+	opts := graph.DefaultPRImpactOptions()
+	opts.Hops = argInt(req, "hops", opts.Hops)
+
+	refs := argStringSlice(req, "refs")
+	base := argString(req, "base", "")
+	head := argString(req, "head", "")
+
+	// Validate mode arguments *before* touching the registry/disk so the error is
+	// deterministic and independent of whether the repo is indexed.
+	conflictsMode := len(refs) > 0
+	if conflictsMode {
+		if len(refs) < 2 {
+			return mcpapi.NewToolResultError("conflicts mode requires at least 2 refs"), nil
+		}
+	} else if base == "" || head == "" {
+		return mcpapi.NewToolResultError(
+			"single mode requires both base= and head=; conflicts mode requires refs=[...]"), nil
+	}
+
+	repoPath, err := diffToolRepoPath(groupName, repoSlug)
+	if err != nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("repo lookup failed: %v", err)), nil
+	}
+
+	// ── Conflicts mode: refs supplied ────────────────────────────────────────
+	if conflictsMode {
+		return s.prImpactConflicts(groupName, repoSlug, repoPath, base, refs, opts)
+	}
+
+	// ── Single mode: base/head ───────────────────────────────────────────────
+	res, errRes := s.prImpactSingle(repoPath, base, head, opts)
+	if errRes != nil {
+		return errRes, nil
+	}
+	return jsonResult(map[string]any{
+		"mode":                     "single",
+		"group":                    groupName,
+		"repo":                     repoSlug,
+		"base":                     base,
+		"head":                     head,
+		"changed_entities":         res.ChangedEntities,
+		"impacted_communities":     res.ImpactedCommunities,
+		"blast_radius":             res.BlastRadius,
+		"changed_count":            res.ChangedCount,
+		"impacted_community_count": res.CommunityCount,
+		"blast_radius_count":       res.BlastRadiusCount,
+		"truncated":                res.Truncated,
+	}), nil
+}
+
+// prImpactSingle loads base+head graphs, diffs them (reusing graph.DiffDocs),
+// and runs the impact analysis on the head graph.
+func (s *Server) prImpactSingle(repoPath, base, head string, opts graph.PRImpactOptions) (graph.PRImpactResult, *mcpapi.CallToolResult) {
+	headDoc, err := loadRefGraph(repoPath, head)
+	if err != nil {
+		return graph.PRImpactResult{}, mcpapi.NewToolResultError(err.Error())
+	}
+	change, errRes := diffChangeSet(repoPath, base, head)
+	if errRes != nil {
+		return graph.PRImpactResult{}, errRes
+	}
+	return graph.AnalyzePRImpact(headDoc.Entities, headDoc.Relationships, change, opts), nil
+}
+
+// prImpactConflicts diffs each ref against the base (defaulting to the first
+// ref) to derive its change set, runs impact analysis to get its impacted
+// communities, then triages pairwise overlaps via graph.AnalyzeMergeRisk.
+func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, refs []string, opts graph.PRImpactOptions) (*mcpapi.CallToolResult, error) {
+	if len(refs) < 2 {
+		return mcpapi.NewToolResultError("conflicts mode requires at least 2 refs"), nil
+	}
+	if base == "" {
+		base = refs[0]
+	}
+
+	impacts := make([]graph.ChangeImpact, 0, len(refs))
+	perRef := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		headDoc, err := loadRefGraph(repoPath, ref)
+		if err != nil {
+			return mcpapi.NewToolResultError(err.Error()), nil
+		}
+		change, errRes := diffChangeSet(repoPath, base, ref)
+		if errRes != nil {
+			return errRes, nil
+		}
+		res := graph.AnalyzePRImpact(headDoc.Entities, headDoc.Relationships, change, opts)
+		comms := res.ImpactedCommunityIDs()
+		impacts = append(impacts, graph.ChangeImpact{Ref: ref, Communities: comms})
+		perRef = append(perRef, map[string]any{
+			"ref":                  ref,
+			"changed_count":        res.ChangedCount,
+			"impacted_communities": comms,
+			"blast_radius_count":   res.BlastRadiusCount,
+		})
+	}
+
+	risk := graph.AnalyzeMergeRisk(impacts)
+	return jsonResult(map[string]any{
+		"mode":             "conflicts",
+		"group":            groupName,
+		"repo":             repoSlug,
+		"base":             base,
+		"per_ref":          perRef,
+		"risk_pairs":       risk.Pairs,
+		"ref_count":        risk.RefCount,
+		"risky_pair_count": risk.RiskyPairs,
+	}), nil
+}
+
+// loadRefGraph loads an indexed graph for a single ref from disk, using the same
+// StateDirForRepoRef path diff_refs and other ref-aware tools use.
+func loadRefGraph(repoPath, ref string) (*graph.Document, error) {
+	dir := daemon.StateDirForRepoRef(repoPath, ref)
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not load graph for ref %q: %v (run `archigraph index` on that branch first)", ref, err)
+	}
+	return doc, nil
+}
+
+// diffChangeSet computes the diff-derived change set between base and head by
+// loading both ref graphs and running graph.DiffDocs (the diff_refs engine).
+// Same-ref is the empty change set.
+func diffChangeSet(repoPath, base, head string) (graph.ChangeSet, *mcpapi.CallToolResult) {
+	if base == head {
+		return graph.ChangeSet{}, nil
+	}
+	baseDoc, err := loadRefGraph(repoPath, base)
+	if err != nil {
+		return graph.ChangeSet{}, mcpapi.NewToolResultError(err.Error())
+	}
+	headDoc, err := loadRefGraph(repoPath, head)
+	if err != nil {
+		return graph.ChangeSet{}, mcpapi.NewToolResultError(err.Error())
+	}
+	d := graph.DiffDocs(baseDoc, headDoc)
+	return graph.ChangeSet{
+		Added:    d.Entities.Added,
+		Removed:  d.Entities.Removed,
+		Modified: d.Entities.Modified,
+	}, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1070,6 +1070,24 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_diff_refs", s.handleDiffRefs))
 
+	// #4292 — diff/PR-scoped impact analysis + cross-change merge-risk. Single
+	// mode {base,head}: changed entities (via the diff_refs DiffDocs engine) ->
+	// impacted Pass-4 communities -> downstream blast radius (inbound BFS, the
+	// impact_radius traversal generalised to a seed set). Conflicts mode
+	// {refs:[...]}: each ref's impacted-community set intersected pairwise into a
+	// ranked merge-order/conflict triage. Core logic is pure (graph.AnalyzePRImpact
+	// / AnalyzeMergeRisk); refs are taken explicitly (offline, deterministic).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_pr_impact",
+		mcpapi.WithDescription("PR impact + merge-risk: changes->communities->blast radius."),
+		mcpapi.WithString("repo", mcpapi.Required()),
+		mcpapi.WithString("base"),
+		mcpapi.WithString("head"),
+		mcpapi.WithArray("refs"),
+		mcpapi.WithNumber("hops", mcpapi.DefaultNumber(3)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_pr_impact", s.handlePRImpact))
+
 	// archigraph_docgen_* — docgen-via-local-staging tools (epic #2207, issue #2214).
 	// start_run: create or resume a per-group staging run.
 	// status:    inspect in-flight run (files written + SHAs).

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -531,6 +531,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_clusters", "archigraph_stats",
 		// #4290 graph-orientation analysis
 		"archigraph_orient",
+		// #4292 PR-scoped impact + cross-change merge-risk
+		"archigraph_pr_impact",
 		// bundled (2 retained; cross_links re-wired)
 		"archigraph_enrichments", "archigraph_repairs",
 		// unchanged — trace included here as it was not renamed
@@ -694,8 +696,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_endpoint_posture (deploy-9 caps surfacing: error_flow/
 	// rate_limit/deprecation/feature_flag/grpc-auth posture).
 	// +1 archigraph_orient (#4290 graph-orientation analysis).
-	if got := len(allRegisteredTools); got != 58 {
-		t.Errorf("expected 58 registered tools, got %d — update this count if tools are added/removed (added archigraph_orient #4290 orientation analysis)", got)
+	// +1 archigraph_pr_impact (#4292 PR-scoped impact + cross-change merge-risk).
+	if got := len(allRegisteredTools); got != 59 {
+		t.Errorf("expected 59 registered tools, got %d — update this count if tools are added/removed (added archigraph_pr_impact #4292 PR-impact/merge-risk)", got)
 	}
 }
 
@@ -3175,6 +3178,9 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_status":               {"group": "g"},
 		// PH5 (#2093): diff tool — repo/ref_a/ref_b all required.
 		"archigraph_diff_refs": {"group": "g", "repo": "r1", "ref_a": "main", "ref_b": "feat/x"},
+		// #4292: PR-impact tool. Single mode args; repo lookup fails gracefully
+		// (text result) in the test registry, which still exercises the wrapper.
+		"archigraph_pr_impact": {"group": "g", "repo": "r1", "base": "main", "head": "feat/x"},
 		// #2214 (epic #2207): 6 docgen staging tools. Pass no_git=true so the
 		// handler doesn't require a real git repo. group is required for most.
 		"archigraph_docgen_start_run": {"group": "g", "no_git": true},
@@ -3256,8 +3262,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 58 {
-		t.Errorf("expected 58 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_orient #4290 orientation analysis)", len(tools))
+	if len(tools) != 59 {
+		t.Errorf("expected 59 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_pr_impact #4292 PR-impact/merge-risk)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
Closes #4292

## What

New MCP tool **`archigraph_pr_impact`** — change-scoped impact analysis with two modes.

### Single mode `{base, head}`
Changed files → impacted entities → communities → downstream blast radius.

1. **Changed set** is derived via the existing diff_refs engine (`graph.DiffDocs`) — the git-diff logic is reused, not duplicated.
2. Each changed entity is annotated with its **Pass-4 community** (`Entity.CommunityID`).
3. A multi-source **inbound BFS** from the changed seeds (callers-of-callers, hop-bounded) computes the downstream **blast radius** — the same inbound-reachability traversal `archigraph_impact_radius` uses, generalised to a set of seeds.
4. Output: `changed_entities`, `impacted_communities` (per-community changed + blast counts), `blast_radius` (hop-ranked), plus aggregate counts.

### Conflicts mode `{refs: [...]}`
Cross-change merge-risk triage.

1. For each ref, diff against `base` (defaults to the first ref) → run single-mode impact → take its **impacted-community set**.
2. **Intersect the sets pairwise**; refs whose impacted-community sets overlap are merge-order/conflict risks.
3. Output `risk_pairs` **ranked by shared-community count desc** (ties broken by ref label), each listing the shared community ids. Disjoint refs are safe in any order and omitted. Ungrouped (-1) is excluded so unrelated changes don't appear to collide.

Refs are taken **explicitly** as input — offline and deterministic, no GitHub auto-discovery.

## Design / reuse
- **`archigraph_diff_refs`** (`graph.DiffDocs`) → changed-entity set.
- **`archigraph_impact_radius`** inbound-BFS traversal → blast radius (generalised to a seed set).
- **`Entity.CommunityID`** (Pass-4, same source as `archigraph_clusters` / `archigraph_orient`) → community assignment.
- Core logic factored into a **pure, MCP-free** package (`graph.AnalyzePRImpact` / `graph.AnalyzeMergeRisk`), mirroring `graph.AnalyzeOrientation` from #4290, so it's unit-testable on an in-memory graph. The handler is a thin shell loading per-ref graphs via the same `StateDirForRepoRef` path other ref-aware tools use.

## Example (conflicts mode)
```json
{
  "mode": "conflicts",
  "base": "main",
  "per_ref": [
    {"ref": "pr-a", "changed_count": 4, "impacted_communities": [0, 2], "blast_radius_count": 11},
    {"ref": "pr-b", "changed_count": 2, "impacted_communities": [0, 3], "blast_radius_count": 6},
    {"ref": "pr-c", "changed_count": 1, "impacted_communities": [9], "blast_radius_count": 0}
  ],
  "risk_pairs": [
    {"ref_a": "pr-a", "ref_b": "pr-b", "shared_community_count": 1, "shared_communities": [0]}
  ],
  "ref_count": 3,
  "risky_pair_count": 1
}
```
(pr-a and pr-b both touch community 0 → flagged; pr-c is disjoint → safe.)

## Tests
- `internal/graph/pr_impact_test.go` — blast radius + community rollup, hops cap, removed-entity handling, merge-risk overlap-vs-disjoint, ranking + tiebreak, ungrouped-ignored.
- `internal/mcp/pr_impact_4292_test.go` — handler arg-validation paths.
- Registry-audit (`server_test.go`) tool count bumped 58→59; `minimalArgs` + `wantPresent` updated. Handshake/token-budget test passes.
- `go build ./...`, `go vet`, `gofmt` clean on touched files; `go test ./internal/graph ./internal/mcp` green.

## Deferred (honest)
- **Deploy-deferred**: no live-daemon ops; the tool ships in code only and activates on the next coordinated daemon rebuild.
- Conflicts mode reasons about **community overlap**, not file-level/line-level diff overlap — it's a coarse "these PRs touch the same module cluster" signal, not a textual-merge-conflict predictor.
- No GitHub PR auto-discovery (intentional: refs are explicit for determinism/offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)