### PR TITLE
fix(js-orm): bind Sequelize/Drizzle/Objection/MikroORM/Prisma model fields to their owning class

### DIFF
--- a/internal/custom/javascript/drizzle.go
+++ b/internal/custom/javascript/drizzle.go
@@ -92,6 +92,19 @@ func (e *drizzleExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		entities = append(entities, ent)
 	}
 
+	// tableOwner maps a table's JS const binding to its model node so column /
+	// reference fields below can hang a CONTAINS membership edge off it (issue
+	// #4365) and so .references(() => other.col) resolves the target table binding
+	// to its model name. Populated while scanning table definitions.
+	type ownerInfo struct {
+		modelName string // SQL table name (the model node name)
+		binding   string // JS const binding
+		off       int    // byte offset of the `const x = pgTable(` opener
+		idx       int    // index into entities
+	}
+	var tableOwners []ownerInfo
+	bindingToModel := make(map[string]string)
+
 	if lang == "typescript" || lang == "javascript" {
 		// Table model definitions.
 		for _, m := range reDrizzleTable.FindAllStringSubmatchIndex(src, -1) {
@@ -101,7 +114,25 @@ func (e *drizzleExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 			ent := makeEntity(table, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "drizzle", "binding", binding, "builder", builder,
 				"table", table, "provenance", "INFERRED_FROM_DRIZZLE_TABLE")
+			if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+				tableOwners = append(tableOwners, ownerInfo{modelName: table, binding: binding, off: m[0], idx: len(entities)})
+				bindingToModel[binding] = table
+			}
 			addEntity(ent)
+		}
+
+		// owningTable returns the table whose pgTable( opener most closely precedes
+		// a body offset (the table body is the object literal that follows).
+		owningTable := func(offset int) (ownerInfo, bool) {
+			best := ownerInfo{idx: -1}
+			found := false
+			for _, o := range tableOwners {
+				if o.off <= offset {
+					best = o
+					found = true
+				}
+			}
+			return best, found
 		}
 
 		// Enum definitions.
@@ -121,17 +152,28 @@ func (e *drizzleExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 			addEntity(ent)
 		}
 
-		// Column definitions: emit SCOPE.Component "column" entities for schema_extraction.
+		// Column definitions: emit SCOPE.Component "column" entities for
+		// schema_extraction. Each column is a CONTAINS member of its owning table
+		// model node (issue #4365) so it is not an orphan. The `colName` here is the
+		// JS binding for membership/field-name purposes.
 		for _, m := range reDrizzleColumnDef.FindAllStringSubmatchIndex(src, -1) {
 			binding := src[m[2]:m[3]]
 			sqlName := src[m[4]:m[5]]
 			ent := makeEntity(sqlName, "SCOPE.Component", "column", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "drizzle", "binding", binding,
 				"provenance", "INFERRED_FROM_DRIZZLE_COLUMN_DEF")
+			if owner, ok := owningTable(m[0]); ok && owner.idx >= 0 {
+				setProps(&ent, "owner_table", owner.modelName)
+				entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+					containsFieldEdge(owner.modelName, ent.ID, binding, "drizzle"))
+			}
 			addEntity(ent)
 		}
 
-		// .references(() => table.col) — emit foreign_key entities.
+		// .references(() => table.col) — emit foreign_key entities. The FK column is
+		// a CONTAINS member of its owning table, and the referenced table is captured
+		// as a REFERENCES edge to that table's model node (issue #4365). The target
+		// JS binding is resolved to the SQL table (model) name via bindingToModel.
 		for _, m := range reDrizzleReferences.FindAllStringSubmatchIndex(src, -1) {
 			refTable := src[m[2]:m[3]]
 			refCol := src[m[4]:m[5]]
@@ -139,6 +181,20 @@ func (e *drizzleExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 			ent := makeEntity(name, "SCOPE.Component", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "drizzle", "ref_table", refTable, "ref_column", refCol,
 				"provenance", "INFERRED_FROM_DRIZZLE_REFERENCES")
+			// Resolve the referenced binding to its SQL table (model) name so the
+			// REFERENCES target stub matches the table model node by name.
+			targetModel := refTable
+			if mn, ok := bindingToModel[refTable]; ok {
+				targetModel = mn
+			}
+			setProps(&ent, "target_table", targetModel)
+			ent.Relationships = append(ent.Relationships,
+				referencesClassEdge(ent.ID, targetModel, "drizzle", refCol))
+			if owner, ok := owningTable(m[0]); ok && owner.idx >= 0 {
+				setProps(&ent, "owner_table", owner.modelName)
+				entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+					containsFieldEdge(owner.modelName, ent.ID, name, "drizzle"))
+			}
 			addEntity(ent)
 		}
 

