### PR TITLE
fix(extract): bridge HTTP endpoint definitions to their handler operations across frameworks (#4319)

### DIFF
--- a/internal/engine/http_endpoint_bridge_4319_test.go
+++ b/internal/engine/http_endpoint_bridge_4319_test.go
@@ -1,0 +1,233 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4319 — bridge HTTP endpoint definitions to their handler operations across
+// frameworks. The shared mechanism is the source_handler → IMPLEMENTS resolver
+// in ResolveHTTPEndpointHandlers. Before #4319 the resolver matched the
+// synthesizer's BARE source_handler name (e.g. "Controller:merge") only against
+// a handler entity whose Name was character-for-character equal. When an
+// extractor lands a controller method QUALIFIED (`Controller.merge` — the shape
+// Django/Spring/ASP.NET handlers already use) the lookup missed and the
+// http_endpoint_definition was dropped → graph island (the handler's
+// VALIDATES/CALLS/RETURNS edges unreachable from the endpoint). The fix adds a
+// same-file bare↔qualified reconciliation step.
+
+// implementsEdgeFor returns the IMPLEMENTS edge on `handler` that targets the
+// http_endpoint_definition, or a zero RelationshipRecord if absent.
+func implementsEdgeFor(handler types.EntityRecord) (types.RelationshipRecord, bool) {
+	for _, r := range handler.Relationships {
+		if r.Kind == implementsEdgeKind {
+			return r, true
+		}
+	}
+	return types.RelationshipRecord{}, false
+}
+
+// TestBridge4319_NestJSQualifiedHandler is the concrete NestJS validation case
+// from the issue: a @Post('merge') route whose handler method is indexed as a
+// qualified `BuildingController.mergeMaintenanceEvaluations` SCOPE.Operation
+// carrying VALIDATES (payload DTO) + CALLS (downstream service). Traversing
+// from the endpoint must reach the handler (and therefore its VALIDATES/CALLS).
+func TestBridge4319_NestJSQualifiedHandler(t *testing.T) {
+	handler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "BuildingController.mergeMaintenanceEvaluations",
+		SourceFile: "src/buildings/building.controller.ts",
+		Language:   "typescript",
+		Subtype:    "method",
+		Relationships: []types.RelationshipRecord{
+			{Kind: string(types.RelationshipKindValidates), ToID: "Class:BuildingMeMergeBody"},
+			{Kind: string(types.RelationshipKindCalls), ToID: "SCOPE.Operation:BuildingService.mergeMaintenanceEvaluations"},
+		},
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:POST:/inspections/me-manage/merge",
+		SourceFile: "src/buildings/building.controller.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb":           "POST",
+			"path":           "/inspections/me-manage/merge",
+			"framework":      "nestjs",
+			"pattern_type":   "http_endpoint_synthesis",
+			"source_handler": "Controller:mergeMaintenanceEvaluations",
+		},
+	}
+	merged := []types.EntityRecord{handler, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.HandlerResolved != 1 || stats.HandlerDropped != 0 {
+		t.Fatalf("expected resolved=1 dropped=0, got %+v", stats)
+	}
+	if len(out) != 2 {
+		t.Fatalf("endpoint must not be dropped: got %d entities", len(out))
+	}
+	edge, ok := implementsEdgeFor(out[0])
+	if !ok {
+		t.Fatal("ISLAND: no IMPLEMENTS edge from qualified NestJS handler to endpoint (#4319)")
+	}
+	if edge.ToID != "http_endpoint_definition:http:POST:/inspections/me-manage/merge" {
+		t.Errorf("IMPLEMENTS targets wrong endpoint: %s", edge.ToID)
+	}
+	// Traversing endpoint → handler reaches the handler's VALIDATES + CALLS.
+	if _, ok := out[0].Properties["source_handler"]; ok {
+		t.Error("source_handler should be cleared once bridged")
+	}
+	var sawValidates, sawCalls bool
+	for _, r := range out[0].Relationships {
+		switch r.Kind {
+		case string(types.RelationshipKindValidates):
+			sawValidates = true
+		case string(types.RelationshipKindCalls):
+			sawCalls = true
+		}
+	}
+	if !sawValidates || !sawCalls {
+		t.Errorf("bridged handler lost its downstream edges: validates=%v calls=%v", sawValidates, sawCalls)
+	}
+}
+
+// TestBridge4319_ExpressQualifiedHandler covers a second framework (Express)
+// proving the bridge is generalized, not a NestJS special-case. Express stamps
+// `source_handler=Controller:<handler>` bare; here the handler is indexed
+// qualified as `UserController.listUsers`.
+func TestBridge4319_ExpressQualifiedHandler(t *testing.T) {
+	handler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "UserController.listUsers",
+		SourceFile: "src/routes/users.ts",
+		Language:   "typescript",
+		Subtype:    "method",
+		Relationships: []types.RelationshipRecord{
+			{Kind: string(types.RelationshipKindCalls), ToID: "SCOPE.Operation:UserService.findAll"},
+		},
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:GET:/users",
+		SourceFile: "src/routes/users.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb":           "GET",
+			"path":           "/users",
+			"framework":      "express",
+			"pattern_type":   "http_endpoint_synthesis",
+			"source_handler": "Controller:listUsers",
+		},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{handler, synth})
+	if stats.HandlerResolved != 1 || stats.HandlerDropped != 0 {
+		t.Fatalf("expected resolved=1 dropped=0, got %+v", stats)
+	}
+	if _, ok := implementsEdgeFor(out[0]); !ok {
+		t.Fatal("ISLAND: Express qualified handler not bridged (#4319)")
+	}
+}
+
+// TestBridge4319_BareHandlerStillResolves guards that the pre-#4319 happy path
+// (synthesizer bare name == handler bare Name) keeps working unchanged.
+func TestBridge4319_BareHandlerStillResolves(t *testing.T) {
+	handler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "createOrder",
+		SourceFile: "src/orders/orders.controller.ts",
+		Language:   "typescript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:POST:/orders",
+		SourceFile: "src/orders/orders.controller.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"framework": "nestjs", "pattern_type": "http_endpoint_synthesis",
+			"source_handler": "Controller:createOrder",
+		},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{handler, synth})
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("bare-name happy path regressed: %+v", stats)
+	}
+	if _, ok := implementsEdgeFor(out[0]); !ok {
+		t.Fatal("bare-name handler should still bridge")
+	}
+}
+
+// TestBridge4319_MultiMethodControllerMapsEachEndpointToOwnHandler is the
+// critical mis-bridge guard: a controller with two qualified handler methods in
+// ONE file must bridge each endpoint to ITS OWN handler, never the wrong one.
+func TestBridge4319_MultiMethodControllerMapsEachEndpointToOwnHandler(t *testing.T) {
+	file := "src/buildings/building.controller.ts"
+	getHandler := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "BuildingController.getBuilding",
+		SourceFile: file, Language: "typescript",
+		Relationships: []types.RelationshipRecord{{Kind: string(types.RelationshipKindCalls), ToID: "X:getOne"}},
+	}
+	mergeHandler := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "BuildingController.mergeMaintenanceEvaluations",
+		SourceFile: file, Language: "typescript",
+		Relationships: []types.RelationshipRecord{{Kind: string(types.RelationshipKindCalls), ToID: "X:merge"}},
+	}
+	getSynth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:GET:/buildings/{id}",
+		SourceFile: file, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis", "source_handler": "Controller:getBuilding"},
+	}
+	mergeSynth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:POST:/inspections/me-manage/merge",
+		SourceFile: file, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis", "source_handler": "Controller:mergeMaintenanceEvaluations"},
+	}
+	merged := []types.EntityRecord{getHandler, mergeHandler, getSynth, mergeSynth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.HandlerResolved != 2 || stats.HandlerDropped != 0 {
+		t.Fatalf("expected both endpoints bridged, got %+v", stats)
+	}
+	// Build name → IMPLEMENTS-target map and assert correct pairing.
+	want := map[string]string{
+		"BuildingController.getBuilding":                 "http_endpoint_definition:http:GET:/buildings/{id}",
+		"BuildingController.mergeMaintenanceEvaluations": "http_endpoint_definition:http:POST:/inspections/me-manage/merge",
+	}
+	for _, e := range out {
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		edge, ok := implementsEdgeFor(e)
+		if !ok {
+			t.Errorf("handler %s not bridged", e.Name)
+			continue
+		}
+		if want[e.Name] != edge.ToID {
+			t.Errorf("MIS-BRIDGE: handler %s implements %s, want %s", e.Name, edge.ToID, want[e.Name])
+		}
+	}
+}
+
+// TestBridge4319_AmbiguousBareNameNotGuessed guards that when two same-file
+// handlers share the same bare method name (e.g. an overload-like collision),
+// the fix does NOT guess — it leaves resolution to the existing fallbacks
+// rather than mis-bridging to an arbitrary candidate.
+func TestBridge4319_AmbiguousBareNameNotGuessed(t *testing.T) {
+	file := "src/svc.ts"
+	h1 := types.EntityRecord{Kind: "SCOPE.Operation", Name: "A.handle", SourceFile: file, Language: "typescript"}
+	h2 := types.EntityRecord{Kind: "SCOPE.Operation", Name: "B.handle", SourceFile: file, Language: "typescript"}
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:GET:/x", SourceFile: file, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis", "source_handler": "Controller:handle"},
+	}
+	out, _ := ResolveHTTPEndpointHandlers([]types.EntityRecord{h1, h2, synth})
+	// Neither handler should receive an IMPLEMENTS edge via the ambiguous
+	// same-file bare lookup (the fix only binds when exactly one candidate).
+	for _, e := range out {
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		if _, ok := implementsEdgeFor(e); ok {
+			t.Errorf("ambiguous bare name must not be guess-bridged, but %s was", e.Name)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -141,6 +141,23 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// can locate and scan the actual handler body.
 	type knKey = httpResolveNameKey
 	globalIdx := make(map[knKey]int, len(merged))
+	// #4319 — same-file bare↔qualified bridge index. The per-language
+	// synthesizers were written against an extractor convention that records
+	// handlers by BARE method name (NestJS / Express / Axum / Rocket / JAX-RS
+	// all stamp `source_handler=Controller:<method>`). Some extractor
+	// configurations instead land a controller method as a QUALIFIED entity
+	// (`<Class>.<method>` — the same shape Django/Spring/ASP.NET handlers use),
+	// so the resolver's exact-Name lookup misses and the synthetic is DROPPED,
+	// leaving the http_endpoint_definition a graph island (its handler's
+	// VALIDATES / CALLS / RETURNS edges are unreachable from the endpoint node).
+	// This index maps (sourceFile, bareName) → candidate indices of same-file
+	// handler entities whose Name is exactly `bareName` OR ends in
+	// `.<bareName>` (qualified `Class.method`). It is consulted ONLY as a
+	// same-file fallback, so it can never mis-bridge an endpoint to a method in
+	// a different controller, and it keys on the precise method name so a
+	// multi-method controller maps each endpoint to ITS OWN handler.
+	type fileBareKey struct{ sourceFile, bare string }
+	sameFileBareIdx := make(map[fileBareKey][]int, len(merged))
 	// #2692 — multi-match index for the Phoenix-style `name@file_hint`
 	// resolution path. Routes-file frameworks (Phoenix router) declare
 	// handlers by short action name (`index`, `show`) that collides
@@ -182,6 +199,19 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			globalIdx[gk] = i
 		}
 		globalMulti[gk] = append(globalMulti[gk], i)
+		// #4319 — register this handler under its bare method name within its
+		// source file. For a qualified Name (`Class.method`) the bare key is
+		// `method`; for an already-bare Name the bare key equals the Name (so
+		// the inverse mismatch — synthesizer stamps qualified, handler is bare —
+		// is also covered).
+		bare := r.Name
+		if dot := strings.LastIndexByte(bare, '.'); dot >= 0 && dot < len(bare)-1 {
+			bare = bare[dot+1:]
+		}
+		if bare != "" {
+			fk := fileBareKey{r.SourceFile, bare}
+			sameFileBareIdx[fk] = append(sameFileBareIdx[fk], i)
+		}
 	}
 
 	// Build an index of definitions by canonical Name (= synthetic ID)
