### PR TITLE
fix(extract): emit endpoint→handler bridge at synthesis time (merge-stable) — long-term fix for endpoint islands (#4319)

### DIFF
--- a/internal/engine/detector_test.go
+++ b/internal/engine/detector_test.go
@@ -438,19 +438,28 @@ func TestDetect_RelationshipProperties(t *testing.T) {
 		t.Fatalf("Detect failed: %v", err)
 	}
 
+	// Scope the YAML-rule assertions to the ROUTES_TO edges this test is about.
+	// #4319 — the producer synthesis pass now ALSO emits a merge-stable
+	// endpoint→handler IMPLEMENTS bridge (pattern_type=http_endpoint_synthesis_
+	// time_bridge) for same-file handler frameworks, Gin included; those are a
+	// separate, intentional edge kind and are validated by the #4319 repro tests.
+	sawRoutesTo := false
 	for _, rel := range result.Relationships {
-		if rel.Kind != "ROUTES_TO" {
-			t.Errorf("relationship Kind = %q, want ROUTES_TO", rel.Kind)
-		}
-		if rel.Properties["framework"] != "go" {
-			t.Errorf("relationship framework property = %q, want go", rel.Properties["framework"])
-		}
-		if rel.Properties["pattern_type"] != "yaml_driven" {
-			t.Errorf("relationship pattern_type = %q, want yaml_driven", rel.Properties["pattern_type"])
+		if rel.Kind == "ROUTES_TO" {
+			sawRoutesTo = true
+			if rel.Properties["framework"] != "go" {
+				t.Errorf("relationship framework property = %q, want go", rel.Properties["framework"])
+			}
+			if rel.Properties["pattern_type"] != "yaml_driven" {
+				t.Errorf("relationship pattern_type = %q, want yaml_driven", rel.Properties["pattern_type"])
+			}
 		}
 		if rel.FromID == "" || rel.ToID == "" {
 			t.Errorf("relationship has empty FromID or ToID: from=%q to=%q", rel.FromID, rel.ToID)
 		}
+	}
+	if !sawRoutesTo {
+		t.Error("expected at least one ROUTES_TO relationship from the gin YAML rule")
 	}
 }
 

--- a/internal/engine/http_endpoint_island_repro_4319_test.go
+++ b/internal/engine/http_endpoint_island_repro_4319_test.go
@@ -1,0 +1,268 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4319 LIVE REPRO + LONG-TERM-FIX gate.
+//
+// The endpoint `POST /inspections/me-manage/merge` (upvate-v3 BuildingController)
+// was a graph ISLAND on the live graph after a full reindex, despite TWO prior
+// detect-and-repair fixes (#4326 bare↔qualified name match, #4330 file:line
+// co-location). Both reproduced in HAND-BUILT fixtures (handler StartLine set
+// equal to the synthetic's) but failed on the live graph because the bridge was
+// rebuilt POST-merge from a string/line that the merge/dedup step destabilises.
+//
+// This file reproduces the LIVE island mechanism faithfully and proves the
+// long-term synthesis-time structural bridge survives it.
+
+const reproControllerFile = "src/modules/buildings/api/building.controller.ts"
+
+// realControllerSrc loads the exact upvate-v3 controller copied into the repo for
+// the repro; falls back to a faithful reconstruction of the merge route shape.
+func realControllerSrc(t *testing.T) []byte {
+	t.Helper()
+	if b, err := os.ReadFile("_repro_building.controller.txt"); err == nil && len(b) > 0 {
+		return b
+	}
+	return []byte(`import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { BuildingService } from '../services/building.service';
+import { BuildingMeMergeBody } from '../dto/request/building-me-merge.body.dto';
+import { BuildingMeMergeResponse } from '../dto/response/building-me.response.dto';
+
+@Controller({ path: 'buildings', version: '1' })
+export class BuildingController {
+  constructor(private readonly service: BuildingService) {}
+
+  @Post('inspections/me-manage/merge')
+  @HttpCode(HttpStatus.OK)
+  mergeMaintenanceEvaluations(@Body() body: BuildingMeMergeBody): Promise<BuildingMeMergeResponse> {
+    return this.service.mergeMaintenanceEvaluations(body);
+  }
+}
+`)
+}
+
+// liveProducers runs the two real producers the indexer runs on a NestJS
+// controller and returns (handler+endpoint entities, synthesis relationships).
+func liveProducers(t *testing.T, src []byte) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+
+	// Producer 1 — tree-sitter JS/TS extractor → handler Operation(s).
+	p := sitter.NewParser()
+	p.SetLanguage(tstypescript.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		t.Fatalf("parseTS: %v", err)
+	}
+	jsEnts, err := javascript.New().Extract(context.Background(), extreg.FileInput{
+		Path: reproControllerFile, Content: src, Language: "typescript", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("js extract: %v", err)
+	}
+
+	// Producer 2 — engine route synthesizer → http_endpoint_definition (+ #4319
+	// synthesis-time bridge relationship).
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extreg.FileInput{
+		Path: reproControllerFile, Content: src, Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	ents := append([]types.EntityRecord{}, jsEnts...)
+	ents = append(ents, res.Entities...)
+	return ents, res.Relationships
+}
+
+func findMergeHandler(ents []types.EntityRecord) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Name == "mergeMaintenanceEvaluations" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func findMergeEndpoint(ents []types.EntityRecord) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == httpEndpointDefinitionKind && ents[i].Properties != nil &&
+			ents[i].Properties["verb"] == "POST" &&
+			ents[i].Properties["path"] == "/inspections/me-manage/merge" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// runFullBridge mirrors buildDocument: ResolveHTTPEndpointHandlers (the
+// http-endpoint resolve pass) over the merged entities, then ComputeID + the
+// CENTRAL resolver (resolve.References) over the synthesis relationships. It
+// returns true iff, after both passes, the merge endpoint has a resolved inbound
+// IMPLEMENTS edge from its handler entity (i.e. it is NOT an island).
+func runFullBridge(t *testing.T, ents []types.EntityRecord, rels []types.RelationshipRecord) (bool, ResolveHTTPEndpointStats) {
+	t.Helper()
+	merged, stats := ResolveHTTPEndpointHandlers(ents)
+
+	// Stamp deterministic IDs (no repo tag, like ComputeID in stampEntityIDs path).
+	for i := range merged {
+		merged[i].ID = merged[i].ComputeID()
+	}
+	endpoint := findMergeEndpoint(merged)
+	handler := findMergeHandler(merged)
+	if endpoint == nil {
+		t.Fatal("no http_endpoint_definition for the merge route")
+	}
+
+	// Central resolver over the standalone synthesis relationships (the #4319
+	// synthesis-time bridge lives here). This is exactly what buildDocument does
+	// via resolve.References(pass2Rels, idx).
+	idx := resolve.BuildIndex(merged)
+	resolve.References(rels, idx)
+
+	// Is the endpoint reachable from a handler via a RESOLVED IMPLEMENTS edge?
+	endpointID := endpoint.ID
+	bridged := false
+
+	// (a) standalone synthesis-time bridge resolved to hex IDs.
+	for _, r := range rels {
+		if r.Kind == implementsEdgeKind && r.ToID == endpointID {
+			if handler != nil && r.FromID == handler.ID {
+				bridged = true
+			}
+		}
+	}
+	// (b) embedded IMPLEMENTS from the http-endpoint resolve pass (stub form —
+	//     resolved later in the real pipeline; here we accept the stub that
+	//     targets the endpoint, which is the legacy co-location/name path).
+	if handler != nil {
+		for _, r := range handler.Relationships {
+			if r.Kind == implementsEdgeKind &&
+				(r.ToID == httpEndpointDefinitionKind+":"+endpoint.Name) {
+				bridged = true
+			}
+		}
+	}
+	return bridged, stats
+}
+
+// TestIslandRepro4319_SynthesisTimeBridgeEmitted proves the bridge is born AT
+// SYNTHESIS time as a merge-stable, file-scoped structural edge — independent of
+// any later name/line resolution. This is the core of the long-term fix.
+func TestIslandRepro4319_SynthesisTimeBridgeEmitted(t *testing.T) {
+	_, rels := liveProducers(t, realControllerSrc(t))
+	want := "scope:operation:method:typescript:" + reproControllerFile + ":mergeMaintenanceEvaluations"
+	var found *types.RelationshipRecord
+	for i := range rels {
+		if rels[i].Kind == implementsEdgeKind &&
+			rels[i].Properties["pattern_type"] == "http_endpoint_synthesis_time_bridge" &&
+			rels[i].FromID == want {
+			found = &rels[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("no synthesis-time IMPLEMENTS bridge emitted for the NestJS merge route")
+	}
+	if found.ToID != httpEndpointDefinitionKind+":http:POST:/inspections/me-manage/merge" {
+		t.Errorf("bridge ToID = %q, want endpoint stub", found.ToID)
+	}
+}
+
+// TestIslandRepro4319_BridgeSurvivesLegacyFailure is the architectural guarantee:
+// the synthesis-time structural bridge resolves the endpoint→handler edge through
+// the CENTRAL resolver EVEN WHEN every legacy resolve-pass path (name resolution
+// AND file:line co-location) is dead. This is the exact failure mode that left the
+// endpoint an island on the live graph after #4326/#4330: a surviving merged
+// synthetic with NO source_handler (so name resolution misses) whose StartLine no
+// longer agrees with the handler's after merge (so co-location misses).
+//
+// We model that worst case by ZEROING the synthetic's StartLine (killing the
+// co-location signal) and confirming source_handler is absent — then assert the
+// http-endpoint resolve pass produces NO bridge, while the synthesis-time
+// structural edge (line-independent, file+name scoped) STILL resolves end-to-end.
+func TestIslandRepro4319_BridgeSurvivesLegacyFailure(t *testing.T) {
+	ents, rels := liveProducers(t, realControllerSrc(t))
+
+	// Kill the co-location signal on the merge endpoint (StartLine→0) and confirm
+	// it carries no source_handler — the live post-merge island shape.
+	ep := findMergeEndpoint(ents)
+	if ep == nil {
+		t.Fatal("merge endpoint not synthesized")
+	}
+	// Model the live post-merge island shape: the merge/dedup step kept a
+	// same-(verb,path) synthetic that carries NO bindable source_handler (a
+	// same-path definition from another pass — e.g. the OpenAPI-spec synthetic
+	// observed on the live upvate graph — won attribution), and the surviving
+	// synthetic's StartLine no longer agrees with the handler's. Strip both.
+	ep.StartLine = 0
+	delete(ep.Properties, "source_handler")
+
+	// The http-endpoint resolve pass alone CANNOT bridge this shape (no name, no
+	// line) — negative control proving the legacy paths are dead here.
+	mergedNoBridge, stats := ResolveHTTPEndpointHandlers(cloneEnts(ents))
+	if legacyBridged(mergedNoBridge, "http:POST:/inspections/me-manage/merge") {
+		t.Fatalf("expected legacy resolve pass to FAIL on the no-handler/no-line shape (the live island), but it bridged (resolved=%d)", stats.HandlerResolved)
+	}
+
+	// The synthesis-time structural bridge resolves it end-to-end via the central
+	// resolver — the endpoint is NOT an island.
+	bridged, _ := runFullBridge(t, ents, rels)
+	if !bridged {
+		t.Fatal("ISLAND: synthesis-time bridge failed to resolve the endpoint→handler edge under the live island shape")
+	}
+}
+
+// cloneEnts deep-enough copies the entity slice (and each record's Relationships
+// header) so a resolve pass that appends embedded edges doesn't perturb the
+// caller's slice.
+func cloneEnts(in []types.EntityRecord) []types.EntityRecord {
+	out := make([]types.EntityRecord, len(in))
+	copy(out, in)
+	for i := range out {
+		out[i].Relationships = append([]types.RelationshipRecord(nil), in[i].Relationships...)
+	}
+	return out
+}
+
+// legacyBridged reports whether any handler entity carries an embedded IMPLEMENTS
+// stub targeting the named endpoint — i.e. the http-endpoint resolve pass bridged
+// it (as opposed to the synthesis-time structural edge, which is a standalone rel).
+func legacyBridged(ents []types.EntityRecord, endpointName string) bool {
+	target := httpEndpointDefinitionKind + ":" + endpointName
+	for i := range ents {
+		if ents[i].Kind == httpEndpointDefinitionKind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == implementsEdgeKind && r.ToID == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestIslandRepro4319_HappyPath_NotIsland is the straightforward gate: on the
+// clean live pipeline the merge endpoint is not an island.
+func TestIslandRepro4319_HappyPath_NotIsland(t *testing.T) {
+	ents, rels := liveProducers(t, realControllerSrc(t))
+	bridged, stats := runFullBridge(t, ents, rels)
+	if !bridged {
+		t.Fatalf("endpoint is an island on the clean pipeline (handler_resolved=%d)", stats.HandlerResolved)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -45,6 +45,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/frameworks/routes"
 	"github.com/cajasmota/archigraph/internal/types"
 )
@@ -136,6 +137,67 @@ func synthesisSupportsLanguage(lang string) bool {
 	default:
 		return false
 	}
+}
+
+// synthesisHandlerStructuralRef returns the merge-stable, file-scoped structural
+// reference to the handler METHOD that a producer-side route synthesizer should
+// use as the FromID of a synthesis-time endpoint→handler IMPLEMENTS bridge
+// (#4319). It returns "" when no same-file handler method is named — in which
+// case no bridge is emitted and the existing name-resolution / co-location
+// fallbacks in ResolveHTTPEndpointHandlers take over.
+//
+// The returned stub has the canonical Format-A shape
+//
+//	scope:operation:method:<lang>:<file>:<methodName>
+//
+// which the central resolver (resolve.References) binds to the same-file handler
+// Operation by (file, name) — independent of line numbers and stable across
+// entity merge. Because it is file-scoped it can never bind a method in another
+// controller, and an unresolved name is left unmatched (no guess).
+//
+// It fires only for refKinds that name a same-file handler METHOD
+// (Controller / View / SCOPE.Operation as emitted by the annotation- and
+// router-DSL synthesizers). It deliberately rejects:
+//   - empty refName (GraphQL-resolver / inline-arrow synthetics with no symbol),
+//   - the Spring `Route:<path>` placeholder (refKind="Route"),
+//   - dotted qualified names (`Class.method`) — the synthesis-time bridge is for
+//     the bare-method, same-file case; qualified cross-file shapes are handled by
+//     the resolve pass. (A dotted name would also not match byLocation[file][name].)
+func synthesisHandlerStructuralRef(lang, file, refKind, refName string) string {
+	if refName == "" || file == "" || lang == "" {
+		return ""
+	}
+	switch refKind {
+	case "Controller", "View", "SCOPE.Operation":
+		// same-file handler-method kinds
+	default:
+		return ""
+	}
+	// Reject dotted qualified names — the same-file byLocation index keys on the
+	// bare method Name, and a dotted ref is the cross-file shape.
+	if strings.ContainsAny(refName, ".:#") {
+		return ""
+	}
+	return extractor.BuildOperationStructuralRef(lang, file, refName)
+}
+
+// dropTrailingSynthesisTimeBridge removes the most-recently-appended
+// synthesis-time endpoint→handler bridge edge (#4319) for canonicalPath, if it
+// is the last element of rels. Used by the CROSS-FILE emitters (emitFile /
+// emitResource) to retract the same-file structural bridge that makeEmit emitted
+// before they learned the handler actually lives in another file. Matching on
+// the trailing element + pattern_type + path keeps it surgical: it only ever
+// removes the bridge this same emit() call just added.
+func dropTrailingSynthesisTimeBridge(rels []types.RelationshipRecord, canonicalPath string) []types.RelationshipRecord {
+	if n := len(rels); n > 0 {
+		last := rels[n-1]
+		if last.Kind == implementsEdgeKind &&
+			last.Properties["pattern_type"] == "http_endpoint_synthesis_time_bridge" &&
+			last.Properties["path"] == canonicalPath {
+			return rels[:n-1]
+		}
+	}
+	return rels
 }
 
 // isTestSourceFile reports whether filePath is a test/spec/fixture file that
@@ -397,6 +459,58 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 				EnrichmentStatus:   types.StatusPending,
 				QualityScore:       0.8,
 			})
+
+			// #4319 LONG-TERM FIX — emit the endpoint→handler bridge AT SYNTHESIS
+			// TIME, from the decorated handler node, using a merge-stable,
+			// file-scoped STRUCTURAL reference to the handler method (rather than
+			// reconstructing the bridge later by name- / co-location matching in
+			// ResolveHTTPEndpointHandlers).
+			//
+			// Two prior detect-and-repair fixes (#4326 bare↔qualified name match,
+			// #4330 file:line co-location) both reproduced in synthetic fixtures
+			// but FAILED on the live graph: the bridge was rebuilt POST-merge from
+			// the `source_handler` string or the synthetic's StartLine, and the
+			// merge/dedup step destabilises both (a same-(verb,path) synthetic from
+			// another pass can win attribution carrying no usable source_handler,
+			// and a duplicate handler Operation at the same file:line trips the
+			// no-guess guard) → the endpoint is left a graph ISLAND.
+			//
+			// The structural edge below is IMMUNE to that lossy round-trip: it is a
+			// `scope:operation:method:<lang>:<file>:<name>` stub that the CENTRAL
+			// resolver (resolve.References, in buildDocument) binds to the same-file
+			// handler by (file, name) — independent of StartLine, independent of the
+			// http-endpoint resolve pass, and stable across entity-merge (it travels
+			// as a stub, not a hex ID, and is rewritten only once, after all merging).
+			// It is file-scoped so it can NEVER mis-bridge to a method in another
+			// controller, and when the name does not resolve in-file the resolver
+			// simply leaves it unmatched (no guess, no phantom edge) — preserving the
+			// no-mis-bridge guarantee the prior fixes established.
+			//
+			// GENERALISED: this fires for EVERY producer synthesizer that hands a
+			// real same-file handler METHOD name (NestJS / Express / Fastify /
+			// FastAPI / Flask / JAX-RS / Axum / Rocket / …) via refKind ∈
+			// {Controller, View, SCOPE.Operation}. It deliberately does NOT fire for
+			// the cross-file `handler_file`-hint frameworks (Rails / Phoenix /
+			// Sails / Adonis / Feathers — refKind=Controller but the method lives in
+			// another file, handled by handlerFileHint resolution) nor for Spring's
+			// `Route:<path>` placeholder, because those carry no same-file method
+			// name. The existing name-resolution + co-location paths remain as
+			// fallbacks; this is the primary, merge-stable bridge.
+			if patternType == "http_endpoint_synthesis" {
+				if bridgeRef := synthesisHandlerStructuralRef(lang, path, refKind, refName); bridgeRef != "" {
+					relationships = append(relationships, types.RelationshipRecord{
+						FromID: bridgeRef,
+						ToID:   kind + ":" + id,
+						Kind:   implementsEdgeKind,
+						Properties: map[string]string{
+							"pattern_type": "http_endpoint_synthesis_time_bridge",
+							"framework":    framework,
+							"verb":         strings.ToUpper(method),
+							"path":         canonicalPath,
+						},
+					})
+				}
+			}
 		}
 	}
 	emit := makeEmit("http_endpoint_synthesis", "source_handler")
@@ -432,6 +546,14 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 				last.Properties = map[string]string{}
 			}
 			last.Properties["handler_file"] = handlerFile
+			// #4319 — this is a CROSS-FILE handler (Rails / Phoenix / Sails /
+			// Adonis / Feathers): the method named by refName lives in
+			// handlerFile, NOT in `path`. The synthesis-time structural bridge
+			// emit() just appended is keyed on THIS file, so it would never
+			// resolve here; drop it so it does not show up as an unmatched stub.
+			// Cross-file attribution stays the job of the handler_file-hint
+			// resolution path in ResolveHTTPEndpointHandlers.
+			relationships = dropTrailingSynthesisTimeBridge(relationships, canonicalPath)
 		}
 		if defLine > 0 {
 			last.StartLine = defLine
@@ -465,6 +587,9 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		}
 		if handlerFile != "" {
 			last.Properties["handler_file"] = handlerFile
+			// #4319 — cross-file handler: drop the same-file synthesis-time
+			// bridge (see emitFile for the rationale).
+			relationships = dropTrailingSynthesisTimeBridge(relationships, canonicalPath)
 		}
 		routes.Stamp(last.Properties, framework, action)
 	}


