### PR TITLE
fix(webui): readable contrast for repo-label chips (WCAG AA across hues + themes)

### DIFF
--- a/webui-v2/src/lib/repo-color.test.ts
+++ b/webui-v2/src/lib/repo-color.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Contrast / accessibility tests for repo-color.tsx
+ *
+ * Verifies the repo-label chip foreground meets WCAG AA (~4.5:1) against its
+ * background for EVERY repo hue in BOTH light and dark themes, covering:
+ *   - the curated pastel-N / pastel-N-ink token pairs (chip bg = pastel @28%
+ *     composited over the theme surface), and
+ *   - the hash-derived hslDerived() path used for groups with >8 repos.
+ *
+ * Run with: npx vitest run src/lib/repo-color.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import { getRepoColor } from "./repo-color";
+
+// --- color math (sRGB relative luminance per WCAG 2.x) --------------------
+
+type RGB = [number, number, number];
+
+function hexToRgb(h: string): RGB {
+  const s = h.replace("#", "");
+  return [
+    parseInt(s.slice(0, 2), 16),
+    parseInt(s.slice(2, 4), 16),
+    parseInt(s.slice(4, 6), 16),
+  ];
+}
+
+function lin(c: number): number {
+  const x = c / 255;
+  return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+}
+
+function luminance([r, g, b]: RGB): number {
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** Alpha-composite `top` (opaque rgb) at `alpha` over opaque `bottom`. */
+function composite(top: RGB, bottom: RGB, alpha: number): RGB {
+  return [0, 1, 2].map((i) => top[i] * alpha + bottom[i] * (1 - alpha)) as RGB;
+}
+
+function contrast(a: RGB, b: RGB): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Parse `hsl(h, s%, l%[, a])` to opaque RGB (alpha ignored — handled separately). */
+function hslStrToRgb(str: string): { rgb: RGB; alpha: number } {
+  const m = str.match(/hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+)\s*)?\)/);
+  if (!m) throw new Error("not an hsl() string: " + str);
+  const h = parseFloat(m[1]);
+  const s = parseFloat(m[2]) / 100;
+  const l = parseFloat(m[3]) / 100;
+  const alpha = m[4] !== undefined ? parseFloat(m[4]) : 1;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return { rgb: [f(0) * 255, f(8) * 255, f(4) * 255] as RGB, alpha };
+}
+
+const AA = 4.5;
+
+// Theme surfaces the chip sits on (from tokens.css).
+const SURFACE_LIGHT: RGB = [255, 255, 255]; // --surface
+const SURFACE_DARK: RGB = [22, 25, 31]; //   approx dark card surface
+
+// --- curated token table (mirrors tokens.css) -----------------------------
+// Keep in sync with src/styles/tokens.css :root / [data-theme="dark"].
+
+const CURATED_LIGHT = {
+  pastel: [
+    "#a5cde3", "#b3dec3", "#fac8a0", "#f0b1bd", "#cdb9e5",
+    "#efd99a", "#b0d3b3", "#f4bfca", "#b8c0e0", "#f7caa3",
+  ],
+  ink: [
+    "#366f8f", "#40765b", "#965d2c", "#9b5266", "#735ba7",
+    "#816928", "#4b734f", "#96586b", "#59659e", "#8c632f",
+  ],
+};
+
+const CURATED_DARK = {
+  pastel: [
+    "#6f9bb3", "#7da689", "#c4956d", "#b8838f", "#9686b3",
+    "#b8a565", "#82a384", "#c08699", "#8a91b3", "#c4986f",
+  ],
+  ink: [
+    "#95c1d9", "#a4cfb0", "#e8b893", "#dcaab5", "#bcabd9",
+    "#dcc88b", "#a9caaa", "#e1aabb", "#b1b8d9", "#e8be93",
+  ],
+};
+
+// Chip background = pastel @28% over surface (see RepoChip / CURATED).
+const BG_MIX_ALPHA = 0.28;
+
+describe("repo chip contrast — curated palette", () => {
+  for (const [theme, table, surface] of [
+    ["light", CURATED_LIGHT, SURFACE_LIGHT],
+    ["dark", CURATED_DARK, SURFACE_DARK],
+  ] as const) {
+    table.pastel.forEach((p, i) => {
+      it(`pastel-${i + 1} ink clears AA in ${theme}`, () => {
+        const bg = composite(hexToRgb(p), surface, BG_MIX_ALPHA);
+        const fg = hexToRgb(table.ink[i]);
+        const ratio = contrast(bg, fg);
+        expect(ratio).toBeGreaterThanOrEqual(AA);
+      });
+    });
+  }
+});
+
+describe("repo chip contrast — hash-derived (>8 repos) path", () => {
+  // hslDerived returns an OPAQUE background, so its contrast is theme-
+  // independent. Sample many distinct slugs to cover the golden-ratio wheel.
+  const slugs = Array.from({ length: 400 }, (_, n) => `repo-${n}-svc`);
+
+  it("every sampled hash-derived slug clears AA over both surfaces", () => {
+    let worst = Infinity;
+    for (const slug of slugs) {
+      const { background, foreground } = getRepoColor(slug);
+      // Only assert the derived (hsl) path here; curated CSS-vars are covered above.
+      if (!background.startsWith("hsl")) continue;
+      const bgParsed = hslStrToRgb(background);
+      const fg = hslStrToRgb(foreground).rgb;
+      for (const surface of [SURFACE_LIGHT, SURFACE_DARK]) {
+        const bg = composite(bgParsed.rgb, surface, bgParsed.alpha);
+        worst = Math.min(worst, contrast(bg, fg));
+      }
+    }
+    expect(worst).toBeGreaterThanOrEqual(AA);
+  });
+});

