### PR TITLE
Link Spring integration-test route-by-string calls to their endpoint definitions

### DIFF
--- a/internal/custom/java/issue4370_spring_e2e_route_tests_test.go
+++ b/internal/custom/java/issue4370_spring_e2e_route_tests_test.go
@@ -1,0 +1,228 @@
+package java_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/java"
+)
+
+// Issue #4370 LIVE-REPRO (extractor side).
+//
+// Spring integration tests (MockMvc / WebTestClient / TestRestTemplate / REST
+// Assured) call routes by string but produced NO link to the
+// http_endpoint_definition they exercise. This mirrors the NestJS/supertest fix
+// #4351 and the Python fix #4369: the JUnit/TestNG extractor (ExtractJUnit5)
+// now captures every Spring test-client `<verb>("/route")` call and stamps the
+// `VERB route` pairs onto the one-per-file test_suite's `e2e_route_calls`
+// property — the raw material the shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints) turns into TESTS→http_endpoint_definition
+// edges.
+
+func extractJava4370(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_java_patterns")
+	if !ok {
+		t.Fatal("custom_java_patterns not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return ents
+}
+
+func suiteRouteCalls4370(t *testing.T, ents []types.EntityRecord) []string {
+	t.Helper()
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			raw := e.Properties["e2e_route_calls"]
+			if raw == "" {
+				return nil
+			}
+			return strings.Split(raw, "\n")
+		}
+	}
+	return nil
+}
+
+// TestIssue4370_SpringTestClientCoverage exercises every required Spring test
+// client — MockMvc, WebTestClient, TestRestTemplate, REST Assured — asserting
+// each verb+route is captured, and that non-path / variable-built routes are
+// NOT captured (conservative).
+func TestIssue4370_SpringTestClientCoverage(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "mockmvc",
+			src: `package com.example.web;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+class InspectionControllerTest {
+    @Autowired MockMvc mockMvc;
+    @Test
+    void createsItem() throws Exception {
+        mockMvc.perform(post("/api/v1/inspections/123/items").content("{}"))
+               .andExpect(status().isCreated());
+    }
+    @Test
+    void getsOne() throws Exception {
+        mockMvc.perform(get("/api/v1/inspections/123"))
+               .andExpect(status().isOk());
+    }
+}
+`,
+			want: []string{"POST /api/v1/inspections/123/items", "GET /api/v1/inspections/123"},
+		},
+		{
+			name: "webtestclient",
+			src: `package com.example.web;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+class InspectionRouterTest {
+    @Autowired WebTestClient webTestClient;
+    @Test
+    void createsItem() {
+        webTestClient.post().uri("/inspections/{id}/items", 7).exchange()
+                     .expectStatus().isCreated();
+    }
+    @Test
+    void getsOne() {
+        webTestClient.get().uri("/inspections/7").exchange()
+                     .expectStatus().isOk();
+    }
+}
+`,
+			want: []string{"POST /inspections/{id}/items", "GET /inspections/7"},
+		},
+		{
+			name: "testresttemplate",
+			src: `package com.example.web;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpEntity;
+
+class InspectionIntegrationTest {
+    @Autowired TestRestTemplate restTemplate;
+    @Test
+    void getsOne() {
+        restTemplate.getForEntity("/inspections/1", String.class);
+    }
+    @Test
+    void posts() {
+        restTemplate.postForObject("/inspections", new HttpEntity<>("{}"), String.class);
+    }
+    @Test
+    void exchanges() {
+        restTemplate.exchange("/inspections/5", HttpMethod.DELETE, HttpEntity.EMPTY, Void.class);
+    }
+}
+`,
+			want: []string{"GET /inspections/1", "POST /inspections", "DELETE /inspections/5"},
+		},
+		{
+			name: "restassured",
+			src: `package com.example.web;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+
+class InspectionApiTest {
+    @Test
+    void getsOne() {
+        given().when().get("/inspections/9").then().statusCode(200);
+    }
+    @Test
+    void posts() {
+        given().body("{}").when().post("/inspections").then().statusCode(201);
+    }
+}
+`,
+			want: []string{"GET /inspections/9", "POST /inspections"},
+		},
+		{
+			name: "conservative_non_path_dropped",
+			src: `package com.example.web;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.util.UriComponentsBuilder;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+class BuiltUrlTest {
+    MockMvc mockMvc;
+    @Test
+    void builtUrl() throws Exception {
+        String url = UriComponentsBuilder.fromPath("/x").build().toUriString();
+        mockMvc.perform(get(url));
+        mockMvc.perform(post("/real/path"));
+    }
+}
+`,
+			want:    []string{"POST /real/path"},
+			notWant: []string{"GET url", "GET x"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ents := extractJava4370(t, "src/test/java/com/example/web/"+tc.name+"Test.java", tc.src)
+			calls := suiteRouteCalls4370(t, ents)
+			joined := strings.Join(calls, "|")
+			for _, w := range tc.want {
+				found := false
+				for _, c := range calls {
+					if c == w {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected %q captured, got=%v", w, calls)
+				}
+			}
+			for _, nw := range tc.notWant {
+				if strings.Contains(joined, nw) {
+					t.Errorf("did NOT expect %q captured, got=%v", nw, calls)
+				}
+			}
+		})
+	}
+}
+
+// TestIssue4370_NonHTTPGetNotCaptured proves a plain map/collection `.get(...)`
+// inside a test never produces a phantom route (the route arg is not a
+// leading-slash path so it is dropped).
+func TestIssue4370_NonHTTPGetNotCaptured(t *testing.T) {
+	const src = `package com.example;
+import org.junit.jupiter.api.Test;
+
+class CacheTest {
+    @Test
+    void usesMap() {
+        java.util.Map<String,String> m = new java.util.HashMap<>();
+        m.put("k", "v");
+        m.get("k");
+        cache.get("some-key");
+    }
+}
+`
+	ents := extractJava4370(t, "src/test/java/com/example/CacheTest.java", src)
+	calls := suiteRouteCalls4370(t, ents)
+	if len(calls) != 0 {
+		t.Errorf("expected NO route calls from non-HTTP gets, got=%v", calls)
+	}
+}

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -125,6 +125,67 @@ var (
 	// count only (the per-assertion orphan nodes are the worst offender).
 	j5AssertionRE = regexp.MustCompile(
 		`(?m)\b(assert\w*|fail|verify|expectThrows|assertThrows)\s*\(`)
+
+	// ── Spring integration-test route-by-string capture (#4370) ──────────────
+	// Spring integration tests drive the app through HTTP by passing the route
+	// as a STRING to a test client, but no edge ever connected that route string
+	// to the http_endpoint_definition it exercises. These four patterns capture
+	// (verb, route) pairs that the shared resolve pass
+	// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches against the
+	// cross-file endpoint index. Route templates carry Spring `{id}` placeholders
+	// and concrete ids alike — the resolver wildcards both.
+
+	// MockMvc: mockMvc.perform(post("/api/v1/inspections/123/items").content(...))
+	// The verb comes from the statically-imported MockMvcRequestBuilders factory
+	// (get/post/put/delete/patch), the route from its first string argument. The
+	// factory call sits inside perform(...) so we anchor on `perform(` to avoid
+	// capturing an unrelated `post(` helper. The route literal is the first
+	// argument; any UriComponentsBuilder / variable arg (non-quoted) is skipped
+	// downstream (route must start with `/`).
+	j5MockMvcRE = regexp.MustCompile(
+		`\.perform\s*\(\s*(get|post|put|delete|patch)\s*\(\s*"([^"\n\r]+)"`)
+
+	// WebTestClient: webTestClient.post().uri("/inspections/{id}", id).exchange()
+	// The verb is the method invoked on the client BEFORE `.uri(...)`; the route
+	// is the first string argument to `.uri(...)`. We capture the verb and route
+	// in one pass: `.<verb>()` immediately (allowing whitespace/newlines)
+	// followed by `.uri("...")`.
+	j5WebTestClientRE = regexp.MustCompile(
+		`(?s)\.(get|post|put|delete|patch)\s*\(\s*\)\s*\.uri\s*\(\s*"([^"\n\r]+)"`)
+
+	// TestRestTemplate / RestTemplate: restTemplate.getForEntity("/x/1", ...),
+	// postForObject(...), exchange("/x", HttpMethod.POST, ...), etc. The verb is
+	// encoded in the method NAME (getForEntity → GET, postForObject → POST). The
+	// route is the first string argument. `exchange(...)` carries the verb as an
+	// HttpMethod.* argument and is handled separately (j5RestTemplateExchangeRE).
+	j5RestTemplateRE = regexp.MustCompile(
+		`\b(getForObject|getForEntity|postForObject|postForEntity|postForLocation|put|delete|patchForObject)\s*\(\s*"([^"\n\r]+)"`)
+
+	// TestRestTemplate.exchange("/x/1", HttpMethod.POST, ...) — verb is the
+	// HttpMethod.* enum, which may appear as the 2nd (route-first) argument.
+	j5RestTemplateExchangeRE = regexp.MustCompile(
+		`\bexchange\s*\(\s*"([^"\n\r]+)"\s*,\s*HttpMethod\.(GET|POST|PUT|DELETE|PATCH)\b`)
+
+	// REST Assured: given()...when().post("/x") / .get("/x"). The verb is the
+	// terminal method, the route its first string argument. REST Assured's verb
+	// methods (get/post/put/delete/patch) are the same tokens as MockMvc's
+	// factory, but here they are invoked as a fluent terminal AFTER `when()` or
+	// directly on the request spec, with the route as the FIRST string arg. To
+	// avoid colliding with the MockMvc factory form (which is inside perform(...))
+	// we require the call NOT be the argument of perform — handled by capturing
+	// REST Assured separately and de-duplicating (verb,route) pairs across all
+	// patterns. We anchor on a `.` receiver so a bare static `post("/x")` (the
+	// MockMvc factory) is not double-counted as REST Assured.
+	j5RestAssuredRE = regexp.MustCompile(
+		`\.(get|post|put|delete|patch)\s*\(\s*"(/[^"\n\r]*)"\s*\)`)
+
+	// j5RestTemplateVerb maps a RestTemplate convenience-method name to its HTTP
+	// verb.
+	j5RestTemplateVerb = map[string]string{
+		"getForObject": "GET", "getForEntity": "GET",
+		"postForObject": "POST", "postForEntity": "POST", "postForLocation": "POST",
+		"put": "PUT", "delete": "DELETE", "patchForObject": "PATCH",
+	}
 )
 
 // ExtractJUnit5 runs the JUnit / TestNG extractor, emitting exactly one
