### PR TITLE
fix(flows): chain resolved cross-repo links end-to-end (http-call→endpoint→handler→service) (#4316)

### DIFF
--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -242,7 +242,14 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 		if res.Root == nil {
 			continue
 		}
-		chain := primaryPath(res.Root)
+		// #4316 — choose the canonical linear chain with cross-repo awareness:
+		// when a fan-out offers both a dead-end consumer http_endpoint
+		// synthetic (FETCHES) and a phantom cross-repo continuation into the
+		// backend handler, follow the continuation so the persisted chain goes
+		// end-to-end (caller → handler → service) instead of dead-ending at the
+		// HTTP-call node. Falls back to leftmost primaryPath for pure intra-repo
+		// flows, so UI-state setter chains stay terminal (no over-chaining).
+		chain := primaryPathCrossRepo(res.Root, adj, byID)
 
 		// #754 — short chains are allowed when the chain traverses a
 		// FETCHES edge (cross-repo bridge) or a phantom cross-repo edge.

--- a/internal/engine/process_flow_dag.go
+++ b/internal/engine/process_flow_dag.go
@@ -262,6 +262,137 @@ func primaryPath(root *ChainStep) []string {
 	return out
 }
 
+// primaryPathCrossRepo returns the canonical linear chain through the DAG,
+// but — unlike primaryPath's pure leftmost walk — it prefers a sibling
+// branch that CONTINUES ACROSS A RESOLVED CROSS-REPO BOUNDARY over a
+// sibling that dead-ends at a consumer http_endpoint synthetic (#4316).
+//
+// Motivation (B1): a frontend caller typically has TWO outgoing edges in
+// the unified adjacency:
+//
+//   - a FETCHES edge to its consumer http_endpoint synthetic (a dead-end:
+//     the synthetic has no outgoing traversable edge in the source repo),
+//     and
+//   - a phantom cross-repo CALLS edge to the resolved backend handler,
+//     which continues handler → service → repository.
+//
+// primaryPath picks whichever child sorts first by entity ID. When the
+// synthetic's ID happens to sort before the handler's, the persisted
+// chain dead-ends at the synthetic and the real end-to-end cross-repo
+// path is buried in a non-primary DAG branch — exactly the "307 resolved
+// links but only 5 cross-repo flows" symptom. This chooser fixes that by,
+// at each fan-out, preferring the child whose subtree actually crosses a
+// repo boundary (and, among those, the one that reaches deepest).
+//
+// Guard-rails (no over-chaining):
+//   - The decision is made ONLY from real edges already present in the
+//     DAG (which itself respects MaxDepth / BranchingFactor / cycle caps).
+//     No edge is fabricated; an unresolved/orphan http-call still has no
+//     cross-repo child and stays terminal.
+//   - When NO sibling subtree crosses a repo boundary the walk is byte-
+//     identical to primaryPath (leftmost), so pure intra-repo flows and
+//     UI-state setter chains (getState/setIsLoading/dispatch) are
+//     unchanged — those never reach a cross-repo edge.
+//
+// adj and byID may be nil; with either nil the function degrades to the
+// leftmost primaryPath behaviour.
+func primaryPathCrossRepo(root *ChainStep, adj *callsAdjacency, byID map[string]*graph.Entity) []string {
+	if root == nil {
+		return nil
+	}
+	if adj == nil {
+		return primaryPath(root)
+	}
+	out := []string{root.EntityID}
+	cur := root
+	for len(cur.Branches) > 0 {
+		next := chooseBranch(cur, adj, byID)
+		if next == nil || next.EntityID == branchOverflowEntityID {
+			break
+		}
+		out = append(out, next.EntityID)
+		cur = next
+	}
+	return out
+}
+
+// chooseBranch selects the child of node to follow as the primary path.
+// It prefers, in order:
+//  1. a real child whose subtree crosses a resolved cross-repo boundary
+//     (and, among those, the one reaching the greatest depth), then
+//  2. the leftmost real child (preserving primaryPath determinism).
+//
+// Returns nil when node has no real (non-overflow) child.
+func chooseBranch(node *ChainStep, adj *callsAdjacency, byID map[string]*graph.Entity) *ChainStep {
+	var leftmost *ChainStep
+	var bestXRepo *ChainStep
+	bestXRepoDepth := -1
+	for _, b := range node.Branches {
+		if b == nil || b.EntityID == branchOverflowEntityID {
+			continue
+		}
+		if leftmost == nil {
+			leftmost = b
+		}
+		// A branch is preferred when EITHER the hop into it is itself a
+		// cross-repo / handler-continuation edge, OR its subtree reaches
+		// such an edge deeper down. The first case captures the phantom
+		// caller→handler hop directly (B1); the second lets a chain that
+		// passes through one extra intra-repo step still find the bridge.
+		d := subtreeCrossRepoDepth(node.EntityID, b, adj)
+		if d >= 0 && d > bestXRepoDepth {
+			bestXRepoDepth = d
+			bestXRepo = b
+		}
+	}
+	if bestXRepo != nil {
+		return bestXRepo
+	}
+	return leftmost
+}
+
+// subtreeCrossRepoDepth returns the depth (number of hops below `child`,
+// 0-based) at which the subtree rooted at `child` first traverses a
+// resolved cross-repo edge (phantom CALLS) or a handler-continuation edge
+// (reversed IMPLEMENTS → http_endpoint_definition). Returns -1 when the
+// subtree never crosses a boundary. `parent` is the EntityID of child's
+// parent so the parent→child hop itself can be classified.
+//
+// The returned depth is used only to break ties toward the branch that
+// reaches the boundary AND continues furthest, so a chain that bridges
+// then chains handler→service is preferred over one that merely touches
+// the boundary and stops.
+func subtreeCrossRepoDepth(parent string, child *ChainStep, adj *callsAdjacency) int {
+	if child == nil || adj == nil {
+		return -1
+	}
+	// Is the parent→child hop itself a boundary-crossing edge?
+	k := edgeKey{parent, child.EntityID}
+	hopCrosses := adj.phantom[k] || adj.handlerCont[k]
+
+	best := -1
+	for _, b := range child.Branches {
+		if b == nil || b.EntityID == branchOverflowEntityID {
+			continue
+		}
+		if d := subtreeCrossRepoDepth(child.EntityID, b, adj); d >= 0 {
+			if d+1 > best {
+				best = d + 1
+			}
+		}
+	}
+	if hopCrosses {
+		// This hop crosses the boundary; depth contribution is how far the
+		// subtree continues past it (0 if the bridge target is a leaf).
+		if best < 0 {
+			return 0
+		}
+		return best
+	}
+	// This hop doesn't cross, but a descendant might. Propagate that depth.
+	return best
+}
+
 // encodeDAGJSON marshals the DAG to a compact JSON blob suitable for
 // stashing on the Process entity's Properties map. Errors are swallowed:
 // the DAG fields are advisory metadata, not load-bearing semantics, and

--- a/internal/engine/process_flow_xrepo_4316_test.go
+++ b/internal/engine/process_flow_xrepo_4316_test.go
@@ -1,0 +1,212 @@
+// process_flow_xrepo_4316_test.go — fix for issue #4316.
+//
+// Symptom (measured on `upvate`): 307 cross-repo HTTP links RESOLVED but
+// only 5 cross-repo FLOWS existed, with many flows dead-ending either AT
+// the http-call node (B1) or AT the backend entry handler (B2).
+//
+// Root cause (B1): a frontend caller has two outgoing edges in the
+// unified adjacency — a FETCHES edge to its dead-end consumer
+// http_endpoint synthetic, and a phantom cross-repo CALLS edge to the
+// resolved backend handler. primaryPath() picked whichever child sorted
+// first by entity ID; when the synthetic sorted first the persisted chain
+// dead-ended at the synthetic and the real end-to-end path was buried in
+// a non-primary DAG branch. primaryPathCrossRepo() now prefers the branch
+// that continues across the resolved cross-repo boundary.
+//
+// B2 (handler → service continuation) already worked once the chain
+// reaches the handler via companion adjacency; the test below pins it so
+// it cannot regress.
+//
+// Guard tests assert NO over-chaining: an UNRESOLVED http-call synthetic
+// (no phantom edge) stays terminal, and a UI-state setter chain is
+// unchanged.
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// b1Docs builds the B1 shape: a frontend caller that both FETCHES a
+// consumer http_endpoint synthetic (dead-end, ID sorts FIRST) and carries
+// a phantom cross-repo CALLS edge to the resolved backend handler, which
+// itself calls a service. The synthetic ID is chosen to sort BEFORE the
+// handler ID so the pre-fix leftmost walk would dead-end at it.
+func b1Docs() (fe, be *graph.Document) {
+	fe = &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "Details", Kind: "SCOPE.Function", Language: "ts", SourceFile: "Details.tsx"},
+			{ID: "aaa_synth", Name: "http:GET:/group-building-settings", Kind: "http_endpoint",
+				Language: "ts", SourceFile: "Details.tsx",
+				Properties: map[string]string{"pattern_type": "http_endpoint_client_synthesis"}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_f1", FromID: "fe_entry", ToID: "aaa_synth", Kind: "FETCHES"},
+			{ID: "fe_ph", FromID: "fe_entry", ToID: "zzz_handler", Kind: "CALLS",
+				Properties: map[string]string{"cross_repo": "true", "target_repo": "be", "link_method": "http"}},
+		},
+	}
+	be = &graph.Document{
+		Repo: "be",
+		Entities: []graph.Entity{
+			{ID: "zzz_handler", Name: "GroupBuildingSettingsViewSet.retrieve", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "views.py"},
+			{ID: "zzz_service", Name: "SettingsService.get", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "service.py"},
+			{ID: "zzz_repo", Name: "SettingsRepository.fetch", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "repo.py"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "be_r1", FromID: "zzz_handler", ToID: "zzz_service", Kind: "CALLS"},
+			{ID: "be_r2", FromID: "zzz_service", ToID: "zzz_repo", Kind: "CALLS"},
+		},
+	}
+	return
+}
+
+func processChain(doc *graph.Document, entryID string) []string {
+	p := findProcessByEntry(doc, entryID)
+	if p == nil {
+		return nil
+	}
+	return strings.Split(p.Properties["chain"], ",")
+}
+
+// B1: a flow reaching an http-call node WITH a resolved cross-repo link
+// must continue past it into the backend handler (and onward), NOT
+// dead-end at the consumer synthetic.
+func TestProcessFlow_4316_B1_ContinuesPastHTTPCall(t *testing.T) {
+	fe, be := b1Docs()
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	RunProcessFlowWithCompanions(fe, []*graph.Document{be}, cfg)
+
+	chain := processChain(fe, "fe_entry")
+	if len(chain) == 0 {
+		t.Fatalf("no Process emitted for fe_entry")
+	}
+	have := map[string]bool{}
+	for _, id := range chain {
+		have[id] = true
+	}
+	// Must NOT dead-end at the synthetic.
+	if chain[len(chain)-1] == "aaa_synth" {
+		t.Fatalf("B1 not fixed: chain dead-ends at consumer synthetic: %v", chain)
+	}
+	if !have["zzz_handler"] {
+		t.Fatalf("B1: chain did not cross into backend handler: %v", chain)
+	}
+	if !have["zzz_service"] {
+		t.Fatalf("B1: chain reached handler but did not continue into service: %v", chain)
+	}
+	p := findProcessByEntry(fe, "fe_entry")
+	if p.Properties["cross_stack"] != "true" {
+		t.Errorf("expected cross_stack=true, got %q", p.Properties["cross_stack"])
+	}
+}
+
+// B2: once at a backend handler reached via the cross-repo link, the flow
+// must continue into the handler's own callees (service → repository),
+// i.e. end-to-end rather than stopping at the entry handler.
+func TestProcessFlow_4316_B2_ChainsHandlerToService(t *testing.T) {
+	fe, be := b1Docs()
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	RunProcessFlowWithCompanions(fe, []*graph.Document{be}, cfg)
+
+	chain := processChain(fe, "fe_entry")
+	last := chain[len(chain)-1]
+	// The terminal must be the deepest backend node, not the entry handler.
+	if last == "zzz_handler" {
+		t.Fatalf("B2 not fixed: chain terminates at entry handler: %v", chain)
+	}
+	if last != "zzz_repo" {
+		t.Fatalf("B2: chain did not reach the deepest backend callee (zzz_repo); terminal=%s chain=%v", last, chain)
+	}
+}
+
+// Guard 1 — an UNRESOLVED http-call (consumer synthetic with NO phantom
+// cross-repo edge) must STAY a terminal. No over-chaining: the flow ends
+// at the synthetic because no resolved link exists to traverse.
+func TestProcessFlow_4316_Guard_UnresolvedHTTPCallStaysTerminal(t *testing.T) {
+	fe := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_a", Name: "loadThing", Kind: "SCOPE.Function", Language: "ts", SourceFile: "a.tsx"},
+			{ID: "fe_b", Name: "callApi", Kind: "SCOPE.Function", Language: "ts", SourceFile: "a.tsx"},
+			{ID: "fe_synth", Name: "http:GET:/orphan", Kind: "http_endpoint", Language: "ts", SourceFile: "a.tsx",
+				Properties: map[string]string{"pattern_type": "http_endpoint_client_synthesis"}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_r1", FromID: "fe_a", ToID: "fe_b", Kind: "CALLS"},
+			{ID: "fe_f1", FromID: "fe_b", ToID: "fe_synth", Kind: "FETCHES"},
+			// No phantom edge: the link never resolved to a backend handler.
+		},
+	}
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	RunProcessFlow(fe, cfg) // no companions; nothing to cross into anyway
+
+	chain := processChain(fe, "fe_a")
+	if len(chain) == 0 {
+		t.Fatalf("no Process emitted for fe_a")
+	}
+	// The synthetic is a legitimate terminal — there is nothing resolved to
+	// chain into. It must remain the terminal and the chain must not invent
+	// downstream steps.
+	if chain[len(chain)-1] != "fe_synth" {
+		t.Fatalf("unresolved http-call should stay terminal; got chain=%v", chain)
+	}
+}
+
+// Guard 2 — a UI-state setter chain (getState/setIsLoading/dispatch) must
+// stay exactly as long as before: the cross-repo chooser only diverges
+// from leftmost when a sibling crosses a repo boundary, which never
+// happens here.
+func TestProcessFlow_4316_Guard_UIStateSetterUnchanged(t *testing.T) {
+	mk := func(id, name string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: "SCOPE.Function", Language: "ts", SourceFile: "ui.tsx"}
+	}
+	fe := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			mk("h", "useThing"),
+			mk("cb", "handleClick"),
+			mk("set", "setIsLoading"),
+			mk("disp", "dispatch"),
+			mk("gs", "getState"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "h", ToID: "cb", Kind: "CALLS"},
+			{ID: "r2", FromID: "cb", ToID: "set", Kind: "CALLS"},
+			{ID: "r3", FromID: "cb", ToID: "disp", Kind: "CALLS"},
+			{ID: "r4", FromID: "disp", ToID: "gs", Kind: "CALLS"},
+		},
+	}
+	feCopy := *fe
+
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	// Cross-repo chooser path (with empty companions).
+	RunProcessFlowWithCompanions(fe, nil, cfg)
+	gotX := strings.Join(processChain(fe, "h"), ",")
+
+	// Reference leftmost path.
+	RunProcessFlow(&feCopy, cfg)
+	gotRef := strings.Join(processChain(&feCopy, "h"), ",")
+
+	if gotX != gotRef {
+		t.Fatalf("UI-state setter chain changed under cross-repo chooser:\n  xrepo = %q\n  ref   = %q", gotX, gotRef)
+	}
+	// Sanity: the chain must not have grown beyond the real call depth.
+	if n := len(strings.Split(gotX, ",")); n > 4 {
+		t.Fatalf("UI-state chain over-chained to %d steps: %q", n, gotX)
+	}
+}


