### PR TITLE
Index Ruby constant collections as queryable value-sets

### DIFF
--- a/internal/extractors/ruby/const_valueset.go
+++ b/internal/extractors/ruby/const_valueset.go
@@ -1,0 +1,280 @@
+package ruby
+
+// const_valueset.go — value-carrying SCOPE.Enum value-set nodes for Ruby
+// CONSTANT COLLECTIONS (#4427, extends #4429 / epic #4419, ref #4334).
+//
+// #4429 indexed Rails ActiveRecord `enum` declarations (see enum_valueset.go).
+// This file generalises the same SCOPE.Enum value-set model to the plain Ruby
+// constant-collection shapes that act as source-of-truth maps but were
+// invisible to search_entities and could not be diffed by a downstream
+// cross-graph parity-audit:
+//
+//	# frozen / plain constant HASH (symbol or string keys)
+//	PERMISSION_PAGES = { core_admin: 'core-admin', billing: 'billing' }.freeze
+//	LIMITS = { 'free' => 10, 'pro' => 100 }
+//
+//	# constant ARRAY of literals (%w / %i / [...] / .freeze)
+//	STATUSES = %w[active inactive].freeze
+//	IDS      = %i[admin user]
+//	ROLES    = ['admin', 'user']
+//
+//	# module-level / class-level constant GROUP
+//	module Roles
+//	  ADMIN = 'admin'
+//	  USER  = 'user'
+//	end
+//
+// Reuses the shared cross-language builder in internal/extractor (EnumEntity /
+// EnumMember / StripLiteralQuotes) so Ruby constant collections converge on the
+// same node model — and the same structured members_json [{key,value,line}] —
+// as Python const maps, TS const-objects, and Rails enums.
+//
+// Honest-partial: an empty collection emits NO node. A member whose value is a
+// non-literal expression (a method call, a constant reference) still records
+// the member — with its source EXPRESSION TEXT as the value (#4427 scope) —
+// rather than being dropped, so the key set stays complete for a parity-audit.
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildConstCollectionValueSet inspects an `assignment` node and, when its
+// left side is a `constant` bound to a hash / array / string_array /
+// symbol_array literal collection (optionally wrapped in a `.freeze` call),
+// returns the SCOPE.Enum value-set node for it.
+//
+// kind_hint is "ruby_const_hash" for hash collections and "ruby_const_array"
+// for array collections, so a downstream consumer can tell the member shape.
+func buildConstCollectionValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	if node == nil || node.Type() != "assignment" {
+		return types.EntityRecord{}, false
+	}
+	lhs := node.ChildByFieldName("left")
+	if lhs == nil || lhs.Type() != "constant" {
+		return types.EntityRecord{}, false
+	}
+	rhs := node.ChildByFieldName("right")
+	if rhs == nil {
+		return types.EntityRecord{}, false
+	}
+
+	coll := unwrapFreeze(rhs)
+	if coll == nil {
+		return types.EntityRecord{}, false
+	}
+
+	name := nodeText(lhs, file.Content)
+	var members []extractor.EnumMember
+	var kindHint string
+	switch coll.Type() {
+	case "hash":
+		members = constHashMembers(coll, file.Content)
+		kindHint = "ruby_const_hash"
+	case "array", "string_array", "symbol_array":
+		members = constArrayMembers(coll, file.Content)
+		kindHint = "ruby_const_array"
+	default:
+		return types.EntityRecord{}, false
+	}
+	if len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+
+	return extractor.EnumEntity(
+		name, "ruby", kindHint, file.Path,
+		int(node.StartPoint().Row)+1, int(node.EndPoint().Row)+1, members,
+	)
+}
+
+// buildModuleConstGroupValueSet aggregates the constant assignments declared
+// directly in a module/class body into a single SCOPE.Enum value-set named
+// after the module/class. Each `CONST = <literal-or-expr>` becomes one member
+// {key=CONST, value=<literal>|<expr-text>, line}. Returns ok=false when the
+// body has no such constant assignments, or when a single constant already
+// holds a collection (that constant gets its own node via
+// buildConstCollectionValueSet, so it is excluded here).
+//
+// kind_hint is "ruby_const_module".
+func buildModuleConstGroupValueSet(scopeName string, body *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	if body == nil || scopeName == "" {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		child := body.Child(i)
+		if child == nil || child.Type() != "assignment" {
+			continue
+		}
+		lhs := child.ChildByFieldName("left")
+		if lhs == nil || lhs.Type() != "constant" {
+			continue
+		}
+		rhs := child.ChildByFieldName("right")
+		if rhs == nil {
+			continue
+		}
+		// A constant bound to a collection literal is its OWN value-set
+		// (buildConstCollectionValueSet handles it) — don't fold it into the
+		// group as a single opaque member.
+		if coll := unwrapFreeze(rhs); coll != nil && isCollectionNode(coll) {
+			continue
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  nodeText(lhs, file.Content),
+			Value: constScalarValue(rhs, file.Content),
+			Line:  int(child.StartPoint().Row) + 1,
+		})
+	}
+	if len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+	return extractor.EnumEntity(
+		scopeName, "ruby", "ruby_const_module", file.Path,
+		int(body.StartPoint().Row)+1, int(body.EndPoint().Row)+1, members,
+	)
+}
+
+// unwrapFreeze returns the underlying collection node, peeling a trailing
+// `.freeze` (or any other no-arg method call) wrapper. For
+// `{ a: 1 }.freeze` tree-sitter wraps the hash in a `call` whose receiver is
+// the hash; this returns that hash. A bare `{ a: 1 }` / `%w[..]` returns the
+// node unchanged.
+func unwrapFreeze(n *sitter.Node) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == "call" {
+		if recv := n.ChildByFieldName("receiver"); recv != nil {
+			return recv
+		}
+		// Receiver is not exposed as a field in some grammar versions — fall
+		// back to the first named child, which is the call's receiver.
+		for i := 0; i < int(n.ChildCount()); i++ {
+			ch := n.Child(i)
+			if ch != nil && ch.IsNamed() && isCollectionNode(ch) {
+				return ch
+			}
+		}
+		return nil
+	}
+	return n
+}
+
+// isCollectionNode reports whether n is one of the literal collection node
+// types this extractor materialises into a value-set.
+func isCollectionNode(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Type() {
+	case "hash", "array", "string_array", "symbol_array":
+		return true
+	}
+	return false
+}
+
+// constHashMembers builds EnumMembers from a `hash` node. Symbol keys
+// (`core_admin:`) and string/rocket keys (`'free' => 10`) are both handled.
+// A non-literal value records its source expression text (#4427) rather than
+// being dropped.
+func constHashMembers(hash *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	for i := 0; i < int(hash.ChildCount()); i++ {
+		pair := hash.Child(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		// Resolve the key. Symbol keys (`core_admin:`) come through the
+		// dedicated hash_key_symbol/simple_symbol path; string/rocket keys
+		// (`'free' => 10`) and constant keys come through the `key` field and
+		// must have their quotes stripped (constScalarValue), so pairKeyName's
+		// raw-text result for non-symbol keys is not used here.
+		var key string
+		if k := pair.ChildByFieldName("key"); k != nil {
+			switch k.Type() {
+			case "hash_key_symbol":
+				key = nodeText(k, src)
+			case "simple_symbol":
+				key = trimLeadingColon(nodeText(k, src))
+			default:
+				key = constScalarValue(k, src)
+			}
+		} else {
+			key = pairKeyName(pair, src)
+		}
+		if key == "" {
+			continue
+		}
+		val := ""
+		if v := pairValueNode(pair); v != nil {
+			val = constScalarValue(v, src)
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  key,
+			Value: val,
+			Line:  int(pair.StartPoint().Row) + 1,
+		})
+	}
+	return members
+}
+
+// constArrayMembers builds EnumMembers from an `array` / `string_array`
+// (`%w[...]`) / `symbol_array` (`%i[...]`) node. Each element's literal becomes
+// BOTH the member key and value so the value-set carries the literal set; a
+// non-literal element records its expression text.
+func constArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	for i := 0; i < int(arr.ChildCount()); i++ {
+		el := arr.Child(i)
+		if el == nil || !el.IsNamed() {
+			continue
+		}
+		var lit string
+		switch el.Type() {
+		case "bare_string", "bare_symbol":
+			// `%w[..]` / `%i[..]` elements: the literal is the inner content.
+			lit = nodeText(el, src)
+		default:
+			lit = constScalarValue(el, src)
+		}
+		if lit == "" {
+			continue
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  lit,
+			Value: lit,
+			Line:  int(el.StartPoint().Row) + 1,
+		})
+	}
+	return members
+}
+
+// constScalarValue returns the statically-known literal of a scalar node
+// (string / number / symbol / boolean / constant ref), or — for any other
+// non-literal node (a method call, an interpolation) — the trimmed source
+// EXPRESSION TEXT (#4427: non-literal values are recorded as expression text,
+// not dropped).
+func constScalarValue(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "string", "bare_string":
+		return extractor.StripLiteralQuotes(nodeText(n, src))
+	case "integer", "float":
+		return nodeText(n, src)
+	case "simple_symbol", "bare_symbol":
+		return trimLeadingColon(nodeText(n, src))
+	case "hash_key_symbol", "constant":
+		return nodeText(n, src)
+	case "true", "false", "nil":
+		return nodeText(n, src)
+	}
+	// Non-literal expression (method call, ternary, interpolation, …): keep
+	// the source text so the key set stays complete and a parity-audit can see
+	// the value is dynamic.
+	return nodeText(n, src)
+}

