### PR TITLE
Resolve Rust cross-module/crate CALLS via stamped path qualifier

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -4047,6 +4047,15 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	if goCrossPkgCallRewrites > 0 {
 		fmt.Fprintf(os.Stderr, "resolver: go-cross-package rewrote=%d CALLS targets\n", goCrossPkgCallRewrites)
 	}
+	// #4373 — Rust cross-module/cross-crate CALLS resolution. Binds
+	// `crate::mod::Func()` / `self::`/`super::` / aliased / `Type::method`
+	// edges stamped with rust_call_pkg_dirs + call_leaf (+ rust_call_scope)
+	// to byPackageOperation / byPackageMember. Same ordering constraints as
+	// the Go pass: after BuildIndex, before the embedded-reference resolver.
+	rustCrossModCallRewrites := idx.ResolveRustCrossModuleCalls(merged)
+	if rustCrossModCallRewrites > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: rust-cross-module rewrote=%d CALLS targets\n", rustCrossModCallRewrites)
+	}
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)
 	embStats := resolve.ReferencesEmbeddedWithAllowlist(merged, idx, allow)
 	standStats := resolve.ReferencesWithAllowlist(pass2Rels, idx, allow)

--- a/internal/extractors/rust/crosspath.go
+++ b/internal/extractors/rust/crosspath.go
@@ -1,0 +1,442 @@
+// crosspath.go — Rust cross-module / cross-crate CALLS qualifier resolution
+// (issue #4373).
+//
+// Background. Rust reaches functions in other modules through a *path*
+// qualifier on a scoped_identifier:
+//
+//	crate::services::order::place_order()   // absolute, crate root
+//	self::sibling::helper()                 // current-module relative
+//	super::parent::helper()                 // parent-module relative
+//	ord::place_order()                      // `use ... as ord;` alias
+//	OrderService::new()                     // Type::assoc_fn associated call
+//
+// The extractor (rustCallTarget) historically returned ONLY the rightmost
+// identifier (`place_order`) for a scoped_identifier, dropping the whole path
+// qualifier. A bare leaf resolves through the resolver's global byName index,
+// which goes ambiguous the moment two modules define a same-named symbol
+// (`place_order` in both services::order and services::invoice) — so the CALLS
+// edge is dropped and the callee module looks falsely uncalled. This is the
+// Rust analogue of the Go cross-package qualifier-drop fixed in #4332.
+//
+// Fix (mirrors #4332 structurally). The extractor maps the call's path
+// qualifier — through the file's `use`/`mod` declarations, the crate root, and
+// the self/super relative roots — to the *directory* the target module's file
+// lives in (the same key `pkgDirOf(sourceFile)` the resolver's
+// byPackageOperation / byPackageMember indexes are keyed on). It stamps that
+// candidate directory (or directories — the mod.rs vs file.rs layout ambiguity
+// yields two) plus the bare leaf and, for associated calls, the type scope.
+// The resolver pass ResolveRustCrossModuleCalls (internal/resolve) binds the
+// edge through those indexes. Conservative: blank / ambiguous → skip, never
+// guess.
+//
+// Stamped Properties (consumed by ResolveRustCrossModuleCalls):
+//   - rust_call_pkg_dirs : ";"-separated candidate package directories
+//   - call_leaf          : the bare callee identifier
+//   - rust_call_scope    : (associated calls only) the Type the leaf is a
+//     member of, e.g. "OrderService" for OrderService::new()
+package rust
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// rustCrossCtx is the per-file context used to translate a call-site path
+// qualifier into target package directories. Built once per file by
+// buildRustCrossCtx and threaded through extractCallRelationships.
+type rustCrossCtx struct {
+	// crateSrc is the crate's source root directory (the dir holding lib.rs /
+	// main.rs), e.g. "src" for "src/services/order.rs", or "crates/foo/src"
+	// for a workspace member. Module paths rooted at `crate::` resolve
+	// relative to this. Empty when the file is not under a recognisable src
+	// root (then crate-absolute resolution is skipped — conservative).
+	crateSrc string
+
+	// selfModDir is the directory that `self::` resolves against: the module
+	// directory of the current file. For "src/services/order.rs" the child
+	// modules live in "src/services/order/…", so selfModDir is
+	// "src/services/order". For a mod.rs / lib.rs / main.rs file the module
+	// dir is simply the file's own directory.
+	selfModDir string
+
+	// superModDir is the directory `super::` resolves against — the parent of
+	// selfModDir. Empty when selfModDir is the crate root.
+	superModDir string
+
+	// aliases maps a `use ... as NAME;` alias (or a plain `use a::b::c;`
+	// trailing name) to the FULL crate-relative path of the item it names,
+	// INCLUDING the trailing target segment. For `use crate::services::order
+	// as ord;` → "ord" → ["services","order"] (the alias names a MODULE; used
+	// as `ord::place_order()` the hosting module chain is exactly this). A
+	// leading crate/self/super root is normalised to a crate-relative segment
+	// list here so call-site resolution is uniform.
+	aliases map[string][]string
+}
+
+// buildRustCrossCtx builds the per-file cross-module resolution context from
+// the file path and its `use` declarations. root is the tree-sitter root node;
+// src the file bytes; filePath the repo-relative source path.
+func buildRustCrossCtx(root *sitter.Node, src []byte, filePath string) *rustCrossCtx {
+	ctx := &rustCrossCtx{aliases: map[string][]string{}}
+	ctx.crateSrc, ctx.selfModDir, ctx.superModDir = rustModuleDirs(filePath)
+	if ctx.crateSrc == "" {
+		// No recognisable crate src root: we can still resolve self::/super::
+		// using selfModDir, but crate-absolute and aliased crate:: paths need
+		// the root. selfModDir/superModDir are still populated below.
+	}
+	collectRustUseAliases(root, src, ctx)
+	return ctx
+}
+
+// rustModuleDirs derives the crate src root, the current file's module
+// directory (self::), and its parent (super::) from a repo-relative path.
+//
+//	src/services/order.rs       → crateSrc=src,  self=src/services/order,        super=src/services
+//	src/services/order/mod.rs   → crateSrc=src,  self=src/services/order,        super=src/services
+//	src/lib.rs / src/main.rs    → crateSrc=src,  self=src,                       super=""
+//	crates/foo/src/a/b.rs       → crateSrc=crates/foo/src, self=crates/foo/src/a/b, super=crates/foo/src/a
+func rustModuleDirs(filePath string) (crateSrc, selfDir, superDir string) {
+	if filePath == "" {
+		return "", "", ""
+	}
+	p := strings.TrimPrefix(filePath, "./")
+	dir := pathDir(p)
+	base := p
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		base = p[i+1:]
+	}
+	// Strip the ".rs" file extension to get the file's module leaf.
+	leaf := strings.TrimSuffix(base, ".rs")
+
+	// Locate the crate src root: the last path segment named "src".
+	segs := strings.Split(dir, "/")
+	srcIdx := -1
+	for i := len(segs) - 1; i >= 0; i-- {
+		if segs[i] == "src" {
+			srcIdx = i
+			break
+		}
+	}
+	if srcIdx >= 0 {
+		crateSrc = strings.Join(segs[:srcIdx+1], "/")
+	}
+
+	// The current file's module directory.
+	switch leaf {
+	case "mod", "lib", "main":
+		// These files ARE their directory's module; child modules live in dir.
+		selfDir = dir
+	default:
+		// A file `foo.rs` introduces module `foo`; its child modules live in
+		// the sibling directory `<dir>/foo`.
+		if dir == "" {
+			selfDir = leaf
+		} else {
+			selfDir = dir + "/" + leaf
+		}
+	}
+	superDir = pathDir(selfDir)
+	if superDir == "." {
+		superDir = ""
+	}
+	return crateSrc, selfDir, superDir
+}
+
+// pathDir returns the directory portion of a slash path, "" when there is no
+// separator (root-level file).
+func pathDir(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[:i]
+	}
+	return ""
+}
+
+// collectRustUseAliases walks the file's `use_declaration` nodes and records
+// alias → crate-relative-module-path-segments mappings into ctx.aliases.
+//
+// It handles:
+//   - `use crate::services::order as ord;`   → ord  → [services order]
+//   - `use crate::services::order::place_order;` (no alias) →
+//     place_order → [services order]    (path to the item's MODULE)
+//   - `use self::sibling::helper as h;`      → h    → [<selfMod…> sibling]
+//   - `use super::parent::helper;`           → helper → [<superMod…> parent]
+//
+// Grouped uses (`use a::{b, c as d}`) are intentionally NOT expanded — they
+// rarely qualify a call by alias and adding them risks mis-binding; the
+// conservative skip leaves the bare-name fallback in place.
+func collectRustUseAliases(root *sitter.Node, src []byte, ctx *rustCrossCtx) {
+	for _, u := range findAllNodes(root, "use_declaration") {
+		raw := strings.TrimSpace(string(src[u.StartByte():u.EndByte()]))
+		raw = stripRustVisibility(raw)
+		raw = strings.TrimPrefix(raw, "use ")
+		raw = strings.TrimSuffix(raw, ";")
+		raw = strings.TrimSpace(raw)
+		if raw == "" || strings.ContainsAny(raw, "{}*") {
+			continue // grouped / glob use — skip (conservative)
+		}
+
+		alias := ""
+		pathStr := raw
+		if i := strings.Index(raw, " as "); i >= 0 {
+			pathStr = strings.TrimSpace(raw[:i])
+			alias = strings.TrimSpace(raw[i+4:])
+		}
+
+		segs := splitRustPath(pathStr)
+		if len(segs) == 0 {
+			continue
+		}
+		// Normalise the path root (crate/self/super) to crate-relative module
+		// segments; the returned segments include the trailing leaf.
+		modSegs, ok := ctx.normalizeToCrateRel(segs)
+		if !ok || len(modSegs) == 0 {
+			continue
+		}
+		leaf := modSegs[len(modSegs)-1]
+		if alias == "" {
+			alias = leaf
+		}
+		// Store the FULL crate-relative chain the alias names, INCLUDING its
+		// trailing target segment. When the alias names a module
+		// (`use crate::app::order as ord;` → [app order]) and is then used as
+		// `ord::run`, the module chain hosting `run` is exactly [app order].
+		// When the alias names a function (`use crate::app::order::run as r;`
+		// → [app order run]) and is used bare as `r()` (an identifier call, not
+		// scoped) this map is simply not consulted — only scoped `alias::…`
+		// calls reach resolveCallPath's alias branch.
+		cp := make([]string, len(modSegs))
+		copy(cp, modSegs)
+		ctx.aliases[alias] = cp
+	}
+}
+
+// splitRustPath splits a `::`-separated path into trimmed segments, dropping
+// any leading `::` (absolute external) and turbofish/generic noise. Segments
+// containing characters that cannot be a module identifier abort the split.
+func splitRustPath(p string) []string {
+	p = strings.TrimPrefix(p, "::")
+	parts := strings.Split(p, "::")
+	out := make([]string, 0, len(parts))
+	for _, s := range parts {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil
+		}
+		// Strip a turbofish / generic argument list off the segment.
+		if i := strings.IndexByte(s, '<'); i >= 0 {
+			s = strings.TrimSpace(s[:i])
+		}
+		if s == "" || !isRustIdentLike(s) {
+			return nil
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// isRustIdentLike reports whether s is a plausible Rust path segment
+// (identifier characters only). Rejects anything with operators/spaces.
+func isRustIdentLike(s string) bool {
+	for _, r := range s {
+		if r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// normalizeToCrateRel turns a raw segment list whose first element may be a
+// `crate` / `self` / `super` root into a crate-relative segment list (rooted
+// at the crate src dir). Returns ok=false when the root cannot be resolved
+// (e.g. an external-crate path, or self/super without a known module dir).
+//
+// The returned segments are crate-src-relative path components — i.e. directly
+// joinable under ctx.crateSrc — INCLUDING the trailing leaf segment.
+func (ctx *rustCrossCtx) normalizeToCrateRel(segs []string) ([]string, bool) {
+	if len(segs) == 0 {
+		return nil, false
+	}
+	switch segs[0] {
+	case "crate":
+		if ctx.crateSrc == "" {
+			return nil, false
+		}
+		return segs[1:], true
+	case "self":
+		rel, ok := dirToCrateRel(ctx.crateSrc, ctx.selfModDir)
+		if !ok {
+			return nil, false
+		}
+		return append(rel, segs[1:]...), true
+	case "super":
+		rel, ok := dirToCrateRel(ctx.crateSrc, ctx.superModDir)
+		if !ok {
+			return nil, false
+		}
+		return append(rel, segs[1:]...), true
+	default:
+		// Not a recognised intra-crate root: an external crate, an alias, or a
+		// bare in-module path. We can't anchor it to the crate src here.
+		return nil, false
+	}
+}
+
+// dirToCrateRel returns the path segments of dir relative to crateSrc. ok is
+// false when dir is empty or not under crateSrc.
+func dirToCrateRel(crateSrc, dir string) ([]string, bool) {
+	if crateSrc == "" || dir == "" {
+		return nil, false
+	}
+	if dir == crateSrc {
+		return []string{}, true
+	}
+	if !strings.HasPrefix(dir, crateSrc+"/") {
+		return nil, false
+	}
+	rest := dir[len(crateSrc)+1:]
+	if rest == "" {
+		return []string{}, true
+	}
+	return strings.Split(rest, "/"), true
+}
+
+// resolveCallPath translates a call-site path's qualifier segments (everything
+// up to and including the segment before the leaf) into candidate package
+// directories — the keys the resolver's byPackageOperation / byPackageMember
+// indexes use. It returns the candidate dirs and a scope type for associated
+// `Type::method` calls (empty for free-function calls).
+//
+// segs is the FULL scoped path including the leaf, e.g.
+// ["crate","services","order","place_order"] or ["OrderService","new"] or
+// ["ord","place_order"] (alias) or ["self","sibling","helper"].
+//
+// Resolution strategy:
+//   - crate:: / self:: / super::  → anchor to crate src, the qualifier (minus
+//     leaf) names a module chain; emit both the mod.rs-layout dir and the
+//     file.rs-layout dir as candidates.
+//   - single-segment qualifier that is a known `use` alias → expand the alias
+//     to its crate-relative module chain, then append the remaining qualifier
+//     segments.
+//   - a leading PascalCase segment with exactly one qualifier segment
+//     (Type::method) → associated call: scope=Type, candidate dirs are the
+//     CURRENT module dir candidates (the type is in-file or in-module). The
+//     resolver also tries the crate-wide member index, so an unqualified
+//     Type::method still binds when the type name is unique.
+func (ctx *rustCrossCtx) resolveCallPath(segs []string) (dirs []string, scope string) {
+	if len(segs) < 2 {
+		return nil, ""
+	}
+	leaf := segs[len(segs)-1]
+	qual := segs[:len(segs)-1] // qualifier chain (modules and/or a type)
+	_ = leaf
+
+	root := qual[0]
+	switch root {
+	case "crate", "self", "super":
+		rel, ok := ctx.normalizeToCrateRel(qual)
+		if !ok {
+			return nil, ""
+		}
+		return ctx.moduleChainDirs(rel), ""
+	}
+
+	// Alias?  `ord::place_order` where `use crate::services::order as ord;`
+	// recorded ord → [services order] (the FULL chain the alias names).
+	if aliasMods, ok := ctx.aliases[root]; ok && len(aliasMods) > 0 {
+		aliasLeaf := aliasMods[len(aliasMods)-1]
+		// An aliased TYPE used as an associated call: `use crate::svc::a::
+		// OrderService; OrderService::new()`. The alias names a type (its
+		// final segment is PascalCase) and exactly one qualifier segment is
+		// the alias — so the leaf is an associated method on that type. Bind
+		// through byPackageMember[dir][Type][leaf] in the type's module dir.
+		if len(qual) == 1 && isPascalCase(aliasLeaf) {
+			modChain := aliasMods[:len(aliasMods)-1] // dirs hosting the type
+			return ctx.moduleChainDirs(modChain), aliasLeaf
+		}
+		// Aliased MODULE used as `ord::fn` (or `ord::sub::fn`): the hosting
+		// module chain is the alias's chain extended by the trailing qualifier
+		// segments after the alias root.
+		full := make([]string, 0, len(aliasMods)+len(qual)-1)
+		full = append(full, aliasMods...)
+		full = append(full, qual[1:]...)
+		return ctx.moduleChainDirs(full), ""
+	}
+
+	// Type::method associated call (single qualifier segment, PascalCase) where
+	// the type is NOT an aliased import — it is defined in the current module.
+	if len(qual) == 1 && isPascalCase(root) {
+		// Offer the current module's dir candidates; the resolver additionally
+		// falls back to the unique crate-wide member index keyed on the type
+		// name when the type lives in a sibling module.
+		return ctx.selfDirCandidates(), root
+	}
+
+	// Unrecognised qualifier — leave the bare-name fallback in place.
+	return nil, ""
+}
+
+// moduleChainDirs maps a crate-relative module chain (segments naming nested
+// modules, WITHOUT a trailing leaf) to the candidate package directories that
+// host that module's items, under both common layouts:
+//
+//	module chain [services order] under crateSrc "src" →
+//	  file-layout : src/services/order.rs   → items keyed at pkgDir "src/services"
+//	  mod-layout  : src/services/order/mod.rs → items keyed at pkgDir "src/services/order"
+//
+// An empty chain (crate root items) yields just the crate src dir.
+func (ctx *rustCrossCtx) moduleChainDirs(chain []string) []string {
+	if ctx.crateSrc == "" {
+		return nil
+	}
+	if len(chain) == 0 {
+		return []string{ctx.crateSrc}
+	}
+	full := ctx.crateSrc + "/" + strings.Join(chain, "/")
+	parent := pathDir(full)
+	// file-layout dir (parent) first — it is the more common single-file
+	// module; mod-layout dir (full) second.
+	out := []string{parent}
+	if full != parent {
+		out = append(out, full)
+	}
+	return dedupeStrings(out)
+}
+
+// selfDirCandidates returns the candidate dirs for items defined in the current
+// file's own module (used for Type::method where the type is local).
+func (ctx *rustCrossCtx) selfDirCandidates() []string {
+	out := []string{}
+	if d := pathDir(ctx.selfModDir); d != "" {
+		out = append(out, d)
+	}
+	if ctx.selfModDir != "" {
+		out = append(out, ctx.selfModDir)
+	}
+	// The file's own directory (where a `foo.rs` file's items are keyed).
+	return dedupeStrings(out)
+}
+
+// isPascalCase reports whether s starts with an uppercase ASCII letter — the
+// Rust convention distinguishing a Type from a module/function (snake_case).
+func isPascalCase(s string) bool {
+	return s != "" && s[0] >= 'A' && s[0] <= 'Z'
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+	seen := map[string]bool{}
+	out := in[:0:0]
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/extractors/rust/issue4373_crossmod_test.go
+++ b/internal/extractors/rust/issue4373_crossmod_test.go
@@ -1,0 +1,325 @@
+// issue4373_crossmod_test.go — end-to-end live-pipeline validation for #4373.
+//
+// Bug: Rust cross-module / cross-crate calls reach a function through a path
+// qualifier on a scoped_identifier (`crate::services::order::place_order()`,
+// `self::`/`super::`, an aliased `use ... as ord; ord::place_order()`, or an
+// associated `OrderService::new()`). The extractor collapsed the callee to the
+// rightmost identifier (`place_order`), dropping the whole path qualifier. The
+// bare leaf resolves through the global byName index, which goes AMBIGUOUS the
+// moment two modules define a same-named symbol — so the CALLS edge dropped and
+// the callee module looked falsely uncalled. This is the Rust analogue of the
+// Go cross-package qualifier-drop fixed in #4332.
+//
+// These tests drive the REAL extraction + resolver passes — the same sequence
+// cmd/archigraph/index.go runs (extract per file → stamp deterministic IDs →
+// BuildIndex → ResolveRustCrossModuleCalls → ReferencesEmbedded) — on a
+// faithful multi-module crate (src/lib.rs + src/services/order.rs + …) that
+// reproduces a cross-module call WITH a same-named symbol collision in two
+// modules. The collision is essential: a globally-unique name would false-pass
+// through the bare-name fallback (the exact trap #4332 documents).
+package rust_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tsrust "github.com/smacker/go-tree-sitter/rust"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/rust"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractRustCrateForTest extracts every (relPath, src) file with the real
+// Rust extractor (real tree-sitter parse + RepoRoot-relative paths so module
+// keying fires), stamps deterministic entity IDs like the indexer, and returns
+// the merged record slice.
+func extractRustCrateForTest(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("rust")
+	if !ok {
+		t.Fatal("rust extractor not registered")
+	}
+	var merged []types.EntityRecord
+	for rel, src := range files {
+		parser := sitter.NewParser()
+		parser.SetLanguage(tsrust.GetLanguage())
+		tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+		if err != nil {
+			t.Fatalf("parse %s: %v", rel, err)
+		}
+		ents, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path: rel, Language: "rust", Content: []byte(src), Tree: tree,
+		})
+		if err != nil {
+			t.Fatalf("extract %s: %v", rel, err)
+		}
+		merged = append(merged, ents...)
+	}
+	for k := range merged {
+		if merged[k].Name == "" {
+			continue
+		}
+		merged[k].ID = graph.EntityID("acme/widgets", merged[k].Kind,
+			merged[k].Name, merged[k].SourceFile)
+	}
+	return merged
+}
+
+func is16HexRust(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// runRustResolve runs the resolver sequence the indexer uses for cross-module
+// call binding.
+func runRustResolve(merged []types.EntityRecord) int {
+	idx := resolve.BuildIndex(merged)
+	n := idx.ResolveRustCrossModuleCalls(merged)
+	resolve.ReferencesEmbedded(merged, idx)
+	return n
+}
+
+// callToID returns the ToID of the CALLS edge for `leaf` emitted from the
+// operation named `caller` in file `srcFile`.
+func callToID(merged []types.EntityRecord, srcFile, caller, leaf string) (string, bool) {
+	for k := range merged {
+		e := merged[k]
+		if e.SourceFile != srcFile || e.Name != caller {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "CALLS" {
+				continue
+			}
+			if r.Properties["call_leaf"] == leaf || r.ToID == leaf {
+				return r.ToID, true
+			}
+		}
+	}
+	return "", false
+}
+
+func findEntityID(merged []types.EntityRecord, srcFile, name string) string {
+	for k := range merged {
+		if merged[k].SourceFile == srcFile && merged[k].Name == name {
+			return merged[k].ID
+		}
+	}
+	return ""
+}
+
+// TestIssue4373_CrateAbsoluteCall_NameCollision is the core regression. The
+// caller invokes `crate::services::order::place_order()`, and a SECOND module
+// (services::invoice) ALSO defines `place_order`. Before the fix the qualifier
+// was dropped and the bare name went ambiguous → the CALLS edge bound nowhere.
+// After the fix it binds to exactly services::order::place_order via the
+// stamped module directory.
+func TestIssue4373_CrateAbsoluteCall_NameCollision(t *testing.T) {
+	// mod.rs layout so the two colliding `place_order` definitions live in
+	// DISTINCT package directories (src/services/order vs src/services/invoice)
+	// — only the path qualifier can pick the right one; the bare leaf is
+	// ambiguous across the two dirs.
+	files := map[string]string{
+		"src/lib.rs":          "pub mod services;\n",
+		"src/services/mod.rs": "pub mod order;\npub mod invoice;\n",
+		"src/services/order/mod.rs":   "pub fn place_order() -> i32 { 1 }\n",
+		"src/services/invoice/mod.rs": "pub fn place_order() -> i32 { 99 }\n",
+		"src/handlers.rs": "pub fn handle() -> i32 {\n" +
+			"    crate::services::order::place_order()\n}\n",
+	}
+	merged := extractRustCrateForTest(t, files)
+
+	orderID := findEntityID(merged, "src/services/order/mod.rs", "place_order")
+	invoiceID := findEntityID(merged, "src/services/invoice/mod.rs", "place_order")
+	if orderID == "" || invoiceID == "" {
+		t.Fatalf("missing place_order entities: order=%q invoice=%q", orderID, invoiceID)
+	}
+
+	// Confirm the extractor stamped the module qualifier on the cross-module
+	// CALLS edge — the structural carrier the resolver consumes.
+	stamped := false
+	var stampedDirs, stampedLeaf string
+	for k := range merged {
+		if merged[k].SourceFile != "src/handlers.rs" {
+			continue
+		}
+		for _, r := range merged[k].Relationships {
+			if r.Kind == "CALLS" && r.Properties["call_leaf"] == "place_order" {
+				stamped = true
+				stampedDirs = r.Properties["rust_call_pkg_dirs"]
+				stampedLeaf = r.Properties["call_leaf"]
+			}
+		}
+	}
+	if !stamped {
+		t.Fatal("extractor did not stamp rust_call_pkg_dirs/call_leaf on crate::…::place_order() CALL")
+	}
+	t.Logf("stamped rust_call_pkg_dirs=%q call_leaf=%q", stampedDirs, stampedLeaf)
+
+	// BEFORE: the edge ToID is the bare leaf (unresolved/ambiguous).
+	before, _ := callToID(merged, "src/handlers.rs", "handle", "place_order")
+	if is16HexRust(before) {
+		t.Fatalf("precondition: edge already a hex id before resolve (%q)", before)
+	}
+	t.Logf("cross-module CALL place_order ToID before=%q", before)
+
+	n := runRustResolve(merged)
+	t.Logf("ResolveRustCrossModuleCalls rewrote=%d", n)
+
+	after, _ := callToID(merged, "src/handlers.rs", "handle", "place_order")
+	t.Logf("cross-module CALL place_order ToID after=%q (order=%q invoice=%q)",
+		after, orderID, invoiceID)
+	switch after {
+	case orderID:
+		// correct
+	case invoiceID:
+		t.Fatal("CALL bound to services::invoice::place_order (wrong module — qualifier ignored)")
+	default:
+		t.Fatalf("cross-module CALL place_order() unresolved/ambiguous after fix, ToID=%q", after)
+	}
+}
+
+// TestIssue4373_SelfSuperAndAlias covers the self::/super:: relative roots and
+// the `use ... as` alias paths, each against a same-named-symbol collision.
+func TestIssue4373_SelfSuperAndAlias(t *testing.T) {
+	// mod.rs layout: each colliding `run` lives in its own package dir, so the
+	// path qualifier (super::invoice vs alias→order vs self::inner) is the only
+	// disambiguator. `dispatch` is itself a directory module (dispatch/mod.rs)
+	// so self::inner names dispatch's own child module dispatch::inner.
+	files := map[string]string{
+		"src/lib.rs":     "pub mod app;\n",
+		"src/app/mod.rs": "pub mod order;\npub mod invoice;\npub mod dispatch;\n",
+		"src/app/order/mod.rs":   "pub fn run() -> i32 { 1 }\n",  // collision A
+		"src/app/invoice/mod.rs": "pub fn run() -> i32 { 99 }\n", // collision B
+		"src/app/dispatch/mod.rs": "use crate::app::order as ord;\n" +
+			"pub mod inner;\n" +
+			"pub fn via_self() -> i32 { self::inner::run() }\n" +
+			"pub fn via_super() -> i32 { super::invoice::run() }\n" +
+			"pub fn via_alias() -> i32 { ord::run() }\n",
+		"src/app/dispatch/inner/mod.rs": "pub fn run() -> i32 { 7 }\n", // collision C
+	}
+	merged := extractRustCrateForTest(t, files)
+
+	orderRun := findEntityID(merged, "src/app/order/mod.rs", "run")
+	invoiceRun := findEntityID(merged, "src/app/invoice/mod.rs", "run")
+	innerRun := findEntityID(merged, "src/app/dispatch/inner/mod.rs", "run")
+	if orderRun == "" || invoiceRun == "" || innerRun == "" {
+		t.Fatalf("missing run entities order=%q invoice=%q inner=%q",
+			orderRun, invoiceRun, innerRun)
+	}
+
+	runRustResolve(merged)
+
+	// self::inner::run — dispatch's module is app::dispatch (dispatch/mod.rs),
+	// so self::inner = app::dispatch::inner = src/app/dispatch/inner.
+	gotSelf, _ := callToID(merged, "src/app/dispatch/mod.rs", "via_self", "run")
+	t.Logf("self::inner::run ToID=%q want=%q", gotSelf, innerRun)
+	if gotSelf != innerRun {
+		t.Errorf("self::inner::run() did not bind to app::dispatch::inner::run (got %q)", gotSelf)
+	}
+
+	gotSuper, _ := callToID(merged, "src/app/dispatch/mod.rs", "via_super", "run")
+	t.Logf("super::invoice::run ToID=%q want=%q", gotSuper, invoiceRun)
+	if gotSuper != invoiceRun {
+		t.Errorf("super::invoice::run() did not bind to app::invoice::run (got %q)", gotSuper)
+	}
+
+	gotAlias, _ := callToID(merged, "src/app/dispatch/mod.rs", "via_alias", "run")
+	t.Logf("ord::run (alias of app::order) ToID=%q want=%q", gotAlias, orderRun)
+	if gotAlias != orderRun {
+		t.Errorf("aliased ord::run() did not bind to app::order::run (got %q)", gotAlias)
+	}
+}
+
+// TestIssue4373_NoFalseStampOnBareOrReceiverCall guards against over-eager
+// stamping: bare calls (`helper()`), receiver/method calls (`self.method()`,
+// `repo.find()`) and macro calls must NOT carry rust_call_pkg_dirs.
+func TestIssue4373_NoFalseStampOnBareOrReceiverCall(t *testing.T) {
+	files := map[string]string{
+		"src/lib.rs": "pub mod m;\n",
+		"src/m.rs": "pub struct R;\n" +
+			"impl R {\n" +
+			"  pub fn build(&self) -> i32 { 1 }\n" +
+			"  pub fn use_it(&self) -> i32 {\n" +
+			"    let x = helper();\n" +       // bare call
+			"    let y = self.build();\n" +    // receiver call
+			"    println!(\"{}\", x + y);\n" + // macro call
+			"    x + y\n" +
+			"  }\n" +
+			"}\n" +
+			"fn helper() -> i32 { 0 }\n",
+	}
+	merged := extractRustCrateForTest(t, files)
+	for k := range merged {
+		for _, r := range merged[k].Relationships {
+			if r.Kind == "CALLS" && r.Properties["rust_call_pkg_dirs"] != "" {
+				t.Errorf("non-path call %q wrongly stamped rust_call_pkg_dirs=%q",
+					r.Properties["call_leaf"], r.Properties["rust_call_pkg_dirs"])
+			}
+		}
+	}
+}
+
+// TestIssue4373_TypeAssocCall binds an associated `Type::method()` call across
+// modules, with a same-named method collision on a different type.
+func TestIssue4373_TypeAssocCall(t *testing.T) {
+	files := map[string]string{
+		"src/lib.rs":       "pub mod svc;\n",
+		"src/svc/mod.rs":   "pub mod a;\npub mod b;\n",
+		// OrderService::new in module svc::a; a same-named `new` exists on a
+		// different type in svc::b — the collision that breaks bare-name bind.
+		"src/svc/a.rs": "pub struct OrderService;\n" +
+			"impl OrderService { pub fn new() -> OrderService { OrderService } }\n",
+		"src/svc/b.rs": "pub struct InvoiceService;\n" +
+			"impl InvoiceService { pub fn new() -> InvoiceService { InvoiceService } }\n",
+		"src/svc/run.rs": "use crate::svc::a::OrderService;\n" +
+			"pub fn go() -> i32 { let _ = OrderService::new(); 0 }\n",
+	}
+	merged := extractRustCrateForTest(t, files)
+
+	orderNew := findEntityID(merged, "src/svc/a.rs", "OrderService.new")
+	invoiceNew := findEntityID(merged, "src/svc/b.rs", "InvoiceService.new")
+	if orderNew == "" || invoiceNew == "" {
+		t.Fatalf("missing assoc-fn entities order=%q invoice=%q", orderNew, invoiceNew)
+	}
+
+	// Stamp check: scope must be the Type.
+	scopeStamped := ""
+	for k := range merged {
+		if merged[k].SourceFile != "src/svc/run.rs" {
+			continue
+		}
+		for _, r := range merged[k].Relationships {
+			if r.Kind == "CALLS" && r.Properties["call_leaf"] == "new" {
+				scopeStamped = r.Properties["rust_call_scope"]
+			}
+		}
+	}
+	if scopeStamped != "OrderService" {
+		t.Fatalf("assoc call did not stamp rust_call_scope=OrderService (got %q)", scopeStamped)
+	}
+
+	runRustResolve(merged)
+
+	got, _ := callToID(merged, "src/svc/run.rs", "go", "new")
+	t.Logf("OrderService::new ToID=%q want=%q (invoice=%q)", got, orderNew, invoiceNew)
+	switch got {
+	case orderNew:
+		// correct
+	case invoiceNew:
+		t.Fatal("OrderService::new() bound to InvoiceService::new (wrong type/module)")
+	default:
+		t.Fatalf("OrderService::new() unresolved/ambiguous, ToID=%q", got)
+	}
+}

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -53,7 +53,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	walk(file.Tree.RootNode(), file, &entities)
+	// Issue #4373 — per-file cross-module call-path resolution context, built
+	// once from the file path + `use` declarations and threaded into call
+	// extraction so cross-module CALLS carry a stamped module qualifier.
+	crossCtx := buildRustCrossCtx(file.Tree.RootNode(), file.Content, file.Path)
+	walk(file.Tree.RootNode(), file, &entities, crossCtx)
 	// Epic #3628 — error-flow topology: typed THROWS / CATCHES edges to the
 	// shared SCOPE.ExceptionType convergence node. Runs after walk so the
 	// host SCOPE.Operation entities (including impl-qualified method names)
@@ -71,7 +75,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // per function_item declared inside their declaration_list, every
 // function_item body emits CALLS edges with stub to_id, and use_declaration
 // nodes already emit IMPORTS (untouched).
-func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord, crossCtx *rustCrossCtx) {
 	if node == nil {
 		return
 	}
@@ -99,7 +103,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		rec, ok := buildComponent(node, file, "trait")
 		if !ok {
 			for i := range node.ChildCount() {
-				walk(node.Child(int(i)), file, out)
+				walk(node.Child(int(i)), file, out, crossCtx)
 			}
 			return
 		}
@@ -109,7 +113,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		if body != nil {
 			before := len(*out)
 			for i := range body.ChildCount() {
-				walk(body.Child(int(i)), file, out)
+				walk(body.Child(int(i)), file, out, crossCtx)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -133,7 +137,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		rec, ok := buildImpl(node, file)
 		if !ok {
 			for i := range node.ChildCount() {
-				walk(node.Child(int(i)), file, out)
+				walk(node.Child(int(i)), file, out, crossCtx)
 			}
 			return
 		}
@@ -152,13 +156,13 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 						paramTypes := collectRustParamTypes(ch, file.Content)
 						// Issue #616 — resolve self.method() and dyn-param calls.
 						fnRec.Relationships = append(fnRec.Relationships,
-							extractCallRelationships(ch.ChildByFieldName("body"), file.Content, fnRec.Name, implName, paramTypes)...)
+							extractCallRelationships(ch.ChildByFieldName("body"), file.Content, fnRec.Name, implName, paramTypes, crossCtx)...)
 						// Qualify the name with the impl type owner.
 						fnRec.Name = implName + "." + fnRec.Name
 						*out = append(*out, fnRec)
 					}
 				} else {
-					walk(ch, file, out)
+					walk(ch, file, out, crossCtx)
 				}
 			}
 			after := len(*out)
@@ -185,7 +189,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		if rec, ok := buildOperation(node, file); ok {
 			paramTypes := collectRustParamTypes(node, file.Content)
 			rec.Relationships = append(rec.Relationships,
-				extractCallRelationships(node.ChildByFieldName("body"), file.Content, rec.Name, "", paramTypes)...)
+				extractCallRelationships(node.ChildByFieldName("body"), file.Content, rec.Name, "", paramTypes, crossCtx)...)
 			*out = append(*out, rec)
 		}
 		return
@@ -197,7 +201,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 	}
 
 	for i := range node.ChildCount() {
-		walk(node.Child(int(i)), file, out)
+		walk(node.Child(int(i)), file, out, crossCtx)
 	}
 }
 
