### PR TITLE
feat(ingest): deterministic markdown doc ingestion — Document/Section nodes + exact-mention links, opt-in (#4306)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 	idiff "github.com/cajasmota/archigraph/internal/indexer/diff"
+	"github.com/cajasmota/archigraph/internal/ingest"
 	"github.com/cajasmota/archigraph/internal/install/detect"
 	"github.com/cajasmota/archigraph/internal/module"
 	"github.com/cajasmota/archigraph/internal/progress"
@@ -182,6 +183,16 @@ type Indexer struct {
 	// Issue #1381 — module extraction via path rollup.
 	moduleMarkers module.MarkerSet
 
+	// ingestDocs enables deterministic markdown documentation ingestion
+	// (#4306, Layer 1 of epic #4294). OFF by default. When true, after the
+	// code graph is built the indexer discovers in-repo *.md files, parses
+	// each into a SCOPE.MarkdownDocument node + heading-delimited SCOPE.Section
+	// nodes (CONTAINS hierarchy), and links section text to code entities by
+	// EXACT identifier-token match (MENTIONS edges). Fully deterministic — no
+	// LLM calls, no network. When false this whole subsystem is skipped and
+	// adds zero overhead. Also honored via env ARCHIGRAPH_INGEST_DOCS=1|true.
+	ingestDocs bool
+
 	// singleModuleLabel, when non-empty, forces every entity in this repo into
 	// ONE module row instead of the per-directory path rollup. It is set for
 	// PLAIN (non-monorepo) repos so the per-module progress + Group-by-Module
@@ -240,6 +251,26 @@ func WithExportJSON(export bool) IndexOption {
 // directory skipped at walk-time is printed to stderr with its rule.
 func WithPrintSkipped(enabled bool) IndexOption {
 	return func(i *Indexer) { i.printSkipped = enabled }
+}
+
+// WithIngestDocs toggles deterministic markdown documentation ingestion
+// (#4306, Layer 1 of epic #4294). Default OFF. When true the indexer discovers
+// in-repo *.md files and emits SCOPE.MarkdownDocument + SCOPE.Section nodes
+// (CONTAINS hierarchy) plus exact-match MENTIONS edges to code entities. Fully
+// deterministic — no LLM calls, no network. Wired from the --ingest-docs CLI
+// flag; also honored via env ARCHIGRAPH_INGEST_DOCS.
+func WithIngestDocs(enabled bool) IndexOption {
+	return func(i *Indexer) { i.ingestDocs = enabled }
+}
+
+// ingestDocsEnvEnabled reports whether ARCHIGRAPH_INGEST_DOCS requests doc
+// ingestion (accepts "1", "true", "yes", "on"; case-insensitive).
+func ingestDocsEnvEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ARCHIGRAPH_INGEST_DOCS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // WithAdditionalSkipDirs extends the hard-coded walk-time skip list
@@ -381,6 +412,14 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	}
 	for _, opt := range opts {
 		opt(idx)
+	}
+
+	// #4306: env fallback for the opt-in markdown-ingestion flag, so the
+	// subsystem can be exercised without threading a new field through the
+	// daemon RPC proto (deploy-deferred). The CLI --ingest-docs flag and any
+	// WithIngestDocs(true) option take precedence; the env var only flips it ON.
+	if !idx.ingestDocs && ingestDocsEnvEnabled() {
+		idx.ingestDocs = true
 	}
 
 	doc, err := idx.Run(context.Background(), absRepo)
@@ -1304,6 +1343,25 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// have been emitted by a Wave 3-5 path) are also caught.
 	if ePruned, rPruned := extractors.PruneMigrationEntities(doc); ePruned > 0 && verbose() {
 		fmt.Fprintf(os.Stderr, "migration-prune: dropped %d entities + %d relationships anchored to Django migration files\n", ePruned, rPruned)
+	}
+
+	// #4306 (Layer 1 of epic #4294): deterministic markdown documentation
+	// ingestion. OPT-IN (--ingest-docs / ARCHIGRAPH_INGEST_DOCS), default OFF.
+	// Runs AFTER buildDocument + incremental merge so the code-entity name
+	// index used for exact-mention linking reflects the full, ID-stamped graph,
+	// and the emitted doc/section nodes participate in Pass 4 graph algorithms
+	// and the on-disk write. Fully deterministic: no LLM calls, no network.
+	// When the flag is off this block is skipped entirely (zero overhead).
+	if i.ingestDocs {
+		mdFiles := ingest.DiscoverMarkdown(allFiles)
+		ingRes := ingest.Ingest(absRepo, i.repoTag, mdFiles, doc.Entities)
+		doc.Entities = append(doc.Entities, ingRes.Entities...)
+		doc.Relationships = append(doc.Relationships, ingRes.Relationships...)
+		if verbose() {
+			fmt.Fprintf(os.Stderr,
+				"ingest-docs: %d markdown files → %d documents, %d sections, %d mentions (deterministic, no LLM)\n",
+				ingRes.FilesRead, ingRes.Documents, ingRes.Sections, ingRes.Mentions)
+		}
 	}
 	// Drop the per-pass record slices now that buildDocument has produced
 	// the merged + deduped graph.Entity / graph.Relationship slices. These

--- a/cmd/archigraph/index_internal.go
+++ b/cmd/archigraph/index_internal.go
@@ -34,6 +34,7 @@ func runIndexInternal(argv []string) int {
 		repoTag    = fs.String("repo-tag", "", "slug written into every graph entity (defaults to dir basename)")
 		skipPasses = fs.String("skip-pass", "", "comma-separated list of pass names to skip")
 		exportJSON = fs.Bool("export-json", false, "also emit graph.json alongside graph.fb")
+		ingestDocs = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md files as Document/Section nodes + exact-mention links (no LLM, no network)")
 	)
 
 	if err := fs.Parse(argv); err != nil {
@@ -61,6 +62,7 @@ func runIndexInternal(argv []string) int {
 	// daemonSchedulerAlgo (which is not on the hot path that needs memory isolation).
 	opts := []IndexOption{
 		WithExportJSON(*exportJSON),
+		WithIngestDocs(*ingestDocs),
 	}
 
 	// Emit a JSON start line so the daemon IPC reader can log the start event

--- a/cmd/archigraph/ingest_docs_pipeline_test.go
+++ b/cmd/archigraph/ingest_docs_pipeline_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runIngestPipeline indexes the ingest_docs fixture with the markdown-ingestion
+// flag set to ingestDocs and returns counts of the doc/section nodes and
+// CONTAINS/MENTIONS edges produced.
+func runIngestPipeline(t *testing.T, ingestDocs bool) (docs, sections, mentions int) {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/ingest_docs")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	idx := newTestIndexer(t, "ingestdocs", nil, "")
+	idx.ingestDocs = ingestDocs
+
+	doc, err := idx.Run(context.Background(), abs)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for i := range doc.Entities {
+		switch doc.Entities[i].Kind {
+		case string(types.EntityKindMarkdownDocument):
+			docs++
+		case string(types.EntityKindSection):
+			sections++
+		}
+	}
+	for i := range doc.Relationships {
+		if doc.Relationships[i].Kind == string(types.RelationshipKindMentions) {
+			mentions++
+		}
+	}
+	return docs, sections, mentions
+}
+
+// TestIngestDocs_FlagOff_NoDocNodes is the off-by-default guarantee: with the
+// opt-in flag OFF the pipeline emits ZERO Document/Section nodes and zero
+// MENTIONS edges — behavior is identical to today.
+func TestIngestDocs_FlagOff_NoDocNodes(t *testing.T) {
+	docs, sections, mentions := runIngestPipeline(t, false)
+	if docs != 0 || sections != 0 || mentions != 0 {
+		t.Fatalf("flag OFF must produce no doc artifacts; got docs=%d sections=%d mentions=%d",
+			docs, sections, mentions)
+	}
+}
+
+// TestIngestDocs_FlagOn_EmitsDocNodes asserts the opt-in path emits the
+// Document + Section nodes and at least one exact-match MENTIONS edge to the
+// indexed Go symbols (WidgetProcessor / ProcessWidget), and that the common
+// words in the fixture did not inflate the link count.
+func TestIngestDocs_FlagOn_EmitsDocNodes(t *testing.T) {
+	docs, sections, mentions := runIngestPipeline(t, true)
+	if docs != 1 {
+		t.Fatalf("flag ON: documents = %d, want 1", docs)
+	}
+	if sections < 2 {
+		t.Fatalf("flag ON: sections = %d, want >= 2 (# + ##)", sections)
+	}
+	if mentions == 0 {
+		t.Fatalf("flag ON: expected >=1 MENTIONS edge to an indexed Go symbol, got 0")
+	}
+}

--- a/cmd/archigraph/testdata/ingest_docs/README.md
+++ b/cmd/archigraph/testdata/ingest_docs/README.md
@@ -1,0 +1,8 @@
+# Widget Subsystem
+
+The WidgetProcessor is the entry point for widget handling.
+
+## Processing
+
+Call ProcessWidget to run a single processing step. This section also
+uses common words like data, file, and test that must not link.

--- a/cmd/archigraph/testdata/ingest_docs/widget.go
+++ b/cmd/archigraph/testdata/ingest_docs/widget.go
@@ -1,0 +1,9 @@
+package widget
+
+// WidgetProcessor processes widgets deterministically.
+type WidgetProcessor struct{}
+
+// ProcessWidget runs the processing step for a single widget.
+func (p *WidgetProcessor) ProcessWidget() error {
+	return nil
+}

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -1,0 +1,52 @@
+package ingest
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// excludedDirSegments are path segments whose presence anywhere in a file's
+// repo-relative path excludes it from markdown ingestion. These mirror the
+// indexer's general vendored/build excludes — documentation living under them
+// is third-party or generated and would pollute the graph.
+var excludedDirSegments = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	".git":         true,
+	".archigraph":  true,
+}
+
+// DiscoverMarkdown filters relPaths (repo-relative slash paths, e.g. the
+// indexer's walked file list) down to the markdown files eligible for
+// ingestion: a ".md" or ".markdown" extension (case-insensitive) and no
+// excluded directory segment. The returned slice is sorted for determinism.
+func DiscoverMarkdown(relPaths []string) []string {
+	var out []string
+	for _, p := range relPaths {
+		rel := filepath.ToSlash(p)
+		if !isMarkdownPath(rel) {
+			continue
+		}
+		if hasExcludedSegment(rel) {
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out
+}
+
+func isMarkdownPath(rel string) bool {
+	ext := strings.ToLower(filepath.Ext(rel))
+	return ext == ".md" || ext == ".markdown"
+}
+
+func hasExcludedSegment(rel string) bool {
+	for _, seg := range strings.Split(rel, "/") {
+		if excludedDirSegments[seg] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,196 @@
+package ingest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// maxDocBytes bounds how much of a single markdown file is read. Documentation
+// files are small; this caps pathological inputs without a config knob.
+const maxDocBytes = 1 << 20 // 1 MiB
+
+// Result is the output of an ingestion run: the doc/section nodes and the
+// CONTAINS/MENTIONS edges to splice into the graph document.
+type Result struct {
+	Entities      []graph.Entity
+	Relationships []graph.Relationship
+	// Stats for the indexer's stderr summary.
+	Documents int
+	Sections  int
+	Mentions  int
+	FilesRead int
+}
+
+// Ingest runs the deterministic markdown pipeline over mdRelPaths (repo-relative
+// slash paths) and returns Document/Section nodes plus CONTAINS (Document→
+// Section→subsection) and MENTIONS (Section→code entity) edges, ready to append
+// to the graph document.
+//
+// repoRoot is the absolute repo path used to read file bodies; repoTag is the
+// per-repo slug stamped into every entity ID (matching graph.EntityID usage
+// elsewhere in the indexer). codeEntities is the current graph entity set used
+// to resolve exact name mentions.
+//
+// Fully deterministic: no LLM calls, no network. Output ordering is stable
+// (files sorted, sections in source order, edges ID-tiebroken).
+func Ingest(repoRoot, repoTag string, mdRelPaths []string, codeEntities []graph.Entity) Result {
+	var res Result
+
+	// Build the exact-name target index once from the code entities. Doc/section
+	// nodes we are about to create are NOT in this set, so a section can never
+	// MENTIONS another doc node.
+	tuples := make([]NameTuple, 0, len(codeEntities))
+	for i := range codeEntities {
+		e := &codeEntities[i]
+		tuples = append(tuples, NameTuple{
+			Name:          e.Name,
+			QualifiedName: e.QualifiedName,
+			ID:            e.ID,
+			Kind:          e.Kind,
+		})
+	}
+	nameIdx := IndexNames(tuples)
+
+	// Sort the file list for deterministic output.
+	paths := append([]string(nil), mdRelPaths...)
+	sort.Strings(paths)
+
+	for _, rel := range paths {
+		rel = filepath.ToSlash(rel)
+		abs := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		content, err := readBoundedFile(abs, maxDocBytes)
+		if err != nil {
+			// Best-effort: a doc we can't read contributes nothing.
+			continue
+		}
+		res.FilesRead++
+
+		doc, sections := ParseDocument(rel, content)
+
+		// Document node.
+		docID := graph.EntityID(repoTag, string(types.EntityKindMarkdownDocument), rel, rel)
+		docEnt := graph.Entity{
+			ID:            docID,
+			Name:          path_base(rel),
+			QualifiedName: repoTag + "::" + rel,
+			Kind:          string(types.EntityKindMarkdownDocument),
+			SourceFile:    rel,
+			StartLine:     1,
+			EndLine:       max1(doc.LineCount),
+			Language:      "markdown",
+			Properties:    map[string]string{"title": doc.Title},
+		}
+		res.Entities = append(res.Entities, docEnt)
+		res.Documents++
+
+		// Section nodes + CONTAINS hierarchy. Section identity is the file path
+		// plus the heading line, so distinct sections (even same heading text)
+		// get distinct IDs and the ID is stable across re-indexes.
+		sectionIDs := make([]string, len(sections))
+		for k := range sections {
+			s := &sections[k]
+			name := fmt.Sprintf("%s#L%d", rel, s.StartLine)
+			secID := graph.EntityID(repoTag, string(types.EntityKindSection), name, rel)
+			sectionIDs[k] = secID
+			res.Entities = append(res.Entities, graph.Entity{
+				ID:            secID,
+				Name:          headingOrAnchor(s.HeadingText, s.StartLine),
+				QualifiedName: repoTag + "::" + name,
+				Kind:          string(types.EntityKindSection),
+				SourceFile:    rel,
+				StartLine:     s.StartLine,
+				EndLine:       s.EndLine,
+				Language:      "markdown",
+				Properties: map[string]string{
+					"depth":   fmt.Sprintf("%d", s.Depth),
+					"heading": s.HeadingText,
+				},
+			})
+			res.Sections++
+
+			// CONTAINS: parent (another section, or the document for top-level).
+			parentID := docID
+			if s.ParentIndex >= 0 {
+				parentID = sectionIDs[s.ParentIndex]
+			}
+			res.Relationships = append(res.Relationships, mkRel(parentID, secID, string(types.RelationshipKindContains), nil))
+		}
+
+		// MENTIONS: Section → code entity, exact-match only.
+		mentions := LinkMentions(sections, nameIdx)
+		for _, m := range mentions {
+			res.Relationships = append(res.Relationships, mkRel(
+				sectionIDs[m.SectionIndex],
+				m.TargetID,
+				string(types.RelationshipKindMentions),
+				map[string]string{"token": m.Token, "target_kind": m.TargetKind},
+			))
+			res.Mentions++
+		}
+	}
+
+	// Deterministic edge ordering (by from, to, kind).
+	sort.SliceStable(res.Relationships, func(a, b int) bool {
+		ra, rb := res.Relationships[a], res.Relationships[b]
+		if ra.FromID != rb.FromID {
+			return ra.FromID < rb.FromID
+		}
+		if ra.ToID != rb.ToID {
+			return ra.ToID < rb.ToID
+		}
+		return ra.Kind < rb.Kind
+	})
+	sort.SliceStable(res.Entities, func(a, b int) bool {
+		return res.Entities[a].ID < res.Entities[b].ID
+	})
+	return res
+}
+
+func mkRel(from, to, kind string, props map[string]string) graph.Relationship {
+	return graph.Relationship{
+		ID:         graph.RelationshipID(from, to, kind),
+		FromID:     from,
+		ToID:       to,
+		Kind:       kind,
+		Properties: props,
+	}
+}
+
+// readBoundedFile reads at most limit bytes from path.
+func readBoundedFile(path string, limit int) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // path derived from repo-relative walk result
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	buf := make([]byte, limit)
+	n, err := f.Read(buf)
+	if err != nil && n == 0 {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func path_base(rel string) string {
+	return filepath.Base(filepath.FromSlash(rel))
+}
+
+func headingOrAnchor(heading string, line int) string {
+	if strings.TrimSpace(heading) != "" {
+		return heading
+	}
+	return fmt.Sprintf("§L%d", line)
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,0 +1,150 @@
+package ingest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func codeEntitiesFixture(repoTag string) []graph.Entity {
+	mk := func(kind, name, qn, src string) graph.Entity {
+		return graph.Entity{
+			ID:            graph.EntityID(repoTag, kind, name, src),
+			Name:          name,
+			QualifiedName: qn,
+			Kind:          kind,
+			SourceFile:    src,
+		}
+	}
+	return []graph.Entity{
+		mk(string(types.EntityKindClass), "OrderService", "orders/order.OrderService", "orders/order.go"),
+		mk(string(types.EntityKindFunction), "placeOrder", "orders/order.OrderService.placeOrder", "orders/order.go"),
+		mk(string(types.EntityKindFunction), "validateOrder", "orders/order.validateOrder", "orders/order.go"),
+	}
+}
+
+func TestDiscoverMarkdown_ExcludesVendored(t *testing.T) {
+	in := []string{
+		"docs/orders.md",
+		"README.markdown",
+		"node_modules/dep.md",
+		"vendor/x/y.md",
+		"src/main.go",
+		"dist/bundle.md",
+	}
+	got := DiscoverMarkdown(in)
+	want := map[string]bool{"docs/orders.md": true, "README.markdown": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want keys %v", got, want)
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected discovered path %q", g)
+		}
+	}
+}
+
+func TestIngest_EmitsDocSectionAndMentionEdges(t *testing.T) {
+	repoRoot, err := filepath.Abs("testdata/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoTag := "repo"
+	code := codeEntitiesFixture(repoTag)
+
+	res := Ingest(repoRoot, repoTag, []string{"docs/orders.md"}, code)
+
+	if res.Documents != 1 {
+		t.Fatalf("documents = %d, want 1", res.Documents)
+	}
+	// # Orders, ## Placing an order, ### Validation, ## Refunds = 4 sections.
+	if res.Sections != 4 {
+		t.Fatalf("sections = %d, want 4", res.Sections)
+	}
+
+	// Exactly one Document node + 4 Section nodes.
+	var docNodes, secNodes int
+	for _, e := range res.Entities {
+		switch e.Kind {
+		case string(types.EntityKindMarkdownDocument):
+			docNodes++
+			if e.SourceFile != "docs/orders.md" {
+				t.Errorf("doc node SourceFile = %q", e.SourceFile)
+			}
+		case string(types.EntityKindSection):
+			secNodes++
+			if e.StartLine <= 0 || e.EndLine < e.StartLine {
+				t.Errorf("section %q has bad span %d-%d", e.Name, e.StartLine, e.EndLine)
+			}
+		}
+	}
+	if docNodes != 1 || secNodes != 4 {
+		t.Fatalf("nodes: doc=%d sec=%d, want 1 and 4", docNodes, secNodes)
+	}
+
+	// CONTAINS edges: 4 (doc->H1, H1->H2 placing, H2->H3 validation, doc/H1->H2 refunds).
+	var contains, mentions int
+	mentionTargets := map[string]bool{}
+	for _, r := range res.Relationships {
+		switch r.Kind {
+		case string(types.RelationshipKindContains):
+			contains++
+		case string(types.RelationshipKindMentions):
+			mentions++
+			mentionTargets[r.ToID] = true
+		}
+	}
+	if contains != 4 {
+		t.Fatalf("CONTAINS edges = %d, want 4", contains)
+	}
+
+	// MENTIONS must point at the known code entities by exact name.
+	wantTargets := map[string]bool{
+		graph.EntityID(repoTag, string(types.EntityKindClass), "OrderService", "orders/order.go"):     true,
+		graph.EntityID(repoTag, string(types.EntityKindFunction), "placeOrder", "orders/order.go"):    true,
+		graph.EntityID(repoTag, string(types.EntityKindFunction), "validateOrder", "orders/order.go"): true,
+	}
+	for id := range wantTargets {
+		if !mentionTargets[id] {
+			t.Errorf("expected a MENTIONS edge to %q, none found", id)
+		}
+	}
+	// Every MENTIONS edge must resolve to one of the 3 known code entities —
+	// common words ("type", "data", "file", "test") must NOT produce edges and
+	// no edge may point anywhere unexpected.
+	if len(mentionTargets) != len(wantTargets) {
+		t.Fatalf("distinct mention targets = %d, want %d (no noisy links)", len(mentionTargets), len(wantTargets))
+	}
+	for id := range mentionTargets {
+		if !wantTargets[id] {
+			t.Errorf("unexpected (noisy) MENTIONS target %q", id)
+		}
+	}
+	// validateOrder is legitimately referenced in two distinct sections, so the
+	// edge COUNT (4) exceeds the distinct-target count (3). Both are correct.
+	if mentions < len(wantTargets) {
+		t.Fatalf("mentions = %d, want >= %d", mentions, len(wantTargets))
+	}
+}
+
+func TestIngest_Deterministic(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	a := Ingest(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	b := Ingest(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	if len(a.Entities) != len(b.Entities) || len(a.Relationships) != len(b.Relationships) {
+		t.Fatal("non-deterministic counts")
+	}
+	for i := range a.Entities {
+		if a.Entities[i].ID != b.Entities[i].ID {
+			t.Fatalf("entity order/ID differs at %d", i)
+		}
+	}
+	for i := range a.Relationships {
+		if a.Relationships[i].ID != b.Relationships[i].ID {
+			t.Fatalf("rel order/ID differs at %d", i)
+		}
+	}
+}

--- a/internal/ingest/linker.go
+++ b/internal/ingest/linker.go
@@ -1,0 +1,243 @@
+package ingest
+
+import (
+	"sort"
+	"strings"
+)
+
+// minTokenLen is the minimum identifier-token length eligible for mention
+// linking. Tokens shorter than this are skipped regardless of whether they
+// match an entity name — short tokens (e.g. "id", "db", "ok") collide with
+// far too many entity names and prose words to link with precision.
+const minTokenLen = 4
+
+// NameTarget is one resolvable code-entity name in the current index. ID is the
+// stamped graph entity ID the MENTIONS edge will point at. Name is the exact
+// token the document text must contain (a bare entity Name or its trailing
+// qualified-name segment). Kind is retained for diagnostics/properties.
+type NameTarget struct {
+	Name string
+	ID   string
+	Kind string
+}
+
+// Mention is one resolved Section→entity link.
+type Mention struct {
+	// SectionIndex indexes into the []Section the caller linked.
+	SectionIndex int
+	// Token is the exact identifier token that matched.
+	Token string
+	// TargetID is the graph entity ID to point the MENTIONS edge at.
+	TargetID string
+	// TargetKind is the matched entity's kind (edge property, diagnostics).
+	TargetKind string
+}
+
+// LinkMentions scans each section's body for identifier tokens that EXACTLY
+// match a single code-entity name and returns one Mention per (section, token)
+// pair. It is precision-first and deterministic.
+//
+// Precision rules (under-link rather than mislink — noisy links erode trust):
+//   - Case-sensitive, whole-token match only. A token is a maximal run of
+//     [A-Za-z0-9_]; "FooService" in prose matches an entity named exactly
+//     "FooService" but the substring inside "MyFooServiceThing" does not.
+//   - Tokens shorter than minTokenLen are skipped.
+//   - Language keywords / very common words (skipWords) are skipped even if an
+//     entity happens to share the name.
+//   - AMBIGUOUS tokens are dropped: if a token resolves to more than one
+//     DISTINCT entity ID, no edge is emitted (we cannot know which is meant).
+//   - At most one Mention per (section, token): a token repeated within a
+//     section yields a single edge.
+//
+// The targets index is built by IndexNames from the current graph entities.
+func LinkMentions(sections []Section, targets map[string][]NameTarget) []Mention {
+	var out []Mention
+	for si := range sections {
+		seen := map[string]bool{}
+		for _, tok := range identifierTokens(sections[si].Body) {
+			if seen[tok] {
+				continue
+			}
+			if len(tok) < minTokenLen {
+				continue
+			}
+			if skipWords[strings.ToLower(tok)] {
+				continue
+			}
+			cands := targets[tok]
+			if len(cands) == 0 {
+				continue
+			}
+			// Ambiguity guard: require exactly one DISTINCT target ID.
+			id := cands[0].ID
+			distinct := true
+			for _, c := range cands[1:] {
+				if c.ID != id {
+					distinct = false
+					break
+				}
+			}
+			if !distinct {
+				continue
+			}
+			seen[tok] = true
+			out = append(out, Mention{
+				SectionIndex: si,
+				Token:        tok,
+				TargetID:     cands[0].ID,
+				TargetKind:   cands[0].Kind,
+			})
+		}
+	}
+	// Deterministic ordering: by section, then token.
+	sort.SliceStable(out, func(a, b int) bool {
+		if out[a].SectionIndex != out[b].SectionIndex {
+			return out[a].SectionIndex < out[b].SectionIndex
+		}
+		return out[a].Token < out[b].Token
+	})
+	return out
+}
+
+// IndexNames builds the token→targets lookup used by LinkMentions from the
+// provided (name, qualifiedName, id, kind) tuples. For each entity it indexes
+// the bare Name and the entity's OWN simple name (the final segment of the
+// qualified name). It deliberately does NOT index ancestor segments of a
+// qualified name (e.g. the parent class of a method): doing so would map a
+// class name to BOTH the class entity AND every one of its methods, which the
+// ambiguity guard would then drop — under-linking the class. Names that are
+// keywords, too short, or non-token shaped are not indexed (they could never
+// match a linkable token anyway).
+func IndexNames(tuples []NameTuple) map[string][]NameTarget {
+	idx := map[string][]NameTarget{}
+	add := func(name, id, kind string) {
+		if !isLinkableName(name) {
+			return
+		}
+		t := NameTarget{Name: name, ID: id, Kind: kind}
+		// Deduplicate identical (name,id) entries.
+		for _, ex := range idx[name] {
+			if ex.ID == id {
+				return
+			}
+		}
+		idx[name] = append(idx[name], t)
+	}
+	for _, tu := range tuples {
+		add(tu.Name, tu.ID, tu.Kind)
+		if seg := lastSegment(tu.QualifiedName); seg != "" {
+			add(seg, tu.ID, tu.Kind)
+		}
+	}
+	// Sort each bucket by ID for deterministic ambiguity handling/output.
+	for k := range idx {
+		sort.SliceStable(idx[k], func(a, b int) bool { return idx[k][a].ID < idx[k][b].ID })
+	}
+	return idx
+}
+
+// NameTuple is the minimal projection of a graph entity the indexer feeds to
+// IndexNames.
+type NameTuple struct {
+	Name          string
+	QualifiedName string
+	ID            string
+	Kind          string
+}
+
+// isLinkableName reports whether name is eligible to be a mention target: it
+// must be a single identifier token (no spaces/punctuation), at least
+// minTokenLen long, and not a skip word.
+func isLinkableName(name string) bool {
+	if len(name) < minTokenLen {
+		return false
+	}
+	if skipWords[strings.ToLower(name)] {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isIdentByte(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// lastSegment returns the final identifier segment of a qualified name, split
+// on common separators. e.g. "pkg/order.OrderService.placeOrder" -> "placeOrder".
+// Returns "" when qn is empty or has no trailing segment.
+func lastSegment(qn string) string {
+	if qn == "" {
+		return ""
+	}
+	repl := strings.NewReplacer("/", "\x00", ".", "\x00", "#", "\x00", ":", "\x00")
+	raw := strings.Split(repl.Replace(qn), "\x00")
+	for i := len(raw) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(raw[i]); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// identifierTokens extracts the distinct-position maximal identifier tokens
+// from body text. A token is a maximal run of [A-Za-z0-9_]. Order is preserved.
+func identifierTokens(body string) []string {
+	var out []string
+	start := -1
+	for i := 0; i < len(body); i++ {
+		if isIdentByte(body[i]) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			out = append(out, body[start:i])
+			start = -1
+		}
+	}
+	if start >= 0 {
+		out = append(out, body[start:])
+	}
+	return out
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// skipWords are tokens that must never be linked even when an entity shares the
+// name: programming keywords across the languages archigraph indexes, plus a
+// handful of extremely common English/prose words that frequently appear in
+// documentation. Kept explicit and lowercase; matching is case-insensitive for
+// the skip check only (entity matching itself stays case-sensitive).
+var skipWords = func() map[string]bool {
+	words := []string{
+		// Cross-language keywords / reserved-ish identifiers.
+		"abstract", "async", "await", "break", "case", "catch", "class",
+		"const", "continue", "default", "defer", "delete", "else", "enum",
+		"export", "extends", "false", "final", "finally", "func", "function",
+		"goto", "import", "interface", "null", "none", "package", "private",
+		"protected", "public", "return", "static", "struct", "super", "switch",
+		"this", "throw", "throws", "true", "type", "typeof", "void", "while",
+		"yield", "self", "from", "with", "match", "where", "select", "insert",
+		"update", "table", "index", "value", "values",
+		// Very common prose words that look like identifiers.
+		"about", "also", "always", "because", "before", "both", "code",
+		"data", "does", "done", "each", "into", "just", "like", "more",
+		"most", "must", "name", "note", "only", "other", "over", "same",
+		"some", "such", "than", "that", "their", "them", "then", "there",
+		"these", "they", "this", "thus", "used", "uses", "using", "very",
+		"what", "when", "which", "will", "with", "your", "here", "have",
+		"file", "files", "test", "tests", "page", "section", "document",
+	}
+	m := make(map[string]bool, len(words))
+	for _, w := range words {
+		m[w] = true
+	}
+	return m
+}()

--- a/internal/ingest/linker_test.go
+++ b/internal/ingest/linker_test.go
@@ -1,0 +1,99 @@
+package ingest
+
+import "testing"
+
+func buildIndex() map[string][]NameTarget {
+	return IndexNames([]NameTuple{
+		{Name: "OrderService", QualifiedName: "orders/order.OrderService", ID: "id_orderservice", Kind: "SCOPE.Class"},
+		{Name: "placeOrder", QualifiedName: "orders/order.OrderService.placeOrder", ID: "id_placeorder", Kind: "SCOPE.Function"},
+		{Name: "validateOrder", QualifiedName: "orders/order.validateOrder", ID: "id_validate", Kind: "SCOPE.Function"},
+		// Two distinct entities sharing a name -> ambiguous, must not link.
+		{Name: "Handler", QualifiedName: "a.Handler", ID: "id_handler_a", Kind: "SCOPE.Class"},
+		{Name: "Handler", QualifiedName: "b.Handler", ID: "id_handler_b", Kind: "SCOPE.Class"},
+		// Short name -> never linkable.
+		{Name: "db", QualifiedName: "x.db", ID: "id_db", Kind: "SCOPE.Variable"},
+	})
+}
+
+func TestLinkMentions_ExactMatchLinks(t *testing.T) {
+	idx := buildIndex()
+	sections := []Section{
+		{HeadingText: "Intro", Body: "The OrderService runs placeOrder and then validateOrder.\n"},
+	}
+	got := LinkMentions(sections, idx)
+
+	want := map[string]string{
+		"OrderService":  "id_orderservice",
+		"placeOrder":    "id_placeorder",
+		"validateOrder": "id_validate",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d mentions, want %d: %+v", len(got), len(want), got)
+	}
+	for _, m := range got {
+		if want[m.Token] != m.TargetID {
+			t.Errorf("token %q -> %q, want %q", m.Token, m.TargetID, want[m.Token])
+		}
+	}
+}
+
+func TestLinkMentions_DropsCommonWordsAndKeywords(t *testing.T) {
+	idx := buildIndex()
+	// "type", "this", "value", "data", "file", "test" are skip-words; a token
+	// like "order" (common) and "the" never appear as entity names anyway.
+	sections := []Section{
+		{HeadingText: "Notes", Body: "This type of data in the file is used for the test value.\n"},
+	}
+	got := LinkMentions(sections, idx)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 links from common/keyword-only prose, got %+v", got)
+	}
+}
+
+func TestLinkMentions_SubstringDoesNotLink(t *testing.T) {
+	idx := buildIndex()
+	// "OrderServiceFactory" must NOT match the entity "OrderService" — exact
+	// whole-token match only.
+	sections := []Section{
+		{HeadingText: "X", Body: "The OrderServiceFactory builds things.\n"},
+	}
+	got := LinkMentions(sections, idx)
+	if len(got) != 0 {
+		t.Fatalf("substring wrongly linked: %+v", got)
+	}
+}
+
+func TestLinkMentions_AmbiguousNameDropped(t *testing.T) {
+	idx := buildIndex()
+	sections := []Section{
+		{HeadingText: "X", Body: "The Handler dispatches requests.\n"},
+	}
+	got := LinkMentions(sections, idx)
+	for _, m := range got {
+		if m.Token == "Handler" {
+			t.Fatalf("ambiguous name 'Handler' was linked to %q (must be dropped)", m.TargetID)
+		}
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no links, got %+v", got)
+	}
+}
+
+func TestLinkMentions_ShortTokenNeverLinks(t *testing.T) {
+	idx := buildIndex()
+	sections := []Section{{HeadingText: "X", Body: "open the db now.\n"}}
+	if got := LinkMentions(sections, idx); len(got) != 0 {
+		t.Fatalf("short token 'db' linked: %+v", got)
+	}
+}
+
+func TestLinkMentions_DedupesWithinSection(t *testing.T) {
+	idx := buildIndex()
+	sections := []Section{
+		{HeadingText: "X", Body: "placeOrder, placeOrder, and again placeOrder.\n"},
+	}
+	got := LinkMentions(sections, idx)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduped mention, got %d: %+v", len(got), got)
+	}
+}

--- a/internal/ingest/markdown.go
+++ b/internal/ingest/markdown.go
@@ -1,0 +1,243 @@
+// Package ingest implements deterministic markdown documentation ingestion
+// for archigraph (Layer 1 of epic #4294, issue #4306).
+//
+// It is FULLY DETERMINISTIC: a markdown file is parsed by a pure line/heading
+// scanner into one Document node and a tree of heading-delimited Section nodes,
+// and section body text is linked to code entities by EXACT identifier-token
+// match only. There are NO LLM calls, NO network access, and NO API keys — any
+// semantic/LLM enrichment is delegated to a later layer (the agent). The whole
+// subsystem is gated behind an opt-in flag (--ingest-docs, default OFF); when
+// the flag is off this package is never invoked and adds zero overhead.
+package ingest
+
+import (
+	"strings"
+)
+
+// Section is a heading-delimited block within a markdown document.
+//
+// Depth is the ATX heading level (1 for "# H", 2 for "## H", ...). HeadingText
+// is the trimmed heading text with the leading '#'s and any trailing '#'s
+// removed. StartLine is the 1-indexed line of the heading itself; EndLine is
+// the 1-indexed last line of the section's full hierarchical span (the line
+// before the next heading of equal-or-shallower depth, or the last line of the
+// file) — this is the span get_source quotes, INCLUDING nested subsections.
+//
+// Body is the section's OWN direct text only: the lines strictly after the
+// heading up to (but excluding) the next heading of ANY depth. It deliberately
+// does NOT re-include nested subsection text, so the mention linker counts each
+// reference against exactly one section (no parent/child double-counting).
+//
+// ParentIndex is the index (into the Sections slice returned by ParseDocument)
+// of the nearest enclosing section of shallower depth, or -1 when the section
+// is a top-level child of the Document.
+type Section struct {
+	HeadingText string
+	Depth       int
+	StartLine   int
+	EndLine     int
+	Body        string
+	ParentIndex int
+	// bodyEnd is the 1-indexed last line of this section's OWN direct content
+	// (the line before the next heading of ANY depth). Internal; slices Body.
+	bodyEnd int
+}
+
+// Document is the file-level node produced for one markdown file.
+type Document struct {
+	// RelPath is the repo-relative, slash-separated path of the markdown file.
+	RelPath string
+	// Title is the text of the first level-1 heading, or "" when the file has
+	// none. Purely informational; never used for identity.
+	Title string
+	// LineCount is the total number of lines in the file (1-indexed EndLine of
+	// the Document span).
+	LineCount int
+}
+
+// ParseDocument parses one markdown file's content into a Document node plus a
+// flat, declaration-ordered slice of Section nodes whose ParentIndex fields
+// encode the heading-depth hierarchy. relPath is stored verbatim on the
+// returned Document (callers pass a repo-relative slash path).
+//
+// The scanner is deliberately small and dependency-free:
+//   - ATX headings only ("# ".."###### "); a line is a heading when, after
+//     stripping up to 3 leading spaces, it begins with 1–6 '#' characters
+//     followed by a space or end-of-line. Setext headings (=== / ---) are not
+//     treated as headings (they are rare and ambiguous with horizontal rules).
+//   - Fenced code blocks (``` or ~~~) are tracked so that a '#' inside a code
+//     fence is NOT mistaken for a heading.
+//
+// Output is deterministic: sections are returned in source order and line
+// spans are derived purely from line positions.
+func ParseDocument(relPath string, content []byte) (Document, []Section) {
+	lines := splitLines(string(content))
+	doc := Document{RelPath: relPath, LineCount: len(lines)}
+
+	var sections []Section
+	// stack holds indices (into sections) of the currently-open ancestor
+	// sections, strictly increasing in depth. Used to assign ParentIndex and
+	// to close sections (set EndLine) when a shallower/equal heading arrives.
+	var stack []int
+
+	inFence := false
+	var fenceMarker string
+
+	closeTo := func(depth, endLine int) {
+		// Close every open section whose depth >= the incoming heading depth.
+		for len(stack) > 0 {
+			top := stack[len(stack)-1]
+			if sections[top].Depth < depth {
+				break
+			}
+			sections[top].EndLine = endLine
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	for i, raw := range lines {
+		lineNo := i + 1
+
+		// Track fenced code blocks so headings inside them are ignored.
+		if marker, ok := fenceMarkerOf(raw); ok {
+			if !inFence {
+				inFence = true
+				fenceMarker = marker
+			} else if marker == fenceMarker {
+				inFence = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		depth, text, ok := atxHeading(raw)
+		if !ok {
+			continue
+		}
+
+		// The immediately-preceding section (in source order) ends its OWN
+		// direct body on the line before this heading, regardless of depth.
+		if n := len(sections); n > 0 {
+			sections[n-1].bodyEnd = lineNo - 1
+		}
+
+		// The new heading closes any open sections of equal-or-greater depth;
+		// they end on the line before this heading.
+		closeTo(depth, lineNo-1)
+
+		parent := -1
+		if len(stack) > 0 {
+			parent = stack[len(stack)-1]
+		}
+
+		sections = append(sections, Section{
+			HeadingText: text,
+			Depth:       depth,
+			StartLine:   lineNo,
+			EndLine:     len(lines), // provisional; finalized on close / EOF
+			ParentIndex: parent,
+		})
+		idx := len(sections) - 1
+		stack = append(stack, idx)
+
+		if depth == 1 && doc.Title == "" {
+			doc.Title = text
+		}
+	}
+
+	// Close every still-open section at EOF.
+	for len(stack) > 0 {
+		top := stack[len(stack)-1]
+		sections[top].EndLine = len(lines)
+		stack = stack[:len(stack)-1]
+	}
+
+	// The last section in source order has no following heading; its own body
+	// runs to EOF.
+	if n := len(sections); n > 0 && sections[n-1].bodyEnd == 0 {
+		sections[n-1].bodyEnd = len(lines)
+	}
+
+	// Populate Body from the section's OWN direct content only: the 1-indexed
+	// line range [StartLine+1, bodyEnd] (lines strictly after the heading, up
+	// to and including bodyEnd). This excludes nested subsection text so a
+	// mention is attributed to exactly one section. Mapped to the 0-indexed
+	// lines slice as [StartLine, bodyEnd).
+	for k := range sections {
+		s := &sections[k]
+		var b strings.Builder
+		for ln := s.StartLine; ln < s.bodyEnd && ln < len(lines); ln++ {
+			b.WriteString(lines[ln])
+			b.WriteByte('\n')
+		}
+		s.Body = b.String()
+	}
+
+	return doc, sections
+}
+
+// splitLines splits s on '\n', dropping a single trailing '\r' per line so
+// CRLF files behave identically to LF. A trailing empty line produced by a
+// final '\n' is dropped to keep LineCount equal to the visible line count.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, "\n")
+	// Drop the trailing empty element from a final newline.
+	if n := len(parts); n > 0 && parts[n-1] == "" {
+		parts = parts[:n-1]
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSuffix(parts[i], "\r")
+	}
+	return parts
+}
+
+// atxHeading reports whether line is an ATX heading and, if so, returns its
+// depth (1–6) and trimmed heading text.
+func atxHeading(line string) (depth int, text string, ok bool) {
+	// Up to 3 leading spaces are permitted before the '#'s (CommonMark).
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	j := i
+	for j < len(line) && line[j] == '#' {
+		j++
+	}
+	level := j - i
+	if level < 1 || level > 6 {
+		return 0, "", false
+	}
+	// A heading marker must be followed by a space or end-of-line.
+	if j < len(line) && line[j] != ' ' {
+		return 0, "", false
+	}
+	rest := strings.TrimSpace(line[j:])
+	// Strip an optional closing run of '#'s (e.g. "## Title ##").
+	rest = strings.TrimRight(rest, "#")
+	rest = strings.TrimSpace(rest)
+	return level, rest, true
+}
+
+// fenceMarkerOf reports whether line opens or closes a fenced code block and,
+// if so, returns a normalized marker ("```" or "~~~") used to match the
+// opening and closing fences. Up to 3 leading spaces are permitted.
+func fenceMarkerOf(line string) (marker string, ok bool) {
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	rest := line[i:]
+	switch {
+	case strings.HasPrefix(rest, "```"):
+		return "```", true
+	case strings.HasPrefix(rest, "~~~"):
+		return "~~~", true
+	}
+	return "", false
+}

--- a/internal/ingest/markdown_test.go
+++ b/internal/ingest/markdown_test.go
@@ -1,0 +1,117 @@
+package ingest
+
+import (
+	"testing"
+)
+
+const sampleDoc = "" +
+	"# Order Service\n" +
+	"\n" +
+	"The OrderService coordinates checkout.\n" +
+	"\n" +
+	"## Placing an order\n" +
+	"\n" +
+	"Call placeOrder to submit. It uses validateOrder under the hood.\n" +
+	"\n" +
+	"```go\n" +
+	"// ## not a heading inside a fence\n" +
+	"func placeOrder() {}\n" +
+	"```\n" +
+	"\n" +
+	"### Validation\n" +
+	"\n" +
+	"validateOrder checks the cart.\n" +
+	"\n" +
+	"## Refunds\n" +
+	"\n" +
+	"Refund flow is documented elsewhere.\n"
+
+func TestParseDocument_HeadingsAndHierarchy(t *testing.T) {
+	doc, sections := ParseDocument("docs/orders.md", []byte(sampleDoc))
+
+	if doc.Title != "Order Service" {
+		t.Fatalf("title = %q, want %q", doc.Title, "Order Service")
+	}
+	if len(sections) != 4 {
+		t.Fatalf("got %d sections, want 4: %+v", len(sections), headings(sections))
+	}
+
+	want := []struct {
+		heading string
+		depth   int
+		parent  int
+	}{
+		{"Order Service", 1, -1},
+		{"Placing an order", 2, 0},
+		{"Validation", 3, 1},
+		{"Refunds", 2, 0},
+	}
+	for i, w := range want {
+		s := sections[i]
+		if s.HeadingText != w.heading {
+			t.Errorf("section %d heading = %q, want %q", i, s.HeadingText, w.heading)
+		}
+		if s.Depth != w.depth {
+			t.Errorf("section %d depth = %d, want %d", i, s.Depth, w.depth)
+		}
+		if s.ParentIndex != w.parent {
+			t.Errorf("section %d parent = %d, want %d (CONTAINS hierarchy by depth)", i, s.ParentIndex, w.parent)
+		}
+	}
+}
+
+func TestParseDocument_LineSpansAndFenceIgnored(t *testing.T) {
+	_, sections := ParseDocument("docs/orders.md", []byte(sampleDoc))
+
+	// The "## not a heading inside a fence" line must NOT have produced a
+	// section; we already asserted there are exactly 4 sections above.
+	for _, s := range sections {
+		if s.HeadingText == "not a heading inside a fence" {
+			t.Fatalf("fenced '##' line was wrongly parsed as a heading")
+		}
+	}
+
+	// Validation (### depth 3) is nested under "Placing an order" and must end
+	// before "## Refunds" begins. Spot-check the span is sane and ordered.
+	val := sections[2]
+	if val.HeadingText != "Validation" {
+		t.Fatalf("section[2] = %q, want Validation", val.HeadingText)
+	}
+	if val.StartLine <= 0 || val.EndLine < val.StartLine {
+		t.Fatalf("Validation span invalid: start=%d end=%d", val.StartLine, val.EndLine)
+	}
+	refund := sections[3]
+	if val.EndLine >= refund.StartLine {
+		t.Fatalf("Validation (end %d) overlaps Refunds (start %d)", val.EndLine, refund.StartLine)
+	}
+	if got := val.Body; !containsToken(got, "validateOrder") {
+		t.Errorf("Validation body missing expected token; body=%q", got)
+	}
+}
+
+func TestParseDocument_CRLFAndNoHeadings(t *testing.T) {
+	doc, sections := ParseDocument("x.md", []byte("just prose\r\nno headings here\r\n"))
+	if len(sections) != 0 {
+		t.Fatalf("expected 0 sections for heading-less doc, got %d", len(sections))
+	}
+	if doc.LineCount != 2 {
+		t.Fatalf("LineCount = %d, want 2", doc.LineCount)
+	}
+}
+
+func headings(ss []Section) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.HeadingText
+	}
+	return out
+}
+
+func containsToken(body, tok string) bool {
+	for _, t := range identifierTokens(body) {
+		if t == tok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingest/testdata/repo/docs/orders.md
+++ b/internal/ingest/testdata/repo/docs/orders.md
@@ -1,0 +1,17 @@
+# Orders
+
+The OrderService coordinates checkout for the storefront.
+
+## Placing an order
+
+Call placeOrder to submit a new order. It internally uses validateOrder
+to check the cart before persisting.
+
+### Validation
+
+validateOrder rejects empty carts. This section should mention nothing
+common like type, data, file, or test.
+
+## Refunds
+
+Refunds are handled by a separate service not described here.

--- a/internal/ingest/testdata/repo/node_modules/dep.md
+++ b/internal/ingest/testdata/repo/node_modules/dep.md
@@ -1,0 +1,4 @@
+# Third Party
+
+This file lives under node_modules and must be excluded from ingestion.
+It mentions OrderService but should never be read.

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -294,6 +294,28 @@ const (
 	// key (`t(keyVar)`, interpolated) or a non-i18n `_('x')` (lodash) /
 	// unrelated `t(...)` emits NO node/edge. See internal/extractor/translation_key.go.
 	EntityKindTranslationKey EntityKind = "SCOPE.TranslationKey"
+
+	// #4306 (Layer 1 of epic #4294): deterministic markdown documentation
+	// ingestion. Two new structural kinds model the prose layer of a repo so
+	// the graph can answer "where is X documented?" and "what does this doc
+	// describe?". Emission is OPT-IN (--ingest-docs, default OFF) and FULLY
+	// DETERMINISTIC — no LLM calls, no network.
+	//
+	// EntityKindMarkdownDocument represents ONE markdown file (a *.md). One
+	// entity per discovered, non-vendored markdown file. SourceFile is the
+	// repo-relative path; StartLine/EndLine span the whole file.
+	//
+	// EntityKindSection represents ONE heading-delimited block within a
+	// markdown document — the heading line plus all body text up to the next
+	// heading of equal-or-shallower depth. Sections nest by heading depth via
+	// CONTAINS (Document → top-level Section → sub-Section). The section's
+	// source span (StartLine/EndLine) is preserved so get_source can quote it.
+	//
+	// Distinct from the pre-existing SCOPE.Document / SCOPE.Heading kinds,
+	// which were reserved for an unrelated detector taxonomy and carry no
+	// hierarchy/span contract.
+	EntityKindMarkdownDocument EntityKind = "SCOPE.MarkdownDocument"
+	EntityKindSection          EntityKind = "SCOPE.Section"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -377,6 +399,9 @@ func AllEntityKinds() []EntityKind {
 		// [sbom] synthetic package convergence node (child of #3628).
 		EntityKindPackage,
 		EntityKindTranslationKey,
+		// #4306 deterministic markdown doc ingestion (opt-in):
+		EntityKindMarkdownDocument,
+		EntityKindSection,
 	}
 }
 
@@ -1213,6 +1238,19 @@ const (
 	// synthetically from the EXTENDS walk + pack so it works before any
 	// indexer-side emission; an indexer producer MAY later materialise it.
 	RelationshipKindInherits RelationshipKind = "INHERITS"
+
+	// #4306 (Layer 1 of epic #4294): deterministic markdown doc ingestion.
+	//   MENTIONS : SCOPE.Section → code entity. Emitted when a section's body
+	//              text contains an identifier token that EXACTLY matches a
+	//              code entity's Name or QualifiedName in the current index
+	//              (word-boundary, case-sensitive). Precision-first: keywords,
+	//              very common short words, and sub-threshold-length tokens are
+	//              skipped, and a token that matches more than one distinct
+	//              entity is dropped (ambiguous → no edge). Under-linking is
+	//              preferred to noisy links. OPT-IN (--ingest-docs), no LLM.
+	//              The document→section hierarchy uses the existing CONTAINS
+	//              edge (RelationshipKindContains); no new hierarchy kind.
+	RelationshipKindMentions RelationshipKind = "MENTIONS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1366,6 +1404,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindTypedAs,
 		// #3834 (epic #3829) member-granularity inheritance edge:
 		RelationshipKindInherits,
+		// #4306 deterministic markdown doc ingestion (opt-in):
+		RelationshipKindMentions,
 	}
 }
 


### PR DESCRIPTION
Closes #4306 (part of #4294)

## Summary
Layer 1 of epic #4294: a new, **fully deterministic** markdown-ingestion subsystem behind an **opt-in flag (`--ingest-docs`, default OFF)**. It parses in-repo `*.md` files into graph nodes and links section prose to code entities by exact identifier match.

**Zero LLM calls, zero network, no API keys** — archigraph makes no LLM calls by design; any semantic/LLM work is delegated to the agent in a later layer. When the flag is off, behavior is identical to today (the whole subsystem is skipped — zero overhead).

## Schema (kinds/edges added) — `internal/types/kinds.go`
| Kind | Meaning |
|---|---|
| `SCOPE.MarkdownDocument` (entity) | one node per discovered `*.md` file; span = whole file |
| `SCOPE.Section` (entity) | one heading-delimited block; nests by heading depth; preserves source span (StartLine/EndLine) for `get_source` |
| `MENTIONS` (edge) | Section → code entity, exact-match only |
| `CONTAINS` (edge) | reused (existing) for Document → Section → subsection hierarchy |

Registered in `AllEntityKinds` / `AllRelationshipKinds`. **Producer-kind validator passes** (`go test ./internal/types/` — 679 Kind literals, all valid).

## Extractor + linker design — `internal/ingest/`
- **`markdown.go`** — pure, dependency-free heading scanner. ATX headings (`#`..`######`), fenced-code-block aware (a `#` inside ``` ``` ``` is not a heading). Emits one Document + a Section tree. `EndLine` is the full hierarchical span (for source quoting, incl. nested subsections); a separate own-body slice (text up to the next heading of *any* depth) is what the linker scans, so a reference is attributed to exactly one section (no parent/child double-counting).
- **`linker.go`** — exact-symbol-mention linker.
- **`ingest.go`** — orchestrator; emits `graph.Entity`/`graph.Relationship` with stable IDs via `graph.EntityID` / `graph.RelationshipID`; deterministic (ID-tiebroken) ordering.
- **`discover.go`** — `*.md` / `*.markdown` discovery, excluding `node_modules`/`vendor`/`dist`/`build`/`.git`/`.archigraph`.

## Mention-linking precision rules (precision-first — under-link beats mislink)
- Case-sensitive, **whole-token** match only (token = maximal `[A-Za-z0-9_]` run). `OrderServiceFactory` does **not** match entity `OrderService`.
- Minimum token length **4**; shorter tokens (e.g. `db`, `id`) are skipped.
- Explicit **skip-list**: cross-language keywords + very common prose words (`type`, `data`, `file`, `test`, `this`, …).
- **Ambiguity guard**: a token matching more than one distinct entity ID emits **no** edge.
- Only the bare entity `Name` and its own simple-name (final qualified segment) are indexed — ancestor segments are deliberately *not* indexed (avoids a class name resolving to all its methods → false ambiguity).
- At most one MENTIONS edge per (section, token).

## Opt-in wiring
`WithIngestDocs(bool)` IndexOption + `--ingest-docs` flag on the index entrypoint + `ARCHIGRAPH_INGEST_DOCS=1` env fallback. Runs after `buildDocument` + incremental merge (so the name index reflects the full ID-stamped graph and doc nodes participate in Pass 4 + the on-disk write). The daemon RPC proto is intentionally untouched (deploy-deferred).

## Tests (all green; scoped to touched packages)
- `internal/types/` — kind registration / producer-kind validator.
- `internal/ingest/` — heading hierarchy by depth, line spans, fence ignoring, CRLF; linker precision (exact match, substring rejection, ambiguous drop, keyword/common-word/short-token skip, per-section dedupe); end-to-end Document+Section+MENTIONS emission; determinism; vendored-dir exclusion.
- `cmd/archigraph/` — pipeline with flag **OFF produces zero doc nodes**; flag **ON** emits Document+Section nodes and exact MENTIONS edges to indexed Go symbols.

`go build ./...`, `go vet`, and `gofmt -l` are clean.

## Confirmation
- Off-by-default ✅
- Makes **no LLM / network calls** ✅
- Deploy-deferred (no live daemon ops) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)