--- a/internal/custom/javascript/issue4365_livedrepro_test.go
+++ b/internal/custom/javascript/issue4365_livedrepro_test.go
@@ -1,0 +1,205 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4365 LIVE-REPRO.
+//
+// Generalises the field-membership fix #4328 (TypeORM / class-validator /
+// mongoose) to the remaining JS/TS ORMs: Sequelize, Drizzle, Objection,
+// MikroORM and Prisma. Before this fix, the model/entity FIELD entities those
+// extractors emit (Sequelize columns, Drizzle columns + FK refs, Objection
+// relationMappings, MikroORM @Property/@relation, Prisma model fields) were
+// standalone graph nodes with NO owning-class CONTAINS edge (orphans) and NO
+// REFERENCES edge to their relation/FK target type.
+//
+// Each test below runs the REAL extractor AND the REAL resolve.BuildIndex
+// symbol table over a faithful fixture and asserts:
+//
+//	(1) field membership — every emitted field/column/relation entity carries a
+//	    CONTAINS edge FROM its owning model/entity class node; and
+//	(2) relation/FK target — the relation or FK target type emits a REFERENCES
+//	    edge to the target Class:<Name> stub, which RESOLVES against the
+//	    same-file model node in the symbol table.
+
+func loadRepro4365(t *testing.T, base, repoPath, lang string) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "issue4365", base)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read repro %s: %v", p, err)
+	}
+	return extreg.FileInput{Path: repoPath, Language: lang, Content: b}
+}
+
+func extract4365(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract %s: %v", name, err)
+	}
+	return ents
+}
+
+// containsToMember reports whether some entity declares a CONTAINS edge whose
+// ToID names the given member entity ID.
+func containsToMember(ents []types.EntityRecord, memberID string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindContains) && r.ToID == memberID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func referencesTo(ents []types.EntityRecord, stub string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindReferences) && r.ToID == stub {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assertFieldsAreMembers asserts every entity with a subtype in fieldSubtypes is
+// a CONTAINS member, returning the orphan count.
+func assertFieldsAreMembers(t *testing.T, ents []types.EntityRecord, fieldSubtypes map[string]bool, orm string) int {
+	t.Helper()
+	var fields []types.EntityRecord
+	for _, e := range ents {
+		if fieldSubtypes[e.Subtype] {
+			fields = append(fields, e)
+		}
+	}
+	if len(fields) == 0 {
+		t.Fatalf("%s: no field/column/relation entities extracted", orm)
+	}
+	orphans := 0
+	for _, fe := range fields {
+		if !containsToMember(ents, fe.ID) {
+			orphans++
+			t.Errorf("%s ORPHAN field (no CONTAINS from owner): subtype=%s name=%q", orm, fe.Subtype, fe.Name)
+		}
+	}
+	t.Logf("%s: orphaned field entities = %d / %d", orm, orphans, len(fields))
+	return orphans
+}
+
+func dumpEnts(t *testing.T, ents []types.EntityRecord) {
+	for _, e := range ents {
+		t.Logf("ENTITY kind=%s subtype=%s name=%q rels=%d", e.Kind, e.Subtype, e.Name, len(e.Relationships))
+		for _, r := range e.Relationships {
+			t.Logf("   EDGE %s from=%s to=%s", r.Kind, r.FromID, r.ToID)
+		}
+	}
+}
+
+func TestIssue4365_Sequelize_FieldsAreMembers(t *testing.T) {
+	file := loadRepro4365(t, "sequelize-user.model.js.txt", "src/models/user.model.js", "javascript")
+	ents := extract4365(t, "custom_js_sequelize", file)
+	dumpEnts(t, ents)
+
+	assertFieldsAreMembers(t, ents, map[string]bool{"column": true, "foreign_key": true}, "sequelize")
+
+	// FK references: Organization model class is REFERENCES'd.
+	if !referencesTo(ents, "Class:Organization") {
+		t.Errorf("sequelize: expected REFERENCES edge to Class:Organization for FK column")
+	}
+
+	// Resolve User model node in the symbol table.
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("Class:User"); !ok {
+		t.Errorf("sequelize: Class:User stub did not resolve to the User model node")
+	}
+}
+
+func TestIssue4365_Drizzle_FieldsAreMembers(t *testing.T) {
+	file := loadRepro4365(t, "drizzle-schema.ts.txt", "src/db/schema.ts", "typescript")
+	ents := extract4365(t, "custom_js_drizzle", file)
+	dumpEnts(t, ents)
+
+	assertFieldsAreMembers(t, ents, map[string]bool{"column": true, "foreign_key": true}, "drizzle")
+
+	// .references(() => users.id) → REFERENCES to the users table model node.
+	if !referencesTo(ents, "Class:users") {
+		t.Errorf("drizzle: expected REFERENCES edge to Class:users for FK .references()")
+	}
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("Class:users"); !ok {
+		t.Errorf("drizzle: Class:users stub did not resolve to the users table node")
+	}
+}
+
+func TestIssue4365_Objection_RelationsAreMembers(t *testing.T) {
+	file := loadRepro4365(t, "objection-person.model.js.txt", "src/models/Person.js", "javascript")
+	ents := extract4365(t, "custom_js_objection", file)
+	dumpEnts(t, ents)
+
+	assertFieldsAreMembers(t, ents, map[string]bool{"relation": true}, "objection")
+
+	// relationMappings.pets → modelClass: Animal; parent → modelClass: Person.
+	if !referencesTo(ents, "Class:Animal") {
+		t.Errorf("objection: expected REFERENCES edge to Class:Animal for pets relation modelClass")
+	}
+	if !referencesTo(ents, "Class:Person") {
+		t.Errorf("objection: expected REFERENCES edge to Class:Person (self-relation) modelClass")
+	}
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("Class:Person"); !ok {
+		t.Errorf("objection: Class:Person stub did not resolve to the Person model node")
+	}
+}
+
+func TestIssue4365_MikroORM_FieldsAreMembers(t *testing.T) {
+	file := loadRepro4365(t, "mikroorm-author.entity.ts.txt", "src/entities/author.entity.ts", "typescript")
+	ents := extract4365(t, "custom_js_mikroorm", file)
+	dumpEnts(t, ents)
+
+	assertFieldsAreMembers(t, ents, map[string]bool{"field": true, "relation": true}, "mikro-orm")
+
+	// @ManyToOne(() => Publisher) and @OneToMany(() => Book) thunk targets.
+	if !referencesTo(ents, "Class:Publisher") {
+		t.Errorf("mikro-orm: expected REFERENCES edge to Class:Publisher for @ManyToOne thunk")
+	}
+	if !referencesTo(ents, "Class:Book") {
+		t.Errorf("mikro-orm: expected REFERENCES edge to Class:Book for @OneToMany thunk")
+	}
+}
+
+func TestIssue4365_Prisma_FieldsAreMembers(t *testing.T) {
+	file := loadRepro4365(t, "prisma-schema.prisma.txt", "prisma/schema.prisma", "")
+	ents := extract4365(t, "custom_js_prisma", file)
+	dumpEnts(t, ents)
+
+	assertFieldsAreMembers(t, ents, map[string]bool{"field": true}, "prisma")
+
+	// Relation fields: User.posts → Post, Post.author → User, etc.
+	if !referencesTo(ents, "Class:Post") {
+		t.Errorf("prisma: expected REFERENCES edge to Class:Post for User.posts relation field")
+	}
+	if !referencesTo(ents, "Class:User") {
+		t.Errorf("prisma: expected REFERENCES edge to Class:User for Post.author relation field")
+	}
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("Class:Post"); !ok {
+		t.Errorf("prisma: Class:Post stub did not resolve to the Post model node")
+	}
+}

--- a/internal/custom/javascript/mikroorm.go
+++ b/internal/custom/javascript/mikroorm.go
@@ -39,6 +39,11 @@ var (
 	reMikroRelation = regexp.MustCompile(
 		`@(ManyToOne|OneToMany|OneToOne|ManyToMany)\s*\([^@]*?\)\s+(\w+)`,
 	)
+	// The `() => Target` / `entity: () => Target` thunk inside a MikroORM relation
+	// decorator names the related entity class (group 1). Issue #4365.
+	reMikroRelationTarget = regexp.MustCompile(
+		`=>\s*([A-Z][A-Za-z0-9_]*)`,
+	)
 	// Relation decorators with lazy: true OR LoadStrategy.LAZY/EXTRA_LAZY in options.
 	// Issue #3071 — lazy_loading_recognition for MikroORM.
 	reMikroLazyRelation = regexp.MustCompile(
@@ -87,11 +92,26 @@ func (e *mikroORMExtractor) Extract(ctx context.Context, file extreg.FileInput) 
 		entities = append(entities, ent)
 	}
 
+	// @Entity / @Embeddable classes. Track each class's byte offset and its index
+	// in the entities slice so @Property / relation fields below can hang a
+	// CONTAINS membership edge off the owning class node (issue #4365) — the same
+	// fix #4328 applied to TypeORM/mongoose, generalised to MikroORM's decorator
+	// form.
+	type ownerInfo struct {
+		name string
+		off  int
+		idx  int
+	}
+	var owners []ownerInfo
+
 	// @Entity classes.
 	for _, m := range reMikroEntity.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "entity", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "mikro-orm", "provenance", "INFERRED_FROM_MIKROORM_ENTITY")
+		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+			owners = append(owners, ownerInfo{name: name, off: m[0], idx: len(entities)})
+		}
 		addEntity(ent)
 	}
 