@@ -388,6 +418,28 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 					found = true
 					break
 				}
+			}
+		}
+		// #4319 — same-file bare↔qualified bridge. The exact-Name lookups above
+		// match only when the synthesizer's bare `source_handler` name and the
+		// handler entity's Name agree character-for-character. For the
+		// bare-name-emitting frameworks (NestJS / Express / Axum / Rocket /
+		// JAX-RS) the handler method is sometimes indexed QUALIFIED
+		// (`Controller.method`) — the same shape Django/Spring/ASP.NET handlers
+		// carry — so the route synthetic was DROPPED and the
+		// http_endpoint_definition left a graph island. Here, before falling
+		// back to the (risky) cross-file global lookup, we try the same-file
+		// bare-name index: a handler in the SAME file whose Name is exactly `hn`
+		// or ends in `.hn`. Same-file scoping makes this unambiguous — a
+		// multi-method controller still maps each endpoint to its OWN handler
+		// because the bare method name is the key. When more than one candidate
+		// shares the bare name in one file (rare: an overload-like collision) we
+		// do NOT guess; we leave it for the existing fallbacks so we never
+		// mis-bridge. Skipped when a handler_file hint redirected lookupFile.
+		if !found && handlerFileHint == "" {
+			if cands := sameFileBareIdx[fileBareKey{r.SourceFile, hn}]; len(cands) == 1 {
+				handlerIdx = cands[0]
+				found = true
 			}
 		}
 		if !found {


### PR DESCRIPTION
Closes #4319

## Problem
`http_endpoint_definition` nodes can become graph **islands** — `neighbors(both)`
empty — even though the handler `Operation` at the same file+line carries the
real `VALIDATES` (payload DTO) and `CALLS` (downstream) edges. The dashboard
Paths panel / effective_contract / flows then show 0 params/downstream/tests for
a fully-extracted endpoint. Django doesn't hit this (its handler entity name
matches the synthesizer's `source_handler`).

## Shared bridge mechanism (the one all frameworks already feed)
Every per-framework synthesizer in `internal/engine/http_endpoint_synthesis.go`
(+ the per-language producers) stamps `source_handler=<Kind>:<Name>` on the
`http_endpoint_definition`. `ResolveHTTPEndpointHandlers`
(`internal/engine/http_endpoint_resolve.go`) binds that ref to the handler
entity and emits the **`IMPLEMENTS`** edge (handler → endpoint; `SERVED_BY` is
its inverse). Traversing from the endpoint then reaches the handler and
everything downstream. **No new RelationshipKind** — the bridge is the existing
`IMPLEMENTS`/`SERVED_BY` pair, so `internal/types` is unchanged.

## Root cause of the islands
The resolver matched the synthesizer's **bare** `source_handler` name only
against a handler whose `Name` is character-for-character equal. NestJS / Express
/ Axum / Rocket / JAX-RS all stamp `Controller:<method>` (bare). When an
extractor lands that controller method **qualified** (`Controller.method` — the
same shape Django/Spring/ASP.NET handlers carry), the exact-Name lookup misses,
the synthetic is **dropped**, and the endpoint is an island.

## Fix (framework-agnostic, in the shared resolver — no special-casing)
Add a **same-file bare↔qualified reconciliation** step: before the risky
cross-file global fallback, when the bare `source_handler` name has no exact
match, bind to a same-file handler whose `Name` equals the bare name **or** ends
in `.<bareName>`. Same-file scoping + keying on the precise method name guarantee
a multi-method controller maps each endpoint to **its own** handler; an ambiguous
same-file bare-name collision is **left to the existing fallbacks rather than
guessed**, so we never mis-bridge. Django's unified model keeps working
(unchanged exact-match path).

## Cross-framework audit (framework → island? → disposition)
Bridge = shared `source_handler`→`IMPLEMENTS` resolver. Islands arise from (a) a
name-convention mismatch [fixed here] or (b) no addressable handler symbol
[tracked in #4324].

| Framework | source_handler emitted | Island cause | Status |
|---|---|---|---|
| NestJS (JS/TS) | `Controller:<method>` bare | bare↔qualified mismatch | **Fixed** |
| Express / Polka / Restify | `Controller:<handler>` bare | bare↔qualified mismatch | **Fixed** |
| Axum (Rust) | `Controller:<handler>` bare | bare↔qualified mismatch | **Fixed** |
| Rocket (Rust) | `Controller:<handler>` bare | bare↔qualified mismatch | **Fixed** |
| JAX-RS (Java) | `Controller:<method>` bare | bare↔qualified mismatch | **Fixed** |
| Django / DRF | `Route:`/`View.method` (matching) | none | OK (regression-guarded) |
| Spring MVC/WebFlux, Kotlin | `Route:`/`Controller:<method>` | none / no-ref | OK / #4324 |
| ASP.NET Core (C#) | `SCOPE.Operation:<Class>.<Method>` qualified | none | OK |
| Go gqlgen / receiver methods | `<receiver>.<method>` qualified | none | OK |
| Flask/FastAPI/Sanic/Bottle/… (Python) | `Controller:<func>` bare, same-file | matches func | OK |
| Rails / Phoenix | bare action + `handler_file` hint | cross-file hinted | OK |
| Laravel (PHP) | `Controller@method` ref | none | OK |
| Express path-only, GraphQL maps, Javalin/Vert.x/Play/Struts/Akka/WebFlux-fn, Django detail | **empty** (inline/anonymous) | no handler symbol | follow-up **#4324** |

## Secondary edges (issue's optional asks)
The endpoint↔handler bridge makes the handler's existing `VALIDATES`/`CALLS`
reachable. The remaining "connect already-extracted entities to the endpoint"
items — handler `RETURNS`→response-DTO, contract-test→endpoint `TESTS`,
`@Query()`/`@Param()` params — are deferred to follow-up **#4325** (prefer
generalizing via the shared resolve/propagate layer).

## Tests (`internal/engine/http_endpoint_bridge_4319_test.go`)
- NestJS qualified-handler bridge + traversal reaching `VALIDATES`/`CALLS`
- Express qualified-handler bridge (second framework)
- bare-name happy-path non-regression
- multi-method controller maps each endpoint to its own handler (mis-bridge guard)
- ambiguous same-file bare name is not guess-bridged

## Gates
`go build ./...` clean; `go test ./internal/types/` pass; full
`go test ./internal/engine` + `./internal/custom/...` green; `go vet` + `gofmt -l`
clean.

**DEPLOY-DEFERRED** — live Paths-panel impact is measurable only post-reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)