### PR TITLE
fix(http): link Sinatra block-route handlers as inline endpoints

### DIFF
--- a/internal/engine/http_endpoint_ruby_producer.go
+++ b/internal/engine/http_endpoint_ruby_producer.go
@@ -156,28 +156,132 @@ func synthesizeRailsRoutes(content, routesPath string, emit emitFileFn, emitReso
 	walkRailsBlocks(content, "", "", rootDir, emit, emitResource)
 }
 
+// sinatraNamespaceOpenRe matches a sinatra-contrib `namespace` opener:
+//
+//	namespace '/api' do
+//	namespace "/v1" do
+//
+// Capture group 1 is the path fragment (string literal). Non-string-literal
+// namespaces (e.g. `namespace %r{/foo}` regex routes) are deliberately not
+// matched — those are rare and would need regex-route handling out of scope here.
+var sinatraNamespaceOpenRe = regexp.MustCompile(
+	`(?m)^\s*namespace\s+['"]([^'"\n\r]{1,200})['"]\s*do\b`,
+)
+
 // synthesizeSinatra scans a Ruby file for Sinatra verb-block registrations
-// and calls emit per (verb, canonical-path, "sinatra", "", "",
-// handlerFile=path, defLine=line-of-block). The handler is the block body
-// in the same file, so source_file/start_line attribution lands on the
-// registration line — which IS the handler line by construction.
+// and emits one inline-handler endpoint per route. Sinatra route handlers are
+// ALWAYS anonymous blocks (`get '/x' do ... end`) — there is no named handler
+// method — so every route is signalled as an inline handler (#4385). Supports
+// classic top-level routes, modular `class App < Sinatra::Base` routes, and
+// sinatra-contrib `namespace '/api' do ... end` path-prefix composition.
 func synthesizeSinatra(content, path string, emit emitFileFn) {
 	if !sinatraGateRe.MatchString(content) {
 		return
 	}
+	walkSinatraBlocks(content, "", path, emit)
+}
+
+// walkSinatraBlocks recursively emits verb routes at the current `pathPrefix`,
+// then descends into nested `namespace` blocks composing their path fragment
+// onto the prefix. Routes inside namespace blocks are stripped from the body
+// scanned at this level so they are emitted exactly once, with the correct
+// prefix, by the recursive call (mirrors walkRailsBlocks).
+func walkSinatraBlocks(content, pathPrefix, path string, emit emitFileFn) {
+	// Emit verb routes that are NOT inside a nested namespace block at this level.
+	flat := stripSinatraNamespaceBlocks(content)
+	emitSinatraVerbRoutes(flat, pathPrefix, path, emit)
+	// Recurse into each nested namespace block with the composed prefix.
+	for _, blk := range findSinatraNamespaceBlocks(content) {
+		childPrefix := joinPathFragments(pathPrefix, blk.name)
+		walkSinatraBlocks(blk.body, childPrefix, path, emit)
+	}
+}
+
+// emitSinatraVerbRoutes emits one inline-handler endpoint for each verb-block
+// route literal in content, prefixing the route with pathPrefix before
+// canonicalization.
+func emitSinatraVerbRoutes(content, pathPrefix, path string, emit emitFileFn) {
 	for _, idx := range sinatraVerbBlockRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(idx) < 6 {
 			continue
 		}
 		verb := strings.ToUpper(content[idx[2]:idx[3]])
 		raw := content[idx[4]:idx[5]]
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		full := raw
+		if pathPrefix != "" {
+			full = joinPathFragments(pathPrefix, raw)
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
 		// def_line points at the verb block's own line; the synthetic's
 		// source_file is the registration file (which is also the
 		// handler file for Sinatra).
+		//
+		// #4385 — a Sinatra route handler is ALWAYS an anonymous block
+		// (`get '/x' do ... end`); there is no named handler method the
+		// resolver could bind to. Signal refKind=inlineHandlerRefKind (empty
+		// refName) so makeEmit synthesizes a stable `<inline VERB /path>`
+		// handler entity + a same-file IMPLEMENTS bridge, instead of leaving
+		// the endpoint a handler-less graph island. handlerFile is left empty
+		// on purpose: the block body lives in THIS file, so the same-file
+		// synthesis-time bridge is correct and must NOT be dropped as a
+		// cross-file hint (emitFile drops the bridge only when handlerFile != "").
 		defLine := lineOfOffset(content, idx[2])
-		emit(verb, canonical, "sinatra", "", "", path, defLine)
+		emit(verb, canonical, "sinatra", inlineHandlerRefKind, "", "", defLine)
 	}
+}
+
+// sinatraBlock describes one `namespace` block discovered in a Sinatra source.
+type sinatraBlock struct {
+	name      string // path fragment, e.g. "/api"
+	body      string // content between `do` and the matching `end`
+	bodyStart int    // absolute byte offset of body in the scanned content
+	bodyEnd   int    // absolute byte offset just past body
+}
+
+// findSinatraNamespaceBlocks returns every top-level `namespace '/x' do ... end`
+// block in content, pairing each opener with its matching `end` by counting
+// block tokens (reusing extractRailsBlockBody's do/end balancer).
+func findSinatraNamespaceBlocks(content string) []sinatraBlock {
+	var out []sinatraBlock
+	i := 0
+	for i < len(content) {
+		m := sinatraNamespaceOpenRe.FindStringSubmatchIndex(content[i:])
+		if m == nil {
+			break
+		}
+		name := content[i+m[2] : i+m[3]]
+		bodyStart := i + m[1]
+		body, after, ok := extractRailsBlockBody(content, bodyStart)
+		if !ok {
+			i = i + m[1]
+			continue
+		}
+		out = append(out, sinatraBlock{
+			name:      name,
+			body:      body,
+			bodyStart: bodyStart,
+			bodyEnd:   bodyStart + len(body),
+		})
+		i = after
+	}
+	return out
+}
+
+// stripSinatraNamespaceBlocks blanks out the bodies of top-level namespace
+// blocks (preserving line/offset counts) so verb routes inside them are not
+// double-emitted at the un-prefixed parent scope.
+func stripSinatraNamespaceBlocks(content string) string {
+	out := []byte(content)
+	for _, blk := range findSinatraNamespaceBlocks(content) {
+		// Blank the body in-place. Preserving newlines (blank only non-newline
+		// bytes) keeps lineOfOffset correct for sibling routes at this scope.
+		for j := blk.bodyStart; j < blk.bodyEnd && j < len(out); j++ {
+			if out[j] != '\n' && out[j] != '\r' {
+				out[j] = ' '
+			}
+		}
+	}
+	return string(out)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/http_endpoint_sinatra_inline_4385_test.go
+++ b/internal/engine/http_endpoint_sinatra_inline_4385_test.go
@@ -1,0 +1,127 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4385 — Sinatra route blocks (`get '/x' do ... end`) are inherently anonymous:
+// the handler is ALWAYS a block, never a named method. Before the fix
+// synthesizeSinatra emitted the endpoint with empty refKind/refName, leaving it a
+// graph ISLAND with no endpoint→handler IMPLEMENTS bridge (invisible to flow /
+// IMPLEMENTS traversal).
+//
+// The fix generalises the #4324/#4382/#4384 inline-handler mechanism to Ruby:
+// every Sinatra verb-block route signals refKind=inlineHandlerRefKind, so
+// makeEmit synthesizes a stable `<inline VERB /path>` handler entity (Name from
+// verb+canonical path → merge-stable) + a same-file IMPLEMENTS bridge bound by
+// the central resolver post-merge. sinatra-contrib `namespace '/api' do ... end`
+// path prefixes compose onto the route before canonicalization.
+//
+// These tests run the REAL extract+synthesis+merge+resolve pipeline (via
+// detectInline / assertInlineEndpointBridged from the #4324 test file) on
+// faithful Sinatra fixtures and prove the endpoints are present AND
+// handler-linked (not islands).
+
+// TestInline4385_SinatraClassicRoutes covers classic top-level Sinatra routes
+// (`get '/path' do`) across verbs, plus a `:param`-templated route.
+func TestInline4385_SinatraClassicRoutes(t *testing.T) {
+	src := `require 'sinatra'
+
+get '/health' do
+  'ok'
+end
+
+post '/items' do
+  create_item(params)
+end
+
+put '/items/:id' do |id|
+  update_item(id, params)
+end
+
+delete '/items/:id' do
+  destroy_item(params[:id])
+end
+`
+	ents, rels := detectInline(t, "ruby", "app.rb", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/health", "sinatra")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/items", "sinatra")
+	assertInlineEndpointBridged(t, ents, rels, "PUT", "/items/{id}", "sinatra")
+	assertInlineEndpointBridged(t, ents, rels, "DELETE", "/items/{id}", "sinatra")
+}
+
+// TestInline4385_SinatraModularRoutes covers modular style
+// (`class App < Sinatra::Base`) — the verb routes live inside a class body but
+// the block-handler shape is identical, so the inline-handler synth must fire.
+func TestInline4385_SinatraModularRoutes(t *testing.T) {
+	src := `require 'sinatra/base'
+
+class App < Sinatra::Base
+  get '/users' do
+    json User.all
+  end
+
+  patch '/users/:id' do |id|
+    User.update(id, params)
+  end
+end
+`
+	ents, rels := detectInline(t, "ruby", "lib/app.rb", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users", "sinatra")
+	assertInlineEndpointBridged(t, ents, rels, "PATCH", "/users/{id}", "sinatra")
+}
+
+// TestInline4385_SinatraNamespacePrefix covers sinatra-contrib namespace blocks:
+// `namespace '/api' do ... end` composes "/api" onto each enclosed route path.
+func TestInline4385_SinatraNamespacePrefix(t *testing.T) {
+	src := `require 'sinatra/base'
+require 'sinatra/contrib'
+
+class App < Sinatra::Base
+  register Sinatra::Namespace
+
+  get '/ping' do
+    'pong'
+  end
+
+  namespace '/api' do
+    get '/widgets' do
+      json Widget.all
+    end
+
+    post '/widgets/:id' do |id|
+      Widget.touch(id)
+    end
+  end
+end
+`
+	ents, rels := detectInline(t, "ruby", "lib/api_app.rb", src)
+	// Root-scope route keeps its bare path.
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/ping", "sinatra")
+	// Namespaced routes get the "/api" prefix composed in.
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/api/widgets", "sinatra")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/api/widgets/{id}", "sinatra")
+}
+
+// TestInline4385_SinatraNamespaceNoDoubleEmit guards that a namespaced route is
+// NOT also emitted at the un-prefixed parent scope (stripSinatraNamespaceBlocks
+// must blank the namespace body for the parent-level pass).
+func TestInline4385_SinatraNamespaceNoDoubleEmit(t *testing.T) {
+	src := `require 'sinatra/base'
+
+class App < Sinatra::Base
+  namespace '/api' do
+    get '/things' do
+      'things'
+    end
+  end
+end
+`
+	ents, _ := detectInline(t, "ruby", "lib/nodup.rb", src)
+	if endpointByVerbPath(ents, "GET", "/api/things") == nil {
+		t.Fatal("namespaced route GET /api/things missing")
+	}
+	if endpointByVerbPath(ents, "GET", "/things") != nil {
+		t.Error("namespaced route must NOT also be emitted un-prefixed as GET /things")
+	}
+}


### PR DESCRIPTION
## Summary

Sinatra routes (`get '/x' do ... end`) are inherently anonymous — the handler is ALWAYS a block, never a named method. `synthesizeSinatra` already emitted the `http_endpoint_definition`, but with empty `refKind`/`refName`, leaving every Sinatra route a graph **ISLAND** with no endpoint→handler `IMPLEMENTS` bridge (invisible to flow / IMPLEMENTS traversal).

This generalises the inline-handler mechanism (#4324 JS, #4382 Go, #4384 Spring) to Ruby/Sinatra.

## Root cause

`synthesizeSinatra` extracted Sinatra block routes into endpoints but passed `refKind=""` / `refName=""` to `emit` — so `makeEmit` synthesized no handler entity and no bridge. The route handler is a block, so there is no addressable symbol the resolver could ever bind to.

## Fix

- Each Sinatra verb-block route now signals `refKind=inlineHandlerRefKind`. `makeEmit` synthesizes a stable `<inline VERB /path>` `SCOPE.Operation` handler entity (Name derived purely from verb + canonical path → deterministic & merge-stable) plus a file-scoped `IMPLEMENTS` bridge bound by the central resolver post-merge. `handlerFile` is left empty so the same-file bridge is **not** dropped as a cross-file hint.
- Added sinatra-contrib `namespace '/api' do ... end` path-prefix composition via a recursive block walker (mirrors `walkRailsBlocks` + reuses `extractRailsBlockBody`). Namespace bodies are blanked for the parent-scope pass so enclosed routes are emitted exactly once, with the composed prefix.

## Coverage

- Classic top-level routes (all verbs + `:param`)
- Modular `class App < Sinatra::Base` routes
- `namespace` path prefixes (+ no-double-emit guard)
- Grape (`resource :x do; get do ...`) and Roda (`r.get 'x' do ...`) block routes remain a follow-up (epic #4334).

## Validation

In-pipeline test (real extract + synthesis + merge + central resolve). Verified **RED before** the fix (endpoint present but no synthesized inline-handler entity / island), **GREEN after**.

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./internal/engine/` ✓ (full package)
- `go test ./internal/custom/ruby/` ✓

Closes #4385

🤖 Generated with [Claude Code](https://claude.com/claude-code)