@@ -100,26 +120,67 @@ func (e *mikroORMExtractor) Extract(ctx context.Context, file extreg.FileInput) 
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "embeddable", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "mikro-orm", "provenance", "INFERRED_FROM_MIKROORM_EMBEDDABLE")
+		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+			owners = append(owners, ownerInfo{name: name, off: m[0], idx: len(entities)})
+		}
 		addEntity(ent)
 	}
 
-	// @Property / @PrimaryKey / @Enum fields.
+	// owningEntity returns the @Entity/@Embeddable class whose declaration most
+	// closely precedes a body offset, and whether one was found.
+	owningEntity := func(offset int) (ownerInfo, bool) {
+		best := ownerInfo{idx: -1}
+		found := false
+		for _, o := range owners {
+			if o.off <= offset {
+				best = o
+				found = true
+			}
+		}
+		return best, found
+	}
+
+	// @Property / @PrimaryKey / @Enum fields. Each field becomes a CONTAINS member
+	// of its owning @Entity (issue #4365) so it is not an orphan.
 	for _, m := range reMikroProperty.FindAllStringSubmatchIndex(src, -1) {
 		decorator := src[m[2]:m[3]]
 		fieldName := src[m[4]:m[5]]
 		ent := makeEntity(fieldName, "SCOPE.Component", "field", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "mikro-orm", "decorator", decorator, "field_name", fieldName,
 			"provenance", "INFERRED_FROM_MIKROORM_PROPERTY")
+		if owner, ok := owningEntity(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_class", owner.name)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.name, ent.ID, fieldName, "mikro-orm"))
+		}
 		addEntity(ent)
 	}
 
