### PR TITLE
fix(webui): prevent graph-view freeze on large/high-degree graphs (cosmos hub handling)

### DIFF
--- a/webui-v2/src/hooks/use-mcp-activity.ts
+++ b/webui-v2/src/hooks/use-mcp-activity.ts
@@ -131,6 +131,21 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
     let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let isFirstConnect = true;
+    // #4319 — guard against a backoff-reset busy-loop. If the daemon emits the
+    // `connected` event and then the stream drops again immediately (a flapping
+    // server), resetting reconnectAttempt to 0 on every `connected` would pin
+    // the backoff at its 1s floor and hammer fetch(/history) + EventSource every
+    // ~1s forever. We only reset the backoff once a connection has proven STABLE
+    // (stayed open past STABLE_MS), so a flapping daemon decays to the 5s cap
+    // instead of a tight reconnect storm.
+    const STABLE_MS = 10_000;
+    let stableTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearStableTimer = () => {
+      if (stableTimer !== null) {
+        clearTimeout(stableTimer);
+        stableTimer = null;
+      }
+    };
 
     const clearReconnectTimer = () => {
       if (reconnectTimer !== null) {
@@ -140,6 +155,9 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
     };
 
     const closeES = () => {
+      // #4319 — a connection is being torn down; cancel the pending "proven
+      // stable" reset so a flapping stream can never reset the backoff.
+      clearStableTimer();
       if (es) {
         // Drop handlers before closing so a late error can't schedule a
         // reconnect against a connection we're tearing down (no ES leaks).
@@ -201,10 +219,18 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
       esRef.current = conn;
 
       conn.addEventListener("connected", () => {
-        // A successful (re)connect resets the backoff progression.
-        reconnectAttempt = 0;
         isFirstConnect = false;
         setState((prev) => ({ ...prev, connected: true }));
+        // #4319 — do NOT reset the backoff here. A flapping daemon that emits
+        // `connected` then immediately drops would otherwise reset to the 1s
+        // floor every cycle and busy-loop fetch(/history)+EventSource. Only
+        // reset once the connection has held open past STABLE_MS, so a flapping
+        // stream decays to the 5s cap instead of hammering the endpoint.
+        clearStableTimer();
+        stableTimer = setTimeout(() => {
+          stableTimer = null;
+          if (!cancelled) reconnectAttempt = 0;
+        }, STABLE_MS);
       });
 
       // The Go backend emits this event as "mcp_activity"
@@ -259,6 +285,7 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
     return () => {
       cancelled = true;
       clearReconnectTimer();
+      clearStableTimer();
       closeES();
       esRef.current = null;
     };

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -60,6 +60,37 @@ const COLOR_MODES: { id: ColorMode; label: string }[] = [
   { id: "degree", label: "Degree" },
 ];
 
+/**
+ * #4319 — SUPER-HUB DEGREE CAP (graph-view freeze fix).
+ *
+ * A single structural aggregate node can be incident to a huge share of the
+ * graph — e.g. the `core-backend-v3` Module is connected to ~every entity via
+ * CONTAINS (degree ~15,613 on the upvate-v3 graph), and new aggregate
+ * "god-nodes" (AggregationBuilder, betweenness ~141k) form similar mega-stars.
+ *
+ * cosmos.gl's force-directed layout does O(edges) work PER TICK (the link
+ * spring is evaluated for every link every frame), and a single node with tens
+ * of thousands of incident edges both (a) dominates that per-tick cost and (b)
+ * creates an extreme force imbalance that makes the layout thrash and never
+ * settle — pinning the main thread and FREEZING the page.
+ *
+ * Such a node is also visually useless: a 15k-edge hairball star conveys no
+ * structure. So we EXCLUDE any node whose incident-edge count (in the currently
+ * rendered edge set) exceeds HUB_DEGREE_CAP, and drop its incident edges, before
+ * the data ever reaches the cosmos canvas. This is a pure pre-render filter:
+ *
+ *   • Normal graphs are untouched — no real entity approaches ~2k incident
+ *     edges; the cap only ever trips on pathological structural aggregates.
+ *   • The count of pruned hubs is surfaced in the LOD badge so the omission is
+ *     visible and explainable, never silent.
+ *   • The canvas stays a pure renderer (it caps nothing itself); the transform
+ *     lives here alongside the existing edge-kind filter.
+ *
+ * The cap is generous (well above any sane real degree) so it degrades ONLY the
+ * pathological mega-stars and never a legitimately well-connected hub.
+ */
+const HUB_DEGREE_CAP = 2000;
+
 export default function GraphScreen() {
   const { groupId = "demo" } = useParams();
   const theme = useAppStore((st) => st.theme);
@@ -164,14 +195,42 @@ export default function GraphScreen() {
   }, [s]);
 
   // Edge-kind filter applied client-side (kinds are cheap to filter locally).
-  const edges = useMemo(() => {
+  const kindFilteredEdges = useMemo(() => {
     if (!data) return [];
     // Fast path: every selectable kind enabled → no filtering needed.
     if (s.enabledEdgeKinds.size === ALL_EDGE_KINDS.length) return data.edges;
     return data.edges.filter((e) => s.enabledEdgeKinds.has(e.kind as EdgeKind));
   }, [data, s.enabledEdgeKinds]);
 
-  const nodes = data?.nodes ?? [];
+  const allNodes = data?.nodes ?? [];
+
+  // ── #4319 — prune pathological super-hub nodes (see HUB_DEGREE_CAP) ───────────
+  // Count each node's incident edges in the CURRENTLY RENDERED edge set (after
+  // the edge-kind filter), then drop any node above the cap together with its
+  // incident edges, so cosmos.gl never sees a 15k-edge star that freezes the
+  // layout. Computed from the rendered edges (not the daemon `degree`) so it
+  // respects the user's edge-kind toggles. No-op on normal graphs.
+  const { nodes, edges, prunedHubCount } = useMemo(() => {
+    const incident = new Map<string, number>();
+    for (const e of kindFilteredEdges) {
+      incident.set(e.source, (incident.get(e.source) ?? 0) + 1);
+      incident.set(e.target, (incident.get(e.target) ?? 0) + 1);
+    }
+    const prunedIds = new Set<string>();
+    for (const n of allNodes) {
+      if ((incident.get(n.id) ?? 0) > HUB_DEGREE_CAP) prunedIds.add(n.id);
+    }
+    if (prunedIds.size === 0) {
+      return { nodes: allNodes, edges: kindFilteredEdges, prunedHubCount: 0 };
+    }
+    return {
+      nodes: allNodes.filter((n) => !prunedIds.has(n.id)),
+      edges: kindFilteredEdges.filter(
+        (e) => !prunedIds.has(e.source) && !prunedIds.has(e.target),
+      ),
+      prunedHubCount: prunedIds.size,
+    };
+  }, [allNodes, kindFilteredEdges]);
 
   // ── monorepo-aware default coloring/grouping (Fix #1532-1) ───────────────────
   // A monorepo is a single repo split into many modules. Repo grouping there is
@@ -330,9 +389,15 @@ export default function GraphScreen() {
     if (!node) exitFocus();
   };
 
-  const lodLabel = `${s.lod.toUpperCase()}  ${nodes.length.toLocaleString()}/${(
-    data?.totalNodeCount ?? nodes.length
-  ).toLocaleString()}`;
+  // #4319 — note any pruned super-hubs in the LOD badge so the omission is
+  // visible (e.g. "… · −1 hub") rather than a silent drop.
+  const lodLabel =
+    `${s.lod.toUpperCase()}  ${nodes.length.toLocaleString()}/${(
+      data?.totalNodeCount ?? nodes.length
+    ).toLocaleString()}` +
+    (prunedHubCount > 0
+      ? ` · −${prunedHubCount} hub${prunedHubCount === 1 ? "" : "s"}`
+      : "");
 
   // Edge-kind filters count as "active" when they deviate from the default-on
   // set (structural kinds ON, semantic kinds OFF): each structural kind turned


### PR DESCRIPTION
## Root cause

The graph view (`/g/<group>/graph`, cosmos.gl canvas) **froze the page** on the upvate-v3 graph.

A single structural aggregate **Module node `core-backend-v3` is incident to ~every entity via `CONTAINS` (degree ~15,613)**, forming a 15k-edge star. New aggregate "god-nodes" (`AggregationBuilder`, betweenness ~141k) form similar mega-stars.

cosmos.gl's force-directed layout does **O(edges) work per tick** (the link spring is evaluated for every link every frame). A single node with ~15k incident edges both (a) dominates that per-tick cost and (b) creates an extreme force imbalance that makes the layout **thrash and never settle** — pinning the main thread.

**Evidence in the code:** neither the data layer nor the canvas caps anything.
- `hooks/use-graph.ts`: *"The cosmos canvas renders the FULL corpus (it caps nothing)"* — the full payload is rendered.
- LOD default is `high` (commit 989b323fc: *"default LoD = HIGH (full graph, no thinning)"*).
- `CONTAINS` is a default-ON structural edge kind (`STRUCTURAL_EDGE_KINDS`), so the 15.6k CONTAINS star edges render by default.
- `graph-canvas.tsx` feeds every packed edge to cosmos each tick; there is no degree threshold / structural-hub exclusion anywhere in the render path.

This is the **primary** cause. Suspect #3 (LOD) is a symptom of the same thing — at LOD=HIGH the full 15.9k/65k graph (incl. the hub star) is rendered at full detail. Suspect #2 (SSE) is a real but secondary latent risk, fixed defensively below.

## Fix

**Primary — prune pathological super-hubs before they reach the canvas** (`routes/graph.tsx`):
Count each node's incident edges in the *currently rendered* edge set (after the edge-kind filter), then drop any node whose incidence exceeds `HUB_DEGREE_CAP = 2000` together with its incident edges. cosmos never sees a 15k-edge star.
- The canvas stays a **pure renderer** (it caps nothing itself); the transform lives alongside the existing edge-kind filter and **respects the user's edge-kind toggles** (computed from rendered edges, not the daemon `degree`).
- The pruned-hub count is surfaced in the LOD badge (`· −N hubs`) so the omission is **visible, never silent**.

**Why it doesn't regress normal graphs:** the cap (2000 incident edges) is far above any sane real entity degree. On a normal graph `prunedIds.size === 0` and the original arrays are returned by identity (no copy, no behavior change). The cap only ever trips on pathological structural aggregates — which render as a useless 15k-edge hairball anyway.

**Secondary — SSE reconnect backoff** (`hooks/use-mcp-activity.ts`):
Backoff was reset to 0 on every `connected` event, so a flapping daemon (connect → drop immediately) would pin the backoff at its 1s floor and busy-loop `fetch(/history)` + EventSource every ~1s. Backoff now resets **only after a connection holds open past `STABLE_MS` (10s)**, decaying a flapping stream to the 5s cap. The stable timer is cleared on teardown/close so it can't leak or fire against a torn-down connection.

## Threshold

`HUB_DEGREE_CAP = 2000` incident edges. The upvate-v3 hub is ~15,613 (≈8× over); no real entity approaches it.

## Gates

- `npm ci` ✓
- `npm run build` (vite) ✓
- `npm run lint` (tsc --noEmit) ✓ clean
- `npm test` (vitest src/lib) ✓ 37/37
- dist/ gitignored — **source only** committed (DEPLOY-DEFERRED; dist re-embeds next deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)