### PR TITLE
Collapse Python pytest/unittest test orphan ring into a single linked test_suite

### DIFF
--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1125,6 +1125,24 @@ def simple_task():
 // Pytest tests
 // ============================================================================
 
+// pytestSuite returns the single collapsed test_suite entity emitted by the
+// pytest/unittest extractor for a file (issue #4357), or fails.
+func pytestSuite(t *testing.T, ents []extractResult) extractResult {
+	t.Helper()
+	var suites []extractResult
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "test_suite" {
+			suites = append(suites, e)
+		}
+	}
+	if len(suites) != 1 {
+		t.Fatalf("expected exactly 1 test_suite entity, got %d", len(suites))
+	}
+	return suites[0]
+}
+
+// Issue #4357: the per-test/per-class/per-fixture nodes are collapsed into one
+// test_suite entity per file with counts folded into properties.
 func TestPytest_TestFunction(t *testing.T) {
 	src := `def test_user_creation():
     assert True
@@ -1133,14 +1151,12 @@ async def test_async_endpoint():
     assert True
 `
 	ents := extract(t, "python_pytest", src)
-	testCount := 0
-	for _, e := range ents {
-		if e.Props["pattern_type"] == "test" {
-			testCount++
-		}
+	suite := pytestSuite(t, ents)
+	if suite.Props["test_func_count"] != "2" {
+		t.Fatalf("expected test_func_count=2, got %q", suite.Props["test_func_count"])
 	}
-	if testCount != 2 {
-		t.Fatalf("expected 2 test functions, got %d", testCount)
+	if suite.Props["toplevel_func_count"] != "2" {
+		t.Fatalf("expected toplevel_func_count=2, got %q", suite.Props["toplevel_func_count"])
 	}
 }
 
@@ -1152,21 +1168,12 @@ func TestPytest_TestClass(t *testing.T) {
         pass
 `
 	ents := extract(t, "python_pytest", src)
-	classCount := 0
-	methodCount := 0
-	for _, e := range ents {
-		if e.Props["pattern_type"] == "test_class" {
-			classCount++
-		}
-		if e.Props["pattern_type"] == "test" {
-			methodCount++
-		}
+	suite := pytestSuite(t, ents)
+	if suite.Props["test_class_count"] != "1" {
+		t.Fatalf("expected test_class_count=1, got %q", suite.Props["test_class_count"])
 	}
-	if classCount != 1 {
-		t.Fatalf("expected 1 test class, got %d", classCount)
-	}
-	if methodCount != 2 {
-		t.Fatalf("expected 2 test methods, got %d", methodCount)
+	if suite.Props["test_method_count"] != "2" {
+		t.Fatalf("expected test_method_count=2, got %q", suite.Props["test_method_count"])
 	}
 }
 
@@ -1174,16 +1181,20 @@ func TestPytest_Fixture(t *testing.T) {
 	src := `@pytest.fixture(scope="session", autouse=True)
 def db_connection():
     pass
+
+def test_uses_db(db_connection):
+    assert True
 `
 	ents := extract(t, "python_pytest", src)
-	found := false
-	for _, e := range ents {
-		if e.Name == "db_connection" && e.Props["fixture_scope"] == "session" && e.Props["autouse"] == "true" {
-			found = true
-		}
+	suite := pytestSuite(t, ents)
+	if suite.Props["fixture_count"] != "1" {
+		t.Fatalf("expected fixture_count=1, got %q", suite.Props["fixture_count"])
 	}
-	if !found {
-		t.Fatal("expected fixture entity")
+	// The fixture is no longer a standalone orphan node.
+	for _, e := range ents {
+		if e.Name == "db_connection" {
+			t.Fatalf("fixture should not be a standalone entity, got %+v", e)
+		}
 	}
 }
 
@@ -1193,14 +1204,9 @@ def test_double(input, expected):
     assert input * 2 == expected
 `
 	ents := extract(t, "python_pytest", src)
-	found := false
-	for _, e := range ents {
-		if e.Name == "test_double" && e.Props["parametrized"] == "true" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatal("expected parametrized test entity")
+	suite := pytestSuite(t, ents)
+	if suite.Props["parametrize_count"] != "1" {
+		t.Fatalf("expected parametrize_count=1, got %q", suite.Props["parametrize_count"])
 	}
 }
 
@@ -4489,37 +4495,22 @@ def test_process_order_task():
     assert result.id
 `
 	ents := extract(t, "python_pytest", src)
-	byName := map[string]extractResult{}
-	for _, e := range ents {
-		byName[e.Name] = e
-	}
-
-	sendTest, ok := byName["test_send_email_task"]
-	if !ok {
-		t.Fatal("expected entity test_send_email_task")
-	}
-	foundDelay := false
-	for _, r := range sendTest.Rels {
+	// Issue #4357: celery TESTS edges are now folded onto the single test_suite.
+	suite := pytestSuite(t, ents)
+	foundDelay, foundApply := false, false
+	for _, r := range suite.Rels {
 		if r.Kind == "TESTS" && r.ToID == "Task:send_email" {
 			foundDelay = true
 		}
-	}
-	if !foundDelay {
-		t.Errorf("test_send_email_task: expected TESTS → Task:send_email (via .delay()), got rels: %+v", sendTest.Rels)
-	}
-
-	processTest, ok := byName["test_process_order_task"]
-	if !ok {
-		t.Fatal("expected entity test_process_order_task")
-	}
-	foundApply := false
-	for _, r := range processTest.Rels {
 		if r.Kind == "TESTS" && r.ToID == "Task:process_order" {
 			foundApply = true
 		}
 	}
+	if !foundDelay {
+		t.Errorf("expected TESTS → Task:send_email (via .delay()), got rels: %+v", suite.Rels)
+	}
 	if !foundApply {
-		t.Errorf("test_process_order_task: expected TESTS → Task:process_order (via .apply_async()), got rels: %+v", processTest.Rels)
+		t.Errorf("expected TESTS → Task:process_order (via .apply_async()), got rels: %+v", suite.Rels)
 	}
 }
 
@@ -4530,24 +4521,15 @@ func TestCelery_TestsEdges_Apply(t *testing.T) {
     assert result.result == 3
 `
 	ents := extract(t, "python_pytest", src)
-	var testEnt *extractResult
-	for i := range ents {
-		if ents[i].Name == "test_sync_task" {
-			testEnt = &ents[i]
-			break
-		}
-	}
-	if testEnt == nil {
-		t.Fatal("expected entity test_sync_task")
-	}
+	suite := pytestSuite(t, ents)
 	found := false
-	for _, r := range testEnt.Rels {
+	for _, r := range suite.Rels {
 		if r.Kind == "TESTS" && r.ToID == "Task:my_task" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected TESTS → Task:my_task (via .apply()), got rels: %+v", testEnt.Rels)
+		t.Errorf("expected TESTS → Task:my_task (via .apply()), got rels: %+v", suite.Rels)
 	}
 }
 

--- a/internal/custom/python/issue4357_livedrepro_test.go
+++ b/internal/custom/python/issue4357_livedrepro_test.go
@@ -1,0 +1,218 @@
+package python_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+// Issue #4357 LIVE-REPRO — Python test (pytest + unittest) orphan collapse +
+// TESTS edge to the SUT symbol.
+//
+// Generalizes the Jest #4343 / Go #4358 / JUnit #4359 fixes to Python. The
+// pytest/unittest custom extractor previously emitted a first-class entity per
+// fixture, per Test class, per test method, and per test_ function — none
+// carrying a relationship (beyond the narrow Celery .delay() case) — producing a
+// forest of orphan assertion/fixture/test nodes with ZERO TESTS edges to the
+// code under test.
+//
+// We run the ACTUAL base python extractor + the ACTUAL regex framework
+// extractors, merge them exactly as the pipeline does (MergeWithCustom), assign
+// real entity IDs, build the REAL resolver symbol table (resolve.BuildIndex)
+// over BOTH the test file and its production module, and assert:
+//   - the per-test/per-fixture orphan ring is gone (exactly ONE test_suite),
+//   - a TESTS edge to the SUT symbol exists, and
+//   - that subject resolves through the symbol table to the production entity.
+
+func loadRepro4357(t *testing.T, base, repoPath string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "issue4357", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read repro %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: repoPath, Language: "python", Content: b}
+}
+
+// mergedEntitiesFor runs the full merged pipeline (base + custom + merge + IDs)
+// for one file. Reuses runMergedPipeline from the #4366 livedrepro test.
+func suiteEntities(ents []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "test_suite" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// orphanTestNodes counts entities that look like the OLD per-test/per-fixture
+// nodes (a standalone Test class, a test_ method/function, or a fixture) that
+// carry no inbound or outbound relationship — the orphan ring #4357 removes.
+func legacyTestNodeNames(ents []types.EntityRecord) []string {
+	var names []string
+	for _, e := range ents {
+		// The old extractor emitted these with pattern_type test/test_class and
+		// framework=pytest. The new one emits none of them.
+		if e.Properties["pattern_type"] == "test" ||
+			e.Properties["pattern_type"] == "test_class" ||
+			e.Properties["pattern_type"] == "pytest_fixture" ||
+			e.Properties["pattern_type"] == "pytest_conftest" {
+			names = append(names, e.Name)
+		}
+	}
+	return names
+}
+
+func testsEdgeTargets(ents []types.EntityRecord) []string {
+	var out []string
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) {
+				out = append(out, r.ToID)
+			}
+		}
+	}
+	return out
+}
+
+// TestIssue4357_UnittestTestCase_CollapsedSuite_AndTestsEdges runs the REAL
+// upvate_core Django unittest file (core/tests/test_schedule_import.py, byte-copied
+// into testdata) paired with its production module (core/helper/schedule_import_helper.py).
+func TestIssue4357_UnittestTestCase_CollapsedSuite_AndTestsEdges(t *testing.T) {
+	testFile := loadRepro4357(t, "test_schedule_import.py.txt", "core/tests/test_schedule_import.py")
+	sutFile := loadRepro4357(t, "schedule_import_helper.py.txt", "core/helper/schedule_import_helper.py")
+
+	testEnts := runMergedPipeline(t, testFile)
+	sutEnts := runMergedPipeline(t, sutFile)
+
+	// AFTER: exactly one test_suite, the legacy per-test/per-fixture orphan ring is gone.
+	suites := suiteEntities(testEnts)
+	if len(suites) != 1 {
+		t.Fatalf("expected exactly 1 collapsed test_suite, got %d", len(suites))
+	}
+	if legacy := legacyTestNodeNames(testEnts); len(legacy) > 0 {
+		t.Errorf("expected 0 legacy per-test/per-fixture orphan nodes, got %d: %v", len(legacy), legacy)
+	}
+
+	suite := suites[0]
+	if suite.Properties["framework"] != "unittest" {
+		t.Errorf("expected framework=unittest, got %q", suite.Properties["framework"])
+	}
+	// Counts folded onto the suite (information preserved).
+	for _, k := range []string{"test_class_count", "test_method_count", "assertion_count", "fixture_count"} {
+		if suite.Properties[k] == "" || suite.Properties[k] == "0" {
+			t.Errorf("expected non-zero folded property %s, got %q", k, suite.Properties[k])
+		}
+	}
+	t.Logf("folded suite props: classes=%s methods=%s asserts=%s fixtures=%s",
+		suite.Properties["test_class_count"], suite.Properties["test_method_count"],
+		suite.Properties["assertion_count"], suite.Properties["fixture_count"])
+
+	// TESTS edges: unittest class ResolveDeviceTest/ResolveContractTest/GroupRowsTest
+	// → resolve_device/resolve_contract/group_rows (snake-case, reference-gated on
+	// the `from core.helper.schedule_import_helper import ...` import).
+	targets := testsEdgeTargets(testEnts)
+	if len(targets) == 0 {
+		t.Fatal("expected at least one TESTS edge from the test_suite, got 0")
+	}
+	t.Logf("TESTS edge targets: %v", targets)
+
+	want := map[string]bool{"resolve_device": false, "resolve_contract": false, "group_rows": false, "parse_csv_file": false}
+	for _, tgt := range targets {
+		if _, ok := want[tgt]; ok {
+			want[tgt] = true
+		}
+	}
+	hits := 0
+	for subj, got := range want {
+		if got {
+			hits++
+		} else {
+			t.Logf("note: expected-ish subject %q not linked (acceptable if name affinity diverges)", subj)
+		}
+	}
+	if hits == 0 {
+		t.Errorf("expected at least one of resolve_device/resolve_contract/group_rows/parse_csv_file as a TESTS target, got %v", targets)
+	}
+
+	// The subject must resolve through the REAL symbol table to the production
+	// function entity (test + SUT entities together).
+	all := append(append([]types.EntityRecord{}, testEnts...), sutEnts...)
+	idx := resolve.BuildIndex(all)
+	resolved := 0
+	for _, tgt := range targets {
+		if _, ok := idx.Lookup(tgt); ok {
+			resolved++
+		}
+	}
+	if resolved == 0 {
+		t.Errorf("no TESTS-edge subject resolved through the symbol table to a production entity; targets=%v", targets)
+	}
+	t.Logf("%d/%d TESTS-edge subjects resolve to production entities", resolved, len(targets))
+}
+
+// TestIssue4357_PytestFunctionStyle_CollapsedSuite_AndTestsEdge covers the
+// pytest function + parametrize + fixture style (the upvate backend is unittest-
+// only, so this representative file exercises the pure-pytest path).
+func TestIssue4357_PytestFunctionStyle_CollapsedSuite_AndTestsEdge(t *testing.T) {
+	testFile := loadRepro4357(t, "test_orders_pytest.py.txt", "tests/test_orders.py")
+	sutFile := loadRepro4357(t, "orders_service.py.txt", "app/services/orders.py")
+
+	testEnts := runMergedPipeline(t, testFile)
+	sutEnts := runMergedPipeline(t, sutFile)
+
+	suites := suiteEntities(testEnts)
+	if len(suites) != 1 {
+		t.Fatalf("expected exactly 1 collapsed test_suite, got %d", len(suites))
+	}
+	suite := suites[0]
+	if legacy := legacyTestNodeNames(testEnts); len(legacy) > 0 {
+		t.Errorf("expected 0 legacy per-test/per-fixture nodes, got %v", legacy)
+	}
+	if suite.Properties["parametrize_count"] == "" || suite.Properties["parametrize_count"] == "0" {
+		t.Errorf("expected non-zero parametrize_count, got %q", suite.Properties["parametrize_count"])
+	}
+	if suite.Properties["fixture_count"] == "" || suite.Properties["fixture_count"] == "0" {
+		t.Errorf("expected non-zero fixture_count, got %q", suite.Properties["fixture_count"])
+	}
+
+	// pytest function test_place_order → place_order (reference-gated import).
+	targets := testsEdgeTargets(testEnts)
+	t.Logf("pytest TESTS targets: %v", targets)
+	found := false
+	for _, tgt := range targets {
+		if tgt == "place_order" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TESTS → place_order (test_place_order name affinity), got %v", targets)
+	}
+
+	all := append(append([]types.EntityRecord{}, testEnts...), sutEnts...)
+	idx := resolve.BuildIndex(all)
+	if _, ok := idx.Lookup("place_order"); !ok {
+		t.Errorf("place_order did not resolve through the symbol table to the production function")
+	}
+}
+
+func TestIssue4357_BeforeAfterContrast_ResolverByName(t *testing.T) {
+	// Sanity: the resolver byName fallback binds a bare subject name to the
+	// production function entity (the mechanism the bare TESTS ToID relies on).
+	sutFile := loadRepro4357(t, "orders_service.py.txt", "app/services/orders.py")
+	ents := runMergedPipeline(t, sutFile)
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("place_order"); !ok {
+		t.Skip("place_order not emitted as a top-level entity by the base extractor; byName binding not assertable here")
+	}
+	_ = context.Background
+}

