### PR TITLE
feat(extract): surface NestJS endpoint params (@Param/@Query/@Body), response type, and TESTS edges (#4325)

### DIFF
--- a/internal/custom/javascript/issue4325_livedrepro_test.go
+++ b/internal/custom/javascript/issue4325_livedrepro_test.go
@@ -1,0 +1,136 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4325 LIVE-REPRO. Byte-copies of the REAL upvate-v3 controllers are
+// committed alongside this test as _repro_*.ts.txt. We run the actual
+// nestjs extractor over them and assert on the endpoint's surfaced params,
+// response_type, and edges — first proving the gap, then the fix.
+
+func loadRepro(t *testing.T, base string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "issue4325", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read repro %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: "src/" + base, Language: "typescript", Content: b}
+}
+
+func nestEndpoint(t *testing.T, file extreg.FileInput, methodName string) types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_nestjs")
+	if !ok {
+		t.Fatal("custom_js_nestjs not registered")
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, ent := range ents {
+		if ent.Subtype == "endpoint" && ent.Properties["method_name"] == methodName {
+			return ent
+		}
+	}
+	t.Fatalf("endpoint with method_name=%q not found among %d entities", methodName, len(ents))
+	return types.EntityRecord{}
+}
+
+func dumpEndpoint(t *testing.T, ep types.EntityRecord) {
+	t.Logf("ENDPOINT name=%q verb=%s path=%q method=%q",
+		ep.Name, ep.Properties["http_method"], ep.Properties["route_path"], ep.Properties["method_name"])
+	t.Logf("  parameters prop = %q", ep.Properties["parameters"])
+	t.Logf("  response_type prop = %q", ep.Properties["response_type"])
+	for _, r := range ep.Relationships {
+		t.Logf("  EDGE %s -> %s  props=%v", r.Kind, r.ToID, r.Properties)
+	}
+}
+
+// device.controller.ts `filters` handler: two @Query params + Promise<DeviceFiltersResponse>.
+func TestIssue4325_LiveRepro_DeviceFilters(t *testing.T) {
+	ep := nestEndpoint(t, loadRepro(t, "device.controller.ts"), "filters")
+	dumpEndpoint(t, ep)
+
+	// --- ASSERT FIX (after) ---
+	params := ep.Properties["parameters"]
+	if params == "" {
+		t.Errorf("GAP: parameters empty — @Query('group_id')/@Query('building_id') not surfaced")
+	}
+	if !strings.Contains(params, "group_id") || !strings.Contains(params, "building_id") {
+		t.Errorf("GAP: query params group_id/building_id missing from parameters=%q", params)
+	}
+	if rt := ep.Properties["response_type"]; rt != "DeviceFiltersResponse" {
+		t.Errorf("GAP: response_type=%q, want DeviceFiltersResponse", rt)
+	}
+}
+
+// building.controller.ts `createNote` handler: @Body() BuildingNoteCreateBody + Promise<BuildingNoteCreateResponse>.
+func TestIssue4325_LiveRepro_BuildingCreateNote(t *testing.T) {
+	ep := nestEndpoint(t, loadRepro(t, "building.controller.ts"), "createNote")
+	dumpEndpoint(t, ep)
+
+	params := ep.Properties["parameters"]
+	if !strings.Contains(params, "BuildingNoteCreateBody") {
+		t.Errorf("GAP: @Body() DTO BuildingNoteCreateBody not surfaced as a body param; parameters=%q", params)
+	}
+	if rt := ep.Properties["response_type"]; rt != "BuildingNoteCreateResponse" {
+		t.Errorf("GAP: response_type=%q, want BuildingNoteCreateResponse", rt)
+	}
+}
+
+// Synthetic unit coverage for the decorator-stacking + param mechanisms that
+// the real fixtures exercise, kept compact so the wire shape is asserted
+// directly (the fixtures assert end-to-end on real source).
+func TestIssue4325_DecoratorStacking_And_Params(t *testing.T) {
+	src := `
+import { Controller, Get, Post, Body, Query, Param, HttpCode, HttpStatus } from '@nestjs/common';
+@Controller('things')
+export class ThingController {
+  @Get(':id')
+  one(@Param('id') id: string, @Query('q') q: string): Promise<ThingResponse> {
+    return this.svc.one(id);
+  }
+
+  @Post('create')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(AuthGuard)
+  create(@Body() dto: CreateThingDto): Promise<ThingResponse> {
+    return this.svc.create(dto);
+  }
+}
+`
+	one := nestEndpoint(t, fi("t.ts", "typescript", src), "one")
+	if got := one.Properties["http_method"]; got != "GET" {
+		t.Errorf("one verb=%q want GET", got)
+	}
+	if p := one.Properties["parameters"]; !strings.Contains(p, `"in":"path"`) || !strings.Contains(p, `"in":"query"`) {
+		t.Errorf("one parameters missing path/query: %q", p)
+	}
+	if rt := one.Properties["response_type"]; rt != "ThingResponse" {
+		t.Errorf("one response_type=%q want ThingResponse", rt)
+	}
+
+	// The POST sits behind @HttpCode + @UseGuards — pre-#4325 it would be
+	// dropped entirely by the adjacency-only verb regex.
+	create := nestEndpoint(t, fi("t.ts", "typescript", src), "create")
+	if got := create.Properties["http_method"]; got != "POST" {
+		t.Errorf("create verb=%q want POST (decorator stacking regression)", got)
+	}
+	if p := create.Properties["parameters"]; !strings.Contains(p, `"in":"body"`) || !strings.Contains(p, "CreateThingDto") {
+		t.Errorf("create parameters missing body DTO: %q", p)
+	}
+	if rt := create.Properties["response_type"]; rt != "ThingResponse" {
+		t.Errorf("create response_type=%q want ThingResponse", rt)
+	}
+}

