### PR TITLE
fix(links): cross-repo HTTP link coverage — strip base-URL vars, normalize prefixes, param-agnostic matching (#4315)

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -708,6 +708,129 @@ func isDynamicPrefixSegment(seg string) bool {
 	return seg == "{*}" || seg == "${*}"
 }
 
+// runtimeEnumMinStaticSuffixSegments is the floor on how many concrete
+// (non-param) segments the post-first-segment SUFFIX of a runtime-enum consumer
+// path must carry before the runtime-enum expansion (#4315) will link it. The
+// first segment is a render-time enum (`{companyType}` →
+// contracting-companies | witnessing-companies); the remainder is what anchors
+// the match. Requiring ≥1 static anchor segment (e.g. `branches`) keeps the
+// expansion from fanning out across unrelated `/{*}/{*}/{*}` shapes.
+const runtimeEnumMinStaticSuffixSegments = 1
+
+// runtimeEnumMaxExpansion caps how many distinct literal-prefixed server routes
+// a single runtime-enum consumer may expand to (#4315). A render-time enum such
+// as companyType has a small, closed value set (2 in upvate:
+// contracting-companies / witnessing-companies); a candidate set larger than
+// this cap signals a generic shape that would fan out into false links, so the
+// consumer is left orphan instead.
+const runtimeEnumMaxExpansion = 4
+
+// runtimeEnumSuffixShape recognises the deferred-by-#2813 consumer shape that
+// #4315 expands: a path whose FIRST segment is a single param placeholder
+// (a render-time enum like `{companyType}`) AND whose REMAINDER is itself
+// param-led (so dynamicSuffixTemplate returned ok=false and left it orphan).
+//
+// It returns the {*}-normalized SUFFIX (everything after the first segment,
+// e.g. `/{*}/branches/{*}`) and the count of STATIC (non-param) segments that
+// suffix carries. ok is false for any shape that is NOT this case — a static
+// first segment, a base-URL prefix the dynamic-suffix matcher already owns, a
+// suffix with no static anchor, or a too-short path.
+//
+// Examples (input → suffix, staticSegs, ok):
+//
+//	/{companyType}/{companyId}/branches/{branchId} → /{*}/branches/{*}, 1, true
+//	/{companyType}/{companyId}/branches            → /{*}/branches,      1, true
+//	/{apiUrl}/schedule/import                       → "", 0, false (static-led suffix; #2813 owns it)
+//	/{companyType}/{companyId}                       → "", 0, false (no static anchor)
+//	/companies/{id}/branches                         → "", 0, false (static first segment)
+func runtimeEnumSuffixShape(consumerPath string) (suffix string, staticSegs int, ok bool) {
+	if consumerPath == "" {
+		return "", 0, false
+	}
+	norm := normalizePathForIndex(consumerPath)
+	segs := strings.Split(norm, "/")
+	// segs[0] is the empty leading-slash segment. Need a param first segment
+	// plus at least one more segment to form a suffix.
+	if len(segs) < 3 || !isDynamicPrefixSegment(segs[1]) {
+		return "", 0, false
+	}
+	rest := segs[2:]
+	// #2813 already owns the static-led suffix (`/{apiUrl}/schedule/import`);
+	// #4315 only claims the param-led remainder it deferred.
+	if rest[0] != "{*}" {
+		return "", 0, false
+	}
+	for _, s := range rest {
+		if s != "" && s != "{*}" {
+			staticSegs++
+		}
+	}
+	if staticSegs < runtimeEnumMinStaticSuffixSegments {
+		return "", 0, false
+	}
+	suffix = "/" + strings.Join(rest, "/")
+	return suffix, staticSegs, true
+}
+
+// runtimeEnumProducerSuffix reports whether a producer path is a viable
+// runtime-enum expansion target for a consumer with the given {*}-normalized
+// suffix shape (#4315). The producer qualifies when, after stripping a leading
+// API/version prefix:
+//
+//   - it has the SAME segment count as the consumer's full shape (first enum
+//     segment + suffix), i.e. one more segment than the suffix; and
+//   - its FIRST post-prefix segment is a concrete LITERAL (the enum value such
+//     as `contracting-companies`) — NOT a param. A param-first producer is the
+//     genuinely-ambiguous case (#2813's RuntimeStaysUnlinked) and is rejected
+//     here; and
+//   - every remaining segment matches the consumer suffix positionally: a
+//     consumer param ({*}) matches any producer segment; a consumer static
+//     must equal the producer static case-insensitively (both are already
+//     lower-cased by normalizePathForIndex).
+//
+// On success it returns the producer's concrete first segment (the resolved
+// enum value) so the link can be stamped with it for traceability.
+func runtimeEnumProducerSuffix(producerPath, consumerSuffix string) (enumValue string, ok bool) {
+	if producerPath == "" || consumerSuffix == "" {
+		return "", false
+	}
+	pNorm := normalizePathForIndex(producerPath)
+	if stripped, had := stripAPIPrefix(pNorm); had {
+		pNorm = stripped
+	}
+	pSegs := strings.Split(pNorm, "/")
+	sufSegs := strings.Split(consumerSuffix, "/")
+	// pSegs and sufSegs both lead with an empty element from the leading slash.
+	// The producer must be exactly: [<empty> <enum-literal> <suffix...>], i.e.
+	// one concrete segment longer than the suffix's content.
+	if len(pSegs) < 2 {
+		return "", false
+	}
+	enum := pSegs[1]
+	// First segment must be a concrete literal, not a param slot.
+	if enum == "" || enum == "{*}" {
+		return "", false
+	}
+	// Remaining producer segments must line up positionally with the suffix.
+	// sufSegs[0] is the empty leading-slash element; sufSegs[1:] is the content.
+	rest := pSegs[2:]
+	sufContent := sufSegs[1:]
+	if len(rest) != len(sufContent) {
+		return "", false
+	}
+	for i := range rest {
+		cs := sufContent[i]
+		ps := rest[i]
+		if cs == "{*}" {
+			continue // consumer param matches any producer segment
+		}
+		if cs != ps {
+			return "", false // static divergence disqualifies
+		}
+	}
+	return enum, true
+}
+
 // patternTypeURLMountPoint is the synthesis marker set by
 // internal/engine/django_urlconf_nested.go (#2677) on the synthetic emitted
 // for every `path("prefix", include(...))` declaration. The consumer-side
@@ -2459,6 +2582,165 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					},
 				}
 				fresh = append(fresh, link)
