### PR TITLE
Link NestJS/supertest e2e route tests to their HTTP endpoints

### DIFF
--- a/internal/custom/javascript/issue4351_livedrepro_test.go
+++ b/internal/custom/javascript/issue4351_livedrepro_test.go
@@ -1,0 +1,140 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4351 LIVE-REPRO (extractor side).
+//
+// Byte-copies of REAL core-backend-v3 *.e2e-spec.ts files are committed under
+// testdata/e2e_4351. We run the ACTUAL jest extractor over them and assert the
+// supertest route-by-string calls are captured onto the one-per-spec
+// test_suite's `e2e_route_calls` property — the raw material the resolve pass
+// (TestIssue4351_E2ERouteTestsLinkToEndpoints in internal/engine) turns into
+// TESTS→http_endpoint_definition edges.
+//
+// Before #4351 the jest extractor recorded NO route information at all, so the
+// resolve pass had nothing to match on and e2e suites never connected to the
+// endpoints they exercise.
+
+func loadSpec4351(t *testing.T, base, repoPath string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "e2e_4351", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read spec %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: repoPath, Language: "typescript", Content: b}
+}
+
+func jestExtract4351(t *testing.T, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_jest")
+	if !ok {
+		t.Fatal("custom_js_jest not registered")
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func suiteRouteCalls(t *testing.T, ents []types.EntityRecord) []string {
+	t.Helper()
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			raw := e.Properties["e2e_route_calls"]
+			if raw == "" {
+				return nil
+			}
+			return strings.Split(raw, "\n")
+		}
+	}
+	return nil
+}
+
+// TestIssue4351_AuthGuardSpec_RouteCallsCaptured runs the real auth-guard e2e
+// spec (literal route strings like get('/probe/buildings')) and asserts the
+// verb+route pairs land on the suite.
+func TestIssue4351_AuthGuardSpec_RouteCallsCaptured(t *testing.T) {
+	ents := jestExtract4351(t, loadSpec4351(t,
+		"auth-guard.e2e-spec.ts", "test/auth-guard.e2e-spec.ts"))
+
+	calls := suiteRouteCalls(t, ents)
+	if len(calls) == 0 {
+		t.Fatal("no e2e_route_calls captured from auth-guard spec (#4351)")
+	}
+	want := map[string]bool{
+		"GET /probe/public":          false,
+		"GET /probe/buildings":       false,
+		"POST /probe/buildings":      false,
+		"GET /probe/devices-lite":    false,
+		"GET /probe/to-reschedule":   false,
+		"GET /probe/devices-lite-composed": false,
+	}
+	for _, c := range calls {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for k, got := range want {
+		if !got {
+			t.Errorf("expected captured route call %q, got=%v", k, calls)
+		}
+	}
+}
+
+// TestIssue4351_AlternateAddressSpec_ConstFoldAndTemplate runs the real
+// alternate-address e2e spec which uses `const ROUTE = '/api/v1/alternate-addresses'`
+// plus `${ROUTE}/${id}` template calls — exercising const-folding and
+// path-param templating in the extractor.
+func TestIssue4351_AlternateAddressSpec_ConstFoldAndTemplate(t *testing.T) {
+	ents := jestExtract4351(t, loadSpec4351(t,
+		"alternate-address-write.e2e-spec.ts", "test/alternate-address-write.e2e-spec.ts"))
+
+	calls := suiteRouteCalls(t, ents)
+	if len(calls) == 0 {
+		t.Fatal("no e2e_route_calls captured from alternate-address spec (#4351)")
+	}
+	joined := strings.Join(calls, "|")
+	// POST to the folded ROUTE constant.
+	if !strings.Contains(joined, "POST /api/v1/alternate-addresses") {
+		t.Errorf("ROUTE const not folded for POST; calls=%v", calls)
+	}
+	// PATCH `${ROUTE}/${id}` → folded base + ${id} param left for the resolver.
+	sawTemplatedPatch := false
+	for _, c := range calls {
+		if strings.HasPrefix(c, "PATCH /api/v1/alternate-addresses/") {
+			sawTemplatedPatch = true
+		}
+	}
+	if !sawTemplatedPatch {
+		t.Errorf("templated PATCH route not captured; calls=%v", calls)
+	}
+}
+
+// TestIssue4351_AppSpec_RootRoute covers the trivial get('/') case.
+func TestIssue4351_AppSpec_RootRoute(t *testing.T) {
+	ents := jestExtract4351(t, loadSpec4351(t,
+		"app.e2e-spec.ts", "test/app.e2e-spec.ts"))
+	calls := suiteRouteCalls(t, ents)
+	found := false
+	for _, c := range calls {
+		if c == "GET /" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected GET / captured from app spec; calls=%v", calls)
+	}
+}

--- a/internal/custom/javascript/jest.go
+++ b/internal/custom/javascript/jest.go
@@ -67,6 +67,41 @@ var (
 	reGetArg     = regexp.MustCompile(`\.get\(\s*([A-Z][A-Za-z0-9_]*)\s*[),]`)
 	// A bare TitleCase identifier (for matching describe labels against imports).
 	reIdentToken = regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*$`)
+
+	// ── supertest e2e route-call resolution (issue #4351) ───────────────────
+	// NestJS/Express e2e specs exercise the app through HTTP via supertest:
+	//   request(app.getHttpServer()).post('/inspections/123/items').send(dto)
+	//   request(httpServer).get(`${ROUTE}/${id}`)...
+	// We capture the HTTP verb + the route argument so the resolve pass can
+	// match (verb, normalized-route) against the synthesized
+	// http_endpoint_definition entities and emit a TESTS edge from the e2e
+	// suite to the endpoint(s) it covers. Without this, e2e suites link (at
+	// best) to a class subject (#4343) and the endpoints they cover look
+	// untested.
+	//
+	// reSupertestCall matches `request(<anything>).<verb>(<route-arg>` — the
+	// route-arg group captures a single-quoted, double-quoted, or back-tick
+	// (template-literal) string. We do NOT require the `request(` and the
+	// verb call to be adjacent on the same line because specs frequently chain
+	// across lines; instead we first find each `request(` opener, then scan a
+	// bounded window for the first verb call. (See extractSupertestRouteCalls.)
+	// The route argument is either a quoted/back-tick string OR a bare
+	// identifier (e.g. `.post(ROUTE)`) that resolves via a local route const.
+	reSupertestVerbCall = regexp.MustCompile(
+		`\.(get|post|put|patch|delete|head|options)\s*\(\s*(` +
+			"`" + `[^` + "`" + `]*` + "`" + `|'[^']*'|"[^"]*"|[A-Za-z_$][\w$]*)`,
+	)
+	// reRequestOpener locates a supertest invocation start. Both bare
+	// `request(` and a `supertest(`-aliased form are recognised.
+	reRequestOpener = regexp.MustCompile(`\b(?:request|supertest)\s*\(`)
+	// reRouteConstDecl folds simple `const ROUTE = '/literal'` /
+	// `const ROUTE = "/literal"` declarations so a `${ROUTE}/${id}` template in
+	// a supertest call resolves to a concrete-ish path. Only literal string
+	// initialisers are captured (no concatenation / function calls) to stay
+	// conservative.
+	reRouteConstDecl = regexp.MustCompile(
+		`(?:^|[;\n])\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*('[^']*'|"[^"]*")`,
+	)
 )
 
 // Extract emits ONE linked test_suite entity per recognised unit-under-test in
@@ -115,6 +150,9 @@ func (e *jestExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 	imported := collectImportedSymbols(src)
 	subjects := resolveTestSubjects(src, imported)
 
+	// ── collect supertest e2e route calls (issue #4351) ──────────────────────
+	routeCalls := extractSupertestRouteCalls(src)
+
 	// Per-spec aggregate counts folded onto the suite(s).
 	caseCount := len(tests)
 	hookCount := len(hooks)
@@ -158,6 +196,21 @@ func (e *jestExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 		"hook_count", strconv.Itoa(hookCount),
 		"mock_count", strconv.Itoa(mockCount),
 	)
+	// #4351 — stamp the supertest route calls so the resolve pass
+	// (ResolveHTTPEndpointHandlers) can match (verb, normalized-route) against
+	// the synthesized http_endpoint_definition entities and emit TESTS edges
+	// from this e2e suite to the endpoints it covers. We attach the raw
+	// "VERB route" pairs (one per line) as a single property rather than
+	// emitting per-call entities, keeping the one-node-per-spec invariant from
+	// #4343. The actual endpoint resolution is deferred to resolve-time because
+	// only there is the cross-file http_endpoint_definition index available —
+	// the controller defining the route usually lives in a different file than
+	// the spec, and resolve-time resolution is merge-stable (it runs over the
+	// fully-merged entity table, the same place the call→definition linkage
+	// resolves).
+	if len(routeCalls) > 0 {
+		setProps(&ent, "e2e_route_calls", strings.Join(routeCalls, "\n"))
+	}
 	if len(subjects) > 0 {
 		setProps(&ent, "tests_target", strings.Join(subjects, ","))
 		for _, subj := range subjects {
@@ -291,6 +344,140 @@ func resolveTestSubjects(src string, imported map[string]bool) []string {
 	}
 
 	return ordered
+}
+
+// extractSupertestRouteCalls returns the de-duplicated set of "VERB route"
+// pairs invoked through supertest in a spec, e.g. ["POST /api/v1/items",
+// "GET /probe/buildings"]. The route is the raw argument string with quotes
+// stripped and simple `${CONST}` template substitutions folded from local
+// `const NAME = '/literal'` declarations; remaining `${expr}` params (path
+// IDs) are left intact for the resolver's structural normalizer to wildcard.
+//
+// Matching strategy: for each `request(` / `supertest(` opener we scan a
+// bounded window (the supertest chain rarely spans more than a few hundred
+// bytes) for the FIRST verb call and capture its route argument. This keeps a
+// `.set('Authorization', ...)` or `.send(dto)` in the chain from being
+// mistaken for the route call, and tolerates the chain breaking across lines.
+//
+// Only the route ARGUMENT is interpreted — no edges are emitted here; the
+// resolve pass owns endpoint matching so the linkage is merge-stable and
+// reuses the same path-normalization the call→definition resolver uses.
+func extractSupertestRouteCalls(src string) []string {
+	consts := collectRouteConsts(src)
+
+	seen := make(map[string]bool)
+	var out []string
+	openers := reRequestOpener.FindAllStringIndex(src, -1)
+	for _, op := range openers {
+		// Bounded forward window from the opener to find the verb call. 400
+		// bytes comfortably covers a multi-line supertest chain without
+		// bleeding into the next statement/test.
+		end := op[1] + 400
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[op[0]:end]
+		m := reSupertestVerbCall.FindStringSubmatch(window)
+		if m == nil {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		route := normalizeRouteArg(m[2], consts)
+		if route == "" {
+			continue
+		}
+		key := verb + " " + route
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	return out
+}
+
+// collectRouteConsts folds `const NAME = '/literal'` declarations into a
+// name→value map so `${NAME}` template substitutions in supertest route
+// arguments can be expanded. Only string-literal initialisers are recorded.
+func collectRouteConsts(src string) map[string]string {
+	out := map[string]string{}
+	for _, m := range reRouteConstDecl.FindAllStringSubmatch(src, -1) {
+		name := m[1]
+		val := stripQuote(m[2])
+		if name != "" && val != "" {
+			out[name] = val
+		}
+	}
+	return out
+}
+
+// normalizeRouteArg turns a captured supertest route argument (a quoted or
+// back-tick string, including surrounding quotes) into a route path. Simple
+// `${NAME}` substitutions resolve from the const map; unresolved `${...}`
+// expressions are kept verbatim so the resolver's structural normalizer can
+// wildcard them. Returns "" when the argument is not a usable route (e.g. an
+// absolute URL to a third-party host, or an empty/relative-less string).
+func normalizeRouteArg(arg string, consts map[string]string) string {
+	arg = strings.TrimSpace(arg)
+	// Bare identifier argument (e.g. `.post(ROUTE)`): resolve via the local
+	// route-const map; if unknown it is too ambiguous to use — skip.
+	if len(arg) > 0 && arg[0] != '\'' && arg[0] != '"' && arg[0] != '`' {
+		if v, ok := consts[arg]; ok {
+			return normalizeRouteArg("'"+v+"'", consts)
+		}
+		return ""
+	}
+	s := stripQuote(arg)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Fold ${NAME} → const value when NAME is a known route const.
+	if strings.Contains(s, "${") {
+		s = reTemplateExpr.ReplaceAllStringFunc(s, func(match string) string {
+			inner := reTemplateExpr.FindStringSubmatch(match)
+			if len(inner) < 2 {
+				return match
+			}
+			name := strings.TrimSpace(inner[1])
+			if v, ok := consts[name]; ok {
+				return v
+			}
+			return match
+		})
+	}
+	// Collapse accidental duplicate slashes introduced by `${ROUTE}/...`
+	// folding where ROUTE already ended in `/`.
+	for strings.Contains(s, "//") && !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = strings.ReplaceAll(s, "//", "/")
+	}
+	// Only path-shaped routes are interpretable; an absolute URL to another
+	// host is not an in-repo endpoint and must be skipped.
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return ""
+	}
+	if !strings.HasPrefix(s, "/") {
+		// Supertest routes are server-relative and start with '/'. Anything
+		// else (a bare path fragment, a variable that didn't fold) is too
+		// ambiguous to resolve — skip conservatively.
+		return ""
+	}
+	return s
+}
+
+// reTemplateExpr matches a `${expr}` substitution in a template literal.
+var reTemplateExpr = regexp.MustCompile(`\$\{([^}]*)\}`)
+
+// stripQuote removes a single layer of surrounding ', ", or ` from s.
+func stripQuote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '\'' || q == '"' || q == '`') && s[len(s)-1] == q {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 // suiteEntityName namespaces a test_suite's entity name so it never collides

--- a/internal/custom/javascript/testdata/e2e_4351/alternate-address-write.e2e-spec.ts
+++ b/internal/custom/javascript/testdata/e2e_4351/alternate-address-write.e2e-spec.ts
@@ -1,0 +1,254 @@
+import request from 'supertest';
+import { INestApplication, VersioningType } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { AllExceptionsFilter } from '../src/common/exceptions/all-exceptions/all-exceptions.filter';
+import { EnvelopeInterceptor } from '../src/common/envelope/interceptor/envelope.interceptor';
+import { ErrorShapeInterceptor } from '../src/common/validation/error-shape-interceptor/error-shape.interceptor';
+import { createValidationPipe } from '../src/common/validation/validation-pipe/validation-pipe.factory';
+import { AuthGuard } from '../src/common/auth/guards/auth.guard';
+import { CognitoTokenValidator } from '../src/common/auth/token-validator/cognito-token.validator';
+import { PagePermissionResolver } from '../src/common/auth/page/page-permission.resolver';
+import { ActionPermissionResolver } from '../src/common/auth/action/action-permission.resolver';
+import { PrincipalFactory } from '../src/common/auth/page/principal.factory';
+import { PageGrantRepository } from '../src/common/auth/persistence/page-grant.repository';
+import { RolePermission } from '../src/common/auth/persistence/role-permission.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AlternateAddressController } from '../src/modules/alternate-addresses/api/alternate-address.controller';
+import { AlternateAddressService } from '../src/modules/alternate-addresses/services/alternate-address.service';
+import { AlternateAddressRepository } from '../src/modules/alternate-addresses/repositories/alternate-address.repository';
+import { AlternateAddress } from '../src/modules/alternate-addresses/models/alternate-address.entity';
+import { buildJwtFixtures, E2E_ISSUER, E2E_AUDIENCE } from './support/jwt-helper';
+import { InMemoryPageGrantRepository } from './support/auth-test-module';
+import { initE2eApp, sealE2eApp, closeE2eApp } from './support/e2e-app';
+import type { JwtFixtures } from './support/jwt-helper';
+
+const TEST_SUB = 'e2e-user-sub';
+const GROUP_A = 'group-a';
+const ROUTE = '/api/v1/alternate-addresses';
+
+class InMemoryAlternateAddressRepo {
+  private seq = 0;
+  private readonly rows = new Map<number, AlternateAddress>();
+
+  create(attributes: Partial<AlternateAddress>): Promise<AlternateAddress> {
+    const entity = new AlternateAddress();
+    entity.id = ++this.seq;
+    entity.buildingId = attributes.buildingId as number;
+    entity.groupId = attributes.groupId ?? null;
+    entity.address = attributes.address as string;
+    entity.createdAt = new Date('2024-01-01T00:00:00Z');
+    entity.updatedAt = new Date('2024-01-01T00:00:00Z');
+    entity.deletedAt = null;
+    this.rows.set(entity.id, entity);
+    return Promise.resolve(entity);
+  }
+
+  applyUpdate(id: number, attributes: Partial<AlternateAddress>): Promise<AlternateAddress | null> {
+    const existing = this.rows.get(id);
+    if (!existing) return Promise.resolve(null);
+    Object.assign(existing, attributes);
+    return Promise.resolve(existing);
+  }
+
+  softDelete(id: number): Promise<boolean> {
+    return Promise.resolve(this.rows.delete(id));
+  }
+}
+
+interface ErrorEnvelope {
+  [field: string]: string[];
+}
+
+describe('AlternateAddressController — write HTTP e2e (F8c, issue #19 lifecycle proof)', () => {
+  let app: INestApplication;
+  let fixtures: JwtFixtures;
+  let grantRepo: InMemoryPageGrantRepository;
+
+  beforeAll(async () => {
+    fixtures = await buildJwtFixtures();
+    grantRepo = new InMemoryPageGrantRepository();
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AlternateAddressController],
+      providers: [
+        AlternateAddressService,
+        { provide: AlternateAddressRepository, useClass: InMemoryAlternateAddressRepo },
+        { provide: APP_FILTER, useClass: AllExceptionsFilter },
+        { provide: APP_INTERCEPTOR, useClass: ErrorShapeInterceptor },
+        { provide: APP_INTERCEPTOR, useClass: EnvelopeInterceptor },
+        { provide: APP_PIPE, useFactory: createValidationPipe },
+        { provide: APP_GUARD, useClass: AuthGuard },
+        PagePermissionResolver,
+        ActionPermissionResolver,
+        PrincipalFactory,
+        {
+          provide: CognitoTokenValidator,
+          useFactory: () => {
+            const config = {
+              get: (key: string): string => {
+                if (key === 'COGNITO_ISSUER') return E2E_ISSUER;
+                if (key === 'COGNITO_AUDIENCE') return E2E_AUDIENCE;
+                return '';
+              },
+            } as ConfigService;
+            return new CognitoTokenValidator(config, fixtures.keyFetcher);
+          },
+        },
+        { provide: PageGrantRepository, useValue: grantRepo },
+        { provide: getRepositoryToken(RolePermission), useValue: {} },
+      ],
+    }).compile();
+
+    app = initE2eApp(moduleRef);
+    app.setGlobalPrefix('api', { exclude: ['health'] });
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    await sealE2eApp(app);
+  });
+
+  afterAll(async () => {
+    await closeE2eApp(app);
+  });
+
+  afterEach(() => {
+    grantRepo.clear();
+  });
+
+  async function writeToken(): Promise<string> {
+    grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: true, write: true }]);
+    return fixtures.mintToken({ group: GROUP_A });
+  }
+
+  describe('auth on the write routes', () => {
+    it('401 when no bearer token is supplied', () => {
+      return request(app.getHttpServer()).post(ROUTE).send({ building: 1, group: 2, address: 'x' }).expect(401);
+    });
+
+    it('403 when the principal has only a read grant (write bit missing)', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 1, group: 2, address: 'x' })
+        .expect(403);
+    });
+  });
+
+  describe('validation-400 over the wire (the #19 proof)', () => {
+    it('returns 400 with the bare field-error map when address is missing', async () => {
+      const token = await writeToken();
+
+      const res = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 10, group: 20 })
+        .expect(400);
+
+      const body = res.body as ErrorEnvelope;
+      expect(body).not.toHaveProperty('success');
+      expect(body).not.toHaveProperty('message');
+      expect(Array.isArray(body.address)).toBe(true);
+      expect(typeof body.address[0]).toBe('string');
+    });
+
+    it('reports every missing required field as its own key', async () => {
+      const token = await writeToken();
+
+      const res = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({})
+        .expect(400);
+
+      const body = res.body as ErrorEnvelope;
+      expect(body).toHaveProperty('building');
+      expect(body).toHaveProperty('group');
+      expect(body).toHaveProperty('address');
+    });
+
+    it('returns 400 when address exceeds the max length', async () => {
+      const token = await writeToken();
+
+      const res = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 10, group: 20, address: 'x'.repeat(256) })
+        .expect(400);
+
+      expect(Array.isArray((res.body as ErrorEnvelope).address)).toBe(true);
+    });
+  });
+
+  describe('success lifecycle', () => {
+    it('201 on a valid create, returning the record inside the success envelope', async () => {
+      const token = await writeToken();
+
+      const res = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 10, group: 20, address: '5 Main St' })
+        .expect(201);
+
+      const body = res.body as { success: boolean; response: Record<string, unknown> };
+      expect(body.success).toBe(true);
+      expect(body.response).toMatchObject({ building: 10, group: 20, address: '5 Main St' });
+      expect(body.response).toHaveProperty('id');
+      expect(body.response).toHaveProperty('created_at');
+    });
+
+    it('200 on a valid PATCH update of an existing record', async () => {
+      const token = await writeToken();
+
+      const created = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 10, group: 20, address: '5 Main St' })
+        .expect(201);
+
+      const id = (created.body as { response: { id: number } }).response.id;
+
+      const res = await request(app.getHttpServer())
+        .patch(`${ROUTE}/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ address: '7 Oak Ave' })
+        .expect(200);
+
+      expect((res.body as { response: { address: string } }).response.address).toBe('7 Oak Ave');
+    });
+
+    it('204 on delete of an existing record', async () => {
+      const token = await writeToken();
+
+      const created = await request(app.getHttpServer())
+        .post(ROUTE)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ building: 10, group: 20, address: '5 Main St' })
+        .expect(201);
+
+      const id = (created.body as { response: { id: number } }).response.id;
+
+      await request(app.getHttpServer()).delete(`${ROUTE}/${id}`).set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(204);
+    });
+
+    it('404 on update of a missing record', async () => {
+      const token = await writeToken();
+
+      return request(app.getHttpServer())
+        .patch(`${ROUTE}/9999`)
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .send({ address: 'nope' })
+        .expect(404);
+    });
+  });
+});

--- a/internal/custom/javascript/testdata/e2e_4351/app.e2e-spec.ts
+++ b/internal/custom/javascript/testdata/e2e_4351/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({ imports: [AppModule] }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/internal/custom/javascript/testdata/e2e_4351/auth-guard.e2e-spec.ts
+++ b/internal/custom/javascript/testdata/e2e_4351/auth-guard.e2e-spec.ts
@@ -1,0 +1,156 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { buildJwtFixtures } from './support/jwt-helper';
+import { buildAuthTestApp, InMemoryPageGrantRepository } from './support/auth-test-module';
+import { closeE2eApp } from './support/e2e-app';
+import type { JwtFixtures } from './support/jwt-helper';
+
+const TEST_SUB = 'e2e-user-sub';
+const GROUP_A = 'group-a';
+const GROUP_B = 'group-b';
+
+describe('AuthGuard — HTTP e2e (F7c)', () => {
+  let app: INestApplication;
+  let fixtures: JwtFixtures;
+  let grantRepo: InMemoryPageGrantRepository;
+
+  beforeAll(async () => {
+    fixtures = await buildJwtFixtures();
+    const built = await buildAuthTestApp(fixtures);
+    app = built.app;
+    grantRepo = built.grantRepo;
+  });
+
+  afterAll(async () => {
+    await closeE2eApp(app);
+  });
+
+  afterEach(() => {
+    grantRepo.clear();
+  });
+
+  describe('@Public route', () => {
+    it('200 with no Authorization header', () => {
+      return request(app.getHttpServer()).get('/probe/public').expect(200);
+    });
+  });
+
+  describe('401 — unauthenticated', () => {
+    it('401 when Authorization header is absent', () => {
+      return request(app.getHttpServer()).get('/probe/buildings').expect(401);
+    });
+
+    it('401 for a malformed token string', () => {
+      return request(app.getHttpServer()).get('/probe/buildings').set('Authorization', 'Bearer not.a.real.jwt').expect(401);
+    });
+
+    it('401 for an expired token', async () => {
+      const token = await fixtures.mintToken({ expiredSecondsAgo: 3600 });
+      return request(app.getHttpServer()).get('/probe/buildings').set('Authorization', `Bearer ${token}`).expect(401);
+    });
+  });
+
+  describe('403 — authenticated, insufficient grants', () => {
+    it('403 when user has no grant for the required page', async () => {
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/buildings').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+
+    it('403 when grant exists for a DIFFERENT group (group-scoping proof at the wire)', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_B, [{ page: 'buildings', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/buildings').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+
+    it('403 when write method used but grant is read-only', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).post('/probe/buildings').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+  });
+
+  describe('200 — authenticated with valid grant', () => {
+    it('200 on GET when user has read grant for the correct group', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/buildings').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(200);
+    });
+
+    it('200 on POST when user has write grant for the correct group', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: false, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).post('/probe/buildings').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(200);
+    });
+  });
+
+  describe('@RequireAction — operation-level (type-2) tier at the wire', () => {
+    it('403 when the user holds the surrounding page grant but NOT the named action grant', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'devices', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/devices-lite').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+
+    it('403 when the action grant exists only in a DIFFERENT group', async () => {
+      grantRepo.seedActions(TEST_SUB, GROUP_B, [{ action: 'lite', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/devices-lite').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+
+    it('200 when the active group holds the matching action grant', async () => {
+      grantRepo.seedActions(TEST_SUB, GROUP_A, [{ action: 'lite', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/devices-lite').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(200);
+    });
+
+    it('composition: holding only the page grant is 403 — the action grant is also required', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'devices', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer())
+        .get('/probe/devices-lite-composed')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .expect(403);
+    });
+
+    it('composition: holding only the action grant is 403 — the page grant is also required', async () => {
+      grantRepo.seedActions(TEST_SUB, GROUP_A, [{ action: 'lite', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer())
+        .get('/probe/devices-lite-composed')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .expect(403);
+    });
+
+    it('composition: 200 only when BOTH the page and the action grant are held', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'devices', read: true, write: true }]);
+      grantRepo.seedActions(TEST_SUB, GROUP_A, [{ action: 'lite', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer())
+        .get('/probe/devices-lite-composed')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Group-Id', GROUP_A)
+        .expect(200);
+    });
+  });
+
+  describe('@RequireAnyPage — OR over page grants at the wire', () => {
+    it('403 when the user holds NONE of the listed pages', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'buildings', read: true, write: true }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/to-reschedule').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(403);
+    });
+
+    it('200 when the user holds the FIRST listed page', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'inspection-results', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/to-reschedule').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(200);
+    });
+
+    it('200 when the user holds the SECOND listed page (OR)', async () => {
+      grantRepo.seed(TEST_SUB, GROUP_A, [{ page: 'scheduling', read: true, write: false }]);
+      const token = await fixtures.mintToken({ group: GROUP_A });
+      return request(app.getHttpServer()).get('/probe/to-reschedule').set('Authorization', `Bearer ${token}`).set('X-Group-Id', GROUP_A).expect(200);
+    });
+  });
+});

--- a/internal/engine/http_endpoint_e2e_testmap.go
+++ b/internal/engine/http_endpoint_e2e_testmap.go
@@ -1,0 +1,318 @@
+// http_endpoint_e2e_testmap.go — link e2e HTTP route tests (supertest /
+// MockMvc-style "call a route by string") to the http_endpoint_definition they
+// exercise, emitting a TESTS edge from the test_suite to the endpoint
+// (issue #4351).
+//
+// Background
+// ----------
+// NestJS / Express e2e specs drive the app through HTTP:
+//
+//	request(app.getHttpServer()).post('/inspections/123/items').send(dto).expect(201)
+//
+// The Jest extractor (internal/custom/javascript/jest.go) collapses such a spec
+// into ONE test_suite entity (#4343) and stamps the verb+route pairs it issues
+// onto an `e2e_route_calls` property (one "VERB route" per line). After #4343
+// the suite links (at best) to a CLASS subject — but the route-string →
+// http_endpoint_definition linkage was missing, so e2e suites never connected
+// to the endpoints they cover and those endpoints looked untested.
+//
+// This pass closes that gap. It runs INSIDE ResolveHTTPEndpointHandlers, after
+// the http_endpoint_definition entities have been migrated and indexed
+// (definitionByPath), so it reuses the exact same path-normalization the
+// call→definition resolver uses and is merge-stable: it operates over the fully
+// merged entity table, the same place call/definition linkage resolves, rather
+// than a fragile post-hoc name match in an extractor that cannot see the
+// controller in another file.
+//
+// Matching
+// --------
+// The route in the test (`/inspections/123/items`) carries CONCRETE path
+// params; the endpoint definition carries a TEMPLATE
+// (`/inspections/:id/items` → synthesized as `/inspections/{id}/items`,
+// possibly under a `/api/v1` mount prefix). We match in two tiers:
+//
+//  1. Structural key match via endpointMatchKeys — handles the common case
+//     where the test route is ALREADY in template/wildcard shape (a
+//     `${ROUTE}/${id}` that folded to `/api/v1/x/{id}`-ish) and the API-prefix
+//     stripping aligns the two sides. Verb must be compatible (verbsMatchCompat).
+//
+//  2. Segment matcher (matchConcreteRouteToDefinition) — handles the
+//     concrete-vs-template case: the test path `/inspections/123/items` is
+//     compared SEGMENT-BY-SEGMENT against every same-verb definition template,
+//     treating a definition `{param}` / `:param` / `<int:id>` segment as a
+//     wildcard that any single concrete test segment satisfies, and requiring
+//     literal segments to be equal (case-insensitively). The API/version mount
+//     prefix on either side is tolerated.
+//
+// Conservatism (no fabricated edges)
+// ----------------------------------
+// An edge is emitted ONLY when verb+route uniquely matches EXACTLY ONE
+// definition. If zero or more-than-one definitions match, the route is skipped
+// (no TESTS edge, no `untested_route` fabrication). This mirrors the
+// no-guessing posture of the #4319 co-location fallback.
+package engine
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// testSuiteKind is the entity Kind the Jest extractor stamps on the one
+// suite-per-spec node (see internal/custom/javascript/jest.go).
+const testSuiteKind = "test_suite"
+
+// linkE2ERouteTestsToEndpoints walks every test_suite carrying an
+// `e2e_route_calls` property and emits a TESTS edge to each
+// http_endpoint_definition uniquely matched by (verb, normalized-route).
+// Returns the number of TESTS edges emitted. definitionByPath/defByIndex are
+// the indices already built by the caller over the merged set.
+func linkE2ERouteTestsToEndpoints(
+	merged []types.EntityRecord,
+	definitionByPath map[string][]int,
+	defIndices []int,
+) int {
+	emitted := 0
+	for i := range merged {
+		s := &merged[i]
+		if s.Kind != testSuiteKind || s.Properties == nil {
+			continue
+		}
+		raw := s.Properties["e2e_route_calls"]
+		if raw == "" {
+			continue
+		}
+		// De-dup target definitions per suite so a suite hitting the same
+		// endpoint under several verbs/fixtures yields ONE TESTS edge.
+		linked := map[int]bool{}
+		for _, line := range strings.Split(raw, "\n") {
+			verb, route, ok := splitVerbRoute(line)
+			if !ok {
+				continue
+			}
+			defIdx, matched := resolveRouteTestToDefinition(verb, route, merged, definitionByPath, defIndices)
+			if !matched || linked[defIdx] {
+				continue
+			}
+			linked[defIdx] = true
+			def := &merged[defIdx]
+			s.Relationships = append(s.Relationships, types.RelationshipRecord{
+				FromID: s.Kind + ":" + s.Name,
+				ToID:   def.Kind + ":" + def.Name,
+				Kind:   string(types.RelationshipKindTests),
+				Properties: map[string]string{
+					"framework":    propOr(s, "framework", "jest"),
+					"match_source": "e2e_supertest_route",
+					"verb":         verb,
+					"route":        route,
+				},
+				Confidence: 0.9,
+			})
+			emitted++
+		}
+	}
+	return emitted
+}
+
+// splitVerbRoute parses a "VERB route" line into its parts. Returns ok=false
+// when the line is empty/malformed or the route is not path-shaped.
+func splitVerbRoute(line string) (verb, route string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", "", false
+	}
+	sp := strings.IndexByte(line, ' ')
+	if sp <= 0 {
+		return "", "", false
+	}
+	verb = strings.ToUpper(strings.TrimSpace(line[:sp]))
+	route = strings.TrimSpace(line[sp+1:])
+	if verb == "" || !strings.HasPrefix(route, "/") {
+		return "", "", false
+	}
+	return verb, route, true
+}
+
+// resolveRouteTestToDefinition resolves a (verb, route) test call to a UNIQUE
+// http_endpoint_definition index. Tier 1 reuses the structural key index
+// (endpointMatchKeys) used by the call→definition resolver. Tier 2 runs the
+// concrete-vs-template segment matcher across every definition. An edge is
+// returned only on a UNIQUE same-verb match in whichever tier first yields one;
+// ambiguous or empty results return matched=false.
+func resolveRouteTestToDefinition(
+	verb, route string,
+	merged []types.EntityRecord,
+	definitionByPath map[string][]int,
+	defIndices []int,
+) (int, bool) {
+	// Tier 1 — structural key match (handles already-templated test routes and
+	// API-prefix alignment). Collect UNIQUE same-verb candidates.
+	tier1 := map[int]bool{}
+	for _, key := range endpointMatchKeys(route) {
+		for _, idx := range definitionByPath[key] {
+			if verbsMatchCompat(verb, propOr(&merged[idx], "verb", "")) {
+				tier1[idx] = true
+			}
+		}
+	}
+	if len(tier1) == 1 {
+		for idx := range tier1 {
+			return idx, true
+		}
+	}
+	if len(tier1) > 1 {
+		// Ambiguous on the structural key — do not guess.
+		return 0, false
+	}
+
+	// Tier 2 — concrete-vs-template segment matcher over all definitions.
+	tier2 := -1
+	count := 0
+	for _, idx := range defIndices {
+		def := &merged[idx]
+		if !verbsMatchCompat(verb, propOr(def, "verb", "")) {
+			continue
+		}
+		if matchConcreteRouteToDefinition(route, propOr(def, "path", "")) {
+			tier2 = idx
+			count++
+			if count > 1 {
+				return 0, false // ambiguous — no guessing
+			}
+		}
+	}
+	if count == 1 {
+		return tier2, true
+	}
+	return 0, false
+}
+
+// matchConcreteRouteToDefinition reports whether a CONCRETE test route (e.g.
+// `/api/v1/inspections/123/items`) matches a definition TEMPLATE (e.g.
+// `/inspections/{id}/items` or `/inspections/:id/items`). A definition
+// param-segment ({x} / :x / <int:x>) is a wildcard satisfied by any single
+// concrete test segment; literal segments must match case-insensitively. The
+// API/version mount prefix (`/api`, `/api/vN`, `/vN`) is tolerated on EITHER
+// side so a prefixed backend route and an unprefixed test route still align.
+func matchConcreteRouteToDefinition(testRoute, defPath string) bool {
+	if defPath == "" {
+		return false
+	}
+	testSegs := routeSegments(testRoute)
+	defSegs := routeSegments(defPath)
+
+	// Try aligning with the API/version prefix present on neither, one, or both
+	// sides: strip from each independently and compare every combination. This
+	// is cheap (at most 4 comparisons) and conservative — only the well-known
+	// prefixes are stripped (stripRouteAPIPrefix).
+	testVariants := [][]string{testSegs}
+	if stripped, ok := stripRouteAPIPrefix(testSegs); ok {
+		testVariants = append(testVariants, stripped)
+	}
+	defVariants := [][]string{defSegs}
+	if stripped, ok := stripRouteAPIPrefix(defSegs); ok {
+		defVariants = append(defVariants, stripped)
+	}
+	for _, ts := range testVariants {
+		for _, ds := range defVariants {
+			if segmentsMatch(ts, ds) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// segmentsMatch compares concrete test segments against definition template
+// segments: same length, definition param-segments wildcard a concrete
+// segment, literal segments compared case-insensitively.
+func segmentsMatch(testSegs, defSegs []string) bool {
+	if len(testSegs) != len(defSegs) {
+		return false
+	}
+	for i := range defSegs {
+		if isRouteParamSegment(defSegs[i]) {
+			continue // wildcard — any single concrete segment satisfies it
+		}
+		// A test segment that is ITSELF an unresolved template (`${expr}`) can
+		// satisfy a literal only if it actually equals it; otherwise treat the
+		// definition literal as required. Concrete test param values are common
+		// (e.g. "123"), so a literal-vs-literal compare is the norm here.
+		if !strings.EqualFold(testSegs[i], defSegs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// routeSegments splits a route path into non-empty segments, dropping any query
+// string and trailing slash. `/api/v1/x/{id}` → ["api","v1","x","{id}"].
+func routeSegments(p string) []string {
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	parts := strings.Split(p, "/")
+	out := parts[:0]
+	for _, s := range parts {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// isRouteParamSegment reports whether a definition path segment is a
+// path-parameter placeholder in any notation the synthesizers emit:
+// `{id}` (OpenAPI/Nest/Express curly), `:id` (Express/Rails colon),
+// `<int:id>` (Flask/Django angle), or a folded-but-unresolved `${expr}`.
+func isRouteParamSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	if strings.HasPrefix(seg, "${") && strings.HasSuffix(seg, "}") {
+		return true
+	}
+	if seg[0] == ':' {
+		return true
+	}
+	if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+		return true
+	}
+	if strings.HasPrefix(seg, "<") && strings.HasSuffix(seg, ">") {
+		return true
+	}
+	return false
+}
+
+// stripRouteAPIPrefix removes a leading `api`, `api/vN`, or `vN` segment group
+// from a segment slice. Returns (stripped, true) when a prefix was present.
+func stripRouteAPIPrefix(segs []string) ([]string, bool) {
+	if len(segs) == 0 {
+		return segs, false
+	}
+	first := strings.ToLower(segs[0])
+	if first == "api" {
+		if len(segs) >= 2 && isVersionSegment(segs[1]) {
+			return segs[2:], true
+		}
+		return segs[1:], true
+	}
+	if isVersionSegment(segs[0]) {
+		return segs[1:], true
+	}
+	return segs, false
+}
+
+// isVersionSegment reports whether a segment is a `vN` API-version marker.
+func isVersionSegment(seg string) bool {
+	seg = strings.ToLower(seg)
+	if len(seg) < 2 || seg[0] != 'v' {
+		return false
+	}
+	for i := 1; i < len(seg); i++ {
+		if seg[i] < '0' || seg[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4351_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4351_test.go
@@ -1,0 +1,172 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4351 — e2e HTTP route tests (supertest route-by-string) must produce a
+// TESTS edge from the test_suite to the http_endpoint_definition they exercise.
+//
+// These tests drive the REAL resolve pass (ResolveHTTPEndpointHandlers) over a
+// merged entity table shaped like the live core-backend-v3 graph: NestJS
+// controller routes synthesized as http_endpoint_definition entities (with an
+// `/api/v1` mount prefix and `:id`/`{id}` template params) plus the one-per-spec
+// test_suite that the Jest extractor stamps with `e2e_route_calls`.
+//
+// BEFORE this fix the resolve pass had no e2e-route linkage step, so a suite's
+// route calls produced ZERO TESTS→endpoint edges and the endpoints looked
+// untested. AFTER, each (verb, normalized-route) that uniquely matches a
+// definition yields a TESTS edge.
+
+// testsEdgesToEndpoints returns the TESTS edges whose target is an
+// http_endpoint_definition stub.
+func testsEdgesToEndpoints(ents []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				len(r.ToID) > len(httpEndpointDefinitionKind) &&
+				r.ToID[:len(httpEndpointDefinitionKind)] == httpEndpointDefinitionKind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func def(verb, path string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:" + verb + ":" + path,
+		SourceFile: "src/x/x.controller.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb":         verb,
+			"path":         path,
+			"framework":    "nestjs",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+}
+
+func e2eSuite(routeCalls string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       testSuiteKind,
+		Subtype:    "test_suite",
+		Name:       "spec:alt-address.e2e:AltAddress",
+		SourceFile: "test/alternate-address-write.e2e-spec.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"framework":       "jest",
+			"e2e_route_calls": routeCalls,
+		},
+	}
+}
+
+// TestIssue4351_E2ERouteTestsLinkToEndpoints is the core RED→GREEN proof. A
+// suite issuing concrete supertest routes against templated, /api/v1-prefixed
+// NestJS endpoints must link to exactly the endpoints it covers.
+func TestIssue4351_E2ERouteTestsLinkToEndpoints(t *testing.T) {
+	// Definitions as the NestJS synthesizer emits them: prefixed + templated.
+	defs := []types.EntityRecord{
+		def("POST", "/api/v1/alternate-addresses"),
+		def("PATCH", "/api/v1/alternate-addresses/{id}"),
+		def("DELETE", "/api/v1/alternate-addresses/{id}"),
+		// An unrelated endpoint that must NOT be linked.
+		def("GET", "/api/v1/buildings/{id}"),
+	}
+
+	// Suite route calls as the Jest extractor captures them (concrete params,
+	// const-folded prefix; PATCH/DELETE hit a concrete id like "9999").
+	suite := e2eSuite(
+		"POST /api/v1/alternate-addresses\n" +
+			"PATCH /api/v1/alternate-addresses/9999\n" +
+			"DELETE /api/v1/alternate-addresses/42",
+	)
+
+	merged := append(append([]types.EntityRecord{}, defs...), suite)
+
+	// BEFORE: no e2e_route_calls property → no edges (control).
+	control := suite
+	control.Properties = map[string]string{"framework": "jest"} // strip the property
+	beforeMerged := append(append([]types.EntityRecord{}, defs...), control)
+	beforeOut, beforeStats := ResolveHTTPEndpointHandlers(beforeMerged)
+	if got := len(testsEdgesToEndpoints(beforeOut)); got != 0 {
+		t.Fatalf("control (no e2e_route_calls) must emit 0 TESTS→endpoint edges, got %d", got)
+	}
+	if beforeStats.E2ERouteTestEdges != 0 {
+		t.Fatalf("control E2ERouteTestEdges=%d, want 0", beforeStats.E2ERouteTestEdges)
+	}
+
+	// AFTER: route calls present → TESTS edges to the matched endpoints.
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	edges := testsEdgesToEndpoints(out)
+	if stats.E2ERouteTestEdges != 3 {
+		t.Fatalf("expected 3 e2e route TESTS edges, got %d (edges=%v)", stats.E2ERouteTestEdges, edges)
+	}
+
+	wantTargets := map[string]bool{
+		"http_endpoint_definition:http:POST:/api/v1/alternate-addresses":        false,
+		"http_endpoint_definition:http:PATCH:/api/v1/alternate-addresses/{id}":  false,
+		"http_endpoint_definition:http:DELETE:/api/v1/alternate-addresses/{id}": false,
+	}
+	for _, e := range edges {
+		if _, ok := wantTargets[e.ToID]; ok {
+			wantTargets[e.ToID] = true
+		} else {
+			t.Errorf("unexpected TESTS edge target %q", e.ToID)
+		}
+	}
+	for tgt, got := range wantTargets {
+		if !got {
+			t.Errorf("missing TESTS edge to %q; edges=%v", tgt, edges)
+		}
+	}
+
+	// The unrelated /buildings endpoint must NOT be a target.
+	for _, e := range edges {
+		if e.ToID == "http_endpoint_definition:http:GET:/api/v1/buildings/{id}" {
+			t.Error("linked an endpoint the suite never called (false TESTS edge)")
+		}
+	}
+}
+
+// TestIssue4351_UnprefixedTestRouteMatchesPrefixedDef proves the API/version
+// prefix is tolerated on either side: a test that calls `/alternate-addresses`
+// (no /api/v1) still links to the prefixed backend definition.
+func TestIssue4351_UnprefixedTestRouteMatchesPrefixedDef(t *testing.T) {
+	defs := []types.EntityRecord{def("POST", "/api/v1/alternate-addresses")}
+	suite := e2eSuite("POST /alternate-addresses")
+	out, stats := ResolveHTTPEndpointHandlers(append(defs, suite))
+	if stats.E2ERouteTestEdges != 1 {
+		t.Fatalf("prefix-tolerant match failed: edges=%d", stats.E2ERouteTestEdges)
+	}
+	_ = out
+}
+
+// TestIssue4351_AmbiguousRouteSkipped proves conservatism: when a (verb, route)
+// matches MORE THAN ONE definition, no TESTS edge is fabricated.
+func TestIssue4351_AmbiguousRouteSkipped(t *testing.T) {
+	// Two definitions whose templates both match `/things/123`.
+	defs := []types.EntityRecord{
+		def("GET", "/things/{id}"),
+		def("GET", "/things/{slug}"),
+	}
+	suite := e2eSuite("GET /things/123")
+	_, stats := ResolveHTTPEndpointHandlers(append(defs, suite))
+	if stats.E2ERouteTestEdges != 0 {
+		t.Fatalf("ambiguous route must be skipped, got %d edges", stats.E2ERouteTestEdges)
+	}
+}
+
+// TestIssue4351_NoMatchNoEdge proves an unmatched route fabricates nothing.
+func TestIssue4351_NoMatchNoEdge(t *testing.T) {
+	defs := []types.EntityRecord{def("GET", "/known")}
+	suite := e2eSuite("GET /totally/unknown/path")
+	_, stats := ResolveHTTPEndpointHandlers(append(defs, suite))
+	if stats.E2ERouteTestEdges != 0 {
+		t.Fatalf("unmatched route must emit 0 edges, got %d", stats.E2ERouteTestEdges)
+	}
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -106,6 +106,9 @@ type ResolveHTTPEndpointStats struct {
 	// separately from emitted so an external DTO (third-party SDK) doesn't
 	// look like a bug in the new pass.
 	DTOHandlerEdgesUnresolved int
+	// #4351 — TESTS edges emitted from an e2e test_suite to the
+	// http_endpoint_definition it exercises via a supertest route-by-string call.
+	E2ERouteTestEdges int
 }
 
 // ResolveHTTPEndpointHandlers runs the Phase-2 post-pass over `merged`.
@@ -255,6 +258,9 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// stripped and ANY-verb is the only cross-verb match (see
 	// http_endpoint_match.go).
 	definitionByPath := make(map[string][]int, len(merged))
+	// #4351 — flat list of definition indices for the e2e route-test matcher,
+	// which scans every definition with the concrete-vs-template segment matcher.
+	var defIndices []int
 	for i := range merged {
 		r := &merged[i]
 		if r.Kind == httpEndpointDefinitionKind {
@@ -264,6 +270,7 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			for _, k := range endpointMatchKeys(propOr(r, "path", "")) {
 				definitionByPath[k] = append(definitionByPath[k], i)
 			}
+			defIndices = append(defIndices, i)
 		}
 	}
 
@@ -612,6 +619,15 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			}
 		}
 	}
+
+	// #4351 — link e2e HTTP route tests (supertest route-by-string) to the
+	// http_endpoint_definition they exercise. The Jest extractor stamps an
+	// `e2e_route_calls` property on the one-per-spec test_suite; here we resolve
+	// each (verb, route) against the definition index built above and emit a
+	// TESTS edge from the suite to each uniquely-matched endpoint. Runs at
+	// resolve-time (merge-stable, cross-file index available) and is
+	// conservative — only unique verb+route matches produce an edge.
+	stats.E2ERouteTestEdges = linkE2ERouteTestsToEndpoints(merged, definitionByPath, defIndices)
 
 	// Issue #1999 — DTO ↔ Handler bidirectional REFERENCES edges.
 	//


### PR DESCRIPTION
## Problem

NestJS e2e specs (`*.e2e-spec.ts`, usually under `test/`) exercise the app through HTTP via supertest:

```ts
return request(app.getHttpServer()).post('/inspections/123/items').send(dto).expect(201)
```

After #4343, the one-per-spec `test_suite` linked (at best) to a **class** subject — but the route-string → `http_endpoint_definition` linkage was missing. So e2e suites never connected to the **endpoints** they cover, and those endpoints looked untested in coverage queries.

## Fix

**Extractor** (`internal/custom/javascript/jest.go`): capture each supertest `request(...).<verb>(<route>)` call and stamp the `VERB route` pairs onto the suite's new `e2e_route_calls` property. Route arguments handled: single/double-quoted, back-tick template literals (`${id}` left intact for the resolver to wildcard), and bare identifiers folded from local `const ROUTE = '/literal'` declarations (`.post(ROUTE)`). One property per spec — preserves the one-node-per-spec invariant from #4343, no per-call orphan nodes.

**Resolve** (`internal/engine/http_endpoint_e2e_testmap.go`, wired into `ResolveHTTPEndpointHandlers`): for each `test_suite` carrying `e2e_route_calls`, resolve `(verb, normalized-route)` against the `http_endpoint_definition` index and emit a TESTS edge to each uniquely-matched endpoint.

### How route-string → endpoint is matched
1. **Tier 1 — structural key** via the existing `endpointMatchKeys` (the same index the call→definition resolver uses): handles already-templated test routes and `/api/vN` prefix alignment.
2. **Tier 2 — concrete-vs-template segment matcher** (`matchConcreteRouteToDefinition`): compares the concrete test path (`/inspections/123/items`) segment-by-segment against each same-verb definition template (`/inspections/{id}/items`), treating `{id}`/`:id`/`<int:id>`/unresolved `${expr}` definition segments as wildcards and requiring literal segments to match (case-insensitively). The `/api`, `/api/vN`, `/vN` mount prefix is tolerated on **either** side, so an unprefixed test route still links to a prefixed backend definition.

**Conservative**: an edge is emitted only when verb+route uniquely matches **exactly one** definition. Zero or multiple matches → skipped (no fabricated edges, no `untested_route`).

### Where the edge is emitted & why it's merge-stable
At **resolve-time** inside `ResolveHTTPEndpointHandlers`, over the fully-merged entity table — not in the extractor. The controller defining a route lives in a **different file** than the spec, so the cross-file `http_endpoint_definition` index only exists at resolve-time. This is the same place call→definition and the #4319 endpoint→handler bridge resolve, so the linkage survives the merge (no fragile post-hoc name match).

## Live validation (fixtures lie at merge — this runs the real pipeline)

Byte-copies of real `core-backend-v3` e2e specs are committed under `testdata/` (source untouched):
- **Extractor test** (`issue4351_livedrepro_test.go`): runs the real jest extractor on `auth-guard.e2e-spec.ts` (literal routes), `alternate-address-write.e2e-spec.ts` (`const ROUTE` fold + `${ROUTE}/${id}` template), and `app.e2e-spec.ts` (`get('/')`); asserts the route calls are captured.
- **In-pipeline resolve test** (`http_endpoint_e2e_testmap_4351_test.go`): drives the real `ResolveHTTPEndpointHandlers`. **Before** (no `e2e_route_calls`) → **0** TESTS→endpoint edges; **after** → **3** edges, including concrete-id (`/...-addresses/9999`) → `{id}` template matching and unprefixed-test → `/api/v1`-prefixed-def matching. Ambiguous (`/things/123` vs two templates) and no-match routes are asserted to emit **0** edges.

### Before/after edge counts (from the in-pipeline test)
| scenario | TESTS→endpoint edges |
|---|---|
| no `e2e_route_calls` (pre-fix world) | 0 |
| 3 supertest calls vs 4 NestJS defs | 3 (the 3 covered endpoints; the unrelated `/buildings` def is not linked) |
| unprefixed test route vs prefixed def | 1 |
| ambiguous route (2 matching templates) | 0 |
| unmatched route | 0 |

## Coverage & follow-ups

Implemented here: **NestJS / Express supertest** (JS/TS). Audited the same e2e-route-test → endpoint gap across other stacks and filed neutrally-worded follow-ups (ref epic #4334):
- #4369 — Django/DRF `APIClient` + FastAPI/Flask `TestClient`. (Note: `tests_edges.go` #2549 already links these to the **ViewSet class** via `ROUTES_TO`, but not to the `http_endpoint_definition` directly — that direct-to-endpoint variant is the follow-up.)
- #4370 — Spring MockMvc / WebTestClient / REST Assured (JVM).
- #4371 — Go `httptest`, Rails request specs, Playwright/Cypress API tests.

All follow-ups are designed to reuse the shared `matchConcreteRouteToDefinition` matcher introduced here.

## Gates
- `go build ./...` ✅
- `go vet ./internal/engine/ ./internal/custom/javascript/` ✅
- `go test ./...` ✅ (full suite, exit 0)
- `go test ./internal/types/` ✅ (producer-kind validator — no new entity/edge Kinds added; reuses existing `test_suite` entity + `TESTS` edge)

Closes #4351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
