### PR TITLE
Link Python API route-by-string tests to endpoint definitions

### DIFF
--- a/internal/custom/python/issue4369_livedrepro_test.go
+++ b/internal/custom/python/issue4369_livedrepro_test.go
@@ -1,0 +1,180 @@
+package python_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+)
+
+// Issue #4369 LIVE-REPRO (extractor side).
+//
+// Python API test clients (DRF APIClient / Django test Client, FastAPI /
+// Starlette TestClient, Flask test_client, httpx / requests in tests) call
+// routes by string but produced NO link to the http_endpoint_definition they
+// exercise. This mirrors the NestJS/supertest fix #4351: the pytest extractor
+// now captures every `<client>.<verb>('/route')` call and stamps the
+// `VERB route` pairs onto the one-per-file test_suite's `e2e_route_calls`
+// property — the raw material the shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints) turns into TESTS→http_endpoint_definition
+// edges.
+//
+// This test runs the ACTUAL pytest extractor over a BYTE-COPY of a REAL DRF
+// APITestCase from the upvate_core legacy Django backend
+// (core/tests/test_schedule_import.py: `self.client.post("/schedule/import/")`)
+// plus synthetic-but-representative FastAPI/Flask/httpx test files, and asserts
+// the route calls land on the suite. Before #4369 the extractor recorded no
+// route information at all, so the resolve pass had nothing to match.
+
+func extractPytest4369(t *testing.T, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("python_pytest")
+	if !ok {
+		t.Fatal("custom_python_pytest not registered")
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func suiteRouteCalls4369(t *testing.T, ents []types.EntityRecord) []string {
+	t.Helper()
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			raw := e.Properties["e2e_route_calls"]
+			if raw == "" {
+				return nil
+			}
+			return strings.Split(raw, "\n")
+		}
+	}
+	return nil
+}
+
+func fileInput4369(path, content string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: "python", Content: []byte(content)}
+}
+
+// TestIssue4369_RealDRFTest_RouteCaptured runs the real upvate_core DRF test
+// (byte-copied) and asserts the `self.client.post("/schedule/import/")` call is
+// captured onto the suite.
+func TestIssue4369_RealDRFTest_RouteCaptured(t *testing.T) {
+	p := filepath.Join("testdata", "issue4369", "core", "tests", "test_schedule_import.py")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read real DRF test: %v", err)
+	}
+	ents := extractPytest4369(t, extreg.FileInput{
+		Path: "core/tests/test_schedule_import.py", Language: "python", Content: b,
+	})
+	calls := suiteRouteCalls4369(t, ents)
+	if len(calls) == 0 {
+		t.Fatal("no e2e_route_calls captured from real DRF test (#4369)")
+	}
+	found := false
+	for _, c := range calls {
+		if c == "POST /schedule/import/" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected captured route call %q from real DRF test, got=%v",
+			"POST /schedule/import/", calls)
+	}
+}
+
+// TestIssue4369_FrameworkCoverage exercises every required Python test client:
+// DRF/Django Client, FastAPI/Starlette TestClient, Flask test_client, and
+// httpx/requests, asserting each verb+route is captured and that ambiguous /
+// non-path routes (f-string base URL, bare verb on a non-client receiver) are
+// NOT captured.
+func TestIssue4369_FrameworkCoverage(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		src     string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "django_drf_client",
+			path: "tests/test_django.py",
+			src: `from rest_framework.test import APITestCase, APIClient
+class InspectionTest(APITestCase):
+    def test_create(self):
+        self.client = APIClient()
+        r = self.client.post('/api/v1/inspections/123/items', data={})
+        r2 = self.client.get("/api/v1/inspections/123")
+        # cache.get must NOT be captured as a route
+        cache.get('some-key')
+`,
+			want:    []string{"POST /api/v1/inspections/123/items", "GET /api/v1/inspections/123"},
+			notWant: []string{"GET some-key"},
+		},
+		{
+			name: "fastapi_testclient",
+			path: "tests/test_fastapi.py",
+			src: `from fastapi.testclient import TestClient
+def test_items():
+    client = TestClient(app)
+    r = client.post('/inspections/123/items', json={})
+    r2 = client.get('/inspections/123')
+`,
+			want: []string{"POST /inspections/123/items", "GET /inspections/123"},
+		},
+		{
+			name: "flask_test_client",
+			path: "tests/test_flask.py",
+			src: `def test_x(client):
+    r = client.get('/x/1')
+    r2 = client.post('/x', data={})
+`,
+			want: []string{"GET /x/1", "POST /x"},
+		},
+		{
+			name: "httpx_requests",
+			path: "tests/test_httpx.py",
+			src: `import httpx, requests
+def test_remote():
+    r = requests.get('http://testserver/inspections/42')
+    r2 = httpx.get(f'/inspections/{id}/items')
+    # f-string with interpolated BASE first segment -> NOT a leading-slash path
+    r3 = httpx.get(f'{BASE}/inspections/99')
+`,
+			want:    []string{"GET /inspections/42", "GET /inspections/{id}/items"},
+			notWant: []string{"GET {BASE}/inspections/99"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ents := extractPytest4369(t, fileInput4369(tc.path, tc.src))
+			calls := suiteRouteCalls4369(t, ents)
+			joined := strings.Join(calls, "|")
+			for _, w := range tc.want {
+				found := false
+				for _, c := range calls {
+					if c == w {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected %q captured, got=%v", w, calls)
+				}
+			}
+			for _, nw := range tc.notWant {
+				if strings.Contains(joined, nw) {
+					t.Errorf("did NOT expect %q captured, got=%v", nw, calls)
+				}
+			}
+		})
+	}
+}

--- a/internal/custom/python/pytest.go
+++ b/internal/custom/python/pytest.go
@@ -92,6 +92,27 @@ var (
 	ptCeleryCallRe = regexp.MustCompile(
 		`(?m)\b(\w+)\.(delay|apply_async|apply)\s*\(`)
 
+	// ptTestClientCallRe captures an HTTP test-client route-by-string call inside
+	// a Python API test, across every supported framework's test client (#4369):
+	//
+	//	DRF/Django:        self.client.post('/api/v1/inspections/123/items', data)
+	//	                   APIClient().get('/x/1')  /  client.get('/x/1')
+	//	FastAPI/Starlette: client.post('/inspections/123/items', json=...)  # TestClient
+	//	Flask:             self.client.get('/x/1')  /  test_client().post('/x')
+	//	httpx/requests:    client.get(f'/inspections/{id}')  /  requests.get('/x/1')
+	//
+	// Group 1 = HTTP verb. Group 2 = the route literal (single/double quoted,
+	// optionally an f-string — the leading `f`/`r`/`b` prefix is consumed before
+	// the quote). Absolute URLs and `{expr}`-interpolated routes are normalised /
+	// filtered downstream (a route that does not start with `/` after
+	// normalisation is dropped by the resolver — conservative). The receiver must
+	// be a recognised test-client token (client, test_client, session, ac,
+	// async_client) or an HTTP library module (requests, httpx) so unrelated
+	// `.get(...)` calls (cache.get, logger.get) never produce phantom routes.
+	// An optional `self.`/`app.`/`cls.` attribute prefix is tolerated.
+	ptTestClientCallRe = regexp.MustCompile(
+		`(?:\b(?:self|app|cls)\s*\.\s*)?\b(?:client|test_client|session|ac|async_client|requests|httpx)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*[rbf]?["']([^"'\n\r]+)["']`)
+
 	// importedSymbolsRe captures names bound by `from X import a, b, c`,
 	// `from X import (\n a,\n b,\n)` (parenthesized multi-line), and `import x`
 	// so the TESTS resolver can reference-gate subjects.
@@ -251,8 +272,78 @@ func (e *PytestExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		})
 	}
 