### PR DESCRIPTION
## Problem (DEPLOY-DEFERRED)

The endpoint `POST /inspections/me-manage/merge` was a graph **island** on the live graph after a full reindex. Two prior detect-and-repair fixes both passed synthetic fixtures and BOTH failed live:

- **#4326** — bare↔qualified `source_handler` NAME match
- **#4330** — file:line co-location

Both rebuild the endpoint→handler bridge **POST-merge** from a `source_handler` string and/or the synthetic's `StartLine`, and the merge/dedup step destabilises both:

- a same-`(verb,path)` synthetic from another pass can win attribution carrying **no usable `source_handler`** (e.g. the OpenAPI-spec synthetic `open-api/buildings.yml → http:POST:/buildings/.../merge` observed orphaned on the live upvate graph), so every name path misses; and
- a **duplicate handler Operation at the same file:line** trips the co-location no-guess guard.

The lossy round-trip (born from one decorated-method node, bridge reconstructed later by matching) is the design flaw.

## Live-repro evidence

`internal/engine/http_endpoint_island_repro_4319_test.go` runs the **REAL two producers** the indexer runs on the upvate-v3 `BuildingController` merge route:

1. the tree-sitter JS/TS extractor → the handler `mergeMaintenanceEvaluations` Operation, and
2. the engine route synthesizer → the `http_endpoint_definition`.

