### PR TITLE
docs(resolve): document why M5 SymbolIndex is unwired (#4331)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -4015,6 +4015,20 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		indexEntities = append(indexEntities, merged...)
 		indexEntities = append(indexEntities, i.incrementalCarryForwardEntities...)
 	}
+	// NOTE (#4331): we intentionally call BuildIndex here, NOT the M5
+	// per-module path resolve.BuildIndexFromModules (#2182/#2184). M5 is a
+	// scale-only speed optimisation (pre-sized maps for big monorepos) and was
+	// built to be edge-set-identical to BuildIndex, but the #4331
+	// investigation found a CONCRETE divergence: M5 re-sorts entities by ID
+	// within a module, and the platform-variant merge (#1818) in
+	// byPackageOperation/byPackageComponent is order-sensitive for 3+
+	// mutually-exclusive GOOS variants of the same (pkgDir, name). That yields
+	// a different PlatformVariants fan-out topology, which clones a different
+	// set of CALLS edges downstream (refs.go ReferencesEmbeddedWithAllowlist).
+	// The guard test is TestM5_PlatformVariantParity_KnownDivergence in
+	// internal/resolve/symbol_index_parity_test.go. Until M5 preserves
+	// extraction order (or the variant merge is made order-independent) and
+	// that test asserts parity, BuildIndex stays the production resolver.
 	idx := resolve.BuildIndex(indexEntities)
 	// #2049 — Django string-FK late-binding: rewrite scope:component:ref:python:*
 	// stubs on REFERENCES edges with django_rel set, using app-label-aware

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -28,6 +28,22 @@
 //   - LazyEdgeKey / LazyEdgeSet — deferred edge registry; hot-path callers
 //     register stubs they know will appear frequently, and the set resolves
 //     them in one pass rather than paying per-edge lookup cost.