--- a/internal/custom/javascript/nestjs.go
+++ b/internal/custom/javascript/nestjs.go
@@ -32,8 +32,17 @@ var (
 	reNestInjectable = regexp.MustCompile(
 		`@Injectable\s*\([^)]*\)\s*(?:export\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
 	)
+	// reNestHTTPMethod matches a verb decorator and the handler method name.
+	// Real NestJS handlers stack additional decorators between the verb
+	// decorator and the method signature — `@HttpCode(HttpStatus.OK)`,
+	// `@UseGuards(...)`, `@Header(...)`, `@RequirePage(...)` — so we skip a run
+	// of intervening decorators (each optionally taking a single-level
+	// argument list) plus visibility/async modifiers before the method name.
+	// Before #4325 the regex required the verb decorator to be immediately
+	// adjacent to the method, so EVERY @Post/@Patch that set @HttpCode (the
+	// dominant POST idiom) was silently dropped from the endpoint inventory.
 	reNestHTTPMethod = regexp.MustCompile(
-		`@(Get|Post|Put|Delete|Patch|Options|Head|All)\s*\(([^)]*)\)\s*(?:async\s+)?(\w+)\s*\(`,
+		`@(Get|Post|Put|Delete|Patch|Options|Head|All)\s*\(([^)]*)\)\s*(?:@[A-Za-z_]\w*(?:\s*\([^()]*\))?\s*)*(?:public\s+|private\s+|protected\s+|async\s+)*(\w+)\s*\(`,
 	)
 	// reNestBodyParam captures a @Body()-decorated handler parameter and its DTO
 	// type: `@Body() dto: CreateUserDto`. Plain @Body() with no type yields no
@@ -288,6 +297,24 @@ func (e *nestjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 				},
 			})
 		}
+
+		// #4325 — surface the handler's @Param/@Query/@Body decorators in the
+		// `parameters` property (the Paths panel reads this, NOT the edges) so
+		// the Parameters table lists path/query/body params. The @Body DTO row
+		// agrees with the ACCEPTS_INPUT edge above.
+		if params := extractNestHandlerParams(paramsBlock); len(params) > 0 {
+			if pj := encodeNestParams(params); pj != "" {
+				setProps(&ent, "parameters", pj)
+			}
+			// Surface request-body type/name for the dashboard's body fields.
+			for _, p := range params {
+				if p.In == "body" {
+					setProps(&ent, "request_body_type", p.Type, "request_body_param_name", p.Name)
+					break
+				}
+			}
+		}
+
 		if rm := reNestReturnType.FindStringSubmatch(src[closeOff+1 : min(closeOff+200, len(src))]); rm != nil {
 			if dto := nestUnwrapType(rm[1]); dto != "" {
 				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
@@ -297,6 +324,11 @@ func (e *nestjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 						"framework": "nestjs", "match_source": "return_type_annotation", "dto_type": dto,
 					},
 				})
+				// #4325 — the RETURNS edge alone made the Paths panel count a
+				// response but render "(none)" because the Response row reads
+				// the `response_type` PROPERTY, which was never set. Set it so
+				// the actual DTO name renders.
+				setProps(&ent, "response_type", dto)
 			}
 		}
 		addEntity(ent)

--- a/internal/custom/javascript/nestjs_params.go
+++ b/internal/custom/javascript/nestjs_params.go
@@ -1,0 +1,172 @@
+// NestJS endpoint Parameters + Response-type surfacing (#4325).
+//
+// Before #4325 the nestjs extractor emitted endpoint→DTO ACCEPTS_INPUT/RETURNS
+// edges but never populated the `parameters` and `response_type` entity
+// properties that the dashboard Paths panel actually reads
+// (internal/dashboard/v2_paths.go → handleV2PathDetail). The live-repro on the
+// real upvate-v3 controllers confirmed:
+//
+//   - GET /filters (device.controller.ts `filters`): Parameters (0) despite two
+//     @Query('group_id')/@Query('building_id') params → @Query never surfaced.
+//   - POST /notes/create (building.controller.ts `createNote`): Parameters (0)
+//     despite @Body() BuildingNoteCreateBody → @Body not surfaced as a param.
+//   - Both: Response shows "(none)" — the RETURNS edge was emitted (so the panel
+//     COUNTED a response) but `response_type` was never set, so the type name
+//     resolved to nothing. This was a property/edge split.
+//
+// This pass parses the handler parameter list and the trailing return-type
+// annotation, then writes:
+//   - `parameters` — a JSON []nestParam list (path/query/body kinds), the exact
+//     wire shape the dashboard's engine.DecodeJavaParameters consumes.
+//   - `response_type` — the resolved response DTO name (unwrapped from
+//     Promise/Observable/Array), the property the Response row renders.
+//
+// The shape mirrors engine.JavaParam (name/in/type/required/default_value/
+// annotations) so the dashboard renders NestJS params identically to Spring /
+// JAX-RS params with no dashboard change. We deliberately re-declare the wire
+// struct locally rather than importing internal/engine, to avoid a package
+// dependency edge from a custom extractor into the engine.
+package javascript
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// nestParam is the JSON wire shape consumed by the dashboard Parameters table
+// (engine.JavaParam). Keep the json tags byte-identical.
+type nestParam struct {
+	Name         string   `json:"name"`
+	In           string   `json:"in"` // path|query|body|header|cookie
+	Type         string   `json:"type"`
+	Required     bool     `json:"required"`
+	DefaultValue string   `json:"default_value,omitempty"`
+	Annotations  []string `json:"annotations,omitempty"`
+}
+
+var (
+	// reNestParamDecorator matches a single param decorator + the parameter
+	// declaration it annotates within a handler parameter list. Handles:
+	//   @Param('id') id: string
+	//   @Query('group_id', ParseIntPipe) groupId: number
+	//   @Query() optional: SomeQueryDto
+	//   @Body() body: SomeBodyDto
+	//   @Body('field') field: string
+	// Group 1 = decorator (Param|Query|Body|Headers|Header|Req|Request|...),
+	// group 2 = the decorator's first quoted key (binding name) when present,
+	// group 3 = the parameter identifier, group 4 = the TS type (when annotated).
+	reNestParamDecorator = regexp.MustCompile(
+		`@(Param|Query|Body|Headers|Header)\s*\(\s*(?:['"]([^'"]*)['"])?[^)]*\)\s*(\w+)\??\s*(?::\s*([A-Za-z_][\w<>\[\], |.]*))?`,
+	)
+)
+
+// nestDecoratorIn maps a NestJS param decorator to its OpenAPI `in` location.
+var nestDecoratorIn = map[string]string{
+	"Param":   "path",
+	"Query":   "query",
+	"Body":    "body",
+	"Header":  "header",
+	"Headers": "header",
+}
+
+// extractNestHandlerParams parses a handler parameter block (the text between
+// the method's `(` and matching `)`) into the ordered parameter list the
+// dashboard renders. Decorator-less parameters (e.g. `@Request() req`) and
+// framework-internal injections are skipped — only request-shaping decorators
+// (@Param/@Query/@Body/@Header) become Parameters rows.
+//
+// For @Query()/@Body() with NO quoted key, the binding name falls back to the
+// parameter identifier (the conventional spelling for a whole-DTO query/body).
+// For @Body the Type is the DTO so the Parameters table and the ACCEPTS_INPUT
+// edge agree.
+func extractNestHandlerParams(paramsBlock string) []nestParam {
+	if paramsBlock == "" {
+		return nil
+	}
+	var out []nestParam
+	for _, m := range reNestParamDecorator.FindAllStringSubmatch(paramsBlock, -1) {
+		dec := m[1]
+		key := strings.TrimSpace(m[2])
+		ident := strings.TrimSpace(m[3])
+		rawType := nestCleanParamType(m[4])
+
+		in := nestDecoratorIn[dec]
+		if in == "" {
+			continue
+		}
+		name := key
+		if name == "" {
+			// @Query()/@Body() whole-object: name after the binding identifier.
+			name = ident
+		}
+		if name == "" {
+			continue
+		}
+
+		p := nestParam{
+			Name:        name,
+			In:          in,
+			Annotations: []string{"@" + dec},
+		}
+		// Type: prefer the user DTO (unwrapped); fall back to the raw TS type
+		// for primitives so the row still shows `number`/`string`.
+		if rawType != "" {
+			if dto := nestUnwrapType(rawType); dto != "" {
+				p.Type = dto
+			} else {
+				p.Type = strings.TrimSpace(strings.SplitN(rawType, "|", 2)[0])
+			}
+		}
+		// Path params are always required; a `?:` parameter (optional) or a
+		// query param is best-effort optional unless we can prove otherwise.
+		if in == "path" {
+			p.Required = true
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// nestCleanParamType trims a captured TS type annotation to the single
+// parameter's type. The capture char class permits `,` (for generic args like
+// Map<string, number>) which can over-consume into the next parameter, so we
+// cut at the first top-level comma (depth-0, outside <>/[]). Trailing
+// whitespace/commas are stripped.
+func nestCleanParamType(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	depth := 0
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '<', '[':
+			depth++
+		case '>', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				raw = raw[:i]
+				goto done
+			}
+		}
+	}
+done:
+	return strings.TrimRight(strings.TrimSpace(raw), ", ")
+}
+
+// encodeNestParams marshals the parameter list to the canonical JSON the
+// dashboard decodes. Empty input → "" so the property is omitted.
+func encodeNestParams(ps []nestParam) string {
+	if len(ps) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(ps)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/internal/custom/javascript/testdata/issue4325/building.controller.ts
+++ b/internal/custom/javascript/testdata/issue4325/building.controller.ts
@@ -1,0 +1,204 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Post, Put, Query, Request } from '@nestjs/common';
+import { RequirePage } from '../../../common/auth/decorators/auth.decorators';
+import { PermissionPage } from '../../../common/auth/page/permission-page';
+import { BuildingService } from '../services/building.service';
+import { BuildingListOptionalQuery } from '../dto/request/building-list.query.dto';
+import { BuildingActiveQuery } from '../dto/request/building-active.query.dto';
+import { BuildingContractCountersQuery } from '../dto/request/building-contract-counters.query.dto';
+import { BuildingNoticesQuery } from '../dto/request/building-notices.query.dto';
+import { BuildingContractsQuery } from '../dto/request/building-contracts.query.dto';
+import { BuildingViolationDevicesQuery } from '../dto/request/building-violation-devices.query.dto';
+import { BuildingDevicesQuery } from '../dto/request/building-devices.query.dto';
+import { BuildingInspectionDevicesQuery } from '../dto/request/building-inspection-devices.query.dto';
+import { BuildingInspectionDevicesFiltersQuery } from '../dto/request/building-inspection-devices-filters.query.dto';
+import { BuildingMeListQuery } from '../dto/request/building-me-list.query.dto';
+import { BuildingMeFiltersQuery } from '../dto/request/building-me-filters.query.dto';
+import { BuildingMeUpdateBody } from '../dto/request/building-me-update.body.dto';
+import { BuildingMeDeleteBody } from '../dto/request/building-me-delete.body.dto';
+import { BuildingMeMergeBody } from '../dto/request/building-me-merge.body.dto';
+import { BuildingNoteCreateBody } from '../dto/request/building-note-create.body.dto';
+import { BuildingNoticesBulkQuery } from '../dto/request/building-notices-bulk.query.dto';
+import { BuildingRefreshBody } from '../dto/request/building-refresh.body.dto';
+import { BuildingDobUpsertBody } from '../dto/request/building-dob-upsert.body.dto';
+import { BuildingDetailResponse, BuildingLiteResponse, BuildingResponse, PaginatedBuildingListResponse } from '../dto/response/building.response.dto';
+import { BuildingNoteResponse } from '../dto/response/building-notes.response.dto';
+import { BuildingContractCountersResponse } from '../dto/response/building-contract-counters.response.dto';
+import { BuildingContractFiltersResponse } from '../dto/response/building-contract-filters.response.dto';
+import { BuildingNoticesResponse } from '../dto/response/building-notices.response.dto';
+import { PaginatedBuildingContractsResponse } from '../dto/response/building-contracts.response.dto';
+import { BuildingViolationDevicesResponse } from '../dto/response/building-violation-devices.response.dto';
+import { BuildingContractClientsResponse } from '../dto/response/building-contract-clients.response.dto';
+import { BuildingDevicesResponse } from '../dto/response/building-devices.response.dto';
+import { BuildingInspectionDevicesResponse } from '../dto/response/building-inspection-devices.response.dto';
+import {
+  BuildingMeResponse,
+  BuildingMeFiltersResponse,
+  BuildingMeUpdateResponse,
+  BuildingMeDeleteResponse,
+  BuildingMeMergeResponse,
+} from '../dto/response/building-me.response.dto';
+import {
+  BuildingDobUpsertResponse,
+  BuildingRefreshResponse,
+  BuildingNoteCreateResponse,
+  BuildingNoteDeleteResponse,
+} from '../dto/response/building-dob.response.dto';
+
+@Controller({ path: 'buildings', version: '1' })
+@RequirePage(PermissionPage.Buildings)
+export class BuildingController {
+  constructor(private readonly service: BuildingService) {}
+
+  @Get('lite')
+  listLite(): Promise<BuildingLiteResponse[]> {
+    return this.service.lite();
+  }
+
+  @Get('active')
+  listActive(@Query() query: BuildingActiveQuery): Promise<BuildingResponse[]> {
+    return this.service.active({ groupIds: query.group_id });
+  }
+
+  @Get('contract-counters')
+  @RequirePage(PermissionPage.ContractProposals)
+  contractCounters(@Query() query: BuildingContractCountersQuery): Promise<BuildingContractCountersResponse> {
+    return this.service.contractCounters(query.building_id, query.group_id);
+  }
+
+  @Get('contract-filters')
+  @RequirePage(PermissionPage.ContractProposals)
+  contractFilters(@Query() query: BuildingContractCountersQuery): Promise<BuildingContractFiltersResponse> {
+    return this.service.contractFilters(query.building_id, query.group_id);
+  }
+
+  @Get('inspection-devices')
+  inspectionDevices(@Query() query: BuildingInspectionDevicesQuery): Promise<BuildingInspectionDevicesResponse> {
+    return this.service.inspectionDevices(query);
+  }
+
+  @Get('inspection-devices/filters')
+  inspectionDevicesFilters(@Query() query: BuildingInspectionDevicesFiltersQuery): Promise<Record<string, unknown>> {
+    return this.service.inspectionDevicesFilters(query);
+  }
+
+  @Get('inspections/maintenance-evaluations')
+  maintenanceEvaluations(@Query() query: BuildingMeListQuery): Promise<BuildingMeResponse> {
+    return this.service.maintenanceEvaluations(query);
+  }
+
+  @Get('inspections/maintenance-evaluations/filters')
+  maintenanceEvaluationsFilters(@Query() query: BuildingMeFiltersQuery): Promise<BuildingMeFiltersResponse> {
+    return this.service.maintenanceEvaluationsFilters(query);
+  }
+
+  @Put('inspections/me-manage')
+  @HttpCode(HttpStatus.OK)
+  updateMaintenanceEvaluations(@Body() body: BuildingMeUpdateBody): Promise<BuildingMeUpdateResponse> {
+    return this.service.updateMaintenanceEvaluations(body);
+  }
+
+  @Delete('inspections/me-manage/delete')
+  @HttpCode(HttpStatus.OK)
+  deleteMaintenanceEvaluations(@Body() body: BuildingMeDeleteBody): Promise<BuildingMeDeleteResponse> {
+    return this.service.deleteMaintenanceEvaluations(body);
+  }
+
+  @Post('inspections/me-manage/merge')
+  @HttpCode(HttpStatus.OK)
+  mergeMaintenanceEvaluations(@Body() body: BuildingMeMergeBody): Promise<BuildingMeMergeResponse> {
+    return this.service.mergeMaintenanceEvaluations(body);
+  }
+
+  @Get('notices')
+  buildingNoticesBulk(@Query() query: BuildingNoticesBulkQuery): Promise<Record<string, unknown>> {
+    return this.service.buildingNoticesBulk(query.group_id, query.ids);
+  }
+
+  @Post('notes/create')
+  @HttpCode(HttpStatus.OK)
+  createNote(@Body() body: BuildingNoteCreateBody, @Request() req: Record<string, unknown>): Promise<BuildingNoteCreateResponse> {
+    const principal = req['principal'] as { sub?: string } | undefined;
+    return this.service.createNote(body, principal?.sub ?? '');
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  refresh(@Body() body: BuildingRefreshBody): Promise<BuildingRefreshResponse> {
+    return Promise.resolve(this.service.refreshBuildings(body));
+  }
+
+  @Post('dob')
+  @HttpCode(HttpStatus.OK)
+  dobUpsert(@Body() body: BuildingDobUpsertBody): Promise<BuildingDobUpsertResponse> {
+    return Promise.resolve(this.service.dobUpsert(body));
+  }
+
+  @Get('violation-devices')
+  violationDevices(@Query() query: BuildingViolationDevicesQuery): Promise<BuildingViolationDevicesResponse> {
+    const limit = query.limit ?? 20;
+    const offset = query.offset ?? 0;
+    return this.service.violationDevices(query.building_id, limit, offset);
+  }
+
+  @Get()
+  list(@Query() query: BuildingListOptionalQuery): Promise<BuildingResponse[] | PaginatedBuildingListResponse> {
+    return this.service.list({ group_id: query.group_id, limit: query.limit, offset: query.offset });
+  }
+
+  @Get(':buildingId/contract-clients')
+  @RequirePage(PermissionPage.ContractProposals)
+  buildingContractClients(
+    @Param('buildingId', ParseIntPipe) buildingId: number,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<BuildingContractClientsResponse> {
+    const parsedLimit = limit !== undefined ? parseInt(limit, 10) : undefined;
+    const parsedOffset = offset !== undefined ? parseInt(offset, 10) : undefined;
+    return this.service.buildingContractClients(buildingId, parsedLimit, parsedOffset);
+  }
+
+  @Get(':buildingId/devices')
+  buildingDevices(@Param('buildingId', ParseIntPipe) buildingId: number, @Query() query: BuildingDevicesQuery): Promise<BuildingDevicesResponse> {
+    return this.service.buildingDevices(buildingId, query);
+  }
+
+  @Get(':buildingId/notes')
+  buildingNotes(@Param('buildingId', ParseIntPipe) buildingId: number): Promise<BuildingNoteResponse[]> {
+    return this.service.buildingNotes(buildingId);
+  }
+
+  @Delete(':noteId/notes/delete')
+  @HttpCode(HttpStatus.OK)
+  deleteNote(@Param('noteId', ParseIntPipe) noteId: number): Promise<BuildingNoteDeleteResponse> {
+    return this.service.deleteNote(noteId);
+  }
+
+  @Get(':buildingId/contracts')
+  @RequirePage(PermissionPage.ContractProposals)
+  buildingContracts(
+    @Param('buildingId', ParseIntPipe) buildingId: number,
+    @Query() query: BuildingContractsQuery,
+  ): Promise<PaginatedBuildingContractsResponse> {
+    return this.service.buildingContracts(buildingId, query);
+  }
+
+  @Get(':buildingId/notices')
+  notices(@Param('buildingId', ParseIntPipe) buildingId: number, @Query() query: BuildingNoticesQuery): Promise<BuildingNoticesResponse> {
+    return this.service.buildingNotices(buildingId, query.group_id);
+  }
+
+  @Get(':buildingId/dob')
+  buildingDob(@Param('buildingId', ParseIntPipe) buildingId: number): Promise<Record<string, unknown>> {
+    return this.service.getBuildingDob(buildingId);
+  }
+
+  @Get(':buildingId/mass')
+  buildingMass(@Param('buildingId') buildingId: string): Promise<Record<string, unknown>> {
+    return this.service.getBuildingMass(buildingId);
+  }
+
+  @Get(':buildingId')
+  retrieve(@Param('buildingId', ParseIntPipe) buildingId: number): Promise<BuildingDetailResponse> {
+    return this.service.findById(buildingId);
+  }
+}

--- a/internal/custom/javascript/testdata/issue4325/device.controller.ts
+++ b/internal/custom/javascript/testdata/issue4325/device.controller.ts
@@ -1,0 +1,88 @@
+import { BadRequestException, Body, Controller, Get, Param, Patch, ParseIntPipe, Query } from '@nestjs/common';
+import { RequirePage } from '../../../common/auth/decorators/auth.decorators';
+import { PermissionPage } from '../../../common/auth/page/permission-page';
+import { DeviceService } from '../services/device.service';
+import { DeviceListOptionalQuery } from '../dto/request/device-list.query.dto';
+import type { DeviceFiltersResponse } from '../dto/response/device-filters.response.dto';
+import type {
+  DeviceDetailResponse,
+  DeviceListItemResponse,
+  LoadTestTypeResponse,
+  PaginatedDeviceListResponse,
+} from '../dto/response/device.response.dto';
+import { DeviceCountersResponse } from '../dto/response/device-counters.response.dto';
+import type { DeviceForBuildingResponse } from '../dto/response/device-for-building.response.dto';
+import { DeviceBulkUpdateBodyDto } from '../dto/request/device-bulk-update.body.dto';
+import type { DeviceEquipmentTypeItemResponse } from '../dto/response/device-equipment-type.response.dto';
+
+@Controller({ path: 'devices', version: '1' })
+@RequirePage(PermissionPage.Devices)
+export class DeviceController {
+  constructor(private readonly service: DeviceService) {}
+
+  @Get()
+  list(
+    @Query('building_id', ParseIntPipe) buildingId: number,
+    @Query() optional: DeviceListOptionalQuery,
+  ): Promise<DeviceListItemResponse[] | PaginatedDeviceListResponse> {
+    return this.service.list({ building_id: buildingId, group_id: optional.group_id, limit: optional.limit, offset: optional.offset });
+  }
+
+  @Get('counters')
+  counters(@Query('group_id') groupIdRaw: string, @Query('building_id') buildingIdRaw?: string): Promise<DeviceCountersResponse> {
+    if (!groupIdRaw) {
+      throw new BadRequestException('group_id is required.');
+    }
+    const groupId = parseInt(groupIdRaw, 10);
+    if (isNaN(groupId)) {
+      throw new BadRequestException('group_id must be a valid integer.');
+    }
+    const buildingId = buildingIdRaw !== undefined ? parseInt(buildingIdRaw, 10) : undefined;
+    if (buildingIdRaw !== undefined && isNaN(buildingId!)) {
+      throw new BadRequestException('building_id must be a valid integer.');
+    }
+    return this.service.getCounters(groupId, buildingId);
+  }
+
+  @Get('filters')
+  filters(@Query('group_id', ParseIntPipe) groupId: number, @Query('building_id', ParseIntPipe) buildingId: number): Promise<DeviceFiltersResponse> {
+    return this.service.getFilters({ groupId, buildingId });
+  }
+
+  @Get('for_building')
+  forBuilding(@Query('building_id') buildingIdRaw: string, @Query('group_id') groupIdRaw: string): Promise<DeviceForBuildingResponse> {
+    if (!buildingIdRaw) {
+      throw new BadRequestException('building_id is required');
+    }
+    if (!groupIdRaw) {
+      throw new BadRequestException('group_id is required');
+    }
+    const buildingId = parseInt(buildingIdRaw, 10);
+    const groupId = parseInt(groupIdRaw, 10);
+    if (isNaN(buildingId) || isNaN(groupId)) {
+      throw new BadRequestException('building_id and group_id must be integers');
+    }
+    return this.service.forBuilding(buildingId, groupId);
+  }
+
+  @Get('load_test_type')
+  loadTestType(): LoadTestTypeResponse {
+    return this.service.getLoadTestTypes();
+  }
+
+  @Get('equipment_type')
+  equipmentType(): Promise<DeviceEquipmentTypeItemResponse[]> {
+    return this.service.getEquipmentTypes();
+  }
+
+  @Patch('bulk')
+  bulk(@Body() body: DeviceBulkUpdateBodyDto): Promise<{ success: boolean; message: string }> {
+    return this.service.bulkUpdate(body.building_id, body.devices).then(() => ({ success: true, message: 'Device(s) have been updated.' }));
+  }
+
+  @Get(':deviceId')
+  retrieve(@Param('deviceId', ParseIntPipe) deviceId: number, @Query('group_id') groupIdRaw?: string): Promise<DeviceDetailResponse> {
+    const groupId = groupIdRaw !== undefined ? parseInt(groupIdRaw, 10) : undefined;
+    return this.service.findById(deviceId, groupId);
+  }
+}


### PR DESCRIPTION
Closes part of #4325 (params + response shipped solidly; TESTS deferred to #4351). Part of resolution-coverage epic #4334. DEPLOY-DEFERRED.

## Root cause
The dashboard Paths panel (`internal/dashboard/v2_paths.go` → `handleV2PathDetail`) renders an endpoint's Parameters table from the `parameters` PROPERTY and its Response row from the `response_type` PROPERTY. The NestJS extractor only emitted `ACCEPTS_INPUT`/`RETURNS` **edges** and never set those properties — so Parameters showed (0) and Response showed "(none)" even though the RETURNS edge made the panel **count** a response.

A second, larger root cause surfaced during live-repro: the verb-decorator regex required `@Get/@Post/...` to be **immediately adjacent** to the handler method. Real handlers stack `@HttpCode(HttpStatus.OK)` / `@UseGuards` / `@RequirePage` between the verb decorator and the signature, so **every** mutating handler using `@HttpCode` (the dominant POST idiom) was dropped from the inventory entirely.

## Live-repro (my own output, on byte-copies of the REAL upvate-v3 source)
`device.controller.ts` `filters` (@Query x2) + `building.controller.ts` `createNote` (@Body):

**BEFORE**
```
ENDPOINT name="GET filters" ...
  parameters prop = ""
  response_type prop = ""
  EDGE RETURNS -> Class:DeviceFiltersResponse   <-- edge exists, property empty => "(none)"
endpoint with method_name="createNote" not found among 15 entities   <-- POST dropped (@HttpCode)
```
All extracted building endpoints were GET-only (15).

**AFTER**
```
ENDPOINT name="GET filters" verb=GET ...
  parameters prop = [{"name":"group_id","in":"query","type":"number",...},{"name":"building_id","in":"query","type":"number",...}]
  response_type prop = "DeviceFiltersResponse"

ENDPOINT name="POST createNote" verb=POST ...
  parameters prop = [{"name":"body","in":"body","type":"BuildingNoteCreateBody",...}]
  response_type prop = "BuildingNoteCreateResponse"
  EDGE ACCEPTS_INPUT -> Class:BuildingNoteCreateBody
  EDGE RETURNS -> Class:BuildingNoteCreateResponse
```
building.controller.ts now yields 26 endpoints across GET/POST/PUT/DELETE (was 15 GET-only).

## What's done
1. **Decorator-stacking** — `reNestHTTPMethod` skips a run of intervening decorators + visibility/async modifiers before the method name. Recovers all `@Post/@Patch/@Put/@Delete` handlers that set `@HttpCode`.
2. **Parameters** — `nestjs_params.go` parses `@Param`(path)/`@Query`(query)/`@Body`(body)/`@Header` into the `parameters` property using the exact `[]JavaParam` wire shape the dashboard decodes; sets `request_body_type`/`request_body_param_name` for @Body.
3. **Response type** — sets the `response_type` property from the resolved return DTO alongside the RETURNS edge, so the Response row renders the type instead of "(none)".

## Deferred (tracked)
- **TESTS edges** (spec↔endpoint by route constant) → #4351. Mechanism scoped: specs name the full composed route as a string constant + `describe` title; a cross-file resolver composes endpoint routes and emits inbound `TESTS` edges (dashboard already buckets them).
- **Generalize** to Spring / FastAPI (same params/response/tests axes, same adjacency + edge-only-response watch-outs) → #4352.

## Gates
`go build ./...` clean; `gofmt -l` / `go vet` clean; `go test ./internal/types/` pass; live-repro `issue4325_livedrepro_test.go` (gap→resolved) + synthetic decorator-stacking test pass; `go test ./internal/custom/... ./internal/engine` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)