### PR TITLE
feat(angular): link @NgModule and standalone bootstrap global providers into the graph

### DIFF
--- a/internal/extractors/javascript/angular_global_di.go
+++ b/internal/extractors/javascript/angular_global_di.go
@@ -1,0 +1,505 @@
+// angular_global_di.go — Angular global dependency-injection wiring (#4378).
+//
+// Angular registers cross-cutting providers app-wide through DI tokens in a
+// module/bootstrap providers array, the same {provide, useClass/useExisting/
+// useFactory, multi} provider-object shape NestJS uses (#4329). Previously the
+// JS/TS extractor recognised the @NgModule class and its constructor injections
+// but never read the `providers` array, so the bound classes — HTTP
+// interceptors, APP_INITIALIZER factories, the global ErrorHandler, custom
+// service tokens — had no edge from a real source entity and looked orphan /
+// dead, and the app-wide scope was invisible. Standalone bootstrap
+// (`bootstrapApplication(App, { providers: [...] })`) produced nothing at all.
+//
+// This pass generalises the NestJS global-DI fix (#4329 / #4380 convention) to
+// Angular. It emits, reusing the existing USES Kind (NO new Kind):
+//
+//   - NgModule providers: for each entry in @NgModule({ providers: [...] }) the
+//     declaring module emits a module → bound-class USES edge marked
+//     global=true, di_token (HTTP_INTERCEPTORS / APP_INITIALIZER / ErrorHandler
+//     / NG_VALIDATORS / a custom InjectionToken / the class itself for a bare
+//     provider), di_role (interceptor / initializer / error_handler / validator
+//     / service), and multi=true for multi-providers.
+//
+//   - Standalone bootstrap: `bootstrapApplication(App, { providers: [...] })`
+//     binds the same provider shapes app-wide with no owning module, so the
+//     edges hang off a synthetic `app` application entity (mirroring the NestJS
+//     bootstrap `app` owner). `provideHttpClient(withInterceptors([fn]))`
+//     functional interceptors and bare/object providers both yield app → target
+//     USES edges marked global=true.
+//
+// Every edge target is a bare class / function identifier; it resolves to the
+// real declaring entity through resolve.BuildIndex's symbol table, connecting
+// the previously-orphan class. The pass is a program-level pass invoked from
+// Extract after the AST walk, so the module/class entities it attaches to
+// already exist.
+//
+// Route guards / resolvers ({ path, canActivate: [Guard], resolve: { x: Res } })
+// are intentionally deferred to a tight follow-up (epic #4334) because route
+// extraction lives on a separate path; see angular_global_di_test.go.
+package javascript
+
+import (
+	"regexp"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// angularAppEntityName is the synthetic owner name for app-level global wiring
+// emitted from a standalone bootstrapApplication(...) call. Matches the NestJS
+// bootstrap convention (#4329) so the two frameworks share the `app` owner.
+const angularAppEntityName = "app"
+
+// angularDITokenRole maps a well-known Angular global DI token to the di_role of
+// the class/function it binds app-wide. Tokens not in this map are still emitted
+// (di_role="service") so custom InjectionToken bindings are connected too.
+var angularDITokenRole = map[string]string{
+	"HTTP_INTERCEPTORS":       "interceptor",
+	"APP_INITIALIZER":         "initializer",
+	"ENVIRONMENT_INITIALIZER": "initializer",
+	"ErrorHandler":            "error_handler",
+	"NG_VALIDATORS":           "validator",
+	"NG_ASYNC_VALIDATORS":     "validator",
+	"NG_VALUE_ACCESSOR":       "value_accessor",
+	"HTTP_INTERCEPTOR_FNS":    "interceptor",
+	"ROUTES":                  "routes",
+}
+
+// reAngularProvideObject matches an object-literal provider entry
+// {provide: TOKEN, useClass|useValue|useFactory|useExisting: Impl}. Group 1 is
+// the raw token expression, group 2 the binding keyword, group 3 the impl
+// expression (best-effort up to the next comma/brace). Mirrors the NestJS
+// reNestProvideObject shape — Angular's provider object is identical.
+var reAngularProvideObject = regexp.MustCompile(
+	`provide\s*:\s*([^,]+?)\s*,\s*(useClass|useValue|useFactory|useExisting)\s*:\s*([^,}]+)`,
+)
+
+// reAngularMulti detects a `multi: true` flag anywhere in a provider object body.
+var reAngularMulti = regexp.MustCompile(`\bmulti\s*:\s*true\b`)
+
+// reAngularWithInterceptors matches `withInterceptors([a, b, ...])` — the
+// standalone functional-interceptor registration passed to provideHttpClient.
+// Group 1 is the array body.
+var reAngularWithInterceptors = regexp.MustCompile(`withInterceptors\s*\(\s*\[([^\]]*)\]`)
+
+// reAngularIdent matches a bare identifier (PascalCase class or camelCase
+// function reference).
+var reAngularIdent = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\b`)
+
+// angularGlobalProviders is the program-level pass that links @NgModule and
+// bootstrapApplication global providers into the graph (#4378). It mutates
+// x.entities: it appends global USES edges onto the declaring @NgModule entity
+// (already emitted by handleAngularClass) and, when a standalone bootstrap is
+// present, emits a synthetic `app` entity owning the bootstrap USES edges.
+func (x *extractor) angularGlobalProviders(root *sitter.Node) {
+	if root == nil {
+		return
+	}
+	x.angularModuleProviders(root)
+	x.angularBootstrapProviders(root)
+}
+
+// angularProviderEdge is one resolved global provider binding.
+type angularProviderEdge struct {
+	target string // bound class / factory / interceptor-fn identifier
+	token  string // di_token (the magic token, custom token, or the class itself)
+	role   string // di_role (interceptor/initializer/error_handler/service/...)
+	multi  bool
+}
+
+// angularParseProviders parses a `providers: [...]` array body and returns the
+// global provider bindings it declares. It handles the two Angular provider
+// shapes uniformly with NestJS:
+//
+//	bare class      : `AuthService`            → token=AuthService, role=service
+//	object provider : `{ provide: TOKEN, useClass|useExisting|useFactory|
+//	                     useValue: Impl, multi?: true }`
+//
+// For an object provider the di_role is derived from the token (interceptor for
+// HTTP_INTERCEPTORS, initializer for APP_INITIALIZER, error_handler for
+// ErrorHandler, …) and the bound target is the use* implementation. Bare class
+// entries bind the class to itself (token=class, role=service).
+func angularParseProviders(arrayBody string) []angularProviderEdge {
+	var out []angularProviderEdge
+	seen := map[string]bool{}
+	add := func(e angularProviderEdge) {
+		if e.target == "" {
+			return
+		}
+		key := e.token + "|" + e.target + "|" + e.role
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, e)
+	}
+
+	// Object-form providers first; record their spans so the bare-class scan can
+	// skip identifiers that live inside an object provider.
+	type span struct{ lo, hi int }
+	var objSpans []span
+	for _, loc := range angularProviderObjectSpans(arrayBody) {
+		objSpans = append(objSpans, span{loc[0], loc[1]})
+		body := arrayBody[loc[0]:loc[1]]
+		pm := reAngularProvideObject.FindStringSubmatch(body)
+		if pm == nil {
+			continue
+		}
+		token := angularNormaliseToken(pm[1])
+		useKind := pm[2]
+		impl := angularImplName(pm[3], useKind)
+		if token == "" || impl == "" {
+			continue
+		}
+		role, ok := angularDITokenRole[token]
+		if !ok {
+			role = "service"
+		}
+		add(angularProviderEdge{
+			target: impl,
+			token:  token,
+			role:   role,
+			multi:  reAngularMulti.MatchString(body),
+		})
+	}
+
+	inObj := func(pos int) bool {
+		for _, s := range objSpans {
+			if pos >= s.lo && pos < s.hi {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Bare class providers: a PascalCase identifier at array top level that is
+	// not inside an object provider and not a provideX(...) helper call. Each
+	// binds the class to itself (token=class, role=service).
+	for _, m := range reAngularIdent.FindAllStringSubmatchIndex(arrayBody, -1) {
+		id := arrayBody[m[2]:m[3]]
+		if id == "" || id[0] < 'A' || id[0] > 'Z' {
+			continue // only PascalCase class names; provideX()/withX() are camelCase
+		}
+		if inObj(m[2]) {
+			continue
+		}
+		// Skip identifiers that are object-literal keys (followed by ':') — none
+		// of the top-level bare entries are key:value, but guard anyway.
+		rest := strings.TrimLeft(arrayBody[m[3]:], " \t")
+		if strings.HasPrefix(rest, ":") {
+			continue
+		}
+		add(angularProviderEdge{target: id, token: id, role: "service"})
+	}
+	return out
+}
+
+// angularProviderObjectSpans returns the [lo,hi) byte spans of each top-level
+// `{...}` object literal inside a providers-array body, so object providers can
+// be parsed and excluded from the bare-class scan.
+func angularProviderObjectSpans(body string) [][2]int {
+	var out [][2]int
+	depth := 0
+	start := -1
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			depth--
+			if depth == 0 && start >= 0 {
+				out = append(out, [2]int{start, i + 1})
+				start = -1
+			}
+		}
+	}
+	return out
+}
+
+// angularModuleProviders scans every @NgModule-decorated class for its
+// providers array and appends a module → bound-class USES edge (global=true)
+// per provider onto the already-emitted module entity.
+func (x *extractor) angularModuleProviders(root *sitter.Node) {
+	for _, dec := range findAllNodes(root, "decorator") {
+		name, call := x.decoratorIdent(dec)
+		if name != "NgModule" || call == nil {
+			continue
+		}
+		module := x.decoratedClassName(dec)
+		if module == "" {
+			continue
+		}
+		body := x.angularDecoratorArrayRaw(call, "providers")
+		if body == "" {
+			continue
+		}
+		idx := x.entityIndexByName(module)
+		if idx < 0 {
+			continue
+		}
+		for _, e := range angularParseProviders(body) {
+			x.entities[idx].Relationships = append(x.entities[idx].Relationships,
+				angularGlobalUsesEdge(module, e, "angular", "angular_ngmodule_provider", false))
+		}
+	}
+}
+
+// angularBootstrapProviders scans for a standalone bootstrapApplication(App,
+// { providers: [...] }) call. When found it emits a synthetic `app` entity and
+// hangs the app → target USES edges (global=true) off it, mirroring the NestJS
+// bootstrap `app` owner (#4329). Functional interceptors registered via
+// `provideHttpClient(withInterceptors([fn]))` also become app → fn edges.
+func (x *extractor) angularBootstrapProviders(root *sitter.Node) {
+	for _, call := range findAllNodes(root, "call_expression") {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || x.nodeText(fn) != "bootstrapApplication" {
+			continue
+		}
+		args := call.ChildByFieldName("arguments")
+		if args == nil {
+			continue
+		}
+		// The options object is the second argument; pull its providers array.
+		raw := x.angularOptionsProvidersRaw(args)
+		if raw == "" {
+			continue
+		}
+		var edges []angularProviderEdge
+		edges = append(edges, angularParseProviders(raw)...)
+		edges = append(edges, angularFunctionalInterceptorEdges(raw)...)
+		if len(edges) == 0 {
+			continue
+		}
+		appIdx := x.ensureAngularAppEntity(call)
+		for _, e := range edges {
+			x.entities[appIdx].Relationships = append(x.entities[appIdx].Relationships,
+				angularGlobalUsesEdge(angularAppEntityName, e, "angular", "angular_bootstrap_provider", true))
+		}
+	}
+}
+
+// angularFunctionalInterceptorEdges extracts `withInterceptors([fn1, fn2])`
+// functional interceptors from a bootstrap providers body. Each function
+// identifier becomes an interceptor binding (di_role=interceptor, multi=true —
+// functional interceptors compose like multi-providers).
+func angularFunctionalInterceptorEdges(body string) []angularProviderEdge {
+	var out []angularProviderEdge
+	seen := map[string]bool{}
+	for _, m := range reAngularWithInterceptors.FindAllStringSubmatch(body, -1) {
+		for _, idm := range reAngularIdent.FindAllStringSubmatch(m[1], -1) {
+			id := idm[1]
+			if id == "" || seen[id] {
+				continue
+			}
+			seen[id] = true
+			out = append(out, angularProviderEdge{
+				target: id,
+				token:  "HTTP_INTERCEPTORS",
+				role:   "interceptor",
+				multi:  true,
+			})
+		}
+	}
+	return out
+}
+
+// angularGlobalUsesEdge builds the module/app → target USES edge for a global
+// provider binding (#4378), tagged global=true + di_token/di_role + multi.
+func angularGlobalUsesEdge(owner string, e angularProviderEdge, framework, via string, fromApp bool) types.RelationshipRecord {
+	props := map[string]string{
+		"framework": framework,
+		"di_role":   e.role,
+		"di_scope":  "global",
+		"di_token":  e.token,
+		"global":    "true",
+		"via":       via,
+	}
+	if fromApp {
+		props["owner"] = owner
+	} else {
+		props["module"] = owner
+	}
+	if e.multi {
+		props["multi"] = "true"
+	}
+	return types.RelationshipRecord{
+		FromID:     owner,
+		ToID:       e.target,
+		Kind:       string(types.RelationshipKindUses),
+		Properties: props,
+	}
+}
+
+// decoratedClassName returns the name of the class a decorator node decorates,
+// by scanning the decorator's parent for the sibling class_declaration.
+func (x *extractor) decoratedClassName(dec *sitter.Node) string {
+	parent := dec.Parent()
+	if parent == nil {
+		return ""
+	}
+	for i := 0; i < int(parent.ChildCount()); i++ {
+		c := parent.Child(i)
+		if c != nil && c.Type() == "class_declaration" {
+			return x.nodeText(c.ChildByFieldName("name"))
+		}
+	}
+	return ""
+}
+
+// angularDecoratorArrayRaw returns the raw source text inside the `key: [...]`
+// array of a decorator call's first object-literal argument (e.g. the
+// `providers` array of @NgModule), or "" when absent. Raw text is used so the
+// uniform provider-object / bare-class parsing (shared with NestJS) applies.
+func (x *extractor) angularDecoratorArrayRaw(call *sitter.Node, key string) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	var obj *sitter.Node
+	for i := 0; i < int(args.ChildCount()); i++ {
+		if args.Child(i).Type() == "object" {
+			obj = args.Child(i)
+			break
+		}
+	}
+	if obj == nil {
+		return ""
+	}
+	return x.angularObjectArrayRaw(obj, key)
+}
+
+// angularOptionsProvidersRaw returns the raw `providers: [...]` array body from
+// the second (options) argument of a bootstrapApplication(App, {providers}) call.
+func (x *extractor) angularOptionsProvidersRaw(args *sitter.Node) string {
+	// Find object-literal arguments (skip the leading component identifier).
+	for i := 0; i < int(args.ChildCount()); i++ {
+		c := args.Child(i)
+		if c == nil || c.Type() != "object" {
+			continue
+		}
+		if raw := x.angularObjectArrayRaw(c, "providers"); raw != "" {
+			return raw
+		}
+	}
+	return ""
+}
+
+// angularObjectArrayRaw returns the raw text inside the `key: [...]` array value
+// of an object-literal node, or "" when the key is absent / not an array.
+func (x *extractor) angularObjectArrayRaw(obj *sitter.Node, key string) string {
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		pair := obj.Child(i)
+		if pair.Type() != "pair" {
+			continue
+		}
+		k := strings.Trim(x.nodeText(pair.ChildByFieldName("key")), `"'`)
+		if k != key {
+			continue
+		}
+		val := pair.ChildByFieldName("value")
+		if val == nil || val.Type() != "array" {
+			return ""
+		}
+		raw := x.nodeText(val)
+		// Strip the surrounding [ ] so the body parses identically to a NestJS
+		// array body.
+		raw = strings.TrimSpace(raw)
+		raw = strings.TrimPrefix(raw, "[")
+		raw = strings.TrimSuffix(raw, "]")
+		return raw
+	}
+	return ""
+}
+
+// entityIndexByName returns the index of the first emitted entity with the given
+// Name, or -1. Used to attach module-provider USES edges to the @NgModule entity.
+func (x *extractor) entityIndexByName(name string) int {
+	for i := range x.entities {
+		if x.entities[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// ensureAngularAppEntity returns the index of the synthetic `app` entity,
+// emitting it (once) when absent. The entity owns the bootstrap global USES
+// edges so the bound classes are retained and resolve through the symbol table.
+func (x *extractor) ensureAngularAppEntity(anchor *sitter.Node) int {
+	if idx := x.entityIndexByName(angularAppEntityName); idx >= 0 {
+		return idx
+	}
+	start, end := lines(anchor)
+	e := types.EntityRecord{
+		Name:          angularAppEntityName,
+		QualifiedName: x.qualify(angularAppEntityName),
+		Kind:          "SCOPE.Component",
+		SourceFile:    x.filePath,
+		StartLine:     start,
+		EndLine:       end,
+		Language:      x.language,
+		Subtype:       "application",
+		Signature:     "bootstrapApplication(...)",
+		Properties: map[string]string{
+			"kind":       "SCOPE.Component",
+			"subtype":    "application",
+			"framework":  "angular",
+			"provenance": "INFERRED_FROM_ANGULAR_BOOTSTRAP",
+		},
+		EnrichmentStatus: types.StatusPending,
+		QualityScore:     1.0,
+	}
+	e.ID = e.ComputeID()
+	x.entities = append(x.entities, e)
+	return len(x.entities) - 1
+}
+
+// angularNormaliseToken strips quotes/whitespace/generics from a DI token
+// expression, mirroring nestNormaliseToken. A string-literal token 'CONFIG'
+// becomes CONFIG; an identifier token (HTTP_INTERCEPTORS, a custom
+// InjectionToken constant, ErrorHandler) keeps its leaf.
+func angularNormaliseToken(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) ||
+		(strings.HasPrefix(s, "`") && strings.HasSuffix(s, "`")) {
+		return strings.Trim(s, "'\"`")
+	}
+	if i := strings.IndexAny(s, " <([{"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
+// angularImplName extracts the implementation identifier bound to a token for
+// the given use-kind, mirroring nestImplName. useClass/useExisting/useFactory
+// yield a class/function leaf; useValue yields a PascalCase reference (else "").
+func angularImplName(expr, useKind string) string {
+	expr = strings.TrimSpace(expr)
+	switch useKind {
+	case "useClass", "useExisting", "useFactory":
+		if i := strings.IndexAny(expr, " <([{,"); i >= 0 {
+			expr = expr[:i]
+		}
+		expr = strings.TrimSpace(expr)
+		return expr
+	case "useValue":
+		if i := strings.IndexAny(expr, " <([{,"); i >= 0 {
+			expr = expr[:i]
+		}
+		expr = strings.TrimSpace(expr)
+		if expr == "" || expr[0] < 'A' || expr[0] > 'Z' {
+			return ""
+		}
+		return expr
+	}
+	return ""
+}

--- a/internal/extractors/javascript/angular_global_di_test.go
+++ b/internal/extractors/javascript/angular_global_di_test.go
@@ -1,0 +1,258 @@
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4378 LIVE-REPRO — Angular global DI wiring.
+//
+// Angular binds cross-cutting providers app-wide via the {provide, useClass/
+// useExisting/useFactory, multi} provider-object shape inside an @NgModule
+// providers array and inside a standalone bootstrapApplication options object —
+// the same mechanism the NestJS fix (#4329) handled for APP_*.
+//
+// PRE-FIX: the JS/TS extractor read the @NgModule class + constructor injections
+// but never the providers array, so the bound HTTP interceptor / APP_INITIALIZER
+// factory / global ErrorHandler classes had NO inbound edge from the module and
+// looked orphan / dead; the standalone bootstrap producers were invisible
+// entirely.
+//
+// POST-FIX: the module emits module → bound-class USES edges (global=true +
+// di_token + di_role + multi); the standalone bootstrap emits a synthetic `app`
+// entity that USES each bound producer. Every target resolves to the real class
+// entity through resolve.BuildIndex.
+//
+// The test runs the REAL JSExtractor.Extract pipeline (AST walk + the new
+// program-level pass) and the REAL resolver over faithful Angular fixtures.
+
+func extractTS4378(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseTS(t, []byte(src))
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Language: "typescript",
+		Content:  []byte(src),
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return ents
+}
+
+// usesEdgeProp returns the property value for the first USES edge whose ToID is
+// target (and, when owner != "", whose FromID is owner), or "" when absent.
+func usesEdgeProp(ents []types.EntityRecord, owner, target, key string) (string, bool) {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindUses) || r.ToID != target {
+				continue
+			}
+			if owner != "" && r.FromID != owner {
+				continue
+			}
+			return r.Properties[key], true
+		}
+	}
+	return "", false
+}
+
+const ngModuleProvidersFixture = `
+import { NgModule, ErrorHandler, APP_INITIALIZER } from '@angular/core';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+
+@Injectable()
+export class AuthService {}
+
+@Injectable()
+export class AuthInterceptor {}
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+  handleError(e: unknown) {}
+}
+
+export function initApp() { return () => Promise.resolve(); }
+
+@NgModule({
+  declarations: [],
+  imports: [],
+  providers: [
+    AuthService,
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: APP_INITIALIZER, useFactory: initApp, multi: true },
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
+  ],
+})
+export class AppModule {}
+`
+
+// TestIssue4378_NgModuleProviders asserts each @NgModule provider yields a
+// module → class USES edge (global=true) with the right di_token/di_role/multi,
+// and that the previously-orphan classes resolve in the symbol table.
+func TestIssue4378_NgModuleProviders(t *testing.T) {
+	ents := extractTS4378(t, "src/app/app.module.ts", ngModuleProvidersFixture)
+
+	type want struct {
+		target string
+		token  string
+		role   string
+		multi  bool
+	}
+	wants := []want{
+		{"AuthService", "AuthService", "service", false},
+		{"AuthInterceptor", "HTTP_INTERCEPTORS", "interceptor", true},
+		{"initApp", "APP_INITIALIZER", "initializer", true},
+		{"GlobalErrorHandler", "ErrorHandler", "error_handler", false},
+	}
+
+	for _, w := range wants {
+		if !hasUses(ents, "AppModule", w.target) {
+			t.Errorf("expected AppModule USES %s (token %s)", w.target, w.token)
+			continue
+		}
+		if v, _ := usesEdgeProp(ents, "AppModule", w.target, "global"); v != "true" {
+			t.Errorf("%s: expected global=true, got %q", w.target, v)
+		}
+		if v, _ := usesEdgeProp(ents, "AppModule", w.target, "di_token"); v != w.token {
+			t.Errorf("%s: expected di_token=%s, got %q", w.target, w.token, v)
+		}
+		if v, _ := usesEdgeProp(ents, "AppModule", w.target, "di_role"); v != w.role {
+			t.Errorf("%s: expected di_role=%s, got %q", w.target, w.role, v)
+		}
+		wantMulti := ""
+		if w.multi {
+			wantMulti = "true"
+		}
+		if v, _ := usesEdgeProp(ents, "AppModule", w.target, "multi"); v != wantMulti {
+			t.Errorf("%s: expected multi=%q, got %q", w.target, wantMulti, v)
+		}
+	}
+
+	// The previously-orphan interceptor must RESOLVE to its real class entity
+	// through the real resolver (it is declared in this same file as a class).
+	idx := resolve.BuildIndex(ents)
+	for _, name := range []string{"AuthInterceptor", "GlobalErrorHandler", "AuthService"} {
+		if _, ok := idx.Lookup(name); !ok {
+			t.Errorf("global provider target %s failed to resolve — would stay orphan", name)
+		}
+	}
+}
+
+// TestIssue4378_NgModuleProviders_RedGreen proves the linkage did not exist
+// before the providers array was read: with the fix, the bound interceptor has
+// an inbound USES edge from the module; without any provider parsing it would
+// have none. We assert the edge count is non-zero (the green side); the red side
+// is documented by the orphan-class problem in the issue.
+func TestIssue4378_BoundClassesNoLongerOrphan(t *testing.T) {
+	ents := extractTS4378(t, "src/app/app.module.ts", ngModuleProvidersFixture)
+	for _, target := range []string{"AuthInterceptor", "initApp", "GlobalErrorHandler"} {
+		if !hasUses(ents, "AppModule", target) {
+			t.Fatalf("%s has no inbound module USES edge — still orphan", target)
+		}
+	}
+}
+
+const standaloneBootstrapFixture = `
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { ErrorHandler } from '@angular/core';
+
+@Injectable()
+export class GlobalErrorHandler {}
+
+export const authInterceptor = (req, next) => next(req);
+export const loggingInterceptor = (req, next) => next(req);
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideHttpClient(withInterceptors([authInterceptor, loggingInterceptor])),
+    provideRouter(routes),
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
+  ],
+});
+`
+
+// TestIssue4378_StandaloneBootstrap asserts the standalone bootstrap emits a
+// synthetic `app` entity USES-linked to its functional interceptors and object
+// providers (global=true), and that those targets resolve.
+func TestIssue4378_StandaloneBootstrap(t *testing.T) {
+	ents := extractTS4378(t, "src/main.ts", standaloneBootstrapFixture)
+
+	// Synthetic app entity must exist.
+	if findByName(ents, "app") == nil {
+		t.Fatalf("expected synthetic `app` entity for standalone bootstrap; names=%v", entityNames(ents))
+	}
+
+	checks := []struct {
+		target string
+		role   string
+	}{
+		{"authInterceptor", "interceptor"},
+		{"loggingInterceptor", "interceptor"},
+		{"GlobalErrorHandler", "error_handler"},
+	}
+	for _, c := range checks {
+		if !hasUses(ents, "app", c.target) {
+			t.Errorf("expected app USES %s (%s)", c.target, c.role)
+			continue
+		}
+		if v, _ := usesEdgeProp(ents, "app", c.target, "global"); v != "true" {
+			t.Errorf("%s: expected global=true, got %q", c.target, v)
+		}
+		if v, _ := usesEdgeProp(ents, "app", c.target, "di_role"); v != c.role {
+			t.Errorf("%s: expected di_role=%s, got %q", c.target, c.role, v)
+		}
+	}
+
+	// Functional interceptors resolve to their exported const arrow declarations.
+	idx := resolve.BuildIndex(ents)
+	for _, name := range []string{"authInterceptor", "loggingInterceptor", "GlobalErrorHandler"} {
+		if _, ok := idx.Lookup(name); !ok {
+			t.Errorf("bootstrap provider %s failed to resolve", name)
+		}
+	}
+}
+
+// TestIssue4378_NoFalseGlobals ensures an ordinary Angular component file with
+// no providers array produces no global USES edges.
+func TestIssue4378_NoFalseGlobals(t *testing.T) {
+	src := `
+import { Component } from '@angular/core';
+@Component({ selector: 'app-root', template: '<div></div>' })
+export class AppComponent {
+  constructor(private http: HttpClient) {}
+}
+`
+	ents := extractTS4378(t, "src/app/app.component.ts", src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) && r.Properties["global"] == "true" {
+				t.Errorf("plain component should not produce a global USES edge, got %+v", r)
+			}
+		}
+	}
+	if findByName(ents, "app") != nil {
+		t.Error("no synthetic app entity should be emitted without a bootstrapApplication call")
+	}
+}
+
+// hasUses reports whether any entity carries a USES edge owner→target.
+func hasUses(ents []types.EntityRecord, owner, target string) bool {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) && r.FromID == owner && r.ToID == target {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -276,6 +276,15 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		// class-decorated), so they are recognised in a dedicated program-level
 		// pass (guard_interceptor_recognition).
 		x.angularFunctionalGuards(root)
+		// Issue #4378 — Angular global DI wiring. @NgModule({ providers: [...] })
+		// and standalone bootstrapApplication(App, { providers: [...] }) bind
+		// cross-cutting providers (HTTP_INTERCEPTORS, APP_INITIALIZER,
+		// ErrorHandler, custom tokens, functional interceptors) app-wide. Emit
+		// module/app → bound-class USES edges marked global so the otherwise-
+		// orphan classes are connected and resolve through the symbol table
+		// (generalises the NestJS global-DI fix #4329). Runs after walk so the
+		// @NgModule entity already exists.
+		x.angularGlobalProviders(root)
 		// Issue #742 — snapshot length before collectImports so we can
 		// identify which entities were added by it (the import-placeholder
 		// SCOPE.Component/import entities). After collectImports we call


### PR DESCRIPTION
## Summary
Angular registers cross-cutting providers app-wide through DI tokens in a module/bootstrap providers array, using the same `{provide, useClass/useExisting/useFactory, multi}` provider-object shape NestJS uses (#4329). The JS/TS extractor recognised the `@NgModule` class and its constructor injections but **never read the `providers` array**, so the bound classes — HTTP interceptors, `APP_INITIALIZER` factories, the global `ErrorHandler`, custom service tokens — had no inbound edge from a real source entity and looked orphan / dead, with the app-wide scope invisible. Standalone `bootstrapApplication(App, { providers: [...] })` produced nothing at all.

This generalises the NestJS global-DI fix (#4329 / #4380 convention) to Angular, **reusing the existing `USES` Kind (no new Kind)**.

## What it does
- **`@NgModule({ providers: [...] })`** — each entry emits a `module → bound-class` `USES` edge marked `global=true`, with `di_token` (`HTTP_INTERCEPTORS` / `APP_INITIALIZER` / `ErrorHandler` / `NG_VALIDATORS` / a custom `InjectionToken` / the class itself for a bare provider), `di_role` (`interceptor` / `initializer` / `error_handler` / `validator` / `service`), and `multi=true` for multi-providers. `useFactory` binds the factory.
- **Standalone bootstrap** — `bootstrapApplication(App, { providers: [...] })` hangs `app → target` `USES` edges off a synthetic `app` application entity (mirroring the NestJS bootstrap `app` owner). `provideHttpClient(withInterceptors([fn]))` functional interceptors and bare/object providers both link to their targets.

Every edge target is a bare class / function identifier resolving to the real declaring entity through `resolve.BuildIndex`'s symbol table, connecting the previously-orphan class. The pass runs program-level from `Extract` after the AST walk, sharing the provider-object / bare-class parsing convention with the NestJS extractor.

## Root cause
The NestJS DI path (`internal/custom/javascript/nestjs_di.go`) is a separate regex-based custom extractor and does **not** cover Angular — Angular is handled by the AST-based extractor in `internal/extractors/javascript/`, which had no provider-array reader at all. So Angular needed its own pass, modelled on the #4329 mechanism (same edge convention, token/role/multi properties, synthetic `app` owner).

## Coverage
- ✅ NgModule providers: multi-provider tokens (`HTTP_INTERCEPTORS`, `APP_INITIALIZER`) + `ErrorHandler` + bare class providers + custom tokens.
- ✅ Standalone `bootstrapApplication` providers, incl. `withInterceptors([...])` functional interceptors.
- ⏭️ Route guards / resolvers (`canActivate` / `resolve`) deferred to a tight follow-up — route extraction is on a separate path (epic #4334).

## Validation (live, in-pipeline)
`angular_global_di_test.go` runs the REAL `JSExtractor.Extract` + `resolve.BuildIndex` over faithful Angular fixtures and asserts the previously-orphan classes go from unlinked → `USES`-linked + resolving (red→green confirmed by disabling the pass):
- `TestIssue4378_NgModuleProviders` — 4 module→class edges, correct token/role/multi, all targets resolve.
- `TestIssue4378_StandaloneBootstrap` — synthetic `app` entity + 3 app→target edges (2 functional interceptors + 1 ErrorHandler), all resolve.
- `TestIssue4378_BoundClassesNoLongerOrphan` / `TestIssue4378_NoFalseGlobals` — orphan-removal + no-false-positive guards.

Before: 0 inbound edges on the bound interceptor/initializer/handler classes. After: each bound class has a `global` `USES` edge from its module / the `app` entity.

## Gates
- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/extractors/javascript/` ✅ (full package) · `go test ./internal/resolve/` ✅
- No new Kind (reuses `USES`), so `internal/types` unchanged.

Closes #4378

🤖 Generated with [Claude Code](https://claude.com/claude-code)