### PR TITLE
Python ORM/validation field membership: model/serializer/column fields as class members

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -90,6 +90,36 @@ var (
 	djangoDRFAuthClassesRe     = regexp.MustCompile(`["']DEFAULT_AUTHENTICATION_CLASSES["']\s*:\s*\[([^\]]*)\]`)
 	djangoDRFThrottleClassesRe = regexp.MustCompile(`["']DEFAULT_THROTTLE_CLASSES["']\s*:\s*\[([^\]]*)\]`)
 	djangoDRFClassItemRe       = regexp.MustCompile(`["']([A-Za-z][\w.]+)["']`)
+
+	// Issue #4366 — model field-membership. A 4+-space-indented body
+	// assignment `<attr> = models.SomethingField(...)` (or a bare
+	// `SomethingField(...)` / a relational `ForeignKey(...)`). Group 1 is the
+	// attribute name. We deliberately match only field-constructor RHS shapes
+	// (CharField / ForeignKey / ...Field / ...) so class-level constants like
+	// `STATUS_CHOICES = [...]` and method defs are NOT treated as fields.
+	djangoModelFieldRe = regexp.MustCompile(
+		`(?m)^\s{4,}(\w+)\s*=\s*([\w.]*(?:Field|ForeignKey|OneToOneField|ManyToManyField|GenericForeignKey|GenericRelation))\s*\(`)
+	// Any class-body attribute assignment `<attr> = ...` at the immediate
+	// (4-space) body indent — used to restore full CONTAINS membership parity
+	// with the base class node this custom model node replaces (issue #4366).
+	// Captures class constants (STATUS_CHOICES = [...]) and Manager attachments
+	// (objects = Manager()) in addition to model fields. Excludes dunder /
+	// type-annotated-only declarations and `==` comparisons.
+	djangoModelAttrRe = regexp.MustCompile(
+		`(?m)^\s{4}(\w+)\s*(?::[^=\n]+)?=\s*[^=]`)
+	// Relational field RHS whose first positional/`to=` argument names the
+	// target model — string form ('app.Model' / 'self') or symbol form (Model).
+	// Group 1 = relation kind, group 2 = quoted target (if string form),
+	// group 3 = identifier target (if symbol form).
+	djangoModelRelTargetRe = regexp.MustCompile(
+		`(?:ForeignKey|OneToOneField|ManyToManyField)\s*\(\s*(?:to\s*=\s*)?(?:["']([^"']+)["']|([A-Z][A-Za-z0-9_]*))`)
+
+	// Issue #4366 — DRF serializer field declaration. A 4+-space-indented body
+	// assignment whose RHS is either a `serializers.XField(...)` / `XField(...)`
+	// call OR a nested serializer constructor `SomeSerializer(...)`. Group 1 is
+	// the attribute name, group 2 the RHS callee (dotted path allowed).
+	djangoSerializerFieldRe = regexp.MustCompile(
+		`(?m)^\s{4,}(\w+)\s*=\s*([\w.]*(?:Field|Serializer))\s*\(`)
 )
 
 func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -314,8 +344,42 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	for _, idx := range allMatchesIndex(djangoDRFSerializerRe, source) {
 		className := source[idx[2]:idx[3]]
 		line := lineOf(source, idx[0])
-		out = append(out, entity(className, "SCOPE.Component", "", file.Path, line,
-			map[string]string{"framework": "drf", "pattern_type": "serializer", "component_kind": "serializer"}))
+		serEnt := entity(className, "SCOPE.Component", "", file.Path, line,
+			map[string]string{"framework": "drf", "pattern_type": "serializer", "component_kind": "serializer"})
+
+		// Issue #4366 — serializer field membership. This serializer node
+		// replaces the base tree-sitter class node (which carried the #526
+		// class→field CONTAINS edges), so re-emit membership for each declared
+		// serializer field. Nested-serializer fields (`items = ItemSerializer(
+		// many=True)`) additionally REFERENCES the target serializer class.
+		body := extractClassBody(source, idx[0])
+		seenSerMember := map[string]bool{}
+		// (a) CONTAINS for every serializer class-body attribute (declared
+		// fields + constants) — restores parity with the replaced base node.
+		for _, aIdx := range allMatchesIndex(djangoModelAttrRe, body) {
+			attr := body[aIdx[2]:aIdx[3]]
+			if attr == "" || seenSerMember[attr] || strings.HasPrefix(attr, "__") {
+				continue
+			}
+			seenSerMember[attr] = true
+			serEnt.Relationships = append(serEnt.Relationships,
+				containsFieldEdge(className, className+"."+attr, attr, "drf"))
+		}
+		// (b) REFERENCES for nested-serializer fields (`items = ItemSerializer(
+		// many=True)`) → the target serializer/model class.
+		for _, fIdx := range allMatchesIndex(djangoSerializerFieldRe, body) {
+			attr := body[fIdx[2]:fIdx[3]]
+			callee := body[fIdx[4]:fIdx[5]]
+			if attr == "" {
+				continue
+			}
+			if strings.HasSuffix(callee, "Serializer") && !strings.Contains(callee, ".") &&
+				callee != "Serializer" && callee != "ModelSerializer" {
+				serEnt.Relationships = append(serEnt.Relationships,
+					referencesClassEdge(className+"."+attr, callee, "drf", attr))
+			}
+		}
+		out = append(out, serEnt)
 	}
 
 	// 5b. DRF viewsets
@@ -433,7 +497,47 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 				props[kv[i]] = kv[i+1]
 			}
 		})