@@ -216,6 +277,20 @@ func ExtractJUnit5(ctx PatternContext) PatternResult {
 		Provenance: "INFERRED_FROM_JUNIT5_TEST",
 		Ref:        suiteRef,
 		Properties: props,
+	}
+
+	// ── Spring route-by-string test calls (#4370) ───────────────────────────
+	// Capture every MockMvc / WebTestClient / TestRestTemplate / REST Assured
+	// route-by-string call and stamp the `VERB route` pairs onto THIS suite's
+	// `e2e_route_calls` property — the exact shape the shared resolve pass
+	// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) consumes to emit a
+	// finer-grained TESTS edge to the specific http_endpoint_definition the test
+	// exercises (complementing the SUT-class TESTS edge below). Resolution is
+	// deferred to resolve-time because only there is the cross-file endpoint
+	// index available — the @RestController defining the route lives in a
+	// different file than the test (merge-stable).
+	if routeCalls := collectSpringTestRouteCalls(source); len(routeCalls) > 0 {
+		suite.Properties["e2e_route_calls"] = strings.Join(routeCalls, "\n")
 	}
 
 	// ── TESTS edge to the production class under test (name affinity + ref) ──
@@ -342,4 +417,84 @@ func resolveJavaTestSubject(src, testClassName string) string {
 		return subject
 	}
 	return ""
