### PR TITLE
feat(extract): data-access semantics from functional Mongo query-builder; generalize (#4320)

### DIFF
--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -170,6 +170,15 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 			func(ent types.EntityRecord) { entities = append(entities, ent) },
 			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
 		)
+		// Sibling pass: FUNCTIONAL aggregation-builder factory chains
+		// (`mongo<…>().lookupOne({from}).…` / `AggregationBuilder.create().…`)
+		// that are RETURNED/assigned without a co-located `.aggregate(...)` call.
+		// Emits the same per-stage SCOPE.DataAccess + JOINS_COLLECTION contract,
+		// closing the live upvate-v3 NestJS pipeline-builder gap (#4320).
+		scanJSMongoFuncBuilder(src, funcs, path, lang,
+			func(ent types.EntityRecord) { entities = append(entities, ent) },
+			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
+		)
 		// Sibling pass: Mongoose / @nestjs/mongoose `ref:` + `.populate()`
 		// reference joins → JOINS_COLLECTION edges, matching the $lookup
 		// contract (#3844). Captures the dominant NestJS-target join idiom.

--- a/internal/engine/orm_queries_jsts_mongo_funcbuilder.go
+++ b/internal/engine/orm_queries_jsts_mongo_funcbuilder.go
@@ -1,0 +1,317 @@
+// Functional / fluent Mongo aggregation-builder extraction for JS/TS (#4320).
+//
+// orm_queries_jsts_mongo_agg.go already extracts data-access semantics from two
+// builder shapes that terminate at a `.aggregate(...)` call site:
+//
+//   - inline pipeline array — `Model.aggregate([ {$lookup...}, ... ])`
+//   - `new …AggregationBuilder().match(...).lookup(...).build()` passed to
+//     `.aggregate(...)`.
+//
+// Both are gated on the `.aggregate(` token (mongoAggCallRe). But a large,
+// idiomatic NestJS pattern never reaches `.aggregate(...)` in the same file:
+// a FUNCTIONAL FACTORY builder whose pipeline functions RETURN the builder for
+// a downstream `model.aggregate(pipeline.build())` executed elsewhere. The live
+// upvate-v3 case (#4320) is `src/common/query/mongo/aggregation.builder.ts`:
+//
+//	export function mongo<Doc>(): AggregationBuilder<Doc> {
+//	  return AggregationBuilder.create<Doc>();
+//	}
+//
+// and its consumers, e.g. me-page-retrieve.pipeline.ts:
+//
+//	return mongo<MePageVersionSource>()
+//	  .matchId(new Types.ObjectId(opts.versionId))
+//	  .lookupOne({ from: 'me_pages', localField: 'page_id', foreignField: '_id', as: 'page' })
+//	  .project({ ... })
+//	  .limit(1);
+//
+// The old scanner produced NO SCOPE.DataAccess node and NO JOINS_COLLECTION
+// edge for this file — flows showed generic `Function` steps and the terminal
+// `AggregationBuilder` was mis-kinded `Render`. This pass closes that gap.
+//
+// RECOGNITION (generalises beyond Mongo): a "fluent query-builder chain" is a
+// FACTORY entry (`mongo<…>()`, `mongo()`, `AggregationBuilder.create<…>()`,
+// `AggregationBuilder.create()`) followed by a chain of `.method(arg)` calls.
+// We map each chained method to a data-access stage operator and, for the
+// lookup family, pull the joined collection out of the `from:` object property
+// (the functional builder passes `{ from: '<collection>', ... }`, not a
+// positional string). The chain is parsed from the factory call to the end of
+// the enclosing statement (string/depth-aware), independent of whether a
+// `.aggregate(...)` ever appears in the file.
+//
+// HONEST LIMITS:
+//   - When the `from:` value is not a static string literal (a variable, an
+//     enum, a runtime expression) no JOINS_COLLECTION edge is fabricated; the
+//     DataAccess stage is still emitted (subtype $lookup) so the topology is
+//     present and the join target is left honestly unresolved.
+//   - The receiver collection (the "left" side of the join) is the functional
+//     builder's enclosing pipeline function — there is no statically-bound base
+//     Mongo collection at the factory call. The high-value output is the join
+//     `to` side and the per-stage data-access topology; the collection-anchored
+//     edge uses the pipeline name as a stable anchor.
+//
+// GENERALISATION / FOLLOW-UPS: the factory→stage recognition is structured so
+// sibling fluent builders (TypeORM QueryBuilder, Prisma, Mongoose
+// `.aggregate()`/`.lookup()`, Knex, SQLAlchemy Core) can reuse the same
+// chain-walk by supplying their own factory regex + method→op table. Those are
+// filed as #4334 children (see the PR body).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongoFuncBuilderFactoryRe matches the FUNCTIONAL factory entry points of the
+// fluent aggregation builder, immediately before the chained `.method(...)`
+// calls begin:
+//
+//	mongo<Doc>()                     mongo()
+//	AggregationBuilder.create<Doc>() AggregationBuilder.create()
+//	<X>AggregationBuilder.create()   <X>AggBuilder.create()
+//
+// The trailing `()` (with optional `<…>` type args) and a following `.` is
+// asserted by the caller via the chain walk, not the regex, so multi-line
+// chains are handled. The match END is positioned right after the factory's
+// closing `)` so the chain walk starts at the first chained `.`.
+// The optional `<…>` type-argument segment allows ONE level of nested angle
+// brackets so generic args like `mongo<Record<string, unknown>>()` match (the
+// live consumers use both the flat `mongo<MePageVersionSource>()` and the nested
+// `mongo<Record<string, unknown>>()` forms).
+var mongoFuncBuilderFactoryRe = regexp.MustCompile(
+	`\b(?:mongo|[\w$]*(?:Agg|Aggregation)Builder\s*\.\s*create)\s*(?:<(?:[^<>()]|<[^<>()]*>)*>)?\s*\(\s*\)`,
+)
+
+// mongoFuncBuilderMethodOp maps a FUNCTIONAL aggregation-builder method name to
+// its MongoDB pipeline stage operator. It is a superset of
+// mongoAggBuilderMethodOp: it adds the functional builder's higher-level method
+// names (matchId/matchExpr/lookupOne/lookupPipeline/lookupJoinOne/…/shape/pick/
+// rename/groupBy/…). Methods that do not correspond to a data-access stage
+// (thru/build/rawBuild/rawStages) return "" and are skipped — never fabricated.
+//
+// The boolean second return reports whether the method is in the LOOKUP family
+// (its argument carries a `from:` joined-collection property).
+func mongoFuncBuilderMethodOp(method string) (op string, isLookup bool) {
+	switch method {
+	// --- lookup family: arg is an object with `from: '<collection>'` ----------
+	case "lookup", "lookupOne", "lookupPipeline", "lookupPipelineOne",
+		"lookupJoinOne", "lookupJoinMany":
+		return "$lookup", true
+	case "graphLookup":
+		return "$graphLookup", true
+	// --- match family ----------------------------------------------------------
+	case "match", "matchAst", "matchExpr", "matchEqVar", "matchInVar",
+		"matchEqVars", "matchIf", "matchId", "matchInIf":
+		return "$match", false
+	// --- projection / shaping --------------------------------------------------
+	case "project", "pick", "omit", "rename", "compute", "shape", "groupDistinct":
+		return "$project", false
+	case "set", "addFields":
+		return "$addFields", false
+	case "unset":
+		return "$unset", false
+	// --- grouping --------------------------------------------------------------
+	case "group", "groupBy":
+		return "$group", false
+	// --- reshaping / ordering / paging ----------------------------------------
+	case "replaceRoot":
+		return "$replaceRoot", false
+	case "unwind":
+		return "$unwind", false
+	case "sort":
+		return "$sort", false
+	case "skip":
+		return "$skip", false
+	case "limit":
+		return "$limit", false
+	case "count":
+		return "$count", false
+	case "facet", "facetPaginate", "pagedFacet":
+		return "$facet", false
+	}
+	return "", false
+}
+
+// scanJSMongoFuncBuilder finds FUNCTIONAL aggregation-builder factory chains
+// (`mongo<…>().…` / `AggregationBuilder.create<…>().…`) and emits per-stage
+// SCOPE.DataAccess entities + JOINS_COLLECTION edges, reusing mongoAggEmitStages
+// so the output contract is identical to the `.aggregate(...)` paths. It runs as
+// a SIBLING to scanJSMongoAggregation and never re-emits the aggregate QUERIES
+// edge. Pipelines that DO terminate at `.aggregate(builder.build())` in the same
+// file are still handled by scanJSMongoAggregation; this pass targets the case
+// where the chain is RETURNED / assigned without a co-located `.aggregate(...)`.
+func scanJSMongoFuncBuilder(
+	src string,
+	funcs []funcSpan,
+	path string,
+	lang string,
+	emitStage func(ent types.EntityRecord),
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	// Gate: only run where the functional builder surface is plausible. The
+	// factory token itself is the signal; this keeps us off arbitrary `mongo`
+	// identifiers that are not the builder factory (the chain walk additionally
+	// requires at least one recognised stage method, so a bare `mongo()` with no
+	// chain emits nothing).
+	for _, loc := range mongoFuncBuilderFactoryRe.FindAllStringIndex(src, -1) {
+		chainStart := loc[1] // just past the factory's `)`
+		chain := mongoFuncBuilderChain(src, chainStart)
+		if chain == "" {
+			continue
+		}
+		stages := mongoFuncBuilderStages(chain)
+		if len(stages) == 0 {
+			continue
+		}
+		caller := enclosingFuncAt(funcs, loc[0])
+		callLine := lineOfOffset(src, loc[0])
+		// Anchor the collection-side of the topology at the enclosing pipeline
+		// function — there is no statically-bound base collection at a functional
+		// factory call. The join `to` side (the real value) is resolved from the
+		// stage `from:` property by mongoAggEmitStages. Fall back to a stable
+		// literal when the factory call is at file scope.
+		anchor := caller
+		if anchor == "" {
+			anchor = "AggregationPipeline"
+		}
+		mongoAggEmitStages(stages, anchor, caller, callLine, path, lang,
+			emitStage, emitJoin)
+	}
+}
+
+// mongoFuncBuilderChain captures the fluent `.method(...)` chain text beginning
+// at `from` (the byte just after the factory's closing `)`), up to the end of
+// the enclosing statement. It is string- and depth-aware so a chain spanning
+// multiple lines (the idiomatic formatting) is kept whole, and a top-level `;`
+// or a non-continuing newline terminates it. The leading content before the
+// first `.` is skipped; "" is returned when no chained method follows.
+func mongoFuncBuilderChain(src string, from int) string {
+	// Require a chained `.` to follow (allowing whitespace). A factory call with
+	// no chain (`return mongo();`) is not a pipeline.
+	i := from
+	for i < len(src) && (src[i] == ' ' || src[i] == '\t' || src[i] == '\r' || src[i] == '\n') {
+		i++
+	}
+	if i >= len(src) || src[i] != '.' {
+		return ""
+	}
+	// Reuse the statement-terminator scan from the .aggregate builder path so the
+	// multi-line/`;`/newline semantics stay identical.
+	return strings.TrimSpace(mongoAggInitializer(src, i))
+}
+
+// mongoFuncBuilderStages walks a functional builder chain and synthesises
+// pipeline-stage substrings in `{ $op: <arg> }` form — the SAME shape the inline
+// splitter and the `new …Builder()` walker produce — so mongoAggEmitStages can
+// uniformly extract `$lookup` join fields (the lookup family already passes a
+// `{ from: '…', localField, foreignField, as }` object literal that
+// mongoAggParseLookup reads directly), `$group` ids, `$facet` keys, etc.
+//
+// It differs from mongoAggBuilderStages only in the method→op table
+// (mongoFuncBuilderMethodOp, a superset covering the higher-level functional
+// methods). The scan is string- and depth-aware so a `.method(` token inside an
+// argument object/string is never mistaken for a top-level chained call.
+func mongoFuncBuilderStages(chain string) []string {
+	var stages []string
+	inStr := byte(0)
+	depthParen, depthBrace, depthBracket := 0, 0, 0
+	for i := 0; i < len(chain); i++ {
+		c := chain[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inStr = c
+			continue
+		case '{':
+			depthBrace++
+			continue
+		case '}':
+			depthBrace--
+			continue
+		case '[':
+			depthBracket++
+			continue
+		case ']':
+			depthBracket--
+			continue
+		case '(':
+			depthParen++
+			continue
+		case ')':
+			depthParen--
+			continue
+		}
+		if c != '.' || depthParen != 0 || depthBrace != 0 || depthBracket != 0 {
+			continue
+		}
+		// Parse the method identifier following the dot.
+		j := i + 1
+		nameStart := j
+		for j < len(chain) && isMongoIdentChar(chain[j]) {
+			j++
+		}
+		method := chain[nameStart:j]
+		// Skip whitespace to the expected `(`.
+		k := j
+		for k < len(chain) && (chain[k] == ' ' || chain[k] == '\t' || chain[k] == '\n' || chain[k] == '\r') {
+			k++
+		}
+		if k >= len(chain) || chain[k] != '(' {
+			continue
+		}
+		op, isLookup := mongoFuncBuilderMethodOp(method)
+		if op != "" {
+			arg := mongoAggFirstArg(chain, k)
+			// The lookup family passes the join spec object directly
+			// (`lookupOne({ from: 'me_pages', ... })`). mongoAggParseLookup reads
+			// `from:`/`localField:`/`foreignField:`/`as:` straight out of that
+			// object, so wrapping it as `{ $lookup: <obj> }` is sufficient. For
+			// the lookupJoinOne/Many helpers the collection is the FIRST positional
+			// string arg (`lookupJoinOne('m_devices', { on, as })`); normalise that
+			// into a `{ from: '…' }` object so the same parser resolves it.
+			if isLookup {
+				arg = mongoFuncBuilderNormaliseLookupArg(arg)
+			}
+			stages = append(stages, "{ "+op+": "+arg+" }")
+		}
+		i = k - 1
+	}
+	return stages
+}
+
+// mongoFuncBuilderLeadingStringRe matches a leading string-literal positional
+// argument (single/double/backtick quoted) of a lookup-family helper whose
+// collection is passed positionally rather than as a `from:` property — e.g.
+// `lookupJoinOne('m_devices', { on: [...], as: 'device' })`.
+var mongoFuncBuilderLeadingStringRe = regexp.MustCompile(
+	`^\s*['"` + "`" + `]([a-zA-Z_$][\w$.]*)['"` + "`" + `]`,
+)
+
+// mongoFuncBuilderNormaliseLookupArg ensures a lookup-family argument is in a
+// shape mongoAggParseLookup can read its `from` from. When the argument already
+// contains a `from:` object property (the lookup/lookupOne/lookupPipeline form),
+// it is returned unchanged. When the collection is the FIRST positional string
+// (the lookupJoinOne/lookupJoinMany form), it is rewritten to a synthetic
+// `{ from: '<coll>' }` object so the join `to` side resolves. Non-static
+// collections (variable/enum first arg) are left unchanged — honestly
+// unresolved, no fabricated join.
+func mongoFuncBuilderNormaliseLookupArg(arg string) string {
+	if mongoAggStringField("{ "+arg+" }", "from") != "" {
+		return arg
+	}
+	if m := mongoFuncBuilderLeadingStringRe.FindStringSubmatch(arg); m != nil {
+		return "{ from: '" + m[1] + "' }"
+	}
+	return arg
+}