-		out = append(out, entity(className, "SCOPE.Schema", "model", file.Path, classLine, props))
+		modelEnt := entity(className, "SCOPE.Schema", "model", file.Path, classLine, props)
+
+		// Issue #4366 — field membership. MergeWithCustom replaces the base
+		// tree-sitter class node (which carried the #526 class→field CONTAINS
+		// edges) with this custom model node, so without re-emitting membership
+		// here every model field is left an orphan. Walk the class body and hang
+		// a CONTAINS edge off the model node for each `<attr> = ...Field(...)`
+		// declaration, plus a REFERENCES edge to the target model for relational
+		// fields (ForeignKey / OneToOneField / ManyToManyField, string- or
+		// symbol-target, including 'self'). The field entity itself is emitted by
+		// the base Python extractor as `<Class>.<attr>` (SCOPE.Schema/field); the
+		// CONTAINS ToID names it by qualified Name so the resolver binds it.
+		seenMember := map[string]bool{}
+		// (a) CONTAINS membership for every class-body attribute (fields,
+		// choices constants, manager attachments) — restores parity with the
+		// base class node that MergeWithCustom replaces.
+		for _, aIdx := range allMatchesIndex(djangoModelAttrRe, body) {
+			attr := body[aIdx[2]:aIdx[3]]
+			if attr == "" || seenMember[attr] || strings.HasPrefix(attr, "__") {
+				continue
+			}
+			seenMember[attr] = true
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attr, attr, "django"))
+		}
+		// (b) REFERENCES to the target model for relational fields
+		// (ForeignKey / OneToOneField / ManyToManyField), string- or
+		// symbol-target including 'self'.
+		for _, fIdx := range allMatchesIndex(djangoModelFieldRe, body) {
+			attr := body[fIdx[2]:fIdx[3]]
+			rhs := body[fIdx[4]:fIdx[5]]
+			if attr == "" || !isDjangoRelationalField(rhs) {
+				continue
+			}
+			fullRHS := body[fIdx[0]:min(fIdx[0]+400, len(body))]
+			if target := djangoRelTarget(fullRHS, className); target != "" {
+				modelEnt.Relationships = append(modelEnt.Relationships,
+					referencesClassEdge(className+"."+attr, target, "django", attr))
+			}
+		}
+		out = append(out, modelEnt)
 	}
 
 	// 11. View decorators
@@ -469,6 +573,7 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		classLine := lineOf(source, idx[0])
 		body := extractClassBody(source, idx[0])
 		var fieldNames, fieldTypes []string
+		var memberEdges []types.RelationshipRecord
 		for _, fIdx := range allMatchesIndex(djangoFormFieldRe, body) {
 			fieldName := body[fIdx[2]:fIdx[3]]
 			fieldType := body[fIdx[4]:fIdx[5]]
@@ -487,15 +592,22 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 					"field_name":   fieldName,
 					"field_type":   fieldType,
 				}))
+			// Issue #4366 — form-field membership. The form_class node below
+			// replaces the base class node; carry CONTAINS so the field is not
+			// orphaned.
+			memberEdges = append(memberEdges,
+				containsFieldEdge(className, className+"."+fieldName, fieldName, "django"))
 		}
 		if len(fieldNames) > 0 {
-			out = append(out, entity(className, "SCOPE.Schema", "form_class", file.Path, classLine,
+			formEnt := entity(className, "SCOPE.Schema", "form_class", file.Path, classLine,
 				map[string]string{
 					"framework":    "django",
 					"pattern_type": "form_class",
 					"field_names":  strings.Join(fieldNames, ","),
 					"field_types":  strings.Join(fieldTypes, ","),
-				}))
+				})
+			formEnt.Relationships = append(formEnt.Relationships, memberEdges...)
+			out = append(out, formEnt)
 		}
 	}
 
@@ -603,6 +715,38 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// isDjangoRelationalField reports whether a field constructor RHS (the matched
+// `models.XField` head) is a relational field carrying a target-model argument.
+func isDjangoRelationalField(rhs string) bool {
+	return strings.HasSuffix(rhs, "ForeignKey") ||
+		strings.HasSuffix(rhs, "OneToOneField") ||
+		strings.HasSuffix(rhs, "ManyToManyField")
+}
+
+// djangoRelTarget extracts the bare target-model class name from a relational
+// field declaration's argument blob. Handles the string form
+// (`ForeignKey('app.Model', ...)` / `ForeignKey('self', ...)`) and the symbol
+// form (`ForeignKey(Model, ...)` / `ForeignKey(to=Model, ...)`). For 'self' it
+// returns the enclosing model class so the edge self-references the owner.
+// Returns "" when no recognizable target is present (e.g. lazy callables).
+func djangoRelTarget(rhs, ownerClass string) string {
+	m := djangoModelRelTargetRe.FindStringSubmatch(rhs)
+	if m == nil {
+		return ""
+	}
+	if m[1] != "" { // string form
+		raw := m[1]
+		if raw == "self" {
+			return ownerClass
+		}
+		if dot := strings.LastIndexByte(raw, '.'); dot >= 0 {
+			return raw[dot+1:] // strip app_label
+		}
+		return raw
+	}
+	return m[2] // symbol form
 }
 
 // extractBalancedBrackets returns the content of a [...] list starting at openPos.

--- a/internal/custom/python/helpers.go
+++ b/internal/custom/python/helpers.go
@@ -38,6 +38,67 @@ func allMatchesIndex(re *regexp.Regexp, source string) [][]int {
 	return re.FindAllStringSubmatchIndex(source, -1)
 }
 
+// pyClassRef returns the structural reference ID used as the FromID/ToID for
+// edges targeting a Python class entity (Django/SQLAlchemy/Pydantic model,
+// DRF serializer, ...). The "Class:<Name>" form resolves through the resolver's
+// byName fallback to the SCOPE.Schema/SCOPE.Component class node the various
+// Python extractors emit — the same convention already used by the SQLAlchemy
+// GRAPH_RELATES and Django HANDLES_SIGNAL/REGISTERS edges.
+func pyClassRef(className string) string { return "Class:" + className }
+
+// containsFieldEdge builds the structural CONTAINS membership edge from an
+// owning model/serializer/schema class to one of its field/column/attribute
+// entities. Issue #4366 (Python generalization of #4328): Django model fields,
+// SQLAlchemy columns/relationships, Pydantic fields and DRF serializer fields
+// were emitted as standalone `<Class>.<field>` nodes with no owning-class
+// membership, leaving them as orphans on the graph.
+//
+// FromID names the owner class (`Class:<owner>`) so the resolver binds it to
+// the real class entity; ToID is the field entity's qualified Name
+// (`<owner>.<field>`), which resolves merge-stably through the byName index
+// regardless of when entity IDs are backfilled. The edge is hung off the owner
+// model node by the caller (mirroring the JS/TS fix).
+func containsFieldEdge(ownerClass, memberName, fieldName, framework string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: pyClassRef(ownerClass),
+		ToID:   memberName,
+		Kind:   string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  framework,
+			"language":   "python",
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// referencesClassEdge builds a REFERENCES edge from a field/column entity to the
+// class it points at — a Django ForeignKey/OneToOne/ManyToMany target, a
+// SQLAlchemy relationship('Other') target, a DRF nested-serializer target, or a
+// Pydantic field whose annotated type is another model. Issue #4366: that target
+// type is the field's only outbound semantic edge; without it the related model /
+// nested serializer rings.
+//
+// FromID is the field entity's qualified Name (`<owner>.<field>`); ToID is the
+// `Class:<target>` stub the resolver binds to the real class entity (same-file
+// or symbol-table wide). The edge is hung off the field entity by the caller.
+func referencesClassEdge(memberName, targetClass, framework, fieldName string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: memberName,
+		ToID:   pyClassRef(targetClass),
+		Kind:   string(types.RelationshipKindReferences),
+		Properties: map[string]string{
+			"framework":   framework,
+			"language":    "python",
+			"ref_kind":    "field_target_type",
+			"field_name":  fieldName,
+			"target_type": targetClass,
+			"provenance":  "INFERRED_FROM_MODEL_FIELD_TARGET",
+		},
+	}
+}
+
 // decoratorWindow returns the contiguous block of stacked decorator lines that
 // immediately precede the byte offset `at` (the start of a route decorator
 // match), plus everything from there up to `end`. It walks backwards over

