### PR TITLE
Resolve Kotlin cross-package CALLS via stamped package qualifier

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -4066,6 +4066,17 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	if csharpCrossNSCallRewrites > 0 {
 		fmt.Fprintf(os.Stderr, "resolver: csharp-cross-namespace rewrote=%d CALLS targets\n", csharpCrossNSCallRewrites)
 	}
+	// #4375 — Kotlin cross-package CALLS resolution. Binds qualified
+	// `pkg.Type.method()` / imported-top-level-fn / imported-or-aliased
+	// `Type.method()` / same-package companion-member edges stamped with
+	// kotlin_call_pkg + kotlin_call_type + call_leaf to a package-keyed
+	// member/operation index (Kotlin packages are not directory-bound). Same
+	// ordering constraints as the Go/Rust/C# passes: after BuildIndex, before
+	// the embedded-reference resolver.
+	kotlinCrossPkgCallRewrites := idx.ResolveKotlinCrossPackageCalls(merged)
+	if kotlinCrossPkgCallRewrites > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: kotlin-cross-package rewrote=%d CALLS targets\n", kotlinCrossPkgCallRewrites)
+	}
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)
 	embStats := resolve.ReferencesEmbeddedWithAllowlist(merged, idx, allow)
 	standStats := resolve.ReferencesWithAllowlist(pass2Rels, idx, allow)

