### PR TITLE
feat(flows): root process-flows at HTTP endpoints + keep short endpoint flows (#4344)

### DIFF
--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -197,8 +197,28 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 	if len(candidates) == 0 {
 		return stats
 	}
+	// #4344 — the MaxEntryPoints cap applies only to NON-endpoint candidates.
+	// Every http_endpoint_definition root is retained so the flow count can
+	// approach the endpoint count: an endpoint root must never be starved by
+	// brokers / UI components competing for the 200 slots. Candidates are in
+	// descending-score order, and all endpoint roots carry the dominating
+	// httpEndpointEntryScore, so they already cluster at the front — but we
+	// cap explicitly on the non-endpoint suffix to keep the guarantee
+	// independent of the exact score constants.
 	if len(candidates) > cfg.MaxEntryPoints {
-		candidates = candidates[:cfg.MaxEntryPoints]
+		capped := make([]entryCandidate, 0, len(candidates))
+		nonEndpoint := 0
+		for _, c := range candidates {
+			if isHTTPEndpointDefinition(byID[c.id]) {
+				capped = append(capped, c)
+				continue
+			}
+			if nonEndpoint < cfg.MaxEntryPoints {
+				capped = append(capped, c)
+				nonEndpoint++
+			}
+		}
+		candidates = capped
 	}
 	// Drop entries that are reachable from a higher-ranked entry — those
 	// are mid-chain functions, not true entry points. This collapses the
@@ -258,6 +278,17 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 		// is load-bearing so we keep them.
 		minSteps := cfg.MinSteps
 		if chainHasFetchesEdge(chain, adj) || chainCrossesRepo(chain, adj) {
+			minSteps = 2
+		}
+		// #4344 — endpoint-rooted flows are exempt from the MinSteps cutoff.
+		// Every HTTP endpoint with a handler should yield a flow labeled by
+		// route, even a short one (endpoint → handler → service is only 3
+		// steps; endpoint → handler is 2). Dropping these for being short is
+		// exactly the bug that starved the flow count below the endpoint
+		// count. The root resolving to an http_endpoint_definition is the
+		// authoritative signal; 2 is the floor so a bare endpoint with no
+		// reachable handler step still can't emit a 1-node flow.
+		if isHTTPEndpointDefinition(byID[chain[0]]) {
 			minSteps = 2
 		}
 		if len(chain) < minSteps {
@@ -936,6 +967,17 @@ func isConsumerHTTPEndpoint(e *graph.Entity) bool {
 	// Fallback: the consumer side stamps `source_caller` on every entity.
 	_, hasCaller := e.Properties["source_caller"]
 	return hasCaller
+}
+
+// isHTTPEndpointDefinition reports whether an entity is a producer-side
+// http_endpoint_definition — the route node that #4344 roots process-flows
+// at. Used to exempt endpoint-rooted flows from the MinSteps cutoff and to
+// derive the route label for the Process.
+func isHTTPEndpointDefinition(e *graph.Entity) bool {
+	if e == nil {
+		return false
+	}
+	return strings.EqualFold(e.Kind, "http_endpoint_definition")
 }
 
 // chainCrossesExternalLib captures the OLD `chainCrossesStack ||

--- a/internal/engine/process_flow_endpoint_root_4344_test.go
+++ b/internal/engine/process_flow_endpoint_root_4344_test.go
@@ -1,0 +1,208 @@
+// process_flow_endpoint_root_4344_test.go — tests for issue #4344.
+//
+// #4344 roots process-flows at the HTTP endpoint via the reversed-IMPLEMENTS
+// bridge (#4319) and stops dropping short endpoint-rooted flows, so every
+// endpoint with a handler yields a flow labeled by route.
+//
+// Shape under test:
+//
+//	http_endpoint_definition --IMPLEMENTS--> handler --CALLS--> service --CALLS--> repo
+//
+// Assertions:
+//  1. The emitted Process ROOTS at the endpoint (step 1 = endpoint, label =
+//     route) and spans endpoint → handler → service → repo with no
+//     double-counting of the handler.
+//  2. A SHORT endpoint flow (endpoint → handler → service, 2 hops) is NOT
+//     dropped by the MinSteps cutoff.
+//  3. Broker / scheduled entry flows are unchanged (guard against regression).
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// endpointRootDoc builds the canonical
+// endpoint --IMPLEMENTS--> handler --CALLS--> service --CALLS--> repo shape.
+// The route label is intentionally distinct from the handler function name so
+// the test can assert the flow is labeled by ROUTE, not by function.
+func endpointRootDoc(repo string) *graph.Document {
+	return &graph.Document{
+		Repo: repo,
+		Entities: []graph.Entity{
+			{ID: "ep:latest", Name: "GET /buildings/{id}/latest", Kind: "http_endpoint_definition",
+				Language: "python", SourceFile: "urls.py",
+				Properties: map[string]string{"http_method": "GET", "route": "/buildings/{id}/latest"}},
+			{ID: "fn:latest", Name: "BuildingViewSet.latest", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "views.py"},
+			{ID: "fn:service", Name: "BuildingService.get_latest", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "service.py"},
+			{ID: "fn:repo", Name: "BuildingRepository.fetch", Kind: "SCOPE.Operation",
+				Language: "python", SourceFile: "repo.py"},
+		},
+		Relationships: []graph.Relationship{
+			// handler IMPLEMENTS endpoint — reversed into a continuation edge.
+			{ID: "impl:1", FromID: "fn:latest", ToID: "ep:latest", Kind: "IMPLEMENTS"},
+			// handler CALLS chain.
+			{ID: "c:1", FromID: "fn:latest", ToID: "fn:service", Kind: "CALLS"},
+			{ID: "c:2", FromID: "fn:service", ToID: "fn:repo", Kind: "CALLS"},
+		},
+	}
+}
+
+// Test 1 — the Process roots at the endpoint and spans the full chain.
+func TestProcessFlow_4344_RootsAtEndpoint(t *testing.T) {
+	doc := endpointRootDoc("fixture-4344")
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+
+	p := findProcessByEntry(doc, "ep:latest")
+	if p == nil {
+		t.Fatalf("no Process rooted at the endpoint ep:latest; processes: %v", allProcessProps(doc))
+	}
+	chain := strings.Split(p.Properties["chain"], ",")
+	want := []string{"ep:latest", "fn:latest", "fn:service", "fn:repo"}
+	if len(chain) != len(want) {
+		t.Fatalf("chain length = %d, want %d; chain=%v", len(chain), len(want), chain)
+	}
+	for i := range want {
+		if chain[i] != want[i] {
+			t.Fatalf("chain[%d] = %q, want %q; chain=%v", i, chain[i], want[i], chain)
+		}
+	}
+	// Step 1 (index 0) must be the endpoint.
+	if chain[0] != "ep:latest" {
+		t.Fatalf("step 1 is not the endpoint: %q", chain[0])
+	}
+	// Label / entry_name must be the ROUTE, not the handler function name.
+	if !strings.Contains(p.Name, "GET /buildings/{id}/latest") {
+		t.Errorf("Process label %q is not the route; expected the route as the entry label", p.Name)
+	}
+	if p.Properties["entry_name"] != "GET /buildings/{id}/latest" {
+		t.Errorf("entry_name = %q, want the route", p.Properties["entry_name"])
+	}
+	if p.Properties["entry_kind"] != "http" {
+		t.Errorf("entry_kind = %q, want http", p.Properties["entry_kind"])
+	}
+	// No double-counting: the handler appears exactly once.
+	handlerCount := 0
+	for _, s := range chain {
+		if s == "fn:latest" {
+			handlerCount++
+		}
+	}
+	if handlerCount != 1 {
+		t.Errorf("handler fn:latest appears %d times in the chain (double-counting); chain=%v", handlerCount, chain)
+	}
+	// And there must NOT also be a separate flow rooted at the handler — the
+	// route would otherwise be counted twice.
+	if hp := findProcessByEntry(doc, "fn:latest"); hp != nil {
+		t.Errorf("a redundant Process is rooted at the handler fn:latest; route double-counted")
+	}
+}
+
+// Test 2 — a SHORT endpoint flow (endpoint → handler → service, 2 hops, 3
+// steps once rooted) is NOT dropped. The pre-#4344 default MinSteps=3 only
+// counted handler-rooted steps (handler → service = 2 < 3) and dropped these.
+func TestProcessFlow_4344_ShortEndpointFlowNotDropped(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "fixture-4344-short",
+		Entities: []graph.Entity{
+			{ID: "ep:ping", Name: "GET /ping", Kind: "http_endpoint_definition",
+				Language: "go", SourceFile: "routes.go"},
+			{ID: "fn:ping", Name: "PingHandler", Kind: "SCOPE.Function",
+				Language: "go", SourceFile: "handler.go"},
+			{ID: "fn:status", Name: "StatusService.check", Kind: "SCOPE.Function",
+				Language: "go", SourceFile: "status.go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "impl:1", FromID: "fn:ping", ToID: "ep:ping", Kind: "IMPLEMENTS"},
+			{ID: "c:1", FromID: "fn:ping", ToID: "fn:status", Kind: "CALLS"},
+		},
+	}
+	cfg := DefaultProcessFlowConfig() // MinSteps = 3
+	stats := RunProcessFlow(doc, cfg)
+	if stats.Processes == 0 {
+		t.Fatalf("short endpoint flow was dropped; expected ≥1 Process")
+	}
+	p := findProcessByEntry(doc, "ep:ping")
+	if p == nil {
+		t.Fatalf("short endpoint flow not rooted at endpoint; processes: %v", allProcessProps(doc))
+	}
+	chain := strings.Split(p.Properties["chain"], ",")
+	want := []string{"ep:ping", "fn:ping", "fn:status"}
+	if strings.Join(chain, ",") != strings.Join(want, ",") {
+		t.Fatalf("short chain = %v, want %v", chain, want)
+	}
+}
+
+// Test 3 — even a 2-step endpoint → handler flow (handler is a leaf) survives.
+func TestProcessFlow_4344_TwoStepEndpointFlowSurvives(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "fixture-4344-tiny",
+		Entities: []graph.Entity{
+			{ID: "ep:health", Name: "GET /health", Kind: "http_endpoint_definition",
+				Language: "go", SourceFile: "routes.go"},
+			{ID: "fn:health", Name: "HealthHandler", Kind: "SCOPE.Function",
+				Language: "go", SourceFile: "handler.go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "impl:1", FromID: "fn:health", ToID: "ep:health", Kind: "IMPLEMENTS"},
+		},
+	}
+	stats := RunProcessFlow(doc, DefaultProcessFlowConfig())
+	if stats.Processes == 0 {
+		t.Fatalf("2-step endpoint→handler flow was dropped; expected 1 Process")
+	}
+	p := findProcessByEntry(doc, "ep:health")
+	if p == nil {
+		t.Fatalf("2-step flow not rooted at endpoint; processes: %v", allProcessProps(doc))
+	}
+	if got := p.Properties["chain"]; got != "ep:health,fn:health" {
+		t.Fatalf("chain = %q, want ep:health,fn:health", got)
+	}
+}
+
+// Test 4 (guard) — broker / scheduled entry flows are unchanged: they do NOT
+// root at an endpoint and keep their broker entry_kind + handler root.
+func TestProcessFlow_4344_BrokerFlowsUnchanged(t *testing.T) {
+	// Kafka consumer — must still root at the handler with entry_kind kafka_consumer.
+	kdoc := buildKafkaConsumerDoc("fixture-4344-broker")
+	RunProcessFlow(kdoc, DefaultProcessFlowConfig())
+	kp := processWithEntryKind(kdoc, "kafka_consumer")
+	if kp == nil {
+		t.Fatalf("kafka consumer flow regressed; processes: %v", allProcessProps(kdoc))
+	}
+	if kp.Properties["chain"] == "" || strings.HasPrefix(kp.Properties["entry_name"], "GET ") {
+		t.Errorf("kafka flow unexpectedly rooted at an endpoint: %v", kp.Properties)
+	}
+	// The kafka chain must still root at the handler op:onFeedback.
+	if got := strings.Split(kp.Properties["chain"], ",")[0]; got != "op:onFeedback" {
+		t.Errorf("kafka flow root = %q, want op:onFeedback", got)
+	}
+
+	// Scheduled handler — must still root at the handler with entry_kind scheduled.
+	sdoc := &graph.Document{
+		Repo: "fixture-4344-sched",
+		Entities: []graph.Entity{
+			{ID: "job:cleanup", Name: "scheduled:cleanup", Kind: "SCOPE.ScheduledJob", Language: "java", SourceFile: "CleanupJob.java"},
+			{ID: "op:cleanup", Name: "CleanupJob.cleanup", Kind: "SCOPE.Operation", Language: "java", SourceFile: "CleanupJob.java"},
+			{ID: "op:del", Name: "RecordStore.deleteExpired", Kind: "SCOPE.Operation", Language: "java", SourceFile: "RecordStore.java"},
+			{ID: "op:notify", Name: "NotificationService.send", Kind: "SCOPE.Operation", Language: "java", SourceFile: "NotificationService.java"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "tr:1", FromID: "job:cleanup", ToID: "op:cleanup", Kind: "TRIGGERS"},
+			{ID: "c:1", FromID: "op:cleanup", ToID: "op:del", Kind: "CALLS"},
+			{ID: "c:2", FromID: "op:del", ToID: "op:notify", Kind: "CALLS"},
+		},
+	}
+	RunProcessFlow(sdoc, DefaultProcessFlowConfig())
+	sp := processWithEntryKind(sdoc, "scheduled")
+	if sp == nil {
+		t.Fatalf("scheduled flow regressed; processes: %v", allProcessProps(sdoc))
+	}
+	if got := strings.Split(sp.Properties["chain"], ",")[0]; got != "op:cleanup" {
+		t.Errorf("scheduled flow root = %q, want op:cleanup", got)
+	}
+}

--- a/internal/engine/process_flow_entry.go
+++ b/internal/engine/process_flow_entry.go
@@ -44,9 +44,29 @@ type entryCandidate struct {
 	entryKind string // e.g. "http", "kafka_consumer", "scheduled", "websocket", "webhook", ""
 }
 
+// httpEndpointEntryScore is the score assigned to an http_endpoint_definition
+// that roots a process-flow (#4344). It sits ABOVE the additive ceiling any
+// handler/broker/UI candidate can reach (fan-out is unbounded in principle,
+// but in practice the +6 HTTP boost + a few name/export points caps real
+// handlers well below this) so endpoint roots are never starved by the
+// MaxEntryPoints cap when they compete with brokers / UI components. The
+// large constant also keeps the deterministic sort stable: all endpoint roots
+// cluster at the top, ordered among themselves by canonical ID (the #481
+// ID-tiebreak contract).
+const httpEndpointEntryScore = 1000.0
+
 // rankEntryPoints scores every Function/Method/Operation/Component entity
 // and returns the candidates in descending score order. Candidates with
 // score ≤ 0 (heavy utility penalty, no fan-out) are dropped.
+//
+// #4344 — http_endpoint_definition entities are ALSO scored as entry
+// candidates when they have a reversed-IMPLEMENTS continuation edge to a
+// backend handler (recorded in adj.handlerCont). Rooting the flow at the
+// endpoint makes the route (e.g. "GET /…/latest") step 1 and labels the
+// flow by route rather than by the handler function name. The handler is
+// then pruned as a separate entry by pruneReachableEntries (it is reachable
+// from the endpoint via the continuation edge), so the route is not
+// double-counted.
 func rankEntryPoints(doc *graph.Document, byID map[string]*graph.Entity, adj *callsAdjacency, cfg ProcessFlowConfig) []entryCandidate {
 	// HTTP-boundary signal: any entity on either side of an IMPLEMENTS /
 	// ROUTES_TO / SERVES edge is almost certainly an entry point (or the
@@ -141,6 +161,33 @@ func rankEntryPoints(doc *graph.Document, byID map[string]*graph.Entity, adj *ca
 			continue
 		}
 		out = append(out, entryCandidate{id: e.ID, name: e.Name, kind: e.Kind, score: score, entryKind: entryKind})
+	}
+
+	// #4344 — root flows at the HTTP endpoint. Any http_endpoint_definition
+	// that has a reversed-IMPLEMENTS continuation edge to a backend handler
+	// (adj.handlerCont[endpoint → handler]) is promoted to an entry candidate
+	// with a dominating score so it is never starved by MaxEntryPoints. The
+	// endpoint becomes step 1; its handler (and the handler's CALLS chain)
+	// follow via the continuation edge. The handler is dropped as a separate
+	// entry by pruneReachableEntries, so the route is not double-counted.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if !strings.EqualFold(e.Kind, "http_endpoint_definition") {
+			continue
+		}
+		// Only endpoints that actually continue into a handler can root a
+		// real (non-fabricated) flow. handlerCont edges originate at the
+		// endpoint, so a non-empty out-list here means a continuation exists.
+		if len(adj.out[e.ID]) == 0 {
+			continue
+		}
+		out = append(out, entryCandidate{
+			id:        e.ID,
+			name:      e.Name,
+			kind:      e.Kind,
+			score:     httpEndpointEntryScore,
+			entryKind: "http",
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {


### PR DESCRIPTION
Closes #4344. Part of resolution-coverage epic #4334. **DEPLOY-DEFERRED** (flow-count rise is only measurable post-reindex).

## Problem
Only **44 flows for 369 endpoints**. Flows seeded from heuristic entry points and rooted at the handler FUNCTION (`latest`, `list`), so they were labeled by function not route, and the endpoint was not step 1. Short handler chains were also dropped by `MinSteps: 3`.

## Changes

### 1. Root flows at the endpoint (via the IMPLEMENTS bridge)
`buildCallsAdjacencyMulti` already reverses `handler --IMPLEMENTS--> http_endpoint_definition` into a continuation edge `endpoint -> handler` (`adj.handlerCont`, #1639/#4316). This PR makes the endpoint the **root**:
- `rankEntryPoints` promotes every `http_endpoint_definition` that has a `handlerCont` outgoing edge to an entry candidate with a dominating score (`httpEndpointEntryScore`).
- The DAG walk begins at the endpoint (step 1), follows the continuation edge into the handler, then chains the handler's own `CALLS` forward (handler -> service -> repo).
- The handler is pruned as a separate entry by `pruneReachableEntries` (it is reachable from the endpoint), so the route is **not double-counted**.
- The `Process` label / `entry_name` becomes the route (e.g. `GET /…/latest`), `entry_kind=http`.

No fabricated steps: only real `IMPLEMENTS`/`CALLS` edges are traversed. An endpoint with no reachable handler produces no flow.

### 2. Keep short endpoint-rooted flows
- **MinSteps exemption:** when `chain[0]` resolves to an `http_endpoint_definition`, the cutoff drops to 2, so `endpoint -> handler -> service` (3 steps) and even `endpoint -> handler` (2 steps) survive.
- **MaxEntryPoints exemption:** the 200-entry cap now applies only to *non-endpoint* candidates, so endpoint roots are never starved by brokers / UI components competing for slots. Flow count can now approach endpoint count.

## Why brokers / UI are not regressed
The new behavior keys strictly off `Kind == http_endpoint_definition` plus the existing `handlerCont` edge (only produced by reversing `handler --IMPLEMENTS--> http_endpoint_definition`). Broker entries (`SUBSCRIBES_TO` / `WS_SUBSCRIBES_TO` / `TRIGGERS`) and UI entries (`SCOPE.JSX`) never carry a `handlerCont` edge, so they keep their handler root and broker/UI `entry_kind`. Note the existing `TestBrokerEntry_HTTPHandlerNotRegressed` fixture uses kind `http_endpoint` (not `http_endpoint_definition`) and is therefore untouched — still rooted at the handler with `entry_kind=http`.

Determinism (#481 ID-tiebreak) preserved: endpoint roots cluster at the top and sort among themselves by canonical ID; the emit sort and `MaxProcesses` cap are unchanged.

## Tests (`internal/engine/process_flow_endpoint_root_4344_test.go`)
- `RootsAtEndpoint` — `endpoint --IMPLEMENTS--> handler --CALLS--> service --CALLS--> repo`: Process roots at the endpoint (step 1 = endpoint, label = route), spans all 4 nodes, handler appears once, no redundant handler-rooted Process.
- `ShortEndpointFlowNotDropped` — `endpoint -> handler -> service` (3 steps) survives default `MinSteps=3`.
- `TwoStepEndpointFlowSurvives` — bare `endpoint -> handler` (2 steps) survives.
- `BrokerFlowsUnchanged` — Kafka + scheduled flows still root at their handler with the right `entry_kind`.

## Gates
`go build ./...` clean; full `go test ./internal/engine` green (incl. all `Flow|Process|Entry|Broker` + #481/#4316/#1893 determinism tests); `go vet` and `gofmt -l` clean.

## Expected impact
Flow count rises toward the endpoint count (369): every endpoint with a handler now yields one route-labeled flow, and short handler chains are no longer dropped. Exact post-reindex numbers are deploy-deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)