+	// HTTP route-by-string test calls (#4369): capture every test-client route
+	// call (DRF/Django Client, FastAPI/Starlette TestClient, Flask test_client,
+	// httpx/requests) and stamp the `VERB route` pairs onto this suite's
+	// `e2e_route_calls` property. The resolve pass
+	// (engine.linkE2ERouteTestsToEndpoints, shared with the NestJS/supertest
+	// path from #4351) matches each (verb, route) against the cross-file
+	// http_endpoint_definition index and emits a TESTS edge to each uniquely
+	// matched endpoint — a finer-grained, complementary edge to the
+	// ViewSet-class TESTS edge that engine.ApplyTestsMultiHopViaHTTP (#2549)
+	// already produces. Resolution is deferred to resolve-time because only
+	// there is the merged endpoint index available (the route is usually defined
+	// in a urls.py / router far from the test file), making it merge-stable.
+	if routeCalls := collectPyTestRouteCalls(source); len(routeCalls) > 0 {
+		ent.Properties["e2e_route_calls"] = strings.Join(routeCalls, "\n")
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", 1))
 	return []types.EntityRecord{ent}, nil
+}
+
+// collectPyTestRouteCalls extracts every HTTP test-client route-by-string call
+// in a Python test file and returns de-duplicated `VERB route` lines (the exact
+// shape the shared resolve pass consumes — see #4369 and the NestJS sibling
+// #4351). The route is normalised to a path: an absolute URL has its
+// scheme+authority stripped, a query string / fragment is dropped, and
+// repeated slashes are collapsed. Concrete path params (`/x/123`) and template
+// params left by an f-string (`/x/{id}`) are preserved verbatim — the resolver
+// treats `{id}`/`<int:id>` definition segments as wildcards. Routes that do not
+// resolve to a leading-slash path (e.g. an f-string whose FIRST segment is an
+// interpolated base URL like `f"{BASE}/x"`) are dropped here, keeping the pass
+// conservative.
+func collectPyTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range ptTestClientCallRe.FindAllStringSubmatch(source, -1) {
+		verb := strings.ToUpper(m[1])
+		route := normalisePyTestRoute(m[2])
+		if route == "" || !strings.HasPrefix(route, "/") {
+			continue
+		}
+		line := verb + " " + route
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	return out
+}
+
+// normalisePyTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix (http://testserver/x → /x), drops a query/fragment,
+// and collapses repeated slashes. Casing and path-param placeholders are left
+// untouched (the resolver compares literals case-insensitively and wildcards
+// `{id}`/`<int:id>` segments). Returns "" when no path remains.
+func normalisePyTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
 }
 
 // hasUnittestBase reports whether any detected test class extends a unittest /

--- a/internal/custom/python/testdata/issue4369/core/routers.py
+++ b/internal/custom/python/testdata/issue4369/core/routers.py
@@ -1,0 +1,215 @@
+from django.urls import path, include
+from rest_framework import routers
+
+from core import views
+
+router = routers.DefaultRouter()
+
+# Health
+router.register(r"health", views.HealthCheckViewSet, basename="health")
+
+#mobile
+router.register(r"mobile", views.MobileViewSet, basename="mobile")
+
+# Authentication
+router.register(r"auth/login", views.LoginViewSet, basename="auth-login")
+router.register(r"users/login", views.LoginViewSet, basename="user-login")
+router.register(
+    r"auth/reset_password", views.ResetPasswordViewSet, basename="auth-reset_password"
+)
+router.register(
+    r"auth/update_password",
+    views.UpdatePasswordViewSet,
+    basename="auth-update_password",
+)
+router.register(r"auth/register", views.RegistrationViewSet, basename="auth-register")
+router.register(r"auth/handle_cognito_status", views.CognitoStatusViewSet, basename="auth-check_status")
+router.register(r"auth/refresh", views.RefreshViewSet, basename="auth-refresh")
+
+# permissions
+router.register(
+    r"permissions", views.PermissionViewSet, basename="permissions"
+)
+
+# Users
+router.register(r"users", views.UserViewSet, basename="users")
+router.register(r"user-profile", views.UserProfileViewSet, basename="user-profile")
+
+# Notifications
+router.register(
+    r"create_notification",
+    views.CreateNotificationViewSet,
+    basename="CreateNotification",
+)
+
+# Roles
+router.register(r"roles", views.RoleViewSet, basename="roles")
+router.register(r"permissions", views.RolePageViewSet, basename="permissions")
+
+# Groups
+router.register(r"groups", views.GroupViewSet, basename="groups")
+
+# Core / Superuser
+router.register(r"core/groups", views.SuperuserGroupViewSet, basename="core-groups")
+
+# Group Company Settings
+router.register(r"group-company-settings", views.GroupCompanySettingsViewSet, basename="group-company-settings")
+
+
+# Group Device Settings
+router.register(r"group-device-settings", views.GroupDeviceSettingsViewSet, basename="group-device-settings")
+
+# Group Building Settings
+router.register(r"group-building-settings", views.GroupBuildingSettingsViewSet, basename="group-building-settings")
+
+# Notes
+router.register(r"notes", views.NoteViewSet, basename="notes")
+
+# Jurisdictions
+router.register(r"jurisdictions", views.JurisdictionViewSet, basename="jurisdictions")
+
+# State
+router.register(r"states", views.StateViewSet, basename="states")
+
+# Buildings
+router.register(r"buildings", views.BuildingViewSet, basename="buildings")
+
+# Alternate Addresses
+router.register(r"alternate-addresses", views.BuildingAlternateAddressViewSet, basename="alternate-addresses")
+
+# Devices
+router.register(r"devices", views.DeviceViewSet, basename="devices")
+router.register(r"ma-devices", views.MassDeviceViewSet, basename="ma-devices")
+
+# Contacts
+router.register(r"contacts", views.ContactViewSet, basename="contacts")
+
+# Schedule
+router.register(r"schedule", views.ScheduleViewset, basename="Schedule")
+
+# Syncs
+router.register(r"syncGroups", views.SyncGroupsViewSet, basename="syncGroups")
+
+# Syncs
+router.register(r"aoc_harvest", views.AocHarvestViewSet, basename="aoc_harvest")
+
+#Imports
+router.register(r"import", views.ImportViewSet, basename="import")
+
+router.register(r"clients", views.ClientViewSet, basename="clients")
+
+# Contracts
+router.register(r"contracts", views.ContractViewSet, basename="contracts")
+
+# Contract Files
+router.register(r"contract-files", views.ContractFileViewSet, basename="contract-files")
+
+# Proposals
+router.register(r"proposals", views.ProposalViewSet, basename="proposals")
+
+# Routs
+router.register(r"routes", views.RouteViewSet, basename="routes")
+
+# Recents
+router.register(r"recents", views.RecentViewedViewSet, basename="recents")
+
+# Checklists
+router.register(r"checklists", views.ChecklistViewSet, basename="checklists")
+router.register(
+    r"checklist-types", views.ChecklistTypeViewSet, basename="checklist-types"
+)
+
+# Reports
+router.register(r"reports", views.ReportViewSet, basename="reports")
+
+router.register(
+    r"checklist-catalogs", views.ChecklistCatalogViewSet, basename="checklist-catalogs"
+)
+
+router.register(r"inspections", views.InspectionViewSet, basename="inspections")
+
+router.register(r"dob-sync", views.DobSyncViewSet, basename="dob-sync")
+
+# S3 Attachments
+router.register(r"attachments", views.S3AttachmentViewSet, basename="attachments")
+
+# Documents
+# router.register(r'document-templates', views.DocumentTemplatesViewSet, basename='documentTemplates')
+
+# router.register(r'generate-document', views.DocumentGenerateViewSet, basename='documentGenerate')
+
+# mailgun webhook
+router.register(
+    r"mailgun-webhook", views.MailgunWebhookViewSet, basename="mailgunWebhook"
+)
+
+
+# automation
+router.register(
+    r"automation", views.AutomationViewSet, basename="automation"
+)
+
+# Companies
+router.register(r"contracting-companies", views.ContractingCompanyViewSet, basename="contracting-companies")
+router.register(r"witnessing-companies", views.WitnessingCompanyViewSet, basename="witnessing-companies")
+router.register(r"inspection-companies", views.InspectionCompanyViewSet, basename="inspection-companies")
+
+# ELV3
+router.register(r"elv3", views.Elv3ViewSet, basename="elv3")
+router.register(r"deficiencies", views.DeficienciesViewSet, basename="deficiencies")
+
+# Aocs
+router.register(r"aoc", views.AocViewSet, basename="aoc")
+
+router.register(r"ma-scrape", views.MAScrapeViewSet, basename="ma-scrape")
+
+router.register(r"me-email-templates", views.MaintenanceEvaluationTemplateViewSet, basename="me-email-templates")
+
+router.register(r"me-content", views.MaintenanceEvaluationContentViewSet, basename="me-content")
+
+router.register(r"me-page", views.MaintenanceEvaluationPageViewSet, basename="me-page")
+
+router.register(r"email-templates", views.EmailTemplateViewSet, basename="email-templates")
+
+router.register(r"inspectors", views.InspectorViewSet, basename="inspectors")
+
+# Reschedule Requests
+router.register(r"reschedule-requests", views.RescheduleRequestViewSet, basename="reschedule-requests")
+
+# PDF Parser
+router.register(r"pdf-parser", views.PdfParserViewSet, basename="pdf-parser")
+
+# nCourt Receipt Parser
+router.register(r"ncourt-parser", views.NcourtParserViewSet, basename="ncourt-parser")
+
+# Permits
+router.register(r"permits", views.PermitViewSet, basename="permits")
+
+# Periodic Tasks (Celery Beat)
+router.register(r"periodic-tasks", views.PeriodicTaskViewSet, basename="periodic-tasks")
+router.register(r"crontab-schedules", views.CrontabScheduleViewSet, basename="crontab-schedules")
+router.register(r"interval-schedules", views.IntervalScheduleViewSet, basename="interval-schedules")
+
+# Branches (nested under companies)
+router.register(r"contracting-companies/(?P<company_pk>\d+)/branches", views.BranchViewSet, basename="contracting-branch")
+router.register(r"witnessing-companies/(?P<company_pk>\d+)/branches", views.BranchViewSet, basename="witnessing-branch")
+
+_notification_list = views.NotificationViewSet.as_view({
+    'get': 'list',
+    'delete': 'delete_all',
+})
+_notification_detail = views.NotificationViewSet.as_view({
+    'patch': 'partial_update',
+    'delete': 'destroy',
+})
+_notification_mark_all_read = views.NotificationViewSet.as_view({
+    'post': 'mark_all_read',
+})
+
+urlpatterns = [
+    path("", include(router.urls)),
+    path("notifications/", _notification_list, name="notifications-list"),
+    path("notifications/mark-all-read/", _notification_mark_all_read, name="notifications-mark-all-read"),
+    path("notifications/test/", views.trigger_test_notification, name="notifications-test"),
+    path("notifications/<int:pk>/", _notification_detail, name="notifications-detail"),
+]