-	// Relations.
+	// Relations. The relation field is a CONTAINS member of its owning entity, and
+	// the `() => Target` thunk class is captured as a REFERENCES edge (issue #4365).
 	for _, m := range reMikroRelation.FindAllStringSubmatchIndex(src, -1) {
 		relType := src[m[2]:m[3]]
 		fieldName := src[m[4]:m[5]]
+		// Decorator args blob spans the matched decorator up to the field name; the
+		// `() => Target` arrow inside names the related entity class.
+		argsBlob := src[m[0]:m[5]]
+		target := ""
+		if tm := reMikroRelationTarget.FindStringSubmatch(argsBlob); tm != nil {
+			target = tm[1]
+		}
 		ent := makeEntity(relType+":"+fieldName, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "mikro-orm", "relation_type", relType, "field_name", fieldName,
 			"provenance", "INFERRED_FROM_MIKROORM_RELATION")
+		if target != "" {
+			setProps(&ent, "target_entity", target)
+			ent.Relationships = append(ent.Relationships,
+				referencesClassEdge(ent.ID, target, "mikro-orm", fieldName))
+		}
+		if owner, ok := owningEntity(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_class", owner.name)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.name, ent.ID, fieldName, "mikro-orm"))
+		}
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/objection.go
+++ b/internal/custom/javascript/objection.go
@@ -43,6 +43,11 @@ var (
 	reObjectionRelation = regexp.MustCompile(
 		`([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\{[^}]*relation\s*:\s*Model\s*\.\s*(BelongsToOneRelation|HasManyRelation|HasOneRelation|ManyToManyRelation|HasOneThroughRelation)`,
 	)
+	// The `modelClass: Target` (or `modelClass: () => Target`) entry inside a
+	// relationMapping names the related model class. Issue #4365.
+	reObjectionModelClass = regexp.MustCompile(
+		`modelClass\s*:\s*(?:\(\s*\)\s*=>\s*)?([A-Z][A-Za-z0-9_]*)`,
+	)
 )
 
 func (e *objectionExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
@@ -76,11 +81,19 @@ func (e *objectionExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		entities = append(entities, ent)
 	}
 
-	// Model classes (extends Model). Capture an optional bound table name.
+	// Model classes (extends Model). Capture an optional bound table name and track
+	// each class's byte offset + entities-slice index so relationMapping entries
+	// can hang a CONTAINS membership edge off the owning model node (issue #4365).
 	tableName := ""
 	if tm := reObjectionTableName.FindStringSubmatch(src); tm != nil {
 		tableName = tm[1]
 	}
+	type ownerInfo struct {
+		name string
+		off  int
+		idx  int
+	}
+	var owners []ownerInfo
 	for _, m := range reObjectionModel.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
@@ -88,7 +101,24 @@ func (e *objectionExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		if tableName != "" {
 			setProps(&ent, "table", tableName)
 		}
+		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+			owners = append(owners, ownerInfo{name: name, off: m[0], idx: len(entities)})
+		}
 		addEntity(ent)
+	}
+
+	// owningModel returns the model class whose declaration most closely precedes
+	// a body offset.
+	owningModel := func(offset int) (ownerInfo, bool) {
+		best := ownerInfo{idx: -1}
+		found := false
+		for _, o := range owners {
+			if o.off <= offset {
+				best = o
+				found = true
+			}
+		}
+		return best, found
 	}
 
 	// jsonSchema field-set marker.
@@ -105,13 +135,29 @@ func (e *objectionExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		addEntity(ent)
 	}
 
-	// Individual relations.
+	// Individual relations. Each relation is a CONTAINS member of its owning model
+	// (issue #4365), and the relation's `modelClass: Target` is captured as a
+	// REFERENCES edge to the target model class.
 	for _, m := range reObjectionRelation.FindAllStringSubmatchIndex(src, -1) {
 		field := src[m[2]:m[3]]
 		relType := src[m[4]:m[5]]
 		ent := makeEntity(relType+":"+field, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "objection", "relation_type", relType, "field_name", field,
 			"provenance", "INFERRED_FROM_OBJECTION_RELATION")
+		// modelClass: Target inside this relation's object block. Search a bounded
+		// window after the match start up to the next relation entry / block end.
+		window := src[m[0]:min(len(src), m[1]+400)]
+		if tm := reObjectionModelClass.FindStringSubmatch(window); tm != nil {
+			target := tm[1]
+			setProps(&ent, "target_model", target)
+			ent.Relationships = append(ent.Relationships,
+				referencesClassEdge(ent.ID, target, "objection", field))
+		}
+		if owner, ok := owningModel(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_class", owner.name)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.name, ent.ID, field, "objection"))
+		}
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/prisma.go
+++ b/internal/custom/javascript/prisma.go
@@ -203,14 +203,59 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	}
 
 	// Prisma model field definitions — emit SCOPE.Component "field" entities for
-	// schema_extraction. Only inside .prisma files.
+	// schema_extraction. Only inside .prisma files. Each field is a CONTAINS member
+	// of its owning model (issue #4365); a field whose type names another model
+	// also carries a REFERENCES edge to that model (the relation target type).
 	if isPrismaSchema {
+		// Map each model field-line global offset to its owning model name by
+		// walking the model blocks. modelFieldOwner returns the owner for an offset.
+		type blockSpan struct {
+			name       string
+			start, end int
+		}
+		var spans []blockSpan
+		for _, m := range rePrismaModel.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			start := m[1]
+			end := len(src)
+			if i := strings.Index(src[start:], "\n}"); i >= 0 {
+				end = start + i + 2
+			}
+			spans = append(spans, blockSpan{name: name, start: start, end: end})
+		}
+		ownerOf := func(off int) (string, bool) {
+			for _, s := range spans {
+				if off >= s.start && off < s.end {
+					return s.name, true
+				}
+			}
+			return "", false
+		}
 		for _, m := range rePrismaModelField.FindAllStringSubmatchIndex(src, -1) {
+			owner, hasOwner := ownerOf(m[0])
+			// Only emit fields that live inside a model block. Lines inside the
+			// datasource/generator blocks (`generator client {`, `model = "..."`)
+			// otherwise leak in as standalone orphan "field" entities (#4365).
+			if !hasOwner {
+				continue
+			}
 			fieldName := src[m[2]:m[3]]
 			fieldType := src[m[4]:m[5]]
 			ent := makeEntity(fieldName, "SCOPE.Component", "field", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "prisma", "field_type", fieldType,
 				"provenance", "INFERRED_FROM_PRISMA_FIELD")
+			setProps(&ent, "owner_model", owner)
+			// Relation field: base type names another model (incl. self-relations).
+			// Capture the target as a REFERENCES edge so the field is not a semantic
+			// orphan.
+			baseType := strings.TrimSuffix(strings.TrimSuffix(fieldType, "[]"), "?")
+			if knownModels[baseType] {
+				setProps(&ent, "target_model", baseType)
+				ent.Relationships = append(ent.Relationships,
+					referencesClassEdge(ent.ID, baseType, "prisma", fieldName))
+			}
+			entities[modelIdx[owner]].Relationships = append(entities[modelIdx[owner]].Relationships,
+				containsFieldEdge(owner, ent.ID, fieldName, "prisma"))
 			addEntity(ent)
 		}
 

--- a/internal/custom/javascript/sequelize.go
+++ b/internal/custom/javascript/sequelize.go
@@ -222,6 +222,17 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		addEntity(ent)
 	}
 