--- a/internal/engine/orm_queries_jsts_mongo_funcbuilder_4320_test.go
+++ b/internal/engine/orm_queries_jsts_mongo_funcbuilder_4320_test.go
@@ -1,0 +1,172 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// realMePageRetrievePipeline is a BYTE-COPY of the live upvate-v3 consumer
+// src/modules/me-page/pipelines/me-page-retrieve.pipeline.ts. It exercises the
+// FUNCTIONAL aggregation-builder factory `mongo<T>()` followed by a fluent
+// chain that includes `.lookupOne({ from: 'me_pages', ... })`. The pipeline is
+// RETURNED (never passed to `.aggregate(...)`), which is precisely the live
+// gap #4320: the existing scanner is gated on a `.aggregate(` call site.
+const realMePageRetrievePipeline = `import { Types } from 'mongoose';
+import { mongo } from '../../../common/query/mongo/aggregation.builder';
+import type { AggregationBuilder } from '../../../common/query/mongo/aggregation.builder';
+import type { MePageRetrieveRaw } from '../projections/me-page-retrieve.projection';
+
+export interface MePageRetrievePipelineOptions {
+  versionId: string;
+}
+
+interface MePageVersionSource {
+  page_id: Types.ObjectId;
+  name?: string;
+  page_content?: Record<string, unknown>;
+  created_at?: Date;
+  updated_at?: Date;
+  updated_by?: string;
+  version_number?: number;
+}
+
+export function mePageRetrievePipeline(opts: MePageRetrievePipelineOptions): AggregationBuilder<MePageRetrieveRaw> {
+  return mongo<MePageVersionSource>()
+    .matchId(new Types.ObjectId(opts.versionId))
+    .lookupOne({ from: 'me_pages', localField: 'page_id', foreignField: '_id', as: 'page' })
+    .project({
+      _id: 0,
+      id: { $toString: '$page._id' },
+      version_id: { $toString: '$_id' },
+      name: 1,
+      page_content: 1,
+      is_current_version: { $eq: ['$_id', '$page.current_version'] },
+      created_at: 1,
+      updated_at: 1,
+      updated_by: 1,
+      version_number: 1,
+    })
+    .limit(1) as unknown as AggregationBuilder<MePageRetrieveRaw>;
+}
+`
+
+// runORMOnSource drives the FULL applyORMQueries pass over a single TS source
+// file (the live extraction entry point), returning the appended DataAccess
+// stage entities and JOINS_COLLECTION edges.
+func runORMOnSource(t *testing.T, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	res := applyORMQueries(DetectorPassArgs{
+		Lang:    "typescript",
+		Path:    path,
+		Content: []byte(src),
+	})
+	var stages []types.EntityRecord
+	for _, e := range res.Entities {
+		if e.Kind == string(types.EntityKindDataAccess) {
+			stages = append(stages, e)
+		}
+	}
+	var joins []types.RelationshipRecord
+	for _, r := range res.Relationships {
+		if r.Kind == string(types.RelationshipKindJoinsCollection) {
+			joins = append(joins, r)
+		}
+	}
+	return stages, joins
+}
+
+// TestMongoFuncBuilder_4320_RealSource reproduces the live gap on a byte-copy of
+// the real upvate-v3 consumer, then (after the fix) asserts the data-access
+// semantics are emitted: a SCOPE.DataAccess node for the pipeline stages and a
+// JOINS_COLLECTION edge to the looked-up `me_pages` collection.
+func TestMongoFuncBuilder_4320_RealSource(t *testing.T) {
+	stages, joins := runORMOnSource(t,
+		"src/modules/me-page/pipelines/me-page-retrieve.pipeline.ts",
+		realMePageRetrievePipeline)
+
+	if len(stages) == 0 {
+		t.Fatalf("GAP: no SCOPE.DataAccess stage entities emitted for functional mongo<>() builder pipeline")
+	}
+
+	// The lookupOne({ from: 'me_pages' }) must yield a $lookup data-access stage.
+	var hasLookup bool
+	for _, s := range stages {
+		if s.Subtype == "$lookup" && s.Properties["from"] == "me_pages" {
+			hasLookup = true
+		}
+	}
+	if !hasLookup {
+		t.Errorf("GAP: no $lookup DataAccess stage with from=me_pages; got stages=%v", stageSubtypesInOrder(stages))
+	}
+
+	// And a JOINS_COLLECTION edge to the me_pages collection Class.
+	if findJoinTo(joins, CapitalisedSingular("me_pages")) == nil {
+		t.Errorf("GAP: no JOINS_COLLECTION edge to Class:%s; joins=%v", CapitalisedSingular("me_pages"), joins)
+	}
+
+	// Stage ORDER is preserved: matchId → lookupOne($lookup) → project → limit.
+	subs := stageSubtypesInOrder(stages)
+	want := []string{"$match", "$lookup", "$project", "$limit"}
+	if len(subs) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v", subs, want)
+	}
+	for i := range want {
+		if subs[i] != want[i] {
+			t.Fatalf("stage subtypes = %v, want %v", subs, want)
+		}
+	}
+}
+
+// realInspectionDevicesPipeline is a TRIMMED byte-faithful copy of the live
+// upvate-v3 consumer inspection-devices.pipeline.ts — it mixes an INLINE
+// `.lookup({ from: 'inspection_groups', ... })` (statically resolvable join)
+// with VARIABLE-passed `.lookupPipelineOne(deviceLookup)` (the `from` lives in a
+// separate const → honestly unresolved). Asserts the inline join resolves and
+// the variable-passed lookups do not crash or fabricate a join.
+const realInspectionDevicesPipeline = `import { mongo, type AggregationBuilder, type PipelineLookup } from '../../../common/query/mongo/aggregation.builder';
+
+const deviceLookup: PipelineLookup = { from: 'm_devices', as: 'device', pipeline: (sub) => sub.limit(1) };
+
+export function inspectionDevicesPipeline(opts: { buildingId: number }): AggregationBuilder<unknown> {
+  return mongo<Record<string, unknown>>()
+    .lookup({ from: 'inspection_groups', localField: 'inspectionGroupId', foreignField: '_id', as: 'inspections_group' })
+    .unwind('inspections_group', { preserveNullAndEmptyArrays: true })
+    .match((w) => { w.eq('building_id', opts.buildingId); })
+    .lookupPipelineOne(deviceLookup)
+    .limit(50) as unknown as AggregationBuilder<unknown>;
+}
+`
+
+func TestMongoFuncBuilder_4320_InlineLookupResolves(t *testing.T) {
+	stages, joins := runORMOnSource(t,
+		"src/modules/buildings/pipelines/inspection-devices.pipeline.ts",
+		realInspectionDevicesPipeline)
+
+	if len(stages) == 0 {
+		t.Fatalf("no DataAccess stages emitted")
+	}
+	// Inline `.lookup({ from: 'inspection_groups' })` → JOINS_COLLECTION edge.
+	if findJoinTo(joins, CapitalisedSingular("inspection_groups")) == nil {
+		t.Errorf("no JOINS_COLLECTION edge to Class:%s; joins=%v",
+			CapitalisedSingular("inspection_groups"), joins)
+	}
+	// Two $lookup stages: the inline one (resolved) AND the variable-passed
+	// lookupPipelineOne (stage present, join honestly unresolved). The latter
+	// must NOT fabricate a join to a phantom collection.
+	var lookupStages int
+	for _, s := range stages {
+		if s.Subtype == "$lookup" {
+			lookupStages++
+		}
+	}
+	if lookupStages < 2 {
+		t.Errorf("expected >=2 $lookup stages (inline + variable-passed), got %d", lookupStages)
+	}
+	// Honest limit: the only resolved join target is inspection_groups; the
+	// variable-passed deviceLookup `from` (m_devices, in a separate const) is NOT
+	// fabricated from the chain.
+	if findJoinTo(joins, CapitalisedSingular("m_devices")) != nil {
+		t.Errorf("fabricated a join to m_devices from a variable-passed lookup (should be unresolved)")
+	}
+}