--- a/internal/extractors/kotlin/crosspath.go
+++ b/internal/extractors/kotlin/crosspath.go
@@ -1,0 +1,366 @@
+// Cross-package CALLS qualifier reconciliation for Kotlin (issue #4375).
+//
+// Kotlin reaches a function/method in another package through a qualifier on a
+// navigation_expression invocation — a fully-qualified
+// `com.app.services.OrderService.place()`, an imported top-level function
+// (`import com.app.services.placeOrder; placeOrder()`), an imported type
+// (`import com.app.services.Orders; Orders.place()`), an aliased import
+// (`import com.app.x.OrderService as Svc; Svc.place()`), or a companion/object
+// member (`OrderService.create()`). The base extractor (kotlinCallTarget) only
+// returns the trailing simple_identifier of the navigation chain, so a
+// multi-segment qualified call collapses to the bare leaf method name
+// (`place`). The bare leaf resolves through the global byName index, which goes
+// ambiguous the moment two packages define a same-named function/type
+// (`OrderService.place` in both com.app.services and com.app.billing) — so the
+// CALLS edge drops and the callee package looks falsely uncalled. This is the
+// Kotlin analogue of the Go cross-package (#4332), Rust cross-module (#4373),
+// and C# cross-namespace (#4374) qualifier drops.
+//
+// Like C# namespaces (and unlike Go/Rust directories), Kotlin `package`
+// declarations are NOT directory-bound: a file's declared package need not
+// match its source directory. So the resolver keys on the Kotlin PACKAGE (not
+// the source directory). The extractor stamps the resolved (package, type,
+// leaf) onto the CALLS edge; the resolver binds it through a package-keyed
+// member/operation index built in BuildIndex (ResolveKotlinCrossPackageCalls in
+// internal/resolve/imports.go). Kotlin function entities carry a bare Name (not
+// a dotted `Type.method`), so unlike the C# pass the index is populated from the
+// `kotlin_package` / `kotlin_enclosing_type` properties stamped on each entity
+// rather than from a dotted Name — a parallel Kotlin index, not byNamespaceMember.
+//
+// Conservative by construction: only fires for a navigation invocation whose
+// receiver chain is a statically-qualified path the file context can map to a
+// concrete (package[, type], leaf). Bare unqualified calls, instance-receiver
+// calls, and star-import / extension-receiver chains we cannot statically
+// resolve are left to the base extractor — no false stamps.
+package kotlin
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// kotlinCrossCtx is the per-file resolution context derived from the file's
+// `package` declaration and `import` directives. Built once per file and
+// threaded through the call extractor so qualified calls can map a leading path
+// qualifier (or an imported leaf) to a concrete Kotlin package.
+type kotlinCrossCtx struct {
+	// filePackage is the package declared by this file's `package` header,
+	// e.g. "com.app.services". A same-package companion/object call
+	// `OrderService.create()` (where OrderService is declared in this package)
+	// is resolved against it.
+	filePackage string
+
+	// importedTypes maps a simple type name brought into scope by
+	// `import com.app.services.Orders` (or an `as` alias) to its declaring
+	// package, so `Orders.place()` recovers the package. The map key is the
+	// in-scope name (the alias when present, else the imported leaf).
+	// name -> package (e.g. "Orders" -> "com.app.services").
+	importedTypes map[string]string
+
+	// aliasRealType maps an `as` alias to the REAL imported leaf name, so an
+	// aliased member call `Svc.place()` (import OrderService as Svc) resolves
+	// the declaring type as the underlying `OrderService`, not the alias.
+	// alias -> realLeaf (e.g. "Svc" -> "OrderService"). Only populated for
+	// aliased imports.
+	aliasRealType map[string]string
+
+	// importedFuncs maps a simple function name brought into scope by
+	// `import com.app.services.placeOrder` (or an `as` alias) to its declaring
+	// package, so a bare `placeOrder()` recovers the package. The map key is
+	// the in-scope name (the alias when present, else the imported leaf).
+	// name -> package (e.g. "placeOrder" -> "com.app.services").
+	importedFuncs map[string]string
+
+	// hasStarImport is true when the file carries any `import com.app.x.*`
+	// wildcard. Wildcard imports make resolution non-unique (any of the
+	// star-imported packages could define the leaf), so a bare/Type-qualified
+	// call under an active star import is conservatively NOT stamped — the
+	// star-import case is a documented follow-up (#4334).
+	hasStarImport bool
+}
+
+// buildKotlinCrossCtx scans the compilation unit for the package header and
+// import headers and assembles the per-file Kotlin cross-package context.
+//
+// An `import` may resolve to either a type or a top-level function; we cannot
+// tell from the import alone, so the imported leaf is registered in BOTH
+// importedTypes and importedFuncs and the resolver disambiguates by which
+// package index actually holds the (type, leaf) vs (leaf) binding.
+func buildKotlinCrossCtx(root *sitter.Node, src []byte) *kotlinCrossCtx {
+	if root == nil {
+		return nil
+	}
+	ctx := &kotlinCrossCtx{
+		importedTypes: map[string]string{},
+		importedFuncs: map[string]string{},
+		aliasRealType: map[string]string{},
+	}
+	for _, p := range findAllNodes(root, "package_header") {
+		if pkg := kotlinPackageOfHeader(p, src); pkg != "" {
+			ctx.filePackage = pkg
+			break
+		}
+	}
+	for _, imp := range findAllNodes(root, "import_header") {
+		full, alias, star := parseKotlinImport(imp, src)
+		if full == "" {
+			continue
+		}
+		if star {
+			ctx.hasStarImport = true
+			continue
+		}
+		dot := strings.LastIndexByte(full, '.')
+		if dot <= 0 {
+			continue
+		}
+		pkg := full[:dot]
+		leaf := full[dot+1:]
+		name := leaf
+		if alias != "" {
+			name = alias
+		}
+		if name == "" || pkg == "" {
+			continue
+		}
+		// The imported leaf may be a type or a top-level function — register
+		// under both; the resolver picks the index that actually binds.
+		ctx.importedTypes[name] = pkg
+		ctx.importedFuncs[name] = pkg
+		if alias != "" {
+			// `import com.app.x.OrderService as Svc` — remember the real leaf
+			// so an aliased member call `Svc.place()` looks up type=OrderService.
+			ctx.aliasRealType[alias] = leaf
+		}
+	}
+	return ctx
+}
+
+// kotlinPackageOfHeader returns the dotted package path of a package_header
+// node (`package com.app.services`), or "" when absent.
+func kotlinPackageOfHeader(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	// tree-sitter-kotlin: package_header → [package] [identifier dotted path].
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch.Type() == "package" {
+			continue
+		}
+		txt := strings.TrimSpace(string(src[ch.StartByte():ch.EndByte()]))
+		if txt != "" {
+			return txt
+		}
+	}
+	return ""
+}
+
+// parseKotlinImport returns the dotted import path (wildcard suffix stripped),
+// the `as` alias (or ""), and whether the import is a `.*` wildcard. Mirrors
+// buildImport's text shaping so the two stay consistent.
+func parseKotlinImport(n *sitter.Node, src []byte) (full, alias string, star bool) {
+	raw := strings.TrimSpace(string(src[n.StartByte():n.EndByte()]))
+	raw = strings.TrimPrefix(raw, "import ")
+	raw = strings.TrimSpace(raw)
+	if i := strings.Index(raw, "//"); i >= 0 {
+		raw = strings.TrimSpace(raw[:i])
+	}
+	if i := strings.Index(raw, " as "); i >= 0 {
+		alias = strings.TrimSpace(raw[i+4:])
+		raw = strings.TrimSpace(raw[:i])
+	}
+	if strings.HasSuffix(raw, ".*") {
+		star = true
+		raw = strings.TrimSpace(strings.TrimSuffix(raw, ".*"))
+	}
+	return raw, alias, star
+}
+
+// qualifiedKotlinCall describes the (package, type, leaf) a qualified Kotlin
+// call resolves to. typ is "" for a top-level-function call
+// (`placeOrder()` via `import ...placeOrder`); pkgCandidates carries the
+// candidate packages (most-specific first).
+type qualifiedKotlinCall struct {
+	leaf          string   // function name
+	typ           string   // declaring type (empty for top-level fn)
+	pkgCandidates []string // candidate packages (most-specific first)
+}
+
+// resolveKotlinQualifiedCall inspects a call_expression node and, when its
+// receiver chain is a statically-qualified cross-package path, returns the
+// (package candidates, type, leaf) binding. Returns nil for shapes that are not
+// statically resolvable (instance receivers, bare same-file calls under no
+// matching import, star-import uncertainty, unresolvable chains) so the base
+// extractor's bare target is used unchanged.
+//
+// localNames is the set of in-scope value names (parameters, properties, locals)
+// whose head segment marks an INSTANCE receiver — those are left to the base
+// extractor, never stamped as a cross-package static qualifier.
+func (c *kotlinCrossCtx) resolveKotlinQualifiedCall(
+	call *sitter.Node,
+	src []byte,
+	localNames map[string]bool,
+) *qualifiedKotlinCall {
+	if c == nil || call == nil || call.ChildCount() == 0 {
+		return nil
+	}
+	first := call.Child(0)
+
+	switch first.Type() {
+	case "simple_identifier":
+		// Bare `placeOrder()` — only a cross-package call when the name was
+		// brought in by a top-level-function import. Same-file / same-package
+		// bare calls have no import entry and are left to the base extractor.
+		leaf := string(src[first.StartByte():first.EndByte()])
+		if leaf == "" {
+			return nil
+		}
+		if c.hasStarImport {
+			return nil // star import could supply this leaf — uncertain, skip.
+		}
+		if pkg, ok := c.importedFuncs[leaf]; ok && pkg != "" {
+			return &qualifiedKotlinCall{leaf: leaf, pkgCandidates: []string{pkg}}
+		}
+		return nil
+
+	case "navigation_expression":
+		return c.resolveKotlinNavigationCall(first, src, localNames)
+	}
+	return nil
+}
+
+// resolveKotlinNavigationCall handles a `a.b.c()` navigation invocation. The
+// trailing navigation_suffix identifier is the leaf; the segments before it are
+// the receiver path. A statically-qualified receiver maps to (package, type).
+func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
+	nav *sitter.Node,
+	src []byte,
+	localNames map[string]bool,
+) *qualifiedKotlinCall {
+	segs, ok := flattenKotlinNavigation(nav, src)
+	if !ok || len(segs) < 2 {
+		return nil
+	}
+	leaf := segs[len(segs)-1]
+	recv := segs[:len(segs)-1] // the receiver path segments
+	if leaf == "" || len(recv) == 0 {
+		return nil
+	}
+	head := recv[0]
+	// Instance-receiver guard: a head that is a known local/param/property is
+	// an instance call (`order.place()`), owned by the base extractor — not a
+	// static cross-package qualifier.
+	if localNames[head] {
+		return nil
+	}
+	// The rightmost receiver segment is the declaring Type; the segments before
+	// it form the package path. A lone Type segment (`OrderService.place()`)
+	// leaves an empty package path → recover via imported-type / file-package
+	// candidates.
+	typ := recv[len(recv)-1]
+	if typ == "" {
+		return nil
+	}
+	pkgPath := strings.Join(recv[:len(recv)-1], ".")
+
+	b := &qualifiedKotlinCall{leaf: leaf, typ: typ}
+	if pkgPath != "" {
+		// Fully-qualified `com.app.services.OrderService.place()`. If the head
+		// is an imported type alias, the path is actually `alias.member` and
+		// should be handled as the lone-type case below; only treat as a fully
+		// qualified package path when the head is NOT an in-scope imported name.
+		if _, aliased := c.importedTypes[head]; !aliased {
+			b.pkgCandidates = []string{pkgPath}
+			return b
+		}
+	}
+	// `Type.method()` (or `alias.method()`): candidate packages are the
+	// imported-type package (incl. aliases) and the file's own package
+	// (most-specific first).
+	if c.hasStarImport {
+		// A wildcard import could also supply this type — conservatively skip
+		// the unqualified case to avoid a wrong bind. (#4334 follow-up.)
+		if _, known := c.importedTypes[typ]; !known {
+			return nil
+		}
+	}
+	if pkg, ok := c.importedTypes[typ]; ok && pkg != "" {
+		b.pkgCandidates = appendUniqueKt(b.pkgCandidates, pkg)
+	}
+	if c.filePackage != "" {
+		b.pkgCandidates = appendUniqueKt(b.pkgCandidates, c.filePackage)
+	}
+	// Resolve an alias `Svc` to its real imported type name `OrderService` for
+	// the index lookup (the package mapping is keyed on the alias, but the
+	// callee entity's enclosing type is the real name).
+	if real, ok := c.aliasRealType[typ]; ok && real != "" {
+		b.typ = real
+	}
+	if len(b.pkgCandidates) == 0 {
+		return nil
+	}
+	return b
+}
+
+func appendUniqueKt(s []string, v string) []string {
+	for _, x := range s {
+		if x == v {
+			return s
+		}
+	}
+	return append(s, v)
+}
+
+// flattenKotlinNavigation flattens a navigation_expression composed solely of
+// simple_identifier receivers and navigation_suffix `.name` steps into its
+// dotted segments. Returns (nil, false) the moment a non-static node (a `this`
+// expression, a call_expression, an index/element access, a string template,
+// etc.) appears in the receiver chain — those are instance chains the base
+// extractor owns.
+func flattenKotlinNavigation(n *sitter.Node, src []byte) ([]string, bool) {
+	if n == nil {
+		return nil, false
+	}
+	switch n.Type() {
+	case "simple_identifier":
+		return []string{string(src[n.StartByte():n.EndByte()])}, true
+	case "navigation_expression":
+		// navigation_expression → <receiver> navigation_suffix
+		var receiver *sitter.Node
+		var suffix *sitter.Node
+		for i := 0; i < int(n.ChildCount()); i++ {
+			ch := n.Child(i)
+			switch ch.Type() {
+			case "navigation_suffix":
+				suffix = ch
+			default:
+				if receiver == nil {
+					receiver = ch
+				}
+			}
+		}
+		if receiver == nil || suffix == nil {
+			return nil, false
+		}
+		ls, ok := flattenKotlinNavigation(receiver, src)
+		if !ok {
+			return nil, false
+		}
+		// The suffix's trailing simple_identifier is the step name.
+		var step string
+		for i := int(suffix.ChildCount()) - 1; i >= 0; i-- {
+			ch := suffix.Child(i)
+			if ch.Type() == "simple_identifier" {
+				step = string(src[ch.StartByte():ch.EndByte()])
+				break
+			}
+		}
+		if step == "" {
+			return nil, false
+		}
+		return append(ls, step), true
+	}
+	return nil, false
+}