@@ -222,7 +226,7 @@ func findRustDeclList(node *sitter.Node) *sitter.Node {
 // "Foo"); it enables `self.method()` calls to resolve to "Foo.method".
 // paramTypes maps parameter names to their declared types so that calls
 // through typed receivers (e.g. `r: &dyn Repo`) resolve to "Repo.method".
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerName string, paramTypes map[string]string) []types.RelationshipRecord {
+func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerName string, paramTypes map[string]string, crossCtx *rustCrossCtx) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -233,7 +237,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerNa
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
-		target := rustCallTarget(call, src, ownerName, paramTypes)
+		target, pathSegs := rustCallTarget(call, src, ownerName, paramTypes)
 		if target == "" || target == callerName {
 			continue
 		}
@@ -243,10 +247,26 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerNa
 		seen[target] = true
 		// Line is 1-based: tree-sitter StartPoint().Row is 0-based.
 		callLine := strconv.Itoa(int(call.StartPoint().Row) + 1)
+		props := map[string]string{"line": callLine}
+		// Issue #4373 — stamp the resolved module/crate path qualifier so the
+		// resolver can bind a cross-module CALL to the exact callee module's
+		// entity instead of collapsing to an ambiguity-prone bare leaf. Only
+		// fires for path-qualified calls (`a::b::leaf`) where the qualifier
+		// maps to in-crate module directories; bare and receiver calls are
+		// untouched.
+		if crossCtx != nil && len(pathSegs) >= 2 {
+			if dirs, scope := crossCtx.resolveCallPath(pathSegs); len(dirs) > 0 {
+				props["rust_call_pkg_dirs"] = strings.Join(dirs, ";")
+				props["call_leaf"] = pathSegs[len(pathSegs)-1]
+				if scope != "" {
+					props["rust_call_scope"] = scope
+				}
+			}
+		}
 		rels = append(rels, types.RelationshipRecord{
 			ToID:       target,
 			Kind:       "CALLS",
-			Properties: map[string]string{"line": callLine},
+			Properties: props,
 		})
 	}
 	return rels