It models the live **post-merge island shape** (surviving synthetic has **no `source_handler`** and a `StartLine` that no longer agrees with the handler's), asserts the legacy resolve pass **cannot** bridge it (**island reproduced**), then asserts the new synthesis-time edge resolves the endpoint→handler `IMPLEMENTS` edge **end-to-end through the central resolver** (**island resolved**). With the synthesis-time edge disabled the test fails — a genuine negative control (the missing piece in the prior two attempts).

## Architectural change

Emit the bridge **AT SYNTHESIS time**, from the decorated handler node, as a merge-stable, file-scoped **structural reference** to the handler method:

```
scope:operation:method:<lang>:<file>:<methodName>
```

The central resolver (`resolve.References`, in `buildDocument`) binds this stub to the same-file handler by `(file, name)` — **independent of `StartLine`, independent of the http-endpoint resolve pass, and stable across entity merge** (it travels as a stub, not a hex ID, and is rewritten only once, after all merging). File-scoped ⇒ can never mis-bridge to a method in another controller; an unresolved name is left unmatched (no guess). The existing name-resolution + co-location paths remain as fallbacks; this is now the primary, merge-stable bridge.

## Cross-framework wiring

Wired in the **shared synthesis layer** (`makeEmit` in `http_endpoint_synthesis.go`), so every producer synthesizer that hands a real same-file handler method name benefits — **NestJS, Express, Fastify, Flask, FastAPI, JAX-RS, Gin/Echo/Chi, Axum, Rocket, …** (verified: the Gin path now emits the bridge for same-file Go handlers). The cross-file `handler_file`-hint frameworks (Rails / Phoenix / Sails / Adonis / Feathers) retract the same-file bridge via `emitFile`/`emitResource` and keep their resolve-pass `handler_file` attribution. Spring's `Route:<path>` placeholder and handler-less GraphQL / inline-arrow synthetics are excluded by `refKind`/`refName`.

## Gates

- `go build ./...` clean
- `go test ./internal/types/` + `go test ./internal/engine -count=1` green
- repro test passes (island reproduced → resolved); negative control fails without the fix
- prior #4326/#4330 tests still pass; no mis-bridge (no-guess guard preserved)
- `go vet` / `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)