### PR TITLE
fix(extract): bridge endpoint→handler by file:line co-location when name resolution fails (#4319 re-fix)

### DIFF
--- a/internal/engine/http_endpoint_colocation_4319_test.go
+++ b/internal/engine/http_endpoint_colocation_4319_test.go
@@ -1,0 +1,212 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4319 re-fix — file:line co-location bridge.
+//
+// #4326 added a same-file bare↔qualified NAME reconciliation, but it only fires
+// when the surviving merged synthetic carries a `source_handler` whose bare name
+// matches a same-file handler entity. The LIVE NestJS island is different: for
+// `POST /inspections/me-manage/merge` the surviving merged http_endpoint_definition
+// carried NO bindable source_handler, so every name-based path missed and the
+// endpoint stayed an island even though its handler Operation sits at the EXACT
+// same file:line (the decorated controller method).
+//
+// The re-fix is two-part:
+//   1. synthesizeNestJS now anchors the synthetic at the handler METHOD line
+//      (TestColocation4319_NestJSSynthCarriesMethodLine).
+//   2. ResolveHTTPEndpointHandlers binds the endpoint to the lone handler-kind
+//      Operation at its own file:line when name resolution fails — guarded to an
+//      exactly-one match so it never guesses.
+
+// TestColocation4319_NestJSSynthCarriesMethodLine proves part 1: the synthetic
+// is anchored at the handler method's line, not 0, so co-location has a signal.
+func TestColocation4319_NestJSSynthCarriesMethodLine(t *testing.T) {
+	src := "import { Controller, Post, Body } from '@nestjs/common';\n" +
+		"\n" +
+		"@Controller('inspections/me-manage')\n" + // line 3
+		"export class BuildingController {\n" + // line 4
+		"  constructor(private readonly svc: BuildingService) {}\n" + // line 5
+		"\n" + // line 6
+		"  @Post('merge')\n" + // line 7
+		"  mergeMaintenanceEvaluations(@Body() body: BuildingMeMergeBody): Promise<void> {\n" + // line 8
+		"    return this.svc.mergeMaintenanceEvaluations(body);\n" +
+		"  }\n" +
+		"}\n"
+	file := "src/modules/buildings/api/building.controller.ts"
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path: file, Content: []byte(src), Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	var got *types.EntityRecord
+	for i := range res.Entities {
+		if res.Entities[i].Kind == httpEndpointDefinitionKind {
+			got = &res.Entities[i]
+		}
+	}
+	if got == nil {
+		t.Fatal("no http_endpoint_definition synthesized for the NestJS @Post route")
+	}
+	// The handler method `mergeMaintenanceEvaluations(...)` is on line 8.
+	if got.StartLine != 8 {
+		t.Errorf("synthetic must anchor at the handler method line 8 for #4319 co-location, got line %d", got.StartLine)
+	}
+}
+
+// TestColocation4319_LiveShape_NoSourceHandler_Bridges is the LIVE-shape repro:
+// an http_endpoint_definition with NO resolvable source_handler and a single
+// handler Operation at the SAME file:line. The bridge must now form and the
+// handler's VALIDATES/CALLS must be reachable from the endpoint.
+func TestColocation4319_LiveShape_NoSourceHandler_Bridges(t *testing.T) {
+	file := "src/modules/buildings/api/building.controller.ts"
+	const line = 108
+	handler := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "mergeMaintenanceEvaluations",
+		SourceFile: file, StartLine: line, Language: "typescript", Subtype: "method",
+		Relationships: []types.RelationshipRecord{
+			{Kind: string(types.RelationshipKindValidates), ToID: "Class:BuildingMeMergeBody"},
+			{Kind: string(types.RelationshipKindCalls), ToID: "SCOPE.Operation:BuildingService.merge"},
+		},
+	}
+	// The surviving merged synthetic carries NO source_handler (the live island).
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:POST:/inspections/me-manage/merge",
+		SourceFile: file, StartLine: line, Language: "typescript",
+		Properties: map[string]string{
+			"verb": "POST", "path": "/inspections/me-manage/merge",
+			"framework": "nestjs", "pattern_type": "http_endpoint_synthesis",
+		},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{handler, synth})
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("ISLAND: co-location did not bridge the live NestJS shape, resolved=%d dropped=%d", stats.HandlerResolved, stats.HandlerDropped)
+	}
+	edge, ok := implementsEdgeFor(out[0])
+	if !ok {
+		t.Fatal("no IMPLEMENTS edge from co-located handler to endpoint (#4319 re-fix)")
+	}
+	if edge.ToID != "http_endpoint_definition:http:POST:/inspections/me-manage/merge" {
+		t.Errorf("IMPLEMENTS targets wrong endpoint: %s", edge.ToID)
+	}
+	// Traversing endpoint→handler reaches the handler's VALIDATES + CALLS.
+	var sawValidates, sawCalls bool
+	for _, r := range out[0].Relationships {
+		switch r.Kind {
+		case string(types.RelationshipKindValidates):
+			sawValidates = true
+		case string(types.RelationshipKindCalls):
+			sawCalls = true
+		}
+	}
+	if !sawValidates || !sawCalls {
+		t.Errorf("co-located handler's downstream edges unreachable: validates=%v calls=%v", sawValidates, sawCalls)
+	}
+}
+
+// TestColocation4319_TwoOperationsSameLine_NoGuess is the no-guess guard: when
+// two handler-kind Operations share the endpoint's file:line, co-location must
+// NOT bind either (it would be a guess), leaving the endpoint to existing
+// fallbacks.
+func TestColocation4319_TwoOperationsSameLine_NoGuess(t *testing.T) {
+	file := "src/svc.ts"
+	const line = 42
+	h1 := types.EntityRecord{Kind: "SCOPE.Operation", Name: "alpha", SourceFile: file, StartLine: line, Language: "typescript"}
+	h2 := types.EntityRecord{Kind: "SCOPE.Operation", Name: "beta", SourceFile: file, StartLine: line, Language: "typescript"}
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:GET:/x",
+		SourceFile: file, StartLine: line, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis"},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{h1, h2, synth})
+	if stats.HandlerResolved != 0 {
+		t.Fatalf("ambiguous co-location must NOT bridge, resolved=%d", stats.HandlerResolved)
+	}
+	for _, e := range out {
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		if _, ok := implementsEdgeFor(e); ok {
+			t.Errorf("ambiguous file:line must not be guess-bridged, but %s was", e.Name)
+		}
+	}
+}
+
+// TestColocation4319_DTOAtLineNotBridged guards that a non-handler entity (a DTO
+// Schema/Component/Class) co-located with the endpoint line is NEVER chosen by
+// co-location — only handler-kind Operations are candidates.
+func TestColocation4319_DTOAtLineNotBridged(t *testing.T) {
+	file := "src/orders.controller.ts"
+	const line = 20
+	dto := types.EntityRecord{Kind: "SCOPE.Class", Name: "CreateOrderDto", SourceFile: file, StartLine: line, Language: "typescript"}
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:POST:/orders",
+		SourceFile: file, StartLine: line, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis"},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{dto, synth})
+	if stats.HandlerResolved != 0 {
+		t.Fatalf("co-location must not bind a DTO at the endpoint line, resolved=%d", stats.HandlerResolved)
+	}
+	for _, e := range out {
+		if _, ok := implementsEdgeFor(e); ok {
+			t.Errorf("DTO %s must not receive an IMPLEMENTS bridge via co-location", e.Name)
+		}
+	}
+}
+
+// TestColocation4319_NoLine_NoColocation guards that an endpoint with no positive
+// line (synthetic anchored at 0) does NOT co-locate to a line-0 handler — line 0
+// is the unset sentinel and carries no co-location signal.
+func TestColocation4319_NoLine_NoColocation(t *testing.T) {
+	file := "src/x.controller.ts"
+	handler := types.EntityRecord{Kind: "SCOPE.Operation", Name: "handle", SourceFile: file, StartLine: 0, Language: "typescript"}
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:GET:/y",
+		SourceFile: file, StartLine: 0, Language: "typescript",
+		Properties: map[string]string{"framework": "nestjs", "pattern_type": "http_endpoint_synthesis"},
+	}
+	_, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{handler, synth})
+	if stats.HandlerResolved != 0 {
+		t.Fatalf("line-0 endpoint must not co-locate (no signal), resolved=%d", stats.HandlerResolved)
+	}
+}
+
+// TestColocation4319_NameResolutionStillWinsFirst guards #4326's name-based path
+// is preserved: when a bindable source_handler IS present, the bridge forms via
+// name resolution (HandlerResolved), and co-location never needs to fire.
+func TestColocation4319_NameResolutionStillWinsFirst(t *testing.T) {
+	file := "src/orders.controller.ts"
+	// Handler at a DIFFERENT line than the synthetic, so ONLY name resolution can
+	// bind it — proving the name path runs and co-location is not required.
+	handler := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "createOrder", SourceFile: file, StartLine: 55, Language: "typescript",
+	}
+	synth := types.EntityRecord{
+		Kind: httpEndpointDefinitionKind, Name: "http:POST:/orders",
+		SourceFile: file, StartLine: 50, Language: "typescript",
+		Properties: map[string]string{
+			"framework": "nestjs", "pattern_type": "http_endpoint_synthesis",
+			"source_handler": "Controller:createOrder",
+		},
+	}
+	out, stats := ResolveHTTPEndpointHandlers([]types.EntityRecord{handler, synth})
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("name-based resolution regressed: resolved=%d", stats.HandlerResolved)
+	}
+	if _, ok := implementsEdgeFor(out[0]); !ok {
+		t.Fatal("name-based handler should still bridge")
+	}
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -158,6 +158,24 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// multi-method controller maps each endpoint to ITS OWN handler.
 	type fileBareKey struct{ sourceFile, bare string }
 	sameFileBareIdx := make(map[fileBareKey][]int, len(merged))
