### PR TITLE
effects: enumerate a function's control-flow branches

### DIFF
--- a/internal/mcp/effects_branches_4423_test.go
+++ b/internal/mcp/effects_branches_4423_test.go
@@ -1,0 +1,268 @@
+package mcp
+
+// effects_branches_4423_test.go — in-pipeline test for the #4423 `branches`
+// facet on REAL upvate Django oracle functions.
+//
+// Per the standing LIVE-VALIDATE rule (fixtures lie at merge): this exercises
+// the REAL effects MCP handler (handleEffects) end-to-end — resolver, on-disk
+// source read, per-language branch analyzer — over byte-copies of actual
+// branchy oracle functions copied verbatim into testdata/branches_4423/ (NOT
+// edited): ContractViewSet.create_contact (400/409/200/201/500 branches +
+// except-swallow) and two ecb_pdf_pipeline helpers (an env-gate + a
+// swallow-only except).
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates every except/early_return/env_gate/guard
+//     with the correct outcome + env_var;
+//   - the env-gate's env_var is surfaced (ECB_PDF_PIPELINE_ENABLED);
+//   - a logging-only except is classified `swallow`, a re-raising one `raise`;
+//   - HTTP statuses (409/200/201) are derived into returns.status.
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// branchesTestServer builds a server whose single repo's Path points at the
+// branches_4423 testdata dir, with one Operation entity per fixture spanning
+// the whole file. Returns the server.
+func branchesTestServer(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_contact", Name: "ContractViewSet.create_contact",
+				Kind: "SCOPE.Operation", QualifiedName: "core.views.contract_viewset.ContractViewSet.create_contact",
+				SourceFile: "contract_viewset_create_contact.py", StartLine: 1, EndLine: 69,
+			},
+			{
+				ID: "op_process_ecb", Name: "process_ecb_pdf_job",
+				Kind: "SCOPE.Function", QualifiedName: "core.tasks.ecb_pdf_pipeline.process_ecb_pdf_job",
+				SourceFile: "ecb_pdf_pipeline_env_gate.py", StartLine: 1, EndLine: 38,
+			},
+			{
+				ID: "op_write_debug", Name: "_write_debug_payload",
+				Kind: "SCOPE.Function", QualifiedName: "core.tasks.ecb_pdf_pipeline._write_debug_payload",
+				SourceFile: "ecb_write_debug_payload_swallow.py", StartLine: 1, EndLine: 34,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+
+	// Point the loaded repo at the real testdata dir so the handler reads the
+	// verbatim oracle bytes off disk (the actual in-pipeline path).
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4423"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["upvate-core"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func callEffects(t *testing.T, srv *Server, entity string, include string) map[string]any {
+	t.Helper()
+	args := map[string]any{"entity_id": entity, "group": "test"}
+	if include != "" {
+		args["include"] = include
+	}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleEffects(nil, req)
+	if err != nil {
+		t.Fatalf("handleEffects(%s, include=%q): %v", entity, include, err)
+	}
+	if res.IsError {
+		t.Fatalf("handleEffects(%s) returned tool error: %+v", entity, res.Content)
+	}
+	var txt string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			txt = tc.Text
+		}
+	}
+	if txt == "" {
+		t.Fatalf("handleEffects(%s) empty content", entity)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(txt), &out); err != nil {
+		t.Fatalf("unmarshal effects result: %v\n%s", err, txt)
+	}
+	return out
+}
+
+func branchList(t *testing.T, out map[string]any) []map[string]any {
+	t.Helper()
+	raw, ok := out["branches"]
+	if !ok {
+		t.Fatalf("no `branches` key in payload: %v", out)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("branches not an array: %T", raw)
+	}
+	res := make([]map[string]any, 0, len(arr))
+	for _, e := range arr {
+		res = append(res, e.(map[string]any))
+	}
+	return res
+}
+
+// findBranch returns the first branch whose condition contains substr.
+func findBranch(branches []map[string]any, substr string) map[string]any {
+	for _, b := range branches {
+		if cond, _ := b["condition"].(string); strings.Contains(cond, substr) {
+			return b
+		}
+	}
+	return nil
+}
+
+// TestEffectsBranches_DefaultUnchanged is the RED-before assertion: a default
+// effects call (no include) must NOT carry a `branches` key. Guards the
+// no-regression contract.
+func TestEffectsBranches_DefaultUnchanged(t *testing.T) {
+	srv := branchesTestServer(t)
+	out := callEffects(t, srv, "ContractViewSet.create_contact", "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("default effects output must NOT contain `branches`; got: %v", out["branches"])
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("default output must not advertise branches_supported")
+	}
+	// Sanity: the resolved entity is still reported.
+	if out["entity_id"] == nil {
+		t.Fatalf("default output lost entity_id: %v", out)
+	}
+}
+
+// TestEffectsBranches_CreateContact is the GREEN-after assertion on the
+// flagship multi-Response ViewSet action.
+func TestEffectsBranches_CreateContact(t *testing.T) {
+	srv := branchesTestServer(t)
+	out := callEffects(t, srv, "ContractViewSet.create_contact", "branches")
+
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for python; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// The function has: 400 guard (client is None), 409 guard, 200 guard
+	// (user is not None), 201 created (fall-through return — no guard), and a
+	// 500 except-swallow handler. The branch facet must enumerate the guards
+	// and the except.
+	if len(branches) < 4 {
+		t.Fatalf("expected >=4 branches, got %d: %v", len(branches), branches)
+	}
+
+	// 400 — the leading guard is classified early_return, return_value, 400.
+	g400 := findBranch(branches, "client is None")
+	if g400 == nil {
+		t.Fatalf("missing the `client is None` 400 guard: %v", branches)
+	}
+	if g400["kind"] != "early_return" {
+		t.Errorf("client-is-None kind=%v; want early_return", g400["kind"])
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("client-is-None outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// 409 conflict guard.
+	g409 := findBranch(branches, "available")
+	if g409 == nil {
+		t.Fatalf("missing the email-availability 409 guard: %v", branches)
+	}
+	if g409["outcome"] != "return_value" {
+		t.Errorf("409 guard outcome=%v; want return_value", g409["outcome"])
+	}
+	assertStatus(t, g409, "409")
+
+	// 500 except — logger? no: it returns a Response, so return_value (NOT
+	// swallow) — the handler returns a 500 Response.
+	gExcept := findBranch(branches, "except Exception")
+	if gExcept == nil {
+		t.Fatalf("missing the except Exception handler: %v", branches)
+	}
+	if gExcept["kind"] != "except" {
+		t.Errorf("except kind=%v; want except", gExcept["kind"])
+	}
+	if gExcept["outcome"] != "return_value" {
+		t.Errorf("create_contact except returns a 500 Response → outcome should be return_value; got %v", gExcept["outcome"])
+	}
+	assertStatus(t, gExcept, "500")
+}
+
+// TestEffectsBranches_EnvGate asserts the env-gate var is surfaced and the
+// swallow/early-return classification on the integration task helper.
+func TestEffectsBranches_EnvGate(t *testing.T) {
+	srv := branchesTestServer(t)
+	out := callEffects(t, srv, "process_ecb_pdf_job", "branches")
+	branches := branchList(t, out)
+
+	// `if not settings.ECB_PDF_PIPELINE_ENABLED: ... return` — env_gate with
+	// env_var surfaced.
+	envGate := findBranch(branches, "ECB_PDF_PIPELINE_ENABLED")
+	if envGate == nil {
+		t.Fatalf("missing the settings.ECB_PDF_PIPELINE_ENABLED env-gate: %v", branches)
+	}
+	if envGate["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", envGate["kind"])
+	}
+	if envGate["env_var"] != "ECB_PDF_PIPELINE_ENABLED" {
+		t.Errorf("env_var=%v; want ECB_PDF_PIPELINE_ENABLED", envGate["env_var"])
+	}
+	if envGate["outcome"] != "return_value" {
+		t.Errorf("env-gate outcome=%v; want return_value (bare return)", envGate["outcome"])
+	}
+
+	// `if missing: ... return` — a second guard (early_return — first non-env
+	// guard).
+	missingGuard := findBranch(branches, "if missing")
+	if missingGuard == nil {
+		t.Fatalf("missing the `if missing` early-return guard: %v", branches)
+	}
+	if missingGuard["outcome"] != "return_value" {
+		t.Errorf("`if missing` outcome=%v; want return_value", missingGuard["outcome"])
+	}
+}
+
+// TestEffectsBranches_SwallowExcept asserts a logging-only except (never
+// re-raises, never returns) is classified `swallow`.
+func TestEffectsBranches_SwallowExcept(t *testing.T) {
+	srv := branchesTestServer(t)
+	out := callEffects(t, srv, "_write_debug_payload", "branches")
+	branches := branchList(t, out)
+
+	ex := findBranch(branches, "except Exception")
+	if ex == nil {
+		t.Fatalf("missing the except Exception handler: %v", branches)
+	}
+	if ex["kind"] != "except" {
+		t.Errorf("kind=%v; want except", ex["kind"])
+	}
+	if ex["outcome"] != "swallow" {
+		t.Errorf("logging-only except outcome=%v; want swallow (catch-and-continue)", ex["outcome"])
+	}
+}
+
+func assertStatus(t *testing.T, b map[string]any, want string) {
+	t.Helper()
+	r, ok := b["returns"].(map[string]any)
+	if !ok {
+		t.Errorf("branch %q has no returns block; want status %s", b["condition"], want)
+		return
+	}
+	if r["status"] != want {
+		t.Errorf("branch %q returns.status=%v; want %s", b["condition"], r["status"], want)
+	}
+}

--- a/internal/mcp/effects_tool.go
+++ b/internal/mcp/effects_tool.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/links"
+	"github.com/cajasmota/archigraph/internal/substrate"
 
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
@@ -119,23 +120,29 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 	// pass; entity.Properties are only populated during an in-process run.
 	sidecar, _ := loadEffectsSidecar(groupName)
 
+	// #4423 — opt-in branches facet. Only computed when include=branches so
+	// the default effects payload stays byte-identical (no regression).
+	wantBranches := includeWants(req, "branches")
+
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
 			if e, ok := r.LabelIndex.ByID[local]; ok {
-				return jsonResult(buildEffectsPayload(r.Repo, e, sidecar)), nil
+				out := buildEffectsPayload(r.Repo, e, sidecar)
+				attachBranchesFacet(out, r, e, wantBranches)
+				return jsonResult(out), nil
 			}
 		}
 	}
 	// Collect every label/qname/id match across the considered repos.
 	type matchPair struct {
 		ent  *graph.Entity
-		repo string
+		repo *LoadedRepo
 	}
 	var matches []matchPair
 	for _, r := range repos {
 		for _, hit := range r.LabelIndex.LookupAll(key) {
-			matches = append(matches, matchPair{ent: hit, repo: r.Repo})
+			matches = append(matches, matchPair{ent: hit, repo: r})
 		}
 	}
 	if len(matches) == 0 {
@@ -145,10 +152,10 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 		out := make([]map[string]any, 0, len(matches))
 		for _, m := range matches {
 			out = append(out, map[string]any{
-				"id":             prefixedID(m.repo, m.ent.ID),
+				"id":             prefixedID(m.repo.Repo, m.ent.ID),
 				"qualified_name": m.ent.QualifiedName,
 				"label":          m.ent.Name,
-				"repo":           m.repo,
+				"repo":           m.repo.Repo,
 				"source_file":    m.ent.SourceFile,
 			})
 		}
@@ -159,7 +166,108 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 			"how_to_choose": "Re-call archigraph_effects with the prefixed id field (e.g. \"repo:1234abcd\").",
 		}), nil
 	}
