### PR TITLE
Bind decorated DTO/entity/schema fields to their owning class (membership + target-type edges)

### DIFF
--- a/internal/custom/javascript/helpers.go
+++ b/internal/custom/javascript/helpers.go
@@ -38,6 +38,48 @@ func makeEntity(name, kind, subtype, filePath, language string, lineNum int) typ
 	return e
 }
 
+// containsFieldEdge builds the structural CONTAINS membership edge from an
+// owning class (DTO / entity / schema) to one of its decorated field/property
+// entities. Issue #4328: decorated DTO properties and entity columns were
+// emitted as standalone nodes with no owner, leaving them as orphans on the
+// graph. The edge is hung off the owner model node; FromID names the owner
+// class (`Class:<owner>`) so the resolver binds it to the real class entity,
+// ToID is the concrete member entity ID.
+func containsFieldEdge(ownerClass, memberID, fieldName, framework string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: "Class:" + ownerClass,
+		ToID:   memberID,
+		Kind:   string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  framework,
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_DECORATED_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// referencesClassEdge builds a REFERENCES edge from a field/property entity to
+// the class named in a decorator thunk — `@ManyToOne(() => Role)`,
+// `@Type(() => AddressDto)`, `@Prop({ type: () => X })`. Issue #4328: the thunk
+// target type carries the field's only outbound semantic edge; without it the
+// nested DTO / related entity rings. ToID is the `Class:<target>` stub the
+// resolver binds to the real class entity (same-file or symbol-table wide).
+func referencesClassEdge(fromID, targetClass, framework, fieldName string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: fromID,
+		ToID:   "Class:" + targetClass,
+		Kind:   string(types.RelationshipKindReferences),
+		Properties: map[string]string{
+			"framework":   framework,
+			"ref_kind":    "field_target_type",
+			"field_name":  fieldName,
+			"target_type": targetClass,
+			"provenance":  "INFERRED_FROM_DECORATOR_THUNK_TARGET",
+		},
+	}
+}
+
 // setProps merges extra key-value pairs into entity.Properties.
 func setProps(e *types.EntityRecord, kv ...string) {
 	if len(kv)%2 != 0 {

--- a/internal/custom/javascript/issue4328_livedrepro_test.go
+++ b/internal/custom/javascript/issue4328_livedrepro_test.go
@@ -1,0 +1,235 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4328 LIVE-REPRO.
+//
+// Byte-copies of REAL core-backend-v3 files are committed under
+// testdata/issue4328. We run the ACTUAL typeorm / validation-schema /
+// nestjs-mongoose extractors AND the ACTUAL resolve.BuildIndex symbol table
+// over them and assert that the DTO properties and entity fields they decorate
+// are NOT orphans:
+//
+//	(1) field membership — every emitted @Column / relation / @Prop field entity
+//	    carries a CONTAINS edge FROM its owning @Entity / @Schema class (so it is
+//	    a member, not a standalone node); and
+//	(2) thunk-target-type resolution — a @ManyToOne(() => Role) relation field and
+//	    a @ValidateNested() @Type(() => XDto) nested-DTO field emit a REFERENCES
+//	    edge to the target class stub, and that stub RESOLVES against a real
+//	    same-file (or symbol-table) class entity.
+//
+// Pre-fix: typeorm.go emitted each @Column / relation as a standalone entity
+// with ZERO inbound/outbound edges (pure orphan), and the class-validator
+// extractor folded nested @Type(() => XDto) targets into props with no edge —
+// leaving the nested DTO with no inbound link. ~619 such fields ringed on v3.
+
+func loadRepro4328(t *testing.T, base, repoPath string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "issue4328", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read repro %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: repoPath, Language: "typescript", Content: b}
+}
+
+func extract4328(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract %s: %v", name, err)
+	}
+	return ents
+}
+
+// hasContainsFrom reports whether some entity in ents declares a CONTAINS edge
+// whose ToID names the given member entity (by ID or by Class:/field name stub),
+// i.e. the member is owned by a class rather than floating free.
+func hasContainsTo(ents []types.EntityRecord, memberID, memberName string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindContains) {
+				continue
+			}
+			if r.ToID == memberID || r.ToID == "Field:"+memberName || r.ToID == memberName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// edgesOfKind collects all relationships of a kind across all entities.
+func edgesOfKind(ents []types.EntityRecord, kind types.RelationshipKind) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(kind) {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// TestIssue4328_TypeORMEntity_FieldsAreMembers_NotOrphans runs the real TypeORM
+// entity through the pipeline and asserts every @Column and the @ManyToOne
+// relation field is a CONTAINS member of UserGroupRole, and the relation's
+// thunk-target (Role) is captured (REFERENCES) and resolves.
+func TestIssue4328_TypeORMEntity_FieldsAreMembers_NotOrphans(t *testing.T) {
+	file := loadRepro4328(t,
+		"user-group-role.entity.ts.txt",
+		"src/common/auth/persistence/user-group-role.entity.ts")
+
+	ents := extract4328(t, "custom_js_typeorm", file)
+	for _, e := range ents {
+		t.Logf("ENTITY kind=%s subtype=%s name=%q rels=%d", e.Kind, e.Subtype, e.Name, len(e.Relationships))
+		for _, r := range e.Relationships {
+			t.Logf("   EDGE %s from=%s to=%s", r.Kind, r.FromID, r.ToID)
+		}
+	}
+
+	// (1) Every @Column / relation field must be a CONTAINS member of its owner.
+	fieldSubtypes := map[string]bool{"column": true, "relation": true}
+	var fieldEnts []types.EntityRecord
+	for _, e := range ents {
+		if fieldSubtypes[e.Subtype] {
+			fieldEnts = append(fieldEnts, e)
+		}
+	}
+	if len(fieldEnts) == 0 {
+		t.Fatal("no column/relation field entities extracted")
+	}
+	orphans := 0
+	for _, fe := range fieldEnts {
+		fieldName := fe.Properties["field_name"]
+		if fieldName == "" {
+			fieldName = fe.Name
+		}
+		if !hasContainsTo(ents, fe.ID, fieldName) {
+			orphans++
+			t.Errorf("ORPHAN field (no CONTAINS from owner): subtype=%s name=%q", fe.Subtype, fe.Name)
+		}
+	}
+	t.Logf("orphaned field entities (TypeORM): %d / %d", orphans, len(fieldEnts))
+
+	// (2) The @ManyToOne(() => Role) relation's target type must be REFERENCES'd.
+	refs := edgesOfKind(ents, types.RelationshipKindReferences)
+	foundRoleRef := false
+	for _, r := range refs {
+		if r.ToID == "Class:Role" {
+			foundRoleRef = true
+		}
+	}
+	if !foundRoleRef {
+		t.Errorf("expected REFERENCES edge to Class:Role for @ManyToOne thunk target; refs=%v", refs)
+	}
+
+	// (2 continued) Role resolves in the symbol table (alongside a real Role entity).
+	roleEnt := types.EntityRecord{
+		Name: "Role", Kind: "SCOPE.Schema", Subtype: "entity",
+		SourceFile: "src/common/auth/persistence/role.entity.ts", Language: "typescript",
+		Properties: map[string]string{"kind": "SCOPE.Schema", "subtype": "entity"},
+	}
+	roleEnt.ID = roleEnt.ComputeID()
+	idx := resolve.BuildIndex(append(ents, roleEnt))
+	if id, ok := idx.Lookup("Class:Role"); !ok || id != roleEnt.ID {
+		t.Errorf("Class:Role stub did not resolve to real Role entity (ok=%v id=%s)", ok, id)
+	}
+}
+
+// TestIssue4328_ClassValidatorDTO_NestedTypeTargetEdge runs the real
+// class-validator DTO with @ValidateNested() @Type(() => XDto) through the
+// pipeline and asserts the nested-DTO target gets a REFERENCES edge that
+// resolves against the same-file nested DTO class entity.
+func TestIssue4328_ClassValidatorDTO_NestedTypeTargetEdge(t *testing.T) {
+	file := loadRepro4328(t,
+		"create-checklist.body.dto.ts.txt",
+		"src/modules/checklists/dto/request/create-checklist.body.dto.ts")
+
+	ents := extract4328(t, "custom_js_validation_schema", file)
+	for _, e := range ents {
+		t.Logf("ENTITY kind=%s subtype=%s name=%q rels=%d", e.Kind, e.Subtype, e.Name, len(e.Relationships))
+		for _, r := range e.Relationships {
+			t.Logf("   EDGE %s from=%s to=%s props=%v", r.Kind, r.FromID, r.ToID, r.Properties)
+		}
+	}
+
+	// CreateChecklistBody.categories -> CreateChecklistCategoryBody (nested DTO).
+	// CreateChecklistCategoryBody.datasource -> CreateChecklistItemBody.
+	refs := edgesOfKind(ents, types.RelationshipKindReferences)
+	wantTargets := map[string]bool{
+		"Class:CreateChecklistCategoryBody": false,
+		"Class:CreateChecklistItemBody":     false,
+	}
+	for _, r := range refs {
+		if _, ok := wantTargets[r.ToID]; ok {
+			wantTargets[r.ToID] = true
+		}
+	}
+	for stub, got := range wantTargets {
+		if !got {
+			t.Errorf("expected REFERENCES edge to nested DTO %q; refs=%v", stub, refs)
+		}
+	}
+
+	// Targets resolve to the same-file nested DTO class entities in the symbol table.
+	idx := resolve.BuildIndex(ents)
+	for stub := range wantTargets {
+		if _, ok := idx.Lookup(stub); !ok {
+			t.Errorf("nested DTO stub %q failed to resolve in symbol table", stub)
+		}
+	}
+}
+
+// TestIssue4328_MongooseSchema_PropFieldsAreMembers runs the real NestJS
+// @Schema()/@Prop() mongoose schema through the pipeline and asserts each @Prop
+// field is a CONTAINS member of the Violation schema class (not an orphan).
+func TestIssue4328_MongooseSchema_PropFieldsAreMembers(t *testing.T) {
+	file := loadRepro4328(t,
+		"violation.schema.ts.txt",
+		"src/modules/buildings/models/violation.schema.ts")
+
+	ents := extract4328(t, "custom_js_mongoose", file)
+	for _, e := range ents {
+		t.Logf("ENTITY kind=%s subtype=%s name=%q rels=%d", e.Kind, e.Subtype, e.Name, len(e.Relationships))
+		for _, r := range e.Relationships {
+			t.Logf("   EDGE %s from=%s to=%s", r.Kind, r.FromID, r.ToID)
+		}
+	}
+
+	// Expect a Violation @Schema class and its @Prop fields as members.
+	var propEnts []types.EntityRecord
+	for _, e := range ents {
+		if e.Subtype == "prop" {
+			propEnts = append(propEnts, e)
+		}
+	}
+	if len(propEnts) == 0 {
+		t.Fatal("no @Prop field entities extracted from NestJS mongoose schema (#4328)")
+	}
+	for _, pe := range propEnts {
+		fieldName := pe.Properties["field_name"]
+		if fieldName == "" {
+			fieldName = pe.Name
+		}
+		if !hasContainsTo(ents, pe.ID, fieldName) {
+			t.Errorf("ORPHAN @Prop field (no CONTAINS from Violation schema): name=%q", pe.Name)
+		}
+	}
+}

--- a/internal/custom/javascript/mongoose.go
+++ b/internal/custom/javascript/mongoose.go
@@ -53,7 +53,34 @@ var (
 	reMongooseIndex = regexp.MustCompile(
 		`([A-Za-z_][A-Za-z0-9_]*)\.index\s*\(\s*\{([^}]*)\}`,
 	)
+
+	// NestJS `@nestjs/mongoose` decorator style (issue #4328): `@Schema(...)
+	// class Foo { @Prop(...) field: type; }`. mongoose.go previously only handled
+	// the classic `new Schema()` form, so the entire decorator-based schema class
+	// — and every @Prop field — was unextracted, orphaning the document shape.
+	reMongooseSchemaClass = regexp.MustCompile(
+		`@Schema\s*\([^@]*?\)\s*(?:export\s+)?(?:abstract\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
+	)
+	// @Prop(...) field: type;  — captures field name (group 1). The optional
+	// decorator run handles companion decorators between @Prop and the property.
+	reMongooseProp = regexp.MustCompile(
+		`@Prop\s*\(([^@]*?)\)\s*(?:@\w+\s*(?:\([^@]*?\))?\s*)*([A-Za-z_]\w*)\s*[!?]?\s*:`,
+	)
+	// Thunk / array target type inside a @Prop options object:
+	// `type: () => Foo`, `type: [Foo]`, `ref: 'Foo'`, `type: Foo`.
+	reMongoosePropThunk = regexp.MustCompile(
+		`(?:type\s*:\s*\(\s*\)\s*=>\s*([A-Z][A-Za-z0-9_]*))` +
+			`|(?:type\s*:\s*\[\s*([A-Z][A-Za-z0-9_]*)\s*\])` +
+			`|(?:ref\s*:\s*['"]([A-Z][A-Za-z0-9_]*)['"])`,
+	)
 )
+
+// mongoosePropPrimitive is the set of mongoose @Prop primitive constructor
+// targets that coerce a scalar rather than reference a document class.
+var mongoosePropPrimitive = map[string]bool{
+	"String": true, "Number": true, "Boolean": true, "Date": true,
+	"Buffer": true, "Mixed": true, "ObjectId": true, "Map": true, "Array": true,
+}
 
 func (e *mongooseExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
@@ -189,6 +216,62 @@ func (e *mongooseExtractor) Extract(ctx context.Context, file extreg.FileInput) 
 		setProps(&ent, "framework", "mongoose", "schema_var", schemaVar, "fields", indexFields,
 			"provenance", "INFERRED_FROM_MONGOOSE_INDEX")
 		addEntity(ent)
+	}
+
+	// NestJS @Schema()/@Prop() decorator-style schemas (issue #4328). Each
+	// @Schema class becomes a SCOPE.Schema model; each @Prop field is emitted as
+	// a member entity with a CONTAINS edge from the owning schema class, and a
+	// `type: () => X` / `type: [X]` / `ref: 'X'` thunk yields a REFERENCES edge
+	// to the target document class so embedded/referenced docs are not orphans.
+	schemaClassMatches := reMongooseSchemaClass.FindAllStringSubmatchIndex(src, -1)
+	for i, m := range schemaClassMatches {
+		className := src[m[2]:m[3]]
+		classEnt := makeEntity(className, "SCOPE.Schema", "schema_class", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&classEnt, "framework", "mongoose", "provenance", "INFERRED_FROM_NESTJS_MONGOOSE_SCHEMA")
+
+		// Class body: from this @Schema to the next @Schema class (or EOF).
+		bodyEnd := len(src)
+		if i+1 < len(schemaClassMatches) {
+			bodyEnd = schemaClassMatches[i+1][0]
+		}
+		body := src[m[0]:bodyEnd]
+
+		classIdx := len(entities)
+		addEntity(classEnt)
+		// addEntity may have skipped a duplicate class name; only attach members
+		// when this class was actually appended at classIdx.
+		appended := classIdx < len(entities) && entities[classIdx].Name == className
+
+		for _, pm := range reMongooseProp.FindAllStringSubmatchIndex(body, -1) {
+			optsBlob := body[pm[2]:pm[3]]
+			fieldName := body[pm[4]:pm[5]]
+			propEnt := makeEntity(fmt.Sprintf("%s.%s", className, fieldName),
+				"SCOPE.Component", "prop", file.Path, file.Language, lineOf(src, m[0]+pm[0]))
+			setProps(&propEnt, "framework", "mongoose", "field_name", fieldName,
+				"owner_class", className, "provenance", "INFERRED_FROM_NESTJS_MONGOOSE_PROP")
+
+			// Thunk / array / ref target document class.
+			if tm := reMongoosePropThunk.FindStringSubmatch(optsBlob); tm != nil {
+				target := tm[1]
+				if target == "" {
+					target = tm[2]
+				}
+				if target == "" {
+					target = tm[3]
+				}
+				if target != "" && !mongoosePropPrimitive[target] {
+					setProps(&propEnt, "target_type", target)
+					propEnt.Relationships = append(propEnt.Relationships,
+						referencesClassEdge(propEnt.ID, target, "mongoose", fieldName))
+				}
+			}
+
+			if appended {
+				entities[classIdx].Relationships = append(entities[classIdx].Relationships,
+					containsFieldEdge(className, propEnt.ID, fieldName, "mongoose"))
+			}
+			addEntity(propEnt)
+		}
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/javascript/testdata/issue4328/create-checklist.body.dto.ts.txt
+++ b/internal/custom/javascript/testdata/issue4328/create-checklist.body.dto.ts.txt
@@ -1,0 +1,75 @@
+import { IsArray, IsBoolean, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateChecklistItemBody {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  required?: boolean;
+
+  @IsOptional()
+  @IsString()
+  value_type?: string;
+
+  @IsOptional()
+  @IsString()
+  value?: string;
+
+  @IsOptional()
+  @IsNumber()
+  part?: number | null;
+
+  @IsOptional()
+  @IsNumber()
+  condition?: number | null;
+
+  @IsOptional()
+  @IsNumber()
+  remedy?: number | null;
+}
+
+export class CreateChecklistCategoryBody {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateChecklistItemBody)
+  datasource?: CreateChecklistItemBody[];
+}
+
+export class CreateChecklistBody {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  shared?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  group_id?: number | null;
+
+  @IsOptional()
+  @IsNumber()
+  type_id?: number | null;
+
+  @IsOptional()
+  @IsNumber()
+  jurisdiction_id?: number | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateChecklistCategoryBody)
+  categories?: CreateChecklistCategoryBody[];
+}

--- a/internal/custom/javascript/testdata/issue4328/user-group-role.entity.ts.txt
+++ b/internal/custom/javascript/testdata/issue4328/user-group-role.entity.ts.txt
@@ -1,0 +1,20 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { MinimalEntity } from '../../entities/base/minimal.entity';
+import { bigintTransformer } from '../../entities/transformers/bigint.transformer';
+import { Role } from './role.entity';
+
+@Entity({ name: 'user_group_roles' })
+export class UserGroupRole extends MinimalEntity {
+  @Column({ name: 'user_id', type: 'bigint', transformer: bigintTransformer })
+  userId!: number;
+
+  @Column({ name: 'group_id', type: 'bigint', transformer: bigintTransformer })
+  groupId!: number;
+
+  @Column({ name: 'role_id', type: 'bigint', transformer: bigintTransformer })
+  roleId!: number;
+
+  @ManyToOne(() => Role)
+  @JoinColumn({ name: 'role_id' })
+  role!: Role;
+}

--- a/internal/custom/javascript/testdata/issue4328/violation.schema.ts.txt
+++ b/internal/custom/javascript/testdata/issue4328/violation.schema.ts.txt
@@ -1,0 +1,15 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type ViolationDocument = Violation & Document;
+
+@Schema({ collection: 'violations', timestamps: false, strict: false })
+export class Violation {
+  @Prop({ type: Number, required: false })
+  building_id?: number;
+
+  @Prop({ type: String, required: false })
+  issue_date?: string;
+}
+
+export const ViolationSchema = SchemaFactory.createForClass(Violation);

--- a/internal/custom/javascript/typeorm.go
+++ b/internal/custom/javascript/typeorm.go
@@ -40,8 +40,17 @@ var (
 	// Uses [^@]* instead of [^)]* to handle arrow functions like (() => Post, post => post.user)
 	// that contain nested parentheses. Stops at next decorator (@) instead.
 	// Group 1 = relation kind, group 2 = decorator-args blob, group 3 = field name.
+	//
+	// The field name is captured AFTER any number of intervening companion
+	// decorators (e.g. `@ManyToOne(() => Role) @JoinColumn({ name: 'role_id' })
+	// role!: Role;`) — issue #4328. Without the optional decorator run the
+	// `@JoinColumn` between the relation decorator and the field name caused the
+	// whole relation (and its member/target edges) to be dropped, orphaning the
+	// field.
 	reTypeORMRelation = regexp.MustCompile(
-		`@(OneToMany|ManyToOne|OneToOne|ManyToMany)\s*\(([^@]*?)\)\s+(\w+)`,
+		`@(OneToMany|ManyToOne|OneToOne|ManyToMany)\s*\(([^@]*?)\)\s*` +
+			`(?:@\w+\s*(?:\([^@]*?\))?\s*)*` +
+			`(\w+)`,
 	)
 	// The type-target arrow inside a relation decorator: `() => Order` or
 	// `type => Order` or `() => Order` (with optional parens around the param).
@@ -262,11 +271,18 @@ func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		addEntity(ent)
 	}
 
-	// @Column properties
+	// @Column properties. Each column becomes a member of its owning @Entity via
+	// a CONTAINS edge hung off the owner model node (issue #4328) so the field is
+	// not an orphan. The edge targets the column entity's own ID.
 	for _, m := range reTypeORMColumn.FindAllStringSubmatchIndex(src, -1) {
 		colName := src[m[2]:m[3]]
 		ent := makeEntity(colName, "SCOPE.Component", "column", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "typeorm", "provenance", "INFERRED_FROM_TYPEORM_COLUMN")
+		if owner, ok := owningEntity(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_class", owner.name)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.name, ent.ID, colName, "typeorm"))
+		}
 		addEntity(ent)
 	}
 
@@ -286,6 +302,20 @@ func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 			"provenance", "INFERRED_FROM_TYPEORM_RELATION")
 		if target != "" {
 			setProps(&ent, "target_entity", target)
+			// REFERENCES edge from the relation field to the thunk-target class.
+			// Emitted even cross-file (issue #4328): the target type is a real
+			// symbol reference, so the field carries an outbound edge instead of
+			// ringing. The resolver matches `Class:<Target>` to the entity by name
+			// when it exists; cross-file targets that never resolve stay honest
+			// (the edge records the topology either way).
+			ent.Relationships = append(ent.Relationships,
+				referencesClassEdge(ent.ID, target, "typeorm", fieldName))
+		}
+		// CONTAINS membership: the relation field belongs to its owning @Entity.
+		if owner, ok := owningEntity(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_class", owner.name)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.name, ent.ID, fieldName, "typeorm"))
 		}
 		addEntity(ent)
 

--- a/internal/custom/javascript/validation_schema.go
+++ b/internal/custom/javascript/validation_schema.go
@@ -68,6 +68,14 @@ var (
 			`(?:\s*@\w+\s*\([^)]*\))*\s*` +
 			`([A-Za-z_]\w*)\s*[!?]?\s*(?::\s*([A-Za-z_][\w.<>\[\] ]*?))?\s*[;=\n]`)
 
+	// cvNestedTypeRe: a class-transformer `@Type(() => TargetClass)` thunk,
+	// optionally preceded/followed by other decorators, bound to a property name.
+	// Group 1 = target class, group 2 = field name. Issue #4328.
+	cvNestedTypeRe = regexp.MustCompile(
+		`(?m)@Type\s*\(\s*\(\s*\)\s*=>\s*([A-Z][A-Za-z0-9_]*)\s*\)` +
+			`(?:\s*@\w+\s*(?:\([^)]*\))?\s*)*\s*` +
+			`([A-Za-z_]\w*)\s*[!?]?\s*:`)
+
 	// route header (express/fastify/koa/nest-style decorator or method call).
 	vsRouteCallRe = regexp.MustCompile(
 		`(?i)(?:app|router|fastify|server|\w+)\s*\.\s*(get|post|put|delete|patch|all|options|head)\s*\(\s*['` + "`" + `"]([^'"` + "`" + ` ]+)['` + "`" + `"]`)
@@ -168,6 +176,15 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 			setProps(&ent, "library", "class-validator", "pattern_type", "validation_schema",
 				"provenance", "INFERRED_FROM_CLASS_VALIDATOR")
 			applyFieldProps(&ent, fields)
+			// Nested-DTO target edges (issue #4328): `@ValidateNested()
+			// @Type(() => AddressDto)` carries a class target in a class-transformer
+			// thunk. Without an outbound edge the nested DTO rings. Emit a REFERENCES
+			// edge from this DTO to each nested target class so the membership /
+			// type topology is preserved and the nested DTO is no longer an orphan.
+			for _, tgt := range extractClassValidatorNestedTargets(body) {
+				ent.Relationships = append(ent.Relationships,
+					referencesClassEdge(ent.ID, tgt.target, "class-validator", tgt.field))
+			}
 			addSchema(ent)
 		}
 	}