+	// #4319 re-fix — file:line co-location index. The bare↔qualified NAME
+	// reconciliation above only fires when the synthetic carries a bindable
+	// `source_handler` whose bare name matches a same-file handler. But the LIVE
+	// NestJS failure is different: entity-merge can keep, for a given (verb,path),
+	// a synthetic that carries NO usable `source_handler` (e.g. a same-path
+	// definition emitted by another pass wins attribution), so every name-based
+	// path misses and the endpoint is left a graph island even though its handler
+	// Operation sits at the EXACT same file:line (the decorated controller
+	// method). This index maps (sourceFile, startLine) → candidate indices of
+	// handler-kind Operation entities at that position. It is consulted ONLY as
+	// the final fallback, AFTER all name-based resolution fails, and ONLY binds
+	// when EXACTLY ONE handler-kind Operation sits at that file:line — so it can
+	// never guess between a DTO/Schema (different line) or two co-located methods.
+	type fileLineKey struct {
+		sourceFile string
+		line       int
+	}
+	sameFileLineIdx := make(map[fileLineKey][]int, len(merged))
 	// #2692 — multi-match index for the Phoenix-style `name@file_hint`
 	// resolution path. Routes-file frameworks (Phoenix router) declare
 	// handlers by short action name (`index`, `show`) that collides