+}
+
+// collectSpringTestRouteCalls extracts every Spring integration-test
+// route-by-string call from a JUnit/TestNG test file and returns de-duplicated
+// `VERB route` lines — the exact shape the shared resolve pass consumes
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369). Four Spring test clients
+// are covered (#4370):
+//
+//	MockMvc:         mockMvc.perform(post("/api/v1/inspections/123/items")...)
+//	WebTestClient:   webTestClient.post().uri("/inspections/{id}", id).exchange()
+//	TestRestTemplate: restTemplate.getForEntity("/x/1", ...) / postForObject(...)
+//	                 restTemplate.exchange("/x", HttpMethod.POST, ...)
+//	REST Assured:    given().when().post("/x")
+//
+// The route is normalised to a path (scheme+authority and query/fragment
+// stripped, repeated slashes collapsed); Spring `{id}` templates and concrete
+// ids are preserved verbatim (the resolver wildcards `{id}`/`:id`/`<int:id>`
+// segments and tolerates the servlet context / `/api/vN` mount prefix). A route
+// that does not resolve to a leading-slash path (e.g. a UriComponentsBuilder- or
+// variable-built URL the regex never captured) is dropped — conservative,
+// matching the no-fabrication posture of the resolver.
+func collectSpringTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseSpringTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	for _, m := range j5MockMvcRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range j5WebTestClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range j5RestTemplateRE.FindAllStringSubmatch(source, -1) {
+		if verb, ok := j5RestTemplateVerb[m[1]]; ok {
+			add(verb, m[2])
+		}
+	}
+	for _, m := range j5RestTemplateExchangeRE.FindAllStringSubmatch(source, -1) {
+		add(m[2], m[1]) // group 2 = HttpMethod verb, group 1 = route
+	}
+	for _, m := range j5RestAssuredRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseSpringTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix (http://localhost:8080/x → /x), drops a query string
+// / fragment, and collapses repeated slashes. Casing and path-param
+// placeholders ({id}) are left untouched (the resolver compares literals
+// case-insensitively and wildcards template segments). Returns "" when no path
+// remains.
+func normaliseSpringTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
 }

