### PR TITLE
fix(http): link Spring functional-routing handlers (lambda + method-ref)

### DIFF
--- a/internal/engine/http_endpoint_springfn_4384_test.go
+++ b/internal/engine/http_endpoint_springfn_4384_test.go
@@ -1,0 +1,188 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4384 — Spring WebFlux / WebMvc.fn FUNCTIONAL routing
+// (`RouterFunction` / `route().GET("/x", handler)`) must capture endpoints AND
+// link them to a handler, generalising the anon-handler fix #4324 to Spring
+// functional routes.
+//
+// Before this fix synthesizeSpringWebFlux emitted endpoints with refKind="Route"
+// and an EMPTY handler — discarding the handler argument entirely — so every
+// functional route was a handler-less graph ISLAND regardless of handler shape.
+//
+// Handler-shape-agnostic linkage (the root fix):
+//   - lambda handler   (`req -> ServerResponse.ok()...`) → inline-handler synth
+//     + merge-stable file-scoped IMPLEMENTS bridge (#4324 mechanism).
+//   - method reference (`this::create`, `handler::getUser`) → resolve to the
+//     NAMED method symbol via the #4319 synthesis-time structural bridge — NOT
+//     an inline stand-in, because it is a real symbol.
+//   - `.nest(path("/api"), ...)` composes its prefix onto inner routes.
+
+// namedHandlerBridgedTo proves the endpoint (verb, path) has a resolved inbound
+// IMPLEMENTS edge from the same-file named handler method `methodName` — i.e. it
+// took the #4319 named-bridge path and is NOT an island, and did NOT synthesize
+// an inline stand-in.
+func assertNamedMethodBridged(t *testing.T, ents []types.EntityRecord, rels []types.RelationshipRecord, srcFile, verb, path, methodName string) {
+	t.Helper()
+
+	endpoint := endpointByVerbPath(ents, verb, path)
+	if endpoint == nil {
+		t.Fatalf("endpoint %s %s NOT emitted", verb, path)
+	}
+	// A method-reference handler is a real symbol: it must NOT get an inline
+	// stand-in.
+	if inlineHandlerEntity(ents, verb, path) != nil {
+		t.Errorf("method-ref handler for %s %s must NOT synthesize an inline-handler stand-in", verb, path)
+	}
+
+	// In the LIVE pipeline the handler method symbol (`methodName`) is extracted
+	// by the base Java symbol extractor and merged into the graph alongside the
+	// engine-synthesised endpoint. detectInline only returns engine-emitted
+	// entities, so we inject the same-file handler-method Operation the base
+	// extractor would produce, exactly as it lands in buildDocument, before
+	// running the resolve passes.
+	ents = append(ents, types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       methodName,
+		Subtype:    "method",
+		SourceFile: srcFile,
+		Language:   "java",
+	})
+
+	merged, _ := ResolveHTTPEndpointHandlers(ents)
+	for i := range merged {
+		merged[i].ID = merged[i].ComputeID()
+	}
+	ep := endpointByVerbPath(merged, verb, path)
+	if ep == nil {
+		t.Fatalf("endpoint %s %s lost after http-endpoint resolve pass", verb, path)
+	}
+	// Find the named handler Operation method in the merged set.
+	var handlerID string
+	for i := range merged {
+		if merged[i].Name == methodName &&
+			(merged[i].Kind == "SCOPE.Operation" || merged[i].Kind == "Operation") {
+			handlerID = merged[i].ID
+		}
+	}
+	if handlerID == "" {
+		t.Fatalf("named handler method %q not found in merged entities for %s %s", methodName, verb, path)
+	}
+
+	idx := resolve.BuildIndex(merged)
+	resolve.References(rels, idx)
+
+	for _, r := range rels {
+		if r.Kind == implementsEdgeKind && r.ToID == ep.ID && r.FromID == handlerID {
+			return
+		}
+	}
+	t.Fatalf("ISLAND: method-ref endpoint %s %s has no resolved IMPLEMENTS edge from named handler %q (#4384)", verb, path, methodName)
+}
+
+// TestSpringFn4384_LambdaHandlers covers the chained builder + predicate-builder
+// forms with LAMBDA handlers — each must produce an inline-handler synth + bridge.
+func TestSpringFn4384_LambdaHandlers(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+
+@Configuration
+public class LambdaRouter {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/health", req -> ServerResponse.ok().build())
+                .POST("/items", request -> ServerResponse.status(201).build())
+                .build();
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> predicateRoutes() {
+        return RouterFunctions
+                .route(GET("/ping"), req -> ServerResponse.ok().build())
+                .andRoute(POST("/orders"), req -> ServerResponse.status(201).build());
+    }
+}
+`
+	ents, rels := detectInline(t, "java", "src/main/java/com/example/LambdaRouter.java", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/health", "spring_webflux")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/items", "spring_webflux")
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/ping", "spring_webflux")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/orders", "spring_webflux")
+}
+
+// TestSpringFn4384_MethodRefHandlers covers method-reference handlers — these
+// resolve to the NAMED same-file method, NOT an inline stand-in.
+func TestSpringFn4384_MethodRefHandlers(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class UserRouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/users", this::listUsers)
+                .POST("/users", this::createUser)
+                .GET("/users/{id}", this::getUser)
+                .build();
+    }
+
+    public Mono<ServerResponse> listUsers(ServerRequest req) { return ServerResponse.ok().build(); }
+    public Mono<ServerResponse> createUser(ServerRequest req) { return ServerResponse.status(201).build(); }
+    public Mono<ServerResponse> getUser(ServerRequest req) { return ServerResponse.ok().build(); }
+}
+`
+	const srcFile = "src/main/java/com/example/UserRouterConfig.java"
+	ents, rels := detectInline(t, "java", srcFile, src)
+	assertNamedMethodBridged(t, ents, rels, srcFile, "GET", "/users", "listUsers")
+	assertNamedMethodBridged(t, ents, rels, srcFile, "POST", "/users", "createUser")
+	assertNamedMethodBridged(t, ents, rels, srcFile, "GET", "/users/{id}", "getUser")
+}
+
+// TestSpringFn4384_NestedPrefix covers `.nest(path("/api"), ...)` prefix
+// composition — inner routes must carry the nest prefix.
+func TestSpringFn4384_NestedPrefix(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import static org.springframework.web.reactive.function.server.RequestPredicates.path;
+
+@Configuration
+public class NestedRouter {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .nest(path("/api"), builder -> builder
+                        .GET("/widgets", req -> ServerResponse.ok().build())
+                        .POST("/widgets", req -> ServerResponse.status(201).build()))
+                .build();
+    }
+}
+`
+	ents, rels := detectInline(t, "java", "src/main/java/com/example/NestedRouter.java", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/api/widgets", "spring_webflux")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/api/widgets", "spring_webflux")
+	// The un-prefixed path must NOT exist — proves the nest prefix composed.
+	if endpointByVerbPath(ents, "GET", "/widgets") != nil {
+		t.Error("un-prefixed /widgets emitted; nest prefix did not compose")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1887,25 +1887,101 @@ func synthesizeAkkaHTTP(content string, emit emitFn) {
 // Spring WebFlux (Java) — functional DSL routing (#3080)
 // ---------------------------------------------------------------------------
 
-// webFluxChainedSynthRe captures chained .GET("/path", ...) / .POST("/path", ...)
+// webFluxChainedSynthRe captures chained .GET("/path", handler) / .POST(...)
 // method calls in a RouterFunctions.route() builder chain. These are always
-// uppercase method names used as direct DSL verbs on the RequestPredicates API.
+// uppercase method names used as direct DSL verbs on the RouterFunctions API.
+//
+// Capture groups:
+//
+//	1: HTTP verb
+//	2: path string
+//	3: the handler argument (everything after the `"path",` up to the next
+//	   top-level `)`, `.`, or end-of-statement). #4384 — captured so a lambda
+//	   (`req -> ...`) can be synthesised as an inline handler and a method
+//	   reference (`this::create`, `handler::create`) can be resolved to the
+//	   named method, mirroring the JS #4324 / Go #4382 inline-handler fix.
+//
+// The handler group is OPTIONAL (`(?:...)?`) because the single-argument
+// predicate-builder shape `.GET("/path")` (handler supplied separately) also
+// occurs; an empty group 3 simply yields no handler signal.
 var webFluxChainedSynthRe = regexp.MustCompile(
-	`\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
+	`\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"\s*(?:,\s*([^,)][^)]*?))?\s*\)`)
 
 // webFluxPredicateSynthRe captures the two-argument overload:
 //
 //	RouterFunctions.route(RequestPredicates.GET("/path"), handler)