@@ -211,6 +229,16 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		if bare != "" {
 			fk := fileBareKey{r.SourceFile, bare}
 			sameFileBareIdx[fk] = append(sameFileBareIdx[fk], i)
+		}
+		// #4319 re-fix — register handler-kind Operations under their file:line so
+		// the co-location fallback can find the controller method an endpoint sits
+		// on. Restricted to handler-shaped kinds (a controller/route method) so a
+		// DTO Component / Schema / Class that happens to share the line is never a
+		// co-location candidate. A non-positive line carries no co-location signal
+		// (synthetics and many declarations land at 0), so skip it.
+		if r.StartLine > 0 && isCoLocationHandlerKind(r.Kind) {
+			flk := fileLineKey{r.SourceFile, r.StartLine}
+			sameFileLineIdx[flk] = append(sameFileLineIdx[flk], i)
 		}
 	}
 
@@ -340,6 +368,17 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			handlerRef = r.Properties["source_handler"]
 		}
 		if handlerRef == "" {
+			// #4319 re-fix — no bindable source_handler (the live NestJS island:
+			// the surviving merged synthetic for this (verb,path) carries no
+			// handler ref). Before giving up, try file:line co-location: bind to
+			// the lone handler-kind Operation sitting at the endpoint's own
+			// file:line (the decorated controller method). Guarded to fire only on
+			// an EXACTLY-ONE match so it never guesses.
+			if hi, ok := resolveCoLocatedHandler(r, sameFileLineIdx[fileLineKey{r.SourceFile, r.StartLine}], merged); ok {
+				bridgeEndpointToHandler(&merged[hi], r)
+				stats.HandlerResolved++
+				continue
+			}
 			stats.NoHandlerProp++
 			continue
 		}