@@ -259,7 +279,12 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerNa
 // Issue #616 — ownerName and paramTypes enable receiver-qualified targets:
 //   - "self.method()" inside impl Foo → "Foo.method"
 //   - "repo.find()" where repo: &dyn Repo → "Repo.find"
-func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes map[string]string) string {
+// The second return value (issue #4373) is the FULL `::`-separated path of a
+// scoped_identifier callee (e.g. ["crate","services","order","place_order"] or
+// ["OrderService","new"]), or nil for bare / receiver / macro calls. The
+// caller uses it to stamp a cross-module qualifier so the resolver can bind to
+// the exact callee module instead of the ambiguity-prone bare leaf.
+func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes map[string]string) (string, []string) {
 	switch call.Type() {
 	case "call_expression":
 		fn := call.ChildByFieldName("function")
@@ -267,14 +292,15 @@ func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes 
 			fn = call.Child(0)
 		}
 		if fn == nil {
-			return ""
+			return "", nil
 		}
 		switch fn.Type() {
 		case "identifier":
-			return string(src[fn.StartByte():fn.EndByte()])
+			return string(src[fn.StartByte():fn.EndByte()]), nil
 		case "scoped_identifier":
 			if name := fn.ChildByFieldName("name"); name != nil {
-				return string(src[name.StartByte():name.EndByte()])
+				return string(src[name.StartByte():name.EndByte()]),
+					rustScopedPathSegments(fn, src)
 			}
 		case "field_expression":
 			method := ""
@@ -282,7 +308,7 @@ func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes 
 				method = string(src[name.StartByte():name.EndByte()])
 			}
 			if method == "" {
-				return ""
+				return "", nil
 			}
 			// Issue #616 — resolve receiver type for self and typed params.
 			recv := ""
@@ -290,26 +316,27 @@ func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes 
 				recv = string(src[value.StartByte():value.EndByte()])
 			}
 			if recv == "self" && ownerName != "" {
-				return ownerName + "." + method
+				return ownerName + "." + method, nil
 			}
 			if recv != "" && len(paramTypes) > 0 {
 				if recvType, ok := paramTypes[recv]; ok && recvType != "" {
-					return recvType + "." + method
+					return recvType + "." + method, nil
 				}
 			}