-var webFluxPredicateSynthRe = regexp.MustCompile(
-	`\bRequestPredicates\s*\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
-
-// synthesizeSpringWebFlux scans a Java file for Spring WebFlux functional-DSL
-// route registrations and emits one http_endpoint_definition per (verb, path)
-// pair.
+//	RouterFunctions.route(GET("/path"), handler)            (static import)
+//	...andRoute(GET("/path"), handler)
 //
-// Two forms are detected:
-//  1. Chained builder: RouterFunctions.route().GET("/path", handler)
-//  2. Static predicate: RouterFunctions.route(RequestPredicates.GET("/path"), handler)
+// Capture groups:
+//
+//	1: HTTP verb
+//	2: path string
+//	3: the handler argument (after the predicate's closing paren + comma, up
+//	   to the enclosing route(...) / andRoute(...) close paren). #4384.
+var webFluxPredicateSynthRe = regexp.MustCompile(
+	`(?:RequestPredicates\s*\.\s*)?\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"\s*\)\s*(?:,\s*([^,)][^)]*?))?\s*\)`)
+
+// webFluxNestRe captures `.nest(path("/prefix"), ...)` / `RouterFunctions
+// .nest(RequestPredicates.path("/prefix"), ...)` calls so the nested prefix can
+// be composed onto the routes declared inside the nest builder. #4384.
+//
+// Capture group 1: the nested path prefix string.
+var webFluxNestRe = regexp.MustCompile(
+	`\.\s*nest\s*\(\s*(?:RequestPredicates\s*\.\s*)?path\s*\(\s*"([^"]+)"`)
+
+// webFluxMethodRefHandler matches a Java method reference used as a functional
+// route handler — `this::create`, `handler::getUser`, `OrderHandler::list`,
+// `co.example.Handler::list`. The captured method name (group 1) is the bare
+// method symbol the endpoint resolves to. #4384.
+var webFluxMethodRefHandler = regexp.MustCompile(
+	`(?:[\w.$]+\s*::\s*)([\w$]+)\s*$`)
+
+// webFluxLambdaHandler matches a Java lambda used as a functional route handler
+// — `req -> ...`, `request -> ...`, `(req) -> ...`, `(ServerRequest r) -> ...`.
+// A lambda has no addressable symbol, so the endpoint gets a synthesised inline
+// handler (#4324 mechanism). #4384.
+var webFluxLambdaHandler = regexp.MustCompile(`->`)
+
+// classifyWebFluxHandler inspects the raw handler-argument text captured from a
+// functional-DSL route registration and returns the (refKind, refName) pair
+// makeEmit needs:
+//
+//   - method reference (`this::create`)  → ("SCOPE.Operation", "create") so the
+//     synthesis-time structural bridge resolves it to the named, same-file
+//     handler method (no inline stand-in — it is a real symbol).
+//   - lambda (`req -> ...`)              → (inlineHandlerRefKind, "") so makeEmit
+//     synthesises a merge-stable inline handler node + bridge.
+//   - unknown / absent                  → (inlineHandlerRefKind, "") — a
+//     functional route ALWAYS has a handler, so model it as inline rather than
+//     leaving the endpoint a handler-less graph island.
+func classifyWebFluxHandler(rawHandler string) (refKind, refName string) {
+	h := strings.TrimSpace(rawHandler)
+	if h == "" {
+		return inlineHandlerRefKind, ""
+	}
+	// Method reference takes precedence: `this::create` contains no `->`.
+	if m := webFluxMethodRefHandler.FindStringSubmatch(h); m != nil &&
+		!webFluxLambdaHandler.MatchString(h) {
+		return "SCOPE.Operation", m[1]
+	}
+	// Anything else with a `->` is a lambda; default everything else to inline.
+	return inlineHandlerRefKind, ""
+}
+
+// synthesizeSpringWebFlux scans a Java file for Spring WebFlux / WebMvc.fn
+// functional-DSL route registrations and emits one http_endpoint_definition per
+// (verb, path) pair, WITH a handler linkage (#4384):
+//
+//   - lambda handler (`req -> ...`)            → inline-handler synth + bridge
+//   - method-ref handler (`this::create`)      → bridge to the named method
+//
+// Forms detected:
+//  1. Chained builder:   RouterFunctions.route().GET("/path", handler)
+//  2. Static predicate:  RouterFunctions.route(GET("/path"), handler)
+//     ...andRoute(GET("/path"), handler)
+//  3. Nested prefix:     .nest(path("/api"), builder -> builder.GET("/x", h))
+//     — the "/api" prefix is composed onto every route inside the nest.
 //
 // Spring WebFlux uses `{param}` curly-brace path parameters (same as Spring
 // MVC), so FrameworkSpring is passed to Canonicalize.
@@ -1922,39 +1998,156 @@ func synthesizeSpringWebFlux(content string, emit emitFn) {
 		return
 	}
 
+	// Compute the nest prefix that applies at each byte offset. A `.nest(
+	// path("/prefix"), ...)` composes its prefix onto every route registered
+	// inside its builder lambda. We approximate the builder scope with the
+	// brace span that follows the nest call; routes whose offset falls inside
+	// that span get the prefix prepended. Multiple/sibling nests are handled
+	// independently and nested nests compose (longest enclosing span wins per
+	// level). This is a deliberately conservative static approximation — when a
+	// route is not inside any nest span it gets no prefix.
+	prefixAt := webFluxNestPrefixIndex(content)
+
 	seen := make(map[string]bool)
 
-	// Form 1: chained .GET/.POST/... verbs.
-	for _, m := range webFluxChainedSynthRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
-			continue
-		}
-		verb := m[1]
-		rawPath := m[2]
-		key := verb + ":" + rawPath
+	emitRoute := func(verb, rawPath, rawHandler string, offset int) {
+		fullPath := prefixAt(offset) + rawPath
+		key := verb + ":" + fullPath
 		if seen[key] {
-			continue
+			return
 		}
 		seen[key] = true
-		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, rawPath)
-		emit(verb, canonical, "spring_webflux", "Route", "")
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, fullPath)
+		refKind, refName := classifyWebFluxHandler(rawHandler)
+		emit(verb, canonical, "spring_webflux", refKind, refName)
 	}
 