-	return jsonResult(buildEffectsPayload(matches[0].repo, matches[0].ent, sidecar)), nil
+	out := buildEffectsPayload(matches[0].repo.Repo, matches[0].ent, sidecar)
+	attachBranchesFacet(out, matches[0].repo, matches[0].ent, wantBranches)
+	return jsonResult(out), nil
+}
+
+// includeWants reports whether the comma/space-separated `include` argument
+// requests facet. Accepts repeated facets ("branches,foo") and a bare match.
+func includeWants(req mcpapi.CallToolRequest, facet string) bool {
+	raw := argString(req, "include", "")
+	if raw == "" {
+		return false
+	}
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' }) {
+		if strings.EqualFold(strings.TrimSpace(part), facet) {
+			return true
+		}
+	}
+	return false
+}
+
+// attachBranchesFacet computes and attaches the #4423 `branches` facet to an
+// effects payload when requested. It reads the resolved function's source
+// window (StartLine..EndLine) from disk, selects the per-language branch
+// analyzer, and enumerates the function's except/early-return/env-gate/guard
+// branches. No-op when not requested (default output unchanged), when the
+// language has no registered analyzer (honest-partial), or when the source is
+// unreadable.
+func attachBranchesFacet(out map[string]any, lr *LoadedRepo, e *graph.Entity, want bool) {
+	if !want || out == nil || lr == nil || e == nil {
+		return
+	}
+	lang := substrate.LanguageForPath(e.SourceFile)
+	analyzer := substrate.BranchAnalyzerFor(lang)
+	if analyzer == nil {
+		// Honest-partial: tell the caller the facet is unsupported for this
+		// language rather than silently implying the function is branchless.
+		out["branches_supported"] = false
+		out["branches_note"] = fmt.Sprintf(
+			"branch classification not yet implemented for language %q (epic #4419); supported: %v",
+			lang, substrate.BranchLanguages())
+		return
+	}
+	start, end := branchSourceSpan(e)
+	if start <= 0 {
+		return
+	}
+	abs := e.SourceFile
+	if !filepath.IsAbs(abs) && lr.Path != "" {
+		abs = filepath.Join(lr.Path, e.SourceFile)
+	}
+	src, err := readRawSourceWindow(abs, start, end)
+	if err != nil || src == "" {
+		return
+	}
+	facets := analyzer(src, start)
+	out["branches_supported"] = true
+	out["branches"] = branchFacetsToJSON(facets)
+}
+
+// branchSourceSpan returns the [start,end] line window for an entity's body,
+// applying the same degenerate-span fallback handleGetNodeSource uses so a
+// synthetic end<=start entity still yields a usable window.
+func branchSourceSpan(e *graph.Entity) (int, int) {
+	start := e.StartLine
+	end := e.EndLine
+	if start <= 0 {
+		return 0, 0
+	}
+	if end <= start {
+		end = start + 400 // generous body fallback; analyzer self-bounds by indent
+	}
+	return start, end
+}
+
+// branchFacetsToJSON converts analyzer facets to the public JSON shape.
+func branchFacetsToJSON(facets []substrate.BranchFacet) []map[string]any {
+	out := make([]map[string]any, 0, len(facets))
+	for _, f := range facets {
+		m := map[string]any{
+			"kind":      string(f.Kind),
+			"condition": f.Condition,
+			"outcome":   string(f.Outcome),
+			"line":      f.Line,
+		}
+		if f.EnvVar != "" {
+			m["env_var"] = f.EnvVar
+		}
+		if f.Returns != nil {
+			r := map[string]any{}
+			if f.Returns.Status != "" {
+				r["status"] = f.Returns.Status
+			}
+			if f.Returns.Shape != "" {
+				r["shape"] = f.Returns.Shape
+			}
+			if len(r) > 0 {
+				m["returns"] = r
+			}
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // buildEffectsPayload constructs the JSON-serialisable response body

--- a/internal/mcp/read_source_export.go
+++ b/internal/mcp/read_source_export.go
@@ -17,6 +17,43 @@ package mcp
 // On error (file not found, fsevents stall, permission denied) the error is
 // returned to the caller; the caller is responsible for deciding whether a
 // missing source window is fatal or a non-fatal warning.
+
+import (
+	"bufio"
+	"strings"
+)
 func ReadSourceWindow(path string, start, end int) (string, error) {
 	return readSourceWindow(path, start, end)
+}
+
+// readRawSourceWindow returns lines [start,end] (1-indexed, inclusive) of path
+// WITHOUT the line-number prefix that readSourceWindow prepends. Used by the
+// #4423 branches facet, whose analyzers regex over verbatim source — the
+// "%5d  " prefix would corrupt indentation-sensitive Python parsing. Reuses the
+// shared cross-platform openSourceFile (and thus the macOS fsevents defense).
+func readRawSourceWindow(path string, start, end int) (string, error) {
+	f, err := openSourceFile(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	var b strings.Builder
+	line := 0
+	for scanner.Scan() {
+		line++
+		if line < start {
+			continue
+		}
+		if line > end {
+			break
+		}
+		b.WriteString(scanner.Text())
+		b.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return b.String(), nil
 }

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -204,6 +204,7 @@ var sharedHelpers = map[string]bool{
 	"FromRequest":            true, // PaginationOpts.FromRequest — all its keys are declared
 	"emitActivity":           true,
 	"argMinConfidence":       true, // #2769 Phase 1C — shared min_confidence reader
+	"includeWants":           true, // #4423 — shared opt-in facet reader (include declared on archigraph_effects)
 }
 
 // argFuncNames is the set of arg-reader function names to match in the AST.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -569,8 +569,9 @@ func (s *Server) registerTools() {
 	// confidence (0..1) and sink primitive tags. Pure functions report
 	// effects=[] with effect_source="pure" and a low confidence floor.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_effects",
-		mcpapi.WithDescription("Effect set (db/http/fs/mutation) for entity + per-effect confidence + sinks."),
+		mcpapi.WithDescription("Effects (db/http/fs/mutation) + confidence + sinks; include=branches for CFG"),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
+		mcpapi.WithString("include"),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),

--- a/internal/mcp/testdata/branches_4423/contract_viewset_create_contact.py
+++ b/internal/mcp/testdata/branches_4423/contract_viewset_create_contact.py
@@ -1,0 +1,69 @@
+    def create_contact(self, request, pk, *args, **kwargs):
+        try:
+            contract = self.get_object()
+            client = contract.client
+            if client is None:
+                return Response(
+                    {
+                        "success": False,
+                        "message": "Contract has no client to attach the contact to.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            serializer = ContractContactCreateSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+
+            upsert_flag = data.get("upsert") or str(
+                request.query_params.get("upsert", "false")
+            ).lower() == "true"
+
+            email = data["email"]
+            email_availability = check_contact_email_availability({"email": email})
+
+            if email_availability["available"] is False and not upsert_flag:
+                existing = User.objects.filter(email__iexact=email).first()
+                return Response(
+                    {
+                        "error": "User with this email/username already exists.",
+                        "existing_user": UserSerializer(existing).data if existing else None,
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            if email_availability["available"] is False:
+                user = User.objects.filter(email__iexact=email).first()
+                if user is not None:
+                    attach_client_to_contact(user, client)
+                    attach_contract_to_contact(user, contract)
+                    return Response(
+                        {
+                            "success": True,
+                            "message": "Existing contact linked to contract",
+                            "contact": user.id,
+                        },
+                        status=status.HTTP_200_OK,
+                    )
+
+            # Create new user, attach to client (M2M + legacy FK), then to contract
+            user = create_contact_for_client(data, client)
+            attach_contract_to_contact(user, contract)
+            return Response(
+                {
+                    "success": True,
+                    "message": "Contact has been created and linked to contract",
+                    "contact": user.id,
+                },
+                status=status.HTTP_201_CREATED,
+            )
+        except Exception as e:
+            return Response(
+                {
+                    "success": False,
+                    "message": "There was an error while creating the contact.",
+                    "errors": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+

--- a/internal/mcp/testdata/branches_4423/ecb_pdf_pipeline_env_gate.py
+++ b/internal/mcp/testdata/branches_4423/ecb_pdf_pipeline_env_gate.py
@@ -1,0 +1,37 @@
+@shared_task(
+    bind=True,
+    queue="ecb_ocr",
+    max_retries=3,
+    default_retry_delay=60,
+    acks_late=True,
+    time_limit=_TASK_TIME_LIMIT,
+    soft_time_limit=_TASK_SOFT_TIME_LIMIT,
+)
+def process_ecb_pdf_job(self, payload: dict):
+    if not settings.ECB_PDF_PIPELINE_ENABLED:
+        logger.warning(
+            "process_ecb_pdf_job: pipeline disabled — dropping task. violation_number=%s",
+            payload.get("violation_number"),
+        )
+        return
+
+    t_total = time.monotonic()
+
+    violation_number = payload.get("violation_number")
+    s3_bucket = payload.get("s3_bucket")
+    s3_key = payload.get("s3_key")
+
+    missing = [f for f, v in [("violation_number", violation_number), ("s3_bucket", s3_bucket), ("s3_key", s3_key)] if not v]
+    if missing:
+        logger.error(
+            "process_ecb_pdf_job: missing required fields=%s — dropping task. payload=%s",
+            missing,
+            payload,
+        )
+        return
+
+    sqs_env = payload.get("env")
+    should_write_to_db = settings.ECB_OCR_WRITE_TO_CONTROLLER_DB and sqs_env == "prod"
+
+    logger.info(
+        "process_ecb_pdf_job: starting. violation_number=%s s3_bucket=%s s3_key=%s task_id=%s",

--- a/internal/mcp/testdata/branches_4423/ecb_write_debug_payload_swallow.py
+++ b/internal/mcp/testdata/branches_4423/ecb_write_debug_payload_swallow.py
@@ -1,0 +1,35 @@
+def _write_debug_payload(violation_number: str, task_id: str, sqs_payload: dict, ocr_result: dict) -> None:
+    """
+    Log and save the full OCR result when ECB_OCR_DEBUG_PAYLOADS is enabled.
+    Never raises — a file write failure must not affect task success/failure.
+    """
+    try:
+        loggable = {k: v for k, v in ocr_result.items() if k not in ("raw_text", "pages")}
+        logger.info(
+            "process_ecb_pdf_job: OCR extracted payload — violation_number=%s task_id=%s\n%s",
+            violation_number,
+            task_id,
+            json.dumps(loggable, default=str, indent=2),
+        )
+
+        _DEBUG_PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+        safe_violation = re.sub(r"[^\w.-]", "_", str(violation_number))
+        output_path = _DEBUG_PAYLOAD_DIR / f"{safe_violation}_{task_id}.json"
+
+        file_payload = {
+            "violation_number": violation_number,
+            "task_id": str(task_id),
+            "sqs_payload": sqs_payload,
+            "ocr_result": ocr_result,
+        }
+        output_path.write_text(json.dumps(file_payload, default=str, indent=2), encoding="utf-8")
+        logger.info("process_ecb_pdf_job: debug payload saved. path=%s", output_path)
+
+    except Exception as exc:
+        logger.warning(
+            "process_ecb_pdf_job: debug payload write failed (non-fatal). violation_number=%s error=%s",
+            violation_number,
+            exc,
+        )
+

--- a/internal/substrate/branches.go
+++ b/internal/substrate/branches.go
@@ -1,0 +1,391 @@
+// Branch inventory facet (#4423, epic #4419 capability 4).
+//
+// The effect substrate (effects.go + effect_sinks_*.go) collapses a branchy
+// function to a SET of effect KINDS — it tells a porting/audit agent THAT a
+// function does db_write + http_out, but not WHICH branches exist, what each
+// one returns, or which env var gates which path. For a faithful port the
+// agent must reproduce every exception handler, early-return guard, and
+// env-conditional with its exact outcome.
+//
+// This file adds a second consumer of the same per-function source window the
+// effect sniffers walk: a branch classifier that enumerates the control-flow
+// decision points of a single function and classifies each one's OUTCOME
+// (raise / return a value / redirect / swallow). It is opt-in — the effects
+// MCP tool only computes it when include="branches" is requested — so the
+// default effects output is byte-for-byte unchanged (no regression risk).
+//
+// Design: this is a long-term, general CFG-shaped walk, NOT a two-function
+// pattern match. It tracks indentation to scope `if`/`except`/`elif` blocks
+// to a function body and inspects each block's immediate statements to decide
+// the outcome. Python is the flagship (the oracle stack); the BranchFacet
+// schema and the outcome lattice are language-neutral so other languages can
+// register their own classifier (see BranchAnalyzerFor; JS/TS + Java + Go
+// classifiers are tracked in follow-up #4434, ref epic #4419).
+package substrate
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// BranchKind names the syntactic shape of a control-flow decision point.
+type BranchKind string
+
+const (
+	// BranchExcept is an exception handler (`except E:` / `catch (e)` /
+	// `rescue E`). Its condition is the caught exception type(s).
+	BranchExcept BranchKind = "except"
+	// BranchEarlyReturn is a guard that returns/raises out of the function
+	// before the main body (`if <cond>: return ...`). The canonical
+	// validation guard (`if not email_availability: return 409`).
+	BranchEarlyReturn BranchKind = "early_return"
+	// BranchEnvGate is an early_return/guard whose condition READS an
+	// environment / settings variable (`if not settings.PROD: ...`). It is
+	// surfaced as its own kind because env-coupling is the single most
+	// important thing a porting agent must reproduce verbatim — a missed
+	// env-gate silently changes behaviour between environments.
+	BranchEnvGate BranchKind = "env_gate"
+	// BranchGuard is a conditional that alters control flow (raise/return)
+	// but is neither the leading early-return nor an env-gate — e.g. a mid
+	// body `if user is None: return ...`.
+	BranchGuard BranchKind = "guard"
+)
+
+// BranchOutcome is what a branch DOES when taken.
+type BranchOutcome string
+
+const (
+	// OutcomeRaise — the branch raises/throws an exception.
+	OutcomeRaise BranchOutcome = "raise"
+	// OutcomeReturnValue — the branch returns a value (often a Response /
+	// HTTP status).
+	OutcomeReturnValue BranchOutcome = "return_value"
+	// OutcomeRedirect — the branch redirects / reroutes (HttpResponseRedirect,
+	// redirect(), res.redirect(), 3xx Location).
+	OutcomeRedirect BranchOutcome = "redirect"
+	// OutcomeSwallow — catch-and-continue: an except handler that logs /
+	// passes / continues WITHOUT re-raising or returning. The classic
+	// silent-failure path an audit must flag.
+	OutcomeSwallow BranchOutcome = "swallow"
+)
+
+// BranchReturns carries the cheaply-derivable shape of a return_value/raise
+// branch: an HTTP status code when one is evident in the returned expression,
+// and a brief shape descriptor (e.g. "Response{error}").
+type BranchReturns struct {
+	// Status is the HTTP status code (e.g. "409", "200") when the branch's
+	// return expression names one (status=status.HTTP_409_CONFLICT,
+	// status=409, NewToolResultError, res.status(500)). Empty otherwise.
+	Status string `json:"status,omitempty"`
+	// Shape is a short descriptor of the returned payload's shape, e.g.
+	// "Response{error}" or "dict{success}". Empty when not cheaply derivable.
+	Shape string `json:"shape,omitempty"`
+}
+
+// BranchFacet is one enumerated branch in a function. It is the unit the
+// `branches` facet returns. JSON shape is the public contract consumed by the
+// effects MCP tool.
+type BranchFacet struct {
+	// Kind is the syntactic shape (except / early_return / env_gate / guard).
+	Kind BranchKind `json:"kind"`
+	// Condition is the verbatim guard/handler condition text, e.g.
+	// "except Exception as e", "if not settings.PROD",
+	// "if email_availability['available'] is False and not upsert_flag".
+	Condition string `json:"condition"`
+	// Outcome is what taking the branch does (raise / return_value /
+	// redirect / swallow).
+	Outcome BranchOutcome `json:"outcome"`
+	// Returns carries the status + shape for return_value/raise branches.
+	// Nil when nothing was cheaply derivable.
+	Returns *BranchReturns `json:"returns,omitempty"`
+	// EnvVar is the environment / settings variable name read by the branch
+	// condition (e.g. "ECB_PDF_PIPELINE_ENABLED", "PROD", "API_KEY") when the
+	// condition reads settings.* / os.environ[...] / process.env.*. Empty
+	// otherwise.
+	EnvVar string `json:"env_var,omitempty"`
+	// Line is the 1-indexed source line of the branch header, relative to the
+	// file the function lives in (the analyzer is given absolute line numbers
+	// so callers can cross-reference get_source output).
+	Line int `json:"line"`
+}
+
+// BranchAnalyzerFn is the per-language contract. Input: the raw source of a
+// SINGLE function body window plus the 1-indexed file line at which that
+// window starts (so emitted Line values are absolute). Output: every branch
+// in source order. Stateless and pure — identical input yields identical
+// output so graph/MCP output stays deterministic.
+type BranchAnalyzerFn func(funcSource string, startLine int) []BranchFacet
+
+var branchRegistry = map[string]BranchAnalyzerFn{}
+
+// RegisterBranchAnalyzer installs a per-language branch analyzer. Mirrors
+// RegisterEffectSniffer so a language can ship branch classification
+// independently of its effect sniffer.
+func RegisterBranchAnalyzer(lang string, fn BranchAnalyzerFn) {
+	if lang == "" || fn == nil {
+		return
+	}
+	branchRegistry[lang] = fn
+}
+
+// BranchAnalyzerFor returns the per-language branch analyzer, or nil when none
+// is registered (the caller then omits the facet — honest-partial: absence of
+// a classifier is reported as "not yet supported", never as "no branches").
+func BranchAnalyzerFor(lang string) BranchAnalyzerFn {
+	return branchRegistry[lang]
+}
+
+// BranchLanguages returns the slugs of every registered branch analyzer in
+// sorted order.
+func BranchLanguages() []string {
+	out := make([]string, 0, len(branchRegistry))
+	for k := range branchRegistry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func init() { RegisterBranchAnalyzer("python", analyzeBranchesPython) }
+
+// --- Python branch analyzer ---------------------------------------------
+//
+// Walk model: Python's significant indentation makes a line-oriented walk a
+// faithful CFG for branch enumeration. For each `except`/`elif`/`if` header we
+// determine the body block as the run of following lines indented deeper than
+// the header, then classify the FIRST control-altering statement in that block
+// (return / raise / redirect / log-and-continue). This is general — it keys on
+// statement shape, not on the two oracle functions.
+
+var (
+	pyExceptRe = regexp.MustCompile(`^(\s*)(except\b[^:]*):`)
+	pyIfRe     = regexp.MustCompile(`^(\s*)((?:el)?if\b.*?):\s*(.*)$`)
+
+	// pyReturnRe / pyRaiseRe detect the block's control-altering statement.
+	pyReturnStmtRe = regexp.MustCompile(`^\s*return\b\s*(.*)$`)
+	pyRaiseStmtRe  = regexp.MustCompile(`^\s*raise\b`)
+	pyContinueRe   = regexp.MustCompile(`^\s*(continue|pass|break)\b`)
+
+	// pyRedirectRe — redirect outcomes.
+	pyRedirectRe = regexp.MustCompile(`\b(?:HttpResponseRedirect|HttpResponsePermanentRedirect|redirect)\s*\(|\bRedirect\b`)
+
+	// pyEnvRefRe captures the env/settings var name a condition reads.
+	// Group order tried: settings.NAME, os.environ["NAME"]/.get("NAME"),
+	// os.getenv("NAME"), getenv("NAME").
+	pyEnvRefRe = regexp.MustCompile(
+		`\bsettings\s*\.\s*([A-Za-z_][\w]*)` +
+			`|\bos\s*\.\s*environb?\s*(?:\[\s*['"]([^'"]+)['"]\s*\]|\.\s*get\s*\(\s*['"]([^'"]+)['"])` +
+			`|\b(?:os\s*\.\s*)?getenv\s*\(\s*['"]([^'"]+)['"]`,
+	)
+
+	// pyHTTPStatusRe extracts an HTTP status from a return expression:
+	// status.HTTP_409_CONFLICT, status=409, HTTP_200_OK.
+	pyHTTPStatusConstRe = regexp.MustCompile(`HTTP_(\d{3})_[A-Z_]+`)
+	pyHTTPStatusNumRe   = regexp.MustCompile(`status\s*=\s*(\d{3})\b`)
+)
+
+func analyzeBranchesPython(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	// firstGuardSeen lets us label the LEADING guard as early_return and
+	// later same-shape guards as guard (mid-body). env-gates override both.
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// except handler.
+		if m := pyExceptRe.FindStringSubmatch(raw); m != nil {
+			indent := m[1]
+			cond := strings.TrimSpace(m[2])
+			body := pyBlockBody(lines, i, len(indent))
+			outcome := classifyPyExceptOutcome(body)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachPyReturns(&bf, body)
+			out = append(out, bf)
+			continue
+		}
+
+		// if / elif guard.
+		if m := pyIfRe.FindStringSubmatch(raw); m != nil {
+			indent := m[1]
+			cond := strings.TrimSpace(m[2])
+			inline := strings.TrimSpace(m[3]) // `if x: return y` single-line form
+			var body []string
+			if inline != "" {
+				body = []string{inline}
+			} else {
+				body = pyBlockBody(lines, i, len(indent))
+			}
+			outcome, alters := classifyPyGuardOutcome(body)
+			if !alters {
+				// A plain branching `if` that neither returns nor raises is
+				// not a porting-critical branch for this facet; skip it so we
+				// don't drown the agent in every conditional.
+				continue
+			}
+			envVar := pyEnvVar(cond)
+			kind := BranchGuard
+			switch {
+			case envVar != "":
+				kind = BranchEnvGate
+			case !firstGuardSeen:
+				kind = BranchEarlyReturn
+			}
+			firstGuardSeen = true
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachPyReturns(&bf, body)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// pyBlockBody returns the statements belonging to the block whose header is at
+// lines[headerIdx] with indentation headerIndent — i.e. the run of subsequent
+// non-blank lines indented strictly deeper than the header, stopping at the
+// first line indented ≤ headerIndent.
+func pyBlockBody(lines []string, headerIdx, headerIndent int) []string {
+	var body []string
+	for j := headerIdx + 1; j < len(lines); j++ {
+		ln := lines[j]
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		if leadingWS(ln) <= headerIndent {
+			break
+		}
+		body = append(body, ln)
+	}
+	return body
+}
+
+// classifyPyGuardOutcome inspects an if/elif block body and returns its
+// outcome + whether it alters control flow (return/raise/redirect). A guard
+// that does none of these is not surfaced.
+func classifyPyGuardOutcome(body []string) (BranchOutcome, bool) {
+	for _, ln := range body {
+		if pyRaiseStmtRe.MatchString(ln) {
+			return OutcomeRaise, true
+		}
+		if pyReturnStmtRe.MatchString(ln) {
+			if pyRedirectRe.MatchString(strings.Join(body, "\n")) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if pyRedirectRe.MatchString(ln) {
+			return OutcomeRedirect, true
+		}
+	}
+	return "", false
+}
+
+// classifyPyExceptOutcome classifies an except handler. An except that
+// re-raises or returns is raise/return_value; one that only logs / passes /
+// continues is a SWALLOW (catch-and-continue) — the audit-critical case.
+func classifyPyExceptOutcome(body []string) BranchOutcome {
+	for _, ln := range body {
+		if pyRaiseStmtRe.MatchString(ln) {
+			return OutcomeRaise
+		}
+		if pyReturnStmtRe.MatchString(ln) {
+			if pyRedirectRe.MatchString(strings.Join(body, "\n")) {
+				return OutcomeRedirect
+			}
+			return OutcomeReturnValue
+		}
+		if pyRedirectRe.MatchString(ln) {
+			return OutcomeRedirect
+		}
+	}
+	// No re-raise / return / redirect anywhere in the handler → swallow.
+	return OutcomeSwallow
+}
+
+// pyEnvVar returns the env/settings variable name a condition reads, or "".
+func pyEnvVar(cond string) string {
+	m := pyEnvRefRe.FindStringSubmatch(cond)
+	if m == nil {
+		return ""
+	}
+	for _, g := range m[1:] {
+		if g != "" {
+			return g
+		}
+	}
+	return ""
+}
+
+// attachPyReturns derives returns.status + returns.shape from a branch body
+// for return_value/raise branches. Only attaches when something is found.
+func attachPyReturns(bf *BranchFacet, body []string) {
+	if bf.Outcome != OutcomeReturnValue && bf.Outcome != OutcomeRaise && bf.Outcome != OutcomeRedirect {
+		return
+	}
+	joined := strings.Join(body, "\n")
+	r := &BranchReturns{}
+	if m := pyHTTPStatusConstRe.FindStringSubmatch(joined); m != nil {
+		r.Status = m[1]
+	} else if m := pyHTTPStatusNumRe.FindStringSubmatch(joined); m != nil {
+		r.Status = m[1]
+	}
+	if shape := pyReturnShape(body); shape != "" {
+		r.Shape = shape
+	}
+	if r.Status != "" || r.Shape != "" {
+		bf.Returns = r
+	}
+}
+
+// pyReturnShape produces a brief descriptor of the returned payload. For a DRF
+// `Response({...}, ...)` it reports `Response{key1,key2}`; for a bare dict it
+// reports `dict{...}`. Best-effort and cheap — empty when not derivable.
+func pyReturnShape(body []string) string {
+	joined := strings.Join(body, " ")
+	// Wrapper call name immediately before a "(" then a "{".
+	wrapper := ""
+	if idx := strings.Index(joined, "Response("); idx >= 0 {
+		wrapper = "Response"
+	}
+	// First brace-delimited dict literal keys.
+	keys := pyDictKeys(joined)
+	switch {
+	case wrapper != "" && len(keys) > 0:
+		return wrapper + "{" + strings.Join(keys, ",") + "}"
+	case wrapper != "":
+		return wrapper
+	case len(keys) > 0:
+		return "dict{" + strings.Join(keys, ",") + "}"
+	}
+	return ""
+}
+
+func pyDictKeys(s string) []string {
+	open := strings.Index(s, "{")
+	if open < 0 {
+		return nil
+	}
+	var keys []string
+	seen := map[string]bool{}
+	for _, m := range pyDictKeyRe.FindAllStringSubmatch(s[open:], -1) {
+		k := m[1]
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+		if len(keys) >= 4 { // bound the descriptor
+			break
+		}
+	}
+	return keys
+}

--- a/internal/substrate/branches_test.go
+++ b/internal/substrate/branches_test.go
@@ -1,0 +1,90 @@
+package substrate
+
+import "testing"
+
+// TestAnalyzeBranchesPython_Outcomes exercises the classifier directly on
+// representative shapes: an except-swallow, an except-raise, an env-gate, an
+// early-return guard, and a redirect. Complements the in-pipeline MCP test
+// (internal/mcp/effects_branches_4423_test.go) which runs the REAL handler on
+// byte-copies of upvate oracle functions.
+func TestAnalyzeBranchesPython_Outcomes(t *testing.T) {
+	src := `def handler(self, request):
+    if not settings.FEATURE_X:
+        return Response({"error": "disabled"}, status=status.HTTP_403_FORBIDDEN)
+    try:
+        if user is None:
+            raise ValueError("no user")
+        return Response({"ok": True}, status=status.HTTP_200_OK)
+    except requests.HTTPError:
+        logger.warning("upstream failed")
+    except Exception:
+        return redirect("/fallback")
+`
+	br := analyzeBranchesPython(src, 10)
+	// env-gate, if-user-none (raise), except requests.HTTPError (swallow),
+	// except Exception (redirect). The bare `return Response(...200)` is NOT in
+	// a conditional, so it is not a branch.
+	if len(br) != 4 {
+		t.Fatalf("expected 4 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "FEATURE_X" {
+		t.Errorf("branch0 = %+v; want env_gate FEATURE_X", br[0])
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("branch0 outcome = %v; want return_value", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "403" {
+		t.Errorf("branch0 returns = %+v; want status 403", br[0].Returns)
+	}
+
+	// guard that raises. It is `guard` (not early_return) because the env-gate
+	// above already consumed the leading-guard slot — env-gates and the first
+	// non-env guard are distinguished, later guards are mid-body `guard`.
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeRaise {
+		t.Errorf("branch1 = %+v; want guard/raise", br[1])
+	}
+
+	// fall-through 200 return guard? No — `return Response(...200)` is not
+	// inside an if, so it is NOT a branch. The next branch is the except-swallow.
+	if br[2].Kind != BranchExcept || br[2].Outcome != OutcomeSwallow {
+		t.Errorf("branch2 = %+v; want except/swallow", br[2])
+	}
+	if br[2].Condition != "except requests.HTTPError" {
+		t.Errorf("branch2 condition = %q", br[2].Condition)
+	}
+
+	// except that redirects
+	if br[3].Kind != BranchExcept || br[3].Outcome != OutcomeRedirect {
+		t.Errorf("branch3 = %+v; want except/redirect", br[3])
+	}
+
+	// Line numbers are absolute (startLine=10 → first guard at line 11).
+	if br[0].Line != 11 {
+		t.Errorf("branch0 line = %d; want 11", br[0].Line)
+	}
+}
+
+// TestAnalyzeBranchesPython_NoBranches confirms a straight-line function
+// yields no branches (the facet must not invent control flow).
+func TestAnalyzeBranchesPython_NoBranches(t *testing.T) {
+	src := `def add(a, b):
+    total = a + b
+    return total
+`
+	if br := analyzeBranchesPython(src, 1); len(br) != 0 {
+		t.Fatalf("straight-line function should have 0 branches, got %+v", br)
+	}
+}
+
+// TestBranchAnalyzerRegistry confirms python is registered and unknown langs
+// return nil (honest-partial at the MCP layer).
+func TestBranchAnalyzerRegistry(t *testing.T) {
+	if BranchAnalyzerFor("python") == nil {
+		t.Fatal("python branch analyzer not registered")
+	}
+	if BranchAnalyzerFor("cobol") != nil {
+		t.Fatal("unexpected analyzer for cobol")
+	}
+}


### PR DESCRIPTION
## What

Adds an opt-in `branches` facet to `archigraph_effects`. The effects analysis collapses a branchy function to a SET of effect KINDS — it tells an agent THAT a function does `db_write` + `http_out`, but not WHICH branches exist, what each returns, or which env var gates which path. For a faithful port or an audit, an agent must reproduce every exception handler, early-return guard, and env-conditional with its exact outcome.

Call `effects(entity_id, group, include="branches")` to get, alongside the existing effect fields:

```jsonc
"branches": [
  {"kind":"early_return","condition":"if client is None","outcome":"return_value","returns":{"status":"400","shape":"Response{success,message}"},"line":355},
  {"kind":"guard","condition":"if email_availability['available'] is False and not upsert_flag","outcome":"return_value","returns":{"status":"409", ...},"line":374},
  {"kind":"env_gate","condition":"if not settings.ECB_PDF_PIPELINE_ENABLED","outcome":"return_value","env_var":"ECB_PDF_PIPELINE_ENABLED","line":11},
  {"kind":"except","condition":"except Exception as exc","outcome":"swallow","line":56}
]
```

- **kind** — `except` | `early_return` | `env_gate` | `guard`
- **outcome** — `raise` | `return_value` | `redirect` | `swallow` (catch-and-continue)
- **env_var** — the var name when the condition reads `settings.*` / `os.environ[...]` / `os.getenv(...)`
- **returns** — `{status, shape}` derived cheaply for return/raise/redirect branches (HTTP status + a brief payload-shape descriptor)

## How

The classifier is a general, indentation-scoped CFG walk over a SINGLE function's source window (`internal/substrate/branches.go`). It keys on statement SHAPE (return / raise / redirect / log-and-continue), not on specific functions, so it is a root capability, not a pattern match on two oracle methods. It reuses the same per-function source the effect sniffers walk, via a new `substrate.BranchAnalyzerFn` registry that mirrors the effect-sniffer registry. The MCP handler reads the resolved function's source window off disk only when `include="branches"` is requested.

**Default behaviour is unchanged** — the effects payload is byte-for-byte identical when `include` is absent (no `branches` / `branches_supported` keys), so there is no regression.

## Languages

- **Python** (the oracle stack) is implemented.
- Other languages honest-partial: `branches_supported:false` + a note rather than implying a branchless function. JS/TS, Java, and Go classifiers are tracked in follow-up #4434.

## Validation (live, in-pipeline)

Per the LIVE-VALIDATE rule, `internal/mcp/effects_branches_4423_test.go` runs the REAL `handleEffects` handler end-to-end (resolver → on-disk source read → analyzer) over byte-copies of ACTUAL upvate Django oracle functions copied verbatim into testdata (not edited):

- `ContractViewSet.create_contact` — 400 / 409 / 200 / 201 guards + a 500 `except Exception` handler
- `process_ecb_pdf_job` — `if not settings.ECB_PDF_PIPELINE_ENABLED: ... return` env-gate + an `if missing: ... return` guard
- `_write_debug_payload` — a log-only `except Exception` (swallow)

It asserts each branch's kind + outcome + `env_var` + `returns.status`, and that the DEFAULT call carries no `branches` key. RED-before / GREEN-after confirmed: disabling the facet makes the branch assertions fail while the default-unchanged test still passes.

## Gates

`go build ./...` ✅ · `go vet ./...` ✅ · `go test ./internal/substrate/ ./internal/mcp/` ✅ (incl. handshake-budget, tool-description, and schema-contract tests). No new entity Kind. Deploy-deferred.

Closes #4423

🤖 Generated with [Claude Code](https://claude.com/claude-code)