--- a/internal/custom/python/issue4366_livedrepro_test.go
+++ b/internal/custom/python/issue4366_livedrepro_test.go
@@ -1,0 +1,208 @@
+package python_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the regex framework extractors under test (Django / SQLAlchemy /
+	// Pydantic / the ORM-schema family).
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	// Register the tree-sitter base Python extractor so we run the REAL merged
+	// pipeline (base #526 field-membership CONTAINS + custom field nodes).
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+// Issue #4366 LIVE-REPRO — Python ORM/validation field membership.
+//
+// Generalizes the JS/TS fix #4328 to Python. The regex framework extractors in
+// internal/custom/python (Django serializer/form fields, SQLAlchemy
+// relationship/column/FK fields, peewee/pony/mongoengine/tortoise/beanie
+// columns) emit `<Class>.<field>` field entities WITHOUT a CONTAINS membership
+// edge from the owning model/serializer class — and MergeWithCustom REPLACES
+// the base-extractor field entity (which DID carry the #526 CONTAINS edge) with
+// the custom node of the same Name, dropping membership entirely. The result is
+// a forest of orphan field nodes.
+//
+// We run the ACTUAL base python extractor + the ACTUAL regex framework
+// extractors, merge them exactly as the pipeline does (MergeWithCustom), assign
+// real entity IDs, build the REAL resolver symbol table (resolve.BuildIndex)
+// and assert that field entities are CONTAINS-members of their owning class and
+// that relation/typed fields carry a resolving REFERENCES edge.
+
+func loadRepro4366(t *testing.T, base, repoPath string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "issue4366", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read repro %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: repoPath, Language: "python", Content: b}
+}
+
+// runMergedPipeline runs the base python extractor + every registered custom
+// python_* extractor over one file, merges them the way the real pipeline does,
+// assigns deterministic IDs, and returns the merged entity slice.
+func runMergedPipeline(t *testing.T, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+
+	base, ok := extreg.Get("python")
+	if !ok {
+		t.Fatal("base python extractor not registered")
+	}
+	baseEnts, err := base.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("base extract: %v", err)
+	}
+
+	customEnts, errs := extractors.RunCustomExtractors(context.Background(), file)
+	for _, e := range errs {
+		t.Fatalf("custom extract: %v", e)
+	}
+
+	merged := extractors.MergeWithCustom(baseEnts, customEnts)
+	for i := range merged {
+		if merged[i].ID == "" {
+			merged[i].ID = merged[i].ComputeID()
+		}
+	}
+	return merged
+}
+
+// inboundContains reports whether some entity declares a CONTAINS edge whose
+// ToID names the given member (by hex ID, by qualified Name, or via a
+// Field:/structural-ref form), i.e. the member is owned by a class rather than
+// floating free.
+func inboundContains(ents []types.EntityRecord, memberID, memberName string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindContains) {
+				continue
+			}
+			if r.ToID == memberID || r.ToID == memberName ||
+				r.ToID == "Field:"+memberName {
+				return true
+			}
+			// Format-A structural-ref class→field stub used by base #526.
+			if len(r.ToID) > len(memberName) && r.ToID[len(r.ToID)-len(memberName):] == memberName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fieldEntities(ents []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Schema" {
+			continue
+		}
+		switch e.Subtype {
+		case "column", "field", "serializer_field", "form_field", "":
+			// Only count "<Class>.<attr>" qualified field-shaped nodes (skip the
+			// bare model class node which is also SCOPE.Schema with subtype "").
+			if hasDot(e.Name) {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+func hasDot(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			return true
+		}
+	}
+	return false
+}
+
+func countOrphans(t *testing.T, ents []types.EntityRecord) (orphans int, total int) {
+	t.Helper()
+	for _, fe := range fieldEntities(ents) {
+		total++
+		if !inboundContains(ents, fe.ID, fe.Name) {
+			orphans++
+			t.Logf("ORPHAN field (no inbound CONTAINS): kind=%s subtype=%q name=%q",
+				fe.Kind, fe.Subtype, fe.Name)
+		}
+	}
+	return orphans, total
+}
+
+func TestIssue4366_DjangoModelFields_AreMembers(t *testing.T) {
+	file := loadRepro4366(t, "contract_models.py.txt", "core/models/contract.py")
+	ents := runMergedPipeline(t, file)
+	orphans, total := countOrphans(t, ents)
+	t.Logf("Django contract.py: %d/%d field entities orphaned", orphans, total)
+	if total == 0 {
+		t.Fatal("no Django model field entities extracted")
+	}
+	if orphans > 0 {
+		t.Errorf("Django model has %d/%d orphan field entities (want 0)", orphans, total)
+	}
+
+	// Relational fields carry a REFERENCES edge to the target model. contract.py
+	// has `group = models.ForeignKey(Group, ...)` and
+	// `recipients = models.ManyToManyField("User", ...)`.
+	if !hasReferencesTo(ents, "Class:Group") {
+		t.Errorf("expected REFERENCES edge to Class:Group (ForeignKey target)")
+	}
+	if !hasReferencesTo(ents, "Class:User") {
+		t.Errorf("expected REFERENCES edge to Class:User (ManyToManyField string target)")
+	}
+}
+
+func TestIssue4366_SQLAlchemyFields_AreMembers(t *testing.T) {
+	file := loadRepro4366(t, "orders_sqlalchemy.py.txt", "app/models/orders.py")
+	ents := runMergedPipeline(t, file)
+	orphans, total := countOrphans(t, ents)
+	t.Logf("SQLAlchemy orders.py: %d/%d field entities orphaned", orphans, total)
+	if total == 0 {
+		t.Fatal("no SQLAlchemy field entities extracted")
+	}
+	if orphans > 0 {
+		t.Errorf("SQLAlchemy model has %d/%d orphan field entities (want 0)", orphans, total)
+	}
+
+	// Relationship target must carry a resolving REFERENCES edge.
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("Class:Order"); !ok {
+		t.Errorf("Class:Order did not resolve in symbol table")
+	}
+	if !hasReferencesTo(ents, "Class:Order") && !hasReferencesTo(ents, "Class:Customer") {
+		t.Errorf("expected a REFERENCES edge to a related SQLAlchemy model")
+	}
+}
+
+func TestIssue4366_PydanticFields_AreMembers(t *testing.T) {
+	file := loadRepro4366(t, "account_pydantic.py.txt", "app/schemas/account.py")
+	ents := runMergedPipeline(t, file)
+	orphans, total := countOrphans(t, ents)
+	t.Logf("Pydantic account.py: %d/%d field entities orphaned", orphans, total)
+	if total == 0 {
+		t.Fatal("no Pydantic field entities extracted")
+	}
+	if orphans > 0 {
+		t.Errorf("Pydantic model has %d/%d orphan field entities (want 0)", orphans, total)
+	}
+}
+
+func hasReferencesTo(ents []types.EntityRecord, toID string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindReferences) && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/custom/python/orm_relationships.go
+++ b/internal/custom/python/orm_relationships.go
@@ -18,6 +18,16 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// ormRelTargetLeaf strips an app-label / module prefix from an ORM relation
+// target so the REFERENCES edge binds to the bare model class name (issue
+// #4366). `"app.Model"` → `"Model"`, `"Model"` → `"Model"`.
+func ormRelTargetLeaf(target string) string {
+	if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
+		return target[dot+1:]
+	}
+	return target
+}
+
 func init() {
 	extractor.Register("python_peewee_rel", &PeeweeRelExtractor{})
 	extractor.Register("python_pony_rel", &PonyRelExtractor{})
@@ -100,7 +110,11 @@ func (e *PeeweeRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			// Issue #4366 — relation field → target model REFERENCES.
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, target, "peewee", attr))
+			out = append(out, relEnt)
 		}
 
 		// ManyToManyField → association / relationship