+	// Model attribute-block spans: map each model's attributes object byte range to
+	// the model node so column definitions inside it become CONTAINS members of the
+	// right model (issue #4365). modelIdx tracks the entities-slice index.
+	type attrSpan struct {
+		model      string
+		start, end int
+		idx        int
+	}
+	var attrSpans []attrSpan
+	modelIdx := make(map[string]int)
+
 	// sequelize.define models. The model node carries data-lifecycle traits
 	// (#3628 child) resolved from the attributes + options objects that follow
 	// the define( opener: paranoid → soft-delete, timestamps default-on, audit
@@ -232,6 +243,16 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		setProps(&ent, "framework", "sequelize", "provenance", "INFERRED_FROM_SEQUELIZE_DEFINE")
 		sequelizeModelLifecycle(src, m[1]).
 			Stamp(func(kv ...string) { setProps(&ent, kv...) })
+		if !seen[fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)] {
+			modelIdx[name] = len(entities)
+			// Attributes object is the brace span starting at/after the define( opener.
+			if _, after := sequelizeBracedSpan(src, m[1]); after > m[1] {
+				open := strings.IndexByte(src[m[1]:], '{')
+				if open >= 0 {
+					attrSpans = append(attrSpans, attrSpan{model: name, start: m[1] + open, end: after, idx: len(entities)})
+				}
+			}
+		}
 		addEntity(ent)
 	}
 