--- a/internal/extractors/kotlin/issue4375_crosspkg_test.go
+++ b/internal/extractors/kotlin/issue4375_crosspkg_test.go
@@ -1,0 +1,417 @@
+// issue4375_crosspkg_test.go — end-to-end live-pipeline validation for #4375.
+//
+// Bug: Kotlin cross-package calls reach a function/method through a qualifier on
+// a navigation_expression — a fully-qualified
+// `com.app.services.OrderService.place()`, an imported top-level function
+// (`import com.app.services.placeOrder; placeOrder()`), an imported type member
+// (`import com.app.services.Orders; Orders.place()`), an aliased import
+// (`import com.app.services.OrderService as Svc; Svc.place()`), or a same-package
+// companion/object member (`OrderService.create()`). The extractor's call target
+// is the trailing simple_identifier of the navigation chain, so a multi-segment
+// qualified call collapses to the bare leaf method name (`place`). The bare leaf
+// resolves through the global byName index, which goes AMBIGUOUS the moment two
+// packages define a same-named function/type (`OrderService.place` in both
+// com.app.services and com.app.billing) — so the CALLS edge dropped and the
+// callee package looked falsely uncalled. This is the Kotlin analogue of the Go
+// cross-package (#4332), Rust cross-module (#4373), and C# cross-namespace
+// (#4374) qualifier drops.
+//
+// These tests drive the REAL extraction + resolver passes — the same sequence
+// cmd/archigraph/index.go runs (extract per file → stamp deterministic IDs →
+// BuildIndex → ResolveKotlinCrossPackageCalls → ReferencesEmbedded) — on a
+// faithful multi-package project that reproduces a cross-package call WITH a
+// same-named type/function collision in two packages. The collision is
+// essential: a globally-unique name would false-pass through the bare-name
+// fallback (the exact trap #4332 documents).
+package kotlin_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/kotlin"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractKotlinProjectForTest(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("kotlin")
+	if !ok {
+		t.Fatal("kotlin extractor not registered")
+	}
+	var merged []types.EntityRecord
+	for rel, src := range files {
+		parser := sitter.NewParser()
+		parser.SetLanguage(tskotlin.GetLanguage())
+		tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+		if err != nil {
+			t.Fatalf("parse %s: %v", rel, err)
+		}
+		ents, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path: rel, Language: "kotlin", Content: []byte(src), Tree: tree,
+		})
+		if err != nil {
+			t.Fatalf("extract %s: %v", rel, err)
+		}
+		merged = append(merged, ents...)
+	}
+	for k := range merged {
+		if merged[k].Name == "" {
+			continue
+		}
+		merged[k].ID = graph.EntityID("acme/shop", merged[k].Kind,
+			merged[k].Name, merged[k].SourceFile)
+	}
+	return merged
+}
+
+func ktIs16Hex(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func runKotlinResolve(merged []types.EntityRecord) int {
+	idx := resolve.BuildIndex(merged)
+	n := idx.ResolveKotlinCrossPackageCalls(merged)
+	resolve.ReferencesEmbedded(merged, idx)
+	return n
+}
+
+// ktCallEdge returns the ToID + props of the CALLS edge whose call_leaf == leaf
+// (or bare ToID == leaf before resolution) emitted from the operation named
+// `caller` in `srcFile`.
+func ktCallEdge(merged []types.EntityRecord, srcFile, caller, leaf string) (string, map[string]string, bool) {
+	for k := range merged {
+		e := merged[k]
+		if e.SourceFile != srcFile || e.Name != caller {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "CALLS" {
+				continue
+			}
+			if r.Properties["call_leaf"] == leaf || r.ToID == leaf {
+				return r.ToID, r.Properties, true
+			}
+		}
+	}
+	return "", nil, false
+}
+
+func ktEntID(merged []types.EntityRecord, srcFile, name string) string {
+	for k := range merged {
+		if merged[k].SourceFile == srcFile && merged[k].Name == name {
+			return merged[k].ID
+		}
+	}
+	return ""
+}
+
+// colliding callee packages: com.app.services.OrderService.place AND
+// com.app.billing.OrderService.place — same Type AND same method in two distinct
+// packages, PLUS a colliding top-level function placeOrder in both. Only the
+// package qualifier on the call can pick the right one.
+func ktCollidingCalleeFiles() map[string]string {
+	return map[string]string{
+		"src/services/OrderService.kt": "" +
+			"package com.app.services\n" +
+			"\n" +
+			"class OrderService {\n" +
+			"    fun place() {}\n" +
+			"    fun create() {}\n" +
+			"}\n" +
+			"\n" +
+			"fun placeOrder() {}\n",
+		"src/billing/OrderService.kt": "" +
+			"package com.app.billing\n" +
+			"\n" +
+			"class OrderService {\n" +
+			"    fun place() {}\n" +
+			"}\n" +
+			"\n" +
+			"fun placeOrder() {}\n",
+	}
+}
+
+// TestIssue4375_FullyQualified — `com.app.services.OrderService.place()`.
+func TestIssue4375_FullyQualified(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        com.app.services.OrderService.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	// BEFORE: extractor stamped the qualifier; the bare leaf alone is ambiguous.
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_pkg"] != "com.app.services" || props["kotlin_call_type"] != "OrderService" {
+		t.Fatalf("expected stamped pkg=com.app.services type=OrderService, got pkg=%q type=%q",
+			props["kotlin_call_pkg"], props["kotlin_call_type"])
+	}
+
+	n := runKotlinResolve(merged)
+	if n < 1 {
+		t.Fatalf("expected >=1 kotlin cross-package rewrite, got %d", n)
+	}
+	want := ktEntID(merged, "src/services/OrderService.kt", "place")
+	collide := ktEntID(merged, "src/billing/OrderService.kt", "place")
+	got, _, _ := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ktIs16Hex(got) {
+		t.Fatalf("ToID not resolved to a hex id: %q", got)
+	}
+	if got != want {
+		t.Fatalf("resolved to wrong package: got %q want %q (collision=%q)", got, want, collide)
+	}
+	if got == collide {
+		t.Fatal("resolved to the COLLIDING billing package — the bug")
+	}
+}
+
+// TestIssue4375_ImportedTopLevelFunc — `import com.app.services.placeOrder; placeOrder()`.
+func TestIssue4375_ImportedTopLevelFunc(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.placeOrder\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        placeOrder()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "placeOrder")
+	if !ok {
+		t.Fatal("CALLS edge to placeOrder not found")
+	}
+	if props["kotlin_call_pkg"] != "com.app.services" {
+		t.Fatalf("expected stamped pkg=com.app.services, got %q", props["kotlin_call_pkg"])
+	}
+	if props["kotlin_call_type"] != "" {
+		t.Fatalf("top-level fn must NOT stamp a type, got %q", props["kotlin_call_type"])
+	}
+
+	n := runKotlinResolve(merged)
+	if n < 1 {
+		t.Fatalf("expected >=1 rewrite, got %d", n)
+	}
+	want := ktEntID(merged, "src/services/OrderService.kt", "placeOrder")
+	collide := ktEntID(merged, "src/billing/OrderService.kt", "placeOrder")
+	got, _, _ := ktCallEdge(merged, "src/app/Caller.kt", "run", "placeOrder")
+	if got != want {
+		t.Fatalf("resolved to wrong package: got %q want %q", got, want)
+	}
+	if got == collide {
+		t.Fatal("resolved to the COLLIDING billing placeOrder — the bug")
+	}
+}
+
+// TestIssue4375_ImportedTypeMember — `import com.app.services.OrderService; OrderService.place()`.
+func TestIssue4375_ImportedTypeMember(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.OrderService\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        OrderService.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_type"] != "OrderService" {
+		t.Fatalf("expected stamped type=OrderService, got %q", props["kotlin_call_type"])
+	}
+
+	n := runKotlinResolve(merged)
+	if n < 1 {
+		t.Fatalf("expected >=1 rewrite, got %d", n)
+	}
+	want := ktEntID(merged, "src/services/OrderService.kt", "place")
+	collide := ktEntID(merged, "src/billing/OrderService.kt", "place")
+	got, _, _ := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if got != want {
+		t.Fatalf("resolved to wrong package: got %q want %q", got, want)
+	}
+	if got == collide {
+		t.Fatal("resolved to the COLLIDING billing package — the bug")
+	}
+}
+
+// TestIssue4375_AliasedImport — `import com.app.services.OrderService as Svc; Svc.place()`.
+func TestIssue4375_AliasedImport(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.OrderService as Svc\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        Svc.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_type"] != "OrderService" {
+		t.Fatalf("aliased import should map Svc->OrderService, got type=%q", props["kotlin_call_type"])
+	}
+	if !strings.Contains(props["kotlin_call_pkg"], "com.app.services") {
+		t.Fatalf("aliased import should include com.app.services candidate, got pkg=%q", props["kotlin_call_pkg"])
+	}
+
+	n := runKotlinResolve(merged)
+	if n < 1 {
+		t.Fatalf("expected >=1 rewrite, got %d", n)
+	}
+	want := ktEntID(merged, "src/services/OrderService.kt", "place")
+	collide := ktEntID(merged, "src/billing/OrderService.kt", "place")
+	got, _, _ := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if got != want {
+		t.Fatalf("resolved to wrong package: got %q want %q", got, want)
+	}
+	if got == collide {
+		t.Fatal("resolved to the COLLIDING billing package — the bug")
+	}
+}
+
+// TestIssue4375_SamePackageObjectMember — a companion/object member call where
+// the object lives in the SAME package as the caller, recovered via the file
+// package even with no import. Uses an `object` so the member is statically
+// reachable as `Registry.lookup()`.
+func TestIssue4375_SamePackageObjectMember(t *testing.T) {
+	files := map[string]string{
+		// Same name `Registry.lookup` collides across two packages.
+		"src/services/Registry.kt": "" +
+			"package com.app.services\n" +
+			"\n" +
+			"object Registry {\n" +
+			"    fun lookup() {}\n" +
+			"}\n",
+		"src/billing/Registry.kt": "" +
+			"package com.app.billing\n" +
+			"\n" +
+			"object Registry {\n" +
+			"    fun lookup() {}\n" +
+			"}\n",
+		// Caller is in com.app.services — same package as the intended Registry.
+		"src/services/Caller.kt": "" +
+			"package com.app.services\n" +
+			"\n" +
+			"class Caller {\n" +
+			"    fun run() {\n" +
+			"        Registry.lookup()\n" +
+			"    }\n" +
+			"}\n",
+	}
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/services/Caller.kt", "run", "lookup")
+	if !ok {
+		t.Fatal("CALLS edge to lookup not found")
+	}
+	if props["kotlin_call_type"] != "Registry" {
+		t.Fatalf("expected stamped type=Registry, got %q", props["kotlin_call_type"])
+	}
+
+	n := runKotlinResolve(merged)
+	if n < 1 {
+		t.Fatalf("expected >=1 rewrite, got %d", n)
+	}
+	want := ktEntID(merged, "src/services/Registry.kt", "lookup")
+	collide := ktEntID(merged, "src/billing/Registry.kt", "lookup")
+	got, _, _ := ktCallEdge(merged, "src/services/Caller.kt", "run", "lookup")
+	if got != want {
+		t.Fatalf("same-package object member resolved wrong: got %q want %q", got, want)
+	}
+	if got == collide {
+		t.Fatal("resolved to the COLLIDING billing package — the bug")
+	}
+}
+
+// TestIssue4375_NegativeInstanceReceiver — an instance receiver
+// (`order.place()` where `order` is a local val) must NOT be stamped as a
+// cross-package static qualifier (no false bind).
+func TestIssue4375_NegativeInstanceReceiver(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.OrderService\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        val order = OrderService()\n" +
+		"        order.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_pkg"] != "" || props["kotlin_call_type"] != "" {
+		t.Fatalf("instance receiver must NOT be stamped, got pkg=%q type=%q",
+			props["kotlin_call_pkg"], props["kotlin_call_type"])
+	}
+}
+
+// TestIssue4375_NegativeStarImport — a star import makes the type non-unique;
+// an unqualified `Type.method()` under a star import must NOT be stamped
+// (conservative skip, #4334 follow-up).
+func TestIssue4375_NegativeStarImport(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.*\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        OrderService.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_pkg"] != "" {
+		t.Fatalf("star-import unqualified call must NOT be stamped, got pkg=%q", props["kotlin_call_pkg"])
+	}
+}

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -62,7 +62,30 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
 	root := file.Tree.RootNode()