--- a/internal/extractors/ruby/issue4427_constvalueset_test.go
+++ b/internal/extractors/ruby/issue4427_constvalueset_test.go
@@ -1,0 +1,250 @@
+package ruby_test
+
+// issue4427_constvalueset_test.go — value-asserting, IN-PIPELINE tests for Ruby
+// CONSTANT-COLLECTION value-sets (#4427, extends #4429 / epic #4419, ref #4334).
+//
+// #4429 indexed Rails `enum` declarations as SCOPE.Enum value-sets. #4427
+// generalises that to the plain Ruby constant-collection shapes that act as
+// source-of-truth maps but were invisible to search_entities and could not be
+// diffed by a downstream cross-graph parity-audit:
+//
+//   - frozen / plain constant HASH  (symbol or string keys)
+//   - constant ARRAY of literals    (%w / %i / [...] / .freeze)
+//   - module-level constant GROUP   (module Roles; ADMIN='admin'; end)
+//   - Rails ActiveRecord enum       (already covered by #4429; re-asserted here)
+//
+// The first test runs the REAL Ruby extract pipeline on a byte-copy fixture
+// (testdata/issue4427/permission_pages.rb) — a frozen constant hash plus a
+// Rails enum — asserting the value-set is emitted, name-searchable, and that
+// members_json enumerates the real {key,value} pairs. RED before the fix
+// (only the Rails enum surfaced); GREEN after.
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+type constMemberEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Line  int    `json:"line"`
+}
+
+func constMembersJSON(t *testing.T, e *types.EntityRecord) []constMemberEntry {
+	t.Helper()
+	raw := e.Properties["members_json"]
+	if raw == "" {
+		t.Fatalf("entity %q has no members_json property; props=%v", e.Name, e.Properties)
+	}
+	var got []constMemberEntry
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("members_json not valid JSON: %v (raw=%s)", err, raw)
+	}
+	return got
+}
+
+func constMemberValue(members []constMemberEntry, key string) (string, bool) {
+	for _, m := range members {
+		if m.Key == key {
+			return m.Value, true
+		}
+	}
+	return "", false
+}
+
+// searchableEnum mirrors how search_entities locates a value-set: by Kind +
+// name. nil means the node would not be findable.
+func searchableEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Enum" && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+// TestIssue4427_RealFrozenConstHash_InPipeline runs the live-shaped fixture
+// through the REAL Ruby extractor and asserts the frozen PERMISSION_PAGES hash
+// surfaces as a name-searchable value-set whose members_json carries the real
+// hyphenated string values with source lines.
+func TestIssue4427_RealFrozenConstHash_InPipeline(t *testing.T) {
+	src, err := os.ReadFile("testdata/issue4427/permission_pages.rb")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	recs := extractRubyForEnum(t, "app/permission_pages.rb", string(src))
+
+	en := searchableEnum(recs, "PERMISSION_PAGES")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:PERMISSION_PAGES value-set node not found (RED before #4427)")
+	}
+	if en.Kind != "SCOPE.Enum" {
+		t.Fatalf("Kind = %q, want SCOPE.Enum", en.Kind)
+	}
+	if got := en.Properties["kind_hint"]; got != "ruby_const_hash" {
+		t.Fatalf("kind_hint = %q, want ruby_const_hash", got)
+	}
+
+	members := constMembersJSON(t, en)
+	want := map[string]string{
+		"core_admin":         "core-admin",
+		"contract_proposals": "contract-proposal",
+		"users":              "users",
+		"sync":               "sync",
+	}
+	for k, v := range want {
+		got, ok := constMemberValue(members, k)
+		if !ok {
+			t.Fatalf("member %q missing from members_json (got %+v)", k, members)
+		}
+		if got != v {
+			t.Fatalf("member %q value = %q, want %q", k, got, v)
+		}
+	}
+	// Each member must carry a real source line so a diff tool can locate it.
+	for _, m := range members {
+		if m.Line <= 0 {
+			t.Fatalf("member %q line = %d, want > 0", m.Key, m.Line)
+		}
+	}
+}
+
+// TestIssue4427_RailsEnumStillSurfaces is the cross-check that the same fixture's
+// Rails `enum status: {...}` (the #4429 shape) still surfaces alongside the new
+// const-collection nodes — generalisation did not regress the original.
+func TestIssue4427_RailsEnumStillSurfaces(t *testing.T) {
+	src, err := os.ReadFile("testdata/issue4427/permission_pages.rb")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	recs := extractRubyForEnum(t, "app/permission_pages.rb", string(src))
+
+	en := searchableEnum(recs, "status")
+	if en == nil {
+		t.Fatal("Rails enum SCOPE.Enum:status not found")
+	}
+	if got := en.Properties["values"]; got != "active=0, archived=1" {
+		t.Fatalf("status values = %q, want active=0, archived=1", got)
+	}
+	// And the class-body frozen hash PRIORITY_LABELS also surfaces.
+	pl := searchableEnum(recs, "PRIORITY_LABELS")
+	if pl == nil {
+		t.Fatal("class-body frozen hash SCOPE.Enum:PRIORITY_LABELS not found")
+	}
+	if v, _ := func() (string, bool) {
+		return constMemberValue(constMembersJSON(t, pl), "low")
+	}(); v != "Low" {
+		t.Fatalf("PRIORITY_LABELS[low] = %q, want Low", v)
+	}
+}
+
+// TestIssue4427_ConstArrayLiterals covers `%w[..]` / `%i[..]` / `[..]` arrays.
+func TestIssue4427_ConstArrayLiterals(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/statuses.rb",
+		`STATUSES = %w[active inactive archived].freeze`)
+	en := searchableEnum(recs, "STATUSES")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:STATUSES value-set (%w array) not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "ruby_const_array" {
+		t.Fatalf("kind_hint = %q, want ruby_const_array", got)
+	}
+	if got := en.Properties["members"]; got != "active, inactive, archived" {
+		t.Fatalf("members = %q, want active, inactive, archived", got)
+	}
+	members := constMembersJSON(t, en)
+	if v, _ := constMemberValue(members, "active"); v != "active" {
+		t.Fatalf("array literal active value = %q, want active", v)
+	}
+}
+
+func TestIssue4427_SymbolArray(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/ids.rb", `IDS = %i[admin user guest].freeze`)
+	en := searchableEnum(recs, "IDS")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:IDS value-set (%i array) not found")
+	}
+	if got := en.Properties["members"]; got != "admin, user, guest" {
+		t.Fatalf("members = %q, want admin, user, guest", got)
+	}
+}
+
+// TestIssue4427_ModuleConstGroup covers `module Roles; ADMIN='admin'; end`.
+func TestIssue4427_ModuleConstGroup(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/roles.rb",
+		`module Roles
+  ADMIN   = 'admin'
+  MANAGER = 'manager'
+  MEMBER  = 'member'
+end`)
+	en := searchableEnum(recs, "Roles")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Roles module-constant-group value-set not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "ruby_const_module" {
+		t.Fatalf("kind_hint = %q, want ruby_const_module", got)
+	}
+	members := constMembersJSON(t, en)
+	want := map[string]string{"ADMIN": "admin", "MANAGER": "manager", "MEMBER": "member"}
+	for k, v := range want {
+		got, ok := constMemberValue(members, k)
+		if !ok {
+			t.Fatalf("module const %q missing", k)
+		}
+		if got != v {
+			t.Fatalf("module const %q = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// TestIssue4427_StringRocketKeys covers `{ 'free' => 10, 'pro' => 100 }`.
+func TestIssue4427_StringRocketKeys(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/limits.rb",
+		`LIMITS = { 'free' => 10, 'pro' => 100 }.freeze`)
+	en := searchableEnum(recs, "LIMITS")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:LIMITS value-set (rocket keys) not found")
+	}
+	members := constMembersJSON(t, en)
+	if v, _ := constMemberValue(members, "free"); v != "10" {
+		t.Fatalf("LIMITS[free] = %q, want 10", v)
+	}
+	if v, _ := constMemberValue(members, "pro"); v != "100" {
+		t.Fatalf("LIMITS[pro] = %q, want 100", v)
+	}
+}
+
+// TestIssue4427_NonLiteralValueAsExpressionText is the #4427 honest-partial
+// contract: a non-literal value records its EXPRESSION TEXT (not dropped), so
+// the key set stays complete and a parity-audit sees the value is dynamic.
+func TestIssue4427_NonLiteralValueAsExpressionText(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/mixed.rb",
+		`MIXED = { a: 1, b: compute_default() }.freeze`)
+	en := searchableEnum(recs, "MIXED")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:MIXED value-set not found")
+	}
+	members := constMembersJSON(t, en)
+	if v, _ := constMemberValue(members, "a"); v != "1" {
+		t.Fatalf("MIXED[a] = %q, want 1", v)
+	}
+	v, ok := constMemberValue(members, "b")
+	if !ok {
+		t.Fatal("non-literal member b dropped; #4427 requires expression-text capture")
+	}
+	if v != "compute_default()" {
+		t.Fatalf("MIXED[b] = %q, want expression text compute_default()", v)
+	}
+}
+
+// TestIssue4427_NonCollectionConst_NoNode is the negative: a constant bound to
+// a single scalar at file scope is NOT a collection and emits no value-set.
+func TestIssue4427_NonCollectionConst_NoNode(t *testing.T) {
+	recs := extractRubyForEnum(t, "app/scalar.rb", `MAX_RETRIES = 5`)
+	if en := searchableEnum(recs, "MAX_RETRIES"); en != nil {
+		t.Fatalf("scalar constant should not emit a value-set, got %+v", en.Properties)
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -116,6 +116,19 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 					*out = append(*out, vs)
 				}
 			}