+//
+// PRODUCTION STATUS (#4331): this module is UNWIRED — the production index
+// pipeline (cmd/archigraph/index.go) still calls BuildIndex, not
+// BuildIndexFromModules. M5 was designed as an edge-set-identical, scale-only
+// speed optimisation, but the #4331 investigation found it is NOT yet parity-
+// safe: BuildModuleSymbols sorts a module's entities by ID, whereas BuildIndex
+// preserves extraction order, and the platform-variant merge (#1818) in
+// byPackageOperation/byPackageComponent is order-sensitive for 3+ mutually-
+// exclusive GOOS variants of one (pkgDir, name). The differing iteration order
+// produces a different PlatformVariants fan-out topology, which clones a
+// different set of CALLS edges in ReferencesEmbeddedWithAllowlist (refs.go).
+// See TestM5_PlatformVariantParity_KnownDivergence (symbol_index_parity_test.go)
+// for the pinned divergence. To wire M5: preserve extraction order for the
+// platform-variant side-tables (or make that merge order-independent), flip the
+// guard test to assert parity, then update cmd/archigraph/index.go. M5 only
+// helps large monorepos; for small/medium codebases BuildIndex is already fine.
 package resolve
 
 import (

--- a/internal/resolve/symbol_index_parity_test.go
+++ b/internal/resolve/symbol_index_parity_test.go
@@ -1,0 +1,101 @@
+// Package resolve — M5 production-parity guard.
+//
+// Issue #4331 investigated wiring BuildIndexFromModules (M5, #2182/#2184)
+// into the production index pipeline (cmd/archigraph/index.go) in place of
+// BuildIndex. The investigation found a CONCRETE edge-set divergence on the
+// platform-variant code path, so M5 was NOT wired. This file is the
+// regression guard: it pins the known divergence so any future wiring attempt
+// must first make this test assert parity (not divergence) before flipping the
+// production call site.
+//
+// # THE DIVERGENCE
+//
+// BuildIndex consumes entities in production extraction order (the order of the
+// `merged` slice). BuildIndexFromModules re-sorts: modules by ModuleKey, then
+// entities WITHIN each module by entity ID (BuildModuleSymbols sorts by ID for
+// O(N) collision detection). The platform-variant merge in byPackageOperation /
+// byPackageComponent (issue #1818) is ORDER-SENSITIVE for 3+ mutually-exclusive
+// variants of the same (pkgDir, name): the pairwise canonical-chaining produces
+// a different PlatformVariants topology depending on which variant is seen
+// first. PlatformVariants is consumed by ReferencesEmbeddedWithAllowlist
+// (refs.go) to CLONE CALLS edges onto every non-canonical sibling, so a
+// different topology = a different output edge set. This is a correctness
+// divergence, not just a speed difference.
+//
+// The pre-existing TestBuildIndexFromModules_Parity does NOT catch this: its
+// synthetic fixture uses globally-unique names, so no collision — and therefore
+// no platform-variant merge — ever fires.
+package resolve
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// platformVariantTriple builds three mutually-exclusive GOOS variants of one
+// top-level operation "Run" in package dir "svc/". Entity IDs are deliberately
+// NOT in source-file order, so BuildModuleSymbols' sort-by-ID reorders them
+// relative to the production extraction order used by the returned `merged`.
+func platformVariantTriple() (merged []types.EntityRecord, modules map[ModuleKey][]types.EntityRecord) {
+	eDarwin := types.EntityRecord{ID: "cccccccccccccccc", Kind: "SCOPE.Operation", Name: "Run",
+		SourceFile: "svc/run_darwin.go", Properties: map[string]string{"build_tag": "darwin"}}
+	eLinux := types.EntityRecord{ID: "aaaaaaaaaaaaaaaa", Kind: "SCOPE.Operation", Name: "Run",
+		SourceFile: "svc/run_linux.go", Properties: map[string]string{"build_tag": "linux"}}
+	eWindows := types.EntityRecord{ID: "bbbbbbbbbbbbbbbb", Kind: "SCOPE.Operation", Name: "Run",
+		SourceFile: "svc/run_windows.go", Properties: map[string]string{"build_tag": "windows"}}
+
+	// Production extraction order (arbitrary, as a real extractor would emit).
+	merged = []types.EntityRecord{eWindows, eDarwin, eLinux}
+	// All three live in the SAME package dir -> SAME M5 module.
+	modules = map[ModuleKey][]types.EntityRecord{"svc": {eWindows, eDarwin, eLinux}}
+	return merged, modules
+}
+
+func normalizePV(m map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(m))
+	for k, v := range m {
+		cp := append([]string(nil), v...)
+		sort.Strings(cp)
+		out[k] = cp
+	}
+	return out
+}
+
+// TestM5_PlatformVariantParity_KnownDivergence pins the #4331 finding: on a
+// 3-way platform-variant collision, BuildIndex and BuildIndexFromModules
+// produce DIFFERENT PlatformVariants topologies. While this asserts divergence,
+// M5 must remain UNWIRED.
+//
+// TO WIRE M5: make BuildModuleSymbols / the merge preserve production
+// extraction order for the platform-variant side-tables (or make the
+// platform-variant merge order-independent), then flip the two asserts below
+// from NotEqual to Equal and update cmd/archigraph/index.go.
+func TestM5_PlatformVariantParity_KnownDivergence(t *testing.T) {
+	merged, modules := platformVariantTriple()
+
+	flat := BuildIndex(merged)
+	mod := BuildIndexFromModules(modules, 0)
+
+	// Canonical winner DOES agree (chosen by lexicographic SourceFile, which is
+	// order-independent): both pick svc/run_darwin.go's entity.
+	flatWinner := flat.byPackageOperation["svc"]["Run"]
+	modWinner := mod.byPackageOperation["svc"]["Run"]
+	if flatWinner != modWinner {
+		t.Errorf("unexpected: byPackageOperation winner already diverges (flat=%q mod=%q)",
+			flatWinner, modWinner)
+	}
+
+	// But the PlatformVariants fan-out topology DIVERGES. This is the blocker.
+	flatPV := normalizePV(flat.PlatformVariants)
+	modPV := normalizePV(mod.PlatformVariants)
+	if reflect.DeepEqual(flatPV, modPV) {
+		t.Fatalf("EXPECTED DIVERGENCE IS GONE — M5 may now be parity-safe to wire.\n"+
+			"flat=%v mod=%v\nIf so: flip this assert to require equality and proceed with wiring (#4331).",
+			flatPV, modPV)
+	}
+	t.Logf("confirmed #4331 divergence (M5 stays unwired):\n  BuildIndex          PlatformVariants=%v\n  BuildIndexFromModules PlatformVariants=%v",
+		flat.PlatformVariants, mod.PlatformVariants)
+}


