### PR TITLE
Capture Go anonymous/inline HTTP route handlers as linked endpoints

### DIFF
--- a/internal/engine/http_endpoint_go_anon_inline_4382_test.go
+++ b/internal/engine/http_endpoint_go_anon_inline_4382_test.go
@@ -1,0 +1,166 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4382 — Go HTTP routes whose handler is an ANONYMOUS / INLINE function literal
+// (`func(w http.ResponseWriter, r *http.Request) {...}`, `func(c *gin.Context)
+// {...}`, `func(c echo.Context) error {...}`, …) must be captured as endpoints
+// AND linked to a handler node — exactly like the JS fix #4324.
+//
+// Before this fix the Go producer synthesizers required the handler argument to
+// be a bare/qualified IDENTIFIER (`[\w.]+`). An inline func literal did not match
+// the registration regex at all, so the endpoint was DROPPED entirely (a strictly
+// worse failure than JS, where the endpoint was emitted but left an island).
+//
+// The fix is handler-shape-agnostic: the Go synthesizers now also match func
+// literals and signal refKind="InlineHandler" (empty refName). makeEmit then
+// synthesizes a stable inline-handler Operation entity (Name derived purely from
+// verb+canonical path → merge-stable) plus a file-scoped structural IMPLEMENTS
+// bridge that the central resolver binds post-merge — the #4324 / #4319 mechanism
+// reused for Go. This test runs the REAL extract+synthesis+merge+resolve pipeline.
+
+// TestInline4382_NetHTTPInlineHandlers covers net/http stdlib inline func
+// literals: http.HandleFunc, mux.HandleFunc (Go 1.22 method prefix), and
+// http.Handle(http.HandlerFunc(func(...){...})).
+func TestInline4382_NetHTTPInlineHandlers(t *testing.T) {
+	src := `package main
+
+import "net/http"
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	http.HandleFunc("/legacy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	http.ListenAndServe(":8080", mux)
+}
+`
+	ents, rels := detectInline(t, "go", "cmd/server/main.go", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/health", "nethttp")
+	assertInlineEndpointBridged(t, ents, rels, "ANY", "/legacy", "nethttp")
+}
+
+// TestInline4382_GorillaMuxInlineHandlers covers gorilla/mux
+// r.HandleFunc("/x", func(...){...}).Methods("GET").
+func TestInline4382_GorillaMuxInlineHandlers(t *testing.T) {
+	src := `package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func register(r *mux.Router) {
+	r.HandleFunc("/widgets", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("[]"))
+	}).Methods("GET")
+}
+`
+	ents, rels := detectInline(t, "go", "internal/api/gorilla.go", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/widgets", "gorilla")
+}
+
+// TestInline4382_GinInlineHandlers covers gin r.GET("/x", func(c *gin.Context){...})
+// including a route group.
+func TestInline4382_GinInlineHandlers(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(200, gin.H{"pong": true})
+	})
+	v1 := r.Group("/v1")
+	v1.POST("/items", func(c *gin.Context) {
+		c.JSON(201, gin.H{"ok": true})
+	})
+	r.Run()
+}
+`
+	ents, rels := detectInline(t, "go", "cmd/gin/main.go", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/ping", "gin")
+	// NOTE: the http_endpoint synthesis layer (synthesizeGoRouters) does not
+	// resolve gin r.Group("/v1") prefixes — it emits the route's own path
+	// ("/items"), for BOTH named and inline handlers alike. That group-prefix
+	// gap is pre-existing and handler-shape-INDEPENDENT (see PR follow-up); this
+	// #4382 assertion deliberately tracks the layer's actual (verb,path) so it
+	// isolates the inline-handler regression it is here to guard.
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/items", "gin")
+}
+
+// TestInline4382_EchoInlineHandlers covers echo e.GET("/x", func(c echo.Context) error {...}).
+func TestInline4382_EchoInlineHandlers(t *testing.T) {
+	src := `package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	e := echo.New()
+	e.GET("/status", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	e.Logger.Fatal(e.Start(":1323"))
+}
+`
+	ents, rels := detectInline(t, "go", "cmd/echo/main.go", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/status", "echo")
+}
+
+// TestInline4382_ChiInlineHandlers covers chi r.Get("/x", func(w, r){...}).
+func TestInline4382_ChiInlineHandlers(t *testing.T) {
+	src := `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Get("/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("[]"))
+	})
+	http.ListenAndServe(":3000", r)
+}
+`
+	ents, rels := detectInline(t, "go", "cmd/chi/main.go", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/items", "chi")
+}
+
+// TestInline4382_NamedHandlerStillNamedBridge guards no regression: a Go NAMED
+// handler reference must still take the named #4319 bridge and must NOT
+// synthesize an inline-handler stand-in.
+func TestInline4382_NamedHandlerStillNamedBridge(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) { c.JSON(200, gin.H{}) }
+
+func main() {
+	r := gin.Default()
+	r.GET("/users", listUsers)
+	r.Run()
+}
+`
+	ents, _ := detectInline(t, "go", "cmd/named/main.go", src)
+	if endpointByVerbPath(ents, "GET", "/users") == nil {
+		t.Fatal("named-handler endpoint missing")
+	}
+	if inlineHandlerEntity(ents, "GET", "/users") != nil {
+		t.Error("named Go handler must NOT synthesize an inline-handler stand-in")
+	}
+}