@@ -114,7 +128,11 @@ func (e *PeeweeRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			// Issue #4366 — relation field → target model REFERENCES.
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, target, "peewee", attr))
+			out = append(out, relEnt)
 		}
 	}
 
@@ -211,7 +229,10 @@ func (e *PonyRelExtractor) Extract(ctx context.Context, file extractor.FileInput
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, target, "pony", attr))
+			out = append(out, relEnt)
 		}
 	}
 
@@ -302,7 +323,10 @@ func (e *BeanieRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 			if hasFetchLinks {
 				props["lazy_loading"] = "fetch_links"
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, target, "beanie", attr))
+			out = append(out, relEnt)
 		}
 
 		// BackLink[Model] fields
@@ -316,7 +340,10 @@ func (e *BeanieRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, target, "beanie", attr))
+			out = append(out, relEnt)
 		}
 	}
 
@@ -426,7 +453,10 @@ func (e *MongoEngineRelExtractor) Extract(ctx context.Context, file extractor.Fi
 				if fp.isLazy {
 					props["lazy_loading"] = "lazy_reference"
 				}
-				out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+				relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+				relEnt.Relationships = append(relEnt.Relationships,
+					referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "mongoengine", attr))
+				out = append(out, relEnt)
 			}
 		}
 	}
@@ -526,7 +556,10 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+			out = append(out, relEnt)
 		}
 
 		// ManyToManyField / ManyToManyRelation
@@ -545,7 +578,10 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+			out = append(out, relEnt)
 		}
 
 		// OneToOneField
@@ -559,7 +595,10 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+			out = append(out, relEnt)
 		}
 
 		// ReverseRelation (back-references)
@@ -573,7 +612,10 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 				"target_model": target,
 				"parent_class": className,
 			}
-			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
+			relEnt.Relationships = append(relEnt.Relationships,
+				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+			out = append(out, relEnt)
 		}
 	}
 

--- a/internal/custom/python/orm_schema.go
+++ b/internal/custom/python/orm_schema.go
@@ -91,8 +91,8 @@ func (e *PeeweeSchemaExtractor) Extract(ctx context.Context, file extractor.File
 		body := extractClassBody(source, idx[0])
 
 		// Emit the model entity
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
-			map[string]string{"framework": "peewee", "pattern_type": "model", "class_name": className}))
+		modelEnt := entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "peewee", "pattern_type": "model", "class_name": className})
 
 		// Emit each field entity
 		for _, fIdx := range allMatchesIndex(peeweeFieldRe, body) {
@@ -106,7 +106,11 @@ func (e *PeeweeSchemaExtractor) Extract(ctx context.Context, file extractor.File
 					"field_type":   fieldType,
 					"parent_class": className,
 				}))
+			// Issue #4366 — column membership.
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attrName, attrName, "peewee"))
 		}
+		out = append(out, modelEnt)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
@@ -167,8 +171,8 @@ func (e *PonySchemaExtractor) Extract(ctx context.Context, file extractor.FileIn
 		body := extractClassBody(source, idx[0])
 
 		// Emit the entity model
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
-			map[string]string{"framework": "pony", "pattern_type": "entity", "class_name": className}))
+		modelEnt := entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "pony", "pattern_type": "entity", "class_name": className})
 
 		// Emit each attribute entity
 		for _, aIdx := range allMatchesIndex(ponyAttrRe, body) {
@@ -182,7 +186,11 @@ func (e *PonySchemaExtractor) Extract(ctx context.Context, file extractor.FileIn
 					"descriptor":   descriptor,
 					"parent_class": className,
 				}))