### PR DESCRIPTION
Closes #4316

## Problem
Measured on `upvate`: **307 cross-repo HTTP links RESOLVED but only 5 cross-repo FLOWS** (26 total, 65 dead-ends). The flow builder wasn't chaining resolved cross-repo links into end-to-end traces. Two failure modes:

- **B1** — flow dead-ends AT the http-call node (e.g. `Details → http:GET:/group-building-settings/...`).
- **B2** — flow crosses into the backend but dead-ends at the ENTRY handler (e.g. `useChecklistCatalogDetailQuery → ChecklistCatalogViewSet.retrieve`).

## Builder location
`internal/engine/process_flow.go` (`RunProcessFlowWithCompanions`) + the DAG walker in `internal/engine/process_flow_dag.go`. Cross-repo adjacency (phantom CALLS edges, FETCHES, reversed `IMPLEMENTS → http_endpoint_definition` handler-continuation) and companion docs were already wired through `internal/cli/links.go::runPhantomEdgePass`.

## Root cause
A frontend caller has **two** outgoing edges in the unified adjacency: a `FETCHES` edge to its dead-end consumer `http_endpoint` synthetic, and a phantom cross-repo `CALLS` edge to the resolved backend handler (`caller → handler`, which continues `handler → service → repo`). The DAG contained the full cross-repo path, but `primaryPath()` persisted the **leftmost child by entity ID**. When the synthetic's ID sorted before the handler's, the persisted `chain` dead-ended at the synthetic and the real end-to-end path was buried in a non-primary branch — so most resolved links never surfaced as a cross-repo flow.