--- a/internal/engine/http_endpoint_e2e_testmap_4370_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4370_test.go
@@ -1,0 +1,205 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Java custom extractor so the test_suite (with e2e_route_calls)
+	// comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/java"
+)
+
+// Issue #4370 LIVE-REPRO (resolve side, full in-pipeline).
+//
+// Proves end-to-end that a Spring integration test calling a route by string
+// (MockMvc / WebTestClient / TestRestTemplate / REST Assured) links to the
+// http_endpoint_definition it exercises — the finer-grained endpoint-level
+// TESTS edge that complements the controller-class TESTS edge ExtractJUnit5
+// (#4359) already produces, mirroring the NestJS/supertest (#4351) and Python
+// (#4369) distinctions.
+//
+// Pipeline (all REAL passes, faithful Spring fixtures):
+//  1. ApplyJavaAnnotationRoutes over a real @RestController with a
+//     class-level @RequestMapping("/inspections") base + @PostMapping("/{id}/items")
+//     / @GetMapping("/{id}") methods → the real http_endpoint entities.
+//  2. The real Java custom extractor over a @SpringBootTest MockMvc test class
+//     → the one-per-file test_suite carrying e2e_route_calls.
+//  3. ResolveHTTPEndpointHandlers over the merged set → migrates http_endpoint
+//     to http_endpoint_definition, builds the endpoint index, and runs the
+//     shared linkE2ERouteTestsToEndpoints pass.
+//
+// BEFORE #4370 the suite carried no e2e_route_calls, so no TESTS→endpoint edge
+// existed. AFTER, the suite links to the matching endpoint definitions, with the
+// servlet base-path prefix and {id}-template segments resolved.
+
+const springControllerSrc4370 = `package com.example.web;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RestController
+@RequestMapping("/api/v1/inspections")
+public class InspectionController {
+
+    @PostMapping("/{id}/items")
+    public Item createItem(@PathVariable Long id, @RequestBody Item body) {
+        return body;
+    }
+
+    @GetMapping("/{id}")
+    public Inspection getOne(@PathVariable Long id) {
+        return null;
+    }
+}
+`
+
+const springMockMvcTestSrc4370 = `package com.example.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InspectionController.class)
+class InspectionControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void createsItem() throws Exception {
+        mockMvc.perform(post("/api/v1/inspections/123/items").content("{}"))
+               .andExpect(status().isCreated());
+    }
+
+    @Test
+    void getsOne() throws Exception {
+        mockMvc.perform(get("/api/v1/inspections/123"))
+               .andExpect(status().isOk());
+    }
+}
+`
+
+func TestIssue4370_SpringE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	// 1. Real Spring route synthesis from the @RestController.
+	files := map[string]string{
+		"src/main/java/com/example/web/InspectionController.java": springControllerSrc4370,
+	}
+	reader := func(p string) []byte {
+		if s, ok := files[p]; ok {
+			return []byte(s)
+		}
+		return nil
+	}
+	defs := ApplyJavaAnnotationRoutes(
+		[]string{"src/main/java/com/example/web/InspectionController.java"}, reader)
+	if len(defs) == 0 {
+		t.Fatal("Spring annotation route synthesis produced no endpoints")
+	}
+
+	// 2. Real Java custom extractor over the MockMvc test → the suite.
+	je, ok := extreg.Get("custom_java_patterns")
+	if !ok {
+		t.Fatal("custom_java_patterns not registered")
+	}
+	suiteEnts, err := je.Extract(context.Background(), extreg.FileInput{
+		Path:     "src/test/java/com/example/web/InspectionControllerTest.java",
+		Language: "java",
+		Content:  []byte(springMockMvcTestSrc4370),
+	})
+	if err != nil {
+		t.Fatalf("java extract: %v", err)
+	}
+	var suite *types.EntityRecord
+	for i := range suiteEnts {
+		if suiteEnts[i].Subtype == "test_suite" {
+			suite = &suiteEnts[i]
+			break
+		}
+	}
+	if suite == nil {
+		t.Fatal("Java extractor emitted no test_suite")
+	}
+	if suite.Properties["e2e_route_calls"] == "" {
+		t.Fatal("suite carries no e2e_route_calls — extractor side regressed (#4370)")
+	}
+
+	// Build the merged set: every real endpoint + the real suite.
+	merged := make([]types.EntityRecord, 0, len(defs)+1)
+	merged = append(merged, defs...)
+	merged = append(merged, *suite)
+
+	// BEFORE control: strip e2e_route_calls — no TESTS→endpoint edges.
+	before := make([]types.EntityRecord, len(merged))
+	copy(before, merged)
+	beforeSuite := *suite
+	beforeProps := map[string]string{}
+	for k, v := range suite.Properties {
+		if k != "e2e_route_calls" {
+			beforeProps[k] = v
+		}
+	}
+	beforeSuite.Properties = beforeProps
+	before[len(before)-1] = beforeSuite
+	beforeOut, beforeStats := ResolveHTTPEndpointHandlers(before)
+	if beforeStats.E2ERouteTestEdges != 0 {
+		t.Fatalf("control (no e2e_route_calls) E2ERouteTestEdges=%d, want 0", beforeStats.E2ERouteTestEdges)
+	}
+	if got := countSuiteEndpointTestsEdges(beforeOut); got != 0 {
+		t.Fatalf("control must emit 0 suite→endpoint TESTS edges, got %d", got)
+	}
+
+	// AFTER: the route calls drive TESTS edges to the matching endpoints.
+	afterOut, afterStats := ResolveHTTPEndpointHandlers(merged)
+	if afterStats.E2ERouteTestEdges == 0 {
+		t.Fatalf("expected >=1 e2e route TESTS edge from the Spring suite, got 0")
+	}
+
+	// The edges must target POST /api/v1/inspections/{id}/items and
+	// GET /api/v1/inspections/{id} (concrete /123 in the test → {id} template).
+	wantPost, wantGet := false, false
+	for _, e := range afterOut {
+		if e.Subtype != "test_suite" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindTests) {
+				continue
+			}
+			if r.Properties["match_source"] != "e2e_supertest_route" {
+				continue
+			}
+			to := r.ToID
+			if strings.Contains(to, "POST:/api/v1/inspections/{id}/items") {
+				wantPost = true
+			}
+			if strings.Contains(to, "GET:/api/v1/inspections/{id}") &&
+				!strings.Contains(to, "items") {
+				wantGet = true
+			}
+			// Framework attributed from the JUnit suite, not hard-coded jest.
+			if fw := r.Properties["framework"]; fw == "jest" {
+				t.Errorf("Spring suite TESTS edge mislabeled framework=%q", fw)
+			}
+		}
+	}
+	if !wantPost {
+		t.Errorf("no TESTS edge from the Spring suite to POST /api/v1/inspections/{id}/items")
+	}
+	if !wantGet {
+		t.Errorf("no TESTS edge from the Spring suite to GET /api/v1/inspections/{id}")
+	}
+
+	t.Logf("#4370 endpoint-level TESTS edges from real Spring MockMvc suite: before=0 after=%d",
+		afterStats.E2ERouteTestEdges)
+}