--- a/internal/custom/python/pytest.go
+++ b/internal/custom/python/pytest.go
@@ -3,6 +3,8 @@ package python
 import (
 	"context"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -12,25 +14,54 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// extractTestFuncBody returns the body text of a function starting at bodyStart
-// (i.e. the byte offset just after the def line's colon). It stops at the next
-// top-level definition or EOF.
-func extractTestFuncBody(source string, bodyStart int) string {
-	rest := source[bodyStart:]
-	// Top-level code starts at indent 0 with non-whitespace.
-	nextToplevel := regexp.MustCompile(`(?m)^\S`).FindStringIndex(rest)
-	if nextToplevel != nil {
-		return rest[:nextToplevel[0]]
-	}
-	return rest
-}
+// ISSUE #4357 — Python test orphan collapse + TESTS edge.
+//
+// The pytest/unittest custom extractor previously emitted a first-class entity
+// per @pytest.fixture, per Test class, per test method, and per top-level
+// test_ function — NONE of which carried any relationship beyond the narrow
+// Celery .delay() TESTS special-case. On a real Python test suite (Django
+// unittest TestCase classes, pytest function/class style, parametrize cases,
+// setUp/conftest fixtures, bare assert / self.assertEqual calls) those edge-less
+// nodes dominate the orphan ring — exactly mirroring the Jest #4343 / Go #4358
+// orphan rings.
+//
+// Root-cause fix at extraction (not a downstream repair), mirroring #4343/#4358:
+//
+//   - Emit exactly ONE test_suite entity per test file. The per-fixture /
+//     per-class / per-method / per-function nodes are no longer emitted as
+//     standalone entities; their counts are folded into properties
+//     (test_func_count, test_class_count, test_method_count, fixture_count,
+//     assertion_count, parametrize_count, mark counts) so no information is lost
+//     while the orphan blast radius collapses from O(funcs+classes+fixtures+
+//     asserts) to one node per file.
+//
+//   - Synthesize a TESTS edge from the file's test_suite to the production
+//     symbol(s) under test, resolved Python-idiomatically by NAME AFFINITY
+//     (test_place_order → place_order; TestOrderService / OrderServiceTest →
+//     OrderService and order_service; module test_foo.py → foo) gated on the
+//     subject being BOTH derivable by name AND actually imported/referenced in
+//     the test file. Requiring both keeps the edge conservative (name affinity
+//     alone over-links; reference alone links fixtures/util). The edge ToID is
+//     the bare subject name, which the resolver binds through its byName index
+//     to the production function/class entity.
+//
+// Reuses the existing SCOPE.Pattern kind + "test_suite" subtype and the TESTS
+// relationship kind — no new producer Kind. The single suite entity is named
+// `pytest_suite:<base>` so it never collides by-name with a production
+// function/class node (which would re-orphan it through the resolver's byName
+// index, as in #4343), and so MergeWithCustom's name-keyed replace does not
+// clobber the base tree-sitter class/func nodes (lesson from #4366).
+//
+// The cross/testmap Python path (test_coverage entities via direct body-call
+// detection, and #2549 Django test-client → ViewSet route linkage) is unchanged
+// and complementary — this fix covers the test→SUT-symbol axis at extraction.
 
 func init() {
 	extractor.Register("python_pytest", &PytestExtractor{})
 }
 
-// PytestExtractor extracts pytest patterns: test functions, test classes,
-// fixtures, parametrize, marks, and conftest.py fixtures.
+// PytestExtractor extracts pytest + unittest test patterns and collapses them
+// into one linked test_suite per file (issue #4357).
 type PytestExtractor struct{}
 
 func (e *PytestExtractor) Language() string { return "python_pytest" }
@@ -38,21 +69,37 @@ func (e *PytestExtractor) Language() string { return "python_pytest" }
 var (
 	ptTestFuncRe = regexp.MustCompile(
 		`(?m)^(?:async\s+)?def\s+(test_\w+)\s*\(([^)]*)\)\s*:`)
+	// Test classes: pytest TestXxx OR unittest XxxTest(Case)/extends (Test)?Case.
 	ptTestClassRe = regexp.MustCompile(
-		`(?m)^class\s+(Test\w+)\s*(?:\([^)]*\))?\s*:`)
+		`(?m)^class\s+(Test\w+|\w*Test|\w*TestCase)\s*(?:\(([^)]*)\))?\s*:`)
 	ptTestMethodRe = regexp.MustCompile(
 		`(?m)^\s{4,}(?:async\s+)?def\s+(test_\w+)\s*\(([^)]*)\)\s*:`)
 	ptFixtureRe = regexp.MustCompile(
 		`(?m)@pytest\.fixture\s*(\([^)]*\))?\s*\n(?:\s*#[^\n]*\n)*\s*(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)`)
-	ptFixtureScopeRe   = regexp.MustCompile(`scope\s*=\s*["'](\w+)["']`)
-	ptFixtureAutouseRe = regexp.MustCompile(`autouse\s*=\s*(True|False)`)
-	ptParametrizeRe    = regexp.MustCompile(`@pytest\.mark\.parametrize\s*\(\s*["']([^"']+)["']`)
-	ptMarkCustomRe     = regexp.MustCompile(`@pytest\.mark\.(\w+)\s*(?:\([^)]*\))?`)
+	ptParametrizeRe = regexp.MustCompile(`@pytest\.mark\.parametrize\s*\(\s*["']([^"']+)["']`)
+	ptMarkCustomRe  = regexp.MustCompile(`@pytest\.mark\.(\w+)\s*(?:\([^)]*\))?`)
+
+	// unittest lifecycle fixtures (setUp / tearDown / setUpClass / tearDownClass /
+	// setUpModule / tearDownModule) and bare assertion calls.
+	ptUnittestFixtureRe = regexp.MustCompile(
+		`(?m)^\s*(?:async\s+)?def\s+(setUp|tearDown|setUpClass|tearDownClass|setUpModule|tearDownModule)\s*\(`)
+	ptUnittestAssertRe = regexp.MustCompile(`\bself\.(assert\w+)\s*\(`)
+	ptBareAssertRe     = regexp.MustCompile(`(?m)^\s*assert\b`)
 
 	// Celery TESTS edges: task.delay() / task.apply() / task.apply_async() call
-	// sites inside test functions → TESTS edge from test to task (issue #3346).
+	// sites inside the file → TESTS edge to the task (issue #3346), folded onto
+	// the single suite entity.
 	ptCeleryCallRe = regexp.MustCompile(
 		`(?m)\b(\w+)\.(delay|apply_async|apply)\s*\(`)
+
+	// importedSymbolsRe captures names bound by `from X import a, b, c`,
+	// `from X import (\n a,\n b,\n)` (parenthesized multi-line), and `import x`
+	// so the TESTS resolver can reference-gate subjects.
+	ptFromImportRe      = regexp.MustCompile(`(?m)^\s*from\s+[\w.]+\s+import\s+([^\n#]+)`)
+	ptFromImportParenRe = regexp.MustCompile(`(?s)from\s+[\w.]+\s+import\s*\(([^)]*)\)`)
+	ptImportRe          = regexp.MustCompile(`(?m)^\s*import\s+([\w.]+)`)
+
+	ptIdentRe = regexp.MustCompile(`^[A-Za-z_]\w*$`)
 )
 
 var ptSkipMarks = map[string]bool{"fixture": true, "parametrize": true, "usefixtures": true}
@@ -69,149 +116,358 @@ func (e *PytestExtractor) Extract(ctx context.Context, file extractor.FileInput)
 
 	source := string(file.Content)
 	isConftest := strings.HasSuffix(file.Path, "conftest.py")
-	var out []types.EntityRecord
 
-	// 1. Fixtures
-	provenance := "pytest_fixture"
-	if isConftest {
-		provenance = "pytest_conftest"
-	}
-	for _, idx := range allMatchesIndex(ptFixtureRe, source) {
-		decoratorArgs := ""
-		if idx[2] != -1 {
-			decoratorArgs = source[idx[2]:idx[3]]
-		}
-		funcName := source[idx[4]:idx[5]]
-		fixtureScope := "function"
-		if sm := ptFixtureScopeRe.FindStringSubmatch(decoratorArgs); sm != nil {
-			fixtureScope = sm[1]
-		}
-		autouse := "false"
-		if am := ptFixtureAutouseRe.FindStringSubmatch(decoratorArgs); am != nil && am[1] == "True" {
-			autouse = "true"
-		}
-		line := lineOf(source, idx[0])
-		out = append(out, entity(funcName, "SCOPE.Pattern", "", file.Path, line,
-			map[string]string{"framework": "pytest", "pattern_type": provenance, "fixture_scope": fixtureScope, "autouse": autouse}))
-	}
+	// ── collect per-file counts (folded onto the single suite entity) ────────
+	testFuncs := allMatchesIndex(ptTestFuncRe, source)     // includes methods + top-level
+	testMethods := allMatchesIndex(ptTestMethodRe, source) // indented test_ defs
+	classMatches := allMatchesIndex(ptTestClassRe, source)
+	fixtureMatches := allMatchesIndex(ptFixtureRe, source)
+	lifecycleFixtures := allMatchesIndex(ptUnittestFixtureRe, source)
+	parametrizeCount := len(ptParametrizeRe.FindAllString(source, -1))
+	assertionCount := len(ptUnittestAssertRe.FindAllString(source, -1)) +
+		len(ptBareAssertRe.FindAllString(source, -1))
+	fixtureCount := len(fixtureMatches) + len(lifecycleFixtures)
 