+			// Issue #4366 — attribute membership.
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attrName, attrName, "pony"))
 		}
+		out = append(out, modelEnt)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
@@ -243,8 +251,8 @@ func (e *BeanieSchemaExtractor) Extract(ctx context.Context, file extractor.File
 		body := extractClassBody(source, idx[0])
 
 		// Emit the document model entity
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
-			map[string]string{"framework": "beanie", "pattern_type": "document", "class_name": className}))
+		modelEnt := entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "beanie", "pattern_type": "document", "class_name": className})
 
 		// Emit each field entity (annotated attributes, skip dunder / class vars)
 		for _, fIdx := range allMatchesIndex(beanieFieldRe, body) {
@@ -262,7 +270,11 @@ func (e *BeanieSchemaExtractor) Extract(ctx context.Context, file extractor.File
 					"type_annotation": typeAnnotation,
 					"parent_class":    className,
 				}))
+			// Issue #4366 — field membership.
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attrName, attrName, "beanie"))
 		}
+		out = append(out, modelEnt)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
@@ -322,8 +334,8 @@ func (e *MongoEngineSchemaExtractor) Extract(ctx context.Context, file extractor
 		body := extractClassBody(source, idx[0])
 
 		// Emit the document entity
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
-			map[string]string{"framework": "mongoengine", "pattern_type": "document", "class_name": className}))
+		modelEnt := entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "mongoengine", "pattern_type": "document", "class_name": className})
 
 		// Emit each field entity
 		for _, fIdx := range allMatchesIndex(mongoengineFieldRe, body) {
@@ -337,7 +349,11 @@ func (e *MongoEngineSchemaExtractor) Extract(ctx context.Context, file extractor
 					"field_type":   fieldType,
 					"parent_class": className,
 				}))
+			// Issue #4366 — field membership.
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attrName, attrName, "mongoengine"))
 		}
+		out = append(out, modelEnt)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
@@ -398,8 +414,8 @@ func (e *TortoiseSchemaExtractor) Extract(ctx context.Context, file extractor.Fi
 		body := extractClassBody(source, idx[0])
 
 		// Emit the model entity
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
-			map[string]string{"framework": "tortoise", "pattern_type": "model", "class_name": className}))
+		modelEnt := entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "tortoise", "pattern_type": "model", "class_name": className})
 
 		// Emit each column entity
 		for _, fIdx := range allMatchesIndex(tortoiseFieldRe, body) {
@@ -413,7 +429,11 @@ func (e *TortoiseSchemaExtractor) Extract(ctx context.Context, file extractor.Fi
 					"field_type":   fieldType,
 					"parent_class": className,
 				}))
+			// Issue #4366 — column membership.
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(className, className+"."+attrName, attrName, "tortoise"))
 		}
