### PR TITLE
fix(extract): parse object-form @Controller({path,version}) base path so NestJS endpoints don't collapse across controllers (#4340)

### DIFF
--- a/internal/engine/http_endpoint_island_repro_4319_test.go
+++ b/internal/engine/http_endpoint_island_repro_4319_test.go
@@ -16,7 +16,7 @@ import (
 
 // #4319 LIVE REPRO + LONG-TERM-FIX gate.
 //
-// The endpoint `POST /inspections/me-manage/merge` (upvate-v3 BuildingController)
+// The endpoint `POST /v1/buildings/inspections/me-manage/merge` (upvate-v3 BuildingController)
 // was a graph ISLAND on the live graph after a full reindex, despite TWO prior
 // detect-and-repair fixes (#4326 bare↔qualified name match, #4330 file:line
 // co-location). Both reproduced in HAND-BUILT fixtures (handler StartLine set
@@ -103,7 +103,7 @@ func findMergeEndpoint(ents []types.EntityRecord) *types.EntityRecord {
 	for i := range ents {
 		if ents[i].Kind == httpEndpointDefinitionKind && ents[i].Properties != nil &&
 			ents[i].Properties["verb"] == "POST" &&
-			ents[i].Properties["path"] == "/inspections/me-manage/merge" {
+			ents[i].Properties["path"] == "/v1/buildings/inspections/me-manage/merge" {
 			return &ents[i]
 		}
 	}
@@ -178,7 +178,7 @@ func TestIslandRepro4319_SynthesisTimeBridgeEmitted(t *testing.T) {
 	if found == nil {
 		t.Fatal("no synthesis-time IMPLEMENTS bridge emitted for the NestJS merge route")
 	}
-	if found.ToID != httpEndpointDefinitionKind+":http:POST:/inspections/me-manage/merge" {
+	if found.ToID != httpEndpointDefinitionKind+":http:POST:/v1/buildings/inspections/me-manage/merge" {
 		t.Errorf("bridge ToID = %q, want endpoint stub", found.ToID)
 	}
 }
@@ -215,7 +215,7 @@ func TestIslandRepro4319_BridgeSurvivesLegacyFailure(t *testing.T) {
 	// The http-endpoint resolve pass alone CANNOT bridge this shape (no name, no
 	// line) — negative control proving the legacy paths are dead here.
 	mergedNoBridge, stats := ResolveHTTPEndpointHandlers(cloneEnts(ents))
-	if legacyBridged(mergedNoBridge, "http:POST:/inspections/me-manage/merge") {
+	if legacyBridged(mergedNoBridge, "http:POST:/v1/buildings/inspections/me-manage/merge") {
 		t.Fatalf("expected legacy resolve pass to FAIL on the no-handler/no-line shape (the live island), but it bridged (resolved=%d)", stats.HandlerResolved)
 	}
 

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -4383,12 +4383,147 @@ func isInlineExpressHandler(fullMatch, raw string) bool {
 // PRECEDING @Controller (by source position), so two controllers in one file
 // keep their own prefixes instead of collapsing onto the first.
 
-// nestControllerRe captures the class-level @Controller('prefix') value.
-// The prefix is optional (`@Controller()` → root prefix ""). Accepts single,
-// double, or backtick quotes.
-var nestControllerRe = regexp.MustCompile(
-	"@Controller\\s*\\(\\s*(?:['\"`]([^'\"`\\n\\r]*)['\"`])?\\s*\\)",
-)
+// nestControllerOpenRe locates the start of a class-level @Controller decorator
+// — `@Controller(` — without consuming its argument. The argument is then read
+// as a balanced span (nestjsBalancedArg) and parsed by nestjsParseControllerArg
+// so EVERY decorator form is supported, not just the bare-string one:
+//
+//	@Controller()                                       → prefix ""        (root)
+//	@Controller('users')                                → prefix "users"
+//	@Controller(['users', 'people'])                    → prefix "users"   (first host)
+//	@Controller({ path: 'users' })                      → prefix "users"
+//	@Controller({ path: 'users', version: '1' })        → prefix "v1/users"
+//	@Controller({ path: ['users','people'], version })  → prefix "v1/users"
+//
+// #4340: the previous regex matched ONLY the bare-string / empty forms; the
+// object form `@Controller({ path, version })` (the canonical NestJS style with
+// URI versioning) failed to match entirely, so the base path was DROPPED and
+// every controller's routes collapsed onto the verb+method-path alone.
+var nestControllerOpenRe = regexp.MustCompile(`@Controller\s*\(`)
+
+// nestjsFirstQuotedRe captures the FIRST quoted string in a span (single,
+// double, or backtick). Used to read the bare-string form and the first host
+// of an array form.
+var nestjsFirstQuotedRe = regexp.MustCompile("['\"`]([^'\"`\\r\\n]*)['\"`]")
+
+// nestjsPathPropRe captures the `path:` value of an object-form @Controller
+// argument when it is a single quoted string: `path: 'users'`.
+var nestjsPathPropRe = regexp.MustCompile(`\bpath\s*:\s*['"` + "`" + `]([^'"` + "`" + `\r\n]*)['"` + "`" + `]`)
+
+// nestjsPathArrayPropRe captures the `path:` value when it is an array literal,
+// so the first host can be read: `path: ['users', 'people']`.
+var nestjsPathArrayPropRe = regexp.MustCompile(`\bpath\s*:\s*\[([^\]]*)\]`)
+
+// nestjsVersionPropRe captures the `version:` value of an object-form
+// @Controller argument when it is a quoted string or bare number:
+// `version: '1'`, `version: "2"`, `version: 1`. NestJS also supports
+// VERSION_NEUTRAL and arrays of versions; those are treated as "no single URI
+// prefix" (handled by the caller leaving the version empty).
+var nestjsVersionPropRe = regexp.MustCompile(`\bversion\s*:\s*(?:['"` + "`" + `]([^'"` + "`" + `\r\n]*)['"` + "`" + `]|(\d+))`)
+
+// nestjsBalancedArg reads the balanced `( ... )` argument span that begins at
+// `openParen` (the index of the '(' in src). It returns the inner text (without
+// the surrounding parens) and the index just past the closing paren. Brackets
+// inside strings are ignored (reuses the same string-aware lexer as
+// nestjsBracketDelta). Returns ("", openParen+1) if unbalanced.
+func nestjsBalancedArg(src string, openParen int) (string, int) {
+	depth := 0
+	var quote byte
+	for i := openParen; i < len(src); i++ {
+		c := src[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			quote = c
+		case '(', '{', '[':
+			depth++
+		case ')', '}', ']':
+			depth--
+			if depth == 0 {
+				return src[openParen+1 : i], i + 1
+			}
+		}
+	}
+	return "", openParen + 1
+}
+
+// nestjsParseControllerArg parses the inner text of a @Controller(...) argument
+// (everything between the outer parens) into a route prefix, handling all
+// NestJS decorator forms. The returned prefix is NOT slash-normalised — the
+// caller joins it via joinPathFragments. Empty string means the root.
+//
+// Forms:
+//   - ""                              → ""            (@Controller())
+//   - "'users'"                       → "users"
+//   - "['users','people']"            → "users"       (first host wins)
+//   - "{ path: 'users' }"             → "users"
+//   - "{ path: 'users', version:'1'}" → "v1/users"    (URI versioning)
+//   - "{ version: '1' }"              → "v1"          (versioned root controller)
+//   - "{ path: ['a','b'], version }"  → "v1/a"
+func nestjsParseControllerArg(arg string) string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return ""
+	}
+	// Object form: `{ ... }`.
+	if strings.HasPrefix(arg, "{") {
+		path := ""
+		if m := nestjsPathPropRe.FindStringSubmatch(arg); m != nil {
+			path = m[1]
+		} else if m := nestjsPathArrayPropRe.FindStringSubmatch(arg); m != nil {
+			// path is an array literal — take the first quoted host.
+			if q := nestjsFirstQuotedRe.FindStringSubmatch(m[1]); q != nil {
+				path = q[1]
+			}
+		}
+		version := ""
+		if m := nestjsVersionPropRe.FindStringSubmatch(arg); m != nil {
+			if m[1] != "" {
+				version = m[1]
+			} else {
+				version = m[2]
+			}
+		}
+		return nestjsComposePrefix(version, path)
+	}
+	// Array form: `['users', 'people']` — first host wins.
+	if strings.HasPrefix(arg, "[") {
+		if q := nestjsFirstQuotedRe.FindStringSubmatch(arg); q != nil {
+			return q[1]
+		}
+		return ""
+	}
+	// Bare-string form: `'users'`.
+	if q := nestjsFirstQuotedRe.FindStringSubmatch(arg); q != nil {
+		return q[1]
+	}
+	return ""
+}
+
+// nestjsComposePrefix combines a NestJS URI version and a path into a single
+// route prefix. NestJS URI versioning mounts the version as a leading path
+// segment with the default `v` prefix (`/v1/...`). An empty version yields just
+// the path; an empty path with a version yields the bare version segment.
+func nestjsComposePrefix(version, path string) string {
+	path = strings.Trim(path, "/")
+	if version == "" {
+		return path
+	}
+	verSeg := "v" + strings.TrimPrefix(version, "v")
+	if path == "" {
+		return verSeg
+	}
+	return verSeg + "/" + path
+}
 
 // nestjsVerbPathRe captures a NestJS HTTP-verb method decorator and its
 // OPTIONAL first quoted path argument. It deliberately matches ONLY the verb
@@ -4543,15 +4678,19 @@ func synthesizeNestJS(content string, emit emitFn, emitDef emitDefFn) {
 	// index is used (rather than a byte offset) because the verb loop below is
 	// line-oriented; an @Controller decorator and its prefix sit on the same
 	// line in every practical NestJS source.
+	//
+	// Collection scans the WHOLE content (not line-by-line) so a multi-line
+	// object-form argument is read as one balanced span; the 0-based line index
+	// is derived from the byte offset of the decorator. nestjsParseControllerArg
+	// handles every form (#4340): bare-string, array, and
+	// object `{ path, version }` with NestJS URI versioning.
 	var controllers []nestController
-	for lineIdx, line := range lines {
-		for _, m := range nestControllerRe.FindAllStringSubmatch(line, -1) {
-			prefix := ""
-			if len(m) >= 2 {
-				prefix = m[1]
-			}
-			controllers = append(controllers, nestController{lineIdx: lineIdx, prefix: prefix})
-		}
+	for _, loc := range nestControllerOpenRe.FindAllStringIndex(content, -1) {
+		openParen := loc[1] - 1 // index of '(' (the regex ends just past it)
+		arg, _ := nestjsBalancedArg(content, openParen)
+		prefix := nestjsParseControllerArg(arg)
+		lineIdx := strings.Count(content[:loc[0]], "\n")
+		controllers = append(controllers, nestController{lineIdx: lineIdx, prefix: prefix})
 	}
 	// Map each byte offset's line to an index for the forward scan. We re-find
 	// the verb decorators on a per-line basis so the handler scan starts from

--- a/internal/engine/http_endpoint_synthesis_nestjs_object_controller_4340_test.go
+++ b/internal/engine/http_endpoint_synthesis_nestjs_object_controller_4340_test.go
@@ -1,0 +1,250 @@
+package engine
+
+// Regression test for #4340 — NestJS object-form `@Controller({ path, version })`
+// base path was not extracted, so the controller prefix was DROPPED and every
+// method route normalised identically across controllers, collapsing distinct
+// endpoints onto one synthetic ("defined in N controllers").
+//
+// Real source (core-backend-v3):
+//
+//	@Controller({ path: 'companies/inspection',  version: '1' })  inspection-company.controller.ts:17
+//	@Controller({ path: 'companies/witnessing',  version: '1' })  witnessing-company.controller.ts:17
+//	@Controller({ path: 'companies/contracting', version: '1' })  contracting-company.controller.ts:17
+//
+// Each declares a root `@Post()` (POST /) and a `@Post(':companyId/hide')`.
+// With the prefix dropped, all three collapse onto `http:POST:/` and
+// `http:POST:/{companyId}/hide`.
+
+import "testing"
+
+// The three real company controllers, object-form @Controller, byte-faithful
+// to the decorator + the two POST routes that collapse (root + hide).
+const nestObjFormInspection = `import { Body, Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Post, Req } from '@nestjs/common';
+
+@Controller({ path: 'companies/inspection', version: '1' })
+export class InspectionCompanyController {
+  constructor(private readonly service: InspectionCompanyService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() body: CreateInspectionCompanyBody): Promise<InspectionCompanyResponse> {
+    return this.service.create(body);
+  }
+
+  @Post(':companyId/hide')
+  @HttpCode(HttpStatus.OK)
+  hide(@Param('companyId', ParseIntPipe) companyId: number, @Body() body: HideCompanyBody): Promise<{ hidden: boolean }> {
+    return this.service.hide(companyId, body);
+  }
+}
+`
+
+const nestObjFormWitnessing = `import { Body, Controller, HttpCode, HttpStatus, Param, ParseIntPipe, Post } from '@nestjs/common';
+
+@Controller({ path: 'companies/witnessing', version: '1' })
+export class WitnessingCompanyController {
+  constructor(private readonly service: WitnessingCompanyService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() body: CreateWitnessingCompanyBody): Promise<WitnessingCompanyResponse> {
+    return this.service.create(body);
+  }
+
+  @Post(':companyId/hide')
+  @HttpCode(HttpStatus.OK)
+  hide(@Param('companyId', ParseIntPipe) companyId: number, @Body() body: HideCompanyBody): Promise<{ hidden: boolean }> {
+    return this.service.hide(companyId, body);
+  }
+}
+`
+
+const nestObjFormContracting = `import { Body, Controller, HttpCode, HttpStatus, Param, ParseIntPipe, Post } from '@nestjs/common';
+
+@Controller({ path: 'companies/contracting', version: '1' })
+export class ContractingCompanyController {
+  constructor(private readonly service: ContractingCompanyService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() body: CreateContractingCompanyBody): Promise<ContractingCompanyResponse> {
+    return this.service.create(body);
+  }
+
+  @Post(':companyId/hide')
+  @HttpCode(HttpStatus.OK)
+  hide(@Param('companyId', ParseIntPipe) companyId: number, @Body() body: HideCompanyBody): Promise<{ hidden: boolean }> {
+    return this.service.hide(companyId, body);
+  }
+}
+`
+
+// nestObjFormIDs runs detect on each controller file and returns the union of
+// endpoint synthetic IDs across the three (mirroring the cross-file merge that
+// collapses them in the real graph).
+func nestObjFormIDs(t *testing.T) []string {
+	t.Helper()
+	files := []struct{ path, src string }{
+		{"src/modules/inspection-companies/api/inspection-company.controller.ts", nestObjFormInspection},
+		{"src/modules/witnessing-companies/api/witnessing-company.controller.ts", nestObjFormWitnessing},
+		{"src/modules/contracting-companies/api/contracting-company.controller.ts", nestObjFormContracting},
+	}
+	seen := map[string]int{}
+	for _, f := range files {
+		ids, _ := runDetect(t, "typescript", f.path, f.src)
+		for _, id := range ids {
+			seen[id]++
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for id, n := range seen {
+		t.Logf("endpoint %s emitted by %d controller(s)", id, n)
+		out = append(out, id)
+	}
+	return out
+}
+
+// TestNestJS_ObjectFormController_4340_DistinctEndpoints proves the object-form
+// @Controller({path,version}) prefix is honoured: the three company controllers
+// produce three DISTINCT root POSTs and three DISTINCT hide endpoints, instead
+// of collapsing onto http:POST:/ and http:POST:/{companyId}/hide.
+//
+// Before the fix this test FAILS: the prefix is dropped and all three collapse.
+func TestNestJS_ObjectFormController_4340_DistinctEndpoints(t *testing.T) {
+	ids := nestObjFormIDs(t)
+	has := func(want string) bool {
+		for _, id := range ids {
+			if id == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The collapsed (buggy) IDs MUST NOT be present after the fix.
+	collapsed := []string{
+		"http:POST:/",
+		"http:POST:/{companyId}/hide",
+	}
+	for _, c := range collapsed {
+		if has(c) {
+			t.Errorf("#4340 COLLAPSE: prefix dropped, endpoints collapsed onto %q (got: %v)", c, ids)
+		}
+	}
+
+	// The three distinct controller-rooted endpoints MUST be present.
+	wantDistinct := []string{
+		"http:POST:/v1/companies/inspection",
+		"http:POST:/v1/companies/witnessing",
+		"http:POST:/v1/companies/contracting",
+		"http:POST:/v1/companies/inspection/{companyId}/hide",
+		"http:POST:/v1/companies/witnessing/{companyId}/hide",
+		"http:POST:/v1/companies/contracting/{companyId}/hide",
+	}
+	for _, w := range wantDistinct {
+		if !has(w) {
+			t.Errorf("#4340: missing distinct endpoint %q (got: %v)", w, ids)
+		}
+	}
+}
+
+// TestNestJS_AllControllerForms_4340 covers the full matrix of @Controller
+// argument forms so the generalization (not just the object form) is locked in.
+func TestNestJS_AllControllerForms_4340(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string // expected synthetic ID for the single @Get('x') route
+	}{
+		{
+			name: "no-arg root",
+			src: `@Controller()
+export class RootController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/x",
+		},
+		{
+			name: "bare string",
+			src: `@Controller('users')
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/users/x",
+		},
+		{
+			name: "array first-host",
+			src: `@Controller(['users', 'people'])
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/users/x",
+		},
+		{
+			name: "object path only",
+			src: `@Controller({ path: 'users' })
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/users/x",
+		},
+		{
+			name: "object path + version",
+			src: `@Controller({ path: 'users', version: '2' })
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/v2/users/x",
+		},
+		{
+			name: "object version-only root",
+			src: `@Controller({ version: '1' })
+export class RootController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/v1/x",
+		},
+		{
+			name: "object path-array + version",
+			src: `@Controller({ path: ['users', 'people'], version: '1' })
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/v1/users/x",
+		},
+		{
+			name: "object numeric version",
+			src: `@Controller({ path: 'users', version: 1 })
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/v1/users/x",
+		},
+		{
+			name: "object multiline",
+			src: `@Controller({
+  path: 'users',
+  version: '3',
+})
+export class UsersController {
+  @Get('x')
+  x() {}
+}`,
+			want: "http:GET:/v3/users/x",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, _ := runDetect(t, "typescript", "src/users/users.controller.ts", tc.src)
+			requireContains(t, ids, []string{tc.want}, tc.name)
+		})
+	}
+}


### PR DESCRIPTION
## #4340 — NestJS object-form `@Controller({ path, version })` base path dropped

**Severity: high** — corrupts the v3 endpoint model (distinct endpoints collapse onto one synthetic, "defined in N controllers").

### Root cause
`synthesizeNestJS` collected the class-level base path with a regex that matched ONLY the bare-string / empty forms:
```
@Controller\s*\(\s*(?:['"`]([^'"`]*)['"`])?\s*\)
```
The canonical NestJS style `@Controller({ path: 'companies/inspection', version: '1' })` did **not** match at all, so that controller was never recorded — methods fell back to the nearest *preceding* controller (or the `""` root). Every controller's method routes then normalised identically and merged into one endpoint.

### Live repro (BEFORE fix) — reproduced in test output
Three real `core-backend-v3` company controllers (object form), each with `@Post()` (root) and `@Post(':companyId/hide')`:
```
endpoint http:POST:/                       emitted by 3 controller(s)
endpoint http:POST:/{companyId}/hide       emitted by 3 controller(s)
COLLAPSE: prefix dropped, endpoints collapsed onto "http:POST:/"
```

### AFTER fix — reproduced in test output
```
http:POST:/v1/companies/inspection                    (1 controller)
http:POST:/v1/companies/witnessing                    (1 controller)
http:POST:/v1/companies/contracting                   (1 controller)
http:POST:/v1/companies/inspection/{companyId}/hide   (1 controller)
http:POST:/v1/companies/witnessing/{companyId}/hide   (1 controller)
http:POST:/v1/companies/contracting/{companyId}/hide  (1 controller)
```
6 DISTINCT endpoints, each emitted by exactly 1 controller. Collapse gone.

### Fix
Replaced the bare-string regex with a balanced-argument parser (`nestjsParseControllerArg`) that handles **every** `@Controller` form:

| Form | Prefix |
|---|---|
| `@Controller()` | `` (root) |
| `@Controller('users')` | `users` |
| `@Controller(['users','people'])` | `users` (first host) |
| `@Controller({ path: 'users' })` | `users` |
| `@Controller({ path: 'users', version: '1' })` | `v1/users` |
| `@Controller({ path: ['a','b'], version: '1' })` | `v1/a` |
| `@Controller({ version: '1' })` | `v1` |
| numeric / multi-line object | handled |

**Version handling:** NestJS URI versioning mounts the version as a leading path segment with the default `v` prefix (`version: '1'` → `/v1/...`), so it composes as `v<n>/<path>`. Matches NestJS's default URI-versioning behaviour and aligns with the buildings controller already expecting `/v1/buildings/...`.

Collection now scans the whole file (not line-by-line) so multi-line object args read as one balanced span; the line index is derived from the byte offset.

### Tests
- `http_endpoint_synthesis_nestjs_object_controller_4340_test.go` — the live repro (collapse → distinct) + a full form-matrix table test (9 forms).
- Updated `http_endpoint_island_repro_4319_test.go`: its fixture uses the object form and had baked in the dropped-prefix path; corrected to `/v1/buildings/inspections/me-manage/merge`.

### Generalization / follow-ups
Surveyed analogous class-level base-path decorators:
- **JAX-RS `@Path`**, **Struts `@Namespace`** — string-only by framework API; no object/array gap.
- **FastAPI `APIRouter(prefix=)`**, **Spring `@RequestMapping`** — composed by the AST passes, not this regex synthesizer.
The object/array-arg gap is NestJS-decorator-specific. No sibling string-form gap found in the regex synthesizers; #4334 children can track any future per-framework object/array-arg audit.

### Gates (native)
`go build ./...`, `go vet`, `gofmt -l` clean; `go test ./internal/types/`, `./internal/custom/...`, `./internal/engine` all green.

**DEPLOY-DEFERRED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)