-	// Form 2: RequestPredicates.GET("/path") — deduplicate against form 1.
-	for _, m := range webFluxPredicateSynthRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
+	// Form 2 FIRST: the predicate overload `route(GET("/p"), handler)` —
+	// its inner `GET("/p")` would also match the chained regex (form 1), so we
+	// claim it here first to capture the trailing handler argument, then
+	// dedup form 1 against it via `seen`.
+	for _, idx := range webFluxPredicateSynthRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
 			continue
 		}
-		verb := m[1]
-		rawPath := m[2]
-		key := verb + ":" + rawPath
-		if seen[key] {
-			continue
+		verb := content[idx[2]:idx[3]]
+		rawPath := content[idx[4]:idx[5]]
+		handler := ""
+		if idx[6] >= 0 {
+			handler = content[idx[6]:idx[7]]
 		}
-		seen[key] = true
-		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, rawPath)
-		emit(verb, canonical, "spring_webflux", "Route", "")
+		emitRoute(verb, rawPath, handler, idx[0])
 	}
+
+	// Form 1: chained .GET/.POST/... verbs with a handler argument.
+	for _, idx := range webFluxChainedSynthRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		verb := content[idx[2]:idx[3]]
+		rawPath := content[idx[4]:idx[5]]
+		handler := ""
+		if idx[6] >= 0 {
+			handler = content[idx[6]:idx[7]]
+		}
+		emitRoute(verb, rawPath, handler, idx[0])
+	}
+}
+
+// webFluxNestPrefixIndex returns a function mapping a byte offset in content to
+// the composed `.nest(path("/prefix"), ...)` prefix that applies there. Each
+// nest call's scope is approximated by the balanced-brace `{...}` or balanced-
+// paren builder span that follows it; offsets inside that span inherit the
+// prefix, and enclosing nests compose (outer prefix + inner prefix). #4384.
+func webFluxNestPrefixIndex(content string) func(offset int) string {
+	type span struct {
+		start, end int
+		prefix     string
+	}
+	var spans []span
+	for _, idx := range webFluxNestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		prefix := content[idx[2]:idx[3]]
+		// Find the builder body that follows this nest call. Spring's nest
+		// builder is `builder -> { ... }` (block) or `builder -> builder...`
+		// (single expr). We scope to the balanced-paren span of the nest(...)
+		// call itself — every route registered as an argument of this nest
+		// lives within it. Start the balance at the nest's opening paren.
+		open := strings.IndexByte(content[idx[0]:], '(')
+		if open < 0 {
+			continue
+		}
+		start := idx[0] + open
+		end := matchBalancedParen(content, start)
+		if end <= start {
+			continue
+		}
+		spans = append(spans, span{start: start, end: end, prefix: prefix})
+	}
+	if len(spans) == 0 {
+		return func(int) string { return "" }
+	}
+	return func(offset int) string {
+		var composed string
+		// Compose all enclosing spans, outermost first (smallest start).
+		// Collect enclosing prefixes, then order by start ascending.
+		var enclosing []span
+		for _, s := range spans {
+			if offset > s.start && offset < s.end {
+				enclosing = append(enclosing, s)
+			}
+		}
+		// Sort by start ascending (outer → inner) so prefixes compose in order.
+		for i := 0; i < len(enclosing); i++ {
+			for j := i + 1; j < len(enclosing); j++ {
+				if enclosing[j].start < enclosing[i].start {
+					enclosing[i], enclosing[j] = enclosing[j], enclosing[i]
+				}
+			}
+		}
+		for _, s := range enclosing {
+			composed += s.prefix
+		}
+		return composed
+	}
+}
+
+// matchBalancedParen returns the offset just past the `)` that balances the `(`
+// at position open in content, or -1 if unbalanced. String literals are skipped
+// so a `)` inside a "..." does not throw off the count.
+func matchBalancedParen(content string, open int) int {
+	if open >= len(content) || content[open] != '(' {
+		return -1
+	}
+	depth := 0
+	inStr := false
+	for i := open; i < len(content); i++ {
+		c := content[i]
+		if inStr {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Spring WebFlux / WebMvc.fn **functional routing** routes were extracted as endpoints but their handler argument was **discarded** — `synthesizeSpringWebFlux` emitted every route with `refKind="Route"` and an empty handler. Each functional route was therefore a handler-less graph **island** (no endpoint→handler `IMPLEMENTS` bridge), regardless of handler shape, and `.nest(path("/api"), ...)` prefixes were never composed onto inner routes.

This generalises the JS anon-handler fix #4324 (and Go #4382) to Spring functional routes.

## Root cause

`route().GET("/x", handler)` / `route(GET("/x"), handler)` / `andRoute(...)` were matched only for `(verb, path)`; the handler argument was never captured, and `.nest(...)` was not handled at all.

## Fix — handler-shape-agnostic linkage

- Chained-builder + predicate-overload regexes now capture the **handler argument**.
- `classifyWebFluxHandler` routes it by shape:
  - **lambda** (`req -> ...`) → `refKind="InlineHandler"` ⇒ `makeEmit` synthesises a merge-stable inline-handler `SCOPE.Operation` (Name derived purely from verb + canonical path) + file-scoped `IMPLEMENTS` bridge (#4324 mechanism).
  - **method reference** (`this::create`, `handler::getUser`) → resolves to the **named** method symbol via the #4319 synthesis-time structural bridge — **not** an inline stand-in, because it is a real symbol.
- `webFluxNestPrefixIndex` composes `.nest(path("/api"), ...)` prefixes onto every route inside the nest's balanced-paren builder span (enclosing nests compose outer→inner), with string-literal-aware paren balancing.

## Validation (in-pipeline: real Java extract + synthesis + merge + central resolve)

`internal/engine/http_endpoint_springfn_4384_test.go` — verified **RED before / GREEN after**:

| case | before fix | after fix |
|---|---|---|
| lambda (`/health`, `/items`, predicate `/ping`, `/orders`) | no inline handler synthesised | endpoint + inline-handler `IMPLEMENTS` bridge |
| method-ref (`this::listUsers/createUser/getUser`) | endpoint is an island (no `IMPLEMENTS`) | bridges to named method, no inline stand-in |
| nested (`.nest(path("/api"), ...)`) | endpoint `GET /api/widgets` **not emitted** | emitted with composed `/api` prefix |

## Coverage

Covered: `route().VERB(...)` builder, `route(GET(...), handler)` / `andRoute(...)` predicate overload, `.nest(path(...), ...)`, lambda + method-reference handlers. Deferred: Kotlin `coRouter { }` DSL (ref epic #4334).

## Gates

`go build ./...` ✅ · `go vet ./internal/engine/` ✅ · `go test ./internal/engine/` ✅ (full package, incl. existing #3080 WebFlux tests). No new Kind added (reuses `inlineHandlerRefKind` / `SCOPE.Operation`).

Closes #4384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