-	walk(root, file, &entities)
+	// #4375 — per-file cross-package context (package + imports). Threaded into
+	// the call extractor so a qualified `pkg.Type.method()` / imported-fn /
+	// `Type.method()` call stamps its resolved (package[, type], leaf) onto the
+	// CALLS edge for the resolver's package-keyed bind.
+	crossCtx := buildKotlinCrossCtx(root, file.Content)
+	walk(root, file, &entities, crossCtx)
+
+	// #4375 — stamp every Kotlin entity with its file's package. Kotlin is
+	// one-package-per-file, so a post-pass is exact. The resolver's
+	// package-keyed cross-package index is built from these stamps.
+	if crossCtx != nil && crossCtx.filePackage != "" {
+		for i := range entities {
+			e := &entities[i]
+			if e.Language != "kotlin" || e.Subtype == "import" || e.Subtype == "file" {
+				continue
+			}
+			if e.Properties == nil {
+				e.Properties = map[string]string{}
+			}
+			if _, ok := e.Properties["kotlin_package"]; !ok {
+				e.Properties["kotlin_package"] = crossCtx.filePackage
+			}
+		}
+	}
 
 	// Track A (analog of #641/#650/#670 for Kotlin) — REFERENCES-edge
 	// emission. Runs after every primary-pass entity is in place so the
