### PR TITLE
Carry base QualifiedName + structural edges through custom-node supersede in MergeWithCustom

### DIFF
--- a/internal/custom/python/issue4402_mergeboundary_test.go
+++ b/internal/custom/python/issue4402_mergeboundary_test.go
@@ -1,0 +1,241 @@
+package python_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the regex framework extractors (Django model/middleware).
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	// Register the tree-sitter base Python extractor so the base class node
+	// carries its real module-qualified QualifiedName + the #526 class→field
+	// CONTAINS membership edges that MergeWithCustom used to drop.
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+// Issue #4402 — MERGE-BOUNDARY ROOT-FIX PROOF.
+//
+// These tests assert the supersede semantics of extractors.MergeWithCustom
+// DIRECTLY at the merge boundary, BEFORE any downstream late-binding pass runs,
+// and with the per-language workarounds (#4366 model-node CONTAINS re-emit /
+// #4379 settings late-binding rebind) DISABLED in the assertion so we prove the
+// ROOT fix — not the prior workarounds — carries QualifiedName + CONTAINS across
+// the merge.
+//
+// Background: the base Python tree-sitter extractor emits a model class as a
+// rich SCOPE.Component node carrying (a) its module-qualified QualifiedName
+// (e.g. core.models.contract.Contract) and (b) ~45 class→field CONTAINS edges
+// (#526). The Django custom extractor emits the SAME class Name as a
+// SCOPE.Schema/model node with NO QualifiedName and NO base membership. The old
+// MergeWithCustom replaced the base node wholesale, dropping both. This was
+// patched per-language (re-emit CONTAINS, late-bind QName). #4402 fixes it at
+// the boundary: supersedeBase carries base QualifiedName onto the survivor when
+// the custom node left it empty, and unions the base CONTAINS edges (re-keyed to
+// the survivor ID) onto the merged entity.
+
+func mergeBoundary4402(t *testing.T, path string) []types.EntityRecord {
+	t.Helper()
+	file := loadRepro4366(t, "contract_models.py.txt", path)
+
+	base, ok := extreg.Get("python")
+	if !ok {
+		t.Fatal("base python extractor not registered")
+	}
+	baseEnts, err := base.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("base extract: %v", err)
+	}
+	customEnts, errs := extractors.RunCustomExtractors(context.Background(), file)
+	for _, e := range errs {
+		t.Fatalf("custom extract: %v", e)
+	}
+
+	// Assign deterministic IDs to the INPUTS the same way the pipeline does,
+	// so MergeWithCustom re-keys base self-edges against real survivor IDs.
+	for i := range baseEnts {
+		if baseEnts[i].ID == "" {
+			baseEnts[i].ID = baseEnts[i].ComputeID()
+		}
+	}
+	merged := extractors.MergeWithCustom(baseEnts, customEnts)
+	for i := range merged {
+		if merged[i].ID == "" {
+			merged[i].ID = merged[i].ComputeID()
+		}
+	}
+	return merged
+}
+
+// findMergedClass returns the single surviving entity named `name`. After the
+// merge there must be exactly ONE node per class Name (custom won the identity).
+func findMergedClass(t *testing.T, ents []types.EntityRecord, name string) types.EntityRecord {
+	t.Helper()
+	var found []types.EntityRecord
+	for _, e := range ents {
+		if e.Name == name {
+			found = append(found, e)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly 1 merged entity named %q, got %d", name, len(found))
+	}
+	return found[0]
+}
+
+// TestIssue4402_QualifiedNameSurvivesMerge proves the merged model node keeps
+// the base node's module-qualified QualifiedName even though the Django custom
+// node emitted none. This is what makes the settings→middleware dotted path
+// resolve via byQualifiedName WITHOUT the #4379 late-binding pass.
+func TestIssue4402_QualifiedNameSurvivesMerge(t *testing.T) {
+	merged := mergeBoundary4402(t, "core/models/contract.py")
+
+	contract := findMergedClass(t, merged, "Contract")
+
+	// Identity is the CUSTOM node's (Django model), proving the custom node won.
+	if contract.Subtype != "model" {
+		t.Errorf("merged Contract should keep custom identity subtype=model, got %q", contract.Subtype)
+	}
+	if contract.Properties["framework"] != "django" {
+		t.Errorf("merged Contract should keep custom Django properties, got %v", contract.Properties)
+	}
+
+	// ROOT FIX: QualifiedName carried over from the base node.
+	want := "core.models.contract.Contract"
+	if contract.QualifiedName != want {
+		t.Fatalf("merged Contract lost QualifiedName: got %q want %q (base-node QName dropped by merge)", contract.QualifiedName, want)
+	}
+
+	// And it resolves via the REAL resolver's byQualifiedName tier with NO
+	// late-binding pass run — the #4379 workaround is unnecessary for this.
+	idx := resolve.BuildIndex(merged)
+	if id, ok := idx.Lookup(want); !ok || id == "" {
+		t.Errorf("byQualifiedName lookup of %q failed after merge (id=%q ok=%v)", want, id, ok)
+	}
+}
+
+// TestIssue4402_BaseContainsSurvivesMerge_WorkaroundDisabled proves the base
+// #526 class→field CONTAINS membership survives the merge on its own. We
+// STRIP the #4366 workaround edges (the model-node re-emitted CONTAINS, marked
+// provenance=INFERRED_FROM_MODEL_FIELD_MEMBERSHIP) from the merged node and
+// assert that fields are STILL members via the base edges the merge preserved.
+func TestIssue4402_BaseContainsSurvivesMerge_WorkaroundDisabled(t *testing.T) {
+	merged := mergeBoundary4402(t, "core/models/contract.py")
+
+	contract := findMergedClass(t, merged, "Contract")
+
+	// Partition the surviving CONTAINS edges into base (#526) vs workaround
+	// (#4366 re-emit). The workaround edges are tagged with the model-field
+	// membership provenance; everything else CONTAINS is base structural.
+	var baseContains, workaroundContains int
+	baseToIDs := map[string]bool{}
+	for _, r := range contract.Relationships {
+		if r.Kind != string(types.RelationshipKindContains) {
+			continue
+		}
+		if r.Properties["provenance"] == "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP" {
+			workaroundContains++
+			continue
+		}
+		baseContains++
+		baseToIDs[r.ToID] = true
+	}
+
+	t.Logf("merged Contract CONTAINS: base(#526)=%d workaround(#4366)=%d", baseContains, workaroundContains)
+
+	// ROOT FIX: the base structural CONTAINS edges survived the merge. Without
+	// the #4402 union these would all be gone (the old merge replaced the base
+	// node entirely), leaving only the #4366 re-emitted edges.
+	if baseContains == 0 {
+		t.Fatal("no base #526 CONTAINS edges survived the merge — root fix not carrying base membership")
+	}
+
+	// The base CONTAINS edges now hang off the merged Contract node itself.
+	// The base extractor embeds these edges in the class node's Relationships
+	// with an empty FromID (implicitly owned by the containing entity), so on
+	// the survivor they remain implicitly-owned (empty FromID) or, where the
+	// base set an explicit self-FromID, are re-keyed to the survivor's ID.
+	// Either way they must NOT dangle to the now-gone base node ID.
+	baseClassProbe := types.EntityRecord{
+		Name: "Contract", Kind: "SCOPE.Component", Subtype: "class",
+		SourceFile: contract.SourceFile,
+	}
+	baseClassID := baseClassProbe.ComputeID()
+	containsOwnedBySurvivor := 0
+	for _, r := range contract.Relationships {
+		if r.Kind != string(types.RelationshipKindContains) ||
+			r.Properties["provenance"] == "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP" {
+			continue
+		}
+		if r.FromID == baseClassID {
+			t.Errorf("base CONTAINS edge still points FROM the gone base node ID %s (dangling)", baseClassID)
+		}
+		if r.FromID == "" || r.FromID == contract.ID {
+			containsOwnedBySurvivor++
+		}
+	}
+	if containsOwnedBySurvivor == 0 {
+		t.Error("base CONTAINS edges are not owned by the surviving Contract node")
+	}
+
+	// WORKAROUND-DISABLED membership check: build a view of the merged graph
+	// with the #4366 re-emitted CONTAINS edges removed, then confirm the base
+	// edges alone still make the model's scalar fields members of Contract.
+	stripped := stripWorkaroundContains(merged)
+
+	// Sample a few concrete scalar fields that the base extractor emits as
+	// `Contract.<attr>` SCOPE.Schema field nodes and verify each has an inbound
+	// base CONTAINS edge from the surviving Contract node.
+	for _, field := range []string{
+		"Contract.status", "Contract.start_date", "Contract.contract_number",
+	} {
+		if !baseInboundContains(stripped, field) {
+			t.Errorf("field %q lost base CONTAINS membership after merge (workaround disabled)", field)
+		}
+	}
+}
+
+// stripWorkaroundContains returns a copy of ents with every #4366
+// workaround-provenance CONTAINS edge removed, so membership assertions rely
+// solely on the base #526 edges that survived MergeWithCustom.
+func stripWorkaroundContains(ents []types.EntityRecord) []types.EntityRecord {
+	out := make([]types.EntityRecord, len(ents))
+	copy(out, ents)
+	for i := range out {
+		if len(out[i].Relationships) == 0 {
+			continue
+		}
+		kept := out[i].Relationships[:0:0]
+		for _, r := range out[i].Relationships {
+			if r.Kind == string(types.RelationshipKindContains) &&
+				r.Properties["provenance"] == "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP" {
+				continue
+			}
+			kept = append(kept, r)
+		}
+		out[i].Relationships = kept
+	}
+	return out
+}
+
+// baseInboundContains reports whether some entity declares a base (#526)
+// CONTAINS edge whose ToID names the given field by its structural-ref form
+// (scope:schema:field:...:<owner>.<attr>) or by qualified Name.
+func baseInboundContains(ents []types.EntityRecord, fieldQName string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindContains) {
+				continue
+			}
+			if r.ToID == fieldQName || strings.HasSuffix(r.ToID, ":"+fieldQName) ||
+				strings.HasSuffix(r.ToID, fieldQName) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -214,6 +214,28 @@ func RunCustomExtractors(ctx context.Context, file FileInput) (entities []types.
 // the base entities in their dispatch order (already deterministic via
 // CustomExtractorsFor's sort).
 //
+// SUPERSEDE SEMANTICS (issue #4402). A naive "custom wins, base discarded"
+// replacement silently drops two kinds of state the base node carried and the
+// custom node usually does not:
+//
+//   - QualifiedName — the module-qualified name that drives byQualifiedName
+//     resolution and cross-repo joins. Custom/framework extractors typically
+//     emit a bare Name with no QualifiedName; dropping the base one leaves the
+//     surviving entity unresolvable by qualified name (root cause behind the
+//     #4379 settings→middleware late-binding workaround).
+//   - Structural edges — relationships already attached to the base node,
+//     notably the class→field CONTAINS membership emitted by the base
+//     class-body walk (#526). Dropping these orphans every field (root cause
+//     behind the #4366 per-language CONTAINS re-emit workaround).
+//
+// supersedeBase therefore carries base-only state onto the surviving custom
+// entity: it fills the QualifiedName (and other) gaps the custom node left
+// empty WITHOUT overriding any value the custom node provided, and UNIONS the
+// base node's relationships into the survivor (re-keying base self-edges from
+// the base ID to the survivor ID and deduping). This makes the dropped-state
+// bug impossible at the merge boundary rather than patching it per-language
+// downstream.
+//
 // This function does NOT perform cross-kind dedup — that is handled downstream
 // by run-extractor's deduplicateEntities pass which runs after this merge.
 func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.EntityRecord {
@@ -232,10 +254,12 @@ func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.
 	used := make(map[int]bool, len(customEntities))
 	merged := make([]types.EntityRecord, 0, len(baseEntities)+len(customEntities))
 
-	// Replace base entities in place when a custom entity shares the Name.
+	// Replace base entities in place when a custom entity shares the Name,
+	// carrying base-only state (QualifiedName + structural edges) onto the
+	// surviving custom entity (issue #4402).
 	for _, be := range baseEntities {
 		if idx, ok := customByName[be.Name]; ok && !used[idx] {
-			merged = append(merged, customEntities[idx])
+			merged = append(merged, supersedeBase(be, customEntities[idx]))
 			used[idx] = true
 			continue
 		}
@@ -250,4 +274,140 @@ func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.
 		merged = append(merged, ce)
 	}
 	return merged
+}
+
+// supersedeBase returns the surviving entity for the case where custom node
+// `ce` replaces base node `be` (same Name). The custom node's identity and all
+// of its non-empty fields WIN; base-only state is carried over to fill gaps:
+//
+//   - QualifiedName is taken from base when the custom node left it empty.
+//   - A conservative set of descriptive/structural string fields (Subtype,
+//     Signature, Description, Domain, Content, Language, SourceFile) are filled
+//     from base only when the custom node left them empty — never overridden.
+//   - StartLine/EndLine are filled from base when the custom node left them 0.
+//   - Properties and Metadata maps are gap-filled key-by-key (custom keys win).
+//   - Tags from base are unioned in (deduped).
+//   - Relationships are UNIONED: base relationships survive on the merged
+//     entity, with base self-edges (FromID == base.ID) re-keyed to the survivor
+//     ID so class→field CONTAINS membership is not dropped. Duplicates (same
+//     from/to/kind) are removed.
+//
+// The custom node's ID/Kind/Name are NOT changed — supersede preserves the
+// custom extractor's chosen identity.
+func supersedeBase(be, ce types.EntityRecord) types.EntityRecord {
+	survivor := ce
+
+	// Resolve the survivor's effective ID for self-edge re-keying. Custom
+	// nodes may not have stamped an ID yet at merge time; fall back to the
+	// deterministic ComputeID so re-keying targets a stable value.
+	survivorID := survivor.ID
+	if survivorID == "" {
+		survivorID = survivor.ComputeID()
+	}
+	baseID := be.ID
+	if baseID == "" {
+		baseID = be.ComputeID()
+	}
+
+	// (1) Preserve QualifiedName — the field that drives byQualifiedName
+	// resolution and cross-repo joins (issue #4379 root cause).
+	if survivor.QualifiedName == "" {
+		survivor.QualifiedName = be.QualifiedName
+	}
+
+	// (2) Gap-fill conservative base-only descriptive/structural fields. Only
+	// fill when the custom node left the field empty — never override a value
+	// the custom extractor deliberately provided.
+	if survivor.Subtype == "" {
+		survivor.Subtype = be.Subtype
+	}
+	if survivor.Signature == "" {
+		survivor.Signature = be.Signature
+	}
+	if survivor.Description == "" {
+		survivor.Description = be.Description
+	}
+	if survivor.Domain == "" {
+		survivor.Domain = be.Domain
+	}
+	if survivor.Content == "" {
+		survivor.Content = be.Content
+	}
+	if survivor.Language == "" {
+		survivor.Language = be.Language
+	}
+	if survivor.SourceFile == "" {
+		survivor.SourceFile = be.SourceFile
+	}
+	if survivor.StartLine == 0 {
+		survivor.StartLine = be.StartLine
+	}
+	if survivor.EndLine == 0 {
+		survivor.EndLine = be.EndLine
+	}
+
+	// (3) Gap-fill Properties / Metadata maps (custom keys win).
+	if len(be.Properties) > 0 {
+		if survivor.Properties == nil {
+			survivor.Properties = make(map[string]string, len(be.Properties))
+		}
+		for k, v := range be.Properties {
+			if _, ok := survivor.Properties[k]; !ok {
+				survivor.Properties[k] = v
+			}
+		}
+	}
+	if len(be.Metadata) > 0 {
+		if survivor.Metadata == nil {
+			survivor.Metadata = make(map[string]interface{}, len(be.Metadata))
+		}
+		for k, v := range be.Metadata {
+			if _, ok := survivor.Metadata[k]; !ok {
+				survivor.Metadata[k] = v
+			}
+		}
+	}
+
+	// (4) Union Tags (dedupe).
+	if len(be.Tags) > 0 {
+		seenTag := make(map[string]bool, len(survivor.Tags)+len(be.Tags))
+		for _, t := range survivor.Tags {
+			seenTag[t] = true
+		}
+		for _, t := range be.Tags {
+			if !seenTag[t] {
+				seenTag[t] = true
+				survivor.Tags = append(survivor.Tags, t)
+			}
+		}
+	}
+
+	// (5) Union relationships. Base edges must survive on the merged entity —
+	// re-key base self-edges (FromID == baseID) to the survivor ID so
+	// structural membership (class→field CONTAINS, #526) is preserved, then
+	// dedupe against the custom node's own relationships.
+	if len(be.Relationships) > 0 {
+		type relKey struct{ from, to, kind string }
+		seen := make(map[relKey]bool, len(survivor.Relationships)+len(be.Relationships))
+		for _, r := range survivor.Relationships {
+			seen[relKey{r.FromID, r.ToID, r.Kind}] = true
+		}
+		for _, r := range be.Relationships {
+			br := r
+			if br.FromID == baseID {
+				br.FromID = survivorID
+			}
+			if br.ToID == baseID {
+				br.ToID = survivorID
+			}
+			k := relKey{br.FromID, br.ToID, br.Kind}
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			survivor.Relationships = append(survivor.Relationships, br)
+		}
+	}
+
+	return survivor
 }

--- a/internal/extractors/custom_dispatch_test.go
+++ b/internal/extractors/custom_dispatch_test.go
@@ -382,6 +382,95 @@ func TestMergeWithCustomPreservesBaseOrder(t *testing.T) {
 	}
 }
 
+// TestMergeWithCustomPreservesBaseQualifiedName proves the supersede rule
+// (issue #4402): when a custom node replaces a base node of the same Name but
+// leaves QualifiedName empty, the base node's QualifiedName is carried onto the
+// survivor. A non-empty custom QualifiedName is never overridden.
+func TestMergeWithCustomPreservesBaseQualifiedName(t *testing.T) {
+	base := []types.EntityRecord{
+		{Name: "Contract", Kind: "SCOPE.Component", QualifiedName: "app.models.Contract"},
+		{Name: "Order", Kind: "SCOPE.Component", QualifiedName: "app.models.Order"},
+	}
+	custom := []types.EntityRecord{
+		{Name: "Contract", Kind: "SCOPE.Schema", Subtype: "model"},                              // empty QName -> inherit
+		{Name: "Order", Kind: "SCOPE.Schema", Subtype: "model", QualifiedName: "custom.Order"},  // explicit QName -> keep
+	}
+	got := MergeWithCustom(base, custom)
+
+	for _, e := range got {
+		switch e.Name {
+		case "Contract":
+			if e.Kind != "SCOPE.Schema" {
+				t.Errorf("Contract should keep custom Kind, got %s", e.Kind)
+			}
+			if e.QualifiedName != "app.models.Contract" {
+				t.Errorf("Contract should inherit base QualifiedName, got %q", e.QualifiedName)
+			}
+		case "Order":
+			if e.QualifiedName != "custom.Order" {
+				t.Errorf("Order custom QualifiedName must not be overridden, got %q", e.QualifiedName)
+			}
+		}
+	}
+}
+
+// TestMergeWithCustomUnionsBaseEdges proves base structural edges survive the
+// merge (issue #4402): CONTAINS membership embedded on the base node (empty
+// FromID = implicitly owned) is unioned onto the survivor, and an explicit base
+// self-edge (FromID == base ID) is re-keyed to the survivor's ID. Duplicate
+// edges already on the custom node are not double-added.
+func TestMergeWithCustomUnionsBaseEdges(t *testing.T) {
+	baseNode := types.EntityRecord{Name: "Contract", Kind: "SCOPE.Component", SourceFile: "m.py"}
+	baseID := baseNode.ComputeID()
+	baseNode.ID = baseID
+	baseNode.Relationships = []types.RelationshipRecord{
+		// Implicitly-owned membership edge (empty FromID).
+		{ToID: "Contract.status", Kind: "CONTAINS"},
+		// Explicit self-edge keyed to the base node ID — must be re-keyed.
+		{FromID: baseID, ToID: "Contract.amount", Kind: "CONTAINS"},
+	}
+	base := []types.EntityRecord{baseNode}
+
+	customNode := types.EntityRecord{Name: "Contract", Kind: "SCOPE.Schema", Subtype: "model", SourceFile: "m.py"}
+	// A duplicate of the implicit membership edge — must not be double-added.
+	customNode.Relationships = []types.RelationshipRecord{
+		{ToID: "Contract.status", Kind: "CONTAINS"},
+	}
+	custom := []types.EntityRecord{customNode}
+
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 merged entity, got %d", len(got))
+	}
+	surv := got[0]
+	if surv.ID == "" {
+		surv.ID = surv.ComputeID()
+	}
+	survID := surv.ComputeID()
+
+	var status, amount int
+	for _, r := range surv.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		switch r.ToID {
+		case "Contract.status":
+			status++
+		case "Contract.amount":
+			amount++
+			if r.FromID != survID {
+				t.Errorf("explicit base self-edge not re-keyed to survivor: FromID=%q want %q", r.FromID, survID)
+			}
+		}
+	}
+	if status != 1 {
+		t.Errorf("Contract.status CONTAINS should appear exactly once (deduped), got %d", status)
+	}
+	if amount != 1 {
+		t.Errorf("Contract.amount CONTAINS (base self-edge) should survive the merge, got %d", amount)
+	}
+}
+
 // ---- helpers ----------------------------------------------------------------
 
 // errorExtractor adapts a string into an error for inline test use.


