### PR TITLE
Index Go constant collections as queryable value-sets

### DIFF
--- a/internal/extractors/golang/constantset.go
+++ b/internal/extractors/golang/constantset.go
@@ -1,0 +1,356 @@
+package golang
+
+// constantset.go — value-carrying SCOPE.Enum value-set nodes for Go constant
+// COLLECTIONS that are not the classic same-file-named-type const block already
+// handled by enum_valueset.go (#4426, extends #4420/#4429, epic #4419).
+//
+// Three additional Go constant-collection shapes become searchable value-sets,
+// each carrying the shared structured members_json ([{key,value,line}]) emitted
+// by extractor.EnumEntity, so a downstream cross-graph parity-audit reads the
+// literal {key,value} set without re-parsing source:
+//
+//   1. Untyped grouped const block whose members share a non-trivial common
+//      identifier prefix — the idiomatic "enum without a named type":
+//
+//          const (
+//              StatusActive = "active"
+//              StatusIdle   = "idle"
+//          )
+//
+//      The shared prefix (`Status`) names the value-set. A grouped block whose
+//      members share no common prefix (`A = 1; B = 2`) is NOT a value-set —
+//      it is an incidental constant grouping, so no node is emitted
+//      (precision-first; preserves the #4429 untyped-const negative behaviour).
+//      iota members are recorded value-less (member name only) — no fabricated
+//      ordinals (honest-partial), mirroring the typed go_iota path.
+//
+//   2. Typed string/int const group whose type is NOT declared in the same
+//      file (so enum_valueset.go's same-file-named-type gate skips it), e.g. a
+//      const group typed by a type imported from another package. Captured the
+//      same way as (1), named by the shared type name.
+//
+//   3. Package-level map-of-constants:
+//
+//          var Pages = map[string]string{"CoreAdmin": "core-admin", ...}
+//
+//      The variable identifier (`Pages`) names the value-set; each keyed_element
+//      contributes a {key,value,line} member. Honest-partial: a node is emitted
+//      ONLY when at least one value is a static literal; a map whose values are
+//      all non-literal expressions (calls, identifiers) is not a closed
+//      enumerated value-set and emits no node.
+//
+// The existing same-file-named-type const block (enum_valueset.go) keeps its
+// dedicated path; this file only adds the shapes that path deliberately skips,
+// so the two never double-emit for the same declaration.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractGoConstantSets scans the file for the additional Go constant-collection
+// shapes (untyped/foreign-typed grouped const blocks, package-level const maps)
+// and emits one SCOPE.Enum value-set node per qualifying collection. `named` is
+// the set of same-file enum-base type names already owned by extractGoEnums; a
+// const block typed by one of those is left to that path (no double-emit).
+func extractGoConstantSets(root *sitter.Node, src []byte, filePath string, named map[string]bool) []types.EntityRecord {
+	if root == nil {
+		return nil
+	}
+	var out []types.EntityRecord
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "const_declaration":
+			if rec, ok := buildGoConstBlockValueSet(n, src, filePath, named); ok {
+				out = append(out, rec)
+			}
+			return
+		case "var_declaration":
+			out = append(out, buildGoConstMapValueSets(n, src, filePath)...)
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return out
+}
+
+// buildGoConstBlockValueSet handles a grouped const block that the same-file-
+// named-type path (enum_valueset.go) does NOT own: either untyped, or typed by
+// a type that is not a same-file enum-base named type. It emits a value-set
+// named by the shared type (foreign-typed group) or by the members' common
+// identifier prefix (untyped idiomatic enum). Returns ok=false when no such
+// name can be derived (incidental const grouping), preserving precision.
+func buildGoConstBlockValueSet(constDecl *sitter.Node, src []byte, filePath string, named map[string]bool) (types.EntityRecord, bool) {
+	// A single-spec const declaration (`const Pi = 3.14`) is not a collection.
+	specCount := 0
+	for i := 0; i < int(constDecl.ChildCount()); i++ {
+		if c := constDecl.Child(i); c != nil && c.Type() == "const_spec" {
+			specCount++
+		}
+	}
+	if specCount < 2 {
+		return types.EntityRecord{}, false
+	}
+
+	// Determine the type carried by the first typed spec (Go repetition: the
+	// type carries implicitly to subsequent specs).
+	var blockType string
+	for i := 0; i < int(constDecl.ChildCount()); i++ {
+		spec := constDecl.Child(i)
+		if spec == nil || spec.Type() != "const_spec" {
+			continue
+		}
+		if tn := firstChildOfType(spec, "type_identifier"); tn != nil {
+			blockType = nodeText(tn, src)
+			break
+		}
+	}
+	// Same-file enum-base named type → owned by enum_valueset.go; skip here.
+	if blockType != "" && named[blockType] {
+		return types.EntityRecord{}, false
+	}
+
+	var members []extractor.EnumMember
+	for i := 0; i < int(constDecl.ChildCount()); i++ {
+		spec := constDecl.Child(i)
+		if spec == nil || spec.Type() != "const_spec" {
+			continue
+		}
+		name := nodeText(firstChildOfType(spec, "identifier"), src)
+		if name == "" || name == "_" {
+			continue
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  name,
+			Value: goConstSpecLiteral(spec, src),
+			Line:  int(spec.StartPoint().Row) + 1,
+		})
+	}
+	if len(members) < 2 {
+		return types.EntityRecord{}, false
+	}
+
+	// Name + kind_hint:
+	//   - foreign-typed group → the type name (a real declared value-set type).
+	//   - untyped group → the members' common identifier prefix, the idiomatic
+	//     enum-without-a-type. No usable prefix → not a value-set (skip).
+	name := blockType
+	kindHint := "go_typed_const_group"
+	if name == "" {
+		name = commonIdentifierPrefix(members)
+		kindHint = "go_const_group"
+		if name == "" {
+			return types.EntityRecord{}, false
+		}
+	}
+
+	return extractor.EnumEntity(
+		name, "go", kindHint, filePath,
+		int(constDecl.StartPoint().Row)+1, int(constDecl.EndPoint().Row)+1, members,
+	)
+}
+
+// buildGoConstMapValueSets handles a `var X = map[K]V{...}` package-level
+// constant map (and grouped `var ( X = map...; Y = map... )` blocks), emitting
+// one value-set per qualifying map-literal-valued var_spec.
+func buildGoConstMapValueSets(varDecl *sitter.Node, src []byte, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for i := 0; i < int(varDecl.ChildCount()); i++ {
+		spec := varDecl.Child(i)
+		if spec == nil || spec.Type() != "var_spec" {
+			continue
+		}
+		name := nodeText(firstChildOfType(spec, "identifier"), src)
+		if name == "" || name == "_" {
+			continue
+		}
+		lit := mapLiteralValue(spec)
+		if lit == nil {
+			continue
+		}
+		members, anyLiteral := goMapMembers(lit, src)
+		if len(members) == 0 || !anyLiteral {
+			// Empty map, or a map whose values are all non-literal expressions
+			// → not a closed enumerated value-set (honest-partial).
+			continue
+		}
+		if rec, ok := extractor.EnumEntity(
+			name, "go", "go_const_map", filePath,
+			int(spec.StartPoint().Row)+1, int(spec.EndPoint().Row)+1, members,
+		); ok {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// mapLiteralValue returns the literal_value node of a var_spec whose RHS is a
+// `map[K]V{...}` composite literal, or nil when the RHS is not a map literal.
+func mapLiteralValue(spec *sitter.Node) *sitter.Node {
+	el := firstChildOfType(spec, "expression_list")
+	if el == nil {
+		return nil
+	}
+	for i := 0; i < int(el.ChildCount()); i++ {
+		ch := el.Child(i)
+		if ch == nil || ch.Type() != "composite_literal" {
+			continue
+		}
+		if firstChildOfType(ch, "map_type") == nil {
+			return nil // a non-map composite literal (struct/slice) is not a const map.
+		}
+		return firstChildOfType(ch, "literal_value")
+	}
+	return nil
+}
+
+// goMapMembers extracts {key,value,line} members from a map literal_value node.
+// Keys must be string literals (a constant-map key); values capture the static
+// literal or "" for non-literal value expressions (the key stays enumerable).
+// anyLiteral reports whether at least one value was a static literal.
+func goMapMembers(lit *sitter.Node, src []byte) (members []extractor.EnumMember, anyLiteral bool) {
+	for i := 0; i < int(lit.ChildCount()); i++ {
+		ke := lit.Child(i)
+		if ke == nil || ke.Type() != "keyed_element" {
+			continue
+		}
+		// keyed_element children: literal_element (key), ':', literal_element (value).
+		var elems []*sitter.Node
+		for j := 0; j < int(ke.ChildCount()); j++ {
+			c := ke.Child(j)
+			if c != nil && c.Type() == "literal_element" {
+				elems = append(elems, c)
+			}
+		}
+		if len(elems) != 2 {
+			continue
+		}
+		key := literalElementString(elems[0], src)
+		if key == "" {
+			continue // non-string-literal key (computed / identifier) — skip.
+		}
+		val := literalElementLiteral(elems[1], src)
+		if val != "" {
+			anyLiteral = true
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  key,
+			Value: val,
+			Line:  int(ke.StartPoint().Row) + 1,
+		})
+	}
+	return members, anyLiteral
+}
+
+// literalElementString returns the string-literal text of a key literal_element
+// (quotes stripped), or "" when the element is not a string literal.
+func literalElementString(le *sitter.Node, src []byte) string {
+	for i := 0; i < int(le.ChildCount()); i++ {
+		c := le.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "interpreted_string_literal", "raw_string_literal":
+			return extractor.StripLiteralQuotes(nodeText(c, src))
+		}
+	}
+	return ""
+}
+
+// literalElementLiteral returns the static literal value of a value
+// literal_element (string quotes stripped; int/float verbatim), or "" for a
+// non-literal value expression (call, identifier, composite).
+func literalElementLiteral(le *sitter.Node, src []byte) string {
+	for i := 0; i < int(le.ChildCount()); i++ {
+		c := le.Child(i)
+		if c == nil || !c.IsNamed() {
+			continue
+		}
+		switch c.Type() {
+		case "interpreted_string_literal", "raw_string_literal":
+			return extractor.StripLiteralQuotes(nodeText(c, src))
+		case "int_literal", "float_literal", "true", "false":
+			return nodeText(c, src)
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+// commonIdentifierPrefix returns the longest common leading identifier segment
+// shared by every member name, used to name an untyped idiomatic enum
+// (`StatusActive`, `StatusIdle` → `Status`). The prefix must be at least 2
+// characters and must not equal a whole member name (so `A`, `AB` does not
+// collapse to `A`). Returns "" when no such prefix exists, so an incidental
+// const grouping (no shared prefix) emits no value-set node.
+func commonIdentifierPrefix(members []extractor.EnumMember) string {
+	if len(members) < 2 {
+		return ""
+	}
+	prefix := members[0].Name
+	for _, m := range members[1:] {
+		prefix = sharedPrefix(prefix, m.Name)
+		if prefix == "" {
+			return ""
+		}
+	}
+	// Trim to the last upper-case boundary so the prefix is a clean PascalCase
+	// segment (`StatusActive`/`StatusArchived` → `Status`, not `StatusA`).
+	prefix = trimToCamelBoundary(prefix)
+	if len(prefix) < 2 {
+		return ""
+	}
+	// Reject a prefix that equals a member name in full (then it is not a
+	// shared *prefix* but a member, e.g. `Status`, `StatusActive`).
+	for _, m := range members {
+		if m.Name == prefix {
+			return ""
+		}
+	}
+	return prefix
+}
+
+// sharedPrefix returns the longest common leading substring of a and b.
+func sharedPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+// trimToCamelBoundary trims a PascalCase prefix back to its last complete
+// upper-case-initiated segment boundary, so a partial trailing segment
+// (`StatusA` from `StatusActive`/`StatusArchived`) reduces to `Status`. A
+// prefix that already ends at a boundary is returned unchanged.
+func trimToCamelBoundary(p string) string {
+	// Find the last index i>0 where p[i] is upper-case (segment start). Trim
+	// there only when characters follow that would make it a partial segment;
+	// since p is a *common* prefix, anything after the last segment start is a
+	// partial word, so cut at the last segment start (keeping >=1 segment).
+	last := 0
+	for i := 1; i < len(p); i++ {
+		if p[i] >= 'A' && p[i] <= 'Z' {
+			last = i
+		}
+	}
+	if last > 0 {
+		return p[:last]
+	}
+	return p
+}

--- a/internal/extractors/golang/enum_valueset.go
+++ b/internal/extractors/golang/enum_valueset.go
@@ -153,6 +153,7 @@ func buildGoEnumValueSet(constDecl *sitter.Node, src []byte, filePath string, na
 		members = append(members, extractor.EnumMember{
 			Name:  name,
 			Value: goConstSpecLiteral(spec, src),
+			Line:  int(spec.StartPoint().Row) + 1,
 		})
 	}
 

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -136,6 +136,13 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	// a same-file named type (data-model, epic #3628).
 	records = append(records, extractGoEnums(root, file.Content, file.Path)...)
 
+	// Additional Go constant-COLLECTION value-sets the same-file-named-type path
+	// above deliberately skips: untyped/foreign-typed grouped const blocks and
+	// package-level const maps (`var X = map[string]string{...}`). #4426.
+	records = append(records,
+		extractGoConstantSets(root, file.Content, file.Path,
+			collectNamedTypes(root, file.Content))...)
+
 	// ----------------------------------------------------------------
 	// 3. Import relationships — emitted as standalone SCOPE.Component
 	//    EntityRecord entries (one per import path). Not fanned out to

--- a/internal/extractors/golang/issue4426_constantset_test.go
+++ b/internal/extractors/golang/issue4426_constantset_test.go
@@ -1,0 +1,206 @@
+package golang_test
+
+// issue4426_constantset_test.go — in-pipeline tests for Go constant-COLLECTION
+// value-sets (#4426, extends #4420/#4429).
+//
+// These run the REAL Go extract pipeline (extractor.Get("go").Extract via
+// extractFromPath) on a byte-copy of a representative fixture — not a synthetic
+// AST — so a fixture that drifts cannot lie at merge time. They assert that the
+// three additional Go constant-collection shapes become name-searchable
+// SCOPE.Enum value-sets whose members_json enumerates the real key→value pairs.
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+type constMemberEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Line  int    `json:"line"`
+}
+
+func membersJSON(t *testing.T, e *types.EntityRecord) []constMemberEntry {
+	t.Helper()
+	raw := e.Properties["members_json"]
+	if raw == "" {
+		t.Fatalf("entity %q has no members_json; props=%v", e.Name, e.Properties)
+	}
+	var got []constMemberEntry
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("members_json not valid JSON: %v (raw=%s)", err, raw)
+	}
+	return got
+}
+
+func memberVal(members []constMemberEntry, key string) (string, bool) {
+	for _, m := range members {
+		if m.Key == key {
+			return m.Value, true
+		}
+	}
+	return "", false
+}
+
+// findSearchableEnum simulates the search_entities name lookup: an entity is
+// "searchable by name" when a SCOPE.Enum record carries that exact Name.
+func findSearchableEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func extract4426(t *testing.T) []types.EntityRecord {
+	t.Helper()
+	src, err := os.ReadFile("testdata/issue4426/constants.go")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	out, err := extractFromPath(string(src), "auth/constants.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	recs := make([]types.EntityRecord, 0, len(out))
+	for _, r := range out {
+		recs = append(recs, r.(types.EntityRecord))
+	}
+	return recs
+}
+
+// TestIssue4426_ConstMapValueSet — `var PermissionPages = map[string]string{...}`
+// becomes a name-searchable value-set enumerating the real {key,value} pairs,
+// including the hyphenated `core-admin` literal captured as structured data.
+func TestIssue4426_ConstMapValueSet(t *testing.T) {
+	recs := extract4426(t)
+
+	en := findSearchableEnum(recs, "PermissionPages")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:PermissionPages value-set not found (RED before fix)")
+	}
+	if got := en.Properties["kind_hint"]; got != "go_const_map" {
+		t.Fatalf("kind_hint = %q, want go_const_map", got)
+	}
+	members := membersJSON(t, en)
+	want := map[string]string{
+		"CoreAdmin":         "core-admin",
+		"ContractProposals": "contract-proposal",
+		"Users":             "users",
+		"Sync":              "sync",
+	}
+	for k, v := range want {
+		got, ok := memberVal(members, k)
+		if !ok {
+			t.Fatalf("member %q missing from members_json", k)
+		}
+		if got != v {
+			t.Fatalf("member %q value = %q, want %q", k, got, v)
+		}
+	}
+	// Every member must carry a real (non-zero) source line so a diff tool can
+	// locate the key→value pair.
+	for _, m := range members {
+		if m.Line <= 0 {
+			t.Fatalf("member %q has no source line (line=%d)", m.Key, m.Line)
+		}
+	}
+}
+
+// TestIssue4426_UntypedPrefixedConstGroup — an idiomatic untyped const block
+// whose members share a `Role` prefix becomes a value-set named `Role`.
+func TestIssue4426_UntypedPrefixedConstGroup(t *testing.T) {
+	recs := extract4426(t)
+
+	en := findSearchableEnum(recs, "Role")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Role value-set not found for untyped prefixed const group")
+	}
+	if got := en.Properties["kind_hint"]; got != "go_const_group" {
+		t.Fatalf("kind_hint = %q, want go_const_group", got)
+	}
+	members := membersJSON(t, en)
+	want := map[string]string{
+		"RoleAdmin":  "admin",
+		"RoleMember": "member",
+		"RoleGuest":  "guest",
+	}
+	for k, v := range want {
+		got, ok := memberVal(members, k)
+		if !ok {
+			t.Fatalf("member %q missing from members_json", k)
+		}
+		if got != v {
+			t.Fatalf("member %q value = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// TestIssue4426_TypedSameFileGroupNotDoubleEmitted — the same-file named-type
+// group (Status) is owned by the existing go_iota path, and the #4426 path must
+// NOT also emit a node for it (no double-emit). Exactly one Status value-set.
+func TestIssue4426_TypedSameFileGroupNotDoubleEmitted(t *testing.T) {
+	recs := extract4426(t)
+
+	count := 0
+	var st *types.EntityRecord
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == "Status" {
+			count++
+			st = &recs[i]
+		}
+	}
+	if count != 1 {
+		t.Fatalf("Status value-set emitted %d times, want exactly 1 (no double-emit)", count)
+	}
+	if got := st.Properties["kind_hint"]; got != "go_iota" {
+		t.Fatalf("Status kind_hint = %q, want go_iota (owned by enum_valueset.go)", got)
+	}
+	// The typed group's members now also carry a source line (#4426 enrichment).
+	members := membersJSON(t, st)
+	if v, ok := memberVal(members, "StatusActive"); !ok || v != "active" {
+		t.Fatalf("StatusActive value = %q (ok=%v), want active", v, ok)
+	}
+	for _, m := range members {
+		if m.Line <= 0 {
+			t.Fatalf("typed-group member %q has no source line", m.Key)
+		}
+	}
+}
+
+// TestIssue4426_IncidentalConstGroupNotEmitted — an untyped const group with no
+// shared identifier prefix (maxRetries / timeoutSec) is an incidental grouping,
+// NOT a value-set: no SCOPE.Enum node (precision-first).
+func TestIssue4426_IncidentalConstGroupNotEmitted(t *testing.T) {
+	recs := extract4426(t)
+	for i := range recs {
+		if recs[i].Kind != "SCOPE.Enum" {
+			continue
+		}
+		mj := recs[i].Properties["members_json"]
+		// The incidental group's members would appear under some derived name;
+		// assert neither member key leaks into any emitted value-set.
+		for _, bad := range []string{"maxRetries", "timeoutSec"} {
+			if containsKey(mj, bad) {
+				t.Fatalf("incidental const %q must not appear in a value-set (entity %q)", bad, recs[i].Name)
+			}
+		}
+	}
+}
+
+func containsKey(membersJSON, key string) bool {
+	var got []constMemberEntry
+	if json.Unmarshal([]byte(membersJSON), &got) != nil {
+		return false
+	}
+	for _, m := range got {
+		if m.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/golang/testdata/issue4426/constants.go
+++ b/internal/extractors/golang/testdata/issue4426/constants.go
@@ -1,0 +1,41 @@
+package auth
+
+// Representative Go constant-collection shapes (#4426) — a stand-in for the
+// kind of source-of-truth permission/status tables a rewrite parity-audit must
+// diff. Mirrors the real Go idioms: a typed string-const group, an idiomatic
+// untyped prefixed const group, and a package-level map-of-constants.
+
+// Status is a same-file named type — its const group is owned by the existing
+// enum_valueset.go go_iota path (NOT by the #4426 constant-set path), and is
+// here only to prove the two paths do not double-emit.
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusInactive Status = "inactive"
+	StatusPending  Status = "pending"
+)
+
+// Idiomatic enum WITHOUT a named type: members share the `Role` prefix, so the
+// untyped grouped const block is named `Role`.
+const (
+	RoleAdmin  = "admin"
+	RoleMember = "member"
+	RoleGuest  = "guest"
+)
+
+// Incidental const grouping (no shared prefix): must NOT become a value-set.
+const (
+	maxRetries = 3
+	timeoutSec = 30
+)
+
+// Package-level map of constants — the Go sibling of the Django PERMISSION_PAGES
+// dict / v3 PermissionPage const-object. The variable name `PermissionPages`
+// names the value-set; each entry is a {key,value,line} member.
+var PermissionPages = map[string]string{
+	"CoreAdmin":         "core-admin",
+	"ContractProposals": "contract-proposal",
+	"Users":             "users",
+	"Sync":              "sync",
+}


### PR DESCRIPTION
## Summary

Extends the constant-collection value-set work (#4420/#4429, epic #4419) to Go. Three Go constant-COLLECTION shapes that were invisible to `search_entities` now become name-searchable `SCOPE.Enum` value-sets (no new Kind), each carrying the shared structured `members_json` (`[{key,value,line}]`) emitted by `extractor.EnumEntity`.

### Go shapes covered
- **Package-level map-of-constants** — `var Pages = map[string]string{...}` → `kind_hint=go_const_map`, named by the variable identifier. Honest-partial: emitted only when at least one value is a static literal.
- **Untyped idiomatic enum const block** — members share a non-trivial common identifier prefix (`StatusActive`/`StatusIdle` → `Status`) → `kind_hint=go_const_group`. A grouped block with no shared prefix (`A=1; B=2`) is an incidental grouping → no node (precision-first; preserves the #4429 untyped-const negative behaviour).
- **Foreign-typed const group** — typed by a non-same-file named type → `kind_hint=go_typed_const_group`, named by the type.

The existing same-file-named-type `go_iota` path (`enum_valueset.go`) keeps its dedicated handler; the new path explicitly skips declarations that path owns, so the two never double-emit. The typed path now also stamps a per-member source line.

### Live-validation (in-pipeline)
`issue4426_constantset_test.go` runs the REAL Go extract pipeline on a byte-copy of a representative fixture (typed string-const group + untyped prefixed group + map-of-constants):

- **Before:** `PermissionPages` / `Role` value-sets not found; typed-group members carry no source line → 3 tests RED.
- **After:** each value-set emitted, name-searchable, `members_json` enumerates the real key→value pairs (hyphenated `core-admin` literal captured as structured data) with non-zero source lines; no double-emit of the `Status` group; incidental const group emits no node → GREEN.

### Gates
- `go build ./...` — OK
- `go vet ./internal/extractors/golang/ ./internal/extractor/ ./internal/types/` — clean
- `go test ./internal/extractors/golang/ ./internal/extractor/ ./internal/types/` — all pass

Closes #4426

🤖 Generated with [Claude Code](https://claude.com/claude-code)