-			return method
+			return method, nil
 		case "generic_function":
 			if path := fn.ChildByFieldName("function"); path != nil {
 				switch path.Type() {
 				case "identifier":
-					return string(src[path.StartByte():path.EndByte()])
+					return string(src[path.StartByte():path.EndByte()]), nil
 				case "scoped_identifier":
 					if name := path.ChildByFieldName("name"); name != nil {
-						return string(src[name.StartByte():name.EndByte()])
+						return string(src[name.StartByte():name.EndByte()]),
+							rustScopedPathSegments(path, src)
 					}
 				case "field_expression":
 					if name := path.ChildByFieldName("field"); name != nil {
-						return string(src[name.StartByte():name.EndByte()])
+						return string(src[name.StartByte():name.EndByte()]), nil
 					}
 				}
 			}
@@ -318,16 +345,34 @@ func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes 
 		if m := call.ChildByFieldName("macro"); m != nil {
 			t := m.Type()
 			if t == "identifier" {
-				return string(src[m.StartByte():m.EndByte()])
+				return string(src[m.StartByte():m.EndByte()]), nil
 			}
 			if t == "scoped_identifier" {
 				if name := m.ChildByFieldName("name"); name != nil {
-					return string(src[name.StartByte():name.EndByte()])
+					return string(src[name.StartByte():name.EndByte()]),
+						rustScopedPathSegments(m, src)
 				}
 			}
 		}
 	}