@@ -107,7 +130,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // per function declared inside the body, and every function body is scanned
 // for call_expression / call_suffix nodes that yield CALLS edges with stub
 // to_id. Imports are still NOT emitted.
-func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord, ctx *kotlinCrossCtx) {
 	if node == nil {
 		return
 	}
@@ -126,7 +149,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		rec, ok := buildComponent(node, file, subtype)
 		if !ok {
 			for i := range node.ChildCount() {
-				walk(node.Child(int(i)), file, out)
+				walk(node.Child(int(i)), file, out, ctx)
 			}
 			return
 		}
@@ -158,7 +181,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 					}
 					continue
 				}
-				walk(ch, file, out)
+				walk(ch, file, out, ctx)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -171,6 +194,12 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 					// when two Kotlin classes/objects in different files declare
 					// same-named functions.
 					toID = extractor.BuildOperationStructuralRef("kotlin", file.Path, child.Name)
+					// #4375 — stamp the enclosing type so the resolver's
+					// package-keyed member index can bind a cross-package
+					// `Type.method()` call. Only the DIRECT member is stamped:
+					// nested-class members were already stamped by the inner
+					// walk (which runs first), so we skip any already set.
+					stampKotlinEnclosingType(child, rec.Name)
 				case child.Kind == "SCOPE.Schema" && child.Subtype == "field":
 					// Issue #690 — CONTAINS for class-body properties,
 					// mirroring the Python fix from #689.