### PR DESCRIPTION
Closes #4320. Part of the resolution-coverage epic #4334. **DEPLOY-DEFERRED.**

## Problem (live upvate-v3)
The functional NestJS Mongo aggregation builder `src/common/query/mongo/aggregation.builder.ts` — `mongo<Doc>()` / `AggregationBuilder.create<Doc>()` factory followed by a fluent `.matchId().lookupOne({ from }).project().limit()` chain that is **RETURNED** from a pipeline function (never co-located with a `.aggregate(...)` call) — yielded NO data-access semantics. Flows showed generic `Function` steps and the terminal `AggregationBuilder` was mis-kinded. No `SCOPE.DataAccess` node, no `JOINS_COLLECTION` edge, unlike the Django pymongo `$lookup` path (#4259).

Root cause: `scanJSMongoAggregation` is gated entirely on the `.aggregate(` token (`mongoAggCallRe`). A builder chain that is assigned/returned without a co-located `.aggregate(...)` is invisible. The collection name also lives in a `from:` **object property**, not a positional method arg.

## Real call shape found
`src/modules/me-page/pipelines/me-page-retrieve.pipeline.ts`:
```ts
return mongo<MePageVersionSource>()
  .matchId(new Types.ObjectId(opts.versionId))
  .lookupOne({ from: 'me_pages', localField: 'page_id', foreignField: '_id', as: 'page' })
  .project({ ... })
  .limit(1);
```
The joined collection is the **literal string** `'me_pages'` in the `from:` property of `lookupOne`'s object arg.

## Live repro (in my own output, byte-copy of real source)
**Before:** `go test -run TestMongoFuncBuilder_4320_RealSource` → `GAP: no SCOPE.DataAccess stage entities emitted for functional mongo<>() builder pipeline` (zero stages, zero joins).
**After:** PASS — stages `[$match $lookup $project $limit]` in order, a `$lookup` DataAccess stage with `from=me_pages`, and a `JOINS_COLLECTION` edge to `Class:Me_page`.
A second real consumer (`inspection-devices.pipeline.ts`) confirms the inline `.lookup({ from: 'inspection_groups' })` resolves while a variable-passed `.lookupPipelineOne(deviceLookup)` is honestly unresolved (stage present, no fabricated `m_devices` join).

## Recognition mechanism
New sibling pass `scanJSMongoFuncBuilder` (`orm_queries_jsts_mongo_funcbuilder.go`):
1. Detect the functional **factory** entry (`mongo<…>()`, `mongo()`, `AggregationBuilder.create<…>()`, supporting nested type args like `Record<string, unknown>`).
2. Capture the fluent chain to the end of the enclosing statement (string/depth-aware, multi-line safe).
3. `mongoFuncBuilderMethodOp` maps the higher-level functional methods to stage operators (a superset of the `new …Builder()` table: `matchId/matchExpr/lookupOne/lookupPipeline/lookupJoinOne/shape/pick/rename/groupBy/…`).
4. Lookup-family args (`{ from: '…' }` object, or a leading positional string for the join helpers) are normalised so the existing `mongoAggParseLookup` resolves the join `to` side.
5. Reuses `mongoAggEmitStages` → identical SCOPE.DataAccess + JOINS_COLLECTION contract (including the #4244 node-anchored twin). Runtime `from` values emit the stage but no fabricated join.

## Generalisation + follow-ups
The factory-regex + method→op table + join-arg extractor are structured for reuse by sibling fluent builders. Filed as #4334 children:
- **#4335** — TypeORM QueryBuilder / Prisma
- **#4336** — Mongoose `.aggregate().lookup()` / Knex / SQLAlchemy Core
- **#4337** — flow-synthesis terminal mis-kind (`Render`); lives in `http_endpoint_synthesis.go` (owned by #4319), deferred to avoid cross-PR conflict.

## Gates (native)
`go build ./...` clean; `go test ./internal/types/` pass (no new kinds — reuses `SCOPE.DataAccess` + `JOINS_COLLECTION`); real-source repro test (gap→fixed); `go test ./internal/engine ./internal/custom/... -count=1` green; `go vet` + `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)