@@ -443,6 +482,23 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			}
 		}
 		if !found {
+			// #4319 re-fix — file:line co-location fallback. All same-file
+			// name-based resolution (exact-kind, cross-kind, bare↔qualified) has
+			// missed: the synthesizer's `source_handler` name does not match any
+			// same-file handler entity (the live NestJS case — the bare ref points
+			// at a method the indexer landed under a different identity, or the
+			// surviving merged synthetic's ref is stale). Before resorting to the
+			// risky cross-file GLOBAL bare-name guess, bind to the lone handler-kind
+			// Operation at the endpoint's OWN file:line — the decorated controller
+			// method. Same-file + same-line + exactly-one makes this unambiguous and
+			// strictly safer than a repo-wide name guess; it never fires when 0 or
+			// >1 handlers share the line (no guessing) and never binds a DTO/Schema
+			// (those sit at a different line and are not handler-kind).
+			if hi, ok := resolveCoLocatedHandler(r, sameFileLineIdx[fileLineKey{r.SourceFile, r.StartLine}], merged); ok {
+				bridgeEndpointToHandler(&merged[hi], r)
+				stats.HandlerResolved++
+				continue
+			}
 			// Cross-file fallback (#753). Django composed routes record
 			// a `View:<ViewSet>` handler reference whose entity lives in
 			// views.py while the synthetic lives in urls.py. Express
@@ -520,71 +576,9 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			}
 		}
 
-		// Resolved. Append an embedded IMPLEMENTS edge on the handler.
-		// Use placeholder ID stubs (Kind:Name) for the endpoints; the
-		// resolver in buildDocument rewrites these against the stamped
-		// entity index after we return.
-		handler := &merged[handlerIdx]
-		fromStub := handler.Kind + ":" + handler.Name
-		toStub := r.Kind + ":" + r.Name
-		handler.Relationships = append(handler.Relationships, types.RelationshipRecord{
-			FromID: fromStub,
-			ToID:   toStub,
-			Kind:   implementsEdgeKind,
-			Properties: map[string]string{
-				"pattern_type": "http_endpoint_synthesis_resolved",
-				"framework":    propOr(r, "framework", ""),
-			},
-		})
-		// deploy-9 item-3 — propagate the synthetic endpoint's resolved
-		// fine-grained authorisation identity onto the handler Operation so a
-		// symbol-keyed query (archigraph_inspect / get_source on the @action
-		// method, e.g. `JurisdictionViewSet.get_inspection_types`) surfaces the
-		// SAME `auth_permissions` page-key the endpoint carries. The DRF
-		// get_permissions per-action page-key pass (#3978) stamps
-		// `auth_permissions` (e.g. JURISDICTIONS) on the synthesized
-		// http_endpoint, but auth_coverage / endpoint_posture consumers that
-		// start from the handler method saw nothing because the property never
-		// reached the handler entity. We copy it here — at the one resolution
-		// site that knows BOTH the endpoint (page-key source) and its handler —
-		// rather than re-deriving it. Honest-partial: when the endpoint carries
-		// no `auth_permissions` (dynamic / unresolvable page key, or a guard
-		// with no PERMISSION_PAGES subscript) nothing is stamped. First write
-		// wins so a handler shared by several verb-routes (the email PATCH/PUT
-		// pair) is not churned, and an explicit value already on the handler is
-		// never overwritten.
-		propagateHandlerAuthPermissions(handler, r)
-		// #2678 — rebind the synthetic's source_file / start_line / end_line
-		// to the resolved handler so the endpoint points at the method body,
-		// not the routing/registration site. Mirrors the DRF fix (#2677): for
-		// route-table frameworks (Laravel, Rust Axum, future Phoenix/ASP.NET)
-		// the synthetic was anchored to the routes file by construction. For
-		// annotation-based frameworks (Spring, JAX-RS) the file was already
-		// correct but the line was unset; this rebind populates it from the
-		// handler entity. Record the previous values as properties so the bug
-		// is auditable and the resolver's strategy is traceable in the graph.
-		if handler.SourceFile != "" {
-			if r.Properties == nil {
-				r.Properties = map[string]string{}
-			}
-			if r.SourceFile != "" && r.SourceFile != handler.SourceFile {
-				r.Properties["registration_source_file"] = r.SourceFile
-			}
-			if r.StartLine > 0 && r.StartLine != handler.StartLine {
-				r.Properties["registration_start_line"] = itoaSmall(r.StartLine)
-			}
-			r.SourceFile = handler.SourceFile
-			r.StartLine = handler.StartLine
-			r.EndLine = handler.EndLine
-			if r.Language == "" {
-				r.Language = handler.Language
-			}
-			// Mark that the handler resolution and re-attribution passed
-			r.Properties["attribution"] = "handler_resolved"
-		}
-		// Clear the now-redundant properties.
-		delete(r.Properties, "source_handler")
-		delete(r.Properties, "handler_file")
+		// Resolved via a name-based path. Emit the IMPLEMENTS bridge and rebind
+		// the synthetic onto the handler body.
+		bridgeEndpointToHandler(&merged[handlerIdx], r)
 		stats.HandlerResolved++
 	}
 