--- a/webui-v2/src/lib/repo-color.tsx
+++ b/webui-v2/src/lib/repo-color.tsx
@@ -65,24 +65,34 @@ function slugIndex(slug: string): number {
 }
 
 /**
- * Derive a comfortable HSL color pair for a repo slug beyond the curated 8.
- * Saturation is capped at 42% and lightness band is 55–68% (light theme) /
- * 35–50% (dark theme, rendered via CSS).  We can't detect theme in pure TS so
- * we output static HSL values tuned for the dark theme (dark is more common
- * in dev tools) and rely on a mild mismatch in light mode being acceptable.
+ * Derive an accessible HSL color pair for a repo slug beyond the curated 8.
+ *
+ * Contrast strategy (issue: repo-chip contrast):
+ *   We can't detect the active theme in pure TS, and a *translucent* chip
+ *   background composites differently over a light vs. dark surface — so a
+ *   single foreground can never clear AA in both themes against a translucent
+ *   tint. We therefore make the hash-derived chip background a FULLY OPAQUE
+ *   pale tint (high lightness, L≈82) so its rendered luminance is the same in
+ *   either theme, and pair it with a DARK, slightly-more-saturated text color
+ *   of the same hue (L≈20). That pair clears ~6:1 across the whole golden-ratio
+ *   hue wheel in both themes, while preserving per-repo hue identity.
+ *
+ *   Worst-case computed contrast across the hue wheel: ≈6.1:1 (light == dark,
+ *   because the opaque background removes theme dependence).
  */
 function hslDerived(slug: string): RepoColors {
   const idx = slugIndex(slug);
   const hue = ((idx * GOLDEN_RATIO) % 1) * 360;
-  // Saturation slightly varied (36–46%) to avoid monotony.
-  const sat = 36 + (idx % 5) * 2;
-  // Lightness in comfortable dark-theme band.
-  const L = 44 + (idx % 7);
-  const Ld = L - 8; // darker for border/ink
+  // Saturation varied (46–58%) to keep adjacent hues distinguishable.
+  const sat = 46 + (idx % 4) * 4;
+  const Lbg = 82; // pale, opaque tint — theme-independent luminance
+  const Lfg = 20; // dark text of the same hue
+  const satFg = Math.min(sat + 15, 90);
 
-  const bg = `hsl(${hue.toFixed(0)}, ${sat}%, ${L}%, 0.28)`;
-  const fg = `hsl(${hue.toFixed(0)}, ${(sat + 20).toFixed(0)}%, ${(L + 22).toFixed(0)}%)`;
-  const border = `hsl(${hue.toFixed(0)}, ${sat}%, ${Ld}%, 0.45)`;
+  const bg = `hsl(${hue.toFixed(0)}, ${sat}%, ${Lbg}%)`;
+  const fg = `hsl(${hue.toFixed(0)}, ${satFg.toFixed(0)}%, ${Lfg}%)`;
+  // Border: same dark hue at moderate opacity for a crisp edge.
+  const border = `hsl(${hue.toFixed(0)}, ${satFg.toFixed(0)}%, ${(Lfg + 14).toFixed(0)}%, 0.55)`;
   return { background: bg, foreground: fg, border };
 }
 

--- a/webui-v2/src/styles/tokens.css
+++ b/webui-v2/src/styles/tokens.css
@@ -55,16 +55,19 @@
   --pastel-9:  #b8c0e0;   /* cornflower */
   --pastel-10: #f7caa3;   /* apricot  */
 
