### PR TITLE
fix(extract): emit implements/extends (+decorator) edges to reduce orphan nodes; generalize (#4322)

### DIFF
--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -277,6 +277,14 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 		props["angular_role"] = role
 		rels = append(rels, guardRels...)
 	}
+
+	// Issue #4322 — generic class heritage. Beyond the narrow Angular guard /
+	// interceptor interfaces handled above, an Angular-decorated class can still
+	// `extends BaseComponent` / `implements OnInit, OnDestroy` (Angular
+	// lifecycle interfaces are a classic orphan source). Emit the generic
+	// EXTENDS / IMPLEMENTS edges, deduped against any guard IMPLEMENTS already
+	// added, so these classes are connected to their base/interface.
+	rels = appendHeritageDeduped(rels, x.classHeritageRels(n, className))
 	if call != nil {
 		meta := x.angularDecoratorMeta(call)
 		if tmpl := meta["template"]; tmpl != "" {

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -940,6 +940,22 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 	classIdx := len(x.entities)
 	x.emit(className, "SCOPE.Component", n, "class", fmt.Sprintf("class %s", className))
 
+	// Issue #4322 — emit generic EXTENDS / IMPLEMENTS edges from the class to
+	// its superclass / implemented interfaces. This connects the large orphan
+	// ring of framework-interface implementors (NestInterceptor, NestMiddleware,
+	// EntitySubscriberInterface, OnApplicationBootstrap/Shutdown, …) and
+	// base-entity subclasses (extends AuditableEntity / SoftDeletableEntity /
+	// MinimalEntity) that were previously extracted as isolated SCOPE.Components.
+	// Mirrors the Java/Python heritage emission; bare-name ToID resolves to a
+	// same-repo class/interface via byName, otherwise stays as a present
+	// (unresolved-target) edge that still de-islands the implementer.
+	if classIdx < len(x.entities) {
+		if hr := x.classHeritageRels(n, className); len(hr) > 0 {
+			x.entities[classIdx].Relationships = append(
+				x.entities[classIdx].Relationships, hr...)
+		}
+	}
+
 	body := n.ChildByFieldName("body")
 	// Issue #2875 — React Internals/suspense_error_boundary: a class component
 	// that declares componentDidCatch / getDerivedStateFromError is a React

--- a/internal/extractors/javascript/heritage.go
+++ b/internal/extractors/javascript/heritage.go
@@ -1,0 +1,167 @@
+package javascript
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// classHeritageRels extracts the generic EXTENDS / IMPLEMENTS edges from a
+// class (or interface) declaration's heritage clause (#4322).
+//
+// Before this pass the JS/TS extractor only emitted IMPLEMENTS edges for the
+// narrow Angular guard / interceptor interfaces (angular_rxjs_guards.go); every
+// other heritage relationship was dropped. That left whole families of
+// framework-interface implementors and base-class subclasses as graph islands
+// on real NestJS/TypeORM corpora — e.g. `class FooInterceptor implements
+// NestInterceptor`, `class Bar implements NestMiddleware`,
+// `class AuditSub implements EntitySubscriberInterface`,
+// `class User extends AuditableEntity`. Each such class was extracted as a
+// SCOPE.Component with no inbound or outbound structural edge.
+//
+// This helper mirrors the Java extractor's heritage emission
+// (internal/extractors/java/java.go, #1996): it walks the heritage clause and
+// emits one EXTENDS edge per superclass and one IMPLEMENTS edge per implemented
+// interface, with a BARE leaf type name as ToID. A bare name resolves through
+// the global byName index to a same-repo class/interface when one exists
+// (e.g. AuditableEntity, MinimalEntity defined in the same project); when the
+// target is an external framework interface (NestInterceptor, NestMiddleware,
+// OnApplicationBootstrap, …) there is no entity to bind to and the edge stays
+// unresolved — but it STILL connects the implementer, so the class is no
+// longer an orphan island. This matches the convention already used by the
+// Java and Python extractors.
+//
+// tree-sitter (TypeScript / JavaScript) grammar shape:
+//
+//	class_declaration
+//	  class_heritage
+//	    extends_clause      extends Base, Mixin(...)   -> EXTENDS Base, Mixin
+//	    implements_clause   implements IFoo, IBar      -> IMPLEMENTS IFoo, IBar
+//
+// JavaScript classes only carry `extends`; TypeScript adds `implements` and
+// allows multiple `extends` targets on interface declarations. We accept the
+// union so the same helper serves both grammars.
+//
+// Guardrail (#4322): edges are emitted ONLY from a real heritage clause node.
+// No name is synthesised, and a clause with no resolvable leaf type contributes
+// no edge. Each ToID carries the implementer/target names in Properties for
+// docgen (ClassManifest bases/interfaces) parity with the Java path.
+func (x *extractor) classHeritageRels(class *sitter.Node, className string) []types.RelationshipRecord {
+	if class == nil || className == "" {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	for i := 0; i < int(class.ChildCount()); i++ {
+		h := class.Child(i)
+		if h == nil || h.Type() != "class_heritage" {
+			continue
+		}
+		for j := 0; j < int(h.ChildCount()); j++ {
+			clause := h.Child(j)
+			if clause == nil {
+				continue
+			}
+			var kind types.RelationshipKind
+			switch clause.Type() {
+			case "extends_clause":
+				kind = types.RelationshipKindExtends
+			case "implements_clause":
+				kind = types.RelationshipKindImplements
+			default:
+				continue
+			}
+			for _, name := range x.heritageClauseTypeNames(clause) {
+				rels = append(rels, types.RelationshipRecord{
+					ToID: name,
+					Kind: string(kind),
+					Properties: map[string]string{
+						"subtype": strings.ToLower(string(kind)),
+						"from":    className,
+						"to":      name,
+					},
+				})
+			}
+		}
+	}
+	return rels
+}
+
+// heritageClauseTypeNames returns the distinct leaf type names referenced by an
+// extends_clause / implements_clause node, in source order. It accepts the
+// identifier shapes tree-sitter produces for heritage targets — bare
+// identifiers, type_identifiers, generic_type (Foo<T>), member/qualified names
+// (ns.Foo) — and reduces each to its leaf type name via heritageLeafTypeName.
+// Punctuation tokens (the `extends`/`implements` keywords, commas) are skipped.
+func (x *extractor) heritageClauseTypeNames(clause *sitter.Node) []string {
+	var out []string
+	seen := map[string]bool{}
+	for k := 0; k < int(clause.ChildCount()); k++ {
+		c := clause.Child(k)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "identifier", "type_identifier", "generic_type",
+			"member_expression", "nested_type_identifier":
+			name := heritageLeafTypeName(x.nodeText(c))
+			if name != "" && !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+// appendHeritageDeduped appends heritage edges (EXTENDS/IMPLEMENTS) to rels,
+// skipping any whose (Kind, ToID) pair already appears in rels. Used by the
+// Angular class path where a narrow guard IMPLEMENTS edge may already be
+// present for the same interface (#4322).
+func appendHeritageDeduped(rels, heritage []types.RelationshipRecord) []types.RelationshipRecord {
+	if len(heritage) == 0 {
+		return rels
+	}
+	seen := map[string]bool{}
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindExtends) ||
+			r.Kind == string(types.RelationshipKindImplements) {
+			seen[r.Kind+"\x00"+r.ToID] = true
+		}
+	}
+	for _, r := range heritage {
+		key := r.Kind + "\x00" + r.ToID
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		rels = append(rels, r)
+	}
+	return rels
+}
+
+// heritageLeafTypeName reduces a heritage target's source text to its leaf type
+// name: strips a generic argument list (`Foo<Bar>` -> `Foo`), a qualified
+// namespace prefix (`ns.Sub.Foo` -> `Foo`), and surrounding whitespace. Returns
+// "" for empty / non-identifier input so callers emit no edge.
+func heritageLeafTypeName(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '<'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	// Qualified name: keep the last dotted segment (the leaf type).
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Must start with an identifier character (letter, _ or $).
+	c := s[0]
+	if !(c == '_' || c == '$' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+		return ""
+	}
+	return s
+}

--- a/internal/extractors/javascript/issue4322_heritage_test.go
+++ b/internal/extractors/javascript/issue4322_heritage_test.go
@@ -1,0 +1,210 @@
+// Package javascript — issue #4322 heritage-edge proving tests.
+//
+// These model the LIVE upvate-v3 orphan shapes (not synthetic primitives):
+// NestJS framework-interface implementors and TypeORM/base-entity subclasses
+// that were extracted as isolated SCOPE.Components because the JS/TS extractor
+// dropped every class heritage clause except the narrow Angular guard path.
+//
+// After #4322 each such class emits an EXTENDS / IMPLEMENTS edge, so the node
+// is no longer a graph island.
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractHeritageTS(t *testing.T, path string, content []byte) []types.EntityRecord {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tstsx.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	ext, _ := extreg.Get("typescript")
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// hasHeritageEdge reports whether the class named `from` carries a relationship
+// of kind `kind` whose ToID leaf is `to`.
+func hasHeritageEdge(ents []types.EntityRecord, from, kind, to string) bool {
+	for _, e := range ents {
+		if e.Name != from || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == kind && r.ToID == to {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// classRels returns the EXTENDS/IMPLEMENTS edges on the named class.
+func classRels(ents []types.EntityRecord, from string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range ents {
+		if e.Name != from || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindExtends) ||
+				r.Kind == string(types.RelationshipKindImplements) {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// TestIssue4322_NestInterfaceImplements proves the clearest orphan win: a class
+// implementing a NestJS framework interface emits an IMPLEMENTS edge so the
+// implementer is connected (the interface itself is external/unresolved — the
+// edge still de-islands the class).
+func TestIssue4322_NestInterfaceImplements(t *testing.T) {
+	src := []byte(`import { NestInterceptor, NestMiddleware, OnApplicationBootstrap } from '@nestjs/common';
+import { EntitySubscriberInterface } from 'typeorm';
+
+export class LoggingInterceptor implements NestInterceptor {
+  intercept(ctx, next) { return next.handle(); }
+}
+
+export class AuthMiddleware implements NestMiddleware {
+  use(req, res, next) { next(); }
+}
+
+export class StartupHook implements OnApplicationBootstrap {
+  onApplicationBootstrap() {}
+}
+
+export class AuditSubscriber implements EntitySubscriberInterface<User> {
+  listenTo() { return User; }
+}
+`)
+	ents := extractHeritageTS(t, "interceptors.ts", src)
+
+	cases := []struct{ from, to string }{
+		{"LoggingInterceptor", "NestInterceptor"},
+		{"AuthMiddleware", "NestMiddleware"},
+		{"StartupHook", "OnApplicationBootstrap"},
+		{"AuditSubscriber", "EntitySubscriberInterface"}, // generic stripped
+	}
+	for _, c := range cases {
+		if !hasHeritageEdge(ents, c.from, string(types.RelationshipKindImplements), c.to) {
+			t.Errorf("expected %s IMPLEMENTS %s edge (orphan not connected)", c.from, c.to)
+		}
+	}
+}
+
+// TestIssue4322_BaseEntityExtends proves the base-entity orphan win: entities
+// that `extends AuditableEntity / SoftDeletableEntity / MinimalEntity` emit an
+// EXTENDS edge. When the base is defined in-repo the bare-name ToID resolves
+// via byName; here we assert the edge is emitted with the right leaf name.
+func TestIssue4322_BaseEntityExtends(t *testing.T) {
+	src := []byte(`import { Entity } from 'typeorm';
+import { AuditableEntity } from './base/auditable.entity';
+
+@Entity()
+export class User extends AuditableEntity {
+  id: number;
+}
+
+export class Product extends SoftDeletableEntity {}
+
+export class Tag extends MinimalEntity {}
+`)
+	ents := extractHeritageTS(t, "user.entity.ts", src)
+
+	cases := []struct{ from, to string }{
+		{"User", "AuditableEntity"},
+		{"Product", "SoftDeletableEntity"},
+		{"Tag", "MinimalEntity"},
+	}
+	for _, c := range cases {
+		if !hasHeritageEdge(ents, c.from, string(types.RelationshipKindExtends), c.to) {
+			t.Errorf("expected %s EXTENDS %s edge (orphan not connected)", c.from, c.to)
+		}
+	}
+}
+
+// TestIssue4322_ExtendsAndImplements proves a class with BOTH clauses emits
+// both edges, and that generic args / qualified prefixes are reduced to the
+// leaf type name.
+func TestIssue4322_ExtendsAndImplements(t *testing.T) {
+	src := []byte(`export class OrderService extends ns.BaseService<Order> implements OnModuleInit, OnModuleDestroy {
+  onModuleInit() {}
+  onModuleDestroy() {}
+}
+`)
+	ents := extractHeritageTS(t, "order.service.ts", src)
+
+	if !hasHeritageEdge(ents, "OrderService", string(types.RelationshipKindExtends), "BaseService") {
+		t.Errorf("expected OrderService EXTENDS BaseService (qualified+generic stripped)")
+	}
+	for _, iface := range []string{"OnModuleInit", "OnModuleDestroy"} {
+		if !hasHeritageEdge(ents, "OrderService", string(types.RelationshipKindImplements), iface) {
+			t.Errorf("expected OrderService IMPLEMENTS %s", iface)
+		}
+	}
+}
+
+// TestIssue4322_NoHeritageNoEdge is the guardrail: a class with no heritage
+// clause emits no EXTENDS/IMPLEMENTS edge (no fabricated edges).
+func TestIssue4322_NoHeritageNoEdge(t *testing.T) {
+	src := []byte(`export class PlainThing {
+  doStuff() {}
+}
+`)
+	ents := extractHeritageTS(t, "plain.ts", src)
+	if rels := classRels(ents, "PlainThing"); len(rels) != 0 {
+		t.Errorf("expected no heritage edges on a class with no heritage clause, got %v", rels)
+	}
+}
+
+// TestIssue4322_AngularLifecycleImplements proves the generalization to the
+// Angular-decorated class path: an @Injectable that `implements OnInit` (a
+// classic Angular lifecycle orphan) still emits the IMPLEMENTS edge, and does
+// not duplicate the existing guard IMPLEMENTS when both apply.
+func TestIssue4322_AngularLifecycleImplements(t *testing.T) {
+	src := []byte(`import { Injectable, OnInit, OnDestroy } from '@angular/core';
+
+@Injectable()
+export class DataService implements OnInit, OnDestroy {
+  ngOnInit() {}
+  ngOnDestroy() {}
+}
+`)
+	ents := extractHeritageTS(t, "data.service.ts", src)
+	for _, iface := range []string{"OnInit", "OnDestroy"} {
+		if !hasHeritageEdge(ents, "DataService", string(types.RelationshipKindImplements), iface) {
+			t.Errorf("expected DataService IMPLEMENTS %s on the Angular path", iface)
+		}
+	}
+	// No duplicate edges.
+	seen := map[string]int{}
+	for _, r := range classRels(ents, "DataService") {
+		seen[r.Kind+"|"+r.ToID]++
+	}
+	for k, n := range seen {
+		if n != 1 {
+			t.Errorf("duplicate heritage edge %s emitted %d times", k, n)
+		}
+	}
+}


### PR DESCRIPTION
Refs #4322

## Problem
On live upvate-v3 a large orphan ring of low-degree SCOPE.Component nodes had no connecting edges: NestJS framework-interface implementors (`NestInterceptor`, `NestMiddleware`, `EntitySubscriberInterface`, `OnApplicationBootstrap`/`OnApplicationShutdown`) and base-entity subclasses (`extends AuditableEntity` / `SoftDeletableEntity` / `MinimalEntity`). Root cause: the JS/TS extractor (`internal/extractors/javascript`) dropped **every** class heritage clause except the narrow Angular guard/interceptor `IMPLEMENTS` path — so `class Foo implements X` / `class Bar extends Y` produced an island.

## Wired (this PR)
- New `heritage.go`: generic class-heritage extraction. For `class_declaration`, emit one **EXTENDS** edge per superclass and one **IMPLEMENTS** edge per implemented interface. ToID is the **bare leaf type name** (generic args `Foo<T>`→`Foo`, qualified `ns.Foo`→`Foo` stripped).
- Mirrors the existing Java (`internal/extractors/java/java.go` #1996) and Python heritage emission. A bare-name ToID resolves to an in-repo class/interface via the resolver's existing `EXTENDS`/`IMPLEMENTS` kind-hint (`hintKinds` → Component-family `byName`); for external framework interfaces (NestInterceptor…) the edge stays present-but-unresolved, which **still de-islands the implementer**.
- Applied to **both** the generic class path (`handleClassDeclaration`) and the Angular-decorated path (`handleAngularClass` — Angular lifecycle `OnInit`/`OnDestroy` were a classic orphan source), deduped against the existing guard `IMPLEMENTS`.
- **Guardrail:** edges emitted only from a real `class_heritage` node; no fabricated names; a class with no heritage clause emits no edge (tested).

## Deferred (follow-ups filed)
- **Decorator-driven field edges** (class-validator `@IsString`, class-transformer, typeorm `@Column`, mongoose) — blocked on resolving the 619 unresolved lib imports; separate effort → follow-up.
- **NestJS global-DI mount-point wiring** (`APP_INTERCEPTOR`/`APP_GUARD`/`APP_FILTER` token providers, `app.use` middleware mounting). `@Module` BINDS + constructor `INJECTED_INTO` already exist in `internal/custom/javascript`; the global-token mount edge does not → follow-up.

## Cross-framework note
`EXTENDS`/`IMPLEMENTS` is universal. Java + Python already emit heritage edges; TS interfaces already emit `EXTENDS` via `extends_type_clause`. This PR closes the JS/TS **class** gap. Decorator/DI field edges recur in Spring/Angular/.NET — generalization path is a shared decorator→field pass keyed on resolved decorator imports.

## Expected orphan reduction
Every JS/TS class with a heritage clause gains ≥1 structural edge. On a NestJS/TypeORM corpus this targets the named orphan classes (interceptor/middleware/lifecycle/subscriber implementors + AuditableEntity/SoftDeletableEntity/MinimalEntity subclasses) — these move from degree-0 islands to connected nodes (resolved when the base/interface is in-repo, present-edge otherwise).

## Tests
`internal/extractors/javascript/issue4322_heritage_test.go` models the live shapes: Nest-interface IMPLEMENTS, base-entity EXTENDS, combined extends+implements (generic/qualified stripping), no-heritage guardrail, Angular lifecycle IMPLEMENTS + no-duplicate.

## Gates
`go build ./...` clean · `go test ./internal/types/` pass · heritage tests green · `go vet` / `gofmt -l` clean · no regressions in javascript/java/python/types/engine packages.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)