-	return ""
+	return "", nil
+}
+
+// rustScopedPathSegments returns the `::`-separated identifier segments of a
+// scoped_identifier node, in source order including the trailing name. The
+// tree-sitter Rust grammar nests scoped_identifier left-associatively:
+// `a::b::c` is scoped_identifier(path=scoped_identifier(path=a, name=b),
+// name=c). We flatten by reading the literal source text of the node and
+// splitting on `::`, which is robust to the nesting and to crate/self/super
+// path keywords (which appear as crate/self/super nodes). Turbofish generics
+// are stripped per-segment by splitRustPath. Returns nil when the path cannot
+// be cleanly segmented (e.g. contains a non-identifier element).
+func rustScopedPathSegments(node *sitter.Node, src []byte) []string {
+	raw := strings.TrimSpace(string(src[node.StartByte():node.EndByte()]))
+	if raw == "" {
+		return nil
+	}
+	return splitRustPath(raw)
 }
 
 // collectRustParamTypes scans a function_item node's parameters child and

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2272,6 +2272,142 @@ func (idx Index) ResolveGoCrossPackageCalls(records []types.EntityRecord) int {
 	return rewrites
 }
 
+// ResolveRustCrossModuleCalls binds Rust CALLS edges that reach a function or
+// associated method in another in-crate module through a path qualifier —
+// `crate::services::order::place_order()`, `self::sibling::helper()`,
+// `super::parent::helper()`, an aliased `use ... as ord; ord::place_order()`,
+// or an associated `OrderService::new()` — to the callee's entity ID.
+//
+// Background (issue #4373): the Rust extractor historically emitted a
+// scoped-identifier call `a::b::leaf()` as a CALLS edge whose ToID was the
+// BARE leaf (`leaf`), dropping the whole `a::b` path qualifier. A bare name
+// resolves through the global byName index, which goes ambiguous the moment
+// two modules define a symbol of the same name (`place_order` in both
+// services::order and services::invoice) — so the edge is dropped and the
+// callee module looks falsely uncalled. This is the Rust analogue of the Go
+// cross-package qualifier drop fixed in #4332.
+//
+// The extractor now stamps, on each path-qualified CALLS edge:
+//   - Properties["rust_call_pkg_dirs"]: ";"-separated candidate package
+//     directories the target module's items are keyed under (the mod.rs vs
+//     file.rs layout ambiguity yields two; tried in order).
+//   - Properties["call_leaf"]: the bare callee identifier.
+//   - Properties["rust_call_scope"]: (associated calls only) the Type the leaf
+//     is a member of, so the bind goes through byPackageMember[dir][Type][leaf].
+//
+// This pass reads those and rewrites ToID to the exact callee:
+//   - free function: byPackageOperation[dir][leaf]
+//   - associated method: byPackageMember[dir][scope][leaf], with a crate-wide
+//     fallback to byMember when the type name is unique (an unqualified
+//     `Type::method` whose type lives in a sibling module).
+//
+// Conservative by construction:
+//   - Only edges carrying rust_call_pkg_dirs AND call_leaf participate.
+//   - Edges whose ToID is already a hex ID are left alone (idempotent).
+//   - A blank-string sentinel marks (dir, name) collisions; those are skipped,
+//     never guessed. The first candidate dir that yields an unambiguous hit
+//     wins; if two candidate dirs both resolve to DIFFERENT ids the edge is
+//     left alone (ambiguous layout).
+//
+// Must run AFTER BuildIndex (needs the package-scoped indexes) and BEFORE the
+// embedded-reference resolver so the rewritten hex ID is seen as resolved.
+// Returns the number of edges rewritten.
+func (idx Index) ResolveRustCrossModuleCalls(records []types.EntityRecord) int {
+	if len(idx.byPackageOperation) == 0 && len(idx.byPackageMember) == 0 {
+		return 0
+	}
+	rewrites := 0
+	for k := range records {
+		rec := &records[k]
+		for j := range rec.Relationships {
+			r := &rec.Relationships[j]
+			if r.Kind != "CALLS" || r.Properties == nil {
+				continue
+			}
+			dirsRaw := r.Properties["rust_call_pkg_dirs"]
+			leaf := r.Properties["call_leaf"]
+			if dirsRaw == "" || leaf == "" {
+				continue
+			}
+			if r.ToID == "" || isHexID(r.ToID) {
+				continue // already resolved
+			}
+			scope := r.Properties["rust_call_scope"]
+			dirs := strings.Split(dirsRaw, ";")
+
+			// Try each candidate directory; require a single unambiguous
+			// non-empty id across the candidates that resolve.
+			resolved := ""
+			conflict := false
+			for _, dir := range dirs {
+				if dir == "" {
+					continue
+				}
+				id := ""
+				if scope != "" {
+					if pkgBucket, ok := idx.byPackageMember[dir]; ok {
+						if scopeBucket, ok := pkgBucket[scope]; ok {
+							id = scopeBucket[leaf] // "" => collision sentinel
+						}
+					}
+				} else {
+					if pkgBucket, ok := idx.byPackageOperation[dir]; ok {
+						id = pkgBucket[leaf] // "" => collision sentinel or miss
+					}
+				}
+				if id == "" {
+					continue
+				}
+				if resolved == "" {
+					resolved = id
+				} else if resolved != id {
+					conflict = true
+					break
+				}
+			}
+
+			// Associated-call crate-wide fallback: an `OrderService::new()`
+			// whose type is unique in the crate but lives outside the offered
+			// candidate dirs. Bind through the unambiguous global member index.
+			if resolved == "" && !conflict && scope != "" {
+				if id := idx.lookupUniqueMember(scope, leaf); id != "" {
+					resolved = id
+				}
+			}
+
+			if conflict || resolved == "" {
+				continue
+			}
+			r.ToID = resolved
+			rewrites++
+		}
+	}
+	return rewrites
+}
+
+// lookupUniqueMember returns the entity id for scope.member if and only if it
+// is unique across the whole crate (every byMember file-bucket that defines it
+// agrees on the same id). Returns "" on miss or any disagreement (ambiguous).
+func (idx Index) lookupUniqueMember(scope, member string) string {
+	found := ""
+	for _, fileBucket := range idx.byMember {
+		scopeBucket, ok := fileBucket[scope]
+		if !ok {
+			continue
+		}
+		id, ok := scopeBucket[member]
+		if !ok || id == "" {
+			continue
+		}
+		if found == "" {
+			found = id
+		} else if found != id {
+			return "" // ambiguous across files
+		}
+	}
+	return found
+}
+
 // buildGoPkgDirIndex builds a map from Go package directory (e.g.
 // "internal/types") to the entity ID of a representative file in that package.
 // Only Go SCOPE.Component subtype="file" entities are considered. When multiple


