### PR TITLE
Link Go httptest and Rails request-spec route-by-string tests to their endpoint definitions

### DIFF
--- a/internal/custom/golang/httptest_e2e.go
+++ b/internal/custom/golang/httptest_e2e.go
@@ -1,0 +1,260 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// httptest_e2e.go — link Go httptest route-by-string tests to the
+// http_endpoint_definition they exercise (issue #4371).
+//
+// Background
+// ----------
+// Go HTTP integration tests drive the app through HTTP by passing the route as
+// a STRING to the stdlib `net/http/httptest` machinery:
+//
+//	req := httptest.NewRequest(http.MethodPost, "/inspections/123/items", body)
+//	rec := httptest.NewRecorder()
+//	router.ServeHTTP(rec, req)
+//
+//	req, _ := http.NewRequest("GET", "/inspections/1", nil)
+//	handler.ServeHTTP(w, req)
+//
+//	srv := httptest.NewServer(router)
+//	resp, _ := http.Get(srv.URL + "/inspections/1")
+//
+// but no edge ever connected that route string to the http_endpoint_definition
+// it exercises — so those endpoints looked untested. This generalizes the
+// NestJS/supertest fix #4351, the Python fix #4369, and the Java/Spring fix
+// #4370 to Go's stdlib httptest, complementing the name-affinity SUT-class
+// TESTS edge the testify/ginkgo/gomega suites (#4358) already produce with a
+// finer-grained endpoint-level edge.
+//
+// Extractor side: this extractor emits exactly ONE test_suite entity per
+// `*_test.go` file that issues at least one httptest route-by-string call, and
+// stamps the `VERB route` pairs onto its `e2e_route_calls` property — the same
+// property the Jest (#4351), pytest (#4369), and JUnit (#4370) extractors
+// stamp. It is decoupled from the testify suite (which gates on a testify
+// marker that a pure-stdlib httptest file lacks); the two suites carry distinct
+// names, and the shared resolve pass fires on whichever carries
+// `e2e_route_calls`.
+//
+// Resolve side: the shared pass (engine.linkE2ERouteTestsToEndpoints, #4351) is
+// REUSED UNCHANGED. It already gates on Kind||Subtype=="test_suite"
+// (isTestSuiteEntity, #4369), wildcards {id}/:id/<int:id> definition segments,
+// and tolerates the /api/vN mount prefix. No matcher fork, no new producer Kind.
+//
+// Conservatism: only literal `/...` routes are captured; a route built from a
+// variable / fmt.Sprintf / non-literal expression (no static leading-slash
+// path) is dropped, and the shared resolver emits an edge only on a UNIQUE
+// verb+route match.
+
+func init() {
+	extractor.Register("custom_go_httptest_e2e", &goHTTPTestE2EExtractor{})
+}
+
+type goHTTPTestE2EExtractor struct{}
+
+func (e *goHTTPTestE2EExtractor) Language() string { return "custom_go_httptest_e2e" }
+
+var (
+	// httptest.NewRequest(<verb>, "/route", body) — verb is the FIRST arg
+	// (a "POST" string literal or an http.MethodX const), route the SECOND
+	// (string literal). http.NewRequest has the same (verb, route, body) shape.
+	// The verb arg is captured as the raw token; resolveHTTPVerbToken maps an
+	// http.MethodX const or a quoted literal to the canonical upper verb.
+	reGoHTTPTestNewRequest = regexp.MustCompile(
+		`\b(?:httptest|http)\.NewRequest\s*\(\s*([^,]+?)\s*,\s*"([^"\n\r]+)"`)
+
+	// httptest.NewRequestWithContext(ctx, <verb>, "/route", body) /
+	// http.NewRequestWithContext(...) — same shape but a leading context arg.
+	reGoHTTPTestNewRequestCtx = regexp.MustCompile(
+		`\b(?:httptest|http)\.NewRequestWithContext\s*\(\s*[^,]+?\s*,\s*([^,]+?)\s*,\s*"([^"\n\r]+)"`)
+
+	// http.Get(srv.URL + "/route") / http.Post(srv.URL+"/route", ...) etc. on
+	// an httptest.NewServer — the verb is encoded in the stdlib helper NAME, the
+	// route is the string literal concatenated onto the server URL. We match the
+	// FIRST quoted "/..."-shaped literal in the call (the path suffix); a bare
+	// srv.URL with no literal path suffix yields no route (dropped).
+	reGoHTTPTestClientVerb = regexp.MustCompile(
+		`\bhttp\.(Get|Post|Head|PostForm)\s*\([^)\n]*?"(/[^"\n\r]*)"`)
+
+	// goHTTPMethodConst maps an http.MethodX constant to its verb.
+	goHTTPMethodConst = map[string]string{
+		"http.MethodGet":     "GET",
+		"http.MethodPost":    "POST",
+		"http.MethodPut":     "PUT",
+		"http.MethodPatch":   "PATCH",
+		"http.MethodDelete":  "DELETE",
+		"http.MethodHead":    "HEAD",
+		"http.MethodOptions": "OPTIONS",
+	}
+
+	// goHTTPClientVerb maps a stdlib http.<Helper> client call to its verb.
+	goHTTPClientVerb = map[string]string{
+		"Get": "GET", "Post": "POST", "Head": "HEAD", "PostForm": "POST",
+	}
+
+	// canonicalHTTPVerbs is the set of bare verb tokens we accept (case-insensitively)
+	// from a quoted string-literal method argument.
+	canonicalHTTPVerbs = map[string]bool{
+		"GET": true, "POST": true, "PUT": true, "PATCH": true,
+		"DELETE": true, "HEAD": true, "OPTIONS": true, "CONNECT": true, "TRACE": true,
+	}
+)
+
+func (e *goHTTPTestE2EExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.go_httptest_e2e_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "go_httptest"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Only fire on test files, and only when an httptest/http route-by-string
+	// signal is present — keeps the extractor a strict no-op everywhere else.
+	if !strings.HasSuffix(file.Path, "_test.go") {
+		return nil, nil
+	}
+	if !strings.Contains(src, "httptest.") &&
+		!strings.Contains(src, "http.NewRequest") {
+		return nil, nil
+	}
+
+	routeCalls := collectGoHTTPTestRouteCalls(src)
+	if len(routeCalls) == 0 {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	ent := makeEntity("httptest_suite:"+goTestBaseName(file.Path), "SCOPE.Pattern", "test_suite",
+		file.Path, file.Language, 1)
+	setProps(&ent, "framework", "go_httptest", "provenance", "INFERRED_FROM_GO_HTTPTEST_ROUTE",
+		"test_framework", "go_httptest",
+		"e2e_route_calls", strings.Join(routeCalls, "\n"),
+		"e2e_route_count", itoa(len(routeCalls)),
+	)
+
+	span.SetAttributes(attribute.Int("entity_count", 1))
+	return []types.EntityRecord{ent}, nil
+}
+
+// collectGoHTTPTestRouteCalls extracts every Go stdlib httptest / http
+// route-by-string call in a `*_test.go` file and returns de-duplicated
+// `VERB route` lines — the exact shape the shared resolve pass consumes
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369/#4370). Three shapes are
+// covered (#4371):
+//
+//	httptest.NewRequest(http.MethodPost, "/x/123/items", body)
+//	http.NewRequest("GET", "/x/1", nil)               (served via ServeHTTP)
+//	http.Get(srv.URL + "/x/1")  / http.Post(srv.URL+"/x", ...)
+//
+// The route is normalised to a path (scheme+authority and query/fragment
+// stripped, repeated slashes collapsed). Concrete ids (`/x/123`) are preserved
+// verbatim — the resolver wildcards `{id}`/`:id`/`<int:id>` definition
+// segments. A call whose verb does not resolve to a known method, or whose
+// route does not reduce to a leading-slash path, is dropped — conservative.
+func collectGoHTTPTestRouteCalls(src string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		verb = strings.ToUpper(strings.TrimSpace(verb))
+		if verb == "" {
+			return
+		}
+		route := normaliseGoTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := verb + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	for _, m := range reGoHTTPTestNewRequest.FindAllStringSubmatch(src, -1) {
+		if verb := resolveGoHTTPVerbToken(m[1]); verb != "" {
+			add(verb, m[2])
+		}
+	}
+	for _, m := range reGoHTTPTestNewRequestCtx.FindAllStringSubmatch(src, -1) {
+		if verb := resolveGoHTTPVerbToken(m[1]); verb != "" {
+			add(verb, m[2])
+		}
+	}
+	for _, m := range reGoHTTPTestClientVerb.FindAllStringSubmatch(src, -1) {
+		if verb, ok := goHTTPClientVerb[m[1]]; ok {
+			add(verb, m[2])
+		}
+	}
+	return out
+}
+
+// resolveGoHTTPVerbToken maps a raw method argument token to a canonical HTTP
+// verb. It accepts an `http.MethodX` constant, a quoted string literal
+// ("POST"), or a bare verb token; anything else (a variable, a function call)
+// yields "" so the call is dropped — conservative.
+func resolveGoHTTPVerbToken(token string) string {
+	token = strings.TrimSpace(token)
+	if v, ok := goHTTPMethodConst[token]; ok {
+		return v
+	}
+	// Quoted string literal: "POST" / `PUT`.
+	if len(token) >= 2 {
+		q := token[0]
+		if (q == '"' || q == '`') && token[len(token)-1] == q {
+			inner := strings.ToUpper(strings.TrimSpace(token[1 : len(token)-1]))
+			if canonicalHTTPVerbs[inner] {
+				return inner
+			}
+			return ""
+		}
+	}
+	// Bare verb token (rare, e.g. a local const already upper-cased).
+	if up := strings.ToUpper(token); canonicalHTTPVerbs[up] {
+		return up
+	}
+	return ""
+}
+
+// normaliseGoTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix (http://127.0.0.1:8080/x → /x), drops a query string
+// / fragment, and collapses repeated slashes. Casing and path-param
+// placeholders ({id}) are left untouched (the resolver compares literals
+// case-insensitively and wildcards template segments). Returns "" when no path
+// remains.
+func normaliseGoTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}

