### PR TITLE
fix(webui): apply WCAG-AA repo-color to the Paths endpoint-detail repo tags (#4341)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -27,6 +27,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Skeleton } from "@/components/ui";
 import { RefLine } from "@/components/RefLine";
+import { getRepoColor } from "@/lib/repo-color";
 import { SectionHeader } from "@/components/SectionHeader";
 import { ShapeTree, type ShapeTreeRow } from "@/components/ShapeTree";
 import { AuthSection } from "@/components/Paths/EndpointDetail/AuthSection";
@@ -810,11 +811,27 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
               {detail.handlers[0].framework}
             </span>
           )}
-          {detail.repos.slice(0, 2).map((r) => (
-            <span key={r} className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-3 font-mono">
-              {r}
-            </span>
-          ))}
+          {detail.repos.slice(0, 2).map((r) => {
+            // #4341: route the header repo tag through the shared repo-color
+            // resolver (same as RefLine, #4323) so it gets the luminance-based
+            // WCAG-AA foreground/background/border instead of low-contrast
+            // bg-surface-2/text-text-3. Layout (pill shape) is unchanged.
+            const repoColors = getRepoColor(r);
+            return (
+              <span
+                key={r}
+                className="text-xs px-2 py-0.5 rounded-full font-mono"
+                style={{
+                  background: repoColors.background,
+                  color: repoColors.foreground,
+                  border: `1px solid ${repoColors.border}`,
+                }}
+                title={r}
+              >
+                {r}
+              </span>
+            );
+          })}
           {detail.repos.length > 2 && (
             <span className="text-xs text-text-4">+{detail.repos.length - 2}</span>
           )}


### PR DESCRIPTION
## Problem

Fixes #4341. In the Paths endpoint-detail panel, the repo-name tag (e.g. `core-backend-v3`) was low-contrast. #4323 fixed `getRepoColor` + the `RefLine` chip, but the **detail-header chip row** rendered the repo tag via a *different* path.

## Component found

`webui-v2/src/routes/paths.tsx` — `DetailPane`, the header "Chip row: auth, framework, repos" (the `detail.repos.slice(0, 2).map(...)` block). It rendered each repo tag with hardcoded `bg-surface-2 text-text-3`, bypassing the shared resolver. The "Defined in" rows already go through `RefLine` → `getRepoColor` (#4323) and were already correct.

## Fix

Route the header repo tag through the **same** `getRepoColor(repo)` from `webui-v2/src/lib/repo-color.tsx` (reused, not hardcoded) so it gets the luminance-based WCAG-AA `{background, foreground, border}` that #4323 established — identical to `RefLine`. The pill shape/size/layout is unchanged; only the color source changed.

## Worst-case contrast (computed across all curated hues + both themes)

| | text-vs-chip ratio |
|---|---|
| **Before** (gray `bg-surface-2`/`text-text-3`), dark theme | **3.20:1 — FAIL AA** |
| Before, light theme | 4.36:1 |
| **After** (getRepoColor), light | **4.59:1** |
| After, dark (blue/warm) | 5.09 / 5.19:1 |
| After, hash-derived (>8 repos, theme-independent) | 6.18:1 |

All post-fix pairs clear WCAG-AA (~4.5:1).

## Gates
- `npm ci` ✓
- `npm run build` (vite) ✓
- `npm run lint` / `tsc --noEmit` clean on touched file ✓
- dist/ not committed (gitignored)

DEPLOY-DEFERRED. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)