@@ -191,7 +220,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		rec, ok := buildComponent(node, file, "object")
 		if !ok {
 			for i := range node.ChildCount() {
-				walk(node.Child(int(i)), file, out)
+				walk(node.Child(int(i)), file, out, ctx)
 			}
 			return
 		}
@@ -210,7 +239,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 					}
 					continue
 				}
-				walk(ch, file, out)
+				walk(ch, file, out, ctx)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -223,6 +252,9 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 					// when two Kotlin classes/objects in different files declare
 					// same-named functions.
 					toID = extractor.BuildOperationStructuralRef("kotlin", file.Path, child.Name)
+					// #4375 — stamp the enclosing object/companion type for the
+					// resolver's package-keyed member index (innermost wins).
+					stampKotlinEnclosingType(child, rec.Name)
 				case child.Kind == "SCOPE.Schema" && child.Subtype == "field":
 					// Issue #690 — CONTAINS for object-body properties.
 					toID = extractor.BuildSchemaFieldStructuralRef("kotlin", file.Path, child.Name)
@@ -241,7 +273,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 	case "function_declaration":
 		if rec, ok := buildOperation(node, file); ok {
 			rec.Relationships = append(rec.Relationships,
-				extractCallRelationships(findFunctionBody(node), file.Content, rec.Name)...)
+				extractCallRelationships(findFunctionBody(node), file.Content, rec.Name, ctx)...)
 			*out = append(*out, rec)
 		}
 		return
@@ -254,7 +286,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 	}
 
 	for i := range node.ChildCount() {
-		walk(node.Child(int(i)), file, out)
+		walk(node.Child(int(i)), file, out, ctx)
 	}
 }
 
@@ -305,7 +337,17 @@ var kotlinKeywordStop = map[string]bool{
 // simple_identifier of the call's expression. FromID is left empty so
 // buildDocument substitutes the caller's entity ID at emit time. Self-recursion
 // is dropped to match Python/Go extractor dedup semantics.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+//
+// When ctx is non-nil (issue #4375), each call is additionally probed for a
+// statically-qualified cross-package shape — a fully-qualified
+// `com.app.services.OrderService.place()`, an imported top-level function, an
+// imported/aliased type member `Orders.place()`, or a same-package
+// companion/object member `OrderService.create()`. A resolvable call carries
+// `kotlin_call_pkg` (";"-separated candidate packages, most-specific first),
+// `kotlin_call_type` (declaring type; absent for a top-level-function call), and
+// `call_leaf` (the bare callee name) so the resolver can bind it through the
+// package-keyed index instead of the ambiguous bare-name path.
+func extractCallRelationships(body *sitter.Node, src []byte, callerName string, ctx *kotlinCrossCtx) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -313,6 +355,9 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 	if len(calls) == 0 {
 		return nil
 	}
+	// Instance-receiver guard inputs: names whose head segment marks an
+	// instance receiver (`order.place()`) rather than a static type qualifier.
+	localNames := kotlinLocalValueNames(body, src)
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
@@ -333,13 +378,61 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 		seen[target] = true
 		// Line is 1-based: tree-sitter StartPoint().Row is 0-based.
 		callLine := strconv.Itoa(int(call.StartPoint().Row) + 1)
+		props := map[string]string{"line": callLine}
+		// #4375 — stamp the cross-package qualifier when statically resolvable.
+		if ctx != nil {
+			if q := ctx.resolveKotlinQualifiedCall(call, src, localNames); q != nil &&
+				q.leaf == target && len(q.pkgCandidates) > 0 {
+				props["kotlin_call_pkg"] = strings.Join(q.pkgCandidates, ";")
+				props["call_leaf"] = q.leaf
+				if q.typ != "" {
+					props["kotlin_call_type"] = q.typ
+				}
+			}
+		}
 		rels = append(rels, types.RelationshipRecord{
 			ToID:       target,
 			Kind:       "CALLS",
-			Properties: map[string]string{"line": callLine},
+			Properties: props,
 		})
 	}
 	return rels
+}
+
+// stampKotlinEnclosingType records the declaring type name on a member
+// Operation entity (issue #4375) so the resolver's package-keyed member index
+// can bind a cross-package `Type.method()` call. Idempotent and innermost-wins:
+// a nested-class member already stamped by the inner walk is left untouched, so
+// the outer class does not overwrite the correct (inner) enclosing type.
+func stampKotlinEnclosingType(e *types.EntityRecord, typeName string) {
+	if e == nil || typeName == "" {
+		return
+	}
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	if _, ok := e.Properties["kotlin_enclosing_type"]; !ok {
+		e.Properties["kotlin_enclosing_type"] = typeName
+	}
+}
+
+// kotlinLocalValueNames collects the in-scope value names declared inside a
+// function body — parameters are not reachable from the body node, so this
+// gathers `val`/`var` property_declaration and variable_declaration names. A
+// head segment matching one of these marks an INSTANCE receiver, which the
+// cross-package qualifier resolver must skip (no false static-qualifier stamp).
+func kotlinLocalValueNames(body *sitter.Node, src []byte) map[string]bool {
+	names := map[string]bool{}
+	for _, vd := range findAllNodes(body, "variable_declaration", "property_declaration") {
+		for i := 0; i < int(vd.ChildCount()); i++ {
+			ch := vd.Child(i)
+			if ch.Type() == "simple_identifier" {
+				names[string(src[ch.StartByte():ch.EndByte()])] = true
+				break
+			}
+		}
+	}
+	return names
 }
 
 // kotlinCallTarget resolves the callee name from a call_expression node.

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2479,6 +2479,103 @@ func (idx Index) ResolveCSharpCrossNamespaceCalls(records []types.EntityRecord) 
 	return rewrites
 }
 