@@ -756,6 +750,96 @@ func hasGlobalCandidate(globalMulti map[httpResolveNameKey][]int, base httpResol
 		}
 	}
 	return false
+}
+
+// isCoLocationHandlerKind reports whether a kind is a plausible HTTP-route
+// HANDLER (a controller/route method or function) for the #4319 file:line
+// co-location fallback. It deliberately EXCLUDES container/data kinds — a
+// SCOPE.Class controller, a SCOPE.Component / Schema / Model DTO — so a DTO or
+// the controller class that shares a line with the method is never a
+// co-location candidate. Mirrors the handler kinds the synthesizers and the
+// cross-kind equivalence table already treat as methods.
+func isCoLocationHandlerKind(kind string) bool {
+	switch kind {
+	case "SCOPE.Operation", "SCOPE.Function", "Operation", "Function", "Method":
+		return true
+	}
+	return false
+}
+
+// resolveCoLocatedHandler returns the index of the unique handler-kind
+// Operation co-located at the endpoint's file:line, or ok=false when the
+// binding would be a guess. `cands` is the pre-filtered candidate list from the
+// file:line index (already restricted to handler-kind Operations at that
+// position). The no-guess guard: bind ONLY when exactly one candidate exists,
+// and never when the endpoint carries no positive line (a synthetic anchored at
+// line 0 has no co-location signal). The candidate is re-validated as a handler
+// kind defensively even though the index is pre-filtered, so a future index
+// change can't silently widen the binding.
+func resolveCoLocatedHandler(endpoint *types.EntityRecord, cands []int, merged []types.EntityRecord) (int, bool) {
+	if endpoint == nil || endpoint.StartLine <= 0 {
+		return 0, false
+	}
+	if len(cands) != 1 {
+		return 0, false
+	}
+	hi := cands[0]
+	if hi < 0 || hi >= len(merged) {
+		return 0, false
+	}
+	if !isCoLocationHandlerKind(merged[hi].Kind) {
+		return 0, false
+	}
+	return hi, true
+}
+
+// bridgeEndpointToHandler emits the IMPLEMENTS bridge edge from a resolved
+// handler to its http_endpoint synthetic and rebinds the synthetic's
+// source_file/line onto the handler body. Shared by every resolution path
+// (name-based and #4319 file:line co-location) so the bridge shape, the
+// deploy-9 auth-permission propagation, and the #2678 attribution rebind stay
+// identical regardless of HOW the handler was found.
+func bridgeEndpointToHandler(handler, r *types.EntityRecord) {
+	// Append an embedded IMPLEMENTS edge on the handler. Use placeholder ID
+	// stubs (Kind:Name) for the endpoint; the resolver in buildDocument rewrites
+	// these against the stamped entity index after we return.
+	handler.Relationships = append(handler.Relationships, types.RelationshipRecord{
+		FromID: handler.Kind + ":" + handler.Name,
+		ToID:   r.Kind + ":" + r.Name,
+		Kind:   implementsEdgeKind,
+		Properties: map[string]string{
+			"pattern_type": "http_endpoint_synthesis_resolved",
+			"framework":    propOr(r, "framework", ""),
+		},
+	})
+	// deploy-9 item-3 — propagate the endpoint's resolved fine-grained
+	// authorisation identity onto the handler Operation (see
+	// propagateHandlerAuthPermissions). Honest-partial + first-write-wins.
+	propagateHandlerAuthPermissions(handler, r)
+	// #2678 — rebind the synthetic's source_file / start_line / end_line to the
+	// resolved handler so the endpoint points at the method body, not the
+	// routing/registration site. Record the previous values for auditability.
+	if handler.SourceFile != "" {
+		if r.Properties == nil {
+			r.Properties = map[string]string{}
+		}
+		if r.SourceFile != "" && r.SourceFile != handler.SourceFile {
+			r.Properties["registration_source_file"] = r.SourceFile
+		}
+		if r.StartLine > 0 && r.StartLine != handler.StartLine {
+			r.Properties["registration_start_line"] = itoaSmall(r.StartLine)
+		}
+		r.SourceFile = handler.SourceFile
+		r.StartLine = handler.StartLine
+		r.EndLine = handler.EndLine
+		if r.Language == "" {
+			r.Language = handler.Language
+		}
+		r.Properties["attribution"] = "handler_resolved"
+	}
+	// Clear the now-redundant properties.
+	delete(r.Properties, "source_handler")
+	delete(r.Properties, "handler_file")
 }
 
 // splitHandlerRef parses "<Kind>:<Name>" into its parts. Returns ok=false

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -706,7 +706,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// receivers match the `app`/`router` allowlist).
 		synthesizeExpress(string(content), emit)
 		// Producer side: NestJS @Controller + @Get/@Post/... decorators (#1418).