@@ -363,6 +380,42 @@ func extractClassValidatorFields(body string) []schemaField {
 		fields = append(fields, schemaField{name: name, typ: typ})
 	}
 	return fields
+}
+
+// cvNestedTarget is a captured `@Type(() => X)` nested-DTO target + the field
+// it decorates.
+type cvNestedTarget struct {
+	target string
+	field  string
+}
+
+// cvPrimitiveCoercion is the set of class-transformer primitive coercion
+// targets — `@Type(() => Number)` etc. coerce a scalar, they are not nested
+// DTO references, so they must NOT yield a class REFERENCES edge.
+var cvPrimitiveCoercion = map[string]bool{
+	"Number": true, "String": true, "Boolean": true, "Date": true,
+	"BigInt": true, "Symbol": true,
+}
+
+// extractClassValidatorNestedTargets pulls `@Type(() => TargetClass) field:`
+// nested-DTO references out of a class body, skipping primitive coercions.
+func extractClassValidatorNestedTargets(body string) []cvNestedTarget {
+	var out []cvNestedTarget
+	seen := make(map[string]bool)
+	for _, m := range cvNestedTypeRe.FindAllStringSubmatch(body, -1) {
+		target := m[1]
+		field := m[2]
+		if target == "" || cvPrimitiveCoercion[target] {
+			continue
+		}
+		key := target + ":" + field
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, cvNestedTarget{target: target, field: field})
+	}
+	return out
 }
 
 // normalizeScalar maps a raw factory/type token to a normalized scalar type.