## Fix
New `primaryPathCrossRepo(root, adj, byID)` chooses, at each fan-out, the branch that **continues across a resolved cross-repo boundary** (phantom CALLS or reversed-IMPLEMENTS handler-continuation), preferring the one reaching deepest; it falls back to the leftmost `primaryPath` when no sibling crosses a boundary.

- **B1 fixed:** the chain follows the phantom continuation past the http-call node into the endpoint/handler instead of dead-ending at the consumer synthetic.
- **B2 fixed:** once at the handler, expansion continues into the handler's own callees (`service → repository`) via companion adjacency (already supported; now reliably the persisted primary path).
- Only edges already present in the DAG are traversed — **no fabricated steps**. Depth/cycle/branching/de-dup limits are unchanged (the chooser only re-ranks existing DAG branches).

## Terminals preserved (no over-chaining)
- An **unresolved/orphan http-call** (no phantom edge) never reaches a cross-repo edge → stays terminal.
- **UI-state setters** (`getState`/`setIsLoading`/`dispatch`/`useCallback`) never cross a repo boundary → the walk is byte-identical to the leftmost `primaryPath`, so those flows are unchanged.

## Tests
`internal/engine/process_flow_xrepo_4316_test.go`:
- B1: flow continues past the http-call into the handler (asserts terminal ≠ synthetic, handler + service present).
- B2: flow chains `handler → service → repository`.
- Guard: unresolved http-call stays terminal.
- Guard: UI-state setter chain identical under the cross-repo chooser vs leftmost reference.

Gates green: `go build ./...`, `go test ./internal/engine ./internal/mcp ./internal/cli ./internal/dashboard` (flow/trace scopes), `go vet ./internal/engine`, `gofmt -l` clean.

## Expected impact
The live flow-count rise is measurable only **post-reindex (DEPLOY-DEFERRED)**. Expected: cross-repo flows rise substantially toward the 307 resolved-link ceiling as B1/B2 dead-ends convert into end-to-end traces, while the ~50 legitimate UI-state terminals stay terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)