### PR TITLE
Link Express/Koa and ASP.NET Core global middleware into the graph

### DIFF
--- a/internal/custom/csharp/issue4380_livedrepro_test.go
+++ b/internal/custom/csharp/issue4380_livedrepro_test.go
@@ -1,0 +1,144 @@
+package csharp_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// Issue #4380 LIVE-REPRO (.NET side).
+//
+// Generalizes the NestJS global-DI fix (#4329) to ASP.NET Core. A faithful
+// Program.cs registers middleware app-wide via app.UseMiddleware<T>() and binds
+// services via builder.Services.AddScoped<IFoo, Foo>() / AddSingleton /
+// AddTransient.
+//
+// PRE-FIX:
+//   - app.UseMiddleware<RequestLoggingMiddleware>() produced only a standalone
+//     "middleware:RequestLoggingMiddleware" entity with NO edge to the class —
+//     the middleware class looked orphan / dead.
+//   - AddScoped<IFoo, Foo>() already produced an IFoo BINDS Foo edge (#3699);
+//     this test pins that the impl class resolves through the symbol table.
+//
+// POST-FIX:
+//   - a synthetic `app` entity owns an app → RequestLoggingMiddleware USES edge
+//     (global=true, di_role=middleware, order), and the class resolves.
+//   - the AddScoped impl binds and resolves to the real impl class.
+
+const issue4380Program = `
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddScoped<IOrderService, OrderService>();
+builder.Services.AddSingleton<IClock, SystemClock>();
+builder.Services.AddTransient<IMailer, SmtpMailer>();
+
+var app = builder.Build();
+
+app.UseMiddleware<RequestLoggingMiddleware>();
+app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+app.Run();
+`
+
+func extract4380CS(t *testing.T, key, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(key)
+	if !ok {
+		t.Fatalf("%s not registered", key)
+	}
+	recs, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "csharp", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("%s extract: %v", key, err)
+	}
+	return recs
+}
+
+func csEdge(ents []types.EntityRecord, kind, fromID, toID string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// TestIssue4380_UseMiddleware_AppUsesClass asserts the app → middleware USES
+// edge for each app.UseMiddleware<T>() and that the previously-orphan class
+// resolves through the real resolver.
+func TestIssue4380_UseMiddleware_AppUsesClass(t *testing.T) {
+	ents := extract4380CS(t, "custom_csharp_middleware_extra", "Program.cs", issue4380Program)
+
+	for i, cls := range []string{"RequestLoggingMiddleware", "CorrelationIdMiddleware"} {
+		r := csEdge(ents, "USES", "app", cls)
+		if r == nil {
+			t.Fatalf("expected app USES %s (UseMiddleware<%s>)", cls, cls)
+		}
+		if r.Properties["global"] != "true" {
+			t.Errorf("%s: expected global=true, got %q", cls, r.Properties["global"])
+		}
+		if r.Properties["di_role"] != "middleware" {
+			t.Errorf("%s: expected di_role=middleware, got %q", cls, r.Properties["di_role"])
+		}
+		if got := r.Properties["order"]; got != itoaTest(i) {
+			t.Errorf("%s: expected order=%d, got %q", cls, i, got)
+		}
+	}
+
+	// The previously-orphan middleware class must RESOLVE against a real class.
+	prod := types.EntityRecord{
+		Name: "RequestLoggingMiddleware", Kind: "SCOPE.Class", Subtype: "class",
+		SourceFile: "Middleware/RequestLoggingMiddleware.cs", Language: "csharp",
+		Properties: map[string]string{"kind": "SCOPE.Class", "subtype": "class"},
+	}
+	prod.ID = prod.ComputeID()
+	idx := resolve.BuildIndex(append(ents, prod))
+	if id, ok := idx.Lookup("RequestLoggingMiddleware"); !ok || id != prod.ID {
+		t.Fatalf("UseMiddleware target failed to resolve (ok=%v id=%s) — would stay orphan", ok, id)
+	}
+}
+
+// TestIssue4380_AddScoped_BindsAndResolves asserts the DI BINDS edge from the
+// interface registration to the impl class and that the impl resolves.
+func TestIssue4380_AddScoped_BindsAndResolves(t *testing.T) {
+	ents := extract4380CS(t, "custom_csharp_dotnet_di", "Program.cs", issue4380Program)
+
+	if csEdge(ents, "BINDS", "", "impl:OrderService") == nil {
+		t.Fatalf("expected IOrderService BINDS OrderService (AddScoped<IOrderService, OrderService>)")
+	}
+
+	prod := types.EntityRecord{
+		Name: "OrderService", Kind: "SCOPE.Class", Subtype: "class",
+		SourceFile: "Services/OrderService.cs", Language: "csharp",
+		Properties: map[string]string{"kind": "SCOPE.Class", "subtype": "class"},
+	}
+	prod.ID = prod.ComputeID()
+	idx := resolve.BuildIndex(append(ents, prod))
+	// impl:OrderService → kind-agnostic bare-name fallback resolves to OrderService.
+	if id, ok := idx.Lookup("impl:OrderService"); !ok || id != prod.ID {
+		t.Fatalf("AddScoped impl OrderService failed to resolve (ok=%v id=%s)", ok, id)
+	}
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/custom/csharp/middleware_extra.go
+++ b/internal/custom/csharp/middleware_extra.go
@@ -65,6 +65,12 @@ type middlewareExtraExtractor struct{}
 
 func (e *middlewareExtraExtractor) Language() string { return "custom_csharp_middleware_extra" }
 
+// dotnetAppEntityName is the synthetic owner name for app-level global
+// middleware wiring emitted from an ASP.NET Core app's app.UseMiddleware<T>()
+// calls (#4380). The app → T USES edges hang off this entity so the registered
+// middleware class is connected and resolves through the symbol table.
+const dotnetAppEntityName = "app"
+
 // ---------------------------------------------------------------------------
 // Regex catalog
 // ---------------------------------------------------------------------------
@@ -271,6 +277,15 @@ func (e *middlewareExtraExtractor) Extract(ctx context.Context, file extractor.F
 	// Generic ASP.NET middleware
 	// -------------------------------------------------------------------------
 
+	// app.UseMiddleware<T>() registers T into the request pipeline app-wide
+	// (#4380, the .NET analog of NestJS app.useGlobal*() #4329). PRE-FIX the
+	// standalone "middleware:T" entity carried NO edge to the middleware class T,
+	// so T looked orphan / dead and the app-wide registration was invisible.
+	// POST-FIX a synthetic `app` entity owns an app → T USES edge (global=true,
+	// di_role=middleware, 0-based order); the bare class name resolves to the
+	// real middleware class through the cross-file symbol table.
+	var appMiddlewareEdges []types.RelationshipRecord
+	mwOrder := 0
 	for _, m := range reMWUseMiddleware.FindAllStringSubmatchIndex(src, -1) {
 		middlewareType := src[m[2]:m[3]]
 		ent := makeEntity("middleware:"+middlewareType, "SCOPE.Component", "middleware_coverage",
@@ -278,6 +293,29 @@ func (e *middlewareExtraExtractor) Extract(ctx context.Context, file extractor.F
 		setProps(&ent, "framework", "aspnet", "provenance", "INFERRED_FROM_USE_MIDDLEWARE",
 			"middleware_type", middlewareType)
 		add(ent)
+
+		appMiddlewareEdges = append(appMiddlewareEdges, types.RelationshipRecord{
+			FromID: dotnetAppEntityName,
+			ToID:   middlewareType,
+			Kind:   string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework": "aspnet-core",
+				"di_role":   "middleware",
+				"di_scope":  "global",
+				"global":    "true",
+				"order":     itoa(mwOrder),
+				"via":       "dotnet_use_middleware",
+			},
+		})
+		mwOrder++
+	}
+	if len(appMiddlewareEdges) > 0 {
+		appEnt := makeEntity(dotnetAppEntityName, "SCOPE.Pattern", "application",
+			file.Path, "csharp", 1)
+		setProps(&appEnt, "framework", "aspnet-core",
+			"provenance", "INFERRED_FROM_ASPNET_BOOTSTRAP")
+		appEnt.Relationships = append(appEnt.Relationships, appMiddlewareEdges...)
+		add(appEnt)
 	}
 
 	for _, m := range reMWUseLambda.FindAllStringIndex(src, -1) {

--- a/internal/custom/javascript/express.go
+++ b/internal/custom/javascript/express.go
@@ -231,9 +231,17 @@ func (e *expressExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		if errorHandlerNames[baseName] || routerVars[baseName] {
 			continue
 		}
-		name := expr
+		// Prefix the standalone middleware entity name with "middleware:" so it
+		// does NOT collide in the symbol table with the real middleware
+		// function/factory symbol of the same bare name (#4380). Before this, a
+		// bare `app.use(authMiddleware)` emitted a SCOPE.Pattern entity literally
+		// named `authMiddleware`, which made the resolver see two `authMiddleware`
+		// entities and treat the name as ambiguous — so the app→middleware USES
+		// edge could never bind to the real function.
+		name := "middleware:" + expr
 		ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "express", "provenance", "INFERRED_FROM_EXPRESS_MIDDLEWARE")
+		setProps(&ent, "framework", "express", "provenance", "INFERRED_FROM_EXPRESS_MIDDLEWARE",
+			"middleware_expr", expr)
 		addEntity(ent)
 	}
 
@@ -308,6 +316,32 @@ func (e *expressExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		setProps(&ent, "framework", "express", "param", param,
 			"provenance", "INFERRED_FROM_EXPRESS_PARAM")
 		addEntity(ent)
+	}
+
+	// 11. Global middleware wiring (#4380): app.use(...) registers cross-cutting
+	// middleware/routers app-wide. Emit a synthetic `app` entity that owns an
+	// app → middleware USES edge for each registration (global=true, di_role,
+	// 0-based order). The edge targets resolve to the real middleware function /
+	// router entity through the cross-file symbol table. Generalizes #4329.
+	globalEdges := extractExpressGlobalMiddleware(src, routerVars)
+	if len(globalEdges) > 0 && expressHasGlobalMiddleware(src) {
+		appEnt := makeEntity(expressAppEntityName, "SCOPE.Pattern", "application",
+			file.Path, file.Language, 1)
+		setProps(&appEnt, "framework", "express",
+			"provenance", "INFERRED_FROM_EXPRESS_BOOTSTRAP")
+		addEntity(appEnt)
+
+		byName := make(map[string]int, len(entities))
+		for i := range entities {
+			if _, ok := byName[entities[i].Name]; !ok {
+				byName[entities[i].Name] = i
+			}
+		}
+		for owner, rels := range globalEdges {
+			if idx, ok := byName[owner]; ok {
+				entities[idx].Relationships = append(entities[idx].Relationships, rels...)
+			}
+		}
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/javascript/express_global_middleware.go
+++ b/internal/custom/javascript/express_global_middleware.go
@@ -1,0 +1,176 @@
+package javascript
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// express_global_middleware.go — Express/Koa global middleware wiring (#4380).
+//
+// Generalizes the NestJS global-DI fix (#4329) to Express/Koa. An Express (or
+// Koa) app registers cross-cutting middleware app-wide via app.use(...):
+//
+//	app.use(helmet())            — factory call → binds the factory `helmet`
+//	app.use(cookieParser())      — factory call → binds the factory `cookieParser`
+//	app.use(authMiddleware)      — bare symbol  → binds the middleware function
+//	app.use(errorHandler)        — bare symbol  → binds the error-handling middleware
+//	app.use('/api', apiRouter)   — mount        → binds the router at the path
+//
+// PRE-FIX: each app.use(...) produced only a standalone SCOPE.Pattern
+// "middleware" / "mount" entity with NO edge from the app to the referenced
+// middleware/router symbol, so the registered middleware function/router looked
+// orphan / dead and the app-wide pipeline was invisible.
+//
+// POST-FIX: a synthetic `app` application entity owns an app → middleware USES
+// edge for every app.use(...) registration, marked global=true with
+// di_role=middleware|router and a 0-based pipeline `order`. The edge target is
+// the resolved middleware/router symbol (a bare identifier, or the callee of a
+// factory call), which binds to the real function/router entity through the
+// real resolve.BuildIndex symbol table. Conditional/env-gated registration is
+// deferred to the order epic (#4334).
+
+// expressAppEntityName is the synthetic owner name for app-level global
+// middleware wiring emitted from an Express/Koa app's app.use(...) calls.
+const expressAppEntityName = "app"
+
+// reExpressUse captures the head of an `<obj>.use(` call. Group 1 is the
+// receiver identifier (app / koa / router var); the argument list is read with
+// balanced-paren scanning from the captured '(' so nested factory calls such as
+// rateLimit({ windowMs: 1000 }) are not truncated.
+var reExpressUse = regexp.MustCompile(`\b([A-Za-z_]\w*)\s*\.\s*use\s*\(`)
+
+// extractExpressGlobalMiddleware returns app.use(...) USES edges keyed by the
+// synthetic `app` owner name (#4380). Each registration yields one
+// app → middleware|router USES edge with di_role + a 0-based pipeline order.
+// routerVars lets a path-mounted router (app.use('/p', r)) be role-tagged as a
+// router rather than a plain middleware.
+func extractExpressGlobalMiddleware(src string, routerVars map[string]bool) map[string][]types.RelationshipRecord {
+	out := map[string][]types.RelationshipRecord{}
+	order := 0
+	for _, m := range reExpressUse.FindAllStringSubmatchIndex(src, -1) {
+		open := m[1] - 1 // index of the '(' captured at the end of the match
+		args := nestBalanced(src, open, '(', ')')
+		params := nestSplitParams(args)
+		if len(params) == 0 {
+			continue
+		}
+
+		// Determine the registration shape from the first top-level argument.
+		first := strings.TrimSpace(params[0])
+		mounted := false
+		target := first
+		if isExpressStringLiteral(first) {
+			// Path-mounted form: app.use('/api', router|middleware). The mount
+			// path is the first arg; the bound symbol is the second.
+			if len(params) < 2 {
+				continue
+			}
+			mounted = true
+			target = strings.TrimSpace(params[1])
+		}
+
+		sym := expressMiddlewareSymbol(target)
+		if sym == "" {
+			continue
+		}
+
+		role := "middleware"
+		if mounted && routerVars[sym] {
+			role = "router"
+		} else if routerVars[sym] {
+			role = "router"
+		}
+
+		out[expressAppEntityName] = append(out[expressAppEntityName], types.RelationshipRecord{
+			FromID: expressAppEntityName,
+			ToID:   sym,
+			Kind:   string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework": "express",
+				"di_role":   role,
+				"di_scope":  "global",
+				"global":    "true",
+				"order":     itoaJS(order),
+				"via":       "express_app_use",
+			},
+		})
+		order++
+	}
+	return out
+}
+
+// expressHasGlobalMiddleware reports whether src contains any `<obj>.use(` call,
+// so the caller knows to emit the synthetic `app` owner entity.
+func expressHasGlobalMiddleware(src string) bool {
+	return reExpressUse.MatchString(src)
+}
+
+// expressMiddlewareSymbol resolves the middleware/router symbol an app.use(...)
+// argument binds to. A bare identifier `authMiddleware` binds to the function;
+// a factory call `helmet()` / `express.json()` binds to the callee leaf
+// (`helmet` / `json`). Inline function/arrow expressions and config objects
+// yield "" (no resolvable symbol — honest-partial).
+func expressMiddlewareSymbol(arg string) string {
+	a := strings.TrimSpace(arg)
+	if a == "" {
+		return ""
+	}
+	// Inline middleware: function (...) / (req,res,next) => / async ... — no
+	// named symbol to bind.
+	if strings.HasPrefix(a, "function") || strings.HasPrefix(a, "async") ||
+		strings.HasPrefix(a, "(") || a[0] == '{' || a[0] == '[' {
+		return ""
+	}
+	// `new Foo(...)` → Foo.
+	a = strings.TrimSpace(strings.TrimPrefix(a, "new "))
+	// Take the callee/identifier head up to the first call/access boundary.
+	if i := strings.IndexAny(a, " ([{,;=>"); i >= 0 {
+		// Preserve a dotted member path (express.json) so we can pick its leaf;
+		// only cut at a real boundary char, not '.'.
+		a = a[:i]
+	}
+	a = strings.TrimSpace(a)
+	// For a dotted factory like express.json, bind to the leaf callee `json`
+	// (the bare `express` namespace is never a middleware entity).
+	if i := strings.LastIndexByte(a, '.'); i >= 0 {
+		a = a[i+1:]
+	}
+	a = strings.TrimSpace(a)
+	if a == "" || !isExpressIdentStart(a[0]) {
+		return ""
+	}
+	return a
+}
+
+// isExpressStringLiteral reports whether the argument chunk is a quoted string
+// literal (a route-mount path), i.e. begins with ' " or `.
+func isExpressStringLiteral(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	return s[0] == '\'' || s[0] == '"' || s[0] == '`'
+}
+
+// isExpressIdentStart reports whether b can start a JS identifier.
+func isExpressIdentStart(b byte) bool {
+	return b == '_' || b == '$' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+// itoaJS renders a small non-negative int without pulling in strconv at the
+// call sites that already use the package-local itoa convention.
+func itoaJS(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/custom/javascript/issue4380_livedrepro_test.go
+++ b/internal/custom/javascript/issue4380_livedrepro_test.go
@@ -1,0 +1,120 @@
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4380 LIVE-REPRO (Express/Koa side).
+//
+// Generalizes the NestJS global-DI fix (#4329) to Express/Koa global middleware.
+// A faithful Express app registers cross-cutting middleware app-wide via
+// app.use(...):
+//
+//	app.use(helmet())              — factory call → binds factory `helmet`
+//	app.use(cookieParser())        — factory call → binds factory `cookieParser`
+//	app.use(express.json())        — factory call → binds leaf `json`
+//	app.use(authMiddleware)        — bare symbol  → binds the middleware fn
+//	app.use('/api', apiRouter)     — mount        → binds router `apiRouter`
+//	app.use(errorHandler)          — bare symbol  → binds the error middleware
+//
+// PRE-FIX: each app.use(...) produced only a standalone "middleware"/"mount"
+// entity with NO edge from the app to the referenced middleware/router symbol,
+// so authMiddleware / errorHandler / apiRouter looked orphan and the app-wide
+// pipeline was invisible.
+//
+// POST-FIX: a synthetic `app` entity owns an app → middleware USES edge per
+// registration (global=true, di_role=middleware|router, 0-based order); the
+// targets resolve to the real symbol through resolve.BuildIndex.
+
+const issue4380ExpressApp = `
+import express from 'express';
+import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
+import { authMiddleware } from './auth';
+import { errorHandler } from './errors';
+
+const app = express();
+const apiRouter = express.Router();
+
+app.use(helmet());
+app.use(cookieParser());
+app.use(express.json());
+app.use(authMiddleware);
+app.use('/api', apiRouter);
+app.use(errorHandler);
+`
+
+func TestIssue4380_ExpressAppUse_GlobalMiddleware(t *testing.T) {
+	ents := extractFull(t, "custom_js_express", fi("app.ts", "typescript", issue4380ExpressApp))
+
+	type want struct {
+		sym   string
+		role  string
+		order string
+	}
+	wants := []want{
+		{"helmet", "middleware", "0"},
+		{"cookieParser", "middleware", "1"},
+		{"json", "middleware", "2"},
+		{"authMiddleware", "middleware", "3"},
+		{"apiRouter", "router", "4"},
+		{"errorHandler", "middleware", "5"},
+	}
+	for _, w := range wants {
+		if !hasEdge(ents, "app", "USES", "app", w.sym) {
+			t.Errorf("expected app USES %s (app.use)", w.sym)
+			continue
+		}
+		if v := edgeProp(ents, "USES", "app", w.sym, "global"); v != "true" {
+			t.Errorf("%s: expected global=true, got %q", w.sym, v)
+		}
+		if v := edgeProp(ents, "USES", "app", w.sym, "di_role"); v != w.role {
+			t.Errorf("%s: expected di_role=%s, got %q", w.sym, w.role, v)
+		}
+		if v := edgeProp(ents, "USES", "app", w.sym, "order"); v != w.order {
+			t.Errorf("%s: expected order=%s, got %q", w.sym, w.order, v)
+		}
+	}
+
+	// The previously-orphan middleware function must RESOLVE against a real
+	// production entity through the real resolver.
+	prod := types.EntityRecord{
+		Name: "authMiddleware", Kind: "SCOPE.Operation", Subtype: "function",
+		SourceFile: "src/auth.ts", Language: "typescript",
+		Properties: map[string]string{"kind": "SCOPE.Operation", "subtype": "function"},
+	}
+	prod.ID = prod.ComputeID()
+	idx := resolve.BuildIndex(append(ents, prod))
+	if id, ok := idx.Lookup("authMiddleware"); !ok || id != prod.ID {
+		t.Fatalf("global middleware authMiddleware failed to resolve (ok=%v id=%s)", ok, id)
+	}
+
+	// The path-mounted router must resolve to the router entity the express
+	// extractor itself emits for `express.Router()`.
+	if id, ok := idx.Lookup("apiRouter"); !ok || id == "" {
+		t.Fatalf("mounted router apiRouter failed to resolve (ok=%v id=%s)", ok, id)
+	}
+}
+
+// TestIssue4380_ExpressInlineMiddleware_NoFalseEdge ensures inline anonymous
+// middleware (no named symbol) does not fabricate a USES edge.
+func TestIssue4380_ExpressInlineMiddleware_NoFalseEdge(t *testing.T) {
+	src := `
+const app = express();
+app.use((req, res, next) => { next(); });
+app.use(function (req, res, next) { next(); });
+`
+	ents := extractFull(t, "custom_js_express", fi("app.ts", "typescript", src))
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) && r.FromID == "app" {
+				t.Errorf("inline middleware should not produce an app USES edge, got ToID=%s", r.ToID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Express/Koa (`app.use(...)`) and ASP.NET Core (`app.UseMiddleware<T>()`) register cross-cutting middleware app-wide, but the referenced middleware function/class previously had **no edge from the app** — so it looked orphan/dead and the app-wide pipeline was invisible. This generalizes the NestJS global-DI fix (#4329) to these stacks, reusing its `USES`-edge + `global=true`/`di_role` + synthetic `app`-owner shape (no new Kind).

## Express/Koa (JS/TS)
- `app.use(...)` now emits an **app → middleware USES** edge per registration (`global=true`, `di_role=middleware|router`, 0-based pipeline `order`) owned by a synthetic `app` entity.
- Target resolution via the real symbol table: bare symbols (`authMiddleware`, `errorHandler`) bind to the function; factory calls (`helmet()`, `express.json()`) bind to the callee leaf; path-mounted routers (`app.use('/api', r)`) bind to the router (role=router).
- Inline `function`/arrow middleware yields no edge (honest-partial).
- Root cause of non-resolution: the standalone `middleware` SCOPE.Pattern entity was named with the bare expression, colliding with the real middleware symbol of the same name and making the resolver treat it as ambiguous. It is now name-prefixed `middleware:<expr>`.

## ASP.NET Core (C#)
- `app.UseMiddleware<T>()` now emits an **app → T USES** edge (`global=true`, `di_role=middleware`, `order`) owned by a synthetic `app` entity; the bare class name resolves to the real middleware class cross-file.
- DI binding (`AddScoped/AddSingleton/AddTransient<I,T>` → `I BINDS T`) already existed (#3699); the live-repro test pins that the impl resolves.
- Built-in pipeline calls (`UseAuthentication`/`UseAuthorization`) keep their existing pipeline-order entities; no spurious USES.

## Validation
In-pipeline live-repro tests run the **real** extract+resolve pipeline (incl. `resolve.BuildIndex`) over faithful fixtures:
- Express: 6 `app.use(...)` registrations → before: 0 app→middleware USES edges; after: 6, all resolving (`authMiddleware`, `apiRouter` confirmed bound).
- .NET: 2 `UseMiddleware<T>` → 2 resolving app→class USES; `AddScoped` impl `OrderService` resolves.

Conditional/env-gated registration deferred to the order epic (#4334).

## Gates
`go build ./...`, `go vet` (both extractor pkgs), `go test ./internal/custom/javascript/ ./internal/custom/csharp/ ./internal/resolve/ ./internal/types/` — all green.

Closes #4380

🤖 Generated with [Claude Code](https://claude.com/claude-code)