### PR DESCRIPTION
## Summary

Spring integration tests drive the app through HTTP by passing the route as a **string** to a test client (MockMvc, WebTestClient, TestRestTemplate, REST Assured), but no edge ever connected that route string to the `http_endpoint_definition` it exercises — so those endpoints looked untested. This generalizes the NestJS/supertest fix #4351 and the Python fix #4369 to Java/Spring, complementing the controller-class TESTS edge `ExtractJUnit5` (#4359) already produces with a finer-grained endpoint-level edge.

## Extractor side (`internal/custom/java/junit5.go`)

`ExtractJUnit5` now captures every Spring test-client route-by-string call and stamps the `VERB route` pairs onto the one-per-file `test_suite`'s `e2e_route_calls` property — the same property the Jest (#4351) and pytest (#4369) extractors stamp. Per client:

- **MockMvc**: `mockMvc.perform(post("/x/123/items")...)` — verb from the static `MockMvcRequestBuilders` factory inside `perform(...)`, route from its string arg.
- **WebTestClient**: `webTestClient.post().uri("/x/{id}", id).exchange()` — verb from `.<verb>()`, route from `.uri("...")`.
- **TestRestTemplate**: `getForEntity` / `postForObject` / `put` / `delete` / ... — verb from the method name; `exchange("/x", HttpMethod.POST, ...)` — verb from the `HttpMethod` enum arg.
- **REST Assured**: `given().when().post("/x")` — verb from the terminal method.