+			}
+		}
+	}
+
+	// #4315: runtime-enum first-segment expansion. This claims the shape #2813
+	// deliberately deferred (RuntimeStaysUnlinked): a consumer whose FIRST
+	// segment is a render-time enum (`/{companyType}/{companyId}/branches/{id}`,
+	// companyType ∈ {contracting-companies, witnessing-companies}) and whose
+	// remainder is param-led, so the static-suffix matcher returned ok=false.
+	//
+	// We resolve it by matching the param-led SUFFIX (`/{*}/branches/{*}`)
+	// against producers whose FIRST post-prefix segment is a CONCRETE LITERAL
+	// (the enum value) and whose remaining segments line up positionally. The
+	// enum's closed value set fans out to a SMALL number of literal routes
+	// (the contracting/witnessing siblings), so — unlike a single dynamic base
+	// URL — linking to ALL surviving candidates is correct, not a guess.
+	//
+	// Guardrails against false links (over-matching erodes trust):
+	//   - the suffix MUST carry ≥ runtimeEnumMinStaticSuffixSegments static
+	//     anchor segments (`branches`); a bare `/{*}/{*}` shape never expands.
+	//   - producers whose first segment is itself a PARAM are rejected — that is
+	//     the genuinely-ambiguous case #2813 keeps orphan; only literal-prefixed
+	//     routes qualify.
+	//   - the distinct candidate set must be 1..runtimeEnumMaxExpansion; a wider
+	//     set signals a generic shape and the consumer stays orphan.
+	//   - runs dead-last (after every exact/normalized/suffix stage) so a
+	//     consumer with any stronger match was already linked.
+	// Links are stamped resolve_strategy=runtime_enum_expansion and confidence
+	// heuristic (param-led suffix, multi-target — weaker than a unique suffix).
+	for _, byRepo := range hits {
+		for _, perRepo := range byRepo {
+			for _, c := range perRepo {
+				if c.side != sideConsumer {
+					continue
+				}
+				cKey := entityKey(c.repo, c.stampedID)
+				if matchedConsumers[cKey] {
+					continue
+				}
+				consumerPath := c.canonicalPath
+				if consumerPath == "" {
+					if _, p, ok := parseHTTPName(c.name); ok {
+						consumerPath = p
+					}
+				}
+				suffix, _, ok := runtimeEnumSuffixShape(consumerPath)
+				if !ok {
+					continue
+				}
+				allConsumers[cKey] = true
+
+				// Collect distinct literal-prefixed producer routes whose suffix
+				// matches positionally, in OTHER repos, verb-compatible. We walk
+				// every producer hit (there is no suffix-keyed index for the
+				// literal-first-segment shape) and filter via runtimeEnumProducerSuffix.
+				var candidates []*httpEndpointHit
+				seenCand := map[string]bool{}
+				seenRoute := map[string]bool{}
+				for _, pByRepo := range hits {
+					for _, pPerRepo := range pByRepo {
+						for _, ph := range pPerRepo {
+							if ph.side != sideProducer || ph.repo == c.repo {
+								continue
+							}
+							if !verbsCompatible(c.verb, ph.verb) {
+								continue
+							}
+							producerPath := ph.canonicalPath
+							if producerPath == "" {
+								if _, pp, ok := parseHTTPName(ph.name); ok {
+									producerPath = pp
+								}
+							}
+							if _, match := runtimeEnumProducerSuffix(producerPath, suffix); !match {
+								continue
+							}
+							pid := entityKey(ph.repo, ph.stampedID)
+							if seenCand[pid] {
+								continue
+							}
+							seenCand[pid] = true
+							// Track distinct ROUTES (verb+canonical path) for the
+							// fan-out gate so a route emitted twice does not inflate
+							// the count.
+							routeKey := strings.ToUpper(ph.verb) + " " + normalizePathForIndex(producerPath)
+							seenRoute[routeKey] = true
+							candidates = append(candidates, ph)
+						}
+					}
+				}
+				if len(candidates) == 0 {
+					// Specific shape but no literal-prefixed producer serves it —
+					// leave as a dynamic_baseurl miss for the classifier below.
+					continue
+				}
+				// Fan-out gate: a render-time enum has a small closed value set.
+				// A wider candidate set is a generic shape — do not guess.
+				if len(seenRoute) > runtimeEnumMaxExpansion {
+					residualCandidates += len(candidates)
+					missesByReason["dynamic_baseurl"]++
+					dynamicSuffixCounted[cKey] = true
+					continue
+				}
+				sort.SliceStable(candidates, func(i, j int) bool { return less(candidates[i], candidates[j]) })
+
+				linkedAny := false
+				for _, p := range candidates {
+					srcID := c.callerID
+					if srcID == "" {
+						srcID = c.stampedID
+					}
+					tgtID := p.handlerID
+					if tgtID == "" {
+						tgtID = p.stampedID
+					}
+					source := entityKey(c.repo, srcID)
+					target := entityKey(p.repo, tgtID)
+					id := MakeID(source, target, MethodHTTP)
+					if emitted[id] {
+						linkedAny = true
+						continue
+					}
+					emitted[id] = true
+					linkedAny = true
+					hitsByStrategy["runtime_enum_expansion"]++
+					enumValue, _ := runtimeEnumProducerSuffix(p.canonicalPath, suffix)
+					ident := canonicalIdentifier(c, p)
+					ch := httpChannel
+					link := Link{
+						ID:           id,
+						Source:       source,
+						Target:       target,
+						Relation:     RelationCalls,
+						Method:       MethodHTTP,
+						Confidence:   ScoreImport(),
+						Channel:      &ch,
+						Identifier:   &ident,
+						DiscoveredAt: now,
+						SourceLocations: [][]string{
+							{c.sourceFile},
+							{p.sourceFile},
+						},
+						MatchQuality: matchQualityAnyFallback,
+						Properties: map[string]string{
+							"resolve_strategy":  "runtime_enum_expansion",
+							"runtime_suffix":    suffix,
+							"runtime_enum":      enumValue,
+							"expansion_targets": strconv.Itoa(len(seenRoute)),
+							// #4315 — the consumer's first segment was a render-time
+							// enum; resolved by matching the param-led suffix against
+							// literal-prefixed routes. Heuristic, not exact.
+							EdgeConfidenceKey: ConfidenceHeuristic,
+						},
+					}
+					fresh = append(fresh, link)
+				}
+				if linkedAny {
+					matchedConsumers[cKey] = true
+				}
 			}
 		}
 	}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -3933,3 +3933,253 @@ func TestHTTPPass_JSONRPCCrossRepoMatch(t *testing.T) {
 		t.Errorf("identifier: want http:JSONRPC:/jsonrpc/add, got %v", hit.Identifier)
 	}
 }