@@ -263,6 +284,11 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 			// so back up one byte to let sequelizeBracedSpan see it.
 			sequelizeModelLifecycle(src, m[1]-1).
 				Stamp(func(kv ...string) { setProps(&entities[idx], kv...) })
+			// Attributes object spans from the consumed '{' (at m[1]-1) to its match.
+			if _, after := sequelizeBracedSpan(src, m[1]-1); after > m[1]-1 {
+				modelIdx[name] = idx
+				attrSpans = append(attrSpans, attrSpan{model: name, start: m[1] - 1, end: after, idx: idx})
+			}
 		}
 		ent := makeEntity(name+".init", "SCOPE.Operation", "model_init", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "model_name", name,
@@ -281,9 +307,21 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		addEntity(ent)
 	}
 
+	// ownerModelAt returns the model whose attributes object encloses the offset.
+	ownerModelAt := func(off int) (attrSpan, bool) {
+		for _, s := range attrSpans {
+			if off >= s.start && off < s.end {
+				return s, true
+			}
+		}
+		return attrSpan{idx: -1}, false
+	}
+
 	// Column definitions: emit SCOPE.Component "column" entities for schema_extraction.
 	// We require that the file contains at least one DataTypes reference to confirm
 	// this is a schema file, then emit each column-def block entry as a field entity.