--- a/internal/engine/http_endpoint_go_trio.go
+++ b/internal/engine/http_endpoint_go_trio.go
@@ -29,6 +29,21 @@ import (
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
 )
 
+// isGoInlineHandlerToken reports whether a handler token captured by a Go HTTP
+// route registration regex is actually the start of an ANONYMOUS / INLINE func
+// literal (`func(...) {...}`) rather than a real, addressable handler symbol.
+//
+// The route regexes capture the handler argument as a `[\w.]+` identifier; when
+// the argument is `func(w, r) {...}` the greedy group captures the bare `func`
+// keyword. `func` is a Go reserved word and can never be a handler name, so it
+// is an unambiguous, name-agnostic signal that the handler is inline. Callers
+// turn this into refKind="InlineHandler" so makeEmit synthesizes a stable
+// inline-handler entity + merge-stable IMPLEMENTS bridge (#4382, mirroring the
+// JS fix #4324) instead of leaving the endpoint a handler-less graph island.
+func isGoInlineHandlerToken(handler string) bool {
+	return handler == "func"
+}
+
 // ---------------------------------------------------------------------------
 // gorilla/mux — issue #2684
 // ---------------------------------------------------------------------------
@@ -114,6 +129,90 @@ func synthesizeGorillaMux(content string, emit emitDefFn) {
 			emit(verb, canonical, "gorilla", "Controller", handler, regLine)
 		}
 	}
