### PR TITLE
ORM field membership for JVM, Ruby & Go: JPA/Hibernate, ActiveRecord, GORM

### DIFF
--- a/internal/custom/golang/gorm.go
+++ b/internal/custom/golang/gorm.go
@@ -60,6 +60,15 @@ var (
 	reGORMFieldTag = regexp.MustCompile(
 		"(?m)^\\s*(\\w+)\\s+([\\w\\.\\[\\]\\*]+)\\s+`[^`]*gorm:\"([^\"]*)\"[^`]*`",
 	)
+	// Any struct field line `Name Type` (with or without a trailing tag),
+	// used to recover untagged association fields (#4367) such as
+	//   Customer Customer
+	//   Items    []Item
+	// that carry no gorm tag and are therefore invisible to reGORMFieldTag.
+	// Group 1 = field name, group 2 = field type (slice/pointer/pkg-qualified).
+	reGORMAssocField = regexp.MustCompile(
+		"(?m)^\\s*([A-Z]\\w*)\\s+([\\w\\.\\[\\]\\*]+)\\s*(?:`[^`]*`)?\\s*$",
+	)
 	// column:<name> inside a gorm tag.
 	reGORMColumnTag = regexp.MustCompile(`(?:^|;)\s*column:([A-Za-z0-9_]+)`)
 	// type:<sqltype> inside a gorm tag.
@@ -165,6 +174,9 @@ func (e *gormExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	gormModelStructs := make(map[string]bool)
 	modelEnts := make(map[string]*types.EntityRecord)
 	modelEmbeds := make(map[string]bool)
+	// seenFields dedups field/relation emission across the tagged-field loop and
+	// the untagged-association pass (#4367), keyed by "<Struct>.<Field>".
+	seenFields := make(map[string]bool)
 	var modelOrder []string
 	for _, m := range reGORMModel.FindAllStringSubmatchIndex(src, -1) {
 		modelName := src[m[2]:m[3]]
@@ -233,7 +245,15 @@ func (e *gormExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			if tm := reGORMTypeTag.FindStringSubmatch(tag); tm != nil {
 				setProps(&fieldEnt, "sql_type", strings.TrimSpace(tm[1]))
 			}
+			// #4367 — CONTAINS membership: the column field belongs to its owning
+			// model struct. Hung off the (deferred) model node so the field is a
+			// member, not an orphan.
+			if me := modelEnts[structName]; me != nil {
+				me.Relationships = append(me.Relationships,
+					containsFieldEdge(structName, fieldEnt.ID, fieldName, "gorm"))
+			}
 			add(fieldEnt)
+			seenFields[structName+"."+fieldName] = true
 
 			// Relationships: association tags.
 			rel := relationshipKind(tag, fieldType, fieldName)
@@ -252,6 +272,53 @@ func (e *gormExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			}
 			if m2m := reGORMManyToMany.FindStringSubmatch(tag); m2m != nil {
 				setProps(&relEnt, "join_table", m2m[1])
+			}
+			// #4367 — REFERENCES to the target model (the relation field's only
+			// outbound semantic edge) + CONTAINS membership from the owner struct.
+			if target != "" {
+				relEnt.Relationships = append(relEnt.Relationships,
+					referencesClassEdge(relEnt.ID, target, "gorm", fieldName))
+			}
+			if me := modelEnts[structName]; me != nil {
+				me.Relationships = append(me.Relationships,
+					containsFieldEdge(structName, relEnt.ID, fieldName, "gorm"))
+			}
+			add(relEnt)
+			seenFields[structName+"."+fieldName] = true
+		}
+
+		// #4367 — untagged association fields. A bare `Customer Customer` or
+		// `Items []Item` struct/slice field has NO gorm tag, so the tag-keyed
+		// field loop above never saw it — the relation (and the related model
+		// edge) were dropped entirely. Scan the struct body for capitalised
+		// struct-ref fields that the loop did not already emit and record them
+		// as association relations with a REFERENCES edge to the target model.
+		for _, am := range reGORMAssocField.FindAllStringSubmatch(body, -1) {
+			fieldName := am[1]
+			fieldType := am[2]
+			if seenFields[structName+"."+fieldName] {
+				continue
+			}
+			if !isStructRefType(fieldType) {
+				continue
+			}
+			seenFields[structName+"."+fieldName] = true
+			rel := relationshipKind("", fieldType, fieldName)
+			if rel == "" {
+				continue
+			}
+			target := relationshipTarget(fieldType)
+			relEnt := makeEntity("rel:"+structName+"."+fieldName, "SCOPE.Component", "relation", file.Path, file.Language, structLine)
+			setProps(&relEnt, "framework", "gorm", "provenance", "INFERRED_FROM_GORM_ASSOCIATION",
+				"model_name", structName, "field_name", fieldName, "relationship", rel,
+				"target_model", target, "untagged", "true")
+			if target != "" {
+				relEnt.Relationships = append(relEnt.Relationships,
+					referencesClassEdge(relEnt.ID, target, "gorm", fieldName))
+			}
+			if me := modelEnts[structName]; me != nil {
+				me.Relationships = append(me.Relationships,
+					containsFieldEdge(structName, relEnt.ID, fieldName, "gorm"))
 			}
 			add(relEnt)
 		}

--- a/internal/custom/golang/helpers.go
+++ b/internal/custom/golang/helpers.go
@@ -57,6 +57,62 @@ func setProps(e *types.EntityRecord, kv ...string) {
 	}
 }
 
+// goClassRef returns the structural reference used as the FromID/ToID for an
+// edge targeting a Go struct/model entity (e.g. a GORM model). The
+// `Class:<Name>` form resolves through the resolver's byName fallback to the
+// SCOPE.Schema model node the extractor emits, mirroring the JS/Python/Ruby ORM
+// field-membership convention (#4328/#4366/#4367).
+func goClassRef(className string) string { return "Class:" + className }
+
+// containsFieldEdge builds the structural CONTAINS membership edge from an
+// owning GORM model struct to one of its column / association field entities.
+// Issue #4367: GORM `field:<Model>.<name>` and `rel:<Model>.<name>` entities
+// were emitted as standalone nodes with no owning-model membership, leaving them
+// as degree-0 orphans on the graph.
+//
+// FromID names the owner struct (`Class:<owner>`) so the resolver binds it to
+// the real model entity; ToID is the field/relation entity's own ID. The edge
+// is hung off the owner model node by the caller.
+func containsFieldEdge(ownerModel, memberID, fieldName, framework string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: goClassRef(ownerModel),
+		ToID:   memberID,
+		Kind:   string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  framework,
+			"language":   "go",
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// referencesClassEdge builds a REFERENCES edge from a GORM association field
+// entity to the model struct it points at — the related struct type of a
+// belongs_to/has_one/has_many/many2many field (`Items []Item` → `Item`). Issue
+// #4367: that target model is the association field's only outbound semantic
+// edge; without it the related model rings.
+//
+// FromID is the relation entity's own ID; ToID is the `Class:<target>` stub the
+// resolver binds to the real model entity. The edge is hung off the relation
+// entity by the caller.
+func referencesClassEdge(memberID, targetModel, framework, fieldName string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: memberID,
+		ToID:   goClassRef(targetModel),
+		Kind:   string(types.RelationshipKindReferences),
+		Properties: map[string]string{
+			"framework":   framework,
+			"language":    "go",
+			"ref_kind":    "field_target_type",
+			"field_name":  fieldName,
+			"target_type": targetModel,
+			"provenance":  "INFERRED_FROM_MODEL_FIELD_TARGET",
+		},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Shared middleware + auth detection (issue #3213)
 //

--- a/internal/custom/golang/issue4367_livedrepro_test.go
+++ b/internal/custom/golang/issue4367_livedrepro_test.go
@@ -1,0 +1,117 @@
+package golang_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+)
+
+// Issue #4367 LIVE-REPRO — GORM half.
+//
+// Runs the ACTUAL registered custom_go_gorm extractor + the ACTUAL
+// resolve.BuildIndex symbol table over a faithful GORM model file, and asserts
+// that GORM column/association fields are CLASS MEMBERS (CONTAINS from the model
+// struct) and that association fields carry a REFERENCES edge to their target
+// model that RESOLVES against the real model entity in the symbol table.
+//
+// Pre-fix: field:/rel: entities were emitted standalone with no CONTAINS and no
+// REFERENCES (degree-0 orphans); the untagged `Customer Customer` association
+// was dropped entirely.
+
+const gormSrc = `package models
+
+import "gorm.io/gorm"
+
+type Order struct {
+	gorm.Model
+	Status     string ` + "`gorm:\"column:status;type:varchar(32)\"`" + `
+	CustomerID uint
+	Customer   Customer
+	Items      []Item ` + "`gorm:\"foreignKey:OrderID\"`" + `
+}
+
+type Customer struct {
+	gorm.Model
+	Name string ` + "`gorm:\"column:name\"`" + `
+}
+
+type Item struct {
+	gorm.Model
+	OrderID uint
+	SKU     string ` + "`gorm:\"column:sku\"`" + `
+}
+`
+
+func gormExtract4367(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_go_gorm")
+	if !ok {
+		t.Fatal("custom_go_gorm not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "go", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func TestIssue4367_GORM_FieldMembership_AndRelationTargets(t *testing.T) {
+	ents := gormExtract4367(t, "models/order.go", gormSrc)
+
+	var contains, references int
+	var refTargets []string
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			switch r.Kind {
+			case string(types.RelationshipKindContains):
+				if r.Properties["member"] == "field" {
+					contains++
+				}
+			case string(types.RelationshipKindReferences):
+				references++
+				refTargets = append(refTargets, r.ToID)
+			}
+		}
+	}
+
+	// Membership: at minimum status + Customer + Items on Order, name on
+	// Customer, sku on Item — multiple CONTAINS field edges.
+	if contains == 0 {
+		t.Fatalf("GORM field CONTAINS membership = 0 (orphan fields); want > 0 (#4367)")
+	}
+	// Relation targets: Order->Customer, Order->Item at least.
+	if references < 2 {
+		t.Fatalf("GORM relation REFERENCES = %d; want >= 2 (Customer, Item) (#4367)", references)
+	}
+	t.Logf("GORM: CONTAINS field edges=%d, REFERENCES edges=%d", contains, references)
+
+	// Untagged association `Customer Customer` must now be recovered.
+	foundUntagged := false
+	for _, e := range ents {
+		if e.Properties["untagged"] == "true" && e.Properties["target_model"] == "Customer" {
+			foundUntagged = true
+		}
+	}
+	if !foundUntagged {
+		t.Errorf("untagged association `Customer Customer` not recovered (#4367)")
+	}
+
+	// REFERENCES targets must RESOLVE against the real model entities.
+	idx := resolve.BuildIndex(ents)
+	for _, target := range []string{"Class:Customer", "Class:Item"} {
+		if _, ok := idx.Lookup(target); !ok {
+			t.Errorf("symbol table did NOT resolve REFERENCES target %q — relation stays orphan (#4367)", target)
+		}
+	}
+
+	// And CONTAINS source (Class:Order) must resolve to the Order model node.
+	if _, ok := idx.Lookup("Class:Order"); !ok {
+		t.Errorf("symbol table did NOT resolve CONTAINS owner Class:Order (#4367)")
+	}
+}

--- a/internal/custom/java/bean_validation.go
+++ b/internal/custom/java/bean_validation.go
@@ -328,12 +328,17 @@ func ExtractBeanValidation(ctx PatternContext) PatternResult {
 			props["collection_type"] = rawTypeName
 			props["element_type"] = elementType
 		}
-		addEntity(&result, seenRefs, SecondaryEntity{
+		if addEntity(&result, seenRefs, SecondaryEntity{
 			Name: ownerClass + "." + fieldName, Kind: "SCOPE.Schema", SourceFile: fp,
 			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
 			Provenance: "INFERRED_FROM_BEAN_VALIDATION_FIELD", Ref: ref,
 			Properties: props,
-		})
+		}) && ownerClass != "unknown" {
+			// #4367 — CONTAINS membership: the DTO field belongs to its owning
+			// (@Validated) class so it is a member, not an orphan. Carrier = the
+			// field entity; source resolves to the real class via FromName.
+			addRel(&result, seenRels, containsFieldRel(ownerClass, ref, fieldName, ctx.Framework))
+		}
 
 		// ── 4. @Valid recursion → VALIDATES edge (nested_model_extraction) ──────
 
@@ -346,6 +351,10 @@ func ExtractBeanValidation(ctx PatternContext) PatternResult {
 			validTarget = elementType
 		}
 		if strings.Contains(annotBlock, "@Valid") && !primitiveTypes[validTarget] {
+			// #4367 — REFERENCES from the @Valid field to the nested DTO type, so
+			// the field carries an outbound edge to the model it validates (the
+			// VALIDATES edge below is class→class; this one is field→class).
+			addRel(&result, seenRels, referencesClassRel(ref, validTarget, fieldName, ctx.Framework))
 			ownerRef := "scope:class:bean_validation:" + fp + ":" + ownerClass
 			nestedRef := findRefForType(validTarget, fp, "bean_validation", &result)
 			addRel(&result, seenRels, Relationship{

--- a/internal/custom/java/hibernate.go
+++ b/internal/custom/java/hibernate.go
@@ -34,6 +34,16 @@ var (
 		`(?s)@(OneToMany|ManyToOne|OneToOne|ManyToMany)\b(?:\s*\([^)]*\))?` +
 			`\s*(?:@\w+(?:\s*\([^)]*\))?\s*)*(?:private|protected|public|var|val|)\s+` +
 			`(?:(?:final|transient)\s+)*(?:\w+<(\w+)>|(\w+))\s+(\w+)(?:\s*[:?=;])`)
+	// hibColumnFieldRE matches a scalar / embedded JPA field declaration
+	// (#4367). Group 1 = annotation head (Column/Embedded/Basic/Lob/Enumerated),
+	// group 2 = declared type, group 3 = field/property name. Companion
+	// annotations (e.g. @Enumerated, @Temporal) between the head annotation and
+	// the field are skipped. Accepts Java (`private String x;`) and Kotlin
+	// (`var x: String`) field forms.
+	hibColumnFieldRE = regexp.MustCompile(
+		`(?s)@(Column|Embedded|Basic|Lob|Enumerated)\b(?:\s*\([^)]*\))?` +
+			`\s*(?:@\w+(?:\s*\([^)]*\))?\s*)*(?:private|protected|public|var|val|)\s+` +
+			`(?:(?:final|transient)\s+)*(\w+)\s+(\w+)(?:\s*[:?=;])`)
 	hibNamedQueryRE = regexp.MustCompile(
 		`(?s)@NamedQuery\s*\(\s*` +
 			`(?:name\s*=\s*\"(?P<name>[^\"]*)\"\s*,\s*query\s*=\s*\"(?P<query>[^\"]*)\"` +
@@ -135,8 +145,13 @@ func ExtractHibernate(ctx PatternContext) PatternResult {
 		if targetType == "" {
 			continue
 		}
+		// Group 4 (m[8:9]) is the field/property name (#4367).
+		fieldName := ""
+		if m[8] >= 0 {
+			fieldName = source[m[8]:m[9]]
+		}
 
-		_, ownerRef := findOwningEntity(m[0])
+		ownerName, ownerRef := findOwningEntity(m[0])
 		if ownerRef == "" {
 			continue
 		}
@@ -149,6 +164,59 @@ func ExtractHibernate(ctx PatternContext) PatternResult {
 				"provenance": "INFERRED_FROM_HIBERNATE_ASSOCIATION",
 			},
 		})
+
+		// #4367 — per-field membership + relation target. The association is a
+		// concrete field of the entity: emit a relation field entity, hang a
+		// CONTAINS edge from the owning @Entity class (so the field is a member,
+		// not an orphan), and a REFERENCES edge to the target entity type (the
+		// generic element type for collection relations, e.g. List<Item> -> Item,
+		// already unwrapped into targetType by hibAssociationRE).
+		if fieldName != "" {
+			fieldRef := "scope:component:hibernate_relation:" + fp + ":" + ownerName + "." + fieldName
+			if addEntity(&result, seenRefs, SecondaryEntity{
+				Name: ownerName + "." + fieldName, Kind: "SCOPE.Component", Subtype: "relation",
+				SourceFile: fp, LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+				Provenance: "INFERRED_FROM_HIBERNATE_ASSOCIATION", Ref: fieldRef,
+				Properties: map[string]any{
+					"framework": "hibernate", "owner_class": ownerName,
+					"field_name": fieldName, "association_kind": ann,
+					"target_type": targetType,
+				},
+			}) {
+				addRel(&result, seenRels, containsFieldRel(ownerName, fieldRef, fieldName, "hibernate"))
+				addRel(&result, seenRels, referencesClassRel(fieldRef, targetType, fieldName, "hibernate"))
+			}
+		}
+	}
+
+	// 2b. JPA @Column / @Embedded scalar + embedded fields (#4367). Each becomes
+	// a member of its owning @Entity via a CONTAINS edge; @Embedded fields also
+	// carry a REFERENCES edge to the embeddable type. These were not emitted at
+	// all before, so the entity's scalar columns had no structural membership.
+	for _, m := range hibColumnFieldRE.FindAllStringSubmatchIndex(source, -1) {
+		ann := source[m[2]:m[3]]      // Column | Embedded | Basic | Lob | Enumerated
+		fieldType := source[m[4]:m[5]] // declared type (may be generic-wrapped)
+		fieldName := source[m[6]:m[7]]
+		ownerName, _ := findOwningEntity(m[0])
+		if ownerName == "" {
+			continue
+		}
+		fieldRef := "scope:component:hibernate_column:" + fp + ":" + ownerName + "." + fieldName
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: ownerName + "." + fieldName, Kind: "SCOPE.Component", Subtype: "column",
+			SourceFile: fp, LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_HIBERNATE_COLUMN", Ref: fieldRef,
+			Properties: map[string]any{
+				"framework": "hibernate", "owner_class": ownerName,
+				"field_name": fieldName, "column_annotation": ann, "field_type": fieldType,
+			},
+		}) {
+			addRel(&result, seenRels, containsFieldRel(ownerName, fieldRef, fieldName, "hibernate"))
+			// @Embedded fields reference their embeddable value type.
+			if ann == "Embedded" && fieldType != "" && !primitiveTypes[fieldType] {
+				addRel(&result, seenRels, referencesClassRel(fieldRef, fieldType, fieldName, "hibernate"))
+			}
+		}
 	}
 
 	// 3. @NamedQuery

--- a/internal/custom/java/issue4367_livedrepro_test.go
+++ b/internal/custom/java/issue4367_livedrepro_test.go
@@ -1,0 +1,189 @@
+package java_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/java"
+)
+
+// Issue #4367 LIVE-REPRO — JPA/Hibernate + Bean Validation half.
+//
+// Runs the ACTUAL registered custom_java_patterns extractor (which dispatches
+// ExtractHibernate + ExtractBeanValidation) + the ACTUAL resolve.BuildIndex
+// symbol table over faithful JPA entity + Bean Validation DTO sources, and
+// asserts that:
+//   - @Column / @ManyToOne / @OneToMany / @Embedded entity fields are CLASS
+//     MEMBERS (CONTAINS, source resolving to the owning @Entity class) — not
+//     orphans;
+//   - relation fields carry a REFERENCES edge to the target entity type (the
+//     generic element type for collection relations, List<Item> -> Item) that
+//     RESOLVES in the symbol table;
+//   - @Valid nested DTO fields carry a REFERENCES edge to the nested DTO.
+//
+// Pre-fix: bean-validation `<Owner>.<field>` nodes had no CONTAINS membership,
+// and Hibernate emitted no per-field entities at all (only class->class
+// DEPENDS_ON), so every JPA column/relation field was a structural orphan.
+
+const jpaOrderSrc = `package com.example;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+	@Id
+	private Long id;
+
+	@Column(name = "status", nullable = false)
+	private String status;
+
+	@ManyToOne
+	private Customer customer;
+
+	@OneToMany(mappedBy = "order")
+	private List<Item> items;
+
+	@Embedded
+	private Address shippingAddress;
+}
+`
+
+const jpaCustomerSrc = `package com.example;
+
+import javax.persistence.*;
+
+@Entity
+public class Customer {
+	@Id
+	private Long id;
+
+	@Column
+	private String name;
+}
+`
+
+const jpaItemSrc = `package com.example;
+
+import javax.persistence.*;
+
+@Entity
+public class Item {
+	@Id
+	private Long id;
+}
+`
+
+const jpaAddressSrc = `package com.example;
+
+import javax.persistence.*;
+
+@Embeddable
+public class Address {
+	@Column
+	private String city;
+}
+`
+
+const bvDtoSrc = `package com.example;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class CreateOrderRequest {
+	@NotNull
+	@Size(min = 1, max = 64)
+	private String status;
+
+	@Valid
+	@NotNull
+	private AddressDto address;
+}
+`
+
+func javaExtract4367(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_java_patterns")
+	if !ok {
+		t.Fatal("custom_java_patterns not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "java", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return ents
+}
+
+func collectEdges4367(ents []types.EntityRecord) (contains int, refTargets map[string]int) {
+	refTargets = map[string]int{}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			switch r.Kind {
+			case string(types.RelationshipKindContains):
+				if r.Properties["member"] == "field" {
+					contains++
+				}
+			case string(types.RelationshipKindReferences):
+				if r.Properties["ref_kind"] == "field_target_type" {
+					refTargets[r.ToID]++
+				}
+			}
+		}
+	}
+	return
+}
+
+func TestIssue4367_JPA_BeanValidation_FieldMembership_AndTargets(t *testing.T) {
+	var all []types.EntityRecord
+	all = append(all, javaExtract4367(t, "src/Order.java", jpaOrderSrc)...)
+	all = append(all, javaExtract4367(t, "src/Customer.java", jpaCustomerSrc)...)
+	all = append(all, javaExtract4367(t, "src/Item.java", jpaItemSrc)...)
+	all = append(all, javaExtract4367(t, "src/Address.java", jpaAddressSrc)...)
+	all = append(all, javaExtract4367(t, "src/CreateOrderRequest.java", bvDtoSrc)...)
+
+	contains, refTargets := collectEdges4367(all)
+
+	if contains == 0 {
+		t.Fatalf("JVM field CONTAINS membership = 0 (orphan fields); want > 0 (#4367)")
+	}
+	t.Logf("JVM: CONTAINS field edges=%d, REFERENCES targets=%v", contains, refTargets)
+
+	// JPA relation targets (collection element unwrapped) + @Embedded + @Valid.
+	for _, want := range []string{"Class:Customer", "Class:Item", "Class:Address", "Class:AddressDto"} {
+		if refTargets[want] == 0 {
+			t.Errorf("expected REFERENCES target %q not emitted (#4367); got %v", want, refTargets)
+		}
+	}
+
+	// The custom extractor itself emits a @Entity SCOPE.Schema node named after
+	// each entity (Order/Customer/Item), and an @Embeddable Address node; these
+	// are the resolution targets for the `Class:<Name>` CONTAINS/REFERENCES
+	// stubs via the byName convention. The Bean Validation DTO class
+	// (CreateOrderRequest) and the nested AddressDto are NOT emitted as standalone
+	// nodes by the custom extractor (they come from the base tree-sitter Java
+	// extractor in the real pipeline), so add faithful base class nodes for those
+	// to exercise the @Valid REFERENCES / DTO-field CONTAINS resolution.
+	for _, cls := range []string{"CreateOrderRequest", "AddressDto"} {
+		c := types.EntityRecord{
+			Name: cls, Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: "src/" + cls + ".java", Language: "java",
+			Properties: map[string]string{"kind": "SCOPE.Component", "subtype": "class"},
+		}
+		c.ID = c.ComputeID()
+		all = append(all, c)
+	}
+
+	idx := resolve.BuildIndex(all)
+	for _, target := range []string{"Class:Customer", "Class:Item", "Class:Order", "Class:CreateOrderRequest", "Class:AddressDto"} {
+		if _, ok := idx.Lookup(target); !ok {
+			t.Errorf("symbol table did NOT resolve %q — field/relation stays orphan (#4367)", target)
+		}
+	}
+}

--- a/internal/custom/java/orm_helpers.go
+++ b/internal/custom/java/orm_helpers.go
@@ -4,6 +4,63 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// javaClassRef returns the resolvable stub naming a Java class entity. The
+// `Class:<Name>` form binds through the resolver's byName fallback to the base
+// tree-sitter SCOPE.Component class node (Java classes are extracted as
+// SCOPE.Component/class), mirroring the JS/Python/Ruby/Go ORM field-membership
+// convention (#4328/#4366/#4367).
+func javaClassRef(className string) string { return "Class:" + className }
+
+// containsFieldRel builds the structural CONTAINS membership edge from an
+// owning entity/DTO class to one of its column / association / validation field
+// entities. Issue #4367 (JVM generalization of #4328/#4366): JPA/Hibernate
+// column + association fields and Bean Validation DTO fields were emitted as
+// standalone `<Owner>.<field>` graph nodes with no owning-class membership,
+// leaving them as degree-0 orphans on the graph.
+//
+// The edge is hung off the FIELD entity (SourceRef = fieldRef, the carrier) but
+// its source resolves to the OWNING CLASS via FromName=`Class:<owner>` — the Java
+// dispatch maps FromName onto the edge's FromID, which ReferencesEmbedded
+// rewrites by name to the real (separately-extracted) class entity.
+func containsFieldRel(ownerClass, fieldRef, fieldName, framework string) Relationship {
+	return Relationship{
+		SourceRef:        fieldRef,
+		TargetRef:        fieldRef,
+		FromName:         javaClassRef(ownerClass),
+		RelationshipType: string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  framework,
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// referencesClassRel builds a REFERENCES edge from a relation/validation field
+// entity to the class it points at — a JPA @ManyToOne/@OneToMany/@OneToOne/
+// @ManyToMany/@Embedded target type (the generic element type for collection
+// relations, e.g. List<Item> -> Item) or a Bean Validation @Valid nested DTO
+// type. Issue #4367: that target type is the field's only outbound semantic
+// edge; without it the related entity / nested DTO rings.
+//
+// The edge is hung off the field entity (SourceRef = fieldRef) and its ToID is
+// `Class:<target>`, which the resolver binds to the real class entity by name.
+func referencesClassRel(fieldRef, targetClass, fieldName, framework string) Relationship {
+	return Relationship{
+		SourceRef:        fieldRef,
+		TargetRef:        javaClassRef(targetClass),
+		RelationshipType: string(types.RelationshipKindReferences),
+		Properties: map[string]string{
+			"framework":   framework,
+			"ref_kind":    "field_target_type",
+			"field_name":  fieldName,
+			"target_type": targetClass,
+			"provenance":  "INFERRED_FROM_MODEL_FIELD_TARGET",
+		},
+	}
+}
+
 // makeEntity builds a minimal EntityRecord with all required fields set.
 // Mirrors the helper used by the registered JS/Kotlin custom extractors so the
 // Java ORM extractors (Ebean / EclipseLink / MyBatis) emit registry-shaped

--- a/internal/custom/java/patterns_dispatch.go
+++ b/internal/custom/java/patterns_dispatch.go
@@ -358,6 +358,15 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 			Kind:       r.RelationshipType,
 			Properties: map[string]string{},
 		}
+		// #4367 — explicit FromID override. When the edge's source must resolve
+		// to an entity OTHER than its carrier (the field-membership CONTAINS edge
+		// whose carrier is the field but whose source is the owning class), the
+		// extractor sets FromName to a resolvable stub (`Class:<Owner>`). The
+		// resolver's ReferencesEmbedded rewrites FromID by name, binding it to the
+		// real class. Left empty -> implicit carrier-as-source (the default).
+		if r.FromName != "" {
+			rr.FromID = r.FromName
+		}
 		for k, v := range r.Properties {
 			rr.Properties[k] = v
 		}

--- a/internal/custom/java/types.go
+++ b/internal/custom/java/types.go
@@ -28,10 +28,19 @@ type SecondaryEntity struct {
 
 // Relationship represents a directed edge between two entities identified
 // by their ref strings.
+//
+// SourceRef names the CARRIER entity the edge is hung off (the entity whose
+// Ref == SourceRef, or a synthesised carrier). By default the edge's FromID is
+// left implicit (the carrier's own ID). When FromName is set, it overrides the
+// edge's FromID with an explicit resolvable stub (e.g. `Class:<Owner>`) so the
+// edge's source binds to a DIFFERENT entity than its carrier — used for #4367
+// field-membership CONTAINS edges, where the field entity carries the edge but
+// the source must resolve to its (separately-extracted) owning class by name.
 type Relationship struct {
 	SourceRef        string            `json:"source_ref"`
 	TargetRef        string            `json:"target_ref"`
 	RelationshipType string            `json:"relationship_type"`
+	FromName         string            `json:"from_name,omitempty"`
 	Properties       map[string]string `json:"properties,omitempty"`
 }
 

--- a/internal/custom/ruby/activerecord.go
+++ b/internal/custom/ruby/activerecord.go
@@ -270,6 +270,16 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 	//    Covers has_many, belongs_to, has_one, has_and_belongs_to_many.
 	// -------------------------------------------------------------------------
 	if !isSchemaFile && !isMigrationFile {
+		// #4367 — owning model class for this file (one model per file is the
+		// Rails convention). When known, every association/FK relation entity
+		// below carries a CONTAINS edge from the model (so it is a member, not
+		// an orphan) and a REFERENCES edge to its target model (so it is not a
+		// dead-end). Both stubs resolve via the `Class:<Name>` byName convention.
+		ownerModel := ""
+		if mm := reARModelClass.FindStringSubmatch(src); mm != nil {
+			ownerModel = mm[1]
+		}
+
 		for _, m := range reARAssociation.FindAllStringSubmatchIndex(src, -1) {
 			assocType := src[m[2]:m[3]]
 			assocName := src[m[4]:m[5]]
@@ -281,6 +291,13 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 				"association_type", assocType,
 				"association_name", assocName,
 			)
+			if ownerModel != "" {
+				target := targetModel(assocType, assocName, assocOptions{})
+				setProps(&ent, "owner_model", ownerModel, "target_model", target)
+				ent.Relationships = append(ent.Relationships,
+					containsFieldEdge(ownerModel, ent.ID, assocName, "activerecord"),
+					referencesClassEdge(ent.ID, target, "activerecord", assocName))
+			}
 			add(ent)
 		}
 
@@ -306,6 +323,13 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 				"association_name", assocName,
 				"through_model", throughName,
 			)
+			if ownerModel != "" {
+				target := targetModel("has_many", assocName, assocOptions{})
+				setProps(&ent, "owner_model", ownerModel, "target_model", target)
+				ent.Relationships = append(ent.Relationships,
+					containsFieldEdge(ownerModel, ent.ID, assocName, "activerecord"),
+					referencesClassEdge(ent.ID, target, "activerecord", assocName))
+			}
 			add(ent)
 		}
 
@@ -319,6 +343,10 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 				"provenance", "INFERRED_FROM_AR_FOREIGN_KEY",
 				"association_name", assocName,
 			)
+			if ownerModel != "" {
+				ent.Relationships = append(ent.Relationships,
+					containsFieldEdge(ownerModel, ent.ID, assocName, "activerecord"))
+			}
 			add(ent)
 		}
 

--- a/internal/custom/ruby/activerecord_deep.go
+++ b/internal/custom/ruby/activerecord_deep.go
@@ -350,6 +350,21 @@ func extractARModelsAndAssociations(src string, file extractor.FileInput, add fu
 		if modelName != "" {
 			setProps(&rel, "owner_model", modelName)
 		}
+		// #4367 — field membership + relation target. The association entity was
+		// a degree-0 orphan: no owning-model membership, no target-model edge.
+		//   • REFERENCES (assoc entity → Class:<target>): the related model is the
+		//     association's only outbound semantic edge. Polymorphic associations
+		//     have no single concrete target, so they stay honest-partial.
+		//   • CONTAINS (Class:<owner> → assoc entity): hung off the owner model
+		//     node so the field is a member, not an orphan.
+		if target != "" && !o.polymorph {
+			rel.Relationships = append(rel.Relationships,
+				referencesClassEdge(rel.ID, target, "activerecord", assocName))
+		}
+		if modelEnt != nil {
+			modelEnt.Relationships = append(modelEnt.Relationships,
+				containsFieldEdge(modelName, rel.ID, assocName, "activerecord"))
+		}
 		add(rel)
 
 		// GRAPH_RELATES model↔model edge with cardinality, hung off the owner
@@ -398,6 +413,16 @@ func extractARModelsAndAssociations(src string, file extractor.FileInput, add fu
 			if o.polymorph {
 				setProps(&fkEnt, "polymorphic", "true")
 				setProps(&fkEnt, "type_column", assocName+"_type")
+			}
+			// #4367 — FK field membership + relation target (same shape as the
+			// association entity above).
+			if target != "" && !o.polymorph {
+				fkEnt.Relationships = append(fkEnt.Relationships,
+					referencesClassEdge(fkEnt.ID, target, "activerecord", assocName))
+			}
+			if modelEnt != nil {
+				modelEnt.Relationships = append(modelEnt.Relationships,
+					containsFieldEdge(modelName, fkEnt.ID, assocName, "activerecord"))
 			}
 			add(fkEnt)
 		}

--- a/internal/custom/ruby/helpers.go
+++ b/internal/custom/ruby/helpers.go
@@ -41,6 +41,64 @@ func setProps(e *types.EntityRecord, kv ...string) {
 	}
 }
 
+// rbClassRef returns the structural reference used as the FromID/ToID for an
+// edge targeting a Ruby class entity (an ActiveRecord/Sequel/ROM model). The
+// `Class:<Name>` form resolves through the resolver's byName fallback to the
+// SCOPE.Schema/SCOPE.Component model node the various extractors emit — the same
+// convention already used by the ActiveRecord GRAPH_RELATES edges.
+func rbClassRef(className string) string { return "Class:" + className }
+
+// containsFieldEdge builds the structural CONTAINS membership edge from an
+// owning model class to one of its association / foreign-key / validation
+// field entities. Issue #4367 (Ruby generalization of #4328/#4366): ActiveRecord
+// association declarations (has_many/belongs_to/...) and validation declarations
+// were emitted as standalone `<macro>:<name>` SCOPE.Pattern nodes with no
+// owning-model membership, leaving them as degree-0 orphans on the graph.
+//
+// FromID names the owner class (`Class:<owner>`) so the resolver binds it to the
+// real model entity; ToID is the member entity's own ID (the caller passes
+// memberID). The edge is hung off the owner model node by the caller (mirroring
+// the JS/TS and Python fixes).
+func containsFieldEdge(ownerClass, memberID, fieldName, framework string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: rbClassRef(ownerClass),
+		ToID:   memberID,
+		Kind:   string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  framework,
+			"language":   "ruby",
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// referencesClassEdge builds a REFERENCES edge from an association field entity
+// to the model class it points at — a belongs_to/has_many/has_one target,
+// singularized + camelized (`:items` → `Item`) or honoring `class_name:`.
+// Issue #4367: that target model is the association field's only outbound
+// semantic edge; without it the related model rings.
+//
+// FromID is the association entity's own ID; ToID is the `Class:<target>` stub
+// the resolver binds to the real model entity. The edge is hung off the
+// association entity by the caller.
+func referencesClassEdge(memberID, targetClass, framework, fieldName string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: memberID,
+		ToID:   rbClassRef(targetClass),
+		Kind:   string(types.RelationshipKindReferences),
+		Properties: map[string]string{
+			"framework":   framework,
+			"language":    "ruby",
+			"ref_kind":    "field_target_type",
+			"field_name":  fieldName,
+			"target_type": targetClass,
+			"provenance":  "INFERRED_FROM_MODEL_FIELD_TARGET",
+		},
+	}
+}
+
 // boolStr converts a bool to its "true"/"false" string representation.
 func boolStr(b bool) string {
 	if b {

--- a/internal/custom/ruby/issue4367_livedrepro_test.go
+++ b/internal/custom/ruby/issue4367_livedrepro_test.go
@@ -1,0 +1,128 @@
+package ruby_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+// Issue #4367 LIVE-REPRO — ActiveRecord half.
+//
+// Runs the ACTUAL registered custom_ruby_activerecord + custom_ruby_validation
+// extractors + the ACTUAL resolve.BuildIndex symbol table over a faithful
+// ActiveRecord model, and asserts that association declarations (has_many /
+// belongs_to) and validations are CLASS MEMBERS (CONTAINS from the model) and
+// that associations carry a REFERENCES edge to their singularized+camelized
+// target model that RESOLVES in the symbol table.
+//
+// Pre-fix: `has_many:items` / `belongs_to:customer` / `assoc:*` / `fk:*` /
+// `validates:*` were emitted standalone with no CONTAINS and no REFERENCES.
+
+const arOrderSrc = `class Order < ApplicationRecord
+  belongs_to :customer
+  has_many :items
+  has_one :invoice
+  validates :status, presence: true
+  validates_presence_of :total
+end
+`
+
+const arCustomerSrc = `class Customer < ApplicationRecord
+  has_many :orders
+end
+`
+
+const arItemSrc = `class Item < ApplicationRecord
+  belongs_to :order
+end
+`
+
+const arInvoiceSrc = `class Invoice < ApplicationRecord
+  belongs_to :order
+end
+`
+
+func rbExtract4367(t *testing.T, key, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(key)
+	if !ok {
+		t.Fatalf("%s not registered", key)
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "ruby", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return ents
+}
+
+func TestIssue4367_ActiveRecord_FieldMembership_AndRelationTargets(t *testing.T) {
+	var all []types.EntityRecord
+	all = append(all, rbExtract4367(t, "custom_ruby_activerecord", "app/models/order.rb", arOrderSrc)...)
+	all = append(all, rbExtract4367(t, "custom_ruby_validation", "app/models/order.rb", arOrderSrc)...)
+	all = append(all, rbExtract4367(t, "custom_ruby_activerecord", "app/models/customer.rb", arCustomerSrc)...)
+	all = append(all, rbExtract4367(t, "custom_ruby_activerecord", "app/models/item.rb", arItemSrc)...)
+	all = append(all, rbExtract4367(t, "custom_ruby_activerecord", "app/models/invoice.rb", arInvoiceSrc)...)
+
+	var contains, references int
+	refTargets := map[string]bool{}
+	for _, e := range all {
+		for _, r := range e.Relationships {
+			switch r.Kind {
+			case string(types.RelationshipKindContains):
+				if r.Properties["member"] == "field" {
+					contains++
+				}
+			case string(types.RelationshipKindReferences):
+				references++
+				refTargets[r.ToID] = true
+			}
+		}
+	}
+
+	if contains == 0 {
+		t.Fatalf("AR field CONTAINS membership = 0 (orphan associations/validations); want > 0 (#4367)")
+	}
+	if references == 0 {
+		t.Fatalf("AR association REFERENCES = 0; want > 0 (#4367)")
+	}
+	t.Logf("ActiveRecord: CONTAINS field edges=%d, REFERENCES edges=%d", contains, references)
+
+	// Singularization: has_many :items -> Item, belongs_to :customer -> Customer.
+	for _, want := range []string{"Class:Item", "Class:Customer"} {
+		if !refTargets[want] {
+			t.Errorf("expected REFERENCES target %q (singularized/camelized) not emitted (#4367); got %v", want, refTargets)
+		}
+	}
+
+	// Targets must RESOLVE against the real model class nodes in the symbol
+	// table. In production these are the base tree-sitter Ruby class entities
+	// (Name == bare class name); the custom AR extractor emits a `model:<Name>`
+	// schema node, so the `Class:<Name>` byName convention binds to the base
+	// class node. We add faithful base class nodes here (the tree-sitter Ruby
+	// extractor runs alongside the custom one in the real pipeline).
+	for _, cls := range []string{"Order", "Customer", "Item", "Invoice"} {
+		c := types.EntityRecord{
+			Name: cls, Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: "app/models/" + cls + ".rb", Language: "ruby",
+			Properties: map[string]string{"kind": "SCOPE.Component", "subtype": "class"},
+		}
+		c.ID = c.ComputeID()
+		all = append(all, c)
+	}
+
+	idx := resolve.BuildIndex(all)
+	for _, target := range []string{"Class:Customer", "Class:Item", "Class:Invoice"} {
+		if _, ok := idx.Lookup(target); !ok {
+			t.Errorf("symbol table did NOT resolve REFERENCES target %q (#4367)", target)
+		}
+	}
+	if _, ok := idx.Lookup("Class:Order"); !ok {
+		t.Errorf("symbol table did NOT resolve CONTAINS owner Class:Order (#4367)")
+	}
+}

--- a/internal/custom/ruby/validation.go
+++ b/internal/custom/ruby/validation.go
@@ -194,6 +194,16 @@ func (e *rubyValidationExtractor) Extract(ctx context.Context, file extractor.Fi
 		entities = append(entities, ent)
 	}
 
+	// #4367 — owning model class for this file (one model per file is the Rails
+	// convention). When present, ActiveModel `validates :field` declarations
+	// carry a CONTAINS edge from the model so the validation field is a member,
+	// not an orphan. Plain (non-model) classes carrying validations stay
+	// honest-partial (no model node to anchor membership).
+	valOwnerModel := ""
+	if mm := reARModelClass.FindStringSubmatch(src); mm != nil {
+		valOwnerModel = mm[1]
+	}
+
 	// 1. Rails strong params: params.require(...)
 	for _, idx := range rbStrongParamRequire.FindAllStringIndex(src, -1) {
 		ln := lineOf(src, idx[0])
@@ -233,6 +243,11 @@ func (e *rubyValidationExtractor) Extract(ctx context.Context, file extractor.Fi
 			"signal", "validation",
 			"field", field,
 		)
+		if valOwnerModel != "" {
+			setProps(&ent, "owner_model", valOwnerModel)
+			ent.Relationships = append(ent.Relationships,
+				containsFieldEdge(valOwnerModel, ent.ID, field, "activemodel"))
+		}
 		add(ent)
 	}
 
@@ -263,6 +278,11 @@ func (e *rubyValidationExtractor) Extract(ctx context.Context, file extractor.Fi
 			"macro", macro,
 			"field", field,
 		)
+		if valOwnerModel != "" {
+			setProps(&ent, "owner_model", valOwnerModel)
+			ent.Relationships = append(ent.Relationships,
+				containsFieldEdge(valOwnerModel, ent.ID, field, "activemodel"))
+		}
 		add(ent)
 	}
 


### PR DESCRIPTION
## Summary

Generalizes the field-membership fix #4328 (JS) / #4366 (Python) to the **JVM, Ruby and Go ORM stacks**. Decorated/declared ORM model fields were emitted as standalone graph nodes with no owning-class membership and (for relations) no target-type edge — a forest of degree-0 orphans on the v3 graph.

Reuses the same `CONTAINS` (owner → field) + `REFERENCES` (field → target class) edge shape as the JS/Python fixes — **no new entity Kinds**. Both edge endpoints use the `Class:<Name>` byName convention so they resolve merge-stably against the real class/model node in `resolve.BuildIndex`.

## Per-stack root cause + coverage

| Stack | Pre-fix gap | Fix |
|---|---|---|
| **Java JPA/Hibernate** | Hibernate emitted only class→class `DEPENDS_ON`, no per-field entities; orphaned columns/relations | Per-field column + relation entities with `CONTAINS` membership + `REFERENCES` to target entity (collection element unwrapped, `List<Item>`→`Item`; `@Embedded`→embeddable type) |
| **Java Bean Validation** | `<Owner>.<field>` DTO field nodes had only an `owner_class` prop, no membership | `CONTAINS` from the owning class; `@Valid` nested fields get `REFERENCES` to the nested DTO |
| **Ruby ActiveRecord** | `has_many:items` / `assoc:*` / `fk:*` / `validates:*` had no model membership, no target reference | `CONTAINS` from owner model + `REFERENCES` to singularized/camelized (or `class_name:`) target; `validates`/`validates_*_of` membership |
| **Go GORM** | `field:`/`rel:` nodes had no `CONTAINS`/`REFERENCES`; bare untagged `Customer Customer` associations dropped entirely | `CONTAINS` for every column/relation field, `REFERENCES` to target struct, **+ new untagged-association recovery pass** |

A new optional `Relationship.FromName` was added to the Java pattern-dispatch path so a field-carried edge can resolve its **source** to the separately-extracted owning class (`Class:<Owner>`) rather than its carrier — the Java DTO/entity class comes from the base tree-sitter extractor, not the custom one.

## Live-validation (in-pipeline, red→green)

`issue4367_livedrepro_test.go` in each package runs the **real registered extractor + `resolve.BuildIndex`** over faithful sources:

- **GORM**: 6 `CONTAINS` / 2 `REFERENCES` (Customer, Item); untagged `Customer Customer` recovered; all targets resolve.
- **ActiveRecord**: 17 `CONTAINS` / 15 `REFERENCES`; `:items`→`Item`, `:customer`→`Customer` singularization; all resolve.
- **JPA/Bean-Validation**: 7 `CONTAINS`; `REFERENCES` to `Customer`, `Item` (collection-unwrapped), `Address` (`@Embedded`), `AddressDto` (`@Valid`); all resolve.

## Deferred / follow-ups

- Ruby ActiveModel `validates` membership is anchored only when an owning `< ApplicationRecord` / `ActiveRecord::Base` model class is present in the file (the Rails convention). Plain non-model classes carrying validations stay honest-partial (no model node to anchor membership). Polymorphic AR associations stay relation-entity-only (no single concrete target). Ref epic #4334.

## Gates

`go build ./...`, `go vet` (java/ruby/golang), and full `go test` for `internal/custom/{java,ruby,golang}` + `internal/resolve` all pass. No new Kind (no `internal/types` change). DEPLOY-DEFERRED.

Closes #4367

🤖 Generated with [Claude Code](https://claude.com/claude-code)