-		synthesizeNestJS(string(content), emit)
+		// emitDef is forwarded (alongside emit) so the synthetic is anchored at
+		// the handler METHOD line (#4319): NestJS controller methods are
+		// co-located with their route decorator, and stamping the method line on
+		// the synthetic lets the Phase-2 resolver bridge the endpoint to its
+		// handler by file:line co-location when the name-based source_handler
+		// resolution misses (e.g. when entity-merge keeps a same-path synthetic
+		// from another pass that carries no bindable source_handler).
+		synthesizeNestJS(string(content), emit, emitDef)
 		// Producer side: Fastify — `fastify.<verb>(...)` / `server.<verb>(...)`.
 		// The Express synthesizer's receiver allowlist does not include
 		// "fastify", so a dedicated pass is needed (#2678 audit).
@@ -4290,9 +4297,12 @@ var nestjsHandlerNameRe = regexp.MustCompile(
 // blank lines, comment lines (`//`, `*`, `/*`, `*/`, `/**`) and decorator lines
 // (`@...`) and returns the first line that looks like a method declaration.
 // Returns "" if no handler is found before the next verb decorator or EOF.
+// The second return value is the 0-based index of the line the handler method
+// declaration sits on (-1 when no handler is found), used by #4319 to anchor
+// the synthetic at the handler method line for file:line co-location bridging.
 //
 // This is the parens-in-strings-immune replacement for the old combined regex.
-func nestjsFindHandlerName(lines []string, fromLine int) string {
+func nestjsFindHandlerName(lines []string, fromLine int) (string, int) {
 	// depth tracks unbalanced ()/{}/[] carried over from a multi-line decorator
 	// argument (e.g. `@ApiOperation({` … `})` or `@ApiResponse(` … `)`). While
 	// depth > 0 we are INSIDE a decorator's argument list — those continuation
@@ -4346,15 +4356,15 @@ func nestjsFindHandlerName(lines []string, fromLine int) string {
 				}
 				continue
 			}
-			return name
+			return name, i
 		}
 		// A non-blank, non-comment, non-decorator, non-handler line means we've
 		// walked past the handler region for this decorator (e.g. into the next
 		// class member without a recognisable signature). Stop to avoid binding
 		// a far-away symbol.
-		return ""
+		return "", -1
 	}
-	return ""
+	return "", -1
 }
 
 // nestjsBracketDelta returns the net change in (){}[]-nesting contributed by a
@@ -4396,7 +4406,7 @@ type nestController struct {
 	prefix  string
 }
 