-  --pastel-1-ink:  #3e7fa3;
-  --pastel-2-ink:  #4e8f6e;
-  --pastel-3-ink:  #c47a3a;
-  --pastel-4-ink:  #b66078;
-  --pastel-5-ink:  #7960b0;
-  --pastel-6-ink:  #b08f36;
-  --pastel-7-ink:  #5d8e62;
-  --pastel-8-ink:  #c2718a;
-  --pastel-9-ink:  #6573b3;
-  --pastel-10-ink: #c08741;
+  /* ink = chip text. Darkened so foreground clears WCAG AA (~4.5:1) over the
+     pastel @28%-over-surface chip background in light theme (issue: repo-chip
+     contrast). Each retains its hue so chips stay per-repo distinct. */
+  --pastel-1-ink:  #366f8f;   /* 4.77:1 */
+  --pastel-2-ink:  #40765b;   /* 4.77:1 */
+  --pastel-3-ink:  #965d2c;   /* 4.79:1 */
+  --pastel-4-ink:  #9b5266;   /* 4.76:1 */
+  --pastel-5-ink:  #735ba7;   /* 4.75:1 */
+  --pastel-6-ink:  #816928;   /* 4.80:1 */
+  --pastel-7-ink:  #4b734f;   /* 4.76:1 */
+  --pastel-8-ink:  #96586b;   /* 4.75:1 */
+  --pastel-9-ink:  #59659e;   /* 4.76:1 */
+  --pastel-10-ink: #8c632f;   /* 4.78:1 */
 
   /* -- Skeleton / loading placeholders -- */
   --skeleton-base:      #e2e6ed;   /* noticeably darker than surface-2 (#f3f5f8) */


### PR DESCRIPTION
## Problem

The repo-label chip (e.g. the greenish-yellow `core-backend-v3` pill shown in Flows / Paths / Topology and across di/dataflow/iac/quality/errorflow) had **unreadable text contrast** — especially in **light theme**. The chip background is `pastel-N @28% over surface` paired with `pastel-N-ink` text (`webui-v2/src/lib/repo-color.tsx`, used by `RefLine.tsx`).

Computing **WCAG 2.x sRGB relative-luminance contrast** on the alpha-composited pairs:

| Path | Worst-case BEFORE | Offender |
|---|---|---|
| Curated (light) | **2.77:1** ❌ | apricot (pastel-10), butter (pastel-6 = 2.80) |
| Curated (dark) | 5.45:1 ✅ | (already fine) |
| Hash-derived `hslDerived` (light) | **1.09:1** ❌ | foreground was *lighter* than background (`L+22`) |
| Hash-derived `hslDerived` (dark) | 3.72:1 ❌ | — |

In light theme **every** curated chip was below AA (4.5:1).

## Fix (hue identity preserved — chips stay per-repo distinct)

- **Light-theme `--pastel-N-ink` tokens** darkened (same hue, lower lightness) so each clears ~4.75:1 over its pale `@28%` background. Dark-theme inks already passed and are untouched.
- **`hslDerived()`** (groups with >8 repos) reworked: **opaque** pale background (L≈82) + **dark same-hue** text (L≈20). An opaque background renders identically in both themes, so one foreground clears ~6:1 across the whole golden-ratio hue wheel — no theme-detection needed.

## Contrast method

Standard WCAG 2.x: per-channel sRGB→linear, relative luminance `0.2126R+0.7152G+0.0722B`, ratio `(L_hi+0.05)/(L_lo+0.05)`, on the chip foreground vs. the alpha-composited background (pastel `@28%` over the theme surface; opaque for the hash path).

| Path | BEFORE → AFTER (worst) |
|---|---|
| Curated (light+dark) | 2.77:1 → **4.74:1** |
| Hash-derived (both themes) | 1.09:1 → **6.09:1** |

## Tests / gates

- Added `webui-v2/src/lib/repo-color.test.ts`: asserts AA for every curated pastel pair (light + dark) and 400 sampled hash-derived slugs. **21 new assertions pass** (37 total in `src/lib`).
- `npm ci` ✅ · `npm run build` (vite) ✅ · `npm run lint` (tsc --noEmit) clean ✅

## Notes

- **Deploy-deferred**: `webui-v2/dist` is gitignored and re-embeds on the next deploy — **source only**, no `dist/` committed.
- Files: `src/lib/repo-color.tsx`, `src/styles/tokens.css`, `src/lib/repo-color.test.ts`. `RefLine.tsx` needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)