### PR DESCRIPTION
## Summary

Rust reaches functions in other modules through a path qualifier on a `scoped_identifier`:

```rust
crate::services::order::place_order()
self::sibling::helper()
super::parent::helper()
use crate::services::order as ord; ord::place_order()
OrderService::new()   // associated call
```

The extractor collapsed the callee to the rightmost identifier (`place_order`), **dropping the whole path qualifier**. The bare leaf resolves through the global byName index, which goes ambiguous the moment two modules define a same-named symbol — so the CALLS edge dropped and the callee module looked falsely uncalled (wrong impact-radius / dead-code / orphan-ish modules). This is the Rust analogue of the Go cross-package qualifier-drop fixed in #4332.

## Root cause

`rustCallTarget` returned only the scoped_identifier `name` field for a path-qualified call, discarding the module/crate qualifier instead of carrying it to the resolver. The resolver had no Rust cross-module binding path.

## Fix (structural, mirrors #4332)

- **extractor** (`internal/extractors/rust/crosspath.go`): a per-file `rustCrossCtx` maps a call's path qualifier — through the file's `use`/`mod` declarations, the crate `src` root, and the `self::`/`super::` relative roots — to the directory the target module's items are keyed under (`pkgDirOf`). It stamps `rust_call_pkg_dirs` (`;`-separated candidates; the `mod.rs` vs `file.rs` layout yields two), `call_leaf`, and (associated calls) `rust_call_scope=Type`. Only fires for path-qualified calls; bare / receiver / macro calls are never stamped.
- **resolver** (`ResolveRustCrossModuleCalls`): binds via `byPackageOperation[dir][leaf]` (free fn) / `byPackageMember[dir][Type][leaf]` (assoc fn), with a unique-crate-wide `byMember` fallback for an assoc call whose type lives in a sibling module. Blank/ambiguous sentinels and cross-candidate disagreement → skip, never guess. Wired in `cmd/archigraph` after `BuildIndex` and before the embedded-reference resolver, alongside the Go pass.