+	synthesizeGorillaMuxInline(content, emit)
+}
+
+// gorillaInlineRouteRe matches a gorilla/mux route whose handler is an
+// ANONYMOUS / INLINE func literal:
+//
+//	r.HandleFunc("/widgets", func(w http.ResponseWriter, r *http.Request) {
+//	r.HandleFunc("/x", func(w, r) { ... }).Methods("GET")
+//
+// The named-handler regex (gorillaRouteRe) requires `handler)` immediately
+// after the path and so cannot match a func literal (the `)` belongs to the
+// func signature, and the registration `)` only appears after the multi-line
+// body). This regex anchors on the `func(` opener instead. Group 1 is the path;
+// the .Methods(...) verb list — which on a multi-line inline handler appears
+// after the body, out of regex reach — is recovered by scanning forward to the
+// statement-terminating `)` (see verbsForGorillaInline). #4382.
+var gorillaInlineRouteRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*HandleFunc\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?\s*,\s*func\s*\(`,
+)
+
+// gorillaInlineMethodsRe finds the `.Methods("GET", http.MethodPost, …)` suffix
+// that may trail an inline gorilla/mux handler after the func body's closing
+// brace, within the forward window the caller passes.
+var gorillaInlineMethodsRe = regexp.MustCompile(`\.\s*Methods\s*\(([^)]*)\)`)
+
+// synthesizeGorillaMuxInline emits endpoints for gorilla/mux routes whose
+// handler is an inline func literal. Each is signalled InlineHandler so makeEmit
+// synthesizes a stable inline-handler node + bridge (#4382). The verb is taken
+// from a trailing `.Methods(...)` when present (scanning past the func body),
+// else ANY — matching gorilla's wildcard semantics for an un-Methods'd route.
+func synthesizeGorillaMuxInline(content string, emit emitDefFn) {
+	for _, m := range gorillaInlineRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		rawPath := content[m[2]:m[3]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, rawPath)
+		regLine := lineOfOffset(content, m[0])
+
+		verbs := verbsForGorillaInline(content, m[1])
+		if len(verbs) == 0 {
+			verbs = []string{"ANY"}
+		}
+		for _, verb := range verbs {
+			emit(verb, canonical, "gorilla", inlineHandlerRefKind, "", regLine)
+		}
+	}
+}
+
+// verbsForGorillaInline recovers the verb list from a `.Methods(...)` suffix on
+// an inline-handler registration. Starting at the `func(` opener offset, it
+// finds the matching close of the func literal body and looks for a `.Methods(`
+// immediately after; returns the parsed verbs, or nil when absent.
+func verbsForGorillaInline(content string, funcOpenOffset int) []string {
+	brace := strings.IndexByte(content[funcOpenOffset:], '{')
+	if brace < 0 {
+		return nil
+	}
+	bodyOpen := funcOpenOffset + brace
+	bodyEnd := findMatchingBracket(content, bodyOpen)
+	if bodyEnd < 0 {
+		return nil
+	}
+	// The registration closes with `)` after the func body; the optional
+	// `.Methods(...)` follows that. Scan a small forward window past the body.
+	rest := content[bodyEnd:]
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		// Allow the `.Methods(...)` on the same line as the closing `})`.
+		if line := rest[:nl]; gorillaInlineMethodsRe.MatchString(line) {
+			mm := gorillaInlineMethodsRe.FindStringSubmatch(line)
+			return parseGorillaVerbs(mm[1])
+		}
+	}
+	if mm := gorillaInlineMethodsRe.FindStringSubmatch(rest); mm != nil {
+		// Only honour a `.Methods(...)` that appears before the next route
+		// registration so we don't borrow a sibling route's verbs.
+		methodsIdx := strings.Index(rest, mm[0])
+		nextReg := strings.Index(rest, "HandleFunc")
+		if nextReg < 0 || methodsIdx < nextReg {
+			return parseGorillaVerbs(mm[1])
+		}
+	}
+	return nil
 }
 
 // parseGorillaVerbs extracts verb strings from a .Methods(...) argument
@@ -222,7 +321,17 @@ func synthesizeNetHTTPStdlib(content string, emit emitDefFn) {
 			path = strings.TrimSpace(mp[2])
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, path)
-		emit(verb, canonical, "nethttp", "Controller", handler, regLine)
+		// #4382 — `http.HandleFunc("/x", func(w, r) {...})`: the `([\w.]+)`
+		// handler group captured the bare `func` literal keyword, not a real
+		// handler symbol. Signal InlineHandler so makeEmit synthesizes a stable
+		// inline-handler node + bridge instead of a dangling `Controller:func`
+		// ref that leaves the endpoint a graph island.
+		refKind := "Controller"
+		if isGoInlineHandlerToken(handler) {
+			handler = ""
+			refKind = inlineHandlerRefKind
+		}
+		emit(verb, canonical, "nethttp", refKind, handler, regLine)
 	}
 }
 

--- a/internal/engine/response_shape_go.go
+++ b/internal/engine/response_shape_go.go
@@ -117,7 +117,19 @@ func synthesizeGoRouters(content string, emit emitFn) {
 			handler = handler[i+1:]
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, raw)
-		emit(verb, canonical, framework, "Controller", handler)
+		// #4382 — the handler argument is an ANONYMOUS / INLINE func literal
+		// (`r.GET("/x", func(c *gin.Context) {...})`). The `([\w.]+)` handler
+		// group greedily captures the bare `func` keyword, which is NOT an
+		// addressable handler symbol — emitting it as a named Controller ref
+		// produces a bridge to a non-existent `func` def, leaving the endpoint
+		// a graph ISLAND. Signal InlineHandler (empty refName) so makeEmit
+		// synthesizes a stable inline-handler entity + merge-stable bridge.
+		refKind := "Controller"
+		if isGoInlineHandlerToken(handler) {
+			handler = ""
+			refKind = inlineHandlerRefKind
+		}
+		emit(verb, canonical, framework, refKind, handler)
 	}
 }
 


### PR DESCRIPTION
## Problem

Go HTTP routes whose handler is an **anonymous / inline func literal** were mishandled by every Go producer synthesizer, because the registration regexes capture the handler argument as a `[\w.]+` identifier:

- **gin / echo / chi** (`synthesizeGoRouters`) and **net/http** (`synthesizeNetHTTPStdlib`) greedily captured the bare `func` keyword as the handler name and emitted a `source_handler=Controller:func` bridge to a non-existent symbol → the endpoint resolved to a graph **island** with no real handler linkage.
- **gorilla/mux** (`synthesizeGorillaMux`) failed to match the registration at all (the `)` belongs to the func signature, not the call) → the endpoint was **dropped entirely**.

This is the Go counterpart of the JS fix #4324.

## Root cause

The producer regexes assume the handler is an addressable symbol. A func literal (`func(w, r) {...}`) either mismatches or has its `func` keyword mis-captured as a handler name.

## Fix (handler-shape-agnostic, long-term root fix)

`func` is a Go reserved word and can never be a handler name, so it is an unambiguous inline signal (`isGoInlineHandlerToken`). The synthesizers now emit `refKind="InlineHandler"` (empty `refName`) for inline literals, and the existing `makeEmit` branch synthesizes:

- a **stable inline-handler `SCOPE.Operation` entity** whose `Name` derives purely from `(verb, canonical path)` — `<inline GET /health>` — never a line number or a captured token, so it is deterministic and merge-stable; plus
- a **file-scoped structural `IMPLEMENTS` bridge** that the central resolver binds post-merge (the #4319 / #4324 mechanism).

`gorilla/mux` gains a dedicated inline pass (`gorillaInlineRouteRe`) that anchors on the `func(` opener and recovers a trailing `.Methods(...)` verb list by scanning past the func body, defaulting to `ANY` (gorilla's wildcard semantics).

## Validation (in-pipeline)

New test `http_endpoint_go_anon_inline_4382_test.go` runs the **real** extract + synthesis + merge + central-resolve pipeline on faithful fixtures. Red before the fix, green after — endpoint present **and** inline-handler-linked (not an island):

| Framework | Inline route | Result |
|---|---|---|
| net/http | `GET /health`, `ANY /legacy` | endpoint + bridge ✅ |
| gorilla/mux | `GET /widgets` (was dropped) | endpoint + bridge ✅ |
| gin | `GET /ping`, `POST /items` | endpoint + bridge ✅ |
| echo | `GET /status` | endpoint + bridge ✅ |
| chi | `GET /items` | endpoint + bridge ✅ |

No-regression guard: a **named** Go handler still takes the named #4319 bridge and never synthesizes an inline stand-in.

## Coverage / deferred

- **Covered:** net/http, gorilla/mux, gin, echo, chi inline func literals.
- **Deferred (pre-existing, handler-shape-INDEPENDENT):** `synthesizeGoRouters` does not resolve gin `r.Group(...)` prefixes in the http_endpoint synthesis layer (emits the route's own path for named *and* inline handlers alike) — confirmed orthogonal to this fix; and middleware-wrapped handler literals.

## Gates

`go build ./...` ✅ · `go vet ./internal/engine/ ./internal/custom/golang/` ✅ · `go test ./internal/engine/ ./internal/custom/golang/` ✅ (no regressions).

Closes #4382

🤖 Generated with [Claude Code](https://claude.com/claude-code)