+			// #4427 — class/module-body constant COLLECTIONS
+			// (`KINDS = { a: 1 }.freeze`, `STATUSES = %w[..]`) → per-constant
+			// value-set SCOPE.Enum nodes are emitted by the recursive
+			// `case "assignment"` branch when walk() descends into the body
+			// below (avoids a double-emit).
+			//
+			// #4427 — a `module Roles; ADMIN='admin'; USER='user'; end` group
+			// of scalar constants → one value-set named after the module/class.
+			// Constants bound to collections are excluded (they get their own
+			// node above).
+			if gs, gok := buildModuleConstGroupValueSet(rec.Name, body, file); gok {
+				*out = append(*out, gs)
+			}
 			before := len(*out)
 			for i := range body.ChildCount() {
 				walk(body.Child(int(i)), file, out)
@@ -164,6 +177,16 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 	case "call":
 		if rec, ok := buildRequireImport(node, file); ok {
 			*out = append(*out, rec)
+		}
+
+	case "assignment":
+		// #4427 — top-level / nested constant COLLECTIONS outside any class or
+		// module body (`PERMISSION_PAGES = { ... }.freeze` at file scope). The
+		// class/module branch handles body-scoped constants directly; this
+		// catches the file-scope and arbitrarily-nested cases. Recursion
+		// continues below so we never miss a deeper assignment.
+		if vs, vok := buildConstCollectionValueSet(node, file); vok {
+			*out = append(*out, vs)
 		}
 	}
 