-func synthesizeNestJS(content string, emit emitFn) {
+func synthesizeNestJS(content string, emit emitFn, emitDef emitDefFn) {
 	if !strings.Contains(content, "@Controller") {
 		return
 	}
@@ -4431,7 +4441,7 @@ func synthesizeNestJS(content string, emit emitFn) {
 		if verb == "ALL" {
 			verb = "ANY"
 		}
-		methodName := nestjsFindHandlerName(lines, lineIdx+1)
+		methodName, methodLineIdx := nestjsFindHandlerName(lines, lineIdx+1)
 		if methodName == "" {
 			continue
 		}
@@ -4443,7 +4453,12 @@ func synthesizeNestJS(content string, emit emitFn) {
 		if canonical == "" {
 			continue
 		}
-		emit(verb, canonical, "nestjs", "Controller", methodName)
+		// #4319 — anchor the synthetic at the handler method's 1-based line so
+		// the Phase-2 resolver can bridge endpoint→handler by file:line
+		// co-location when the name-based source_handler match fails. methodLineIdx
+		// is a 0-based index into `lines`; +1 makes it the 1-based StartLine the
+		// treesitter handler Operation also carries.
+		emitDef(verb, canonical, "nestjs", "Controller", methodName, methodLineIdx+1)
 	}
 }
 


### PR DESCRIPTION
Refs #4319

## Why #4326 missed the live NestJS case
#4326 added a same-file bare↔qualified NAME reconciliation in `ResolveHTTPEndpointHandlers`. It only fires when the surviving merged synthetic carries a **bindable `source_handler`** whose bare name matches a same-file handler. It false-passed on fixtures (which stamped `source_handler: Controller:mergeMaintenanceEvaluations`) while the live shape stayed broken — the classic fixture trap.

Live evidence (reindexed upvate): `POST /inspections/me-manage/merge` (`http_endpoint_definition`, `building.controller.ts`) was an ISLAND — `neighbors(both)` empty. Its handler `mergeMaintenanceEvaluations` (`SCOPE.Operation`, same file) had `VALIDATES`→BuildingMeMergeBody + `CALLS`→building.service.ts but **no IMPLEMENTS/SERVED_BY** edge to the endpoint. The surviving merged synthetic for that (verb,path) carries **no bindable `source_handler`**, so every name-based path misses and the synthetic is dropped → island.

Reproduced honestly via the full `Detect` pipeline (not just a synthetic resolver fixture): the per-file synthesizer stamps `source_handler` but the merge survivor that reaches the resolver does not, leaving the endpoint unbridged even though the handler Operation sits at the SAME file:line.

## The co-location fallback (framework-agnostic)
The endpoint and its handler are at the SAME `file:line` (the decorated controller method). Two parts:

1. **`synthesizeNestJS`** now anchors the synthetic at the handler METHOD line (was line 0) via `emitDef`, so co-location has a real signal. `nestjsFindHandlerName` returns the method line.
2. **`ResolveHTTPEndpointHandlers`** binds the endpoint to the lone handler-kind `Operation` at its own `file:line` when name-based resolution fails — emitting the same `IMPLEMENTS`/`SERVED_BY` bridge #4326 uses (shared `bridgeEndpointToHandler` helper, so the auth-permission propagation and #2678 attribution rebind stay identical). Fires both when `source_handler` is empty and when all name resolution misses, as the last fallback before the cross-file global guess.

## The no-guess guard
Bind ONLY when **EXACTLY ONE** handler-kind Operation sits at that `file:line`. If 0 or >1 → do NOT guess, leave to existing fallbacks. Never binds a non-handler entity (DTO/Schema/Class at a different line is not a candidate — `isCoLocationHandlerKind`). Never fires on a line-0 synthetic (line 0 is the unset sentinel, no signal). #4326's name-based path runs first and is preserved unchanged.

Where the endpoint is synthesized at a route-registration site DISTINCT from the handler (some Express/Go router cases), co-location simply does not fire — those keep relying on name resolution.

## Test coverage
- `LiveShape_NoSourceHandler_Bridges` — the live repro: endpoint with no source_handler + a single co-located handler → bridge forms, handler's VALIDATES/CALLS reachable from endpoint.
- `NestJSSynthCarriesMethodLine` — full `Detect` pipeline asserts the synthetic anchors at the handler method line.
- `TwoOperationsSameLine_NoGuess` — two ops at the line → no bridge.
- `DTOAtLineNotBridged` — non-handler at the line → no bridge.
- `NoLine_NoColocation` — line-0 → no bridge.
- `NameResolutionStillWinsFirst` — bindable source_handler still bridges via name path.
- All #4326 name-based tests (`Bridge4319_*`) unchanged and passing.

Gates: `go build ./...` clean, `go test ./internal/types/` pass, full `go test ./internal/engine` pass (25s), `go vet` + `gofmt -l` clean.

**DEPLOY-DEFERRED** — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)