--- a/internal/custom/golang/httptest_e2e_test.go
+++ b/internal/custom/golang/httptest_e2e_test.go
@@ -1,0 +1,117 @@
+package golang
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// Issue #4371 (Go extractor side): the Go httptest extractor must capture every
+// stdlib httptest / http route-by-string call in a *_test.go file and stamp the
+// `VERB route` pairs onto a one-per-file test_suite's e2e_route_calls property.
+
+const goHTTPTestSrc4371 = `package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateItem(t *testing.T) {
+	body := strings.NewReader("{}")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/inspections/123/items", body)
+	rec := httptest.NewRecorder()
+	NewRouter().ServeHTTP(rec, req)
+}
+
+func TestGetOne(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/api/v1/inspections/1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+}
+
+func TestDelete(t *testing.T) {
+	req := httptest.NewRequestWithContext(ctx, http.MethodDelete, "/inspections/9", nil)
+	_ = req
+}
+
+func TestServerGet(t *testing.T) {
+	srv := httptest.NewServer(NewRouter())
+	defer srv.Close()
+	resp, _ := http.Get(srv.URL + "/inspections/42")
+	_ = resp
+}
+
+func TestBuiltURLDropped(t *testing.T) {
+	// Variable-built route — no static leading-slash literal → must be dropped.
+	path := fmt.Sprintf("/inspections/%d", id)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	_ = req
+}
+`
+
+func TestGoHTTPTestE2E_CapturesRoutes(t *testing.T) {
+	ex := &goHTTPTestE2EExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "internal/web/handler_test.go",
+		Language: "go",
+		Content:  []byte(goHTTPTestSrc4371),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("want exactly 1 test_suite, got %d", len(ents))
+	}
+	suite := ents[0]
+	if suite.Subtype != "test_suite" {
+		t.Fatalf("entity subtype = %q, want test_suite", suite.Subtype)
+	}
+	calls := suite.Properties["e2e_route_calls"]
+	if calls == "" {
+		t.Fatal("suite carries no e2e_route_calls")
+	}
+	got := map[string]bool{}
+	for _, l := range strings.Split(calls, "\n") {
+		got[l] = true
+	}
+	want := []string{
+		"POST /api/v1/inspections/123/items", // httptest.NewRequest + http.MethodPost
+		"GET /api/v1/inspections/1",          // http.NewRequest + "GET" literal
+		"DELETE /inspections/9",              // NewRequestWithContext + http.MethodDelete
+		"GET /inspections/42",                // http.Get(srv.URL + "/...")
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing route call %q (got: %v)", w, got)
+		}
+	}
+	// Conservative negative: the fmt.Sprintf-built path must NOT appear.
+	for l := range got {
+		if strings.Contains(l, "%d") || strings.HasPrefix(l, "GET path") {
+			t.Errorf("unexpected non-literal route captured: %q", l)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("captured %d routes, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// Conservative: a non-test file (no _test.go suffix) must produce nothing.
+func TestGoHTTPTestE2E_NonTestFileNoOp(t *testing.T) {
+	ex := &goHTTPTestE2EExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "internal/web/handler.go",
+		Language: "go",
+		Content:  []byte(goHTTPTestSrc4371),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("non-test file must emit 0 entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/ruby/rspec.go
+++ b/internal/custom/ruby/rspec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -45,6 +46,31 @@ var (
 	)
 	reRspecInclude = regexp.MustCompile(
 		`(?m)^\s*(?:include_examples|it_behaves_like|include_context)\s+['"]([^'"]+)['"]`,
+	)
+
+	// ── Rails request-spec route-by-string capture (#4371) ───────────────────
+	// Rails request / integration specs (RSpec) drive the app through HTTP by
+	// passing the route as a STRING to a request method, but no edge ever
+	// connected that route string to the http_endpoint_definition it exercises.
+	// This generalizes the NestJS/supertest (#4351), Python (#4369), and
+	// Java/Spring (#4370) e2e-route fixes to Ruby/Rails.
+	//
+	//	get  '/inspections/123'
+	//	post '/inspections', params: { ... }
+	//	patch "/inspections/#{id}", params: { ... }
+	//	delete "/inspections/1"
+	//
+	// Group 1 = the RSpec request verb, group 2 = the route string literal. The
+	// route MUST start with `/` so a named-route helper (inspections_path — an
+	// identifier, not a `/path` literal) and a controller-spec symbol action
+	// (get :show — no leading slash) are conservatively skipped. A `#{...}` Ruby
+	// interpolation inside a route is left verbatim (the resolver treats a
+	// definition `:id`/`{id}` segment as a wildcard; a concrete `/1` likewise
+	// matches). The verb-method boundary is anchored to the line start (after
+	// optional whitespace) so `.get` / `response.get` receivers and chained
+	// matchers never match.
+	reRspecRequestRoute = regexp.MustCompile(
+		`(?m)^\s*(get|post|put|patch|delete)\s+(?:\(\s*)?['"](/[^'"\n\r]*)['"]`,
 	)
 )
 
@@ -156,6 +182,106 @@ func (e *rspecExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		add(ent)
 	}
 
+	// 8. Rails request-spec route-by-string calls (#4371). When this spec drives
+	//    the app through HTTP by calling a route by string (get '/x/1', post
+	//    '/x', ...), emit ONE one-per-file test_suite carrying the `VERB route`
+	//    pairs on an `e2e_route_calls` property — the exact shape the shared
+	//    resolve pass (engine.linkE2ERouteTestsToEndpoints, #4351/#4369/#4370)
+	//    consumes to emit a finer-grained TESTS edge to the specific
+	//    http_endpoint_definition (synthesized from routes.rb) the spec
+	//    exercises. Resolution is deferred to resolve-time because only there is
+	//    the cross-file endpoint index available (the route is defined in
+	//    config/routes.rb, far from the spec) — merge-stable.
+	//
+	//    RSpec has no one-suite-per-file collapse like the Go/JS/Python/Java
+	//    extractors (#4358/#4343), so this is a NEW, additional node minted only
+	//    when route calls are present; it does not disturb the per-construct
+	//    entities above. A full RSpec test-suite collapse à la #4358 is left as a
+	//    follow-up (ref #4334).
+	if routeCalls := collectRailsRequestSpecRouteCalls(src); len(routeCalls) > 0 {
+		suite := makeEntity("rspec_request_suite:"+rspecFileBaseName(file.Path),
+			"SCOPE.Pattern", "test_suite", file.Path, file.Language, 1)
+		setProps(&suite, "framework", "rspec",
+			"provenance", "INFERRED_FROM_RSPEC_REQUEST_ROUTE",
+			"test_framework", "rspec",
+			"e2e_route_calls", strings.Join(routeCalls, "\n"),
+			"e2e_route_count", fmt.Sprintf("%d", len(routeCalls)),
+		)
+		add(suite)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// collectRailsRequestSpecRouteCalls extracts every Rails request/integration
+// spec route-by-string call in an RSpec file and returns de-duplicated
+// `VERB route` lines — the exact shape the shared resolve pass consumes
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369/#4370). Only literal
+// `/...` routes are captured: named-route helpers (`inspections_path`) and
+// controller-spec symbol actions (`get :show`) are conservatively skipped
+// because they are not leading-slash string literals. The route is normalised
+// to a path (scheme+authority and query/fragment stripped, repeated slashes
+// collapsed); a `#{...}` Ruby interpolation and concrete ids are preserved
+// verbatim (the resolver wildcards `:id`/`{id}` definition segments).
+func collectRailsRequestSpecRouteCalls(src string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range reRspecRequestRoute.FindAllStringSubmatch(src, -1) {
+		verb := strings.ToUpper(strings.TrimSpace(m[1]))
+		route := normaliseRubyTestRoute(m[2])
+		if route == "" || !strings.HasPrefix(route, "/") {
+			continue
+		}
+		line := verb + " " + route
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	return out
+}
+
+// normaliseRubyTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix (http://www.example.com/x → /x), drops a query string
+// / fragment, and collapses repeated slashes. Casing and path-param
+// placeholders / interpolations are left untouched (the resolver compares
+// literals case-insensitively and wildcards `:id`/`{id}` segments). Returns ""
+// when no path remains.
+func normaliseRubyTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	// Drop a query string. A literal `#` fragment marker is rare in a route and
+	// collides with Ruby's `#{...}` interpolation, so we only strip `#` when it
+	// is NOT the start of an interpolation (`#{`).
+	if q := strings.IndexByte(p, '?'); q >= 0 {
+		p = p[:q]
+	}
+	if h := strings.IndexByte(p, '#'); h >= 0 && (h+1 >= len(p) || p[h+1] != '{') {
+		p = p[:h]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// rspecFileBaseName derives a human label from an RSpec file path, e.g.
+// `spec/requests/inspections_spec.rb` → `inspections`.
+func rspecFileBaseName(path string) string {
+	p := path
+	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
+		p = p[i+1:]
+	}
+	p = strings.TrimSuffix(p, ".rb")
+	p = strings.TrimSuffix(p, "_spec")
+	return p
 }

--- a/internal/custom/ruby/rspec_e2e_route_test.go
+++ b/internal/custom/ruby/rspec_e2e_route_test.go
@@ -1,0 +1,129 @@
+package ruby
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// Issue #4371 (Ruby extractor side): the RSpec extractor must capture every
+// Rails request/integration-spec route-by-string call and stamp the
+// `VERB route` pairs onto a one-per-file test_suite's e2e_route_calls property.
+// Named-route helpers and controller-spec symbol actions are skipped.
+
+const railsRequestSpecSrc4371 = `require 'rails_helper'
+
+RSpec.describe 'Inspections API', type: :request do
+  let(:inspection) { create(:inspection) }
+
+  it 'lists inspections' do
+    get '/api/v1/inspections'
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'shows one' do
+    get "/api/v1/inspections/#{inspection.id}"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'creates an item' do
+    post '/api/v1/inspections/123/items', params: { name: 'x' }
+    expect(response).to have_http_status(:created)
+  end
+
+  it 'updates' do
+    patch "/api/v1/inspections/1", params: { name: 'y' }
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'deletes' do
+    delete '/api/v1/inspections/9'
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it 'uses a named route helper (skipped)' do
+    get inspections_path
+    expect(response).to have_http_status(:ok)
+  end
+end
+`
+
+const railsControllerSpecSrc4371 = `require 'rails_helper'
+
+RSpec.describe InspectionsController, type: :controller do
+  it 'shows' do
+    get :show, params: { id: 1 }
+    expect(response).to have_http_status(:ok)
+  end
+end
+`
+
+func TestRSpecRequestSpecE2E_CapturesRoutes(t *testing.T) {
+	ex := &rspecExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "spec/requests/inspections_spec.rb",
+		Language: "ruby",
+		Content:  []byte(railsRequestSpecSrc4371),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	var suite *struct {
+		calls string
+	}
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			suite = &struct{ calls string }{calls: e.Properties["e2e_route_calls"]}
+		}
+	}
+	if suite == nil {
+		t.Fatal("RSpec extractor emitted no request-spec test_suite")
+	}
+	got := map[string]bool{}
+	for _, l := range strings.Split(suite.calls, "\n") {
+		got[l] = true
+	}
+	want := []string{
+		"GET /api/v1/inspections",
+		"GET /api/v1/inspections/#{inspection.id}",
+		"POST /api/v1/inspections/123/items",
+		"PATCH /api/v1/inspections/1",
+		"DELETE /api/v1/inspections/9",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing route call %q (got: %v)", w, got)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("captured %d routes, want %d: %v", len(got), len(want), got)
+	}
+	// Named-route helper (get inspections_path) must NOT be captured.
+	for l := range got {
+		if strings.Contains(l, "inspections_path") {
+			t.Errorf("named-route helper leaked into capture: %q", l)
+		}
+	}
+}
+
+// Controller specs use a symbol action (get :show) — no leading-slash path, so
+// no suite / route is emitted.
+func TestRSpecControllerSpecE2E_NoRoutes(t *testing.T) {
+	ex := &rspecExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "spec/controllers/inspections_controller_spec.rb",
+		Language: "ruby",
+		Content:  []byte(railsControllerSpecSrc4371),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			t.Errorf("controller spec must not emit a route test_suite, got %q with calls=%q",
+				e.Name, e.Properties["e2e_route_calls"])
+		}
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4371_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4371_test.go
@@ -1,0 +1,247 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Go + Ruby custom extractors so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractors, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+// Issue #4371 LIVE-REPRO (resolve side, full in-pipeline) — Go + Rails.
+//
+// Proves end-to-end that a Go httptest / Rails request spec calling a route by
+// string links to the http_endpoint_definition it exercises, the finer-grained
+// endpoint-level TESTS edge that complements the SUT-class edge — mirroring the
+// NestJS/supertest (#4351), Python (#4369), and Java/Spring (#4370) work.
+//
+// Pipeline (all REAL passes, faithful fixtures):
+//  1. applyHTTPEndpointSynthesis over the real router/handler source (Go
+//     net/http mux registration; Rails config/routes.rb) → http_endpoint_*.
+//  2. The real custom extractor over the test file → the one-per-file
+//     test_suite carrying e2e_route_calls.
+//  3. ResolveHTTPEndpointHandlers over the merged set → migrates the endpoints
+//     and runs the shared linkE2ERouteTestsToEndpoints pass.
+//
+// BEFORE #4371 the suite carried no e2e_route_calls, so no TESTS→endpoint edge
+// existed. AFTER, the suite links to the matching endpoint definitions.
+
+// synthEndpoints drives the REAL per-language endpoint synthesis over one
+// production source file and returns the synthesized endpoint entities.
+func synthEndpoints(t *testing.T, lang, path, src string) []types.EntityRecord {
+	t.Helper()
+	res := applyHTTPEndpointSynthesis(DetectorPassArgs{
+		Ctx:     context.Background(),
+		Lang:    lang,
+		Path:    path,
+		Content: []byte(src),
+	})
+	var defs []types.EntityRecord
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind {
+			defs = append(defs, e)
+		}
+	}
+	return defs
+}
+
+// realSuite runs the named custom extractor over a test file and returns the
+// emitted test_suite (with e2e_route_calls), failing if none is produced.
+func realSuite(t *testing.T, extractorName, path, lang, src string) types.EntityRecord {
+	t.Helper()
+	ex, ok := extreg.Get(extractorName)
+	if !ok {
+		t.Fatalf("%s not registered", extractorName)
+	}
+	ents, err := ex.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: lang, Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("%s extract: %v", extractorName, err)
+	}
+	for _, e := range ents {
+		if e.Subtype == "test_suite" && e.Properties["e2e_route_calls"] != "" {
+			return e
+		}
+	}
+	t.Fatalf("%s emitted no test_suite with e2e_route_calls", extractorName)
+	return types.EntityRecord{}
+}
+
+// runE2ERouteResolve runs the full RED→GREEN check: BEFORE (e2e_route_calls
+// stripped) must yield 0 endpoint-TESTS edges; AFTER yields >=1. Returns the
+// resolved AFTER entities and the after-stats edge count.
+func runE2ERouteResolve(t *testing.T, defs []types.EntityRecord, suite types.EntityRecord) ([]types.EntityRecord, int) {
+	t.Helper()
+	if len(defs) == 0 {
+		t.Fatal("no endpoints synthesized — fixture/route-synthesis regressed")
+	}
+	merged := make([]types.EntityRecord, 0, len(defs)+1)
+	merged = append(merged, defs...)
+	merged = append(merged, suite)
+
+	// BEFORE control: strip e2e_route_calls → no TESTS→endpoint edges.
+	before := make([]types.EntityRecord, len(merged))
+	copy(before, merged)
+	beforeSuite := suite
+	bp := map[string]string{}
+	for k, v := range suite.Properties {
+		if k != "e2e_route_calls" {
+			bp[k] = v
+		}
+	}
+	beforeSuite.Properties = bp
+	before[len(before)-1] = beforeSuite
+	beforeOut, beforeStats := ResolveHTTPEndpointHandlers(before)
+	if beforeStats.E2ERouteTestEdges != 0 {
+		t.Fatalf("control E2ERouteTestEdges=%d, want 0", beforeStats.E2ERouteTestEdges)
+	}
+	if got := countSuiteEndpointTestsEdges(beforeOut); got != 0 {
+		t.Fatalf("control must emit 0 suite→endpoint TESTS edges, got %d", got)
+	}
+
+	afterOut, afterStats := ResolveHTTPEndpointHandlers(merged)
+	if afterStats.E2ERouteTestEdges == 0 {
+		t.Fatalf("expected >=1 e2e route TESTS edge, got 0")
+	}
+	return afterOut, afterStats.E2ERouteTestEdges
+}
+
+// edgeTargets returns the ToIDs of every e2e route-test TESTS edge from a suite.
+func edgeTargets(ents []types.EntityRecord) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range ents {
+		if e.Subtype != "test_suite" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				r.Properties["match_source"] == "e2e_supertest_route" {
+				out[r.ToID] = true
+			}
+		}
+	}
+	return out
+}
+
+// ── Go httptest ────────────────────────────────────────────────────────────
+
+const goRouterSrc4371 = `package web
+
+import "net/http"
+
+func NewRouter() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /inspections/{id}/items", createItem)
+	mux.HandleFunc("GET /inspections/{id}", getOne)
+	return mux
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {}
+func getOne(w http.ResponseWriter, r *http.Request)     {}
+`
+
+const goHTTPTestSrc4371Pipeline = `package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateItem(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/inspections/123/items", nil)
+	rec := httptest.NewRecorder()
+	NewRouter().ServeHTTP(rec, req)
+}
+
+func TestGetOne(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/inspections/123", nil)
+	w := httptest.NewRecorder()
+	NewRouter().ServeHTTP(w, req)
+}
+`
+
+func TestIssue4371_GoHTTPTestE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := synthEndpoints(t, "go", "internal/web/router.go", goRouterSrc4371)
+	suite := realSuite(t, "custom_go_httptest_e2e",
+		"internal/web/handler_test.go", "go", goHTTPTestSrc4371Pipeline)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	targets := edgeTargets(afterOut)
+
+	wantPost, wantGet := false, false
+	for to := range targets {
+		if strings.Contains(to, "POST:/inspections/{id}/items") {
+			wantPost = true
+		}
+		if strings.Contains(to, "GET:/inspections/{id}") && !strings.Contains(to, "items") {
+			wantGet = true
+		}
+	}
+	if !wantPost {
+		t.Errorf("no TESTS edge to POST /inspections/{id}/items (targets=%v)", targets)
+	}
+	if !wantGet {
+		t.Errorf("no TESTS edge to GET /inspections/{id} (targets=%v)", targets)
+	}
+	t.Logf("#4371 Go httptest endpoint-level TESTS edges: before=0 after=%d", edges)
+}
+
+// ── Rails request specs ─────────────────────────────────────────────────────
+
+const railsRoutesSrc4371 = `Rails.application.routes.draw do
+  get    '/inspections/:id',       to: 'inspections#show'
+  post   '/inspections/:id/items', to: 'items#create'
+  patch  '/inspections/:id',       to: 'inspections#update'
+end
+`
+
+const railsRequestSpecSrc4371Pipeline = `require 'rails_helper'
+
+RSpec.describe 'Inspections API', type: :request do
+  it 'shows one' do
+    get '/inspections/123'
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'creates an item' do
+    post '/inspections/123/items', params: { name: 'x' }
+    expect(response).to have_http_status(:created)
+  end
+end
+`
+
+func TestIssue4371_RailsRequestSpecE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := synthEndpoints(t, "ruby", "config/routes.rb", railsRoutesSrc4371)
+	suite := realSuite(t, "custom_ruby_rspec",
+		"spec/requests/inspections_spec.rb", "ruby", railsRequestSpecSrc4371Pipeline)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	targets := edgeTargets(afterOut)
+
+	wantShow, wantCreate := false, false
+	for to := range targets {
+		// Rails synthesizes :id-style template segments; the resolver wildcards
+		// them, so the concrete /123 test routes match the templates.
+		if strings.Contains(to, "GET:/inspections/") && !strings.Contains(to, "items") {
+			wantShow = true
+		}
+		if strings.Contains(to, "POST:/inspections/") && strings.Contains(to, "items") {
+			wantCreate = true
+		}
+	}
+	if !wantShow {
+		t.Errorf("no TESTS edge to GET /inspections/:id (targets=%v)", targets)
+	}
+	if !wantCreate {
+		t.Errorf("no TESTS edge to POST /inspections/:id/items (targets=%v)", targets)
+	}
+	t.Logf("#4371 Rails request-spec endpoint-level TESTS edges: before=0 after=%d", edges)
+}