+
+// TestRuntimeEnumSuffixShape unit-tests the #4315 shape detector: a param-led
+// suffix after a param first segment is claimed (ok=true); a static-led suffix
+// (#2813's territory), a static first segment, an anchor-less shape, or a too-
+// short path are all rejected.
+func TestRuntimeEnumSuffixShape(t *testing.T) {
+	cases := []struct {
+		path       string
+		wantSuffix string
+		wantStatic int
+		wantOK     bool
+	}{
+		// The canonical #4315 case: param first segment (companyType), param-led
+		// remainder with a static anchor (branches).
+		{"/{companyType}/{companyId}/branches/{branchId}", "/{*}/branches/{*}", 1, true},
+		{"/{companyType}/{companyId}/branches", "/{*}/branches", 1, true},
+		{"/{companyType}/{companyId}/branches/{id}/migrate", "/{*}/branches/{*}/migrate", 2, true},
+		// Static-led suffix → #2813 owns it, not us.
+		{"/{apiUrl}/schedule/import", "", 0, false},
+		// No static anchor in the suffix → never expand (would fan out).
+		{"/{companyType}/{companyId}", "", 0, false},
+		{"/{a}/{b}/{c}", "", 0, false},
+		// Static first segment → ordinary path, not a runtime enum.
+		{"/companies/{id}/branches", "", 0, false},
+		// Too short / empty.
+		{"/{companyType}", "", 0, false},
+		{"", "", 0, false},
+	}
+	for _, tc := range cases {
+		gotSuffix, gotStatic, gotOK := runtimeEnumSuffixShape(tc.path)
+		if gotOK != tc.wantOK {
+			t.Errorf("runtimeEnumSuffixShape(%q) ok = %v, want %v", tc.path, gotOK, tc.wantOK)
+			continue
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if gotSuffix != tc.wantSuffix || gotStatic != tc.wantStatic {
+			t.Errorf("runtimeEnumSuffixShape(%q) = (%q, %d), want (%q, %d)",
+				tc.path, gotSuffix, gotStatic, tc.wantSuffix, tc.wantStatic)
+		}
+	}
+}
+
+// TestRuntimeEnumProducerSuffix unit-tests the #4315 producer matcher: only a
+// LITERAL-first-segment route whose remaining segments line up positionally
+// with the consumer suffix qualifies. A param-first producer (the ambiguous
+// case #2813 keeps orphan), a static divergence, or a segment-count mismatch
+// are all rejected.
+func TestRuntimeEnumProducerSuffix(t *testing.T) {
+	const suffix = "/{*}/branches/{*}"
+	cases := []struct {
+		producer  string
+		wantEnum  string
+		wantMatch bool
+	}{
+		// Literal first segment + matching suffix shape → qualifies; the literal
+		// (enum value) is returned. API prefix is stripped first.
+		{"/api/v1/contracting-companies/{id}/branches/{branchId}", "contracting-companies", true},
+		{"/witnessing-companies/{pk}/branches/{bid}", "witnessing-companies", true},
+		// Param first segment → the genuinely-ambiguous case; rejected.
+		{"/api/v1/{companyId}/branches/{branchId}", "", false},
+		// Static divergence in the suffix (offices != branches) → rejected.
+		{"/contracting-companies/{id}/offices/{bid}", "", false},
+		// Segment-count mismatch → rejected.
+		{"/contracting-companies/{id}/branches", "", false},
+		{"/contracting-companies/{id}/branches/{bid}/extra", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		gotEnum, gotMatch := runtimeEnumProducerSuffix(tc.producer, suffix)
+		if gotMatch != tc.wantMatch {
+			t.Errorf("runtimeEnumProducerSuffix(%q) match = %v, want %v", tc.producer, gotMatch, tc.wantMatch)
+			continue
+		}
+		if gotMatch && gotEnum != tc.wantEnum {
+			t.Errorf("runtimeEnumProducerSuffix(%q) enum = %q, want %q", tc.producer, gotEnum, tc.wantEnum)
+		}
+	}
+}
+
+// TestHTTPPass_RuntimeEnumExpansion_AutoLink is the end-to-end #4315 success
+// case: a frontend call `GET /{companyType}/{companyId}/branches/{branchId}`
+// (companyType is a render-time enum) expands to BOTH literal-prefixed backend
+// routes — the contracting and witnessing siblings — each stamped
+// resolve_strategy=runtime_enum_expansion with heuristic confidence.
+func TestHTTPPass_RuntimeEnumExpansion_AutoLink(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "hc", "name": "ContractingBranchView", "kind": "Controller", "source_file": "core/views/contracting.py"},
+			{
+				"id": "epc", "name": "http:GET:/api/v1/contracting-companies/{companyId}/branches/{branchId}", "kind": "http_endpoint",
+				"source_file": "core/views/contracting.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/contracting-companies/{companyId}/branches/{branchId}",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+			{"id": "hw", "name": "WitnessingBranchView", "kind": "Controller", "source_file": "core/views/witnessing.py"},
+			{
+				"id": "epw", "name": "http:GET:/api/v1/witnessing-companies/{companyId}/branches/{branchId}", "kind": "http_endpoint",
+				"source_file": "core/views/witnessing.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/witnessing-companies/{companyId}/branches/{branchId}",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "hc", "to_id": "epc", "kind": "IMPLEMENTS"},
+			{"from_id": "hw", "to_id": "epw", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "getBranch", "kind": "Function", "source_file": "src/stores/company/branchService.js"},
+			{
+				"id": "ep2", "name": "http:GET:/{companyType}/{companyId}/branches/{branchId}", "kind": "http_endpoint",
+				"source_file": "src/stores/company/branchService.js",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/{companyType}/{companyId}/branches/{branchId}",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"url_kind": "dynamic_baseurl", "dynamic_baseurl": "true",
+					"source_caller": "Function:getBranch",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g4315-auto", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g4315-auto-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotTargets := map[string]*Link{}
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP && l.Source == "frontend::fn1" {
+			gotTargets[l.Target] = &doc.Links[i]
+		}
+	}
+	for _, want := range []string{"backend::hc", "backend::hw"} {
+		l, ok := gotTargets[want]
+		if !ok {
+			t.Errorf("#4315: expected runtime_enum_expansion link frontend::fn1 → %s; got %v", want, gotTargets)
+			continue
+		}
+		if l.Properties["resolve_strategy"] != "runtime_enum_expansion" {
+			t.Errorf("%s resolve_strategy: want runtime_enum_expansion, got %q", want, l.Properties["resolve_strategy"])
+		}
+		if l.Properties[EdgeConfidenceKey] != ConfidenceHeuristic {
+			t.Errorf("%s confidence: want heuristic, got %q", want, l.Properties[EdgeConfidenceKey])
+		}
+	}
+	if l := gotTargets["backend::hc"]; l != nil && l.Properties["runtime_enum"] != "contracting-companies" {
+		t.Errorf("hc runtime_enum: want contracting-companies, got %q", l.Properties["runtime_enum"])
+	}
+}
+
+// TestHTTPPass_RuntimeEnumExpansion_NoFalseLinks is the guardrail case: shapes
+// that MUST stay orphan. (a) A param-first producer (no literal enum) keeps the
+// #2813 RuntimeStaysUnlinked behaviour. (b) A static asset `/version.txt` and a
+// genuinely-nonexistent route never link. (c) An anchor-less `/{*}/{*}` shape
+// never expands.
+func TestHTTPPass_RuntimeEnumExpansion_NoFalseLinks(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			// Param-first producer only — NOT a literal enum prefix.
+			{"id": "h1", "name": "BranchView", "kind": "Controller", "source_file": "v.py"},
+			{
+				"id": "ep1", "name": "http:GET:/api/v1/{companyId}/branches/{branchId}", "kind": "http_endpoint",
+				"source_file": "v.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/{companyId}/branches/{branchId}",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			// Runtime-enum shape, but only a param-first producer exists → orphan.
+			{"id": "fnRuntime", "name": "getBranch", "kind": "Function", "source_file": "src/b.js"},
+			{
+				"id": "epRuntime", "name": "http:GET:/{companyType}/{companyId}/branches/{branchId}", "kind": "http_endpoint",
+				"source_file": "src/b.js",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/{companyType}/{companyId}/branches/{branchId}",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"url_kind": "dynamic_baseurl", "dynamic_baseurl": "true",
+					"source_caller": "Function:getBranch",
+				},
+			},
+			// Static asset — must STAY orphan.
+			{"id": "fnAsset", "name": "loadVersion", "kind": "Function", "source_file": "src/v.js"},
+			{
+				"id": "epAsset", "name": "http:GET:/version.txt", "kind": "http_endpoint",
+				"source_file": "src/v.js",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/version.txt",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadVersion",
+				},
+			},
+			// Anchor-less runtime shape — never expands.
+			{"id": "fnNoAnchor", "name": "getThing", "kind": "Function", "source_file": "src/t.js"},
+			{
+				"id": "epNoAnchor", "name": "http:GET:/{companyType}/{companyId}", "kind": "http_endpoint",
+				"source_file": "src/t.js",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/{companyType}/{companyId}",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"url_kind": "dynamic_baseurl", "dynamic_baseurl": "true",
+					"source_caller": "Function:getThing",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g4315-orphan", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g4315-orphan-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method != MethodHTTP {
+			continue
+		}
+		switch l.Source {
+		case "frontend::fnRuntime":
+			t.Errorf("#4315: param-first producer must NOT expand (RuntimeStaysUnlinked), got %+v", l)
+		case "frontend::fnAsset":
+			t.Errorf("#4315: static asset /version.txt must stay orphan, got %+v", l)
+		case "frontend::fnNoAnchor":
+			t.Errorf("#4315: anchor-less /{*}/{*} must stay orphan, got %+v", l)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4315

Improves cross-repo HTTP link coverage in the matcher (`internal/links/http_pass.go`). The investigation found rules 1–3 from the issue were **already shipped** (mostly by #2813/#2808/#2569/#3752); the remaining gap was rule 4, the runtime-variable first-segment case that #2813 explicitly deferred. This PR implements rule 4 precisely.

## Rules
- **Rule 1 — strip base-URL/host vars** (e.g. `/{apiUrl}/schedule/confirm/{token}` → `/schedule/confirm/{token}`): already shipped in #2813 via `dynamicSuffixTemplate` (strips the leading `{apiUrl}`/`${baseURL}` segment, then suffix-matches). No change needed.
- **Rule 2 — API-prefix normalization** (`/api`, `/api/v1`, `/api/v2`, trailing slashes on both sides): already shipped via `stripAPIPrefix` / `pathNormPrefixSegments` / `crossRepoPrefixCandidates`. No change needed.
- **Rule 3 — param-name-agnostic positional matching** (`{id}`↔`{pk}`↔`{building_id}`): already shipped via `normalizePathForIndex` ({*}-collapse), `paramOnlyMismatch`, `literalFillsParamSlot`. No change needed.
- **Rule 4 — runtime-variable first-segment expansion** (`/{companyType}/{companyId}/branches/{branchId}` → the contracting/witnessing literal routes): **IMPLEMENTED.** New dead-last sweep `runtime_enum_expansion` matches the param-led suffix against producers whose first post-prefix segment is a concrete literal (the enum value) and whose remaining segments line up positionally. The enum's small closed value set expands to all surviving literal-prefixed siblings.

## No-false-link guardrails
Over-matching erodes trust, so the expansion is conservatively gated:
- The suffix must carry **≥1 static anchor segment** (`branches`); a bare `/{*}/{*}` shape never expands.
- **Param-first producers are rejected** — that is the genuinely-ambiguous case #2813 keeps orphan (`TestHTTPPass_DynamicSuffix_RuntimeStaysUnlinked` still passes unchanged).
- Distinct candidate routes are **capped at `runtimeEnumMaxExpansion` (4)**; a wider set is a generic shape and stays orphan as a `dynamic_baseurl` residual.
- Runs **dead-last**, after every exact/normalized/suffix stage, so a stronger match always wins first.
- **Static assets** (`/version.txt`) and genuinely-nonexistent routes stay orphan. The mobile repo (typed client, literal paths) does not match this shape, so it gains no false links.
- Links are stamped `resolve_strategy=runtime_enum_expansion`, confidence `heuristic` (existing semantics preserved — heuristic stays heuristic).

## Tests
- `TestRuntimeEnumSuffixShape` / `TestRuntimeEnumProducerSuffix` — unit tables for the shape detector + producer matcher, including reject cases (param-first, static divergence, count mismatch, no anchor).
- `TestHTTPPass_RuntimeEnumExpansion_AutoLink` — end-to-end: `/{companyType}/...` expands to BOTH contracting + witnessing routes, heuristic confidence, enum value recorded.
- `TestHTTPPass_RuntimeEnumExpansion_NoFalseLinks` — guardrail: param-first producer, `/version.txt`, and anchor-less `/{*}/{*}` all stay orphan.

`go build ./...`, `go vet ./internal/links`, `gofmt -l` all clean. `./internal/links` and `./internal/engine` test packages green.

## Expected impact
Targets the `branchService.js`-style frontend orphans (`/{companyType}/{companyId}/branches/{branchId}` and siblings) in the upvate `frontend` repo's 113 orphans, expanding each to its contracting/witnessing backend routes. The `{apiUrl}` base-URL orphans were already resolved by #2813. Exact orphan-rate drop is measurable only after a reindex.

**DEPLOY-DEFERRED** — lands at the next reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)