Routes are normalised to a path (scheme+authority/query stripped, slashes collapsed); Spring `{id}` templates and concrete ids are preserved verbatim and `(verb,route)` pairs de-duplicated across patterns. A route that does not resolve to a leading-slash path (e.g. a `UriComponentsBuilder`/variable-built URL) is dropped — conservative.

## Resolve side

The shared pass `engine.linkE2ERouteTestsToEndpoints` (#4351) is **reused unchanged**. It already gates on `Kind||Subtype=="test_suite"` (`isTestSuiteEntity`, generalised in #4369 — the JUnit suite carries the marker in `Subtype`), already wildcards `{id}`/`:id`/`<int:id>` definition segments, and already tolerates the servlet context / `/api/vN` mount prefix. No matcher fork, no new producer `Kind`.

## Live validation (fixtures lie at merge)

- **Extractor test** (`internal/custom/java/issue4370_spring_e2e_route_tests_test.go`): asserts route capture across all four clients plus conservative negatives (built-URL and plain `map.get` dropped).
- **In-pipeline resolve test** (`internal/engine/http_endpoint_e2e_testmap_4370_test.go`): runs the REAL `ApplyJavaAnnotationRoutes` over a `@RestController` with a class-level `@RequestMapping("/api/v1/inspections")` base + `@PostMapping("/{id}/items")` / `@GetMapping("/{id}")` methods, plus the REAL Java extractor's `@WebMvcTest` MockMvc suite, through `ResolveHTTPEndpointHandlers` — proving the TESTS→endpoint edges are absent **before (0)** and present **after (2)**, with concrete `/123` → `{id}` and the servlet base-path prefix resolved.

## Coverage

MockMvc, WebTestClient, TestRestTemplate, REST Assured — all covered. **Deferred** (ref #4334): `UriComponentsBuilder`-built and variable-built routes (no static leading-slash path → dropped); literal-string routes are covered.

## Gates

`go build ./...`, `go vet`, `go test ./internal/custom/java/ ./internal/engine/` all green. No new `Kind` (reuses `test_suite` subtype + `TESTS` edge + existing `e2e_route_calls` property), so `internal/types/` is unaffected.

Closes #4370

🤖 Generated with [Claude Code](https://claude.com/claude-code)