--- a/internal/custom/python/testdata/issue4369/core/tests/test_schedule_import.py
+++ b/internal/custom/python/testdata/issue4369/core/tests/test_schedule_import.py
@@ -1,0 +1,1207 @@
+"""
+Tests for the MASS Scheduled Inspection CSV Import feature.
+
+Covers:
+  1. Missing required columns
+  2. Non-MASS group rejection
+  3. Dry run with unknown inspectors
+  4. Finalize with new inspector creation
+  5. Device resolution by Device.name
+  6. Contract/client derivation
+  7. Duplicate row skipped (warning, not error)
+  8. Grouping rows into a single inspection group
+  9. Partial success when some rows fail and others succeed
+"""
+import io
+import json
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytz
+from django.test import TestCase
+from rest_framework.test import APIClient, APITestCase
+
+from core.helper.schedule_import_helper import (
+    InspectionGroupKey,
+    group_rows,
+    map_test_type_to_checklist_name,
+    normalize_row,
+    parse_csv_file,
+    resolve_checklist,
+    resolve_contract,
+    resolve_device,
+    strip_test_type_tag_suffix,
+)
+from core.models import (
+    Building,
+    Checklist,
+    Client,
+    Contract,
+    ContractDevice,
+    Device,
+    Group,
+    GroupJurisdiction,
+    Jurisdiction,
+    Role,
+    User,
+    UserGroup,
+    UserGroupRole,
+)
+
+UTC = pytz.utc
+
+# ---------------------------------------------------------------------------
+# Fixtures helpers
+# ---------------------------------------------------------------------------
+
+def make_jurisdiction(name="Massachusetts"):
+    return Jurisdiction.objects.create(
+        name=name,
+        description="Test jurisdiction",
+        is_public=False,
+    )
+
+
+def make_group(name="Test Elevator Co", jurisdiction=None):
+    group = Group.objects.create(name=name, type="1")
+    if jurisdiction:
+        GroupJurisdiction.objects.create(group=group, jurisdiction=jurisdiction)
+    return group
+
+
+def make_building(jurisdiction=None, physical_address="123 Main St"):
+    return Building.objects.create(
+        physical_address=physical_address,
+        jurisdiction=jurisdiction,
+    )
+
+
+def make_client(group):
+    return Client.objects.create(name="Test Client", group=group)
+
+
+def make_contract(group, client, building, status="active"):
+    return Contract.objects.create(
+        group=group,
+        client=client,
+        building=building,
+        status=status,
+        contract_number="CTR-001",
+        contract_type="Cat1",
+    )
+
+
+def make_device(building, name="ELV-100"):
+    return Device.objects.create(building=building, name=name)
+
+
+def make_contract_device(contract, device, status="active"):
+    return ContractDevice.objects.create(contract=contract, device=device, status=status)
+
+
+def make_inspector(group, first_name="Jane", last_name="Smith"):
+    inspector_role, _ = Role.objects.get_or_create(name="Inspector", defaults={"description": "Inspector"})
+    user = User.objects.create(
+        username=f"{first_name.lower()}.{last_name.lower()}@test.com",
+        email=f"{first_name.lower()}.{last_name.lower()}@test.com",
+        first_name=first_name,
+        last_name=last_name,
+        status="active",
+    )
+    UserGroup.objects.create(user=user, group=group)
+    UserGroupRole.objects.create(user=user, group=group, role=inspector_role)
+    return user
+
+
+def make_checklist(name="Cat1", jurisdiction=None, group=None):
+    from core.models import ChecklistType
+    ctype, _ = ChecklistType.objects.get_or_create(name=name, defaults={"description": name})
+    return Checklist.objects.create(
+        name=name,
+        description=name,
+        type=ctype,
+        jurisdiction=jurisdiction,
+        group=group,
+        status="active",
+        active=True,
+    )
+
+
+def make_csv(*rows, headers=None):
+    """Build CSV bytes from a list of row dicts."""
+    if headers is None and rows:
+        headers = list(rows[0].keys())
+    buf = io.StringIO()
+    import csv as _csv
+    writer = _csv.DictWriter(buf, fieldnames=headers)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buf.getvalue().encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing required columns
+# ---------------------------------------------------------------------------
+
+class ParseCsvFileMissingColumnsTest(TestCase):
+
+    def test_missing_test_type_column(self):
+        csv_bytes = make_csv(
+            {"Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith", "Tag# / Device ID": "ELV-100"},
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(rows, [])
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "MISSING_COLUMNS")
+        self.assertIn("test type", errors[0]["context"]["missing"])
+
+    def test_missing_device_column(self):
+        csv_bytes = make_csv(
+            {"Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith", "Test Type": "Cat1"},
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(rows, [])
+        self.assertIn("tag# / device id", errors[0]["context"]["missing"])
+
+    def test_empty_file(self):
+        rows, errors = parse_csv_file(b"")
+        self.assertEqual(rows, [])
+        self.assertEqual(errors[0]["code"], "EMPTY_FILE")
+
+    def test_valid_headers_returns_rows(self):
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026",
+                "Time": "09:00",
+                "Inspector": "Jane Smith",
+                "Tag# / Device ID": "ELV-100",
+                "Test Type": "Cat1",
+            }
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(rows), 1)
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-MASS group rejection
+# ---------------------------------------------------------------------------
+
+class NonMassGroupRejectionTest(APITestCase):
+
+    def setUp(self):
+        # Group with NO jurisdiction
+        self.non_mass_group = Group.objects.create(name="NYC Group", type="1")
+        self.user = User.objects.create(
+            username="admin@test.com", email="admin@test.com", status="active",
+            is_staff=True,
+        )
+        UserGroup.objects.create(user=self.user, group=self.non_mass_group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_non_mass_group_returns_403(self):
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00", "Inspector": "Jane Smith",
+                "Tag# / Device ID": "ELV-100", "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.non_mass_group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["code"], "NOT_MASS_JURISDICTION")
+
+
+# ---------------------------------------------------------------------------
+# 3. Dry run — unknown inspectors
+# ---------------------------------------------------------------------------
+
+class DryRunUnknownInspectorTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building)
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+
+        self.user = User.objects.create(
+            username="admin2@test.com", email="admin2@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_dry_run_returns_unknown_inspector(self, mock_get_col):
+        mock_col = MagicMock()
+        mock_col.aggregate.return_value = []
+        mock_get_col.return_value = mock_col
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "Unknown Person",
+                "Tag# / Device ID": self.device.name,
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "preview")
+        self.assertIn("Unknown Person", response.data["unknown_inspectors"])
+        row = response.data["row_results"][0]
+        self.assertEqual(row["status"], "pending_inspector")
+
+
+# ---------------------------------------------------------------------------
+# 4. Finalize — new inspector creation
+# ---------------------------------------------------------------------------
+
+class FinalizeNewInspectorTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-200")
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+
+        self.user = User.objects.create(
+            username="admin3@test.com", email="admin3@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_finalize_creates_inspector_and_returns_201(self, mock_get_col):
+        mock_ig_col = MagicMock()
+        mock_ig_col.insert_one.return_value = MagicMock(inserted_id="fake_ig_id")
+        mock_ig_col.aggregate.return_value = []
+
+        mock_i_col = MagicMock()
+        mock_i_col.bulk_write.return_value = MagicMock()
+
+        def get_col_side_effect(name):
+            if name == "inspection_groups":
+                return mock_ig_col
+            return mock_i_col
+
+        mock_get_col.side_effect = get_col_side_effect
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "New Inspector",
+                "Tag# / Device ID": "ELV-200",
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "false",
+                "inspector_emails": json.dumps({"New Inspector": "newinspector@test.com"}),
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(response.data["created_inspectors"]), 1)
+        self.assertEqual(response.data["created_inspectors"][0]["email"], "newinspector@test.com")
+        self.assertEqual(response.data["imported_count"], 1)
+
+        # Verify user was created in the DB
+        new_user = User.objects.get(email="newinspector@test.com")
+        self.assertEqual(new_user.first_name, "New")
+        self.assertEqual(new_user.last_name, "Inspector")
+        # Verify role linkage
+        self.assertTrue(
+            UserGroupRole.objects.filter(user=new_user, group=self.group, role__name="Inspector").exists()
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Device resolution by Device.name
+# ---------------------------------------------------------------------------
+
+class ResolveDeviceTest(TestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-300")
+        make_contract_device(self.contract, self.device)
+
+    def test_matches_by_name_exact(self):
+        device, errors = resolve_device("ELV-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.name, "ELV-300")
+        self.assertEqual(errors, [])
+
+    def test_matches_case_insensitive(self):
+        device, errors = resolve_device("elv-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_not_found_returns_error(self):
+        device, errors = resolve_device("NONEXISTENT", self.group.id)
+        self.assertIsNone(device)
+        self.assertEqual(errors[0]["code"], "DEVICE_NOT_FOUND")
+
+    def test_wrong_group_still_finds_device_by_name(self):
+        # resolve_device no longer filters by group in the primary query.
+        # The device is found; group/contract validation is left to resolve_contract().
+        other_group = make_group("Other Group")
+        device, errors = resolve_device("ELV-300", other_group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_inactive_contract_device_still_found_by_name(self):
+        # Contract status does not block the primary device lookup.
+        # resolve_contract() will return NO_ACTIVE_CONTRACT for the caller to handle.
+        self.device.device_contracts.update(status="inactive")
+        device, errors = resolve_device("ELV-300", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 6. Contract / client derivation
+# ---------------------------------------------------------------------------
+
+class ResolveContractTest(TestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-400")
+        self.cd = make_contract_device(self.contract, self.device)
+
+    def test_returns_contract_device_with_client(self):
+        cd, errors, warnings = resolve_contract(self.device.id, self.group.id)
+        self.assertIsNotNone(cd)
+        self.assertEqual(errors, [])
+        self.assertEqual(cd.contract.client.name, "Test Client")
+
+    def test_inactive_contract_returns_error(self):
+        self.contract.status = "inactive"
+        self.contract.save()
+        cd, errors, warnings = resolve_contract(self.device.id, self.group.id)
+        self.assertIsNone(cd)
+        self.assertEqual(errors[0]["code"], "NO_ACTIVE_CONTRACT")
+
+    def test_wrong_group_returns_error(self):
+        other_group = make_group("Other Group 2")
+        cd, errors, warnings = resolve_contract(self.device.id, other_group.id)
+        self.assertIsNone(cd)
+        self.assertEqual(errors[0]["code"], "NO_ACTIVE_CONTRACT")
+
+
+# ---------------------------------------------------------------------------
+# 7. Duplicate row — skipped with warning, not error
+# ---------------------------------------------------------------------------
+
+class DuplicateRowSkippedTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-500")
+        make_contract_device(self.contract, self.device)
+        self.checklist = make_checklist("Cat1", jurisdiction=self.jurisdiction)
+        self.inspector = make_inspector(self.group)
+
+        self.user = User.objects.create(
+            username="admin4@test.com", email="admin4@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.validate_existing_inspection")
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_duplicate_row_is_skipped_not_errored(self, mock_get_col, mock_validate):
+        mock_col = MagicMock()
+        mock_col.aggregate.return_value = []
+        mock_get_col.return_value = mock_col
+
+        # Simulate duplicate detected
+        mock_validate.return_value = (False, "An inspection of this type already exists within the specified range.")
+
+        csv_bytes = make_csv(
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": f"{self.inspector.first_name} {self.inspector.last_name}",
+                "Tag# / Device ID": "ELV-500",
+                "Test Type": "Cat1",
+            }
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "true",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 200)
+        row = response.data["row_results"][0]
+        self.assertEqual(row["status"], "skipped")
+        warning_codes = [w["code"] for w in row["warnings"]]
+        self.assertIn("DUPLICATE_INSPECTION_SKIPPED", warning_codes)
+
+
+# ---------------------------------------------------------------------------
+# 8. Row grouping — same date + inspector + building → one group
+# ---------------------------------------------------------------------------
+
+class GroupRowsTest(TestCase):
+
+    def _make_resolved_row(self, row_index, start_date_iso, inspector_id, building_id):
+        return {
+            "row_index": row_index,
+            "raw_inspector": "Jane Smith",
+            "raw_tag_number": f"ELV-{row_index}",
+            "raw_address": "",
+            "raw_company": "",
+            "resolved": {
+                "device_id": row_index,
+                "device_name": f"ELV-{row_index}",
+                "building_id": building_id,
+                "building_name": "Test Building",
+                "building_address": "123 Main St",
+                "contract_id": 1,
+                "contract_number": "CTR-001",
+                "contract_type": "Cat1",
+                "client_id": 1,
+                "client_name": "Test Client",
+                "jurisdiction_id": 1,
+                "inspector_id": inspector_id,
+                "inspector_name": "Jane Smith",
+                "checklist_id": 1,
+                "checklist_type_int": 1,
+                "checklist_name": "Cat1",
+                "start_date_iso": start_date_iso,
+                "start_time_str": "09:00:00",
+                "_start_dt": datetime(2026, 5, 1, 9, 0, 0, tzinfo=UTC),
+                "_end_dt": datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+            },
+            "errors": [],
+            "warnings": [],
+            "status": "valid",
+        }
+
+    def test_two_devices_same_date_inspector_building_are_one_group(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=10, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 1)
+        key = list(grouped.keys())[0]
+        self.assertEqual(len(grouped[key]), 2)
+
+    def test_different_buildings_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=10, building_id=6),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+    def test_different_dates_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-02", inspector_id=10, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+    def test_different_inspectors_produce_separate_groups(self):
+        rows = [
+            self._make_resolved_row(1, "2026-05-01", inspector_id=10, building_id=5),
+            self._make_resolved_row(2, "2026-05-01", inspector_id=11, building_id=5),
+        ]
+        grouped = group_rows(rows)
+        self.assertEqual(len(grouped), 2)
+
+
+# ---------------------------------------------------------------------------
+# 9. Partial success — some rows fail, others succeed
+# ---------------------------------------------------------------------------
+
+class PartialSuccessTest(APITestCase):
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(jurisdiction=self.jurisdiction)
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="ELV-600")
+        make_contract_device(self.contract, self.device)
+        make_checklist("Cat1", jurisdiction=self.jurisdiction)
+        self.inspector = make_inspector(self.group, first_name="John", last_name="Doe")
+
+        self.user = User.objects.create(
+            username="admin5@test.com", email="admin5@test.com", status="active",
+        )
+        UserGroup.objects.create(user=self.user, group=self.group)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    @patch("core.views.schedule_viewset.validate_existing_inspection")
+    @patch("core.views.schedule_viewset.MongoDBConnection.get_collection")
+    def test_one_valid_one_bad_device_returns_partial(self, mock_get_col, mock_validate):
+        mock_ig_col = MagicMock()
+        mock_ig_col.insert_one.return_value = MagicMock(inserted_id="fake_id")
+        mock_ig_col.aggregate.return_value = []
+        mock_i_col = MagicMock()
+        mock_i_col.bulk_write.return_value = MagicMock()
+
+        def get_col_side_effect(name):
+            if name == "inspection_groups":
+                return mock_ig_col
+            return mock_i_col
+
+        mock_get_col.side_effect = get_col_side_effect
+        mock_validate.return_value = (True, "Inspection can be scheduled.")
+
+        csv_bytes = make_csv(
+            # Row 1: valid
+            {
+                "Date": "05/01/2026", "Time": "09:00",
+                "Inspector": "John Doe",
+                "Tag# / Device ID": "ELV-600",
+                "Test Type": "Cat1",
+            },
+            # Row 2: bad device
+            {
+                "Date": "05/01/2026", "Time": "10:00",
+                "Inspector": "John Doe",
+                "Tag# / Device ID": "NONEXISTENT",
+                "Test Type": "Cat1",
+            },
+        )
+        response = self.client.post(
+            "/schedule/import/",
+            data={
+                "file": io.BytesIO(csv_bytes),
+                "group_id": self.group.id,
+                "dry_run": "false",
+            },
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["status"], "partial")
+        self.assertEqual(response.data["imported_count"], 1)
+        self.assertEqual(response.data["skipped_count"], 1)
+        skipped_reasons = [r["reason"] for r in response.data["skipped_rows"]]
+        self.assertIn("DEVICE_NOT_FOUND", skipped_reasons)
+
+
+# ---------------------------------------------------------------------------
+# 10. Production CSV format — headers with leading spaces, Elevator Company
+# ---------------------------------------------------------------------------
+
+class MassProductionCsvHeadersTest(TestCase):
+    """
+    Verify that headers with leading spaces (as produced by the MASS CSV
+    export) parse correctly after _norm() whitespace trimming.
+    """
+
+    def test_leading_space_headers_are_accepted(self):
+        # Headers exactly as received in production (spaces before most cols)
+        csv_bytes = (
+            b"Date, Time, Inspector, Tag #, Address, Test Type, Elevator Company\r\n"
+            b"1/5/2026,8:00,Ronald Travers,282-P-12,18 DANA HILL ROAD,Annual Inspection - 282-P-12,Otis Elevator Company-RI\r\n"
+        )
+        rows, errors = parse_csv_file(csv_bytes)
+        self.assertEqual(errors, [], msg=f"Unexpected top-level errors: {errors}")
+        self.assertEqual(len(rows), 1)
+        # Normalized keys must be present
+        row = rows[0]
+        self.assertIn("tag #", row)
+        self.assertIn("test type", row)
+        self.assertIn("elevator company", row)
+
+    def test_elevator_company_maps_to_raw_company(self):
+        """normalize_row() must populate raw_company from 'elevator company'."""
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "18 DANA HILL ROAD, STERLING",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "Otis Elevator Company-RI",
+        }
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["raw_company"], "Otis Elevator Company-RI")
+
+    def test_blank_elevator_company_does_not_crash(self):
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "",
+        }
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["raw_company"], "")
+        # No error from blank optional fields
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("MISSING_INSPECTOR", error_codes)
+
+
+# ---------------------------------------------------------------------------
+# 11. Test-type keyword mapping
+# ---------------------------------------------------------------------------
+
+class MapTestTypeTest(TestCase):
+    """Unit tests for map_test_type_to_checklist_name()."""
+
+    # --- "Annual Inspection" variants → Cat1 ---
+
+    def test_annual_inspection_plain(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Inspection")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_annual_inspection_with_tag_suffix(self):
+        # Production value: "Annual Inspection - 282-P-12"
+        name, unsupported = map_test_type_to_checklist_name("Annual Inspection - 282-P-12")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_annual_inspection_case_insensitive(self):
+        name, unsupported = map_test_type_to_checklist_name("ANNUAL INSPECTION - ELV")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    # --- "Annual Weight Test" variants → Cat5 ---
+
+    def test_annual_weight_test_plain(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Weight Test")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_annual_weight_test_with_tag_suffix(self):
+        name, unsupported = map_test_type_to_checklist_name("Annual Weight Test - 282-P-12")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_annual_weight_test_not_swallowed_by_annual_inspection(self):
+        # "annual weight test" contains "annual" but must NOT resolve to Cat1.
+        name, _ = map_test_type_to_checklist_name("Annual Weight Test")
+        self.assertEqual(name, "Cat5", msg="'annual weight test' must map to Cat5, not Cat1")
+
+    # --- "90 Day Annual" → unsupported (skip, not error) ---
+
+    def test_90_day_annual_is_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("90 Day Annual")
+        self.assertIsNone(name)
+        self.assertTrue(unsupported)
+
+    def test_90_day_annual_with_suffix_is_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("90 Day Annual - 282-P-12")
+        self.assertIsNone(name)
+        self.assertTrue(unsupported)
+
+    # --- Existing short-form values still resolve (backward compat) ---
+
+    def test_exact_cat1_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("Cat1")
+        self.assertEqual(name, "Cat1")
+        self.assertFalse(unsupported)
+
+    def test_exact_five_year_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("5 year")
+        self.assertEqual(name, "Cat5")
+        self.assertFalse(unsupported)
+
+    def test_periodic_still_works(self):
+        name, unsupported = map_test_type_to_checklist_name("Periodic")
+        self.assertEqual(name, "Periodic")
+        self.assertFalse(unsupported)
+
+    # --- Completely unknown → error signal ---
+
+    def test_unknown_returns_none_not_unsupported(self):
+        name, unsupported = map_test_type_to_checklist_name("Biennial Safety Check")
+        self.assertIsNone(name)
+        self.assertFalse(unsupported)
+
+
+# ---------------------------------------------------------------------------
+# 12. normalize_row — production CSV values end-to-end
+# ---------------------------------------------------------------------------
+
+class NormalizeRowProductionValuesTest(TestCase):
+    """
+    normalize_row() behaviour with the exact field values from the
+    production MASS CSV (already normalized to lowercase keys by
+    parse_csv_file → _norm()).
+    """
+
+    def _base_row(self, **overrides):
+        row = {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": "282-P-12",
+            "address": "18 DANA HILL ROAD, STERLING",
+            "test type": "Annual Inspection - 282-P-12",
+            "elevator company": "Otis Elevator Company-RI",
+        }
+        row.update(overrides)
+        return row
+
+    def test_annual_inspection_resolves_to_cat1(self):
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_annual_weight_test_resolves_to_cat5(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "Annual Weight Test - 282-P-12"}),
+            row_index=1,
+        )
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_90_day_annual_is_skipped_not_errored(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "90 Day Annual - 282-P-12"}),
+            row_index=1,
+        )
+        self.assertEqual(result["status"], "skipped")
+        warning_codes = [w["code"] for w in result["warnings"]]
+        self.assertIn("UNSUPPORTED_TEST_TYPE", warning_codes)
+        # Must NOT be in errors — other rows should not be blocked
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("UNKNOWN_TEST_TYPE", error_codes)
+
+    def test_unknown_test_type_is_error(self):
+        result = normalize_row(
+            self._base_row(**{"test type": "Completely Unknown Type XYZ"}),
+            row_index=1,
+        )
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("UNKNOWN_TEST_TYPE", error_codes)
+
+    def test_missing_inspector_is_error(self):
+        result = normalize_row(self._base_row(inspector=""), row_index=1)
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("MISSING_INSPECTOR", error_codes)
+
+    def test_missing_tag_number_is_error(self):
+        row = self._base_row()
+        row["tag #"] = ""
+        result = normalize_row(row, row_index=1)
+        self.assertEqual(result["status"], "error")
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertIn("MISSING_TAG_NUMBER", error_codes)
+
+    def test_blank_address_and_company_do_not_error(self):
+        result = normalize_row(
+            self._base_row(address="", **{"elevator company": ""}),
+            row_index=1,
+        )
+        self.assertEqual(result["raw_address"], "")
+        self.assertEqual(result["raw_company"], "")
+        # Should still be valid (optional fields)
+        self.assertEqual(result["status"], "valid")
+
+    def test_date_parses_m_d_yyyy(self):
+        """1/5/2026 (no zero-padding) must parse correctly."""
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["start_date_iso"], "2026-01-05")
+
+    def test_time_parses_h_mm(self):
+        """8:00 (no zero-padding on hour) must parse correctly."""
+        result = normalize_row(self._base_row(), row_index=1)
+        self.assertEqual(result["resolved"]["start_time_str"], "08:00:00")
+
+
+# ---------------------------------------------------------------------------
+# 13. resolve_device — new name-first lookup behaviour
+# ---------------------------------------------------------------------------
+
+class ResolveDeviceNameFirstTest(TestCase):
+    """
+    Verify that resolve_device finds devices by name without requiring an
+    active contract, and uses the contract / address only for disambiguation
+    when multiple devices share the same name.
+    """
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+        self.building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="18 DANA HILL ROAD, STERLING",
+        )
+        self.client_obj = make_client(self.group)
+        self.contract = make_contract(self.group, self.client_obj, self.building)
+        self.device = make_device(self.building, name="282-P-12")
+        make_contract_device(self.contract, self.device)
+
+    def test_finds_device_by_name_with_active_contract(self):
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.name, "282-P-12")
+        self.assertEqual(errors, [])
+
+    def test_finds_device_even_when_contract_device_inactive(self):
+        """Contract status must not block the primary name lookup."""
+        self.device.device_contracts.update(status="inactive")
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_finds_device_for_wrong_group(self):
+        """Device IS returned; the group mismatch surfaces via resolve_contract."""
+        other_group = make_group("Other Group MASS")
+        device, errors = resolve_device("282-P-12", other_group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_not_found_returns_device_not_found(self):
+        device, errors = resolve_device("NONEXISTENT-TAG", self.group.id)
+        self.assertIsNone(device)
+        self.assertEqual(errors[0]["code"], "DEVICE_NOT_FOUND")
+
+    def test_whitespace_in_tag_is_trimmed(self):
+        device, errors = resolve_device("  282-P-12  ", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_case_insensitive_match(self):
+        device, errors = resolve_device("282-p-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(errors, [])
+
+    def test_ambiguous_disambiguated_by_group_contract(self):
+        """
+        Two devices share the same name; the one linked to the uploading group's
+        active contract should be returned.
+        """
+        other_building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="99 OTHER STREET, BOSTON",
+        )
+        other_group = make_group("Other Group MASS 2")
+        other_client = make_client(other_group)
+        other_contract = make_contract(other_group, other_client, other_building)
+        other_device = make_device(other_building, name="282-P-12")
+        make_contract_device(other_contract, other_device)
+
+        device, errors = resolve_device("282-P-12", self.group.id)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.id, self.device.id)
+        self.assertEqual(errors, [])
+
+    def test_ambiguous_disambiguated_by_address(self):
+        """
+        Two devices share the same name AND same group — address breaks the tie.
+        """
+        other_building = make_building(
+            jurisdiction=self.jurisdiction,
+            physical_address="99 OTHER STREET, BOSTON",
+        )
+        other_client = make_client(self.group)
+        other_contract = make_contract(self.group, other_client, other_building)
+        other_device = make_device(other_building, name="282-P-12")
+        make_contract_device(other_contract, other_device)
+
+        device, errors = resolve_device(
+            "282-P-12", self.group.id,
+            raw_address="18 DANA HILL ROAD, STERLING",
+        )
+        self.assertIsNotNone(device)
+        self.assertEqual(device.id, self.device.id)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 14. resolve_checklist — type__name__iexact lookup
+# ---------------------------------------------------------------------------
+
+class ResolveChecklistByTypeTest(TestCase):
+    """
+    Verify that resolve_checklist finds checklists by their ChecklistType.name
+    (e.g. 'CAT1', 'CAT5') rather than by the Checklist display name.
+    This handles production DBs where checklists are named arbitrarily but
+    their type is always the stable semantic identifier.
+    """
+
+    def setUp(self):
+        self.jurisdiction = make_jurisdiction()
+        self.group = make_group(jurisdiction=self.jurisdiction)
+
+    def _make_checklist_with_type(self, type_name, checklist_name, jurisdiction=None):
+        from core.models import ChecklistType
+        ctype, _ = ChecklistType.objects.get_or_create(
+            name=type_name, defaults={"description": type_name}
+        )
+        return Checklist.objects.create(
+            name=checklist_name,
+            description=checklist_name,
+            type=ctype,
+            jurisdiction=jurisdiction or self.jurisdiction,
+            status="active",
+            active=True,
+        )
+
+    def test_finds_checklist_when_type_name_is_uppercase_cat1(self):
+        """ChecklistType.name='CAT1' must match canonical name 'Cat1' via iexact."""
+        self._make_checklist_with_type("CAT1", "Annual Inspection Checklist")
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_finds_checklist_when_type_name_is_uppercase_cat5(self):
+        self._make_checklist_with_type("CAT5", "Weight Test Checklist")
+        checklist, errors = resolve_checklist("Cat5", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_finds_checklist_with_custom_display_name(self):
+        """Display name 'Cat1 ELV3 Checklist' should still resolve for type Cat1."""
+        self._make_checklist_with_type("CAT1", "Cat1 ELV3 Checklist")
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_returns_error_when_no_checklist_for_jurisdiction(self):
+        """Correct error code when no checklist is configured for this jurisdiction."""
+        other_jurisdiction = make_jurisdiction("New York")
+        self._make_checklist_with_type("CAT1", "Cat1", jurisdiction=other_jurisdiction)
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNone(checklist)
+        self.assertEqual(errors[0]["code"], "CHECKLIST_NOT_FOUND")
+
+    def test_annual_inspection_maps_to_cat1_checklist(self):
+        """
+        End-to-end: 'Annual Inspection - tag' → canonical 'Cat1' →
+        resolve_checklist finds checklist by ChecklistType.name='CAT1'.
+        """
+        self._make_checklist_with_type("CAT1", "Mass Annual Inspection")
+        # normalize_row maps "Annual Inspection - ..." to "Cat1"
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "Annual Inspection - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+
+        checklist, errors = resolve_checklist("Cat1", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+    def test_annual_weight_test_maps_to_cat5_checklist(self):
+        self._make_checklist_with_type("CAT5", "Mass Weight Test")
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "Annual Weight Test - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+
+        checklist, errors = resolve_checklist("Cat5", self.jurisdiction.id)
+        self.assertIsNotNone(checklist)
+        self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 15. 90-day annual rows are skipped before resolution (no DB side effects)
+# ---------------------------------------------------------------------------
+
+class NinetyDayAnnualSkippedBeforeResolutionTest(TestCase):
+    """
+    Rows with unsupported test type ('90 Day Annual') must be marked 'skipped'
+    by normalize_row() and must NOT reach device/checklist resolution.
+    The view-level guard (status in ('error', 'skipped')) prevents spurious
+    DEVICE_NOT_FOUND / CHECKLIST_NOT_FOUND errors on these rows.
+    """
+
+    def test_normalize_row_marks_90_day_as_skipped(self):
+        row = {
+            "date": "1/5/2026", "time": "8:00",
+            "inspector": "Ronald Travers", "tag #": "282-P-12",
+            "test type": "90 Day Annual - 282-P-12",
+        }
+        result = normalize_row(row, 1)
+        self.assertEqual(result["status"], "skipped")
+        warning_codes = [w["code"] for w in result["warnings"]]
+        self.assertIn("UNSUPPORTED_TEST_TYPE", warning_codes)
+        error_codes = [e["code"] for e in result["errors"]]
+        self.assertNotIn("UNKNOWN_TEST_TYPE", error_codes)
+        self.assertNotIn("DEVICE_NOT_FOUND", error_codes)
+        self.assertNotIn("CHECKLIST_NOT_FOUND", error_codes)
+
+
+# ---------------------------------------------------------------------------
+# 16. strip_test_type_tag_suffix — unit tests
+# ---------------------------------------------------------------------------
+
+class StripTestTypeSuffixTest(TestCase):
+    """
+    Unit tests for strip_test_type_tag_suffix().
+
+    The function must strip the device-tag suffix embedded in Test Type values
+    ("<type text> - <tag>") so only the semantic type text is passed to the
+    inspection-type mapper.
+    """
+
+    def test_annual_inspection_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-P-12", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_annual_weight_test_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Weight Test - 282-P-12", "282-P-12"),
+            "Annual Weight Test",
+        )
+
+    def test_90_day_annual_with_tag(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("90 Day Annual - 282-P-12", "282-P-12"),
+            "90 Day Annual",
+        )
+
+    def test_no_tag_suffix_returns_original(self):
+        """Plain values like 'Cat1' or 'Periodic' pass through unchanged."""
+        self.assertEqual(strip_test_type_tag_suffix("Cat1", "282-P-12"), "Cat1")
+        self.assertEqual(strip_test_type_tag_suffix("Periodic", "ELV-999"), "Periodic")
+
+    def test_empty_tag_returns_original(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-P-12", ""),
+            "Annual Inspection - 282-P-12",
+        )
+
+    def test_case_insensitive_suffix_match(self):
+        """Tag casing difference between columns must be tolerated."""
+        self.assertEqual(
+            strip_test_type_tag_suffix("Annual Inspection - 282-p-12", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_extra_whitespace_is_trimmed(self):
+        self.assertEqual(
+            strip_test_type_tag_suffix("  Annual Inspection - 282-P-12  ", "282-P-12"),
+            "Annual Inspection",
+        )
+
+    def test_partial_match_not_stripped(self):
+        """Only a true suffix match strips; a mid-string occurrence is left alone."""
+        self.assertEqual(
+            strip_test_type_tag_suffix("282-P-12 Annual Inspection - OTHER", "282-P-12"),
+            "282-P-12 Annual Inspection - OTHER",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 17. normalize_row — full tag-suffix stripping end-to-end
+# ---------------------------------------------------------------------------
+
+class NormalizeRowTagSuffixStrippingTest(TestCase):
+    """
+    Verify that normalize_row() strips the device-tag suffix from the raw
+    Test Type field before performing inspection-type mapping.
+    """
+
+    def _row(self, test_type, tag="282-P-12"):
+        return {
+            "date": "1/5/2026",
+            "time": "8:00",
+            "inspector": "Ronald Travers",
+            "tag #": tag,
+            "test type": test_type,
+        }
+
+    def test_annual_inspection_suffix_resolves_to_cat1(self):
+        result = normalize_row(self._row("Annual Inspection - 282-P-12"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_annual_weight_test_suffix_resolves_to_cat5(self):
+        result = normalize_row(self._row("Annual Weight Test - 282-P-12"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_90_day_annual_suffix_is_skipped(self):
+        result = normalize_row(self._row("90 Day Annual - 282-P-12"), row_index=1)
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("UNSUPPORTED_TEST_TYPE", [w["code"] for w in result["warnings"]])
+
+    def test_plain_cat1_without_suffix_still_works(self):
+        """Backward compat: existing short-form values must still resolve."""
+        result = normalize_row(self._row("Cat1"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")
+        self.assertEqual(result["status"], "valid")
+
+    def test_plain_5_year_without_suffix_still_works(self):
+        result = normalize_row(self._row("5 year"), row_index=1)
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat5")
+        self.assertEqual(result["status"], "valid")
+
+    def test_unknown_cleaned_type_returns_error(self):
+        """After stripping the suffix, if the type is still unknown → UNKNOWN_TEST_TYPE."""
+        result = normalize_row(self._row("Biennial Safety Check - 282-P-12"), row_index=1)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("UNKNOWN_TEST_TYPE", [e["code"] for e in result["errors"]])
+
+    def test_different_tag_number_not_stripped(self):
+        """Suffix only stripped when it matches the Tag # column value."""
+        # Tag # is "ELV-999", test type ends with "282-P-12" — no match, no strip
+        result = normalize_row(self._row("Annual Inspection - 282-P-12", tag="ELV-999"), row_index=1)
+        # "Annual Inspection - 282-P-12" does NOT end with "ELV-999", so it
+        # passes through as-is, which still maps to Cat1 via substring match
+        self.assertEqual(result["resolved"]["checklist_name"], "Cat1")

--- a/internal/custom/python/testdata/issue4369/core/views/schedule_viewset.py
+++ b/internal/custom/python/testdata/issue4369/core/views/schedule_viewset.py
@@ -1,0 +1,23 @@
+# Byte-derived trim of core/views/schedule_viewset.py from the upvate_core
+# legacy Django backend, kept to the declarations the DRF route synthesizer
+# reads: the ScheduleViewset class header and the @action(url_path="import")
+# method whose route the test file exercises. Verbatim copies of the real
+# decorators/signatures; method bodies elided.
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class ScheduleViewset(viewsets.ModelViewSet):
+
+    serializer_class = DeviceSerializer
+    pagination_class = LimitOffsetPagination
+    http_method_names = ['get', 'post', 'put', 'delete']
+
+    def retrieve(self, request, pk=None, **kwargs):
+        return None
+
+    @action(detail=False, methods=["post"], url_path="import", url_name="import")
+    def import_csv(self, request):
+        """Import a MASS scheduled inspection CSV."""
+        return None

--- a/internal/engine/http_endpoint_e2e_testmap.go
+++ b/internal/engine/http_endpoint_e2e_testmap.go
@@ -58,9 +58,20 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// testSuiteKind is the entity Kind the Jest extractor stamps on the one
-// suite-per-spec node (see internal/custom/javascript/jest.go).
+// testSuiteKind is the canonical test_suite marker. The Jest extractor and the
+// Python pytest/unittest extractor both label their one-suite-per-file node
+// with this string, but they put it in DIFFERENT fields: Jest emits
+// Kind="SCOPE.Operation" Subtype="test_suite" and the Python extractor emits
+// Kind="SCOPE.Pattern" Subtype="test_suite". Resolve-side hand-built fixtures
+// set it directly as Kind. isTestSuiteEntity accepts any of these so the pass
+// fires on live extractor output (#4351/#4369).
 const testSuiteKind = "test_suite"
+
+// isTestSuiteEntity reports whether e is a one-per-file test suite node,
+// matching the marker in EITHER Kind or Subtype (see testSuiteKind).
+func isTestSuiteEntity(e *types.EntityRecord) bool {
+	return e.Kind == testSuiteKind || e.Subtype == testSuiteKind
+}
 
 // linkE2ERouteTestsToEndpoints walks every test_suite carrying an
 // `e2e_route_calls` property and emits a TESTS edge to each
@@ -75,7 +86,7 @@ func linkE2ERouteTestsToEndpoints(
 	emitted := 0
 	for i := range merged {
 		s := &merged[i]
-		if s.Kind != testSuiteKind || s.Properties == nil {
+		if !isTestSuiteEntity(s) || s.Properties == nil {
 			continue
 		}
 		raw := s.Properties["e2e_route_calls"]

--- a/internal/engine/http_endpoint_e2e_testmap_4369_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4369_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the pytest extractor so the suite (with e2e_route_calls) comes
+	// from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+)
+
+// Issue #4369 LIVE-REPRO (resolve side, full in-pipeline).
+//
+// Proves end-to-end that a Python DRF/Django API test calling a route by string
+// links to the http_endpoint_definition it exercises — the finer-grained
+// endpoint-level TESTS edge that complements the ViewSet-class TESTS edge
+// ApplyTestsMultiHopViaHTTP (#2549) already produces, exactly mirroring the
+// NestJS/supertest distinction in #4351.
+//
+// Pipeline (all REAL passes, byte-copies of upvate_core sources):
+//  1. ApplyDjangoDRFRoutes over byte-copied core/routers.py + the ScheduleViewset
+//     trim → the real http_endpoint entities (incl. POST /schedule/import).
+//  2. The real pytest extractor over byte-copied core/tests/test_schedule_import.py
+//     → the one-per-file test_suite carrying e2e_route_calls
+//     (POST /schedule/import/).
+//  3. ResolveHTTPEndpointHandlers over the merged set → migrates http_endpoint to
+//     http_endpoint_definition, builds the endpoint index, and runs the shared
+//     linkE2ERouteTestsToEndpoints pass.
+//
+// BEFORE #4369 the suite carried no e2e_route_calls, so no TESTS→endpoint edge
+// existed. AFTER, the suite links to exactly POST /schedule/import.
+func TestIssue4369_PythonE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	root := filepath.Join("..", "custom", "python", "testdata", "issue4369")
+	reader := func(p string) []byte {
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(p)))
+		if err != nil {
+			return nil
+		}
+		return b
+	}
+
+	// 1. Real DRF route synthesis.
+	endpointFiles := []string{"core/routers.py", "core/views/schedule_viewset.py"}
+	defs := ApplyDjangoDRFRoutes(endpointFiles, reader)
+	if len(defs) == 0 {
+		t.Fatal("DRF synthesis produced no endpoints")
+	}
+
+	// 2. Real pytest extractor over the real DRF test file → the suite.
+	pe, ok := extreg.Get("python_pytest")
+	if !ok {
+		t.Fatal("python_pytest not registered")
+	}
+	testSrc := reader("core/tests/test_schedule_import.py")
+	if len(testSrc) == 0 {
+		t.Fatal("could not read byte-copied DRF test file")
+	}
+	suiteEnts, err := pe.Extract(context.Background(), extreg.FileInput{
+		Path: "core/tests/test_schedule_import.py", Language: "python", Content: testSrc,
+	})
+	if err != nil {
+		t.Fatalf("pytest extract: %v", err)
+	}
+	var suite *types.EntityRecord
+	for i := range suiteEnts {
+		if suiteEnts[i].Subtype == "test_suite" {
+			suite = &suiteEnts[i]
+			break
+		}
+	}
+	if suite == nil {
+		t.Fatal("pytest extractor emitted no test_suite")
+	}
+	if suite.Properties["e2e_route_calls"] == "" {
+		t.Fatal("suite carries no e2e_route_calls — extractor side regressed (#4369)")
+	}
+
+	// Build the merged set: every real endpoint + the real suite.
+	merged := make([]types.EntityRecord, 0, len(defs)+1)
+	merged = append(merged, defs...)
+	merged = append(merged, *suite)
+
+	// BEFORE control: strip e2e_route_calls — no TESTS→endpoint edges.
+	before := make([]types.EntityRecord, len(merged))
+	copy(before, merged)
+	beforeSuite := *suite
+	beforeProps := map[string]string{}
+	for k, v := range suite.Properties {
+		if k != "e2e_route_calls" {
+			beforeProps[k] = v
+		}
+	}
+	beforeSuite.Properties = beforeProps
+	before[len(before)-1] = beforeSuite
+	beforeOut, beforeStats := ResolveHTTPEndpointHandlers(before)
+	if beforeStats.E2ERouteTestEdges != 0 {
+		t.Fatalf("control (no e2e_route_calls) E2ERouteTestEdges=%d, want 0", beforeStats.E2ERouteTestEdges)
+	}
+	if got := countSuiteEndpointTestsEdges(beforeOut); got != 0 {
+		t.Fatalf("control must emit 0 suite→endpoint TESTS edges, got %d", got)
+	}
+
+	// AFTER: the route calls drive a TESTS edge to POST /schedule/import.
+	afterOut, afterStats := ResolveHTTPEndpointHandlers(merged)
+	if afterStats.E2ERouteTestEdges == 0 {
+		t.Fatalf("expected >=1 e2e route TESTS edge from the Python suite, got 0")
+	}
+
+	// The edge must target the POST /schedule/import endpoint definition.
+	wantTarget := false
+	for _, e := range afterOut {
+		if e.Subtype != "test_suite" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindTests) {
+				continue
+			}
+			if r.Properties["match_source"] != "e2e_supertest_route" {
+				continue
+			}
+			// ToID is "<defKind>:<defName>"; defName is the SyntheticID
+			// "http:POST:/schedule/import".
+			if strings.Contains(r.ToID, "POST:/schedule/import") {
+				wantTarget = true
+			}
+			// Framework attributed from the suite, not hard-coded jest.
+			if fw := r.Properties["framework"]; fw == "jest" {
+				t.Errorf("Python suite TESTS edge mislabeled framework=%q", fw)
+			}
+		}
+	}
+	if !wantTarget {
+		t.Fatalf("no TESTS edge from the Python suite to POST /schedule/import (edges=%d)",
+			afterStats.E2ERouteTestEdges)
+	}
+
+	t.Logf("#4369 endpoint-level TESTS edges from real DRF suite: before=0 after=%d",
+		afterStats.E2ERouteTestEdges)
+}
+
+// countSuiteEndpointTestsEdges counts e2e route-test TESTS edges (match_source
+// e2e_supertest_route) emitted from any test_suite to an endpoint definition.
+func countSuiteEndpointTestsEdges(ents []types.EntityRecord) int {
+	n := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				r.Properties["match_source"] == "e2e_supertest_route" {
+				n++
+			}
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

Python API test clients — DRF `APIClient` / Django test `Client`, FastAPI/Starlette `TestClient`, Flask `test_client`, and `httpx`/`requests` in tests — call routes by string (`self.client.post('/api/v1/inspections/123/items')`) but produced **no TESTS edge to the `http_endpoint_definition`** they exercise. This generalizes the NestJS/supertest fix #4351 to Python.

It **complements** the existing #2549 linkage (which links such calls to the ViewSet **class** via the ROUTES_TO graph) with the finer-grained edge to the specific **verb+route endpoint definition** — exactly the #4351 distinction.

## How it works

**Extractor (`internal/custom/python/pytest.go`)** — captures every test-client `<receiver>.<verb>('/route')` call and stamps the `VERB route` pairs onto the one-per-file `test_suite`'s `e2e_route_calls` property (the same property the Jest extractor stamps). The receiver is gated to recognised test-client / HTTP-library tokens so `cache.get(...)` / `logger.get(...)` never produce phantom routes. Routes are normalised to a path; concrete (`/x/123`) and f-string template (`/x/{id}`) params are preserved; interpolated-base-URL f-strings (`f"{BASE}/x"`) are dropped (conservative).

**Resolver** — the shared `linkE2ERouteTestsToEndpoints` pass from #4351 is **reused unchanged** for matching (it already wildcards `{id}`/`:id`/`<int:id>` and tolerates the `/api/vN` prefix). The only resolver change generalises the suite gate from `Kind=="test_suite"` to `Kind || Subtype=="test_suite"` (`isTestSuiteEntity`): the real Jest **and** pytest extractors carry the marker in `Subtype` while `Kind` is the structural bucket (`SCOPE.Operation`/`SCOPE.Pattern`), so the pass now fires on **live extractor output**, not just hand-built fixtures — this also activates the JS/supertest path end-to-end. Framework is attributed from the suite (`pytest`/`unittest`), not hard-coded `jest`. Unique verb+route match only.

## Live validation (byte-copies of the real upvate_core legacy Django backend)

- **Extractor test**: asserts `self.client.post("/schedule/import/")` is captured from the real DRF `APITestCase`, plus per-framework coverage (DRF/FastAPI/Flask/httpx+requests) with negative cases.
- **In-pipeline resolve test**: runs the **real** `ApplyDjangoDRFRoutes` over the real `core/routers.py` + `ScheduleViewset` trim (synthesizing `POST /schedule/import`) plus the **real** pytest extractor's suite through `ResolveHTTPEndpointHandlers`. Endpoint-level TESTS edge: **before = 0, after = 1**, targeting exactly `POST /schedule/import`.

## Coverage / follow-ups

- Covered: DRF/Django `Client`, FastAPI/Starlette `TestClient`, Flask `test_client`, `httpx`/`requests` literal-string routes.
- Deferred (ref epic #4334): `reverse('name', args=[...])` name resolution — those routes are not leading-slash paths so they're skipped, not mis-linked.

## Gates

`go build ./...` ✓ · `go vet ./...` ✓ · `go test ./internal/custom/python/ ./internal/engine/` ✓ (incl. the #4351 suite, still green).

Closes #4369

🤖 Generated with [Claude Code](https://claude.com/claude-code)