## Live-validation (real extract + real resolver passes)

In-pipeline tests on a realistic crate (`src/lib.rs` + `src/services/order/mod.rs` etc.) with a same-named symbol collision in **two distinct module dirs** (the bug only manifests under collision — a globally-unique name would false-pass, the trap #4332 documents):

- `crate::` absolute call `place_order()`: ToID `"place_order"` (bare/ambiguous) **before** → correct module's hex entity **after**, never the colliding module.
- `self::` / `super::` / `use ... as` alias and `Type::method` associated calls each bind to the correct module/type under collision.
- negative test: bare / receiver / macro calls are never stamped.

## Coverage

Covered here for Rust: `crate::` / `self::` / `super::` / aliased `use` / `Type::assoc`. The resolver pass keys on the shared package-scoped indexes, so **C# (#4374)** and **Kotlin (#4375)** can reuse `ResolveRustCrossModuleCalls`' binding shape; only a language-specific qualifier→dir extractor stamp is needed there (separate tickets, not implemented here).

## Gates

`go build ./...`, `go vet` (rust/resolve/cmd), `go test ./internal/extractors/rust/ ./internal/resolve/ ./cmd/archigraph/ ./internal/extractor/...` — all green.

Closes #4373

🤖 Generated with [Claude Code](https://claude.com/claude-code)