+// ResolveKotlinCrossPackageCalls binds Kotlin CALLS edges that reach a
+// function/method in another package through a qualifier on a navigation
+// invocation — a fully-qualified `com.app.services.OrderService.place()`, an
+// imported top-level function (`import com.app.services.placeOrder;
+// placeOrder()`), an imported/aliased type member (`import
+// com.app.services.Orders; Orders.place()`), or a same-package companion/object
+// member (`OrderService.create()`) — to the callee's entity ID.
+//
+// Background (issue #4375): the Kotlin extractor's call target is the trailing
+// simple_identifier of the navigation chain, so a multi-segment qualified call
+// collapses to the bare leaf method name (`place`). A bare name resolves through
+// the global byName index, which goes ambiguous the moment two packages define a
+// same-named function/type (`OrderService.place` in both com.app.services and
+// com.app.billing) — so the CALLS edge drops and the callee package looks
+// falsely uncalled. This is the Kotlin analogue of the Go cross-package (#4332),
+// Rust cross-module (#4373), and C# cross-namespace (#4374) qualifier drops.
+//
+// Like C# namespaces, Kotlin `package` declarations are NOT directory-bound, so
+// this pass keys on the Kotlin PACKAGE via byKotlinPkgMember[pkg][Type][leaf]
+// (members) and byKotlinPkgFunc[pkg][leaf] (top-level functions) rather than a
+// source directory. The extractor stamps, on each qualified CALLS edge:
+//   - Properties["kotlin_call_pkg"]: ";"-separated candidate packages (a
+//     fully-qualified path yields one; a `Type.method()` member call yields the
+//     imported-type / file packages, most-specific first).
+//   - Properties["kotlin_call_type"]: the declaring type (absent for a
+//     top-level-function call).
+//   - Properties["call_leaf"]: the bare callee name.
+//
+// Conservative by construction, mirroring the Go/Rust/C# passes:
+//   - Only edges carrying kotlin_call_pkg AND call_leaf participate.
+//   - Edges whose ToID is already a hex ID are left alone (idempotent).
+//   - The first candidate package that yields an unambiguous non-blank id wins;
+//     if two candidates resolve to DIFFERENT ids the edge is left alone
+//     (ambiguous). A blank-string sentinel (collision) is skipped, never guessed.
+//
+// Must run AFTER BuildIndex (needs the Kotlin package indexes) and BEFORE the
+// embedded-reference resolver so the rewritten hex ID is seen as resolved.
+// Returns the number of edges rewritten.
+func (idx Index) ResolveKotlinCrossPackageCalls(records []types.EntityRecord) int {
+	if len(idx.byKotlinPkgMember) == 0 && len(idx.byKotlinPkgFunc) == 0 {
+		return 0
+	}
+	rewrites := 0
+	for k := range records {
+		rec := &records[k]
+		for j := range rec.Relationships {
+			r := &rec.Relationships[j]
+			if r.Kind != "CALLS" || r.Properties == nil {
+				continue
+			}
+			pkgRaw := r.Properties["kotlin_call_pkg"]
+			leaf := r.Properties["call_leaf"]
+			if pkgRaw == "" || leaf == "" {
+				continue
+			}
+			if r.ToID == "" || isHexID(r.ToID) {
+				continue // already resolved
+			}
+			typ := r.Properties["kotlin_call_type"] // "" => top-level function
+			resolved := ""
+			conflict := false
+			for _, pkg := range strings.Split(pkgRaw, ";") {
+				if pkg == "" {
+					continue
+				}
+				id := ""
+				if typ != "" {
+					if pkgBucket, ok := idx.byKotlinPkgMember[pkg]; ok {
+						if typeBucket, ok := pkgBucket[typ]; ok {
+							id = typeBucket[leaf] // "" => collision sentinel or miss
+						}
+					}
+				} else {
+					if pkgBucket, ok := idx.byKotlinPkgFunc[pkg]; ok {
+						id = pkgBucket[leaf] // "" => collision sentinel or miss
+					}
+				}
+				if id == "" {
+					continue
+				}
+				if resolved == "" {
+					resolved = id
+				} else if resolved != id {
+					conflict = true
+					break
+				}
+			}
+			if conflict || resolved == "" {
+				continue
+			}
+			r.ToID = resolved
+			rewrites++
+		}
+	}
+	return rewrites
+}
+
 // lookupUniqueMember returns the entity id for scope.member if and only if it
 // is unique across the whole crate (every byMember file-bucket that defines it
 // agrees on the same id). Returns "" on miss or any disagreement (ambiguous).

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -507,6 +507,21 @@ type Index struct {
 	// than binding to the wrong overload.
 	byNamespaceMember map[string]map[string]map[string]string
 
+	// byKotlinPkgMember[package][type_name][member_name] = entity_id and
+	// byKotlinPkgFunc[package][func_name] = entity_id power the Kotlin
+	// cross-package CALLS path (issue #4375). Like C# namespaces, Kotlin
+	// `package` declarations are NOT directory-bound — a file's declared
+	// package need not match its source directory — so neither the package-dir
+	// keyed byPackageMember nor a dotted-Name index (Kotlin function entities
+	// carry a BARE Name, not `Type.method`) can disambiguate a cross-package
+	// call. These indexes key on the Kotlin package stamped on each entity
+	// (Properties["kotlin_package"]), with the declaring type from
+	// Properties["kotlin_enclosing_type"] for members. A blank-string sentinel
+	// marks collisions so the resolver leaves the edge alone rather than binding
+	// to the wrong package's same-named symbol.
+	byKotlinPkgMember map[string]map[string]map[string]string
+	byKotlinPkgFunc   map[string]map[string]string
+
 	// PlatformVariants maps a canonical platform-variant entity ID to the
 	// slice of non-canonical variant entity IDs that were merged into it
 	// during BuildIndex. Populated when byPackageOperation detects a
@@ -722,6 +737,8 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byNamespaceMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgFunc:    make(map[string]map[string]string),
 		byQualifiedName:    make(map[string]string),
 		PlatformVariants:   make(map[string][]string),
 	}