### PR DESCRIPTION
## Problem

On the live `upvate-v3` (NestJS/TS) graph, decorated DTO properties and entity/schema fields were emitted as standalone nodes with no owning-class membership and no target-type edge — orphaning hundreds of fields (the recurring "v3 has a LOT of orphans" complaint). ~619 unresolved `class-validator` / `class-transformer` / `typeorm` / `mongoose` decorator imports were a symptom of this: the fields they decorate had no edge to attach.

## Root causes (all three reproduced in-pipeline before fixing)

1. **Field membership** — `@Column` (TypeORM) and `@Prop` (NestJS mongoose) field entities had no `CONTAINS` edge from their owning `@Entity`/`@Schema` class. They were pure orphans.
2. **Decorator-thunk target type** — `@ManyToOne(() => Role)`, `@ValidateNested() @Type(() => XDto)`, and `@Prop({ type: () => X } / [X] / ref: 'X')` carry a target class in a thunk, but no edge was emitted, so the related/nested class had no inbound link and ringed.
3. **Dropped relation (TypeORM)** — the relation regex required the field name immediately after the relation decorator's `)`. A companion `@JoinColumn(...)` between `@ManyToOne(...)` and the field name caused the **entire relation** (and its member + target edges) to be dropped.

Additionally, NestJS `@Schema()`/`@Prop()` decorator-style mongoose schemas were **entirely unextracted** (only the classic `new Schema()` form was handled).