### PR DESCRIPTION
## Summary

Go httptest and Rails request/integration specs drive the app through HTTP by passing the route as a **string** to the test machinery, but no edge ever connected that route string to the `http_endpoint_definition` it exercises — so those endpoints looked untested. This generalizes the NestJS/supertest (#4351), Python (#4369), and Java/Spring (#4370) e2e-route fixes to **Go + Ruby**.

## Extractor side

**Go** (`internal/custom/golang/httptest_e2e.go`) — a new `custom_go_httptest_e2e` extractor emits exactly one `test_suite` per `*_test.go` file that issues an httptest/http route-by-string call, stamping the `VERB route` pairs onto `e2e_route_calls`. Decoupled from the testify suite (which gates on a testify marker a pure-stdlib httptest file lacks). Shapes:
- `httptest.NewRequest(http.MethodPost, "/x/123/items", body)` — verb from the `http.MethodX` const or a `"POST"` literal
- `http.NewRequest("GET", "/x/1", nil)` (served via `ServeHTTP`)
- `httptest.NewRequestWithContext(ctx, http.MethodDelete, "/x/9", nil)`
- `http.Get(srv.URL + "/x/1")` / `http.Post(...)` — verb from the helper name, route from the `"/..."` literal suffix

**Ruby** (`internal/custom/ruby/rspec.go`) — the RSpec extractor captures Rails request-spec `get/post/put/patch/delete '/path'` calls and, when present, emits one additional one-per-file `test_suite` carrying the pairs. RSpec has no one-suite-per-file collapse like the Go/JS/Python/Java extractors (#4358/#4343), so this is a new node minted only when route calls exist; existing per-construct entities are untouched.

## Resolve side

The shared pass (`engine.linkE2ERouteTestsToEndpoints`, #4351) is **reused unchanged** — it already gates on `Kind||Subtype=="test_suite"`, wildcards `{id}`/`:id`/`<int:id>` segments, and tolerates the `/api/vN` prefix. No matcher fork, no new producer Kind; framework attributed from the suite; unique verb+route match only.

## Conservatism

Only literal leading-slash routes are captured. Named-route helpers (`inspections_path`), controller-spec symbol actions (`get :show`), and variable-/`fmt.Sprintf`-built routes are skipped. Routes are normalised to a path; concrete ids and `#{...}` interpolations are preserved verbatim.

## Validation

- Extractor tests assert capture across all Go httptest shapes and Rails verbs, plus negatives (`fmt.Sprintf`-built route, named-route helper, controller-spec symbol action).
- In-pipeline resolve test runs the **real** `applyHTTPEndpointSynthesis` over a Go `net/http` mux and a Rails `config/routes.rb`, plus the **real** Go/RSpec extractor suites, through `ResolveHTTPEndpointHandlers`: TESTS→endpoint edges absent **before (0)**, present **after (2 each)** for both Go and Rails (concrete `/123` → `{id}`/`:id` template).

Gates: `go build ./...`, `go vet`, `go test ./internal/custom/golang/ ./internal/custom/ruby/ ./internal/engine/ ./internal/types/` all green.

## Covered vs deferred

- **Covered:** Go httptest (NewRequest/NewRequestWithContext/NewServer client helpers), Rails request/integration specs.
- **Deferred (ref #4334):** full RSpec request-spec test-suite collapse à la #4358; TS Playwright/Cypress API-call e2e routes; named-route-helper resolution (`inspections_path` → `/path`).

Closes #4371

🤖 Generated with [Claude Code](https://claude.com/claude-code)