### PR TITLE
Capture anonymous/inline HTTP route handlers as handler-linked endpoints

### DIFF
--- a/internal/engine/http_endpoint_anon_inline_4324_test.go
+++ b/internal/engine/http_endpoint_anon_inline_4324_test.go
@@ -1,0 +1,198 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4324 — anonymous / inline HTTP route handlers (arrow or function-expression)
+// must be captured as endpoints AND linked to a handler node. Before the fix the
+// route's http_endpoint_definition was emitted but left a graph ISLAND: the
+// handler is an inline function with no addressable symbol, so no
+// endpoint→handler IMPLEMENTS bridge formed and the route was untraceable.
+//
+// The long-term fix is handler-shape-agnostic: the producer synthesizer signals
+// refKind="InlineHandler", and makeEmit synthesizes a stable inline-handler
+// Operation entity (Name derived purely from verb+canonical path → merge-stable)
+// plus a file-scoped structural IMPLEMENTS bridge that the CENTRAL resolver binds
+// post-merge — the same mechanism #4319 uses for decorated handlers.
+
+// detectInline runs the real engine detector (extract + synthesis) on a single
+// file and returns its emitted entities + relationships.
+func detectInline(t *testing.T, language, path, content string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extreg.FileInput{
+		Path: path, Content: []byte(content), Language: language,
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res.Entities, res.Relationships
+}
+
+// endpointByVerbPath returns the http_endpoint_definition with the given
+// canonical (verb, path), or nil.
+func endpointByVerbPath(ents []types.EntityRecord, verb, path string) *types.EntityRecord {
+	for i := range ents {
+		e := ents[i]
+		if e.Kind == httpEndpointDefinitionKind && e.Properties != nil &&
+			e.Properties["verb"] == verb && e.Properties["path"] == path {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// inlineHandlerEntity returns the synthesized inline-handler Operation for a
+// (verb, canonicalPath), or nil.
+func inlineHandlerEntity(ents []types.EntityRecord, verb, path string) *types.EntityRecord {
+	want := inlineHandlerName(verb, path)
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Name == want {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// assertInlineEndpointBridged runs the full in-pipeline merge+resolve and proves
+// the endpoint exists AND has a resolved inbound IMPLEMENTS edge from its
+// synthesized inline-handler entity (i.e. is NOT an island).
+func assertInlineEndpointBridged(t *testing.T, ents []types.EntityRecord, rels []types.RelationshipRecord, verb, path, framework string) {
+	t.Helper()
+
+	endpoint := endpointByVerbPath(ents, verb, path)
+	if endpoint == nil {
+		t.Fatalf("[%s] endpoint %s %s NOT emitted", framework, verb, path)
+	}
+	handler := inlineHandlerEntity(ents, verb, path)
+	if handler == nil {
+		t.Fatalf("[%s] no synthesized inline-handler entity for %s %s", framework, verb, path)
+	}
+	if handler.Properties["handler_kind"] != "inline" || handler.Properties["framework"] != framework {
+		t.Errorf("[%s] inline handler props = %v", framework, handler.Properties)
+	}
+
+	// Mirror buildDocument: resolve the http-endpoint pass, stamp IDs, then run
+	// the CENTRAL resolver over the synthesis relationships.
+	merged, _ := ResolveHTTPEndpointHandlers(ents)
+	for i := range merged {
+		merged[i].ID = merged[i].ComputeID()
+	}
+	ep := endpointByVerbPath(merged, verb, path)
+	h := inlineHandlerEntity(merged, verb, path)
+	if ep == nil || h == nil {
+		t.Fatalf("[%s] endpoint/handler lost after http-endpoint resolve pass", framework)
+	}
+
+	idx := resolve.BuildIndex(merged)
+	resolve.References(rels, idx)
+
+	bridged := false
+	for _, r := range rels {
+		if r.Kind == implementsEdgeKind && r.ToID == ep.ID && r.FromID == h.ID &&
+			r.Properties["handler_kind"] == "inline" {
+			bridged = true
+		}
+	}
+	if !bridged {
+		t.Fatalf("[%s] ISLAND: inline endpoint %s %s has no resolved IMPLEMENTS edge from its handler (#4324)", framework, verb, path)
+	}
+}
+
+// TestInline4324_ExpressArrowHandlers covers Express inline arrow / async-arrow /
+// function-expression handlers on app and router receivers.
+func TestInline4324_ExpressArrowHandlers(t *testing.T) {
+	src := `const express = require('express');
+const app = express();
+const router = express.Router();
+
+app.get('/health', (req, res) => res.send('ok'));
+
+router.post('/widgets', async (req, res) => {
+  const w = await create(req.body);
+  res.status(201).json(w);
+});
+
+app.put('/items/:id', function (req, res) {
+  res.json({ updated: req.params.id });
+});
+
+module.exports = app;
+`
+	ents, rels := detectInline(t, "javascript", "src/routes/app.js", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/health", "express")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/widgets", "express")
+	assertInlineEndpointBridged(t, ents, rels, "PUT", "/items/{id}", "express")
+}
+
+// TestInline4324_FastifyArrowHandlers covers Fastify inline handlers.
+func TestInline4324_FastifyArrowHandlers(t *testing.T) {
+	src := `const Fastify = require('fastify');
+const fastify = Fastify();
+
+fastify.get('/ping', (request, reply) => {
+  reply.send({ pong: true });
+});
+
+fastify.post('/orders', async (request, reply) => {
+  return reply.code(201).send(await place(request.body));
+});
+
+module.exports = fastify;
+`
+	ents, rels := detectInline(t, "javascript", "src/server/fastify.js", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/ping", "fastify")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/orders", "fastify")
+}
+
+// TestInline4324_KoaRouterArrowHandlers covers koa-router inline handlers, which
+// are captured through the Express synthesizer (router receiver allowlist).
+func TestInline4324_KoaRouterArrowHandlers(t *testing.T) {
+	src := `const Koa = require('koa');
+const Router = require('@koa/router');
+const app = new Koa();
+const router = new Router();
+
+router.get('/status', async (ctx) => {
+  ctx.body = 'ok';
+});
+
+router.delete('/sessions/:id', (ctx) => {
+  ctx.status = 204;
+});
+
+app.use(router.routes());
+module.exports = app;
+`
+	ents, rels := detectInline(t, "javascript", "src/koa/routes.js", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/status", "express")
+	assertInlineEndpointBridged(t, ents, rels, "DELETE", "/sessions/{id}", "express")
+}
+
+// TestInline4324_NamedHandlerStillNamedBridge guards no regression: a NAMED
+// handler reference must still bridge through the #4319 named/qualified path and
+// must NOT produce a synthesized inline-handler stand-in.
+func TestInline4324_NamedHandlerStillNamedBridge(t *testing.T) {
+	src := `const express = require('express');
+const app = express();
+function listUsers(req, res) { res.json([]); }
+app.get('/users', listUsers);
+module.exports = app;
+`
+	ents, _ := detectInline(t, "javascript", "src/named.js", src)
+	if endpointByVerbPath(ents, "GET", "/users") == nil {
+		t.Fatal("named-handler endpoint missing")
+	}
+	if inlineHandlerEntity(ents, "GET", "/users") != nil {
+		t.Error("named handler must NOT synthesize an inline-handler stand-in")
+	}
+}

--- a/internal/engine/http_endpoint_jsts_extra.go
+++ b/internal/engine/http_endpoint_jsts_extra.go
@@ -183,8 +183,11 @@ func synthesizeFastify(content string, emit emitFn) {
 		}
 		verb := strings.ToUpper(content[m[4]:m[5]])
 		handler := content[m[8]:m[9]]
+		refKind := "Controller"
 		if isInlineExpressHandler(content[m[0]:m[1]], raw) {
+			// #4324 — inline arrow/function-expression handler; no symbol.
 			handler = ""
+			refKind = inlineHandlerRefKind
 		}
 		full := joinPathFragments(fastifyComposedPrefix(pluginSpans, m[0]), raw)
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
@@ -193,7 +196,7 @@ func synthesizeFastify(content string, emit emitFn) {
 		}
 		key := verb + ":" + canonical
 		withHandler[key] = true
-		emit(verb, canonical, "fastify", "Controller", handler)
+		emit(verb, canonical, "fastify", refKind, handler)
 	}
 	for _, m := range fastifyVerbPathOnlyRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 8 {
@@ -217,7 +220,8 @@ func synthesizeFastify(content string, emit emitFn) {
 		if withHandler[key] {
 			continue
 		}
-		emit(verb, canonical, "fastify", "Controller", "")
+		// #4324 — handler-named pass missed this (verb,path) ⇒ inline handler.
+		emit(verb, canonical, "fastify", inlineHandlerRefKind, "")
 	}
 	// Structured form: fastify.route({ method, url, handler }).
 	for _, m := range fastifyRouteRe.FindAllStringSubmatchIndex(content, -1) {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -163,6 +163,25 @@ func synthesisSupportsLanguage(lang string) bool {
 //   - dotted qualified names (`Class.method`) — the synthesis-time bridge is for
 //     the bare-method, same-file case; qualified cross-file shapes are handled by
 //     the resolve pass. (A dotted name would also not match byLocation[file][name].)
+// inlineHandlerRefKind is the sentinel refKind a producer synthesizer passes to
+// emit() when it has detected an HTTP route whose handler is an ANONYMOUS /
+// INLINE function (arrow or function-expression) rather than a named handler
+// symbol. refName is empty in this case. makeEmit recognises it and synthesizes
+// a stable inline-handler entity + endpoint→handler bridge (#4324) so the
+// endpoint is never left a handler-less graph island.
+const inlineHandlerRefKind = "InlineHandler"
+
+// inlineHandlerName returns the deterministic, merge-stable Name for the
+// synthetic Operation entity that stands in for an inline HTTP route handler
+// (#4324). It is derived purely from the HTTP verb and the canonical route
+// path — never a line number or a captured parameter — so the same route always
+// yields the same handler node and the structural-ref that bridges the endpoint
+// to it (BuildOperationStructuralRef over this Name) is stable across
+// entity-merge. Shape: `<inline GET /health>`.
+func inlineHandlerName(verb, canonicalPath string) string {
+	return "<inline " + verb + " " + canonicalPath + ">"
+}
+
 func synthesisHandlerStructuralRef(lang, file, refKind, refName string) string {
 	if refName == "" || file == "" || lang == "" {
 		return ""
@@ -504,6 +523,58 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 						Kind:   implementsEdgeKind,
 						Properties: map[string]string{
 							"pattern_type": "http_endpoint_synthesis_time_bridge",
+							"framework":    framework,
+							"verb":         strings.ToUpper(method),
+							"path":         canonicalPath,
+						},
+					})
+				} else if refKind == inlineHandlerRefKind {
+					// #4324 — the route handler is an ANONYMOUS / INLINE function
+					// (arrow or function-expression), e.g.
+					//   app.get('/health', (req, res) => res.send('ok'))
+					// There is no addressable handler SYMBOL the structural-ref
+					// could bind to, so the synthesizer signals refKind=
+					// "InlineHandler" (refName is empty). Without this branch the
+					// endpoint is emitted but left a graph ISLAND with no handler
+					// linkage — invisible to flow / IMPLEMENTS traversal.
+					//
+					// LONG-TERM ROOT FIX (handler-shape-agnostic): synthesize a
+					// stable inline-handler Operation entity and bridge to it. The
+					// entity's Name — and the structural-ref that targets it — are
+					// derived purely from (verb, canonicalPath), NOT from a line
+					// number or a captured parameter token, so both are:
+					//   * deterministic   — same route ⇒ same handler node, and
+					//   * merge-stable    — survives entity-merge/dedup the same way
+					//                       the #4319 decorated-handler bridge does
+					//                       (it travels as a Format-A stub bound by
+					//                       (file, Name) after all merging, never a
+					//                       hex ID or a line-sensitive co-location).
+					// File-scoped ⇒ it can never mis-bridge to another file.
+					handlerName := inlineHandlerName(strings.ToUpper(method), canonicalPath)
+					entities = append(entities, types.EntityRecord{
+						Name:             handlerName,
+						QualifiedName:    handlerName,
+						Kind:             "SCOPE.Operation",
+						Subtype:          "inline_handler",
+						SourceFile:       path,
+						Language:         lang,
+						EnrichmentStatus: types.StatusPending,
+						QualityScore:     0.7,
+						Properties: map[string]string{
+							"framework":    framework,
+							"handler_kind": "inline",
+							"verb":         strings.ToUpper(method),
+							"route_path":   canonicalPath,
+							"provenance":   "SYNTHESIZED_INLINE_HTTP_HANDLER",
+						},
+					})
+					relationships = append(relationships, types.RelationshipRecord{
+						FromID: extractor.BuildOperationStructuralRef(lang, path, handlerName),
+						ToID:   kind + ":" + id,
+						Kind:   implementsEdgeKind,
+						Properties: map[string]string{
+							"pattern_type": "http_endpoint_synthesis_time_bridge",
+							"handler_kind": "inline",
 							"framework":    framework,
 							"verb":         strings.ToUpper(method),
 							"path":         canonicalPath,
@@ -4305,8 +4376,14 @@ func synthesizeExpress(content string, emit emitFn) {
 		// source_handler (NoHandlerProp keep-path) and survives resolve. The
 		// path-only second pass would otherwise dedup it away with a handler
 		// it can't use, so we MUST claim the (verb,path) here.
+		refKind := "Controller"
 		if isInlineExpressHandler(m[0], raw) {
+			// #4324 — anonymous/inline arrow or function-expression handler:
+			// no addressable symbol. Signal InlineHandler so makeEmit
+			// synthesizes a stable handler node + bridge instead of leaving
+			// the endpoint a handler-less island.
 			handler = ""
+			refKind = inlineHandlerRefKind
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, composeExpressMount(mountPrefixes, receiver, raw))
 		// Express `.all(...)` registers every verb on the path; emit as ANY.
@@ -4315,7 +4392,7 @@ func synthesizeExpress(content string, emit emitFn) {
 		}
 		key := verb + ":" + canonical
 		withHandler[key] = true
-		emit(verb, canonical, "express", "Controller", handler)
+		emit(verb, canonical, "express", refKind, handler)
 	}
 	// Second pass: path-only form (groups: receiver, verb, path), skipping any
 	// (verb, path) already claimed by the handler-named scan.
@@ -4341,7 +4418,12 @@ func synthesizeExpress(content string, emit emitFn) {
 		if withHandler[key] {
 			continue
 		}
-		emit(verb, canonical, "express", "Controller", "")
+		// #4324 — the handler-named pass did not claim this (verb,path), which
+		// means the handler is an inline arrow / function-expression whose body
+		// the handler-named regex couldn't span (e.g. a multi-line block). A
+		// route ALWAYS has a handler argument, so model it as an inline handler
+		// rather than emitting a handler-less island.
+		emit(verb, canonical, "express", inlineHandlerRefKind, "")
 	}
 }
 


### PR DESCRIPTION
## Problem

HTTP routes whose handler is an **anonymous / inline function** (arrow or function-expression) emitted an `http_endpoint_definition` but **no endpoint→handler `IMPLEMENTS` bridge** — leaving the endpoint a graph **island** with no handler linkage, so the route was invisible to flow / IMPLEMENTS traversal. Examples:

```js
app.get('/health', (req, res) => res.send('ok'));
router.post('/widgets', async (req, res) => { ... });
app.put('/items/:id', function (req, res) { ... });
```

## Root cause

The Express / Fastify producer synthesizers already cleared the captured "handler" token for inline handlers (#1423) and emitted the endpoint with an **empty** `source_handler`. The `makeEmit` synthesis-time bridge (#4319) only fires when a real, addressable handler **symbol** is present (`synthesisHandlerStructuralRef` returns `""` for an empty refName), so inline-handler endpoints got **no bridge at all**.

## Fix (long-term, handler-shape-agnostic)

- Producers (Express, Fastify, and koa-router via the Express receiver allowlist) now signal `refKind="InlineHandler"` when the handler is inline (the handler-named scan detects a `(`/`function` inside the arg, or the handler-named scan misses entirely → the path-only fallback).
- `makeEmit` recognises the sentinel and **synthesizes a stable inline-handler `SCOPE.Operation` entity** whose `Name` is derived **purely from `(verb, canonical path)`** — `<inline GET /health>` — never a line number or a captured parameter token. It then emits a **file-scoped structural `IMPLEMENTS` bridge** (`scope:operation:method:<lang>:<file>:<name>`) that the **central resolver** (`resolve.References`) binds post-merge.

### Why merge-stable

The handler Name and the structural-ref that targets it are deterministic functions of `(verb, canonical path)`, so the same route always yields the same handler node and the same bridge. The bridge travels as a Format-A stub bound by `(file, Name)` **after all merging** (never a hex ID, never a line-sensitive co-location) — immune to the entity-merge/dedup round-trip that destabilised the prior name-/line-based repairs. This mirrors the #4319 decorated-handler synthesis-time bridge. File-scoped ⇒ it can never mis-bridge to another file.

## Live validation (in-pipeline)

`internal/engine/http_endpoint_anon_inline_4324_test.go` runs the **real** extract + synthesis + merge (`ResolveHTTPEndpointHandlers`) + central resolve (`resolve.BuildIndex` / `resolve.References`) on faithful Express / Fastify / koa-router fixtures (inline-arrow, async-arrow, function-expression). It asserts each endpoint is **present AND has a resolved inbound `IMPLEMENTS` edge** from its synthesized handler. Before the fix there was no synthesized handler entity and no bridge (island); after, both exist and resolve end-to-end. A no-regression guard proves a **named** handler still takes the named-bridge path and never synthesizes an inline stand-in.

## Coverage vs deferred

- **Covered here:** Express, Fastify, koa-router (koa-router flows through the Express synthesizer). NestJS is decorator-on-named-method (already #4319-linked).
- **Audited + filed as follow-ups** (ref epic #4334): Go net/http + chi/gin/echo inline `func(w,r)` (#4382), Python Flask/FastAPI/Starlette functional routes (#4383), Spring WebFlux `RouterFunction` lambdas (#4384), Ruby Sinatra blocks (#4385).

## Gates

`go build ./...`, `go vet ./...` clean; `go test ./internal/engine/ ./internal/custom/javascript/ ./internal/types/ ./internal/resolve/` all pass (new tests + full engine suite green).

Closes #4324

🤖 Generated with [Claude Code](https://claude.com/claude-code)