+	// Each column is a CONTAINS member of the model whose attributes object encloses
+	// it (issue #4365) so it is not an orphan.
 	if reSequelizeDataType.MatchString(src) {
 		for _, m := range reSequelizeColumnDef.FindAllStringSubmatchIndex(src, -1) {
 			fieldName := src[m[2]:m[3]]
@@ -296,16 +334,30 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 			}
 			ent := makeEntity(fieldName, "SCOPE.Component", "column", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "sequelize", "provenance", "INFERRED_FROM_SEQUELIZE_COLUMN_DEF")
+			if owner, ok := ownerModelAt(m[0]); ok && owner.idx >= 0 {
+				setProps(&ent, "owner_model", owner.model)
+				entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+					containsFieldEdge(owner.model, ent.ID, fieldName, "sequelize"))
+			}
 			addEntity(ent)
 		}
 	}
 
-	// Foreign-key columns: references: { model: 'X' } inside a column def.
+	// Foreign-key columns: references: { model: 'X' } inside a column def. The FK
+	// entity is a CONTAINS member of its owning model and carries a REFERENCES edge
+	// to the referenced model class (issue #4365).
 	for _, m := range reSequelizeColumnRef.FindAllStringSubmatchIndex(src, -1) {
 		refModel := src[m[2]:m[3]]
 		ent := makeEntity("fk:"+refModel, "SCOPE.Component", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "referenced_model", refModel,
 			"provenance", "INFERRED_FROM_SEQUELIZE_COLUMN_REFERENCE")
+		ent.Relationships = append(ent.Relationships,
+			referencesClassEdge(ent.ID, refModel, "sequelize", "fk:"+refModel))
+		if owner, ok := ownerModelAt(m[0]); ok && owner.idx >= 0 {
+			setProps(&ent, "owner_model", owner.model)
+			entities[owner.idx].Relationships = append(entities[owner.idx].Relationships,
+				containsFieldEdge(owner.model, ent.ID, "fk:"+refModel, "sequelize"))
+		}
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/testdata/issue4365/drizzle-schema.ts.txt
+++ b/internal/custom/javascript/testdata/issue4365/drizzle-schema.ts.txt
@@ -1,0 +1,14 @@
+import { pgTable, serial, text, integer, timestamp } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+});
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  authorId: integer('author_id').references(() => users.id),
+  createdAt: timestamp('created_at').defaultNow(),
+});

--- a/internal/custom/javascript/testdata/issue4365/mikroorm-author.entity.ts.txt
+++ b/internal/custom/javascript/testdata/issue4365/mikroorm-author.entity.ts.txt
@@ -1,0 +1,20 @@
+import { Entity, PrimaryKey, Property, ManyToOne, OneToMany, Collection } from '@mikro-orm/core';
+import { Book } from './book.entity';
+
+@Entity()
+export class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ unique: true })
+  email!: string;
+
+  @ManyToOne(() => Publisher)
+  publisher!: Publisher;
+
+  @OneToMany(() => Book, (book) => book.author)
+  books = new Collection<Book>(this);
+}

--- a/internal/custom/javascript/testdata/issue4365/objection-person.model.js.txt
+++ b/internal/custom/javascript/testdata/issue4365/objection-person.model.js.txt
@@ -1,0 +1,41 @@
+const { Model } = require('objection');
+
+class Person extends Model {
+  static get tableName() {
+    return 'persons';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      properties: {
+        id: { type: 'integer' },
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+      },
+    };
+  }
+
+  static get relationMappings() {
+    return {
+      pets: {
+        relation: Model.HasManyRelation,
+        modelClass: Animal,
+        join: {
+          from: 'persons.id',
+          to: 'animals.ownerId',
+        },
+      },
+      parent: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Person,
+        join: {
+          from: 'persons.parentId',
+          to: 'persons.id',
+        },
+      },
+    };
+  }
+}
+
+module.exports = Person;