@@ -1071,6 +1088,48 @@ func BuildIndex(entities []types.EntityRecord) Index {
 						} else {
 							nsScopeBucket[member] = e.ID
 						}
+					}
+				}
+			}
+		}
+
+		// Kotlin package-scoped indexes (issue #4375). Kotlin function
+		// entities carry a BARE Name (not `Type.method`), so the dotted-Name
+		// block above never populates a Kotlin member; index from the
+		// kotlin_package / kotlin_enclosing_type properties instead. A member
+		// (kotlin_enclosing_type present) lands in byKotlinPkgMember
+		// [package][Type][bareName]; a top-level function lands in
+		// byKotlinPkgFunc[package][bareName]. Blank-string sentinel marks
+		// collisions. Components (classes/objects) are not indexed here — the
+		// resolver binds calls to functions, not to type declarations.
+		if e.Properties != nil && isOperationKind(e.Kind) {
+			if pkg := e.Properties["kotlin_package"]; pkg != "" && e.Name != "" {
+				if typ := e.Properties["kotlin_enclosing_type"]; typ != "" {
+					pkgBucket := idx.byKotlinPkgMember[pkg]
+					if pkgBucket == nil {
+						pkgBucket = make(map[string]map[string]string)
+						idx.byKotlinPkgMember[pkg] = pkgBucket
+					}
+					typeBucket := pkgBucket[typ]
+					if typeBucket == nil {
+						typeBucket = make(map[string]string)
+						pkgBucket[typ] = typeBucket
+					}
+					if existing, ok := typeBucket[e.Name]; ok && existing != e.ID {
+						typeBucket[e.Name] = "" // ambiguous within (pkg, type, member)
+					} else {
+						typeBucket[e.Name] = e.ID
+					}
+				} else {
+					funcBucket := idx.byKotlinPkgFunc[pkg]
+					if funcBucket == nil {
+						funcBucket = make(map[string]string)
+						idx.byKotlinPkgFunc[pkg] = funcBucket
+					}
+					if existing, ok := funcBucket[e.Name]; ok && existing != e.ID {
+						funcBucket[e.Name] = "" // ambiguous within (pkg, func)
+					} else {
+						funcBucket[e.Name] = e.ID
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Kotlin qualified cross-package calls collapsed to a bare leaf method name and went unresolved / ambiguous under a same-name collision across packages. This completes the cross-package-CALLS axis after Go (#4332), Rust (#4373), and C# (#4374).

Kotlin reaches a function/method in another package through a qualifier on a `navigation_expression` invocation — fully-qualified `com.app.services.OrderService.place()`, an imported top-level function (`import com.app.services.placeOrder; placeOrder()`), an imported type (`Orders.place()`), an aliased import (`import ... as Svc; Svc.place()`), or a same-package companion/object member (`OrderService.create()`). `kotlinCallTarget` returned only the trailing `simple_identifier`, dropping the entire receiver qualifier. The bare leaf then resolves through the global byName index, which goes ambiguous the moment two packages define a same-named symbol (`OrderService.place` in both `com.app.services` and `com.app.billing`) — so the edge drops and the callee package looks falsely uncalled.

## Fix (structural, mirrors #4332/#4373/#4374)

Like C# namespaces, Kotlin `package` declarations are **not** directory-bound, so the resolver keys on the **package**, not the source dir. Unlike C#, Kotlin function entities carry a **bare** Name (not `Type.method`), so the C# `byNamespaceMember` (dotted-Name) index could not be reused — a parallel package-keyed index was added.

- **Extractor** (`internal/extractors/kotlin/crosspath.go`, new): per-file `kotlinCrossCtx` from `package` + `import` (incl. `as` aliases and `.*` star imports). Statically-qualified navigation calls stamp `kotlin_call_pkg` (";"-separated candidates, most-specific first), `kotlin_call_type` (absent for top-level fns), and `call_leaf`. Instance-receiver and star-import-uncertain calls are left unstamped. Each entity is stamped with `kotlin_package`; members with `kotlin_enclosing_type` (innermost wins).
- **Resolver** (`internal/resolve/refs.go` + `imports.go`): two package-keyed indexes built in `BuildIndex` from the stamped properties — `byKotlinPkgMember[pkg][Type][leaf]` and `byKotlinPkgFunc[pkg][leaf]`. `ResolveKotlinCrossPackageCalls` binds the edges; first unambiguous non-blank candidate wins, disagreement / collision sentinel → skip.
- **Wiring** (`cmd/archigraph/index.go`): after `BuildIndex`, before the embedded-reference resolver, alongside the Go/Rust/C# passes.

## Live-validation

In-pipeline test (`issue4375_crosspkg_test.go`) runs the real extract → BuildIndex → ResolveKotlinCrossPackageCalls → ReferencesEmbedded sequence on a multi-package project with a same-named `OrderService.place` / `placeOrder` collision in two packages. Fully-qualified, imported-top-level-fn, imported-type-member, aliased-import, and same-package object-member calls each bind to the correct package after; RED baseline confirmed the edge stays the unresolved bare `place` without the pass. Negative tests: instance receivers and unqualified calls under a star import are never stamped.

## Coverage

Covered: fully-qualified, top-level-fn import, imported/aliased type member, same-package companion/object member. Deferred (follow-ups, ref epic #4334): star-imports and extension-function receiver inference — conservatively skipped, never a wrong bind.

## Gates

`go build ./...`, `go vet ./...`, `go test ./internal/extractors/kotlin/ ./internal/resolve/ ./internal/types/` all green.

Closes #4375

🤖 Generated with [Claude Code](https://claude.com/claude-code)