--- a/internal/extractors/ruby/testdata/issue4427/permission_pages.rb
+++ b/internal/extractors/ruby/testdata/issue4427/permission_pages.rb
@@ -1,0 +1,26 @@
+# Representative Ruby source-of-truth maps for #4427 in-pipeline validation.
+# A frozen constant hash (the cross-graph parity oracle), a constant array,
+# a module-level constant group, and a Rails ActiveRecord enum — all of which
+# must surface as name-searchable SCOPE.Enum value-sets carrying structured
+# {key,value,line} members.
+
+PERMISSION_PAGES = {
+  core_admin:         'core-admin',
+  contract_proposals: 'contract-proposal',
+  users:              'users',
+  sync:               'sync',
+}.freeze
+
+STATUSES = %w[active inactive archived].freeze
+
+module Roles
+  ADMIN   = 'admin'
+  MANAGER = 'manager'
+  MEMBER  = 'member'
+end
+
+class Order < ApplicationRecord
+  enum status: { active: 0, archived: 1 }
+
+  PRIORITY_LABELS = { low: 'Low', high: 'High' }.freeze
+end


### PR DESCRIPTION
## What

Generalises the SCOPE.Enum value-set model (introduced for Rails `enum` in #4429) to plain Ruby **constant collections** so source-of-truth maps held in constants are name-searchable and carry a structured, enumerable `members_json` `[{key,value,line}]` for a downstream cross-graph parity-audit.

Ruby shapes now indexed:
- frozen / plain constant **hash** — symbol keys (`core_admin:`), string/rocket keys (`'free' => 10`)
- constant **array** of literals — `%w[..]`, `%i[..]`, `[..]`, optionally `.freeze`
- module / class-level constant **group** — `module Roles; ADMIN='admin'; end` → one value-set named after the module/class
- Rails `enum` (already #4429) — re-asserted, no regression

A trailing `.freeze` is peeled via the call receiver. Reuses `extractor.EnumEntity` — **no new Kind, no change to the shared helper**.

## Honest-partial
- empty collection → no node
- a **non-literal** value records its source **expression text** (not dropped), per ticket scope, so the key set stays complete and a parity-audit sees the value is dynamic
- a bare scalar constant is not a collection → no node

## Validation
New in-pipeline tests run the **real** Ruby extract pipeline on a byte-copy fixture (`testdata/issue4427/permission_pages.rb` — a frozen constant hash + a Rails enum) and assert the value-set is emitted, name-searchable, and that `members_json` enumerates the real `{key,value}` pairs with source lines. Verified **RED before / GREEN after** by disabling the wiring.

Gates: `go build ./...`, `go vet`, `go test ./internal/custom/ruby/ ./internal/extractor/ ./internal/extractors/ruby/ ./internal/types/` all green. Deploy-deferred.

Closes #4427

🤖 Generated with [Claude Code](https://claude.com/claude-code)