--- a/internal/custom/javascript/testdata/issue4365/prisma-schema.prisma.txt
+++ b/internal/custom/javascript/testdata/issue4365/prisma-schema.prisma.txt
@@ -1,0 +1,30 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int    @id @default(autoincrement())
+  bio    String
+  user   User   @relation(fields: [userId], references: [id])
+  userId Int    @unique
+}

--- a/internal/custom/javascript/testdata/issue4365/sequelize-user.model.js.txt
+++ b/internal/custom/javascript/testdata/issue4365/sequelize-user.model.js.txt
@@ -1,0 +1,33 @@
+'use strict';
+const { Model, DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+class User extends Model {}
+
+User.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING,
+      unique: true,
+    },
+    organizationId: {
+      type: DataTypes.INTEGER,
+      references: { model: 'Organization', key: 'id' },
+    },
+  },
+  { sequelize, modelName: 'User', paranoid: true }
+);
+
+User.hasMany(Post);
+User.belongsTo(Organization);
+
+module.exports = User;


### PR DESCRIPTION
## What

Generalises the decorated-field membership fix #4328 (TypeORM / class-validator / mongoose) to the remaining JS/TS ORMs: **Sequelize, Drizzle, Objection, MikroORM, Prisma**.

Their model/entity FIELD entities (columns, fields, relations, FK refs) were emitted as standalone graph nodes with **no owning-class CONTAINS edge (orphans)** and **no REFERENCES edge** to their relation/FK target type — leaving hundreds of columns/fields ringing on the v3 graph.

## Root cause + fix (per ORM)

Field membership — each column/field/relation entity now carries a `CONTAINS` edge from its owning model/entity class node (shared `containsFieldEdge` helper from #4328). Owner determined structurally:

| ORM | Owner resolution | REFERENCES target |
|---|---|---|
| Sequelize | model attributes-object brace span (`define()`/`init()`) | `references:{model:'X'}` FK columns |
| Drizzle | `pgTable`/`mysqlTable`/`sqliteTable` opener offset | `.references(() => other.col)` (binding → table/model name) |
| Objection | nearest preceding `class X extends Model` | relationMappings `modelClass: Target` (incl. `() => Target`) |
| MikroORM | nearest preceding `@Entity`/`@Embeddable` | `@ManyToOne(() => X)` / `@OneToMany(() => X)` thunks |
| Prisma | enclosing `model { ... }` block | relation field whose base type names another model |

Target classes are captured as `REFERENCES` edges to the `Class:<Target>` stub (`referencesClassEdge`), which resolves through the real `resolve.BuildIndex` symbol table.

Also stops Prisma from leaking `generator client {` / datasource block lines in as standalone orphan `field` entities (now scoped to model blocks only).

## Live-validation (fixtures lie at merge)

`issue4365_livedrepro_test.go` runs the **real** extractors + `resolve.BuildIndex` over faithful per-ORM fixtures. Confirmed red→green by stashing the source fix and re-running:

| ORM | orphan fields before → after |
|---|---|
| Sequelize | 5 → 0 |
| Drizzle | 7 → 0 |
| Objection | 2 → 0 |
| MikroORM | 5 → 0 |
| Prisma | 13 → 0 (11 real fields; 2 false positives dropped) |

Relation/FK target `REFERENCES` edges present and resolving in the symbol table for each ORM.

## Scope

All five TS-parseable / `.prisma`-parseable ORMs in the ticket are **covered** — Prisma's `.prisma` schema parsing already exists in-pipeline, so nothing was deferred.

## Notes

- No new entity/relationship `Kind` (reuses `CONTAINS` / `REFERENCES`).
- Edits confined to the JS/TS extractor path (no overlap with the sibling #4379 Django work).

## Gates

- `go build ./...` ✅
- `go vet ./internal/custom/javascript/` ✅
- `go test ./internal/custom/javascript/` ✅ (full package, no regressions)
- `go test ./internal/types/ ./internal/resolve/` ✅

Closes #4365

🤖 Generated with [Claude Code](https://claude.com/claude-code)