### PR DESCRIPTION
## Summary

Investigated wiring archigraph's **M5 per-module SymbolIndex** (`BuildIndexFromModules`, #2182/#2184) into the production index pipeline (`cmd/archigraph/index.go:4018`) in place of `resolve.BuildIndex`, per **#4331**.

**Decision: DO NOT WIRE.** M5 is not yet edge-set-parity-safe. This PR documents the deferral, adds a regression guard, and explains the exact precondition to wire it later. **No production behaviour change** — `BuildIndex` remains the resolver.

## Why it was never wired (investigation)

- M5 landed in PR #2184 (2026-05-25) as a self-contained module + benchmarks. **Zero production callers** ever followed — only `scale_bench_test.go` references it. No TODO/blocker comment existed explaining the gap.
- The landing benchmark itself shows a **modest, scale-only win** (32.8ms vs 34.2ms ≈ 4% at 500 modules). It helps large monorepos only; small/medium codebases see no benefit.

## The divergence (the real blocker)

`BuildIndex` consumes entities in **production extraction order**. `BuildIndexFromModules` re-sorts: modules by key, then entities **within a module by ID** (`BuildModuleSymbols`).

The platform-variant merge (#1818) in `byPackageOperation` / `byPackageComponent` is **order-sensitive** for 3+ mutually-exclusive GOOS variants of one `(pkgDir, name)`. Different iteration order → different `PlatformVariants` fan-out topology → a **different set of cloned CALLS edges** in `ReferencesEmbeddedWithAllowlist` (`refs.go`). This is a correctness divergence, not just speed.

### Parity evidence

A 3-way variant collision (`run_darwin.go` / `run_linux.go` / `run_windows.go`, IDs not in source-file order):

```
BuildIndex            PlatformVariants = {darwin: [windows, linux]}   ✅ single canonical, correct fan-out
BuildIndexFromModules PlatformVariants = {linux: [windows], darwin: [linux]}  ❌ split topology
```

The canonical *winner* agrees (chosen by lexicographic SourceFile — order-independent), but the variant fan-out **topology diverges**.

The pre-existing `TestBuildIndexFromModules_Parity` misses this: its fixture uses globally-unique names, so the platform-variant path **never fires** — the classic fixtures-pass / live-fails trap.

## Changes

- **`internal/resolve/symbol_index_parity_test.go`** (new): `TestM5_PlatformVariantParity_KnownDivergence` pins the divergence. If it ever disappears, the test fails loudly, signalling M5 may be wire-ready.
- **`cmd/archigraph/index.go`** + **`internal/resolve/symbol_index.go`**: deferral docs with the exact precondition to wire M5 (preserve extraction order for the variant side-tables, or make that merge order-independent).

## To wire M5 later

Make the platform-variant side-table population order-independent (or preserve extraction order), flip the guard test to assert parity, then update the call site.

## Gates (native)

- `go build ./...` clean
- `go test ./internal/resolve/ -count=1` all green (incl. parity / resolution-rate / sub-quadratic 5.11×)
- `go vet` / `gofmt -l` clean

**DEPLOY-DEFERRED.** Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)