## Fix (structural — orphan made impossible at emit time)

- New `containsFieldEdge` helper: every `@Column` / relation / `@Prop` field is emitted with a `CONTAINS` edge from `Class:<owner>` to the field entity.
- New `referencesClassEdge` helper: relation/nested-DTO/prop thunk targets emit a `REFERENCES` edge to `Class:<target>`, which binds via the real `resolve.BuildIndex` symbol table (same-file or symbol-table-wide).
- TypeORM relation regex now skips intervening companion decorators (`@JoinColumn`, etc.).
- Added NestJS `@Schema()`/`@Prop()` mongoose extraction (class + member props + thunk/array/ref target edges), with primitive-coercion targets (`Number`/`String`/`type: [String]`/...) correctly excluded from class references.

No new entity or relationship Kinds — reuses `CONTAINS` / `REFERENCES` and existing `SCOPE.*` kinds (producer-kind validator stays green).

## Live validation (in-pipeline, real source)

`internal/custom/javascript/issue4328_livedrepro_test.go` runs the **actual** extractors + `resolve.BuildIndex` over byte-copies of real `core-backend-v3` files. Red → green:

| Case | Before | After |
|---|---|---|
| TypeORM `user-group-role.entity.ts` columns | 3/3 orphan; `@ManyToOne` relation dropped | 0/4 orphan; 3 column + 1 relation `CONTAINS`; `REFERENCES → Class:Role` resolves |
| class-validator `create-checklist.body.dto.ts` nested `@Type(() => XDto)` | 0 target edges | `REFERENCES` to `CreateChecklistCategoryBody` + `CreateChecklistItemBody`, both resolve |
| NestJS mongoose `violation.schema.ts` `@Prop` | schema + props not extracted at all | `Violation` schema + 2 `@Prop` `CONTAINS` members |

## Frameworks covered vs deferred

Covered here (the v3 stack): **class-validator, class-transformer, TypeORM, @nestjs/mongoose**.

Deferred (same gap audited, follow-up issues filed, ref epic #4334):
- #4365 — JS/TS: Prisma, Sequelize, MikroORM, Drizzle, Objection
- #4366 — Python: Django, SQLAlchemy, Pydantic, DRF serializers
- #4367 — JVM/Ruby/Go: JPA-Hibernate, Bean Validation, ActiveRecord, GORM

## Gates

`go build ./...`, `go vet`, and `go test ./internal/custom/javascript/ ./internal/types/ ./internal/resolve/ ./internal/quality/...` all pass (incl. the producer-kind validator and existing TypeORM/ORM/validation tests).

Deploy-deferred.

Closes #4328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