### PR DESCRIPTION
## Summary

`MergeWithCustom` replaced a base tree-sitter node wholesale whenever a custom/framework extractor emitted an entity of the same `Name`. That silently dropped two kinds of base-only state the custom node almost never carries:

- **`QualifiedName`** — the module-qualified name driving `byQualifiedName` resolution and cross-repo joins. Custom extractors emit a bare `Name`; losing the base QName left the survivor unresolvable by qualified name. This is the root cause the #4379 `django_global_wiring` late-binding pass was working around.
- **Structural edges** — relationships already attached to the base node, notably class→field `CONTAINS` membership from the base class-body walk (#526). Dropping these orphaned every model field. This is the root cause the #4366 per-language CONTAINS re-emit was working around.

This has been worked around N times per-language (#4366/#4357/#4379/#4328). This PR fixes it once, at the merge boundary.

## How `MergeWithCustom` changed

New helper `supersedeBase(base, custom)` replaces the old "custom wins, base discarded" line. The custom node keeps its identity (ID/Kind/Name) and **all of its non-empty fields win**; base-only state is carried onto the survivor:

1. **Preserve QualifiedName** — if the custom node left `QualifiedName` empty, inherit the base node's. A non-empty custom QName is never overridden.
2. **Union the edge sets** — base `Relationships` survive on the merged entity. Base self-edges (`FromID == baseID`) are **re-keyed to the survivor ID** (the custom node's Kind differs, so its ComputeID differs); membership edges the base embeds with an empty `FromID` (implicitly owned by the containing entity) stay implicitly owned by the survivor. Duplicates (same from/to/kind) are de-duped against the custom node's own edges.
3. **Conservative gap-fill** — `Subtype`/`Signature`/`Description`/`Domain`/`Content`/`Language`/`SourceFile`/`StartLine`/`EndLine` filled from base only when the custom node left them empty; `Properties`/`Metadata` gap-filled key-by-key (custom keys win); `Tags` unioned. Never overrides a custom-provided value.

This makes the bad state (dropped QName/edges) impossible at the boundary rather than reconstructing it downstream.

## Before/after proof (workarounds disabled)

In-pipeline test `internal/custom/python/issue4402_mergeboundary_test.go` runs the **real** base Python extractor + real Django custom extractors over the existing #4366 `contract_models.py` fixture, merges via `extractors.MergeWithCustom`, and asserts at the merge boundary **before any late-binding pass**:

- `TestIssue4402_QualifiedNameSurvivesMerge` — the merged `Contract` node keeps the custom Django identity (`subtype=model`, `framework=django`) **and** the base `QualifiedName` `core.models.contract.Contract`, and resolves via `resolve.BuildIndex` `byQualifiedName` with **no** late-binding pass run (the #4379 workaround is unnecessary for this).
- `TestIssue4402_BaseContainsSurvivesMerge_WorkaroundDisabled` — the test **strips the #4366 workaround edges** (the model-node re-emitted CONTAINS, tagged `provenance=INFERRED_FROM_MODEL_FIELD_MEMBERSHIP`) from the merged node, then confirms the model's fields are **still** CONTAINS-members via the base #526 edges the merge preserved. Observed on the real fixture: `base(#526)=45` CONTAINS edges survive (vs `workaround(#4366)=41`), and no base edge dangles to the gone base-node ID.

Both fail against the old wholesale-replace `MergeWithCustom` (base edges/QName gone, leaving only the workaround edges) and pass with the fix.

Plus merge-core unit tests in `custom_dispatch_test.go`: `TestMergeWithCustomPreservesBaseQualifiedName` (inherit when empty, never override) and `TestMergeWithCustomUnionsBaseEdges` (implicit + explicit self-edge survival, re-key, dedupe).

## Full-suite result

`go build ./...` ✅, `go vet ./...` ✅, `go test ./...` — **165 packages green, 0 real failures.** The only failure is the known-unrelated environmental one: `internal/verify/TestHarness_FixturesCorpus` cannot start its `/tmp` daemon because the canonical daemon already holds the socket (`daemon refusing to start: another daemon … is running on the canonical socket`). Not related to this change.

**No existing test assertions were changed.** The supersede semantics only ADD preserved state (QName + edges that were previously wrongly dropped); existing merge tests (`TestMergeWithCustomOverridesBaseEntityByName`, `…PreservesBaseOrder`, etc.) assert the custom node's winning fields, which still hold.

## Now-redundant per-language workarounds (future cleanup — NOT removed here)

Left in place as belt-and-suspenders; a separate PR should retire the CONTAINS-membership halves:

- `internal/custom/python/django.go` (#4366) — model-node CONTAINS membership re-emit. The CONTAINS half is now redundant (base #526 edges survive the merge); the REFERENCES (field→target) half is **not** redundant (the base extractor doesn't emit it).
- `internal/custom/python/{orm_schema,orm_relationships,sqlalchemy}.go` — same `containsFieldEdge` CONTAINS re-emit pattern; CONTAINS half redundant, REFERENCES half retained.
- `internal/resolve/django_global_wiring.go` (#4379) — `ResolveDjangoGlobalWiringRefs` tier (2) unique-leaf-name fallback exists specifically to recover the merge-dropped QualifiedName; tier (1) `byQualifiedName` now resolves directly, so tier (2) is redundant for the merge-drop case (still useful for genuine bare-name nodes).
- JS/TS #4328 analog referenced in `internal/custom/python/helpers.go` — same membership-re-emit shape; worth auditing in the same cleanup.

## Blast radius note

`MergeWithCustom` is the documented merge boundary but is currently invoked only by the repro/unit test harnesses — the production daemon path (`internal/daemon/extract/subproc.go`) emits base + custom as independent entities and dedups downstream. So this change makes the boundary correct-by-construction for the repro harnesses and any future production caller, with bounded blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4402