-	// 2. Test classes + their test methods
-	type classRange struct{ start, end int }
-	var classRanges []classRange
-
-	for _, idx := range allMatchesIndex(ptTestClassRe, source) {
-		className := source[idx[2]:idx[3]]
-		classStart := idx[0]
-		classLine := lineOf(source, classStart)
-
-		// Determine class body end
+	// Top-level test functions = all test_ defs not nested inside a class.
+	var classRanges []struct{ start, end int }
+	for _, idx := range classMatches {
 		rest := source[idx[1]:]
 		nextToplevel := regexp.MustCompile(`(?m)^\S`).FindStringIndex(rest)
-		classEnd := len(source)
+		end := len(source)
 		if nextToplevel != nil {
-			classEnd = idx[1] + nextToplevel[0]
+			end = idx[1] + nextToplevel[0]
 		}
-		classRanges = append(classRanges, classRange{classStart, classEnd})
-		classBody := source[idx[1]:classEnd]
-
-		// Collect class-level marks
-		preClass := collectDecorators(source, classStart)
-		marks := collectMarks(preClass)
-		props := map[string]string{"framework": "pytest", "pattern_type": "test_class"}
-		if len(marks) > 0 {
-			props["marks"] = strings.Join(marks, ",")
-		}
-		out = append(out, entity(className, "SCOPE.Component", "", file.Path, classLine, props))
-
-		// Test methods inside the class
-		for _, mIdx := range allMatchesIndex(ptTestMethodRe, classBody) {
-			methodName := classBody[mIdx[2]:mIdx[3]]
-			methodLine := classLine + strings.Count(classBody[:mIdx[0]], "\n")
-			preMethod := collectDecorators(classBody, mIdx[0])
-			methodMarks := collectMarks(preMethod)
-			parametrized := len(ptParametrizeRe.FindAllString(preMethod, -1)) > 0
-			mProps := map[string]string{"framework": "pytest", "pattern_type": "test"}
-			if len(methodMarks) > 0 {
-				mProps["marks"] = strings.Join(methodMarks, ",")
-			}
-			if parametrized {
-				mProps["parametrized"] = "true"
-			}
-			out = append(out, entity(className+"."+methodName, "SCOPE.Operation", "function", file.Path, methodLine, mProps))
-		}
+		classRanges = append(classRanges, struct{ start, end int }{idx[0], end})
 	}
-
-	// 3. Top-level test functions (skip those inside classes)
-	for _, idx := range allMatchesIndex(ptTestFuncRe, source) {
-		funcStart := idx[0]
-		insideClass := false
+	topLevelFuncCount := 0
+	for _, idx := range testFuncs {
+		inside := false
 		for _, cr := range classRanges {
-			if funcStart > cr.start && funcStart < cr.end {
-				insideClass = true
+			if idx[0] > cr.start && idx[0] < cr.end {
+				inside = true
 				break
 			}
 		}
-		if insideClass {
-			continue
+		if !inside {
+			topLevelFuncCount++
 		}
-		funcName := source[idx[2]:idx[3]]
-		line := lineOf(source, funcStart)
-		preFunc := collectDecorators(source, funcStart)
-		marks := collectMarks(preFunc)
-		parametrized := len(ptParametrizeRe.FindAllString(preFunc, -1)) > 0
-		props := map[string]string{"framework": "pytest", "pattern_type": "test"}
-		if len(marks) > 0 {
-			props["marks"] = strings.Join(marks, ",")
-		}
-		if parametrized {
-			props["parametrized"] = "true"
-		}
-		ent := entity(funcName, "SCOPE.Operation", "function", file.Path, line, props)
+	}
 
-		// Celery TESTS edges: scan this test body for .delay()/.apply_async()/.apply() call
-		// sites and emit a TESTS relationship from the test function to the task (issue #3346).
-		funcBody := extractTestFuncBody(source, idx[1])
-		for _, cIdx := range allMatchesIndex(ptCeleryCallRe, funcBody) {
-			taskRef := funcBody[cIdx[2]:cIdx[3]]
-			callKind := funcBody[cIdx[4]:cIdx[5]]
+	// Collect distinct custom marks across the file.
+	markSet := map[string]bool{}
+	for _, m := range ptMarkCustomRe.FindAllStringSubmatch(source, -1) {
+		if !ptSkipMarks[m[1]] {
+			markSet[m[1]] = true
+		}
+	}
+
+	// Nothing test-shaped → emit nothing (conftest with only fixtures still
+	// emits a suite so its fixtures are accounted for; a plain module that
+	// merely imports pytest does not).
+	if len(testFuncs) == 0 && len(classMatches) == 0 && fixtureCount == 0 {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// ── one linked test_suite per file ───────────────────────────────────────
+	provenance := "INFERRED_FROM_PYTEST_FILE"
+	framework := "pytest"
+	if len(classMatches) > 0 && hasUnittestBase(source, classMatches) {
+		framework = "unittest"
+		provenance = "INFERRED_FROM_UNITTEST_FILE"
+	}
+	if isConftest {
+		provenance = "INFERRED_FROM_PYTEST_CONFTEST"
+	}
+
+	line := 1
+	if len(classMatches) > 0 {
+		line = lineOf(source, classMatches[0][0])
+	} else if len(testFuncs) > 0 {
+		line = lineOf(source, testFuncs[0][0])
+	} else if len(fixtureMatches) > 0 {
+		line = lineOf(source, fixtureMatches[0][0])
+	}
+
+	props := map[string]string{
+		"framework":           framework,
+		"test_framework":      framework,
+		"pattern_type":        "test_suite",
+		"provenance":          provenance,
+		"test_func_count":     strconv.Itoa(len(testFuncs)),
+		"toplevel_func_count": strconv.Itoa(topLevelFuncCount),
+		"test_method_count":   strconv.Itoa(len(testMethods)),
+		"test_class_count":    strconv.Itoa(len(classMatches)),
+		"fixture_count":       strconv.Itoa(fixtureCount),
+		"assertion_count":     strconv.Itoa(assertionCount),
+		"parametrize_count":   strconv.Itoa(parametrizeCount),
+	}
+	if isConftest {
+		props["conftest"] = "true"
+	}
+	if len(markSet) > 0 {
+		props["marks"] = strings.Join(sortedSet(markSet), ",")
+	}
+
+	ent := entity("pytest_suite:"+pyTestBaseName(file.Path), "SCOPE.Pattern", "test_suite",
+		file.Path, line, props)
+
+	// ── TESTS edges: name affinity, reference-gated (issue #4357) ────────────
+	referenced := collectPyReferencedSymbols(source)
+	subjects := resolvePyTestSubjects(source, file.Path, classMatches, testFuncs, referenced)
+	if len(subjects) > 0 {
+		ent.Properties["tests_target"] = strings.Join(subjects, ",")
+		for _, subj := range subjects {
 			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
-				ToID: "Task:" + taskRef,
-				Kind: "TESTS",
+				ToID: subj,
+				Kind: string(types.RelationshipKindTests),
 				Properties: map[string]string{
-					"framework": "celery",
-					"call_kind": callKind,
+					"framework":    framework,
+					"match_source": "python_test_name_affinity",
+					"target":       subj,
 				},
+				Confidence: 0.9,
 			})
 		}
-
-		out = append(out, ent)
 	}
 
-	span.SetAttributes(attribute.Int("entity_count", len(out)))
-	return out, nil
+	// Celery TESTS edges (folded onto the suite): scan for .delay()/.apply_async()/
+	// .apply() call sites and emit a TESTS relationship to the task (issue #3346).
+	seenTask := map[string]bool{}
+	for _, cIdx := range allMatchesIndex(ptCeleryCallRe, source) {
+		taskRef := source[cIdx[2]:cIdx[3]]
+		callKind := source[cIdx[4]:cIdx[5]]
+		if seenTask[taskRef] {
+			continue
+		}
+		seenTask[taskRef] = true
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "Task:" + taskRef,
+			Kind: string(types.RelationshipKindTests),
+			Properties: map[string]string{
+				"framework": "celery",
+				"call_kind": callKind,
+			},
+		})
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", 1))
+	return []types.EntityRecord{ent}, nil
 }
 
-func collectDecorators(source string, defStart int) string {
-	lines := strings.Split(source[:defStart], "\n")
-	var result []string
-	for i := len(lines) - 1; i >= 0; i-- {
-		stripped := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(stripped, "@") || stripped == "" {
-			result = append([]string{lines[i]}, result...)
+// hasUnittestBase reports whether any detected test class extends a unittest /
+// Django TestCase base (the strong signal that this is a unittest-style file).
+func hasUnittestBase(source string, classMatches [][]int) bool {
+	for _, idx := range classMatches {
+		if idx[4] != -1 {
+			bases := source[idx[4]:idx[5]]
+			if strings.Contains(bases, "TestCase") || strings.Contains(bases, "unittest.") {
+				return true
+			}
+		}
+	}
+	return strings.Contains(source, "import unittest") ||
+		strings.Contains(source, "from django.test") ||
+		strings.Contains(source, "rest_framework.test")
+}
+
+// pyTestBaseName derives a human label from a Python test file path, e.g.
+// `core/tests/test_schedule_import.py` → `test_schedule_import`.
+func pyTestBaseName(path string) string {
+	p := path
+	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
+		p = p[i+1:]
+	}
+	return strings.TrimSuffix(p, ".py")
+}
+
+// pySubjectFromModulePath derives the SUT module-name candidate from a test
+// file's path: test_foo.py → foo, foo_test.py → foo, tests.py → "".
+func pySubjectFromModulePath(path string) string {
+	stem := pyTestBaseName(path)
+	switch stem {
+	case "tests", "test", "conftest":
+		return ""
+	}
+	if strings.HasPrefix(stem, "test_") {
+		return strings.TrimPrefix(stem, "test_")
+	}
+	if strings.HasSuffix(stem, "_test") {
+		return strings.TrimSuffix(stem, "_test")
+	}
+	return ""
+}
+
+// collectPyReferencedSymbols returns the set of names imported into the test
+// file (via `from X import a, b` and `import x`). A TESTS subject is eligible
+// only when it is in this set — i.e. actually pulled into the test file —
+// which keeps the edge pointed at an in-repo production symbol rather than a
+// helper/util/fixture name.
+func collectPyReferencedSymbols(source string) map[string]bool {
+	out := map[string]bool{}
+	addClause := func(clause string) {
+		// Strip parentheses/backslashes used for multi-line import groups, drop
+		// inline comments, then split on commas.
+		clause = strings.NewReplacer("(", "", ")", "", "\\", "").Replace(clause)
+		for _, part := range strings.Split(clause, ",") {
+			name := strings.TrimSpace(part)
+			if i := strings.IndexByte(name, '#'); i >= 0 {
+				name = strings.TrimSpace(name[:i])
+			}
+			// handle `foo as bar` → bind name is `bar`.
+			if i := strings.Index(name, " as "); i >= 0 {
+				name = strings.TrimSpace(name[i+4:])
+			}
+			if ptIdentRe.MatchString(name) {
+				out[name] = true
+			}
+		}
+	}
+	// Parenthesized multi-line: `from X import (\n a,\n b,\n)`.
+	for _, m := range ptFromImportParenRe.FindAllStringSubmatch(source, -1) {
+		addClause(m[1])
+	}
+	// Single-line: `from X import a, b`.
+	for _, m := range ptFromImportRe.FindAllStringSubmatch(source, -1) {
+		clause := m[1]
+		// Skip the opening of a parenthesized group (handled above).
+		if strings.Contains(clause, "(") && !strings.Contains(clause, ")") {
+			continue
+		}
+		addClause(clause)
+	}
+	for _, m := range ptImportRe.FindAllStringSubmatch(source, -1) {
+		mod := m[1]
+		// `import a.b.c` binds the leaf? In Python it binds `a`, but the SUT
+		// reference convention uses the leaf module; record both ends.
+		parts := strings.Split(mod, ".")
+		if ptIdentRe.MatchString(parts[0]) {
+			out[parts[0]] = true
+		}
+		if leaf := parts[len(parts)-1]; ptIdentRe.MatchString(leaf) {
+			out[leaf] = true
+		}
+	}
+	return out
+}
+
+// classSubjectCandidates derives production-symbol candidates from a unittest /
+// pytest test class name, most-specific first:
+//
+//	TestOrderService    → ["OrderService", "order_service"]
+//	OrderServiceTest    → ["OrderService", "order_service"]
+//	ResolveDeviceTest   → ["ResolveDevice", "resolve_device"]
+//	ParseCsvFileMissingColumnsTest → ["ParseCsvFileMissingColumns", "parse_csv_file_missing_columns"]
+//
+// Returns both the CamelCase base (matches a production class) and its
+// snake_case form (matches a production function) — the reference gate then
+// selects whichever was actually imported.
+func classSubjectCandidates(className string) []string {
+	base := className
+	switch {
+	case strings.HasPrefix(base, "Test"):
+		base = base[len("Test"):]
+	case strings.HasSuffix(base, "TestCase"):
+		base = base[:len(base)-len("TestCase")]
+	case strings.HasSuffix(base, "Test"):
+		base = base[:len(base)-len("Test")]
+	}
+	if base == "" || !ptIdentRe.MatchString(base) {
+		return nil
+	}
+	cands := []string{base}
+	if snake := camelToSnake(base); snake != base {
+		cands = append(cands, snake)
+	}
+	return cands
+}
+
+// funcSubjectCandidates derives the production-symbol candidate from a pytest
+// test function name: test_place_order → place_order.
+func funcSubjectCandidates(funcName string) []string {
+	base := strings.TrimPrefix(funcName, "test_")
+	if base == "" || base == funcName || !ptIdentRe.MatchString(base) {
+		return nil
+	}
+	return []string{base}
+}
+
+// camelToSnake converts CamelCase/PascalCase to snake_case, treating runs of
+// uppercase as acronyms (CSVFile → csv_file).
+func camelToSnake(s string) string {
+	var b strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				prev := runes[i-1]
+				next := rune(0)
+				if i+1 < len(runes) {
+					next = runes[i+1]
+				}
+				prevLower := prev >= 'a' && prev <= 'z' || prev >= '0' && prev <= '9'
+				nextLower := next >= 'a' && next <= 'z'
+				if prevLower || (nextLower && prev >= 'A' && prev <= 'Z') {
+					b.WriteByte('_')
+				}
+			}
+			b.WriteRune(r - 'A' + 'a')
 		} else {
-			break
+			b.WriteRune(r)
 		}
 	}
-	return strings.Join(result, "\n")
+	return b.String()
 }
 
-func collectMarks(decoratorBlock string) []string {
-	var marks []string
-	for _, m := range ptMarkCustomRe.FindAllStringSubmatch(decoratorBlock, -1) {
-		markName := m[1]
-		if !ptSkipMarks[markName] {
-			marks = append(marks, markName)
+// resolvePyTestSubjects determines the unit(s) under test for a Python test
+// file, de-duplicated and in priority order. A subject is emitted ONLY when it
+// is both (a) derivable by name affinity from a test class, a test_ function,
+// or the module path, AND (b) actually imported/referenced in the test file.
+func resolvePyTestSubjects(source, path string, classMatches, testFuncs [][]int, referenced map[string]bool) []string {
+	var ordered []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name == "" || seen[name] || !referenced[name] {
+			return
+		}
+		seen[name] = true
+		ordered = append(ordered, name)
+	}
+
+	// 1. test classes → strip Test prefix/suffix → CamelCase + snake candidates.
+	for _, idx := range classMatches {
+		for _, cand := range classSubjectCandidates(source[idx[2]:idx[3]]) {
+			if referenced[cand] {
+				add(cand)
+				break
+			}
 		}
 	}
-	return marks
+
+	// 2. top-level test_ functions → strip test_ prefix.
+	for _, idx := range testFuncs {
+		for _, cand := range funcSubjectCandidates(source[idx[2]:idx[3]]) {
+			if referenced[cand] {
+				add(cand)
+				break
+			}
+		}
+	}
+
+	// 3. module-path affinity (test_foo.py → foo) — only when nothing else
+	//    resolved, to avoid over-linking on broad multi-subject files.
+	if len(ordered) == 0 {
+		add(pySubjectFromModulePath(path))
+	}
+
+	return ordered
+}
+
+func sortedSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/custom/python/testdata/issue4357/orders_service.py.txt
+++ b/internal/custom/python/testdata/issue4357/orders_service.py.txt
@@ -1,0 +1,26 @@
+"""Order service — production module under test (representative SUT)."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Order:
+    id: int
+    total: float
+
+
+class OrderService:
+    def __init__(self, repo):
+        self.repo = repo
+
+    def total(self, order: Order) -> float:
+        return order.total
+
+
+def place_order(customer_id: int, items: list) -> Order:
+    total = sum(i["price"] for i in items)
+    return Order(id=customer_id, total=total)
+
+
+def cancel_order(order: Order) -> bool:
+    return order.total == 0

--- a/internal/custom/python/testdata/issue4357/schedule_import_helper.py.txt
+++ b/internal/custom/python/testdata/issue4357/schedule_import_helper.py.txt
@@ -1,0 +1,939 @@
+"""
+Helper functions for the MASS scheduled inspection CSV import feature.
+
+All functions here are pure (no HTTP/request objects) so they can be
+unit-tested independently of the view.  MongoDB-dependent logic
+(duplicate detection) intentionally lives in the view, which already
+owns the MongoDBConnection and validate_existing_inspection().
+"""
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import re
+from collections import defaultdict, namedtuple
+from datetime import datetime
+from typing import Optional
+
+import pytz
+from django.db import transaction, IntegrityError
+from django.db.models import Q
+
+from core.models import (
+    Checklist,
+    ContractDevice,
+    Device,
+    Group,
+    GroupDeviceSettings,
+    Jurisdiction,
+    User,
+    UserGroup,
+    UserGroupRole,
+)
+
+# ---------------------------------------------------------------------------
+# Utility functions — mirror implementations in import_viewset.py.
+# Defined here rather than imported to avoid a circular import through
+# core.views.__init__ → schedule_viewset → this module.
+# ---------------------------------------------------------------------------
+
+def _s(v) -> str:
+    """Strip and normalize a value to string."""
+    return (v or "").strip() if isinstance(v, str) else (str(v).strip() if v is not None else "")
+
+
+def _norm(v) -> str:
+    """Normalize to lowercase, single-space."""
+    return " ".join(_s(v).split()).lower()
+
+
+def _norm_addr(v: str) -> str:
+    """Normalize an address string for loose comparison (alphanumeric + space only)."""
+    return re.sub(r"[^a-z0-9 ]", "", v.lower()).strip()
+
+
+_device_token_re = re.compile(r"[A-Za-z]+|\d+")
+
+
+def normalize_device_number(value: str) -> Optional[str]:
+    """
+    Normalize a raw device tag into the canonical hyphen-separated format
+    used when devices are stored (mirrors import_viewset.normalize_device_number):
+      "281P154"   → "281-P-154"
+      "281 P 154" → "281-P-154"
+      "281-P-154" → "281-P-154"
+    Returns None if the input is empty or contains no alphanumeric tokens.
+    """
+    if not value:
+        return None
+    s = str(value).strip().upper()
+    if not s:
+        return None
+    parts = _device_token_re.findall(s)
+    if not parts:
+        return None
+    return "-".join(parts)
+
+
+def strip_test_type_tag_suffix(raw_test_type: str, tag_number: str) -> str:
+    """
+    Remove the appended device-tag suffix from a raw CSV Test Type string.
+
+    The MASS CSV format embeds the device tag directly in the Test Type column:
+        "Annual Inspection - 282-P-12"
+        "Annual Weight Test - 282-P-12"
+        "90 Day Annual - 282-P-12"
+
+    The tag is already captured from the Tag # column, so only the leading
+    type text is needed for inspection-type mapping.
+
+    Uses a case-insensitive suffix check so minor casing differences between
+    the Tag # value and the embedded suffix are handled gracefully.
+
+    Returns the cleaned type text, or the original string unchanged when no
+    matching suffix is found (e.g. a plain "Cat1" value still works).
+    """
+    cleaned = _s(raw_test_type)
+    tag = _s(tag_number)
+    if tag and cleaned.lower().endswith(tag.lower()):
+        # Remove the tag portion, then strip any trailing separator ("  -  ", " - ", "-")
+        cleaned = cleaned[: -len(tag)].rstrip(" -").strip()
+    return cleaned
+
+
+def split_full_name(full_name: str) -> tuple[str, str]:
+    """Split 'First Last Name' into ('First', 'Last Name')."""
+    s = (full_name or "").strip()
+    if not s:
+        return "", ""
+    parts = s.split()
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], " ".join(parts[1:])
+
+
+def ensure_user_group_and_roles(*, user: User, group: Group, role_ids: list) -> tuple:
+    """
+    Idempotently ensure UserGroup + UserGroupRole records exist.
+    Mirrors ensure_user_group_and_roles() in import_viewset.py.
+    """
+    cleaned = [int(r) for r in (role_ids or []) if r]
+    with transaction.atomic():
+        ug, _ = UserGroup.objects.get_or_create(user_id=user.id, group_id=group.id)
+        ugrs = []
+        for rid in cleaned:
+            ugr, _ = UserGroupRole.objects.get_or_create(
+                user_id=user.id, group_id=group.id, role_id=rid
+            )
+            ugrs.append(ugr)
+    return ug, ugrs
+
+logger = logging.getLogger(__name__)
+
+UTC = pytz.utc
+
+# ---------------------------------------------------------------------------
+# Column definitions
+# ---------------------------------------------------------------------------
+
+REQUIRED_COLUMNS = {"date", "time", "inspector", "test type"}
+
+# Any of these (normalized) is accepted as the device/tag column.
+DEVICE_COLUMN_ALIASES = {
+    "tag#",
+    "tag #",
+    "device id",
+    "tag# / device id",
+    "tag#/device id",
+    "tag # / device id",
+    "tag # /device id",
+    "tag # / device id",
+}
+
+# Map normalized CSV test-type strings → internal type codes.
+# Internal codes: "cat1", "retest", "placard".
+TEST_TYPE_NORMALIZATION: dict[str, str] = {
+    # Annual / Cat1
+    "cat1": "cat1",
+    "cat 1": "cat1",
+    "category 1": "cat1",
+    "annual": "cat1",
+    "annual inspection": "cat1",
+    "one year": "cat1",
+    "1 year": "cat1",
+    "1-year": "cat1",
+    # Re-Test
+    "retest": "retest",
+    "re-test": "retest",
+    "re test": "retest",
+    "cat1 retest": "retest",
+    "cat1 re-test": "retest",
+    # Placard
+    "placard": "placard",
+}
+
+# Human-readable labels returned in the API response.
+CHECKLIST_DISPLAY_LABELS: dict[str, str] = {
+    "cat1": "Annual",
+    "retest": "Re-Test",
+    "placard": "Placard",
+}
+
+# Names used for ChecklistType DB lookup (resolved via iexact).
+CHECKLIST_DB_NAMES: dict[str, str] = {
+    "cat1": "Cat1",
+    "retest": "Retest",
+    "placard": "Placard",
+}
+
+DATE_FORMATS = ["%m/%d/%Y", "%Y-%m-%d", "%m-%d-%Y", "%d/%m/%Y"]
+TIME_FORMATS = ["%H:%M", "%H:%M:%S", "%I:%M %p", "%I:%M:%S %p"]
+
+# ---------------------------------------------------------------------------
+# Keyword-based test-type mapping for free-text values (e.g. MASS CSV exports)
+# ---------------------------------------------------------------------------
+
+# Ordered substring patterns applied after the exact-match lookup fails.
+# "cat1 re-test" MUST appear before "re-test" and "cat1" so the combined
+# form is not split across two separate matches.
+_TEST_TYPE_KEYWORD_MAP: list[tuple[str, str]] = [
+    ("cat1 re-test", "retest"),
+    ("cat1 retest", "retest"),
+    ("annual inspection", "cat1"),
+    ("annual", "cat1"),
+    ("re-test", "retest"),
+    ("retest", "retest"),
+]
+
+# Patterns that are valid MASS inspection types but not supported for this
+# import — yield a skip warning rather than an error so other rows are not
+# blocked.
+_TEST_TYPE_UNSUPPORTED_KEYWORDS: list[str] = [
+    "90 day annual",
+]
+
+# Test types that belong to a different jurisdiction and are explicitly
+# rejected (hard error, not skipped).
+_TEST_TYPE_REJECTED_KEYWORDS: list[str] = [
+    "annual weight test",   # Cat5 — wrong jurisdiction
+    "cat5",
+    "cat 5",
+    "category 5",
+    "five year",
+    "5 year",
+    "5-year",
+    "periodic",
+    "maintenance",
+]
+
+
+def map_test_type_to_checklist_name(test_type_raw: str) -> tuple[Optional[str], bool, bool]:
+    """
+    Map a raw CSV test-type string to an internal type code.
+
+    Strategy (in order):
+      1. Unsupported-keyword check ("90 day annual") → (None, True, False).
+         Caller should skip the row with a warning, not an error.
+      2. Rejected-keyword check (Cat5, Periodic, etc.) → (None, False, True).
+         Caller should error the row — these types are not valid for this import.
+      3. Exact lookup in TEST_TYPE_NORMALIZATION.
+      4. Ordered substring matching via _TEST_TYPE_KEYWORD_MAP.
+      5. Completely unknown → (None, False, False). Caller records an error.
+
+    Returns:
+        (internal_code_or_None, is_unsupported, is_rejected)
+    """
+    norm = _norm(test_type_raw)
+
+    for keyword in _TEST_TYPE_UNSUPPORTED_KEYWORDS:
+        if keyword in norm:
+            return None, True, False
+
+    for keyword in _TEST_TYPE_REJECTED_KEYWORDS:
+        if keyword in norm:
+            return None, False, True
+
+    code = TEST_TYPE_NORMALIZATION.get(norm)
+    if code:
+        return code, False, False
+
+    for keyword, internal_code in _TEST_TYPE_KEYWORD_MAP:
+        if keyword in norm:
+            return internal_code, False, False
+
+    return None, False, False
+
+# Named tuple used as dict key for grouping rows.
+InspectionGroupKey = namedtuple("InspectionGroupKey", ["start_date_iso", "inspector_id", "building_id"])
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+# ---------------------------------------------------------------------------
+
+def _find_device_key(norm_fieldnames: list[str]) -> Optional[str]:
+    """Return the first normalized fieldname that matches a device column alias."""
+    for f in norm_fieldnames:
+        if f in DEVICE_COLUMN_ALIASES:
+            return f
+    return None
+
+
+def parse_csv_file(file_bytes: bytes) -> tuple[list[dict], list[dict]]:
+    """
+    Parse CSV bytes into a list of normalized row dicts.
+
+    Returns:
+        (rows, top_level_errors)
+        On top-level error, rows is empty and top_level_errors contains one entry.
+        Row dicts have normalized (lowercase, single-space) keys.
+    """
+    for encoding in ("utf-8-sig", "utf-8", "latin-1"):
+        try:
+            content = file_bytes.decode(encoding)
+            break
+        except UnicodeDecodeError:
+            continue
+    else:
+        return [], [
+            {
+                "code": "INVALID_FILE_TYPE",
+                "message": "Could not decode file. Please upload a UTF-8 or Latin-1 CSV.",
+                "context": {},
+            }
+        ]
+
+    reader = csv.DictReader(io.StringIO(content))
+    raw_fieldnames = list(reader.fieldnames or [])
+
+    if not raw_fieldnames:
+        return [], [{"code": "EMPTY_FILE", "message": "CSV file is empty or has no headers.", "context": {}}]
+
+    # Read all rows first so we can check for data before validating columns.
+    # Filter out rows where every value is blank (e.g. trailing empty rows in Excel exports).
+    rows = []
+    for raw_row in reader:
+        norm_row = {_norm(k): _s(v) for k, v in raw_row.items() if k is not None}
+        if any(v for v in norm_row.values()):
+            rows.append(norm_row)
+
+    # Collect all top-level errors so the user can fix everything at once.
+    top_errors = []
+
+    if not rows:
+        top_errors.append({"code": "NO_DATA", "message": "CSV file has no data rows.", "context": {}})
+
+    norm_fieldnames = [_norm(f) for f in raw_fieldnames]
+    device_key = _find_device_key(norm_fieldnames)
+
+    missing = sorted(REQUIRED_COLUMNS - set(norm_fieldnames))
+    if device_key is None:
+        missing = sorted(set(missing) | {"tag# / device id"})
+
+    if missing:
+        top_errors.append(
+            {
+                "code": "MISSING_COLUMNS",
+                "message": "Required columns missing from CSV.",
+                "context": {"missing": missing},
+            }
+        )
+
+    if top_errors:
+        return [], top_errors
+
+    return rows, []
+
+
+def normalize_row(raw_row: dict, row_index: int) -> dict:
+    """
+    Parse and normalize one raw CSV row.
+
+    Returns a row_result dict with keys:
+        row_index, raw_inspector, raw_tag_number, raw_address, raw_company,
+        resolved (dict of resolved fields, filled incrementally),
+        errors (list of error dicts),
+        warnings (list of warning dicts),
+        status ('valid' | 'error' — caller may later change to 'pending_inspector' or 'skipped')
+    """
+    row_result: dict = {
+        "row_index": row_index,
+        "raw_inspector": "",
+        "raw_tag_number": "",
+        "raw_address": "",
+        "raw_company": "",
+        "resolved": {
+            "device_id": None,
+            "device_name": None,
+            "building_id": None,
+            "building_name": None,
+            "building_address": None,
+            "contract_id": None,
+            "contract_number": None,
+            "contract_type": None,
+            "client_id": None,
+            "client_name": None,
+            "jurisdiction_id": None,
+            "inspector_id": None,
+            "inspector_name": None,
+            "checklist_id": None,
+            "checklist_type_int": None,
+            "checklist_name": None,
+            "start_date_iso": None,
+            "start_time_str": None,
+            # Internal fields — stripped from API response (keys prefixed with _)
+            "_start_dt": None,
+            "_end_dt": None,
+            "_checklist_db_name": None,
+        },
+        "errors": [],
+        "warnings": [],
+        "status": "valid",
+    }
+
+    # --- Inspector ---
+    row_result["raw_inspector"] = _s(raw_row.get("inspector", ""))
+    if not row_result["raw_inspector"]:
+        row_result["errors"].append(
+            {"code": "MISSING_INSPECTOR", "field": "inspector", "message": "Inspector name is required."}
+        )
+
+    # --- Device / Tag# ---
+    tag_number = ""
+    for alias in DEVICE_COLUMN_ALIASES:
+        if alias in raw_row:
+            tag_number = _s(raw_row[alias])
+            break
+    row_result["raw_tag_number"] = tag_number
+    if not tag_number:
+        row_result["errors"].append(
+            {"code": "MISSING_TAG_NUMBER", "field": "tag_number", "message": "Tag# / Device ID is required."}
+        )
+
+    # --- Optional columns ---
+    row_result["raw_address"] = _s(raw_row.get("address", ""))
+    # Accept "elevator company" (MASS CSV export) as well as legacy column names.
+    row_result["raw_company"] = _s(
+        raw_row.get("company / client name", "")
+        or raw_row.get("elevator company", "")
+        or raw_row.get("company", "")
+    )
+
+    # --- Date ---
+    date_str = _s(raw_row.get("date", ""))
+    parsed_date = None
+    for fmt in DATE_FORMATS:
+        try:
+            parsed_date = datetime.strptime(date_str, fmt).date()
+            break
+        except ValueError:
+            pass
+    if parsed_date is None:
+        row_result["errors"].append(
+            {"code": "INVALID_DATE", "field": "date", "message": f"Cannot parse date '{date_str}'."}
+        )
+
+    # --- Time ---
+    time_str = _s(raw_row.get("time", ""))
+    parsed_time = None
+    for fmt in TIME_FORMATS:
+        try:
+            parsed_time = datetime.strptime(time_str, fmt).time()
+            break
+        except ValueError:
+            pass
+    if parsed_time is None:
+        row_result["errors"].append(
+            {"code": "INVALID_TIME", "field": "time", "message": f"Cannot parse time '{time_str}'."}
+        )
+
+    # --- Build UTC datetimes ---
+    if parsed_date and parsed_time:
+        start_dt = datetime(
+            parsed_date.year, parsed_date.month, parsed_date.day,
+            parsed_time.hour, parsed_time.minute, parsed_time.second,
+            tzinfo=UTC,
+        )
+        # endDate = same calendar date, time stripped (midnight UTC)
+        end_dt = datetime(parsed_date.year, parsed_date.month, parsed_date.day, 0, 0, 0, tzinfo=UTC)
+        row_result["resolved"]["_start_dt"] = start_dt
+        row_result["resolved"]["_end_dt"] = end_dt
+        row_result["resolved"]["start_date_iso"] = parsed_date.isoformat()
+        row_result["resolved"]["start_time_str"] = parsed_time.strftime("%H:%M:%S")
+
+    # --- Test type ---
+    # Strip the appended device-tag suffix ("Annual Inspection - 282-P-12" →
+    # "Annual Inspection") before mapping. The tag is already captured via
+    # Tag #, so only the leading type text is needed.
+    test_type_raw = _s(raw_row.get("test type", ""))
+    test_type_clean = strip_test_type_tag_suffix(test_type_raw, tag_number)
+    internal_code, is_unsupported, is_rejected = map_test_type_to_checklist_name(test_type_clean)
+
+    if is_unsupported:
+        row_result["warnings"].append(
+            {
+                "code": "UNSUPPORTED_TEST_TYPE",
+                "field": "test type",
+                "message": (
+                    f"Test type '{test_type_raw}' is not yet supported "
+                    "and will be skipped."
+                ),
+            }
+        )
+    elif is_rejected:
+        accepted_labels = [CHECKLIST_DISPLAY_LABELS[c] for c in ("cat1", "retest", "placard")]
+        row_result["errors"].append(
+            {
+                "code": "INVALID_TEST_TYPE",
+                "field": "test type",
+                "message": (
+                    f"Test type '{test_type_raw}' is not valid for this import. "
+                    f"Accepted values: {', '.join(accepted_labels)}."
+                ),
+            }
+        )
+    elif internal_code is None:
+        accepted_labels = [CHECKLIST_DISPLAY_LABELS[c] for c in ("cat1", "retest", "placard")]
+        row_result["errors"].append(
+            {
+                "code": "UNKNOWN_TEST_TYPE",
+                "field": "test type",
+                "message": (
+                    f"Unknown test type '{test_type_raw}'. "
+                    f"Accepted values: {', '.join(accepted_labels)}."
+                ),
+            }
+        )
+    else:
+        row_result["resolved"]["checklist_name"] = CHECKLIST_DISPLAY_LABELS[internal_code]
+        row_result["resolved"]["_checklist_db_name"] = CHECKLIST_DB_NAMES[internal_code]
+
+    # Errors take priority; unsupported rows are skipped (not errored) so
+    # valid rows in the same file are not blocked.
+    if row_result["errors"]:
+        row_result["status"] = "error"
+    elif is_unsupported:
+        row_result["status"] = "skipped"
+
+    return row_result
+
+
+# ---------------------------------------------------------------------------
+# Inspector cache
+# ---------------------------------------------------------------------------
+
+def build_inspector_cache(raw_rows: list[dict], uploading_group_id: int) -> dict[str, object]:
+    """
+    Build a name → User mapping for every unique inspector name in the CSV.
+
+    Values:
+        User object       — exactly one active inspector matched
+        'ambiguous'       — more than one user matched the name
+        None              — no match found (unknown inspector)
+
+    Strategy: search within the uploading group first; fall back to
+    system-wide (any group) if not found in group.  Cross-group matches
+    are returned as User objects — the caller must call
+    ensure_user_group_and_roles() during finalize to link them.
+    """
+    unique_names: set[str] = set()
+    for row in raw_rows:
+        name = _norm(row.get("inspector", ""))
+        if name:
+            unique_names.add(name)
+
+    cache: dict[str, object] = {}
+
+    for norm_name in unique_names:
+        fn, ln = split_full_name(norm_name)
+
+        # 1. Group-scoped
+        qs_group = User.objects.filter(
+            first_name__iexact=fn,
+            last_name__iexact=ln,
+            usergrouprole__group_id=uploading_group_id,
+            usergrouprole__role_id=4,
+            status="active",
+        ).distinct()
+
+        count_group = qs_group.count()
+        if count_group == 1:
+            cache[norm_name] = qs_group.first()
+            continue
+        if count_group > 1:
+            cache[norm_name] = "ambiguous"
+            continue
+
+        # 2. System-wide fallback
+        qs_all = User.objects.filter(
+            first_name__iexact=fn,
+            last_name__iexact=ln,
+            usergrouprole__role_id=4,
+            status="active",
+        ).distinct()
+
+        count_all = qs_all.count()
+        if count_all == 1:
+            cache[norm_name] = qs_all.first()
+        elif count_all > 1:
+            cache[norm_name] = "ambiguous"
+        else:
+            cache[norm_name] = None  # unknown
+
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# Device / contract / checklist resolution
+# ---------------------------------------------------------------------------
+
+def resolve_device(
+    tag_number: str,
+    uploading_group_id: int,
+    raw_address: str = "",
+) -> tuple[Optional[Device], list[dict]]:
+    """
+    Resolve a device by Device.name.
+
+    Strategy:
+      1. Find all devices whose name exactly matches the tag number (no
+         contract filter).  This prevents spurious DEVICE_NOT_FOUND errors
+         when the device exists but its ContractDevice / Contract status is
+         in any state other than "active".  Group / contract validation is
+         the responsibility of resolve_contract(), which is called separately.
+      2. If exactly one candidate → return it.
+      3. If multiple candidates, narrow by the uploading group's active
+         contracts (prefers the device already linked to this group).
+      4. If still multiple (or none match the group), narrow further by
+         building address.
+      5. Still ambiguous → DEVICE_AMBIGUOUS.
+
+    The returned Device has building pre-fetched via select_related.
+    """
+    tag_number = _s(tag_number)
+    if not tag_number:
+        return None, [
+            {
+                "code": "MISSING_TAG_NUMBER",
+                "field": "tag_number",
+                "message": "Tag# / Device ID is required.",
+            }
+        ]
+
+    # Normalize to the canonical hyphenated format used when devices are stored.
+    # Handles format variations like "281P154" or "281 P 154" → "281-P-154".
+    # Falls back to the raw value if normalization produces nothing.
+    normalized_tag = normalize_device_number(tag_number) or tag_number
+
+    qs = (
+        Device.objects.filter(
+            Q(name__iexact=normalized_tag)
+            | Q(
+                group_device_settings__name__iexact=normalized_tag,
+                group_device_settings__group_id=uploading_group_id,
+            )
+        )
+        .select_related("building")
+        .distinct()
+    )
+
+    count = qs.count()
+    if count == 0:
+        return None, [
+            {
+                "code": "DEVICE_NOT_FOUND",
+                "field": "tag_number",
+                "message": f"No device found with name '{tag_number}'.",
+            }
+        ]
+    if count == 1:
+        return qs.first(), []
+
+    # --- Multiple devices share this name — disambiguate ---
+
+    # Step 2: prefer the device linked to an active contract for this group
+    group_qs = (
+        qs.filter(
+
+            device_contracts__contract__group_id=uploading_group_id,
+            device_contracts__contract__status="active",
+            device_contracts__status="active",
+        )
+        .distinct()
+    )
+    group_count = group_qs.count()
+    if group_count == 1:
+        return group_qs.first(), []
+
+    # Step 3: narrow further by building address (optional — only used if provided).
+    # Building address is always derived from device.building in the caller;
+    # the CSV address is only used here as a disambiguation hint.
+    # Use premises_address (MA canonical) falling back to physical_address,
+    # consistent with how building_address is resolved in the view.
+    candidates = list(group_qs if group_count > 1 else qs)
+    if raw_address:
+        norm_input = _norm_addr(raw_address)
+        addr_matches = [
+            d for d in candidates
+            if d.building and norm_input in _norm_addr(
+                d.building.premises_address or d.building.physical_address or ""
+            )
+        ]
+        if len(addr_matches) == 1:
+            return addr_matches[0], []
+
+    return None, [
+        {
+            "code": "DEVICE_AMBIGUOUS",
+            "field": "tag_number",
+            "message": (
+                f"Multiple devices matched '{tag_number}'. "
+                "Provide a unique device ID or verify the address."
+            ),
+        }
+    ]
+
+
+def resolve_contract(
+    device_id: int,
+    uploading_group_id: int,
+) -> tuple[Optional[ContractDevice], list[dict], list[dict]]:
+    """
+    Find the active ContractDevice for the given device and group.
+
+    Returns (contract_device_or_none, errors, warnings).
+    The returned ContractDevice has contract and client pre-fetched.
+    """
+    qs = (
+        ContractDevice.objects.filter(
+            device_id=device_id,
+            status="active",
+            contract__status="active",
+            contract__group_id=uploading_group_id,
+        )
+        .select_related("contract__client")
+        .order_by("-contract__start_date")
+    )
+
+    count = qs.count()
+    if count == 0:
+        return None, [
+            {
+                "code": "NO_ACTIVE_CONTRACT",
+                "field": "tag_number",
+                "message": "No active contract found for this device and group.",
+            }
+        ], []
+
+    warnings: list[dict] = []
+    if count > 1:
+        warnings.append(
+            {
+                "code": "MULTIPLE_ACTIVE_CONTRACTS",
+                "field": "tag_number",
+                "message": f"{count} active contracts found for this device; using the most recent.",
+            }
+        )
+
+    return qs.first(), [], warnings
+
+
+def resolve_checklist(
+    checklist_name: str,
+    jurisdiction_id: int,
+    group_id: Optional[int] = None,
+    display_name: Optional[str] = None,
+) -> tuple[Optional[Checklist], list[dict]]:
+    """
+    Find the Checklist record for the given canonical name and jurisdiction.
+
+    checklist_name is the DB lookup name (matched via ChecklistType.name iexact,
+    e.g. "Cat1", "Retest", "Placard").  display_name, if provided, is used in
+    error messages instead of checklist_name so the user sees human-readable
+    labels (e.g. "Annual" rather than "Cat1").
+
+    Resolution order:
+      1. group-scoped + jurisdiction  (specific override)
+      2. jurisdiction-only            (shared checklist)
+    """
+    # Filter by ChecklistType.name rather than Checklist.name.
+    # Checklist display names vary ("Cat1 ELV3 Checklist", "Mobile Check List 1",
+    # etc.) while ChecklistType.name is the stable semantic identifier used
+    # throughout the scheduling system (e.g. "CAT1", "CAT5", "Periodic").
+    # iexact handles the casing difference ("Cat1" vs "CAT1").
+    #
+    # Phase 2: lookup goes through the M2M `jurisdictions` rather than the
+    # legacy `jurisdiction_id` FK. The Phase 1 backfill mirrored every
+    # non-null FK into the through table, so this filter returns the same
+    # set as before for legacy data — plus any new multi-jurisdiction
+    # mappings going forward. `.distinct()` guards against duplicate rows
+    # when a checklist maps to multiple matching jurisdictions.
+    base_qs = Checklist.objects.filter(
+        type__name__iexact=checklist_name,
+        jurisdictions__id=jurisdiction_id,
+        status="active",
+    ).distinct()
+
+    # Prefer group-specific checklist if one exists
+    if group_id:
+        group_qs = base_qs.filter(group_id=group_id)
+        if group_qs.exists():
+            return group_qs.first(), []
+
+    # Fall back to shared / jurisdiction-level
+    shared_qs = base_qs.filter(group__isnull=True)
+    if shared_qs.exists():
+        return shared_qs.first(), []
+
+    # Last resort: any active checklist for the jurisdiction
+    if base_qs.exists():
+        return base_qs.first(), []
+
+    label = display_name or checklist_name
+    return None, [
+        {
+            "code": "CHECKLIST_NOT_FOUND",
+            "field": "test type",
+            "message": (
+                f"No active checklist found for inspection type '{label}' "
+                f"in jurisdiction id={jurisdiction_id}. "
+                "Ensure a checklist with the matching ChecklistType is configured "
+                "for this jurisdiction."
+            ),
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Row grouping
+# ---------------------------------------------------------------------------
+
+def group_rows(resolved_rows: list[dict]) -> dict[InspectionGroupKey, list[dict]]:
+    """
+    Group valid resolved rows by (start_date_iso, inspector_id, building_id).
+    Rows missing any of the three keys are silently excluded (they should
+    already be marked 'error' by the time this is called).
+    """
+    groups: dict[InspectionGroupKey, list[dict]] = defaultdict(list)
+    for row in resolved_rows:
+        r = row["resolved"]
+        start_date = r.get("start_date_iso")
+        inspector_id = r.get("inspector_id")
+        building_id = r.get("building_id")
+        if start_date and inspector_id and building_id:
+            key = InspectionGroupKey(
+                start_date_iso=start_date,
+                inspector_id=inspector_id,
+                building_id=building_id,
+            )
+            groups[key].append(row)
+    return dict(groups)
+
+
+# ---------------------------------------------------------------------------
+# MongoDB document builders
+# ---------------------------------------------------------------------------
+
+def build_inspection_group_data(
+    group_key: InspectionGroupKey,
+    rows: list[dict],
+    uploading_group_id: int,
+    jurisdiction: Optional[Jurisdiction],
+) -> dict:
+    """
+    Build the inspection_groups MongoDB document dict from a group of resolved rows.
+    All rows in the group share the same date, inspector, and building.
+    """
+    first = rows[0]["resolved"]
+    start_dt = first["_start_dt"]
+    end_dt = first["_end_dt"]
+    start_time_str = first.get("start_time_str", "")
+
+    return {
+        "groupId": int(uploading_group_id),
+        "clientId": int(first.get("client_id") or 0),
+        "clientName": first.get("client_name", ""),
+        "buildingId": int(group_key.building_id),
+        "buildingName": first.get("building_name", ""),
+        "buildingAddress": first.get("building_address", ""),
+        "jurisdictionId": jurisdiction.id if jurisdiction else None,
+        "jurisdictionName": jurisdiction.name if jurisdiction else "",
+        "startDate": start_dt,
+        "endDate": end_dt,
+        "inspectorId": int(group_key.inspector_id),
+        "performingInspectorId": int(group_key.inspector_id),
+        "witnessingInspectorId": 0,
+        "jobNumber": None,
+        "witnessingCompanyId": None,
+        "elevator_company_id": None,
+        "startTime": start_time_str,
+        "endTime": "",
+    }
+
+
+def build_device_inspections(rows: list[dict]) -> list[dict]:
+    """
+    Convert resolved row dicts into the device_inspections format expected by
+    ScheduleViewset._persist_inspection_group().
+
+    Each item maps to one inspection document in MongoDB.
+    """
+    device_inspections = []
+    for row in rows:
+        r = row["resolved"]
+        device_inspections.append(
+            {
+                "device_id": r.get("device_id"),
+                "name": r.get("device_name", "Unknown Device"),
+                "contract_id": r.get("contract_id"),
+                "contract_number": r.get("contract_number", ""),
+                "contract_type": r.get("contract_type", ""),
+                "fsot_date": None,
+                "checklist": [
+                    {
+                        "id": r.get("checklist_id"),
+                        "type": r.get("checklist_type_int"),
+                    }
+                ],
+            }
+        )
+    return device_inspections
+
+
+# ---------------------------------------------------------------------------
+# Inspector creation (no Cognito)
+# ---------------------------------------------------------------------------
+
+def create_inspector_without_cognito(
+    name: str,
+    email: Optional[str],
+    group: Group,
+) -> User:
+    """
+    Create a User record for an imported inspector and link them to the group.
+
+    No Cognito provisioning.  email is stored when provided but is not
+    required (User.email is nullable in this project).
+    Raises IntegrityError if a duplicate username/email cannot be resolved.
+    """
+    fn, ln = split_full_name(name)
+    base_username = email.lower() if email else f"import.{fn.lower()}.{ln.lower()}".strip(".")
+
+    username = base_username
+    counter = 1
+    while User.objects.filter(username=username).exists():
+        username = f"{base_username}.{counter}"
+        counter += 1
+
+    with transaction.atomic():
+        new_user = User.objects.create(
+            username=username,
+            email=email if email else None,
+            first_name=fn,
+            last_name=ln or "",
+            status="active",
+        )
+
+    ensure_user_group_and_roles(user=new_user, group=group, role_ids=[4])
+    return new_user

--- a/internal/custom/python/testdata/issue4357/test_orders_pytest.py.txt
+++ b/internal/custom/python/testdata/issue4357/test_orders_pytest.py.txt
@@ -1,0 +1,44 @@
+"""Pytest function + class style tests for the order service.
+
+Representative pure-pytest file: module-level test_ functions, a fixture, a
+parametrized case, and a pytest-style Test class with test methods. Exercises
+the test→SUT-symbol axis (test_place_order → place_order, reference-gated on the
+import below).
+"""
+import pytest
+
+from app.services.orders import place_order, cancel_order, OrderService
+
+
+@pytest.fixture
+def sample_items():
+    return [{"price": 10.0}, {"price": 5.0}]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def db():
+    yield "conn"
+
+
+def test_place_order(sample_items):
+    order = place_order(1, sample_items)
+    assert order.total == 15.0
+    assert order.id == 1
+
+
+@pytest.mark.parametrize("items,expected", [([], 0.0), ([{"price": 2.0}], 2.0)])
+def test_place_order_totals(items, expected):
+    order = place_order(7, items)
+    assert order.total == expected
+
+
+def test_cancel_order():
+    order = place_order(2, [])
+    assert cancel_order(order) is True
+
+
+class TestOrderServiceComputes:
+    def test_total(self):
+        svc = OrderService(repo=None)
+        order = place_order(3, [{"price": 1.0}])
+        assert svc.total(order) == 1.0

--- a/internal/custom/python/testdata/issue4357/test_schedule_import.py.txt
+++ b/internal/custom/python/testdata/issue4357/test_schedule_import.py.txt
@@ -1,0 +1,1207 @@
+"""
+Tests for the MASS Scheduled Inspection CSV Import feature.
+
+Covers:
+  1. Missing required columns
+  2. Non-MASS group rejection
+  3. Dry run with unknown inspectors
+  4. Finalize with new inspector creation
+  5. Device resolution by Device.name
+  6. Contract/client derivation
+  7. Duplicate row skipped (warning, not error)
+  8. Grouping rows into a single inspection group
+  9. Partial success when some rows fail and others succeed
+"""
+import io
+import json
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytz
+from django.test import TestCase
+from rest_framework.test import APIClient, APITestCase
+
+from core.helper.schedule_import_helper import (
+    InspectionGroupKey,
+    group_rows,
+    map_test_type_to_checklist_name,
+    normalize_row,
+    parse_csv_file,
+    resolve_checklist,
+    resolve_contract,
+    resolve_device,
+    strip_test_type_tag_suffix,
+)
+from core.models import (
+    Building,
+    Checklist,
+    Client,
+    Contract,
+    ContractDevice,
+    Device,
+    Group,
+    GroupJurisdiction,
+    Jurisdiction,
+    Role,
+    User,
+    UserGroup,
+    UserGroupRole,
+)
+
+UTC = pytz.utc
+
+# ---------------------------------------------------------------------------
+# Fixtures helpers
+# ---------------------------------------------------------------------------
+
+def make_jurisdiction(name="Massachusetts"):
+    return Jurisdiction.objects.create(
+        name=name,
+        description="Test jurisdiction",
+        is_public=False,
+    )
+
+
+def make_group(name="Test Elevator Co", jurisdiction=None):
+    group = Group.objects.create(name=name, type="1")
+    if jurisdiction:
+        GroupJurisdiction.objects.create(group=group, jurisdiction=jurisdiction)
+    return group
+
+
+def make_building(jurisdiction=None, physical_address="123 Main St"):
+    return Building.objects.create(
+        physical_address=physical_address,
+        jurisdiction=jurisdiction,
+    )
+
+
+def make_client(group):
+    return Client.objects.create(name="Test Client", group=group)
+
+
+def make_contract(group, client, building, status="active"):
+    return Contract.objects.create(
+        group=group,
+        client=client,
+        building=building,
+        status=status,
+        contract_number="CTR-001",
+        contract_type="Cat1",
+    )
+
+
+def make_device(building, name="ELV-100"):
+    return Device.objects.create(building=building, name=name)
+
+
+def make_contract_device(contract, device, status="active"):
+    return ContractDevice.objects.create(contract=contract, device=device, status=status)
+
+
+def make_inspector(group, first_name="Jane", last_name="Smith"):
+    inspector_role, _ = Role.objects.get_or_create(name="Inspector", defaults={"description": "Inspector"})
+    user = User.objects.create(
+        username=f"{first_name.lower()}.{last_name.lower()}@test.com",
+        email=f"{first_name.lower()}.{last_name.lower()}@test.com",
+        first_name=first_name,
+        last_name=last_name,
+        status="active",
+    )
+    UserGroup.objects.create(user=user, group=group)
+    UserGroupRole.objects.create(user=user, group=group, role=inspector_role)
+    return user
+
+
+def make_checklist(name="Cat1", jurisdiction=None, group=None):
+    from core.models import ChecklistType
+    ctype, _ = ChecklistType.objects.get_or_create(name=name, defaults={"description": name})
+    return Checklist.objects.create(
+        name=name,
+        description=name,
+        type=ctype,
+        jurisdiction=jurisdiction,
+        group=group,
+        status="active",
+        active=True,
+    )
+
+
+def make_csv(*rows, headers=None):
+    """Build CSV bytes from a list of row dicts."""
+    if headers is None and rows:
+        headers = list(rows[0].keys())
+    buf = io.StringIO()
+    import csv as _csv
+    writer = _csv.DictWriter(buf, fieldnames=headers)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buf.getvalue().encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing required columns
+# ---------------------------------------------------------------------------
+
+class ParseCsvFileMissingColumnsTest(TestCase):
+
+    def test_missing_test_type_column(self):
+        csv_bytes = make_csv(
+            {"Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith", "Tag# / Device ID": "ELV-100"},
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(rows, [])
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "MISSING_COLUMNS")
+        self.assertIn("test type", errors[0]["context"]["missing"])
+
+    def test_missing_device_column(self):
+        csv_bytes = make_csv(
+            {"Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith", "Test Type": "Cat1"},
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(rows, [])
+        self.assertIn("tag# / device id", errors[0]["context"]["missing"])
+
+    def test_empty_file(self):
+        rows, errors = parse_csv_file(b"")
+        self.assertEqual(rows, [])
+        self.assertEqual(errors[0]["code"], "EMPTY_FILE")
+
+    def test_valid_headers_returns_rows(self):
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026",
+                "Time": "09:00",
+                "Inspector": "Jane Smith",
+                "Tag# / Device ID": "ELV-100",
+                "Test Type": "Cat1",
+            }
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(rows), 1)
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-MASS group rejection
+# ---------------------------------------------------------------------------
+
+class NonMassGroupRejectionTest(APITestCase):
+
+    def setUp(self):
+        # Group with NO jurisdiction
+        self.non_mass_group = Group.objects.create(name="NYC Group", type="1")
+        self.user = User.objects.create(
+            username="admin@test.com", email="admin@test.com", status="active",
+            is_staff=True,
+        )
+        UserGroup.objects.create(user=self.user, group=self.non_mass_group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_non_mass_group_returns_403(self):
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith",
+                "Tag# / Device ID": "ELV-100", "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.non_mass_group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["code"], "NOT_MASS_JURISDICTION")
+
+
+# ---------------------------------------------------------------------------
+# 3. Dry run — unknown inspectors
+# ---------------------------------------------------------------------------
+
+class DryRunUnknownInspectorTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building)
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+
+        self.user = User.objects.create(
+            username="admin2@test.com", email="admin2@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_dry_run_returns_unknown_inspector(self, mock_get_col):
+        mock_col = MagicMock()
+        mock_col.aggregate.return_value = []
+        mock_get_col.return_value = mock_col
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "Unknown Person",
+                "Tag# / Device ID": self.device.name,
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "preview")
+        self.assertIn("Unknown Person", response.data["unknown_inspectors"])
+        row = response.data["row_results"][0]
+        self.assertEqual(row["status"], "pending_inspector")
+
+
+# ---------------------------------------------------------------------------
+# 4. Finalize — new inspector creation
+# ---------------------------------------------------------------------------
+
+class FinalizeNewInspectorTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-200")
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+
+        self.user = User.objects.create(
+            username="admin3@test.com", email="admin3@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_finalize_creates_inspector_and_returns_201(self, mock_get_col):
+        mock_ig_col = MagicMock()
+        mock_ig_col.insert_one.return_value = MagicMock(inserted_id="fake_ig_id")
+        mock_ig_col.aggregate.return_value = []
+
+        mock_i_col = MagicMock()
+        mock_i_col.bulk_write.return_value = MagicMock()
+
+        def get_col_side_effect(name):
+            if name == "inspection_groups":
+                return mock_ig_col
+            return mock_i_col
+
+        mock_get_col.side_effect = get_col_side_effect
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "New Inspector",
+                "Tag# / Device ID": "ELV-200",
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "false",
+                "inspector_emails": json.dumps({"New Inspector": "newinspector@test.com"}),
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data["created_inspectors"]), 1)
+        self.assertEqual(response.data["created_inspectors"][0]["email"], "newinspector@test.com")
+        self.assertEqual(response.data["imported_count"], 1)
+
+        # Verify user was created in the DB
+        new_user = User.objects.get(email="newinspector@test.com")
+        self.assertEqual(new_user.first_name, "New")
+        self.assertEqual(new_user.last_name, "Inspector")
+        # Verify role linkage
+        self.assertTrue(
+            UserGroupRole.objects.filter(user=new_user, group=self.group, role__name="Inspector").exists()
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Device resolution by Device.name
+# ---------------------------------------------------------------------------
+
+class ResolveDeviceTest(TestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-300")
+        make_contract_device(self.contract, self.device)
+
+    def test_matches_by_name_exact(self):
+        device, errors = resolve_device("ELV-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.name, "ELV-300")
+        self.assertEqual(errors, [])
+
+    def test_matches_case_insensitive(self):
+        device, errors = resolve_device("elv-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_not_found_returns_error(self):
+        device, errors = resolve_device("NONEXISTENT", self.group.id)
+        self.assertIsNone(device)
+        self.assertEqual(errors[0]["code"], "DEVICE_NOT_FOUND")
+
+    def test_wrong_group_still_finds_device_by_name(self):
+        # resolve_device no longer filters by group in the primary query.
+        # The device is found; group/contract validation is left to resolve_contract().
+        other_group = make_group("Other Group")
+        device, errors = resolve_device("ELV-300", other_group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_inactive_contract_device_still_found_by_name(self):
+        # Contract status does not block the primary device lookup.
+        # resolve_contract() will return NO_ACTIVE_CONTRACT for the caller to handle.
+        self.device.device_contracts.update(status="inactive")
+        device, errors = resolve_device("ELV-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 6. Contract / client derivation
+# ---------------------------------------------------------------------------
+
+class ResolveContractTest(TestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-400")
+        self.cd = make_contract_device(self.contract, self.device)
+
+    def test_returns_contract_device_with_client(self):
+        cd, errors, warnings = resolve_contract(self.device.id, self.group.id)
+        self.assertIsNotNone(cd)
+        self.assertEqual(errors, [])
+        self.assertEqual(cd.contract.client.name, "Test Client")
+
+    def test_inactive_contract_returns_error(self):
+        self.contract.status = "inactive"
+        self.contract.save()
+        cd, errors, warnings = resolve_contract(self.device.id, self.group.id)
+        self.assertIsNone(cd)
+        self.assertEqual(errors[0]["code"], "NO_ACTIVE_CONTRACT")
+
+    def test_wrong_group_returns_error(self):
+        other_group = make_group("Other Group 2")
+        cd, errors, warnings = resolve_contract(self.device.id, other_group.id)
+        self.assertIsNone(cd)
+        self.assertEqual(errors[0]["code"], "NO_ACTIVE_CONTRACT")
+
+
+# ---------------------------------------------------------------------------
+# 7. Duplicate row — skipped with warning, not error
+# ---------------------------------------------------------------------------
+
+class DuplicateRowSkippedTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-500")
+        make_contract_device(self.contract, self.device)
+        self.checklist = make_checklist("Cat1", jurisdiction=self.jurisdiction)
+        self.inspector = make_inspector(self.group)
+
+        self.user = User.objects.create(
+            username="admin4@test.com", email="admin4@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.validate_existing_inspection")
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_duplicate_row_is_skipped_not_errored(self, mock_get_col, mock_validate):
+        mock_col = MagicMock()
+        mock_col.aggregate.return_value = []
+        mock_get_col.return_value = mock_col
+
+        # Simulate duplicate detected
+        mock_validate.return_value = (False, "An inspection of this type already exists within the specified range.")
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": f"{self.inspector.first_name} {self.inspector.last_name}",
+                "Tag# / Device ID": "ELV-500",
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 200)
+        row = response.data["row_results"][0]
+        self.assertEqual(row["status"], "skipped")
+        warning_codes = [w["code"] for w in row["warnings"]]
+        self.assertIn("DUPLICATE_INSPECTION_SKIPPED", warning_codes)
+
+
+# ---------------------------------------------------------------------------
+# 8. Row grouping — same date + inspector + building → one group
+# ---------------------------------------------------------------------------
+
+class GroupRowsTest(TestCase):
+
+    def _make_resolved_row(self, row_index, start_date_iso, inspector_id, building_id):
+        return {
+            "row_index": row_index,
+            "raw_inspector": "Jane Smith",
+            "raw_tag_number": f"ELV-{row_index}",
+            "raw_address": "",
+            "raw_company": "",
+            "resolved": {
+                "device_id": row_index,
+                "device_name": f"ELV-{row_index}",
+                "building_id": building_id,
+                "building_name": "Test Building",
+                "building_address": "123 Main St",
+                "contract_id": 1,
+                "contract_number": "CTR-001",
+                "contract_type": "Cat1",
+                "client_id": 1,
+                "client_name": "Test Client",
+                "jurisdiction_id": 1,
+                "inspector_id": inspector_id,
+                "inspector_name": "Jane Smith",
+                "checklist_id": 1,
+                "checklist_type_int": 1,
+                "checklist_name": "Cat1",
+                "start_date_iso": start_date_iso,
+                "start_time_str": "09:00:00",
+                "_start_dt": datetime(2026, 5, 1, 9, 0, 0, tzinfo=UTC),
+                "_end_dt": datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+            },
+            "errors": [],
+            "warnings": [],
+            "status": "valid",
+        }
+
+    def test_two_devices_same_date_inspector_building_are_one_group(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=10, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 1)
+        key = list(grouped.keys())[0]
+        self.assertEqual(len(grouped[key]), 2)
+
+    def test_different_buildings_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=10, building_id=6),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+    def test_different_dates_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-02", inspector_id=10, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+    def test_different_inspectors_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=11, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+
+# ---------------------------------------------------------------------------
+# 9. Partial success — some rows fail, others succeed
+# ---------------------------------------------------------------------------
+
+class PartialSuccessTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-600")
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+        self.inspector = make_inspector(self.group, first_name="John", last_name="Doe")
+
+        self.user = User.objects.create(
+            username="admin5@test.com", email="admin5@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.validate_existing_inspection")
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_one_valid_one_bad_device_returns_partial(self, mock_get_col, mock_validate):
+        mock_ig_col = MagicMock()
+        mock_ig_col.insert_one.return_value = MagicMock(inserted_id="fake_id")
+        mock_ig_col.aggregate.return_value = []
+        mock_i_col = MagicMock()
+        mock_i_col.bulk_write.return_value = MagicMock()
+
+        def get_col_side_effect(name):
+            if name == "inspection_groups":
+                return mock_ig_col
+            return mock_i_col
+
+        mock_get_col.side_effect = get_col_side_effect
+        mock_validate.return_value = (True, "Inspection can be scheduled.")
+
+        csv_bytes = make_csv(
+            # Row 1: valid
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "John Doe",
+                "Tag# / Device ID": "ELV-600",
+                "Test Type": "Cat1",
+            },
+            # Row 2: bad device
+            {
+                "Date": "05/01/2026", "Time": "10:00",
+                "Inspector": "John Doe",
+                "Tag# / Device ID": "NONEXISTENT",
+                "Test Type": "Cat1",
+            },
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "false",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["status"], "partial")
+        self.assertEqual(response.data["imported_count"], 1)
+        self.assertEqual(response.data["skipped_count"], 1)
+        skipped_reasons = [r["reason"] for r in response.data["skipped_rows"]]
+        self.assertIn("DEVICE_NOT_FOUND", skipped_reasons)
+
+
+# ---------------------------------------------------------------------------
+# 10. Production CSV format — headers with leading spaces, Elevator Company
+# ---------------------------------------------------------------------------
+
+class MassProductionCsvHeadersTest(TestCase):
+    """
+    Verify that headers with leading spaces (as produced by the MASS CSV
+    export) parse correctly after _norm() whitespace trimming.
+    """
+
+    def test_leading_space_headers_are_accepted(self):
+        # Headers exactly as received in production (spaces before most cols)
+        csv_bytes = (
+            b"Date, Time, Inspector, Tag #, Address, Test Type, Elevator Company\r\n"
+            b"1/5/2026,8:00,Ronald Travers,282-P-12,18 DANA HILL ROAD,Annual Inspection - 282-P-12,Otis Elevator Company-RI\r\n"
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(errors, [], msg=f"Unexpected top-level errors: {errors}")
+        self.assertEqual(len(rows), 1)
+        # Normalized keys must be present
+        row = rows[0]
+        self.assertIn("tag #", row)
+        self.assertIn("test type", row)
+        self.assertIn("elevator company", row)
+
+    def test_elevator_company_maps_to_raw_company(self):
+        """normalize_row() must populate raw_company from 'elevator company'."""
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "18 DANA HILL ROAD, STERLING",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "Otis Elevator Company-RI",
+        }
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["raw_company"], "Otis Elevator Company-RI")
+
+    def test_blank_elevator_company_does_not_crash(self):
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "",
+        }
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["raw_company"], "")
+        # No error from blank optional fields
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("MISSING_INSPECTOR", error_codes)
+
+
+# ---------------------------------------------------------------------------
+# 11. Test-type keyword mapping
+# ---------------------------------------------------------------------------
+
+class MapTestTypeTest(TestCase):
+    """Unit tests for map_test_type_to_checklist_name()."""
+
+    # --- "Annual Inspection" variants → Cat1 ---
+
+    def test_annual_inspection_plain(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Inspection")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_annual_inspection_with_tag_suffix(self):
+        # Production value: "Annual Inspection - 282-P-12"
+        name, unsupported = map_test_type_to_checklist_name("Annual Inspection - 282-P-12")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_annual_inspection_case_insensitive(self):
+        name, unsupported = map_test_type_to_checklist_name("ANNUAL INSPECTION - ELV")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    # --- "Annual Weight Test" variants → Cat5 ---
+
+    def test_annual_weight_test_plain(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Weight Test")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_annual_weight_test_with_tag_suffix(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Weight Test - 282-P-12")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_annual_weight_test_not_swallowed_by_annual_inspection(self):
+        # "annual weight test" contains "annual" but must NOT resolve to Cat1.
+        name, _ = map_test_type_to_checklist_name("Annual Weight Test")
+        self.assertEqual(name, "Cat5", msg="'annual weight test' must map to Cat5, not Cat1")
+
+    # --- "90 Day Annual" → unsupported (skip, not error) ---
+
+    def test_90_day_annual_is_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("90 Day Annual")
+        self.assertIsNone(name)
+        self.assertTrue(unsupported)
+
+    def test_90_day_annual_with_suffix_is_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("90 Day Annual - 282-P-12")
+        self.assertIsNone(name)
+        self.assertTrue(unsupported)
+
+    # --- Existing short-form values still resolve (backward compat) ---
+
+    def test_exact_cat1_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("Cat1")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_exact_five_year_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("5 year")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_periodic_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("Periodic")
+        self.assertEqual(name, "Periodic")
+        self.assertFalse(unsupported)
+
+    # --- Completely unknown → error signal ---
+
+    def test_unknown_returns_none_not_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("Biennial Safety Check")
+        self.assertIsNone(name)
+        self.assertFalse(unsupported)
+
+
+# ---------------------------------------------------------------------------
+# 12. normalize_row — production CSV values end-to-end
+# ---------------------------------------------------------------------------
+
+class NormalizeRowProductionValuesTest(TestCase):
+    """
+    normalize_row() behaviour with the exact field values from the
+    production MASS CSV (already normalized to lowercase keys by
+    parse_csv_file → _norm()).
+    """
+
+    def _base_row(self, **overrides):
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "18 DANA HILL ROAD, STERLING",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "Otis Elevator Company-RI",
+        }
+        row.update(overrides)
+        return row
+
+    def test_annual_inspection_resolves_to_cat1(self):
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_annual_weight_test_resolves_to_cat5(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "Annual Weight Test - 282-P-12"}),
+            row_index=1,
+        )
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_90_day_annual_is_skipped_not_errored(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "90 Day Annual - 282-P-12"}),
+            row_index=1,
+        )
+        self.assertEqual(result["status"], "skipped")
+        warning_codes = [w["code"] for w in result["warnings"]]
+        self.assertIn("UNSUPPORTED_TEST_TYPE", warning_codes)
+        # Must NOT be in errors — other rows should not be blocked
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("UNKNOWN_TEST_TYPE", error_codes)
+
+    def test_unknown_test_type_is_error(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "Completely Unknown Type XYZ"}),
+            row_index=1,
+        )
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("UNKNOWN_TEST_TYPE", error_codes)
+
+    def test_missing_inspector_is_error(self):
+        result = normalize_row(self._base_row(inspector=""), row_index=1)
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("MISSING_INSPECTOR", error_codes)
+
+    def test_missing_tag_number_is_error(self):
+        row = self._base_row()
+        row["tag #"] = ""
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("MISSING_TAG_NUMBER", error_codes)
+
+    def test_blank_address_and_company_do_not_error(self):
+        result = normalize_row(
+            self._base_row(address="", **{"elevator company": ""}),
+            row_index=1,
+        )
+        self.assertEqual(result["raw_address"], "")
+        self.assertEqual(result["raw_company"], "")
+        # Should still be valid (optional fields)
+        self.assertEqual(result["status"], "valid")
+
+    def test_date_parses_m_d_yyyy(self):
+        """1/5/2026 (no zero-padding) must parse correctly."""
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["start_date_iso"], "2026-01-05")
+
+    def test_time_parses_h_mm(self):
+        """8:00 (no zero-padding on hour) must parse correctly."""
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["start_time_str"], "08:00:00")
+
+
+# ---------------------------------------------------------------------------
+# 13. resolve_device — new name-first lookup behaviour
+# ---------------------------------------------------------------------------
+
+class ResolveDeviceNameFirstTest(TestCase):
+    """
+    Verify that resolve_device finds devices by name without requiring an
+    active contract, and uses the contract / address only for disambiguation
+    when multiple devices share the same name.
+    """
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="18 DANA HILL ROAD, STERLING",
+        )
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="282-P-12")
+        make_contract_device(self.contract, self.device)
+
+    def test_finds_device_by_name_with_active_contract(self):
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.name, "282-P-12")
+        self.assertEqual(errors, [])
+
+    def test_finds_device_even_when_contract_device_inactive(self):
+        """Contract status must not block the primary name lookup."""
+        self.device.device_contracts.update(status="inactive")
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_finds_device_for_wrong_group(self):
+        """Device IS returned; the group mismatch surfaces via resolve_contract."""
+        other_group = make_group("Other Group MASS")
+        device, errors = resolve_device("282-P-12", other_group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_not_found_returns_device_not_found(self):
+        device, errors = resolve_device("NONEXISTENT-TAG", self.group.id)
+        self.assertIsNone(device)
+        self.assertEqual(errors[0]["code"], "DEVICE_NOT_FOUND")
+
+    def test_whitespace_in_tag_is_trimmed(self):
+        device, errors = resolve_device("  282-P-12  ", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_case_insensitive_match(self):
+        device, errors = resolve_device("282-p-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_ambiguous_disambiguated_by_group_contract(self):
+        """
+        Two devices share the same name; the one linked to the uploading group's
+        active contract should be returned.
+        """
+        other_building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="99 OTHER STREET, BOSTON",
+        )
+        other_group = make_group("Other Group MASS 2")
+        other_client = make_client(other_group)
+        other_contract = make_contract(other_group, other_client, other_building)
+        other_device = make_device(other_building, name="282-P-12")
+        make_contract_device(other_contract, other_device)
+
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.id, self.device.id)
+        self.assertEqual(errors, [])
+
+    def test_ambiguous_disambiguated_by_address(self):
+        """
+        Two devices share the same name AND same group — address breaks the tie.
+        """
+        other_building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="99 OTHER STREET, BOSTON",
+        )
+        other_client = make_client(self.group)
+        other_contract = make_contract(self.group, other_client, other_building)
+        other_device = make_device(other_building, name="282-P-12")
+        make_contract_device(other_contract, other_device)
+
+        device, errors = resolve_device(
+            "282-P-12", self.group.id,
+            raw_address="18 DANA HILL ROAD, STERLING",
+        )
+        self.assertIsNotNone(device)
+        self.assertEqual(device.id, self.device.id)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 14. resolve_checklist — type__name__iexact lookup
+# ---------------------------------------------------------------------------
+
+class ResolveChecklistByTypeTest(TestCase):
+    """
+    Verify that resolve_checklist finds checklists by their ChecklistType.name
+    (e.g. 'CAT1', 'CAT5') rather than by the Checklist display name.
+    This handles production DBs where checklists are named arbitrarily but
+    their type is always the stable semantic identifier.
+    """
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+
+    def _make_checklist_with_type(self, type_name, checklist_name, jurisdiction=None):
+        from core.models import ChecklistType
+        ctype, _ = ChecklistType.objects.get_or_create(
+            name=type_name, defaults={"description": type_name}
+        )
+        return Checklist.objects.create(
+            name=checklist_name,
+            description=checklist_name,
+            type=ctype,
+            jurisdiction=jurisdiction or self.jurisdiction,
+            status="active",
+            active=True,
+        )
+
+    def test_finds_checklist_when_type_name_is_uppercase_cat1(self):
+        """ChecklistType.name='CAT1' must match canonical name 'Cat1' via iexact."""
+        self._make_checklist_with_type("CAT1", "Annual Inspection Checklist")
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_finds_checklist_when_type_name_is_uppercase_cat5(self):
+        self._make_checklist_with_type("CAT5", "Weight Test Checklist")
+        checklist, errors = resolve_checklist("Cat5", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_finds_checklist_with_custom_display_name(self):
+        """Display name 'Cat1 ELV3 Checklist' should still resolve for type Cat1."""
+        self._make_checklist_with_type("CAT1", "Cat1 ELV3 Checklist")
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_returns_error_when_no_checklist_for_jurisdiction(self):
+        """Correct error code when no checklist is configured for this jurisdiction."""
+        other_jurisdiction = make_jurisdiction("New York")
+        self._make_checklist_with_type("CAT1", "Cat1", jurisdiction=other_jurisdiction)
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNone(checklist)
+        self.assertEqual(errors[0]["code"], "CHECKLIST_NOT_FOUND")
+
+    def test_annual_inspection_maps_to_cat1_checklist(self):
+        """
+        End-to-end: 'Annual Inspection - tag' → canonical 'Cat1' →
+        resolve_checklist finds checklist by ChecklistType.name='CAT1'.
+        """
+        self._make_checklist_with_type("CAT1", "Mass Annual Inspection")
+        # normalize_row maps "Annual Inspection - ..." to "Cat1"
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "Annual Inspection - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_annual_weight_test_maps_to_cat5_checklist(self):
+        self._make_checklist_with_type("CAT5", "Mass Weight Test")
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "Annual Weight Test - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+
+        checklist, errors = resolve_checklist("Cat5", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 15. 90-day annual rows are skipped before resolution (no DB side effects)
+# ---------------------------------------------------------------------------
+
+class NinetyDayAnnualSkippedBeforeResolutionTest(TestCase):
+    """
+    Rows with unsupported test type ('90 Day Annual') must be marked 'skipped'
+    by normalize_row() and must NOT reach device/checklist resolution.
+    The view-level guard (status in ('error', 'skipped')) prevents spurious
+    DEVICE_NOT_FOUND / CHECKLIST_NOT_FOUND errors on these rows.
+    """
+
+    def test_normalize_row_marks_90_day_as_skipped(self):
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "90 Day Annual - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["status"], "skipped")
+        warning_codes = [w["code"] for w in result["warnings"]]
+        self.assertIn("UNSUPPORTED_TEST_TYPE", warning_codes)
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("UNKNOWN_TEST_TYPE", error_codes)
+        self.assertNotIn("DEVICE_NOT_FOUND", error_codes)
+        self.assertNotIn("CHECKLIST_NOT_FOUND", error_codes)
+
+
+# ---------------------------------------------------------------------------
+# 16. strip_test_type_tag_suffix — unit tests
+# ---------------------------------------------------------------------------
+
+class StripTestTypeSuffixTest(TestCase):
+    """
+    Unit tests for strip_test_type_tag_suffix().
+
+    The function must strip the device-tag suffix embedded in Test Type values
+    ("<type text> - <tag>") so only the semantic type text is passed to the
+    inspection-type mapper.
+    """
+
+    def test_annual_inspection_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-P-12", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_annual_weight_test_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Weight Test - 282-P-12", "282-P-12"),
+            "Annual Weight Test",
+        )
+
+    def test_90_day_annual_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("90 Day Annual - 282-P-12", "282-P-12"),
+            "90 Day Annual",
+        )
+
+    def test_no_tag_suffix_returns_original(self):
+        """Plain values like 'Cat1' or 'Periodic' pass through unchanged."""
+        self.assertEqual(strip_test_type_tag_suffix("Cat1", "282-P-12"), "Cat1")
+        self.assertEqual(strip_test_type_tag_suffix("Periodic", "ELV-999"), "Periodic")
+
+    def test_empty_tag_returns_original(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-P-12", ""),
+            "Annual Inspection - 282-P-12",
+        )
+
+    def test_case_insensitive_suffix_match(self):
+        """Tag casing difference between columns must be tolerated."""
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-p-12", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_extra_whitespace_is_trimmed(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("  Annual Inspection - 282-P-12  ", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_partial_match_not_stripped(self):
+        """Only a true suffix match strips; a mid-string occurrence is left alone."""
+        self.assertEqual(
+            strip_test_type_tag_suffix("282-P-12 Annual Inspection - OTHER", "282-P-12"),
+            "282-P-12 Annual Inspection - OTHER",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 17. normalize_row — full tag-suffix stripping end-to-end
+# ---------------------------------------------------------------------------
+
+class NormalizeRowTagSuffixStrippingTest(TestCase):
+    """
+    Verify that normalize_row() strips the device-tag suffix from the raw
+    Test Type field before performing inspection-type mapping.
+    """
+
+    def _row(self, test_type, tag="282-P-12"):
+        return {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": tag,
+            "test type": test_type,
+        }
+
+    def test_annual_inspection_suffix_resolves_to_cat1(self):
+        result = normalize_row(self._row("Annual Inspection - 282-P-12"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_annual_weight_test_suffix_resolves_to_cat5(self):
+        result = normalize_row(self._row("Annual Weight Test - 282-P-12"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_90_day_annual_suffix_is_skipped(self):
+        result = normalize_row(self._row("90 Day Annual - 282-P-12"), row_index=1)
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("UNSUPPORTED_TEST_TYPE", [w["code"] for w in result["warnings"]])
+
+    def test_plain_cat1_without_suffix_still_works(self):
+        """Backward compat: existing short-form values must still resolve."""
+        result = normalize_row(self._row("Cat1"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_plain_5_year_without_suffix_still_works(self):
+        result = normalize_row(self._row("5 year"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_unknown_cleaned_type_returns_error(self):
+        """After stripping the suffix, if the type is still unknown → UNKNOWN_TEST_TYPE."""
+        result = normalize_row(self._row("Biennial Safety Check - 282-P-12"), row_index=1)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("UNKNOWN_TEST_TYPE", [e["code"] for e in result["errors"]])
+
+    def test_different_tag_number_not_stripped(self):
+        """Suffix only stripped when it matches the Tag # column value."""
+        # Tag # is "ELV-999", test type ends with "282-P-12" — no match, no strip
+        result = normalize_row(self._row("Annual Inspection - 282-P-12", tag="ELV-999"), row_index=1)
+        # "Annual Inspection - 282-P-12" does NOT end with "ELV-999", so it
+        # passes through as-is, which still maps to Cat1 via substring match
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")


### PR DESCRIPTION
## Summary

The Python pytest/unittest custom extractor (`internal/custom/python/pytest.go`) emitted a first-class entity per `@pytest.fixture`, per `Test` class, per test method, and per top-level `test_` function — none carrying a relationship beyond the narrow Celery `.delay()` special-case. On a real Django/unittest suite those edge-less assertion/fixture/test nodes dominate the orphan ring, exactly mirroring the Jest and Go orphan rings already collapsed.

This is a root-cause fix at extraction (not a downstream repair pass), mirroring the established test-suite-collapse shape:

- **One `test_suite` per file.** Per-fixture / per-class / per-method / per-function nodes are no longer standalone entities; their counts fold into properties (`test_func_count`, `toplevel_func_count`, `test_class_count`, `test_method_count`, `fixture_count`, `assertion_count`, `parametrize_count`, `marks`). No information lost; orphan blast radius collapses from O(funcs+classes+fixtures+asserts) to one node per file.
- **TESTS edge to the SUT symbol**, resolved by **name affinity, reference-gated**: `test_place_order` → `place_order`; `ResolveDeviceTest` / `TestOrderService` → `resolve_device` / `OrderService` (CamelCase + snake_case candidates); module `test_foo.py` → `foo`. A subject is emitted only when it is BOTH derivable by name AND actually imported/referenced in the test file (parenthesized multi-line `from X import (...)` handled). ToID is the bare subject name, bound through the resolver's `byName` index to the production entity.

The suite is named `pytest_suite:<base>` so it never collides by-name with a production symbol (which would re-orphan it) and so `MergeWithCustom`'s name-keyed replace does not clobber base tree-sitter nodes. Celery TESTS edges are preserved, folded onto the suite. Reuses the existing `SCOPE.Pattern` kind + `test_suite` subtype + `TESTS` relationship — no new producer Kind.

## Live validation (in-pipeline, real fixtures)

`internal/custom/python/issue4357_livedrepro_test.go` runs the REAL merged pipeline (base + custom + `MergeWithCustom` + `resolve.BuildIndex`) on byte-copies of the real `upvate_core` Django unittest file `core/tests/test_schedule_import.py` paired with its production module `core/helper/schedule_import_helper.py`:

- **Before:** 17 test classes + 75 methods + 163 assertions + 9 fixtures, all orphan, 0 TESTS edges.
- **After:** exactly 1 `test_suite` (counts folded), 3 resolving TESTS edges (`resolve_device`, `resolve_contract`, `group_rows`) that bind through the symbol table to the production functions.

A representative pure-pytest file (function + `parametrize` + fixture + Test class) yields `test_place_order` → `place_order`.

The `cross/testmap` Python path (test_coverage body-call detection, Django test-client → ViewSet route linkage) is unchanged and complementary — this covers the test→SUT-symbol axis at extraction.

## Gates

`go build ./...`, `go vet ./internal/custom/python/`, `gofmt`, and `go test ./internal/custom/python/ ./internal/extractors/cross/testmap/ ./internal/types/ ./internal/resolve/` all green.

Closes #4357

🤖 Generated with [Claude Code](https://claude.com/claude-code)