+		out = append(out, modelEnt)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -39,13 +39,21 @@ var (
 	// uselist=False the relationship is scalar (one_to_one / many_to_one);
 	// otherwise it is a collection (one_to_many). Used for GRAPH_RELATES
 	// cardinality.
-	saUselistRe         = regexp.MustCompile(`\buselist\s*=\s*(True|False)\b`)
-	saForeignKeyRe      = regexp.MustCompile(`ForeignKey\s*\(\s*["']([^"']+)["']`)
-	saAssocTableRe      = regexp.MustCompile(`(?m)^(\w+)\s*=\s*Table\s*\(\s*["']([^"']+)["']`)
-	saCreateEngineRe    = regexp.MustCompile(`(?m)(\w+)\s*=\s*create_(?:async_)?engine\s*\(\s*["']([^"']*)["']`)
-	saSessionQueryRe    = regexp.MustCompile(`(\w+)\.query\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
-	saSessionExecuteRe  = regexp.MustCompile(`(\w+)\.execute\s*\(\s*select\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
-	saSelectCallRe      = regexp.MustCompile(`(?:^|[^\w])select\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
+	saUselistRe        = regexp.MustCompile(`\buselist\s*=\s*(True|False)\b`)
+	saForeignKeyRe     = regexp.MustCompile(`ForeignKey\s*\(\s*["']([^"']+)["']`)
+	saAssocTableRe     = regexp.MustCompile(`(?m)^(\w+)\s*=\s*Table\s*\(\s*["']([^"']+)["']`)
+	saCreateEngineRe   = regexp.MustCompile(`(?m)(\w+)\s*=\s*create_(?:async_)?engine\s*\(\s*["']([^"']*)["']`)
+	saSessionQueryRe   = regexp.MustCompile(`(\w+)\.query\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
+	saSessionExecuteRe = regexp.MustCompile(`(\w+)\.execute\s*\(\s*select\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
+	saSelectCallRe     = regexp.MustCompile(`(?:^|[^\w])select\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`)
+	// saColumnAttrRe matches a column/attribute declaration in a declarative
+	// model body: `name = Column(...)`, `id: Mapped[int] = mapped_column(...)`,
+	// `addr = relationship(...)`. Group 1 is the attribute name. Used for issue
+	// #4366 field-membership CONTAINS emission. The custom SQLAlchemy model node
+	// replaces the base tree-sitter class node (and its #526 CONTAINS edges), so
+	// every column/relationship/mapped_column must re-acquire membership here.
+	saColumnAttrRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*(?::\s*[\w.\[\], |]+)?\s*=\s*(?:Column|mapped_column|relationship|Mapped|deferred|composite|column_property|association_proxy|synonym)\s*\(`)
 	saHybridPropertyRe  = regexp.MustCompile(`(?m)@hybrid_property\s*\n\s*def\s+(\w+)\s*\(`)
 	saEventListenRe     = regexp.MustCompile(`(?m)event\.listen\s*\(\s*(\w+)\s*,\s*["'](\w+)["']`)
 	saEventListensForRe = regexp.MustCompile(`(?m)@event\.listens_for\s*\(\s*(\w+)\s*,\s*["'](\w+)["']\s*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
@@ -156,6 +164,10 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, line, props))
 		modelIdx := len(out) - 1 // index of this model node, for GRAPH_RELATES edges
 
+		// Issue #4366 — track attribute names that already received a CONTAINS
+		// membership edge so the plain-column scan at the end doesn't double-emit.
+		seenAttr := map[string]bool{}
+
 		// Relationships within the class body
 		for _, rIdx := range allMatchesIndex(saRelationshipRe, body) {
 			relAttr := body[rIdx[2]:rIdx[3]]
@@ -180,6 +192,13 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 				}
 			}
 			out = append(out, entity(className+"."+relAttr, "SCOPE.Schema", "", file.Path, relLine, relProps))
+
+			// Issue #4366 — relationship field membership + target reference.
+			seenAttr[relAttr] = true
+			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
+				containsFieldEdge(className, className+"."+relAttr, relAttr, "sqlalchemy"))
+			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
+				referencesClassEdge(className+"."+relAttr, targetModel, "sqlalchemy", relAttr))
 
 			// GRAPH_RELATES model↔model edge with cardinality. SQLAlchemy
 			// relationship() default is a collection (one_to_many); uselist=False
@@ -209,8 +228,12 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 			fkTarget := body[fkIdx[2]:fkIdx[3]]
 			fkLine := line + strings.Count(body[:fkIdx[0]], "\n")
 			tableName := strings.Split(fkTarget, ".")[0]
-			out = append(out, entity(className+".fk:"+fkTarget, "SCOPE.Schema", "", file.Path, fkLine,
-				map[string]string{"framework": "sqlalchemy", "pattern_type": "foreign_key", "fk_target": fkTarget, "target_table": tableName, "parent_class": className}))
+			fkEnt := entity(className+".fk:"+fkTarget, "SCOPE.Schema", "", file.Path, fkLine,
+				map[string]string{"framework": "sqlalchemy", "pattern_type": "foreign_key", "fk_target": fkTarget, "target_table": tableName, "parent_class": className})
+			out = append(out, fkEnt)
+			// Issue #4366 — FK pseudo-field membership.
+			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
+				containsFieldEdge(className, className+".fk:"+fkTarget, "fk:"+fkTarget, "sqlalchemy"))
 		}
 
 		// Hybrid properties
@@ -219,6 +242,27 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 			propLine := line + strings.Count(body[:hIdx[0]], "\n")
 			out = append(out, entity(className+"."+propName, "SCOPE.Operation", "function", file.Path, propLine,
 				map[string]string{"framework": "sqlalchemy", "pattern_type": "hybrid_property", "parent_class": className}))
+			// Issue #4366 — hybrid-property membership.
+			seenAttr[propName] = true
+			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
+				containsFieldEdge(className, className+"."+propName, propName, "sqlalchemy"))
+		}
+
+		// Issue #4366 — plain Column / mapped_column / Mapped[] attribute
+		// membership. These attribute entities are emitted by the BASE Python
+		// extractor as `<Class>.<attr>` SCOPE.Schema/field nodes (#526), but the
+		// custom SQLAlchemy model node REPLACES the base class node that carried
+		// their CONTAINS edges — so re-emit membership here for every declared
+		// column attribute. Relationship/hybrid attrs already got an edge above;
+		// dedup by attribute name via the shared seenAttr set.
+		for _, cIdx := range allMatchesIndex(saColumnAttrRe, body) {
+			attr := body[cIdx[2]:cIdx[3]]
+			if attr == "" || seenAttr[attr] {
+				continue
+			}
+			seenAttr[attr] = true
+			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
+				containsFieldEdge(className, className+"."+attr, attr, "sqlalchemy"))
 		}
 	}
 

--- a/internal/custom/python/testdata/issue4366/account_pydantic.py.txt
+++ b/internal/custom/python/testdata/issue4366/account_pydantic.py.txt
@@ -1,0 +1,21 @@
+"""Representative Pydantic models (byte-fixture for issue #4366).
+
+Shapes exercised:
+  - scalar annotated fields (name: str)
+  - a field whose annotated type is another BaseModel (addr: Address)
+  - Field(...) constraints
+"""
+
+from pydantic import BaseModel, Field
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    zip_code: str = Field(..., max_length=10)
+
+
+class Account(BaseModel):
+    id: int
+    name: str = Field(..., max_length=255)
+    addr: Address

--- a/internal/custom/python/testdata/issue4366/contract_models.py.txt
+++ b/internal/custom/python/testdata/issue4366/contract_models.py.txt
@@ -1,0 +1,297 @@
+from django.db import models
+from django.db.models import Q
+from django.utils import timezone
+from django.utils.text import slugify
+
+from .building import Building
+from .client import Client
+from .device import Device
+from .group import Group
+
+
+def upload_contract_to(instance, filename):
+    group_name = slugify(instance.contract.group.name)
+    contract_id = instance.contract.id
+    return f"{group_name}/contracts/{contract_id}/{filename}"
+
+
+def upload_to(instance, filename):
+    return f"contracts/notes/{filename}"
+
+
+class ContractGroup(models.Model):
+
+    class Meta:
+        db_table = "contract_groups"
+
+    def __str__(self):
+        return f"{self.id}"
+
+
+class Contract(models.Model):
+    STATUS_CHOICES = (
+        ("proposal", "Proposal"),
+        ("active", "Active"),
+        ("rejected", "Rejected"),
+        ("expired", "Expired"),
+        ("inactive", "Inactive"),
+        ("cancelled", "Cancelled"),
+    )
+
+    PROPOSAL_CHOICES = (
+        ("renew", "Renew"),
+        ("sent", "Sent"),
+        ("approved", "Approved"),
+        ("merged", "Merged"),
+        ("removed", "Removed"),
+        ("rejected", "Rejected"),
+    )
+
+    ADDRESS_TYPE_CHOICES = (
+        ("PREMISES", "Premises Address"),
+        ("ALTERNATE", "Alternate Address"),
+    )
+
+    group = models.ForeignKey(Group, on_delete=models.PROTECT, db_index=True)
+    client = models.ForeignKey(Client, on_delete=models.PROTECT, db_index=True)
+    building = models.ForeignKey(
+        Building, on_delete=models.PROTECT, db_index=True, blank=True, null=True
+    )
+    sales_agent = models.ForeignKey(
+        "User",
+        null=True,
+        on_delete=models.PROTECT,
+        related_name="sales_agent_contracts",
+        blank=True,
+    )
+    contract_number = models.CharField(max_length=255, blank=True, null=True)
+    contract_year = models.CharField(max_length=4, default=timezone.now().year)
+    contract_type = models.CharField(max_length=255, blank=True, null=True, default="")
+    testing_covered_in_contract = models.BooleanField(default=False)
+    filing_covered_in_contract = models.BooleanField(default=False)
+    covered_in_maintenance_contract = models.BooleanField(default=False)
+    fine_obligation = models.BooleanField(default=False)
+    start_date = models.DateTimeField(blank=True, null=True)
+    cancel_date = models.DateTimeField(blank=True, null=True)
+    end_date = models.DateTimeField(blank=True, null=True)
+    status = models.CharField(max_length=255, choices=STATUS_CHOICES, default="active")
+    inspector_hourly_rate = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+    proposal_status = models.CharField(
+        max_length=255, choices=PROPOSAL_CHOICES, default="renew"
+    )
+    modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=False, default=timezone.now)
+
+    # proposal_info
+    contract_length = models.CharField(
+        max_length=255, default=None, null=True, blank=True
+    )
+    recipients = models.ManyToManyField("User", related_name="recipients", blank=True)
+    proposal_email = models.CharField(max_length=255, default="", blank=True)
+    cat1_prices = models.JSONField(max_length=255, default=dict, blank=True)
+    cat1_devices = models.ManyToManyField(
+        Device, related_name="cat1_devices", blank=True
+    )
+    cat5_prices = models.JSONField(max_length=255, default=dict, blank=True)
+    cat5_devices = models.ManyToManyField(
+        Device, related_name="cat5_devices", blank=True
+    )
+    maintenance_prices = models.JSONField(max_length=255, default=dict, blank=True)
+    maintenance_devices = models.ManyToManyField(
+        Device, related_name="maintenance_devices", blank=True
+    )
+    periodic_prices = models.JSONField(max_length=255, default=dict, blank=True)
+    periodic_devices = models.ManyToManyField(
+        Device, related_name="periodic_devices", blank=True
+    )
+    contract_total = models.DecimalField(
+        max_digits=14, decimal_places=2, default=0.00, blank=True
+    )
+    date_approved = models.DateTimeField(
+        auto_now_add=False, blank=True, null=True, default=None
+    )
+    date_rejected = models.DateTimeField(
+        auto_now_add=False, blank=True, null=True, default=None
+    )
+    contract_group = models.ForeignKey(
+        ContractGroup,
+        blank=True,
+        null=True,
+        on_delete=models.PROTECT,
+        related_name="contracts",
+    )
+    selected_address_type = models.CharField(
+        max_length=10,
+        choices=ADDRESS_TYPE_CHOICES,
+        default="PREMISES",
+        help_text="Indicates if the selected address is the building's physical, premises, or an alternate address.",
+    )
+    selected_address = models.ForeignKey(
+        "BuildingAlternateAddress",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="Reference to an alternate address, used only if selected_address_type is 'ALTERNATE'.",
+    )
+    elv3_signee = models.ForeignKey(
+        "User",
+        null=True,
+        on_delete=models.PROTECT,
+        related_name="elv3_signee_contracts",
+        help_text="The selected contact who will sign ELV3 for this contract.",
+        blank=True,
+    )
+    contractor = models.ForeignKey(
+        "Group",
+        null=True,
+        on_delete=models.PROTECT,
+        related_name="contractor_contracts",
+        help_text="The selected contractor for this contract.",
+        blank=True,
+    )
+
+    # subscriptions
+    # workflow_id
+    # routes
+
+    def __str__(self):
+        return self.contract_number
+
+    class Meta:
+        db_table = "contracts"
+        indexes = [
+            models.Index(
+                fields=["group", "proposal_status", "start_date"],
+                name="contract_composite_1_idx",
+            )
+        ]
+
+class ContractNote(models.Model):
+
+    STATUS_CHOICES = (
+        ("active", "Active"),
+        ("inactive", "Inactive"),
+    )
+
+    TYPE_CHOICES = (
+        ("1", "No type specified"),
+        ("2", "proposals"),
+        ("3", "inspections"),
+        ("4", "Proposal Rejection"),
+    )
+
+    SYSTEM_TYPE_CHOICES = (
+        ("1", "system"),
+        ("2", "user"),
+    )
+
+    note = models.TextField(max_length=1200, default="", blank=True)
+    status = models.CharField(choices=STATUS_CHOICES, default="active")
+    type = models.CharField(choices=TYPE_CHOICES, default="1")
+    system_type = models.CharField(choices=SYSTEM_TYPE_CHOICES, default="1")
+    contract = models.ForeignKey(Contract, on_delete=models.CASCADE)
+    file = models.FileField(null=True, blank=True, upload_to=upload_to, default=None)
+    group = models.ForeignKey(Group, on_delete=models.CASCADE)
+    author = models.ForeignKey(
+        "User", on_delete=models.CASCADE, related_name="contract_user_notes"
+    )
+    modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=False, default=timezone.now)
+
+    def __str__(self):
+        return f"{self.id}"
+
+    class Meta:
+        db_table = "contract_note"
+
+
+class ContractDevice(models.Model):
+    STATUS_CHOICES = (("active", "Active"), ("inactive", "Inactive"))
+
+    contract = models.ForeignKey(
+        Contract, on_delete=models.CASCADE, related_name="contract_devices"
+    )
+    group = models.ForeignKey('Group', on_delete=models.SET_NULL, null=True, blank=True, related_name='contract_devices')
+    device = models.ForeignKey(
+        Device, on_delete=models.CASCADE, related_name="device_contracts"
+    )
+    status = models.CharField(max_length=255, choices=STATUS_CHOICES, default="active", db_index=True)
+    cancel_date = models.DateTimeField(blank=True, null=True)
+
+    class Meta:
+        db_table = "contract_devices"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["device", "group"],
+                condition=Q(status="active"),
+                name="unique_active_contract_device_per_device_group",
+            ),
+        ]
+
+    def __str__(self):
+        return self.device.name + " from " + self.contract.contract_number
+
+
+class ContractDeviceWorkflow(models.Model):
+    contract_device = models.ForeignKey(
+        ContractDevice,
+        on_delete=models.CASCADE,
+        related_name="contract_devices_workflow",
+    )
+    workflow_id = models.CharField(max_length=255, default="")
+
+    class Meta:
+        db_table = "contract_device_workflow"
+
+
+class ContractFile(models.Model):
+    contract = models.ForeignKey(
+        Contract, on_delete=models.CASCADE, related_name="contract_file"
+    )
+    doc_type = models.CharField(max_length=255, default="")
+    path = models.CharField(max_length=255, default="")
+    storage = models.CharField(max_length=255, default="")
+    file_name = models.CharField(max_length=255, default="")
+    orig_name = models.CharField(max_length=255, default="")
+    md5 = models.CharField(max_length=255, default="")
+    mime_type = models.CharField(max_length=255, default="")
+    file = models.FileField(
+        max_length=255,
+        null=True,
+        blank=True,
+        upload_to=upload_contract_to,
+        default=None,
+    )
+    modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=False, default=timezone.now)
+
+    class Meta:
+        db_table = "contract_files"
+
+    def __str__(self):
+        return self.contract.contract_number + " | " + self.file_name
+
+
+class UserContract(models.Model):
+    STATUS_CHOICES = (("active", "Active"), ("inactive", "Inactive"))
+
+    user = models.ForeignKey(
+        "User", on_delete=models.CASCADE, related_name="users_contracts"
+    )
+    contract = models.ForeignKey(
+        "Contract", on_delete=models.CASCADE, related_name="contracts_users"
+    )
+    status = models.CharField(max_length=255, choices=STATUS_CHOICES, default="active", db_index=True)
+
+    class Meta:
+        db_table = "user_contracts"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "contract"],
+                condition=Q(status="active"),
+                name="unique_active_user_contract_per_user_contract",
+            ),
+        ]
+
+    def __str__(self):
+        return self.user.email + " | " + self.contract.contract_number

--- a/internal/custom/python/testdata/issue4366/orders_sqlalchemy.py.txt
+++ b/internal/custom/python/testdata/issue4366/orders_sqlalchemy.py.txt
@@ -1,0 +1,29 @@
+"""Representative SQLAlchemy declarative models (byte-fixture for issue #4366).
+
+Shapes exercised:
+  - Column(...) scalar fields
+  - relationship('Other') string-target relationships
+  - mapped_column / Mapped[X] typing
+  - ForeignKey('other.id')
+"""
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from .base import Base
+
+
+class Customer(Base):
+    __tablename__ = "customers"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255))
+    orders = relationship("Order", back_populates="customer")
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    customer_id = Column(Integer, ForeignKey("customers.id"))
+    customer = relationship("Customer", back_populates="orders")
+    total = Column(Integer, default=0)


### PR DESCRIPTION
## Summary

Generalizes the JS/TS field-membership fix #4328 to the Python stack. Django model fields, DRF serializer fields, Django form fields, SQLAlchemy columns/relationships/FKs/hybrid-properties, and the peewee/pony/beanie/mongoengine/tortoise ORM column+relation fields were emitted as standalone `<Class>.<field>` graph nodes with **no owning-class membership** and (for relations) **no target-type edge** — a forest of degree-0 orphans.

## Root cause (reproduced in-pipeline first)

The regex framework extractors in `internal/custom/python` emit their own model/serializer/form **class node** under the same Name as the base tree-sitter class node. `MergeWithCustom` **replaces** the base node with the custom one, dropping the class→field `CONTAINS` edges the base extractor attached under #526. The ORM column/relation extractors additionally replace the base field nodes with custom field nodes that never carried membership. Net effect: every field of every recognized Python model lost its membership.

## Fix (long-term, structural at extraction; mirrors #4328, no new Kinds)

- New shared helpers `containsFieldEdge` / `referencesClassEdge` (`internal/custom/python/helpers.go`). `CONTAINS` FromID=`Class:<owner>`, ToID=`<owner>.<field>` (qualified member Name) — resolves merge-stably via the resolver `byName` index regardless of ID-backfill timing. `REFERENCES` FromID=`<owner>.<field>`, ToID=`Class:<target>` for relation/nested targets.
- **Django** (`django.go`): re-emit `CONTAINS` for every model / serializer / form class-body attribute (full membership parity with the replaced base node, incl. `*_CHOICES` constants + manager attachments), plus `REFERENCES` to the target model for `ForeignKey`/`OneToOneField`/`ManyToManyField` (string-, symbol- and `'self'`-target, app_label-stripped) and to the target serializer for nested-serializer fields.
- **SQLAlchemy** (`sqlalchemy.go`): `CONTAINS` for every `Column`/`mapped_column`/`Mapped[]`/`relationship`/FK/hybrid-property attribute, plus `REFERENCES` from each `relationship` to its string-target model.
- **Other ORMs** (`orm_schema.go` + `orm_relationships.go`): `CONTAINS` for peewee/pony/beanie/mongoengine/tortoise columns, plus `REFERENCES` from each relation field to its (app_label-stripped) target model.

## Live-validation (fixtures lie at merge)

`issue4366_livedrepro_test.go` runs the **real** base python extractor + the **real** regex framework extractors, merges them via the actual `MergeWithCustom` pipeline path, assigns real IDs and builds the real `resolve.BuildIndex` symbol table over byte-copies of representative source — **including the real `upvate_core` `core/models/contract.py` Django models**.

Red → green:

| Sub-framework | Orphan fields before | after |
|---|---|---|
| Django (real contract.py) | 77 / 87 | **0 / 87** |
| SQLAlchemy | 8 / 8 | **0 / 8** |
| Pydantic | 0 / 6 | 0 / 6 (already membered by base #526, unbroken) |

Relation targets (`Class:Group`, `Class:User`, `Class:Order`/`Customer`) emit resolving `REFERENCES` edges.

## Gates

- `go build ./...` ✅
- `go vet ./internal/custom/python/ ./internal/extractors/python/` ✅
- `go test ./internal/custom/python/ ./internal/extractors/python/ ./internal/resolve/ ./internal/engine/` ✅
- Full `go test ./...`: only `internal/verify` `TestHarness_FixturesCorpus` fails, and that is **environmental** (it refuses to start a /tmp daemon because the host's canonical daemon pid is already bound to the socket) — unrelated to this change, which touches no `internal/verify` code.

No new entity/relationship Kinds (reuses existing `CONTAINS` / `REFERENCES`).

Closes #4366

🤖 Generated with [Claude Code](https://claude.com/claude-code)